### PR TITLE
TypeAhead plugin

### DIFF
--- a/yii/bootstrap/TypeAhead.php
+++ b/yii/bootstrap/TypeAhead.php
@@ -8,6 +8,7 @@
 namespace yii\bootstrap;
 
 use Yii;
+use yii\base\InvalidConfigException;
 use yii\base\Model;
 use yii\helpers\Html;
 
@@ -52,11 +53,15 @@ class TypeAhead extends Widget
 	 * @var string the model attribute that this field is associated with
 	 */
 	public $attribute;
-
 	/**
 	 * @var string the input name. This must be set if [[form]] is not set.
 	 */
 	public $name;
+	/**
+	 * @var string the input value.
+	 */
+	public $value;
+
 
 	/**
 	 * Renders the widget
@@ -72,20 +77,20 @@ class TypeAhead extends Widget
 	 * If [[model]] is null or not from an [[Model]] instance, then the field will be rendered according to
 	 * the [[name]] attribute.
 	 * @return string the rendering result
-	 * @throws InvalidParamException when none of the required attributes are set to render the textInput. That is,
+	 * @throws InvalidConfigException when none of the required attributes are set to render the textInput. That is,
 	 * if [[model]] and [[attribute]] are not set, then [[name]] is required.
 	 */
 	public function renderField()
 	{
 		if ($this->model instanceof Model && $this->attribute !== null) {
 
-			$this->options['id'] = $this->id = Html::getInputId($this->model, $this->attribute);
+			$this->options['id'] = Html::getInputId($this->model, $this->attribute);
 
 			return Html::activeTextInput($this->model, $this->attribute, $this->options);
 		}
 
 		if ($this->name === null) {
-			throw new InvalidParamException(
+			throw new InvalidConfigException(
 				get_class($this) . ' must specify "form", "model" and "attribute" or "name" property values'
 			);
 		}

--- a/yii/bootstrap/TypeAhead.php
+++ b/yii/bootstrap/TypeAhead.php
@@ -105,7 +105,7 @@ class TypeAhead extends Widget
 			)->textInput();
 		}
 
-		if (null === $this->name)
+		if ($this->name === null)
 			throw new InvalidParamException(
 				get_class($this) . ' must specify "form", "model" and "attribute" or "name" property values'
 			);

