### PR TITLE
`yii\bootstrap\*` another refactioring

### DIFF
--- a/framework/yii/bootstrap/Alert.php
+++ b/framework/yii/bootstrap/Alert.php
@@ -79,7 +79,7 @@ class Alert extends Widget
 
 		$this->initOptions();
 
-		echo Html::beginTag('div', $this->options) . "\n";
+		echo Html::beginTag('div', $this->htmlOptions) . "\n";
 		echo $this->renderBodyBegin() . "\n";
 	}
 
@@ -136,11 +136,11 @@ class Alert extends Widget
 	 */
 	protected function initOptions()
 	{
-		$this->options = array_merge(array(
+		$this->htmlOptions = array_merge(array(
 			'class' => 'fade in',
-		), $this->options);
+		), $this->htmlOptions);
 
-		$this->addCssClass($this->options, 'alert');
+		$this->addCssClass($this->htmlOptions, 'alert');
 
 		if ($this->closeButton !== null) {
 			$this->closeButton = array_merge(array(

--- a/framework/yii/bootstrap/Alert.php
+++ b/framework/yii/bootstrap/Alert.php
@@ -79,7 +79,7 @@ class Alert extends Widget
 
 		$this->initOptions();
 
-		echo Html::beginTag('div', $this->htmlOptions) . "\n";
+		echo Html::beginTag('div', $this->options) . "\n";
 		echo $this->renderBodyBegin() . "\n";
 	}
 
@@ -136,11 +136,11 @@ class Alert extends Widget
 	 */
 	protected function initOptions()
 	{
-		$this->htmlOptions = array_merge(array(
+		$this->options = array_merge(array(
 			'class' => 'fade in',
-		), $this->htmlOptions);
+		), $this->options);
 
-		$this->addCssClass($this->htmlOptions, 'alert');
+		$this->addCssClass($this->options, 'alert');
 
 		if ($this->closeButton !== null) {
 			$this->closeButton = array_merge(array(

--- a/framework/yii/bootstrap/Modal.php
+++ b/framework/yii/bootstrap/Modal.php
@@ -105,7 +105,7 @@ class Modal extends Widget
 		$this->initOptions();
 
 		echo $this->renderToggleButton() . "\n";
-		echo Html::beginTag('div', $this->htmlOptions) . "\n";
+		echo Html::beginTag('div', $this->options) . "\n";
 		echo $this->renderHeader() . "\n";
 		echo $this->renderBodyBegin() . "\n";
 	}
@@ -212,14 +212,14 @@ class Modal extends Widget
 	 */
 	protected function initOptions()
 	{
-		$this->htmlOptions = array_merge(array(
-			'class' => 'modal hide',
-		), $this->htmlOptions);
-		$this->addCssClass($this->htmlOptions, 'modal');
-
 		$this->options = array_merge(array(
-			'show' => false,
+			'class' => 'modal hide',
 		), $this->options);
+		$this->addCssClass($this->options, 'modal');
+
+		$this->clientOptions = array_merge(array(
+			'show' => false,
+		), $this->clientOptions);
 
 		if ($this->closeButton !== null) {
 			$this->closeButton = array_merge(array(
@@ -234,7 +234,7 @@ class Modal extends Widget
 				'data-toggle' => 'modal',
 			), $this->toggleButton);
 			if (!isset($this->toggleButton['data-target']) && !isset($this->toggleButton['href'])) {
-				$this->toggleButton['data-target'] = '#' . $this->htmlOptions['id'];
+				$this->toggleButton['data-target'] = '#' . $this->options['id'];
 			}
 		}
 	}

--- a/framework/yii/bootstrap/Modal.php
+++ b/framework/yii/bootstrap/Modal.php
@@ -105,7 +105,7 @@ class Modal extends Widget
 		$this->initOptions();
 
 		echo $this->renderToggleButton() . "\n";
-		echo Html::beginTag('div', $this->options) . "\n";
+		echo Html::beginTag('div', $this->htmlOptions) . "\n";
 		echo $this->renderHeader() . "\n";
 		echo $this->renderBodyBegin() . "\n";
 	}
@@ -212,14 +212,14 @@ class Modal extends Widget
 	 */
 	protected function initOptions()
 	{
-		$this->options = array_merge(array(
+		$this->htmlOptions = array_merge(array(
 			'class' => 'modal hide',
-		), $this->options);
-		$this->addCssClass($this->options, 'modal');
+		), $this->htmlOptions);
+		$this->addCssClass($this->htmlOptions, 'modal');
 
-		$this->pluginOptions = array_merge(array(
+		$this->options = array_merge(array(
 			'show' => false,
-		), $this->pluginOptions);
+		), $this->options);
 
 		if ($this->closeButton !== null) {
 			$this->closeButton = array_merge(array(
@@ -234,7 +234,7 @@ class Modal extends Widget
 				'data-toggle' => 'modal',
 			), $this->toggleButton);
 			if (!isset($this->toggleButton['data-target']) && !isset($this->toggleButton['href'])) {
-				$this->toggleButton['data-target'] = '#' . $this->options['id'];
+				$this->toggleButton['data-target'] = '#' . $this->htmlOptions['id'];
 			}
 		}
 	}

--- a/framework/yii/bootstrap/TypeAhead.php
+++ b/framework/yii/bootstrap/TypeAhead.php
@@ -21,7 +21,7 @@ use yii\helpers\Html;
  * echo TypeAhead::widget(array(
  *     'model' => $model,
  *     'attribute' => 'country',
- *     'options' => array(
+ *     'clientOptions' => array(
  *         'source' => array('USA', 'ESP'),
  *     ),
  * ));
@@ -32,7 +32,7 @@ use yii\helpers\Html;
  * ```php
  * echo TypeAhead::widget(array(
  *     'name'  => 'country',
- *     'options' => array(
+ *     'cloentOptions' => array(
  *         'source' => array('USA', 'ESP'),
  *     ),
  * ));
@@ -82,9 +82,9 @@ class TypeAhead extends Widget
 	public function renderField()
 	{
 		if ($this->model instanceof Model && $this->attribute !== null) {
-			return Html::activeTextInput($this->model, $this->attribute, $this->htmlOptions);
+			return Html::activeTextInput($this->model, $this->attribute, $this->options);
 		} elseif ($this->name !== null) {
-			return Html::textInput($this->name, $this->value, $this->htmlOptions);
+			return Html::textInput($this->name, $this->value, $this->options);
 		} else {
 			throw new InvalidConfigException("Either 'name' or 'model' and 'attribute' properties must be specified.");
 		}

--- a/framework/yii/bootstrap/TypeAhead.php
+++ b/framework/yii/bootstrap/TypeAhead.php
@@ -19,10 +19,9 @@ use yii\helpers\Html;
  *
  * ```php
  * echo TypeAhead::widget(array(
- *     'form' => $form,
  *     'model' => $model,
  *     'attribute' => 'country',
- *     'pluginOptions' => array(
+ *     'options' => array(
  *         'source' => array('USA', 'ESP'),
  *     ),
  * ));
@@ -33,7 +32,7 @@ use yii\helpers\Html;
  * ```php
  * echo TypeAhead::widget(array(
  *     'name'  => 'country',
- *     'pluginOptions' => array(
+ *     'options' => array(
  *         'source' => array('USA', 'ESP'),
  *     ),
  * ));
@@ -77,17 +76,17 @@ class TypeAhead extends Widget
 	 * If [[model]] is null or not from an [[Model]] instance, then the field will be rendered according to
 	 * the [[name]] attribute.
 	 * @return string the rendering result
-	 * @throws InvalidConfigException when none of the required attributes are set to render the textInput. That is,
-	 * if [[model]] and [[attribute]] are not set, then [[name]] is required.
+	 * @throws InvalidConfigException when none of the required attributes are set to render the textInput.
+	 * That is, if [[model]] and [[attribute]] are not set, then [[name]] is required.
 	 */
 	public function renderField()
 	{
 		if ($this->model instanceof Model && $this->attribute !== null) {
-			return Html::activeTextInput($this->model, $this->attribute, $this->options);
+			return Html::activeTextInput($this->model, $this->attribute, $this->htmlOptions);
 		} elseif ($this->name !== null) {
-			return Html::textInput($this->name, $this->value, $this->options);
+			return Html::textInput($this->name, $this->value, $this->htmlOptions);
 		} else {
-			throw new InvalidConfigException('Either "name" or "model" and "attribute" properties must be specified.');
+			throw new InvalidConfigException("Either 'name' or 'model' and 'attribute' properties must be specified.");
 		}
 	}
 }

--- a/framework/yii/bootstrap/Widget.php
+++ b/framework/yii/bootstrap/Widget.php
@@ -28,21 +28,21 @@ class Widget extends \yii\base\Widget
 	/**
 	 * @var array the HTML attributes for the widget container tag.
 	 */
-	public $htmlOptions = array();
+	public $options = array();
 	/**
 	 * @var array the options for the underlying Bootstrap JS plugin.
 	 * Please refer to the corresponding Bootstrap plugin Web page for possible options.
 	 * For example, [this page](http://twitter.github.io/bootstrap/javascript.html#modals) shows
 	 * how to use the "Modal" plugin and the supported options (e.g. "remote").
 	 */
-	public $options = array();
+	public $clientOptions = array();
 	/**
 	 * @var array the event handlers for the underlying Bootstrap JS plugin.
 	 * Please refer to the corresponding Bootstrap plugin Web page for possible events.
 	 * For example, [this page](http://twitter.github.io/bootstrap/javascript.html#modals) shows
 	 * how to use the "Modal" plugin and the supported events (e.g. "shown").
 	 */
-	public $events = array();
+	public $clientEvents = array();
 
 
 	/**
@@ -53,8 +53,8 @@ class Widget extends \yii\base\Widget
 	public function init()
 	{
 		parent::init();
-		if (!isset($this->options['id'])) {
-			$this->options['id'] = $this->getId();
+		if (!isset($this->clientOptions['id'])) {
+			$this->clientOptions['id'] = $this->getId();
 		}
 	}
 
@@ -64,20 +64,20 @@ class Widget extends \yii\base\Widget
 	 */
 	protected function registerPlugin($name)
 	{
-		$id = $this->options['id'];
+		$id = $this->clientOptions['id'];
 		$view = $this->getView();
 		$view->registerAssetBundle(static::$responsive ? 'yii/bootstrap/responsive' : 'yii/bootstrap');
 		$view->registerAssetBundle("yii/bootstrap/$name");
 
-		if ($this->options !== false) {
-			$options = empty($this->options) ? '' : Json::encode($this->options);
+		if ($this->clientOptions !== false) {
+			$options = empty($this->clientOptions) ? '' : Json::encode($this->clientOptions);
 			$js = "jQuery('#$id').$name($options);";
 			$view->registerJs($js);
 		}
 
-		if (!empty($this->events)) {
+		if (!empty($this->clientEvents)) {
 			$js = array();
-			foreach ($this->events as $event => $handler) {
+			foreach ($this->clientEvents as $event => $handler) {
 				$js[] = "jQuery('#$id').on('$event', $handler);";
 			}
 			$view->registerJs(implode("\n", $js));

--- a/framework/yii/bootstrap/Widget.php
+++ b/framework/yii/bootstrap/Widget.php
@@ -53,8 +53,8 @@ class Widget extends \yii\base\Widget
 	public function init()
 	{
 		parent::init();
-		if (!isset($this->clientOptions['id'])) {
-			$this->clientOptions['id'] = $this->getId();
+		if (!isset($this->options['id'])) {
+			$this->options['id'] = $this->getId();
 		}
 	}
 
@@ -64,7 +64,7 @@ class Widget extends \yii\base\Widget
 	 */
 	protected function registerPlugin($name)
 	{
-		$id = $this->clientOptions['id'];
+		$id = $this->options['id'];
 		$view = $this->getView();
 		$view->registerAssetBundle(static::$responsive ? 'yii/bootstrap/responsive' : 'yii/bootstrap');
 		$view->registerAssetBundle("yii/bootstrap/$name");

--- a/framework/yii/bootstrap/Widget.php
+++ b/framework/yii/bootstrap/Widget.php
@@ -28,21 +28,21 @@ class Widget extends \yii\base\Widget
 	/**
 	 * @var array the HTML attributes for the widget container tag.
 	 */
-	public $options = array();
+	public $htmlOptions = array();
 	/**
 	 * @var array the options for the underlying Bootstrap JS plugin.
 	 * Please refer to the corresponding Bootstrap plugin Web page for possible options.
 	 * For example, [this page](http://twitter.github.io/bootstrap/javascript.html#modals) shows
 	 * how to use the "Modal" plugin and the supported options (e.g. "remote").
 	 */
-	public $pluginOptions = array();
+	public $options = array();
 	/**
 	 * @var array the event handlers for the underlying Bootstrap JS plugin.
 	 * Please refer to the corresponding Bootstrap plugin Web page for possible events.
 	 * For example, [this page](http://twitter.github.io/bootstrap/javascript.html#modals) shows
 	 * how to use the "Modal" plugin and the supported events (e.g. "shown").
 	 */
-	public $pluginEvents = array();
+	public $events = array();
 
 
 	/**
@@ -69,15 +69,15 @@ class Widget extends \yii\base\Widget
 		$view->registerAssetBundle(static::$responsive ? 'yii/bootstrap/responsive' : 'yii/bootstrap');
 		$view->registerAssetBundle("yii/bootstrap/$name");
 
-		if ($this->pluginOptions !== false) {
-			$options = empty($this->pluginOptions) ? '' : Json::encode($this->pluginOptions);
+		if ($this->options !== false) {
+			$options = empty($this->options) ? '' : Json::encode($this->options);
 			$js = "jQuery('#$id').$name($options);";
 			$view->registerJs($js);
 		}
 
-		if (!empty($this->pluginEvents)) {
+		if (!empty($this->events)) {
 			$js = array();
-			foreach ($this->pluginEvents as $event => $handler) {
+			foreach ($this->events as $event => $handler) {
 				$js[] = "jQuery('#$id').on('$event', $handler);";
 			}
 			$view->registerJs(implode("\n", $js));


### PR DESCRIPTION
Changes:
- `pluginOptions` renamed to `clientOptions` because its more generic
- `pluginEvents` renamed to `clientEvents` because its more generic

Its done to be consistent with JUI widgets. Since `clientOptions` and `clientEvents` is generic names both widget groups can use it.
- some comments fixed
- error message style fixed
