### PR TITLE
Fix build command.

### DIFF
--- a/build/build
+++ b/build/build
@@ -16,5 +16,5 @@ require(__DIR__ . '/../framework/yii.php');
 $id = 'yiic-build';
 $basePath = __DIR__;
 
-$application = new yii\console\Application($id, $basePath);
+$application = new yii\console\Application(array('id' => $id, 'basePath' => $basePath));
 $application->run();


### PR DESCRIPTION
Application::__construct() expects an array two parameters were given.

Before this:

```
Fatal error: Uncaught exception 'yii\base\InvalidConfigException' with message '
The "basePath" configuration is required.' in D:\dev\www\vhosts\yii2\framework\b
ase\Application.php:86
Stack trace:
#0 D:\dev\www\vhosts\yii2\build\build(19): yii\base\Application->__construct(Arr
ay, 'D:\dev\www\vhos...')
#1 {main}
  thrown in D:\dev\www\vhosts\yii2\framework\base\Application.php on line 86
```

After:

```
D:\dev\www\vhosts\yii2>build\build
The following commands are available:

* app
* asset
* cache
* help
* locale
* message
* migrate

To see the help of each command, enter:

  yiic help <command-name>

```
