### PR TITLE
mod: convert bizRules into callables, avoiding eval()

### DIFF
--- a/framework/yii/rbac/Assignment.php
+++ b/framework/yii/rbac/Assignment.php
@@ -27,7 +27,7 @@ class Assignment extends Object
 	 */
 	public $manager;
 	/**
-	 * @var string the business rule associated with this assignment
+	 * @var callable the business rule associated with this assignment
 	 */
 	public $bizRule;
 	/**

--- a/framework/yii/rbac/DbManager.php
+++ b/framework/yii/rbac/DbManager.php
@@ -217,12 +217,15 @@ class DbManager extends Manager
 			if (($data = @unserialize($row['data'])) === false) {
 				$data = null;
 			}
+			if (($bizRule = @unserialize($row['biz_rule'])) === false) {
+				$bizRule = null;
+			}
 			$children[$row['name']] = new Item(array(
 				'manager' => $this,
 				'name' => $row['name'],
 				'type' => $row['type'],
 				'description' => $row['description'],
-				'bizRule' => $row['biz_rule'],
+				'bizRule' => $bizRule,
 				'data' => $data,
 			));
 		}
@@ -233,7 +236,7 @@ class DbManager extends Manager
 	 * Assigns an authorization item to a user.
 	 * @param mixed $userId the user ID (see [[User::id]])
 	 * @param string $itemName the item name
-	 * @param string $bizRule the business rule to be executed when [[checkAccess()]] is called
+	 * @param callable $bizRule the business rule to be executed when [[checkAccess()]] is called
 	 * for this particular authorization item.
 	 * @param mixed $data additional data associated with this assignment
 	 * @return Assignment the authorization assignment information.
@@ -248,7 +251,7 @@ class DbManager extends Manager
 			->insert($this->assignmentTable, array(
 				'user_id' => $userId,
 				'item_name' => $itemName,
-				'biz_rule' => $bizRule,
+				'biz_rule' => serialize($bizRule),
 				'data' => serialize($data),
 			))
 			->execute();
@@ -308,11 +311,14 @@ class DbManager extends Manager
 			if (($data = @unserialize($row['data'])) === false) {
 				$data = null;
 			}
+			if (($bizRule = @unserialize($row['biz_rule'])) === false) {
+				$bizRule = null;
+			}
 			return new Assignment(array(
 				'manager' => $this,
 				'userId' => $row['user_id'],
 				'itemName' => $row['item_name'],
-				'bizRule' => $row['biz_rule'],
+				'bizRule' => $bizRule,
 				'data' => $data,
 			));
 		} else {
@@ -338,11 +344,14 @@ class DbManager extends Manager
 			if (($data = @unserialize($row['data'])) === false) {
 				$data = null;
 			}
+			if (($bizRule = @unserialize($row['biz_rule'])) === false) {
+				$bizRule = null;
+			}
 			$assignments[$row['item_name']] = new Assignment(array(
 				'manager' => $this,
 				'userId' => $row['user_id'],
 				'itemName' => $row['item_name'],
-				'bizRule' => $row['biz_rule'],
+				'bizRule' => $bizRule,
 				'data' => $data,
 			));
 		}
@@ -357,7 +366,7 @@ class DbManager extends Manager
 	{
 		$this->db->createCommand()
 			->update($this->assignmentTable, array(
-				'biz_rule' => $assignment->bizRule,
+				'biz_rule' => serialize($assignment->bizRule),
 				'data' => serialize($assignment->data),
 			), array(
 				'user_id' => $assignment->userId,
@@ -400,12 +409,15 @@ class DbManager extends Manager
 			if (($data = @unserialize($row['data'])) === false) {
 				$data = null;
 			}
+			if (($bizRule = @unserialize($row['biz_rule'])) === false) {
+				$bizRule = null;
+			}
 			$items[$row['name']] = new Item(array(
 				'manager' => $this,
 				'name' => $row['name'],
 				'type' => $row['type'],
 				'description' => $row['description'],
-				'bizRule' => $row['biz_rule'],
+				'bizRule' => $bizRule,
 				'data' => $data,
 			));
 		}
@@ -421,8 +433,8 @@ class DbManager extends Manager
 	 * @param string $name the item name. This must be a unique identifier.
 	 * @param integer $type the item type (0: operation, 1: task, 2: role).
 	 * @param string $description description of the item
-	 * @param string $bizRule business rule associated with the item. This is a piece of
-	 * PHP code that will be executed when [[checkAccess()]] is called for the item.
+	 * @param callable $bizRule business rule associated with the item. This is a callable
+	 * that will be executed when [[checkAccess()]] is called for the item.
 	 * @param mixed $data additional data associated with the item.
 	 * @return Item the authorization item
 	 * @throws Exception if an item with the same name already exists
@@ -434,7 +446,7 @@ class DbManager extends Manager
 				'name' => $name,
 				'type' => $type,
 				'description' => $description,
-				'biz_rule' => $bizRule,
+				'biz_rule' => serialize($bizRule),
 				'data' => serialize($data),
 			))
 			->execute();
@@ -485,12 +497,15 @@ class DbManager extends Manager
 			if (($data = @unserialize($row['data'])) === false) {
 				$data = null;
 			}
+			if (($bizRule = @unserialize($row['biz_rule'])) === false) {
+				$bizRule = null;
+			}
 			return new Item(array(
 				'manager' => $this,
 				'name' => $row['name'],
 				'type' => $row['type'],
 				'description' => $row['description'],
-				'bizRule' => $row['biz_rule'],
+				'bizRule' => $bizRule,
 				'data' => $data,
 			));
 		} else
@@ -521,7 +536,7 @@ class DbManager extends Manager
 				'name' => $item->getName(),
 				'type' => $item->type,
 				'description' => $item->description,
-				'biz_rule' => $item->bizRule,
+				'biz_rule' => serialize($item->bizRule),
 				'data' => serialize($item->data),
 			), array(
 				'name' => $oldName === null ? $item->getName() : $oldName,

--- a/framework/yii/rbac/Item.php
+++ b/framework/yii/rbac/Item.php
@@ -37,7 +37,7 @@ class Item extends Object
 	 */
 	public $description;
 	/**
-	 * @var string the business rule associated with this item
+	 * @var callable the business rule associated with this item
 	 */
 	public $bizRule;
 	/**
@@ -144,7 +144,7 @@ class Item extends Object
 	/**
 	 * Assigns this item to a user.
 	 * @param mixed $userId the user ID (see [[User::id]])
-	 * @param string $bizRule the business rule to be executed when [[checkAccess()]] is called
+	 * @param callable $bizRule the business rule to be executed when [[checkAccess()]] is called
 	 * for this particular authorization item.
 	 * @param mixed $data additional data associated with this assignment
 	 * @return Assignment the authorization assignment information.

--- a/framework/yii/rbac/Manager.php
+++ b/framework/yii/rbac/Manager.php
@@ -65,7 +65,7 @@ abstract class Manager extends Component
 	 * This is a shortcut method to [[Manager::createItem()]].
 	 * @param string $name the item name
 	 * @param string $description the item description.
-	 * @param string $bizRule the business rule associated with this item
+	 * @param callable $bizRule the business rule associated with this item
 	 * @param mixed $data additional data to be passed when evaluating the business rule
 	 * @return Item the authorization item
 	 */
