### PR TITLE
Add ensureBehaviors() to detachBehavior*()

### DIFF
--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -496,6 +496,7 @@ class Component extends Object
 	 */
 	public function detachBehavior($name)
 	{
+		$this->ensureBehaviors();
 		if (isset($this->_behaviors[$name])) {
 			$behavior = $this->_behaviors[$name];
 			unset($this->_behaviors[$name]);
@@ -511,6 +512,7 @@ class Component extends Object
 	 */
 	public function detachBehaviors()
 	{
+		$this->ensureBehaviors();
 		if ($this->_behaviors !== null) {
 			foreach ($this->_behaviors as $name => $behavior) {
 				$this->detachBehavior($name);


### PR DESCRIPTION
Need to add ensureBehaviors() to detachBehavior*().

The intent may be to detach behaviors defined in behaviors().
In the original implementation, if these behaviors() are not yet attached, they can not selectively be detached.
