### PR TITLE
Check apc.enable_cli for ApcTestCase unit tests

### DIFF
--- a/tests/unit/framework/caching/ApcCacheTest.php
+++ b/tests/unit/framework/caching/ApcCacheTest.php
@@ -17,6 +17,8 @@ class ApcCacheTest extends CacheTest
 	{
 		if(!extension_loaded("apc")) {
 			$this->markTestSkipped("APC not installed. Skipping.");
+		} else if ('cli' === PHP_SAPI && !ini_get('apc.enable_cli')) {
+			$this->markTestSkipped("APC cli is not enabled. Skipping.");
 		}
 
 		if($this->_cacheInstance === null) {


### PR DESCRIPTION
apc.enable_cli disabled by default. #119
