### PR TITLE
Fix undefined SORT_FLAG_CASE in ArrayHelper

### DIFF
--- a/framework/helpers/base/ArrayHelper.php
+++ b/framework/helpers/base/ArrayHelper.php
@@ -264,7 +264,8 @@ class ArrayHelper
 		$args = array();
 		foreach ($keys as $i => $key) {
 			$flag = $sortFlag[$i];
-			if ($flag == (SORT_STRING | SORT_FLAG_CASE)) {
+			if ((defined('SORT_FLAG_CASE') && $flag == (SORT_STRING | SORT_FLAG_CASE))
+			    || $flag == SORT_STRING) {
 				$flag = SORT_STRING;
 				$column = array();
 				foreach (static::getColumn($array, $key) as $k => $value) {

--- a/framework/helpers/base/ArrayHelper.php
+++ b/framework/helpers/base/ArrayHelper.php
@@ -246,6 +246,9 @@ class ArrayHelper
 	 */
 	public static function multisort(&$array, $key, $ascending = true, $sortFlag = SORT_REGULAR)
 	{
+		// Prior to PHP 5.4, SORT_FLAG_CASE isnt available
+		defined('SORT_FLAG_CASE') or define('SORT_FLAG_CASE', 8);
+
 		$keys = is_array($key) ? $key : array($key);
 		if (empty($keys) || empty($array)) {
 			return;
@@ -264,8 +267,7 @@ class ArrayHelper
 		$args = array();
 		foreach ($keys as $i => $key) {
 			$flag = $sortFlag[$i];
-			if ((defined('SORT_FLAG_CASE') && $flag == (SORT_STRING | SORT_FLAG_CASE))
-			    || $flag == SORT_STRING) {
+			if ($flag == (SORT_STRING | SORT_FLAG_CASE)) {
 				$flag = SORT_STRING;
 				$column = array();
 				foreach (static::getColumn($array, $key) as $k => $value) {

--- a/tests/unit/framework/helpers/ArrayHelperTest.php
+++ b/tests/unit/framework/helpers/ArrayHelperTest.php
@@ -14,6 +14,9 @@ class ArrayHelperTest extends \yii\test\TestCase
 
 	public function testMultisort()
 	{
+		// Prior to PHP 5.4, SORT_FLAG_CASE isnt available
+		defined('SORT_FLAG_CASE') or define('SORT_FLAG_CASE', 8);
+
 		// single key
 		$array = array(
 			array('name' => 'b', 'age' => 3),
@@ -43,13 +46,7 @@ class ArrayHelperTest extends \yii\test\TestCase
 			array('name' => 'A', 'age' => 1),
 		);
 
-		if (defined('SORT_FLAG_CASE')) {
-			$flags = array(SORT_STRING|SORT_FLAG_CASE, SORT_REGULAR);
-		} else {
-			$flags = array(SORT_STRING, SORT_REGULAR);
-		}
-
-		ArrayHelper::multisort($array, array('name', 'age'), SORT_ASC, $flags);
+		ArrayHelper::multisort($array, array('name', 'age'), SORT_ASC, array(SORT_STRING|SORT_FLAG_CASE, SORT_REGULAR));
 		$this->assertEquals(array('name' => 'A', 'age' => 1), $array[0]);
 		$this->assertEquals(array('name' => 'a', 'age' => 3), $array[1]);
 		$this->assertEquals(array('name' => 'b', 'age' => 2), $array[2]);

--- a/tests/unit/framework/helpers/ArrayHelperTest.php
+++ b/tests/unit/framework/helpers/ArrayHelperTest.php
@@ -42,7 +42,14 @@ class ArrayHelperTest extends \yii\test\TestCase
 			array('name' => 'b', 'age' => 2),
 			array('name' => 'A', 'age' => 1),
 		);
-		ArrayHelper::multisort($array, array('name', 'age'), SORT_ASC, array(SORT_STRING|SORT_FLAG_CASE, SORT_REGULAR));
+
+		if (defined('SORT_FLAG_CASE')) {
+			$flags = array(SORT_STRING|SORT_FLAG_CASE, SORT_REGULAR);
+		} else {
+			$flags = array(SORT_STRING, SORT_REGULAR);
+		}
+
+		ArrayHelper::multisort($array, array('name', 'age'), SORT_ASC, $flags);
 		$this->assertEquals(array('name' => 'A', 'age' => 1), $array[0]);
 		$this->assertEquals(array('name' => 'a', 'age' => 3), $array[1]);
 		$this->assertEquals(array('name' => 'b', 'age' => 2), $array[2]);


### PR DESCRIPTION
Based by minimum requirement (php 5.3.*) that stated in readme, the use of `SORT_FLAG_CASE` would [fail](https://travis-ci.org/toopay/yii2/jobs/6883042#L35) in any php version prior to 5.4.
