### PR TITLE
fix: prevent error if \Yii::$app is not set

### DIFF
--- a/yii/caching/Cache.php
+++ b/yii/caching/Cache.php
@@ -77,7 +77,7 @@ abstract class Cache extends Component implements \ArrayAccess
 	public function init()
 	{
 		parent::init();
-		if ($this->keyPrefix === null) {
+		if ($this->keyPrefix === null && \Yii::$app instanceof \yii\base\Application) {
 			$this->keyPrefix = \Yii::$app->id;
 		}
 	}


### PR DESCRIPTION
Think this is the easiest way to prevent errors while still keeping the handy default.

If you want to completely remove Yii::$app from cache, while keeping the default, we can make this as complex as you wish. :wink: 

Maybe introducing a DefaultPrefixProvider that can be configured with strategies:
1. Try Yii::$app->id
2. Try entry script name
3. ...

Removing the default altogether would be a simpler alternative.
