### PR TITLE
Object::spaceName()

### DIFF
--- a/framework/yii/base/Object.php
+++ b/framework/yii/base/Object.php
@@ -23,6 +23,14 @@ class Object
 	}
 
 	/**
+	 * @return string the namespace of this class.
+	 */
+	public static function spaceName()
+	{
+		return dirname(get_called_class());
+	}
+
+	/**
 	 * Constructor.
 	 * The default implementation does two things:
 	 *


### PR DESCRIPTION
For example we have models:

```
namespace common\models;

class Article extends ActiveRecord
{
    public function getCategory()
    {
        $class = self::spaceName() . '/Category';
        return $class::find()->all();
    }
}
```

```
namespace backend\models;

class Article extends \common\models\Article
{
}
```

```
namespace frontend\models;

class Article extends \common\models\Article
{
}
```

So code like:

```
use frontend\models\Article;
...
$article->category //gets \frontend\models\Category
```

```
use baclend\models\Article;
...
$article->category //gets \backend\models\Category
```
