### PR TITLE
Unittest app dependency

### DIFF
--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -21,12 +21,12 @@ class TestCase extends \yii\test\TestCase
 		}
 	}
 	
-	public function getParam($name)
+	public function getParam($name,$default=null)
 	{
 		if (self::$params === null) {
 			self::$params = require(__DIR__ . '/data/config.php');
 		}
-		return isset(self::$params[$name]) ? self::$params[$name] : null;
+		return isset(self::$params[$name]) ? self::$params[$name] : $default;
 	}
 	
 	protected function requireApp($requiredConfig=array())
@@ -38,12 +38,13 @@ class TestCase extends \yii\test\TestCase
 		);
 		
 		$newConfig = array_merge( $defaultConfig, $requiredConfig );
+		$appClass = $this->getParam( 'appClass', '\yii\web\Application' );
 		
-		if (!(\yii::$app instanceof \yii\web\Application)) {
-			new \yii\web\Application( $newConfig );
+		if (!(\yii::$app instanceof $appClass)) {
+			new $appClass( $newConfig );
 			$usedConfig = $newConfig;
 		} elseif ($newConfig !== $usedConfig) {
-			new \yii\web\Application( $newConfig );
+			new $appClass( $newConfig );
 			$usedConfig = $newConfig;
 		}
 	}

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -13,12 +13,7 @@ class TestCase extends \yii\test\TestCase
 	protected function tearDown()
 	{
 		parent::tearDown();
-		// If defined and set to true, destroy the app after each test.
-		// This will cause tests to fail, that rely on an existing app, but don't
-		// call requireApp() in their setUp().
-		if (defined('YII_DESTROY_APP_ON_TEARDOWN') && YII_DESTROY_APP_ON_TEARDOWN === true) {
-			$this->destroyApp();
-		}
+		$this->destroyApp();
 	}
 	
 	public function getParam($name,$default=null)
@@ -29,28 +24,19 @@ class TestCase extends \yii\test\TestCase
 		return isset(self::$params[$name]) ? self::$params[$name] : $default;
 	}
 	
-	protected function requireApp($requiredConfig=array())
+	protected function mockApplication($requiredConfig=array())
 	{
-		static $usedConfig = array();
 		static $defaultConfig = array(
 			'id' => 'testapp',
 			'basePath' => __DIR__,
 		);
 		
-		$newConfig = array_merge( $defaultConfig, $requiredConfig );
 		$appClass = $this->getParam( 'appClass', '\yii\web\Application' );
-		
-		if (!(\yii::$app instanceof $appClass)) {
-			new $appClass( $newConfig );
-			$usedConfig = $newConfig;
-		} elseif ($newConfig !== $usedConfig) {
-			new $appClass( $newConfig );
-			$usedConfig = $newConfig;
-		}
+		new $appClass(array_merge($defaultConfig,$requiredConfig));
 	}
 	
 	protected function destroyApp()
 	{
-		\yii::$app = null;
+		\Yii::$app = null;
 	}
 }

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -13,4 +13,23 @@ class TestCase extends \yii\test\TestCase
 		}
 		return isset(self::$params[$name]) ? self::$params[$name] : null;
 	}
+	
+	protected function requireApp($requiredConfig=array())
+	{
+		static $usedConfig = array();
+		static $defaultConfig = array(
+			'id' => 'testapp',
+			'basePath' => __DIR__,
+		);
+		
+		$newConfig = array_merge( $defaultConfig, $requiredConfig );
+		
+		if (!(\yii::$app instanceof \yii\web\Application)) {
+			new \yii\web\Application( $newConfig );
+			$usedConfig = $newConfig;
+		} elseif ($newConfig !== $usedConfig) {
+			new \yii\web\Application( $newConfig );
+			$usedConfig = $newConfig;
+		}
+	}
 }

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -6,6 +6,21 @@ class TestCase extends \yii\test\TestCase
 {
 	public static $params;
 
+	protected function setUp() {
+		parent::setUp();
+	}
+
+	protected function tearDown()
+	{
+		parent::tearDown();
+		// If defined and set to true, destroy the app after each test.
+		// This will cause tests to fail, that rely on an existing app, but don't
+		// call requireApp() in their setUp().
+		if (defined('YII_DESTROY_APP_ON_TEARDOWN') && YII_DESTROY_APP_ON_TEARDOWN === true) {
+			$this->destroyApp();
+		}
+	}
+	
 	public function getParam($name)
 	{
 		if (self::$params === null) {
@@ -31,5 +46,10 @@ class TestCase extends \yii\test\TestCase
 			new \yii\web\Application( $newConfig );
 			$usedConfig = $newConfig;
 		}
+	}
+	
+	protected function destroyApp()
+	{
+		\yii::$app = null;
 	}
 }

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -2,7 +2,6 @@
 
 define('YII_ENABLE_ERROR_HANDLER', false);
 define('YII_DEBUG', true);
