### PR TITLE
Var dumper dump call static dump as string

### DIFF
--- a/framework/helpers/base/VarDumper.php
+++ b/framework/helpers/base/VarDumper.php
@@ -39,7 +39,7 @@ class VarDumper
 	 */
 	public static function dump($var, $depth = 10, $highlight = false)
 	{
-		echo self::dumpAsString($var, $depth, $highlight);
+		echo static::dumpAsString($var, $depth, $highlight);
 	}
 
 	/**


### PR DESCRIPTION
This way we can extend VarDumper::dumpAsString
