### PR TITLE
Exception propagation in \yii\db\mysql\Schema

### DIFF
--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -177,6 +177,7 @@ class Schema extends \yii\db\Schema
 	/**
 	 * Collects the metadata of table columns.
 	 * @param TableSchema $table the table metadata
+	 * @throws Exception
 	 * @return boolean whether the table exists in the database
 	 */
 	protected function findColumns($table)
@@ -185,7 +186,12 @@ class Schema extends \yii\db\Schema
 		try {
 			$columns = $this->db->createCommand($sql)->queryAll();
 		} catch (\Exception $e) {
-			return false;
+			$previous = $e->getPrevious();
+			if ($previous instanceof \PDOException && $previous->getCode() === '42S02') {
+				return false;
+			}
+			
+			throw $e;
 		}
 		foreach ($columns as $info) {
 			$column = $this->loadColumnSchema($info);


### PR DESCRIPTION
Such exception must be propagated to prevent execution of code with
incomplete incoming data and other unexpected behaviors.

Second fix with exception check to find is this is an exception for
missing table or not
