### PR TITLE
Throw exception if the app is not set [YiiBase::t()]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+
+script: phpunit --bootstrap tests/unit/bootstrap.php --coverage-text tests/unit/

--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license http://www.yiiframework.com/license/
  */
+use yii\base\Application;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
 use yii\base\InvalidParamException;
@@ -597,9 +598,14 @@ class YiiBase
 	 * @param string $language the language code (e.g. `en_US`, `en`). If this is null, the current
 	 * [[\yii\base\Application::language|application language]] will be used.
 	 * @return string the translated message.
+	 * @throws Exception if the application is not set.
 	 */
 	public static function t($message, $params = array(), $language = null)
 	{
+		if (!self::$app instanceof Application) {
+			throw new Exception('Application is not set');
+		}
+
 		return self::$app->getI18N()->translate($message, $params, $language);
 	}
 }


### PR DESCRIPTION
Current test suite are blocked by a [fatal error](https://travis-ci.org/toopay/yii2/jobs/6874059#L24). It seems that all component basically assumed the `$app` within `YiiBase` class always already setup, BEFORE anything else. Also, the fact that all exception classes within `base` directory, use `YiiBase::t` api directly, seems not right for me.

But ignoring all of above notes, the obvious options we have here were :
1. Make the `YiiBase::t` api works, even if the `$app` is not set yet (sprintf?)
2. Halt the execution and throw exception.

At this pull, i proposed to the second option.
