### PR TITLE
Multilevel Nav items

### DIFF
--- a/framework/yii/bootstrap/Nav.php
+++ b/framework/yii/bootstrap/Nav.php
@@ -27,13 +27,19 @@ use yii\helpers\Html;
  *         ),
  *         array(
  *             'label' => 'Dropdown',
- *             'dropdown' => array(
+ *             'items' => array(
  *                  array(
- *                      'label' => 'DropdownA',
+ *                      'label' => 'Level 1 -DropdownA',
  *                      'url' => '#',
+ *                      'items' => array(
+ *                          array(
+ *                              'label' => 'Level 2 -DropdownA',
+ *                              'url' => '#',
+ *                          ),
+ *                      ),
  *                  ),
  *                  array(
- *                      'label' => 'DropdownB',
+ *                      'label' => 'Level 1 -DropdownB',
  *                      'url' => '#',
  *                  ),
  *             ),
@@ -114,7 +120,7 @@ class Nav extends Widget
 		}
 		$label = $this->encodeLabels ? Html::encode($item['label']) : $item['label'];
 		$options = ArrayHelper::getValue($item, 'options', array());
-		$dropdown = ArrayHelper::getValue($item, 'dropdown');
+		$items = ArrayHelper::getValue($item, 'items');
 		$url = Html::url(ArrayHelper::getValue($item, 'url', '#'));
 		$linkOptions = ArrayHelper::getValue($item, 'linkOptions', array());
 
@@ -122,19 +128,19 @@ class Nav extends Widget
 			$this->addCssClass($options, 'active');
 		}
 
-		if ($dropdown !== null) {
+		if ($items !== null) {
 			$linkOptions['data-toggle'] = 'dropdown';
 			$this->addCssClass($options, 'dropdown');
 			$this->addCssClass($urlOptions, 'dropdown-toggle');
 			$label .= ' ' . Html::tag('b', '', array('class' => 'caret'));
-			if (is_array($dropdown)) {
-				$dropdown = Dropdown::widget(array(
-					'items' => $dropdown,
+			if (is_array($items)) {
+				$items = Dropdown::widget(array(
+					'items' => $items,
 					'clientOptions' => false,
 				));
 			}
 		}
 
-		return Html::tag('li', Html::a($label, $url, $linkOptions) . $dropdown, $options);
+		return Html::tag('li', Html::a($label, $url, $linkOptions) . $items, $options);
 	}
 }


### PR DESCRIPTION
In multilevel menus in which the items have been dynamically provided for Nav class, the sameness of index items of both Dropdown and Nav classes facilitate the implementaion. Otherwise, the changes of index items from the first level onward should be controlled.
