### PR TITLE
Fix unsupported flag in php 5.3.x environment [ArrayHelper::multisort]

### DIFF
--- a/framework/helpers/base/ArrayHelper.php
+++ b/framework/helpers/base/ArrayHelper.php
@@ -272,7 +272,7 @@ class ArrayHelper
 		foreach ($keys as $i => $key) {
 			$flag = $sortFlag[$i];
 			$cs = $caseSensitive[$i];
-			if (!$cs && ($flag === SORT_STRING || $flag === SORT_NATURAL)) {
+			if (!$cs && ($flag === SORT_STRING)) {
 				if (defined('SORT_FLAG_CASE')) {
 					$flag = $flag | SORT_FLAG_CASE;
 					$args[] = static::getColumn($array, $key);

--- a/framework/helpers/base/ArrayHelper.php
+++ b/framework/helpers/base/ArrayHelper.php
@@ -237,11 +237,11 @@ class ArrayHelper
 	 * @param boolean|array $ascending whether to sort in ascending or descending order. When
 	 * sorting by multiple keys with different ascending orders, use an array of ascending flags.
 	 * @param integer|array $sortFlag the PHP sort flag. Valid values include
-	 * `SORT_REGULAR`, `SORT_NUMERIC`, `SORT_STRING`, `SORT_LOCALE_STRING` and `SORT_NATURAL`.
-	 * and `SORT_STRING | SORT_FLAG_CASE`. Please refer to [PHP manual](http://php.net/manual/en/function.sort.php)
+	 * `SORT_REGULAR`, `SORT_NUMERIC`, `SORT_STRING` and `SORT_LOCALE_STRING`.
+	 * Please refer to [PHP manual](http://php.net/manual/en/function.sort.php)
 	 * for more details. When sorting by multiple keys with different sort flags, use an array of sort flags.
 	 * @param boolean|array $caseSensitive whether to sort string in case-sensitive manner. This parameter
-	 * is used only when `$sortFlag` is either `SORT_STRING` or `SORT_NATURAL`.
+	 * is used only when `$sortFlag` is `SORT_STRING`.
 	 * When sorting by multiple keys with different case sensitivities, use an array of boolean values.
 	 * @throws InvalidParamException if the $ascending or $sortFlag parameters do not have
 	 * correct number of elements as that of $key.


### PR DESCRIPTION
The use of `SORT_NATURAL` flag, causing the [same trouble](https://travis-ci.org/toopay/yii2/jobs/6890963#L37) we have in #7 and #93. Since we're already add case-insensitive flag internally within the method, i think its save to remove completely any php 5.4-only constants.
