### PR TITLE
Fixed an example of using buildKey in the doc

### DIFF
--- a/framework/yii/caching/Cache.php
+++ b/framework/yii/caching/Cache.php
@@ -94,7 +94,7 @@ abstract class Cache extends Component implements \ArrayAccess
 	 * The following example builds a cache key using three parameters:
 	 *
 	 * ~~~
-	 * $key = $cache->buildKey($className, $method, $id);
+	 * $key = $cache->buildKey(array($className, $method, $id));
 	 * ~~~
 	 *
 	 * @param array|string $key the key to be normalized


### PR DESCRIPTION
Fixed an example of using buildKey in the doc