@@ -79,7 +79,7 @@ abstract class Manager extends Component
 	 * This is a shortcut method to [[Manager::createItem()]].
 	 * @param string $name the item name
 	 * @param string $description the item description.
-	 * @param string $bizRule the business rule associated with this item
+	 * @param callable $bizRule the business rule associated with this item
 	 * @param mixed $data additional data to be passed when evaluating the business rule
 	 * @return Item the authorization item
 	 */
@@ -93,7 +93,7 @@ abstract class Manager extends Component
 	 * This is a shortcut method to [[Manager::createItem()]].
 	 * @param string $name the item name
 	 * @param string $description the item description.
-	 * @param string $bizRule the business rule associated with this item
+	 * @param callable $bizRule the business rule associated with this item
 	 * @param mixed $data additional data to be passed when evaluating the business rule
 	 * @return Item the authorization item
 	 */
@@ -140,7 +140,7 @@ abstract class Manager extends Component
 
 	/**
 	 * Executes the specified business rule.
-	 * @param string $bizRule the business rule to be executed.
+	 * @param callable $bizRule the business rule to be executed.
 	 * @param array $params parameters passed to [[Manager::checkAccess()]].
 	 * @param mixed $data additional data associated with the authorization item or assignment.
 	 * @return boolean whether the business rule returns true.
@@ -148,7 +148,15 @@ abstract class Manager extends Component
 	 */
 	public function executeBizRule($bizRule, $params, $data)
 	{
-		return $bizRule === '' || $bizRule === null || ($this->showErrors ? eval($bizRule) != 0 : @eval($bizRule) != 0);
+		if (empty($bizRule)) {
+			return true;
+		}
+		
+		if (is_callable($bizRule)) {
+			return call_user_func_array($bizRule,array($this,$params,$data));
+		}
+		
+		return false;		
 	}
 
 	/**
@@ -185,7 +193,7 @@ abstract class Manager extends Component
 	 * @param string $name the item name. This must be a unique identifier.
 	 * @param integer $type the item type (0: operation, 1: task, 2: role).
 	 * @param string $description description of the item
-	 * @param string $bizRule business rule associated with the item. This is a piece of
+	 * @param callable $bizRule business rule associated with the item. This is a piece of
 	 * PHP code that will be executed when [[checkAccess()]] is called for the item.
 	 * @param mixed $data additional data associated with the item.
 	 * @throws \yii\base\Exception if an item with the same name already exists
@@ -254,7 +262,7 @@ abstract class Manager extends Component
 	 * Assigns an authorization item to a user.
 	 * @param mixed $userId the user ID (see [[User::id]])
 	 * @param string $itemName the item name
-	 * @param string $bizRule the business rule to be executed when [[checkAccess()]] is called
+	 * @param callable $bizRule the business rule to be executed when [[checkAccess()]] is called
 	 * for this particular authorization item.
 	 * @param mixed $data additional data associated with this assignment
 	 * @return Assignment the authorization assignment information.

--- a/framework/yii/rbac/PhpManager.php
+++ b/framework/yii/rbac/PhpManager.php
@@ -181,7 +181,7 @@ class PhpManager extends Manager
 	 * Assigns an authorization item to a user.
 	 * @param mixed $userId the user ID (see [[User::id]])
 	 * @param string $itemName the item name
-	 * @param string $bizRule the business rule to be executed when [[checkAccess()]] is called
+	 * @param callable $bizRule the business rule to be executed when [[checkAccess()]] is called
 	 * for this particular authorization item.
 	 * @param mixed $data additional data associated with this assignment
 	 * @return Assignment the authorization assignment information.
@@ -296,8 +296,8 @@ class PhpManager extends Manager
 	 * @param string $name the item name. This must be a unique identifier.
 	 * @param integer $type the item type (0: operation, 1: task, 2: role).
 	 * @param string $description description of the item
-	 * @param string $bizRule business rule associated with the item. This is a piece of
-	 * PHP code that will be executed when [[checkAccess()]] is called for the item.
+	 * @param callable $bizRule business rule associated with the item. This is a callable
+	 * that will be executed when [[checkAccess()]] is called for the item.
 	 * @param mixed $data additional data associated with the item.
 	 * @return Item the authorization item
 	 * @throws Exception if an item with the same name already exists


### PR DESCRIPTION
This changes the implementation of bizRules. They are no longer strings containing PHP code to be evaluated. Instead they are now callables to be invoked. Related issues are #24 and #42.

Of course Manager-implementations need to be able to (de)serialize the callables, so the usage is most likely limited to defining callbacks in the form of `array($classOrInstance,$methodName)`. PhpManager already used var_export, which works nicely with such callback definitions. DbManager now uses (de)serialize for bizRules just like it does for data.

Since some people were concerned about loosing flexibility if they couldn't pass php code as bizRules, I included an example of an evaluating bizRule callback in the tests. I still don't think this is a commonly required use case, but if someone really requires users being able to write their own bizRule code, they can use such an approach. So we won't loose anything, only difference is it's now in the responsibility of the developer to provide the bizRule callback that does the evaluation.
