### PR TITLE
Fixed VarDumper::dump for objects

### DIFF
--- a/framework/helpers/base/VarDumper.php
+++ b/framework/helpers/base/VarDumper.php
@@ -116,7 +116,7 @@ class VarDumper
 				} elseif (self::$_depth <= $level) {
 					self::$_output .= get_class($var) . '(...)';
 				} else {
-					$id = self::$_objects[] = $var;
+					$id = array_push(self::$_objects, $var);
 					$className = get_class($var);
 					$members = (array)$var;
 					$spaces = str_repeat(' ', $level * 4);

--- a/tests/unit/framework/helpers/VarDumperTest.php
+++ b/tests/unit/framework/helpers/VarDumperTest.php
@@ -1,0 +1,12 @@
+<?php
+namespace yiiunit\framework\helpers;
+use \yii\helpers\VarDumper;
+
+class VarDumperTest extends \yii\test\TestCase
+{
+	public function testDumpObject()
+	{
+		$obj = new \StdClass();
+		VarDumper::dump($obj);
+	}
+}


### PR DESCRIPTION
Otherwise it throws an exception that "Object of class ClassName
could not be converted to string"
