### PR TITLE
yii\mysql\QueryBuilder PK fix

### DIFF
--- a/yii/db/mysql/QueryBuilder.php
+++ b/yii/db/mysql/QueryBuilder.php
@@ -22,7 +22,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
 	 * @var array mapping from abstract column types (keys) to physical column types (values).
 	 */
 	public $typeMap = array(
-		Schema::TYPE_PK => 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY',
+		Schema::TYPE_PK => 'int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
 		Schema::TYPE_STRING => 'varchar(255)',
 		Schema::TYPE_TEXT => 'text',
 		Schema::TYPE_SMALLINT => 'smallint(6)',


### PR DESCRIPTION
Its always meaningless to make PK like not UNSIGNED. We lose a half of this values. Moreover this is db designing antipattern.