-define('YII_DESTROY_APP_ON_TEARDOWN', false);
 $_SERVER['SCRIPT_NAME'] = '/' . __DIR__;
 $_SERVER['SCRIPT_FILENAME'] = __FILE__;
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -2,13 +2,12 @@
 
 define('YII_ENABLE_ERROR_HANDLER', false);
 define('YII_DEBUG', true);
+define('YII_DESTROY_APP_ON_TEARDOWN', false);
 $_SERVER['SCRIPT_NAME'] = '/' . __DIR__;
 $_SERVER['SCRIPT_FILENAME'] = __FILE__;
 
 require_once(__DIR__ . '/../../yii/Yii.php');
 
 Yii::setAlias('@yiiunit', __DIR__);
-
-new \yii\web\Application(array('id' => 'testapp', 'basePath' => __DIR__));
 
 require_once(__DIR__ . '/TestCase.php');

--- a/tests/unit/data/config.php
+++ b/tests/unit/data/config.php
@@ -1,6 +1,8 @@
 <?php
 
 return array(
+	//'appClass' => '\yii\web\Application',
+	'appClass' => '\yii\console\Application',
 	'mysql' => array(
 		'dsn' => 'mysql:host=127.0.0.1;dbname=yiitest',
 		'username' => 'travis',

--- a/tests/unit/framework/caching/CacheTest.php
+++ b/tests/unit/framework/caching/CacheTest.php
@@ -13,6 +13,12 @@ abstract class CacheTest extends TestCase
 	 */
 	abstract protected function getCacheInstance();
 
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->requireApp();
+	}
+	
 	public function testSet()
 	{
 		$cache = $this->getCacheInstance();

--- a/tests/unit/framework/caching/CacheTest.php
+++ b/tests/unit/framework/caching/CacheTest.php
@@ -16,7 +16,7 @@ abstract class CacheTest extends TestCase
 	protected function setUp()
 	{
 		parent::setUp();
-		$this->requireApp();
+		$this->mockApplication();
 	}
 	
 	public function testSet()

--- a/tests/unit/framework/caching/DbCacheTest.php
+++ b/tests/unit/framework/caching/DbCacheTest.php
@@ -17,6 +17,8 @@ class DbCacheTest extends CacheTest
 			$this->markTestSkipped('pdo and pdo_mysql extensions are required.');
 		}
 
+		parent::setUp();
+		
 		$this->getConnection()->createCommand("
 			CREATE TABLE IF NOT EXISTS tbl_cache (
 				id char(128) NOT NULL,

--- a/tests/unit/framework/helpers/HtmlTest.php
+++ b/tests/unit/framework/helpers/HtmlTest.php
@@ -10,7 +10,7 @@ class HtmlTest extends TestCase
 {
 	public function setUp()
 	{
-		$this->requireApp(array(
+		$this->mockApplication(array(
 			'components' => array(
 				'request' => array(
 					'class' => 'yii\web\Request',

--- a/tests/unit/framework/helpers/HtmlTest.php
+++ b/tests/unit/framework/helpers/HtmlTest.php
@@ -4,15 +4,13 @@ namespace yiiunit\framework\helpers;
 
 use Yii;
 use yii\helpers\Html;
-use yii\web\Application;
+use yiiunit\TestCase;
 
-class HtmlTest extends \yii\test\TestCase
+class HtmlTest extends TestCase
 {
 	public function setUp()
 	{
-		new Application(array(
-			'id' => 'test',
-			'basePath' => '@yiiunit/runtime',
+		$this->requireApp(array(
 			'components' => array(
 				'request' => array(
 					'class' => 'yii\web\Request',
@@ -28,11 +26,6 @@ class HtmlTest extends \yii\test\TestCase
 		$actual = str_replace("\r\n", "\n", $actual);
 
 		$this->assertEquals($expected, $actual);
-	}
-
-	public function tearDown()
-	{
-		Yii::$app = null;
 	}
 
 	public function testEncode()


### PR DESCRIPTION
Another approach on issue #199.

Make unit tests responsible for creating app instance if they require one.

Also introduce a unit test param that defines which application class should be used for the unit tests. This way, we can quickly validate that the components not only work with one special application implementation.

Not yet happy with that param approach, because it requires us to hack the config and run tests twice. But didn't find a solution to automate that yet.