--- a/yii/bootstrap/TypeAhead.php
+++ b/yii/bootstrap/TypeAhead.php
@@ -12,31 +12,31 @@ use yii\helpers\Html;
 use yii\widgets\ActiveForm;
 
 /**
- * Modal renders a modal window that can be toggled by clicking on a button.
+ * TypeAhead renders a typehead bootstrap javascript component.
  *
  * For example,
  *
- * ~~~php
+ * ```php
  * echo TypeAhead::widget(array(
  *     'form' => $form,
  *     'model' => $model,
- * 	   'attribute' => 'country',
+ *       'attribute' => 'country',
  *     'pluginOptions' => array(
  *         'source' => array('USA', 'ESP'),
  *     ),
  * ));
- * ~~~
+ * ```
  *
  * The following example will use the name property instead
  *
- * ~~~php
+ * ```php
  * echo TypeAhead::widget(array(
  *     'name'  => 'country',
- * 	   'pluginOptions' => array(
+ *       'pluginOptions' => array(
  *         'source' => array('USA', 'ESP'),
  *     ),
  * ));
- *
+ *```
  *
  * @see http://twitter.github.io/bootstrap/javascript.html#typeahead
  * @author Antonio Ramirez <amigo.cobos@gmail.com>
@@ -87,6 +87,7 @@ class TypeAhead extends Widget
 	 * If [[TypeAhead::form]] is null not from an [[ActiveForm]] instance, then the field will be rendered according to
 	 * the `name` key setting of [[TypeAhead::options]] array attribute.
 	 * @return string the rendering result
+	 * @throws InvalidParamException
 	 */
 	public function renderField()
 	{

--- a/yii/bootstrap/TypeAhead.php
+++ b/yii/bootstrap/TypeAhead.php
@@ -8,8 +8,8 @@
 namespace yii\bootstrap;
 
 use Yii;
+use yii\base\Model;
 use yii\helpers\Html;
-use yii\widgets\ActiveForm;
 
 /**
  * TypeAhead renders a typehead bootstrap javascript component.
@@ -18,12 +18,12 @@ use yii\widgets\ActiveForm;
  *
  * ```php
  * echo TypeAhead::widget(array(
- * 	'form' => $form,
- *	'model' => $model,
- *		'attribute' => 'country',
- * 	'pluginOptions' => array(
- *		'source' => array('USA', 'ESP'),
- * 	),
+ *     'form' => $form,
+ *     'model' => $model,
+ *     'attribute' => 'country',
+ *     'pluginOptions' => array(
+ *         'source' => array('USA', 'ESP'),
+ *     ),
  * ));
  * ```
  *
@@ -31,10 +31,10 @@ use yii\widgets\ActiveForm;
  *
  * ```php
  * echo TypeAhead::widget(array(
- *	'name'  => 'country',
- * 		'pluginOptions' => array(
- *			'source' => array('USA', 'ESP'),
- * 	),
+ *     'name'  => 'country',
+ *     'pluginOptions' => array(
+ *         'source' => array('USA', 'ESP'),
+ *     ),
  * ));
  *```
  *
@@ -44,11 +44,6 @@ use yii\widgets\ActiveForm;
  */
 class TypeAhead extends Widget
 {
-	/**
-	 * @var ActiveForm the form that the TypeAhead field is associated with. If no form is associated with the widget
-	 * then the id will be used instead
-	 */
-	public $form;
 	/**
 	 * @var \yii\base\Model the data model that this field is associated with
 	 */
@@ -64,50 +59,32 @@ class TypeAhead extends Widget
 	public $name;
 
 	/**
-	 * Initializes the widget.
-	 * Renders the input field.
-	 */
-	public function init()
-	{
-		parent::init();
-		echo "\n" . $this->renderField() . "\n";
-	}
-
-	/**
-	 * Registers the plugin.
+	 * Renders the widget
 	 */
 	public function run()
 	{
+		echo "\n" . $this->renderField() . "\n";
 		$this->registerPlugin('typeahead');
 	}
 
 	/**
-	 * Renders the TypeAhead field. If [[form]] has been specified then it will render an active field.
-	 * Please, note that function will only check whether the form has been set, model and attributes will not.
-	 * If [[form]] is null not from an [[ActiveForm]] instance, then the field will be rendered according to
-	 * the `name` key setting of [[options]] array attribute.
+	 * Renders the TypeAhead field. If [[model]] has been specified then it will render an active field.
+	 * If [[model]] is null or not from an [[Model]] instance, then the field will be rendered according to
+	 * the [[name]] attribute.
 	 * @return string the rendering result
 	 * @throws InvalidParamException when none of the required attributes are set to render the textInput. That is,
-	 * if [[form]], [[model]] and [[attribute]] are not set, then [[name]] is required.
+	 * if [[model]] and [[attribute]] are not set, then [[name]] is required.
 	 */
 	public function renderField()
 	{
-		if ($this->form instanceof ActiveForm) {
+		if ($this->model instanceof Model && $this->attribute !== null) {
 
 			$this->options['id'] = $this->id = Html::getInputId($this->model, $this->attribute);
 
-			return Yii::createObject(
-				array(
-					'class' => 'yii\widgets\ActiveField',
-					'model' => $this->model,
-					'attribute' => $this->attribute,
-					'form' => $this->form,
-				)
-			)->textInput();
+			return Html::activeTextInput($this->model, $this->attribute, $this->options);
 		}
 
-		if ($this->name === null)
-		{
+		if ($this->name === null) {
 			throw new InvalidParamException(
 				get_class($this) . ' must specify "form", "model" and "attribute" or "name" property values'
 			);

--- a/yii/bootstrap/TypeAhead.php
+++ b/yii/bootstrap/TypeAhead.php
@@ -18,12 +18,12 @@ use yii\widgets\ActiveForm;
  *
  * ```php
  * echo TypeAhead::widget(array(
- *     'form' => $form,
- *     'model' => $model,
- *       'attribute' => 'country',
- *     'pluginOptions' => array(
- *         'source' => array('USA', 'ESP'),
- *     ),
+ * 	'form' => $form,
+ *	'model' => $model,
+ *		'attribute' => 'country',
+ * 	'pluginOptions' => array(
+ *		'source' => array('USA', 'ESP'),
+ * 	),
  * ));
  * ```
  *
@@ -31,10 +31,10 @@ use yii\widgets\ActiveForm;
  *
  * ```php
  * echo TypeAhead::widget(array(
- *     'name'  => 'country',
- *       'pluginOptions' => array(
- *         'source' => array('USA', 'ESP'),
- *     ),
+ *	'name'  => 'country',
+ * 		'pluginOptions' => array(
+ *			'source' => array('USA', 'ESP'),
+ * 	),
  * ));
  *```
  *
@@ -59,7 +59,7 @@ class TypeAhead extends Widget
 	public $attribute;
 
 	/**
-	 * @var string the input name. This must be set if [[TypeAhead::$form]] is not set.
+	 * @var string the input name. This must be set if [[form]] is not set.
 	 */
 	public $name;
 
@@ -70,7 +70,7 @@ class TypeAhead extends Widget
 	public function init()
 	{
 		parent::init();
-		echo "\n" . $this->renderField();
+		echo "\n" . $this->renderField() . "\n";
 	}
 
 	/**
@@ -82,12 +82,13 @@ class TypeAhead extends Widget
 	}
 
 	/**
-	 * Renders the TypeAhead field. If [[TypeAhead::form]] has been specified then it will render an active field.
+	 * Renders the TypeAhead field. If [[form]] has been specified then it will render an active field.
 	 * Please, note that function will only check whether the form has been set, model and attributes will not.
-	 * If [[TypeAhead::form]] is null not from an [[ActiveForm]] instance, then the field will be rendered according to
-	 * the `name` key setting of [[TypeAhead::options]] array attribute.
+	 * If [[form]] is null not from an [[ActiveForm]] instance, then the field will be rendered according to
+	 * the `name` key setting of [[options]] array attribute.
 	 * @return string the rendering result
-	 * @throws InvalidParamException
+	 * @throws InvalidParamException when none of the required attributes are set to render the textInput. That is,
+	 * if [[form]], [[model]] and [[attribute]] are not set, then [[name]] is required.
 	 */
 	public function renderField()
 	{
@@ -100,7 +101,7 @@ class TypeAhead extends Widget
 					'class' => 'yii\widgets\ActiveField',
 					'model' => $this->model,
 					'attribute' => $this->attribute,
-					'form' => $this->form
+					'form' => $this->form,
 				)
 			)->textInput();
 		}

--- a/yii/bootstrap/TypeAhead.php
+++ b/yii/bootstrap/TypeAhead.php
@@ -95,6 +95,6 @@ class TypeAhead extends Widget
 			);
 		}
 
-		return Html::textInput($this->name, '', $this->options);
+		return Html::textInput($this->name, $this->value, $this->options);
 	}
 }

