### PR TITLE
Travis Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+
+env:
+  - DB=mysql
+
+before_script:
+  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS yiitest;'; fi"
+
+script: phpunit

--- a/tests/unit/data/config.php
+++ b/tests/unit/data/config.php
@@ -3,7 +3,7 @@
 return array(
 	'mysql' => array(
 		'dsn' => 'mysql:host=127.0.0.1;dbname=yiitest',
-		'username' => 'root',
+		'username' => 'travis',
 		'password' => '',
 		'fixture' => __DIR__ . '/mysql.sql',
 	),


### PR DESCRIPTION
- I introduce `env` within `.travis.yml` to work easier with multiple database configuration in the future (ref : http://about.travis-ci.org/docs/user/database-setup/#Multiple-database-systems).
- I also alter the database username within config (from `root` to `travis`). The reason is because mostly, any user with `phpmyadmin` installed, will be forced to set up their `root` user with a password. And for that reason, i think it is easier for them to create another passwordless user, rather than altering their `root` user which may be already used by other app. But let me know if someone think it was unnecessary and i will revert these one. 
