### PR TITLE
added run method to execute yii commands

### DIFF
--- a/apps/bootstrap/commands/HelloController.php
+++ b/apps/bootstrap/commands/HelloController.php
@@ -24,6 +24,6 @@ class HelloController extends Controller
 	 */
 	public function actionIndex($message = 'hello world')
 	{
-		echo $message;
+		echo $message."\n";
 	}
 }

--- a/extensions/composer/yii/composer/InstallHandler.php
+++ b/extensions/composer/yii/composer/InstallHandler.php
@@ -66,12 +66,21 @@ class InstallHandler
 	{
 		$options = array_merge(array(
 			'run' => array(),
+			'config' => null,
 		), $event->getComposer()->getPackage()->getExtra());
 
-		$appPath = realpath(__DIR__ . '/../../../../..');
+		// resolve and include config file
+		if (($options['config'] === null)) {
+			throw new console\Exception('Config file not specified in composer.json extra.config');
+		} else {
+			if (!is_file(getcwd() . '/' . $options['config'])) {
+				throw new console\Exception("Config file '{$options['config']}' specified in composer.json extra.config not found");
+			} else {
+				$config = require($options['config']);
+			}
+		}
 
-		require($appPath . '/vendor/yiisoft/yii2/yii/Yii.php');
-		$config = require($appPath . '/config/console.php');
+		require(__DIR__ . '/../../../yii2/yii/Yii.php');
 
 		foreach ((array)$options['run'] as $rawParams) {
 			// TODO: we're doing about the same here like console\Request::resolve()

--- a/extensions/composer/yii/composer/InstallHandler.php
+++ b/extensions/composer/yii/composer/InstallHandler.php
@@ -64,8 +64,8 @@ class InstallHandler
 	public static function run($event)
 	{
 		$options = array_merge(array(
-									'run' => array(),
-							   ), $event->getComposer()->getPackage()->getExtra());
+			'run' => array(),
+		), $event->getComposer()->getPackage()->getExtra());
 
 		$appPath = realpath(__DIR__ . '/../../../../..');
 

--- a/extensions/composer/yii/composer/InstallHandler.php
+++ b/extensions/composer/yii/composer/InstallHandler.php
@@ -80,17 +80,17 @@ class InstallHandler
 			}
 		}
 
+		// prepare console application
 		require(__DIR__ . '/../../../yii2/yii/Yii.php');
+		$application = new \yii\console\Application($config);
+		$request = $application->getRequest();
 
-		foreach ((array)$options['run'] as $rawParams) {
-			// TODO: we're doing about the same here like console\Request::resolve()
-			$command = $rawParams[0];
-			unset($rawParams[0]);
-			$params[\yii\console\Request::ANONYMOUS_PARAMS] = $rawParams;
-			// TODO end
-
+		// run commands from extra.run
+		foreach ((array)$options['run'] as $rawCommand) {
+			$opts = str_getcsv($rawCommand, ' '); // see http://stackoverflow.com/a/6609509/291573
+			$request->setParams($opts);
+			list($command, $params) = $request->resolve();
 			echo "Running command: {$command}\n";
-			$application = new \yii\console\Application($config);
 			$application->runAction($command, $params);
 		}
 	}

--- a/extensions/composer/yii/composer/InstallHandler.php
+++ b/extensions/composer/yii/composer/InstallHandler.php
@@ -70,7 +70,6 @@ class InstallHandler
 		$appPath = realpath(__DIR__ . '/../../../../..');
 
 		require($appPath . '/vendor/yiisoft/yii2/yii/Yii.php');
-		require($appPath . '/vendor/autoload.php');
 		$config = require($appPath . '/config/console.php');
 
 		foreach((array)$options['run'] as $params){

--- a/extensions/composer/yii/composer/InstallHandler.php
+++ b/extensions/composer/yii/composer/InstallHandler.php
@@ -90,7 +90,7 @@ class InstallHandler
 			$opts = str_getcsv($rawCommand, ' '); // see http://stackoverflow.com/a/6609509/291573
 			$request->setParams($opts);
 			list($command, $params) = $request->resolve();
-			echo "Running command: {$command}\n";
+			echo "Running command: yiic {$rawCommand}\n";
 			$application->runAction($command, $params);
 		}
 	}

--- a/extensions/composer/yii/composer/InstallHandler.php
+++ b/extensions/composer/yii/composer/InstallHandler.php
@@ -8,6 +8,7 @@
 namespace yii\composer;
 
 use Composer\Script\CommandEvent;
+use yii\console;
 
 defined('YII_DEBUG') or define('YII_DEBUG', true);
 
@@ -72,11 +73,13 @@ class InstallHandler
 		require($appPath . '/vendor/yiisoft/yii2/yii/Yii.php');
 		$config = require($appPath . '/config/console.php');
 
-		foreach((array)$options['run'] as $params){
-			$command = $params[0];
-			unset($params[0]);
-			$params = array();
-			// TODO: add params to array
+		foreach ((array)$options['run'] as $rawParams) {
+			// TODO: we're doing about the same here like console\Request::resolve()
+			$command = $rawParams[0];
+			unset($rawParams[0]);
+			$params[\yii\console\Request::ANONYMOUS_PARAMS] = $rawParams;
+			// TODO end
+
 			echo "Running command: {$command}\n";
 			$application = new \yii\console\Application($config);
 			$application->runAction($command, $params);


### PR DESCRIPTION
Discussion: https://github.com/yiisoft/yii2/issues/350

ToDos:
- add params
- execute by namespace
- autoload by namespace

Can be tested with this `composer.json` and `composer install`:

```
"scripts": {
    "post-install-cmd": [
        "yii\\composer\\InstallHandler::setPermissions",
        "yii\\composer\\InstallHandler::run"
    ],
    "post-update-cmd": [
        "yii\\composer\\InstallHandler::setPermissions"
    ]
},
"extra": {
    "run": [
        ["help"],
        ["hello", "Hello World!"],
        ["yii\\console\\controllers\\HelpController"]
    ],
    "writable": [
        "runtime",
        "www/assets"
    ],
    "executable": [
        "yii"
    ]
}
```

Will execute `help` and `hello` (without params) without errors, but currently fails on yii\console\controllers\HelpController.