--- a/yii/bootstrap/TypeAhead.php
+++ b/yii/bootstrap/TypeAhead.php
@@ -107,9 +107,11 @@ class TypeAhead extends Widget
 		}
 
 		if ($this->name === null)
+		{
 			throw new InvalidParamException(
 				get_class($this) . ' must specify "form", "model" and "attribute" or "name" property values'
 			);
+		}
 
 		return Html::textInput($this->name, '', $this->options);
 	}

--- a/yii/bootstrap/TypeAhead.php
+++ b/yii/bootstrap/TypeAhead.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\bootstrap;
+
+use Yii;
+use yii\helpers\Html;
+use yii\widgets\ActiveForm;
+
+/**
+ * Modal renders a modal window that can be toggled by clicking on a button.
+ *
+ * For example,
+ *
+ * ~~~php
+ * echo TypeAhead::widget(array(
+ *     'form' => $form,
+ *     'model' => $model,
+ * 	   'attribute' => 'country',
+ *     'pluginOptions' => array(
+ *         'source' => array('USA', 'ESP'),
+ *     ),
+ * ));
+ * ~~~
+ *
+ * The following example will use the name property instead
+ *
+ * ~~~php
+ * echo TypeAhead::widget(array(
+ *     'name'  => 'country',
+ * 	   'pluginOptions' => array(
+ *         'source' => array('USA', 'ESP'),
+ *     ),
+ * ));
+ *
+ *
+ * @see http://twitter.github.io/bootstrap/javascript.html#typeahead
+ * @author Antonio Ramirez <amigo.cobos@gmail.com>
+ * @since 2.0
+ */
+class TypeAhead extends Widget
+{
+	/**
+	 * @var ActiveForm the form that the TypeAhead field is associated with. If no form is associated with the widget
+	 * then the id will be used instead
+	 */
+	public $form;
+	/**
+	 * @var \yii\base\Model the data model that this field is associated with
+	 */
+	public $model;
+	/**
+	 * @var string the model attribute that this field is associated with
+	 */
+	public $attribute;
+
+	/**
+	 * @var string the input name. This must be set if [[TypeAhead::$form]] is not set.
+	 */
+	public $name;
+
+	/**
+	 * Initializes the widget.
+	 * Renders the input field.
+	 */
+	public function init()
+	{
+		parent::init();
+		echo "\n" . $this->renderField();
+	}
+
+	/**
+	 * Registers the plugin.
+	 */
+	public function run()
+	{
+		$this->registerPlugin('typeahead');
+	}
+
+	/**
+	 * Renders the TypeAhead field. If [[TypeAhead::form]] has been specified then it will render an active field.
+	 * Please, note that function will only check whether the form has been set, model and attributes will not.
+	 * If [[TypeAhead::form]] is null not from an [[ActiveForm]] instance, then the field will be rendered according to
+	 * the `name` key setting of [[TypeAhead::options]] array attribute.
+	 * @return string the rendering result
+	 */
+	public function renderField()
+	{
+		if ($this->form instanceof ActiveForm) {
+
+			$this->options['id'] = $this->id = Html::getInputId($this->model, $this->attribute);
+
+			return Yii::createObject(
+				array(
+					'class' => 'yii\widgets\ActiveField',
+					'model' => $this->model,
+					'attribute' => $this->attribute,
+					'form' => $this->form
+				)
+			)->textInput();
+		}
+
+		if (null === $this->name)
+			throw new InvalidParamException(
+				get_class($this) . ' must specify "form", "model" and "attribute" or "name" property values'
+			);
+
+		return Html::textInput($this->name, '', $this->options);
+	}
+}


### PR DESCRIPTION
Added TypeAhead plugin. Trying to keep the simplicity of the code at the `Modal` widget. 

Examples of use: 

```
// with active form
<?php echo \yii\bootstrap\TypeAhead::widget(array(
    'form' => $form,
    'model' => $model,
    'attribute' => 'name',
    'pluginOptions' => array(
        'source' => array('ESP', 'USA')
    )
));?>
```

without 

```
<?php echo \yii\bootstrap\TypeAhead::widget(array(
    'name' => 'test',
    'pluginOptions' => array(
        'source' => array('ESP', 'USA')
    )
));?>
```

closes #327 
