### PR TITLE
Issue 466 (add/drop PrimaryKeys)

### DIFF
--- a/framework/yii/db/Command.php
+++ b/framework/yii/db/Command.php
@@ -652,6 +652,32 @@ class Command extends \yii\base\Component
 		$sql = $this->db->getQueryBuilder()->alterColumn($table, $column, $type);
 		return $this->setSql($sql);
 	}
+	
+	/**
+	 * Creates a SQL command for adding a primary key constraint to an existing table.
+	 * The method will properly quote the table and column names.
+	 * @param string $name the name of the primary key constraint.
+	 * @param string $table the table that the primary key constraint will be added to.
+	 * @param string|array $columns comma separated string or array of columns that the primary key will consist of.
+	 * @return Command the command object itself.
+	 */	
+	public function addPrimaryKey($name,$table,$columns)
+	{
+		$sql = $this->db->getQueryBuilder()->addPrimaryKey($name, $table, $columns);
+		return $this->setSql($sql);
+	}
+	
+	/**
+	 * Creates a SQL command for removing a primary key constraint to an existing table.
+	 * @param string $name the name of the primary key constraint to be removed.
+	 * @param string $table the table that the primary key constraint will be removed from.
+	 * @return Command the command object itself
+	 */	
+	public function dropPrimarykey($name,$table)
+	{
+		$sql = $this->db->getQueryBuilder()->dropPrimarykey($name, $table);
+		return $this->setSql($sql);
+	}
 
 	/**
 	 * Creates a SQL command for adding a foreign key constraint to an existing table.

--- a/framework/yii/db/Command.php
+++ b/framework/yii/db/Command.php
@@ -661,7 +661,7 @@ class Command extends \yii\base\Component
 	 * @param string|array $columns comma separated string or array of columns that the primary key will consist of.
 	 * @return Command the command object itself.
 	 */	
-	public function addPrimaryKey($name,$table,$columns)
+	public function addPrimaryKey($name, $table, $columns)
 	{
 		$sql = $this->db->getQueryBuilder()->addPrimaryKey($name, $table, $columns);
 		return $this->setSql($sql);
@@ -673,7 +673,7 @@ class Command extends \yii\base\Component
 	 * @param string $table the table that the primary key constraint will be removed from.
 	 * @return Command the command object itself
 	 */	
-	public function dropPrimarykey($name,$table)
+	public function dropPrimarykey($name, $table)
 	{
 		$sql = $this->db->getQueryBuilder()->dropPrimarykey($name, $table);
 		return $this->setSql($sql);

--- a/framework/yii/db/QueryBuilder.php
+++ b/framework/yii/db/QueryBuilder.php
@@ -276,12 +276,16 @@ class QueryBuilder extends \yii\base\Object
 	 * @param string|array $columns comma separated string or array of columns that the primary key will consist of.
 	 * @return string the SQL statement for adding a primary key constraint to an existing table.
 	 */
-	public function addPrimaryKey($name,$table,$columns)
+	public function addPrimaryKey($name, $table, $columns)
 	{
-		if(is_string($columns))
+		if (is_string($columns)) {
 			$columns=preg_split('/\s*,\s*/',$columns,-1,PREG_SPLIT_NO_EMPTY);
-		foreach($columns as $i=>$col)
+		}
+		
+		foreach ($columns as $i=>$col) {
 			$columns[$i]=$this->db->quoteColumnName($col);
+		}
+		
 		return 'ALTER TABLE ' . $this->db->quoteTableName($table) . ' ADD CONSTRAINT '
 			. $this->db->quoteColumnName($name) . '  PRIMARY KEY ('
 			. implode(', ', $columns). ' )';
@@ -293,7 +297,7 @@ class QueryBuilder extends \yii\base\Object
 	 * @param string $table the table that the primary key constraint will be removed from.
 	 * @return string the SQL statement for removing a primary key constraint from an existing table.	 *
 	 */
-	public function dropPrimarykey($name,$table)
+	public function dropPrimarykey($name, $table)
 	{
 		return 'ALTER TABLE ' . $this->db->quoteTableName($table)
 			. ' DROP CONSTRAINT ' . $this->db->quoteColumnName($name);

--- a/framework/yii/db/QueryBuilder.php
+++ b/framework/yii/db/QueryBuilder.php
@@ -268,6 +268,36 @@ class QueryBuilder extends \yii\base\Object
 	{
 		return "DROP TABLE " . $this->db->quoteTableName($table);
 	}
+	
+	/**
+	 * Builds a SQL statement for adding a primary key constraint to an existing table.
+	 * @param string $name the name of the primary key constraint.
+	 * @param string $table the table that the primary key constraint will be added to.
+	 * @param string|array $columns comma separated string or array of columns that the primary key will consist of.
+	 * @return string the SQL statement for adding a primary key constraint to an existing table.
+	 */
+	public function addPrimaryKey($name,$table,$columns)
+	{
+		if(is_string($columns))
+			$columns=preg_split('/\s*,\s*/',$columns,-1,PREG_SPLIT_NO_EMPTY);
+		foreach($columns as $i=>$col)
+			$columns[$i]=$this->quoteColumnName($col);
+		return 'ALTER TABLE ' . $this->quoteTableName($table) . ' ADD CONSTRAINT '
+			. $this->quoteColumnName($name) . '  PRIMARY KEY ('
+			. implode(', ', $columns). ' )';
+	}	
+	
+	/**
+	 * Builds a SQL statement for removing a constraint to an existing table.
+	 * @param string $name the name of the constraint to be removed.
+	 * @param string $table the table that constraint will be removed from.
+	 * @return string the SQL statement for removing constraint from an existing table.
+	 */
+	public function dropConstraint($name,$table)
+	{
+		return 'ALTER TABLE ' . $this->quoteTableName($table) . ' DROP CONSTRAINT '
+			. $this->quoteColumnName($name);
+	}	
 
 	/**
 	 * Builds a SQL statement for truncating a DB table.

--- a/framework/yii/db/QueryBuilder.php
+++ b/framework/yii/db/QueryBuilder.php
@@ -288,15 +288,16 @@ class QueryBuilder extends \yii\base\Object
 	}	
 	
 	/**
-	 * Builds a SQL statement for removing a constraint to an existing table.
-	 * @param string $name the name of the constraint to be removed.
-	 * @param string $table the table that constraint will be removed from.
-	 * @return string the SQL statement for removing constraint from an existing table.
+	 * Builds a SQL statement for removing a primary key constraint to an existing table.
+	 * @param string $name the name of the primary key constraint to be removed.
+	 * @param string $table the table that the primary key constraint will be removed from.
+	 * @return string the SQL statement for removing a primary key constraint from an existing table.	 *
 	 */
-	public function dropConstraint($name,$table)
+	public function dropPrimarykey($name,$table)
 	{
-		return 'ALTER TABLE ' . $this->quoteTableName($table) . ' DROP CONSTRAINT '
-			. $this->quoteColumnName($name);
+		return 'ALTER TABLE ' . $this->db->quoteTableName($table)
+			. ' DROP CONSTRAINT ' . $this->db->quoteColumnName($name);
+		
 	}	
 
 	/**

--- a/framework/yii/db/QueryBuilder.php
+++ b/framework/yii/db/QueryBuilder.php
@@ -281,9 +281,9 @@ class QueryBuilder extends \yii\base\Object
 		if(is_string($columns))
 			$columns=preg_split('/\s*,\s*/',$columns,-1,PREG_SPLIT_NO_EMPTY);
 		foreach($columns as $i=>$col)
-			$columns[$i]=$this->quoteColumnName($col);
-		return 'ALTER TABLE ' . $this->quoteTableName($table) . ' ADD CONSTRAINT '
-			. $this->quoteColumnName($name) . '  PRIMARY KEY ('
+			$columns[$i]=$this->db->quoteColumnName($col);
+		return 'ALTER TABLE ' . $this->db->quoteTableName($table) . ' ADD CONSTRAINT '
+			. $this->db->quoteColumnName($name) . '  PRIMARY KEY ('
 			. implode(', ', $columns). ' )';
 	}	
 	

--- a/framework/yii/db/mysql/QueryBuilder.php
+++ b/framework/yii/db/mysql/QueryBuilder.php
@@ -94,7 +94,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
 	 * @param string $table the table that the primary key constraint will be removed from.
 	 * @return string the SQL statement for removing a primary key constraint from an existing table.	 *
 	 */
-	public function dropPrimarykey($name,$table)
+	public function dropPrimarykey($name, $table)
 	{
 		return 'ALTER TABLE ' . $this->db->quoteTableName($table) . ' DROP PRIMARY KEY';		
 	}

--- a/framework/yii/db/mysql/QueryBuilder.php
+++ b/framework/yii/db/mysql/QueryBuilder.php
@@ -89,6 +89,17 @@ class QueryBuilder extends \yii\db\QueryBuilder
 	}
 
 	/**
+	 * Builds a SQL statement for removing a primary key constraint to an existing table.
+	 * @param string $name the name of the primary key constraint to be removed.
+	 * @param string $table the table that the primary key constraint will be removed from.
+	 * @return string the SQL statement for removing a primary key constraint from an existing table.	 *
+	 */
+	public function dropPrimarykey($name,$table)
+	{
+		return 'ALTER TABLE ' . $this->db->quoteTableName($table) . ' DROP PRIMARY KEY';		
+	}
+	
+	/**
 	 * Creates a SQL statement for resetting the sequence value of a table's primary key.
 	 * The sequence will be reset such that the primary key of the next new row inserted
 	 * will have the specified value or 1.

--- a/framework/yii/db/pgsql/QueryBuilder.php
+++ b/framework/yii/db/pgsql/QueryBuilder.php
@@ -22,13 +22,13 @@ class QueryBuilder extends \yii\db\QueryBuilder
 	 */
 	public $typeMap = array(
 	    Schema::TYPE_PK => 'serial not null primary key',
-	    Schema::TYPE_STRING => 'varchar',
+	    Schema::TYPE_STRING => 'varchar(255)',
 	    Schema::TYPE_TEXT => 'text',
 	    Schema::TYPE_SMALLINT => 'smallint',
 	    Schema::TYPE_INTEGER => 'integer',
 	    Schema::TYPE_BIGINT => 'bigint',
 	    Schema::TYPE_FLOAT => 'double precision',
-	    Schema::TYPE_DECIMAL => 'numeric',
+	    Schema::TYPE_DECIMAL => 'numeric(10,0)',
 	    Schema::TYPE_DATETIME => 'timestamp',
 	    Schema::TYPE_TIMESTAMP => 'timestamp',
 	    Schema::TYPE_TIME => 'time',

--- a/framework/yii/db/pgsql/Schema.php
+++ b/framework/yii/db/pgsql/Schema.php
@@ -43,6 +43,7 @@ class Schema extends \yii\db\Schema
 		'circle' => self::TYPE_STRING,
 		'date' => self::TYPE_DATE,
 		'real' => self::TYPE_FLOAT,
+		'decimal' => self::TYPE_DECIMAL,
 		'double precision' => self::TYPE_DECIMAL,
 		'inet' => self::TYPE_STRING,
 		'smallint' => self::TYPE_SMALLINT,
@@ -55,7 +56,6 @@ class Schema extends \yii\db\Schema
 		'money' => self::TYPE_MONEY,
 		'name' => self::TYPE_STRING,
 		'numeric' => self::TYPE_STRING,
-		'numrange' => self::TYPE_DECIMAL,
 		'oid' => self::TYPE_BIGINT, // should not be used. it's pg internal!
 		'path' => self::TYPE_STRING,
 		'point' => self::TYPE_STRING,

--- a/framework/yii/db/sqlite/QueryBuilder.php
+++ b/framework/yii/db/sqlite/QueryBuilder.php
@@ -179,4 +179,30 @@ class QueryBuilder extends \yii\db\QueryBuilder
 	{
 		throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');
 	}
+	
+	/**
+	 * Builds a SQL statement for adding a primary key constraint to an existing table.
+	 * @param string $name the name of the primary key constraint.
+	 * @param string $table the table that the primary key constraint will be added to.
+	 * @param string|array $columns comma separated string or array of columns that the primary key will consist of.
+	 * @return string the SQL statement for adding a primary key constraint to an existing table.
+	 * @throws NotSupportedException this is not supported by SQLite
+	 */
+	public function addPrimaryKey($name,$table,$columns)
+	{
+		throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');
+	}	
+	
+	/**
+	 * Builds a SQL statement for removing a primary key constraint to an existing table.
+	 * @param string $name the name of the primary key constraint to be removed.
+	 * @param string $table the table that the primary key constraint will be removed from.
+	 * @return string the SQL statement for removing a primary key constraint from an existing table.
+	 * @throws NotSupportedException this is not supported by SQLite	 *
+	 */
+	public function dropPrimarykey($name,$table)
+	{
+		throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');		
+	}		
 }
+

--- a/framework/yii/db/sqlite/QueryBuilder.php
+++ b/framework/yii/db/sqlite/QueryBuilder.php
@@ -188,7 +188,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
 	 * @return string the SQL statement for adding a primary key constraint to an existing table.
 	 * @throws NotSupportedException this is not supported by SQLite
 	 */
-	public function addPrimaryKey($name,$table,$columns)
+	public function addPrimaryKey($name, $table, $columns)
 	{
 		throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');
 	}	
@@ -200,7 +200,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
 	 * @return string the SQL statement for removing a primary key constraint from an existing table.
 	 * @throws NotSupportedException this is not supported by SQLite	 *
 	 */
-	public function dropPrimarykey($name,$table)
+	public function dropPrimarykey($name, $table)
 	{
 		throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');		
 	}		

--- a/tests/unit/data/mysql.sql
+++ b/tests/unit/data/mysql.sql
@@ -9,6 +9,14 @@ DROP TABLE IF EXISTS tbl_order CASCADE;
 DROP TABLE IF EXISTS tbl_category CASCADE;
 DROP TABLE IF EXISTS tbl_customer CASCADE;
 DROP TABLE IF EXISTS tbl_type CASCADE;
+DROP TABLE IF EXISTS tbl_constraints CASCADE;
+
+CREATE TABLE `tbl_constraints`
+(
+  `id` integer not null,
+  `field1` varchar(255)
+);
+
 
 CREATE TABLE `tbl_customer` (
   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/tests/unit/data/postgres.sql
+++ b/tests/unit/data/postgres.sql
@@ -10,6 +10,13 @@ DROP TABLE IF EXISTS tbl_order CASCADE;
 DROP TABLE IF EXISTS tbl_category CASCADE;
 DROP TABLE IF EXISTS tbl_customer CASCADE;
 DROP TABLE IF EXISTS tbl_type CASCADE;
+DROP TABLE IF EXISTS tbl_constraints CASCADE;
+
+CREATE TABLE tbl_constraints
+(
+  id integer not null,
+  field1 varchar(255)
+);
 
 CREATE TABLE tbl_customer (
   id serial not null primary key,

--- a/tests/unit/framework/db/pgsql/PostgreSQLQueryBuilderTest.php
+++ b/tests/unit/framework/db/pgsql/PostgreSQLQueryBuilderTest.php
@@ -1,22 +1,23 @@
 <?php
 
-namespace yiiunit\framework\db\sqlite;
+namespace yiiunit\framework\db\pgsql;
 
 use yii\base\NotSupportedException;
-use yii\db\sqlite\Schema;
+use yii\db\pgsql\Schema;
 use yiiunit\framework\db\QueryBuilderTest;
 
-class SqliteQueryBuilderTest extends QueryBuilderTest
+class PostgreSQLQueryBuilderTest extends QueryBuilderTest
 {
-	public $driverName = 'sqlite';
 
+	public $driverName = 'pgsql';
+	
 	public function columnTypes()
 	{
 		return array(
-			array(Schema::TYPE_PK, 'integer PRIMARY KEY AUTOINCREMENT NOT NULL'),
-			array(Schema::TYPE_PK . '(8)', 'integer PRIMARY KEY AUTOINCREMENT NOT NULL'),
-			array(Schema::TYPE_PK . ' CHECK (value > 5)', 'integer PRIMARY KEY AUTOINCREMENT NOT NULL CHECK (value > 5)'),
-			array(Schema::TYPE_PK . '(8) CHECK (value > 5)', 'integer PRIMARY KEY AUTOINCREMENT NOT NULL CHECK (value > 5)'),
+			array(Schema::TYPE_PK, 'serial not null primary key'),
+			array(Schema::TYPE_PK . '(8)', 'serial not null primary key'),
+			array(Schema::TYPE_PK . ' CHECK (value > 5)', 'serial not null primary key CHECK (value > 5)'),
+			array(Schema::TYPE_PK . '(8) CHECK (value > 5)', 'serial not null primary key CHECK (value > 5)'),
 			array(Schema::TYPE_STRING, 'varchar(255)'),
 			array(Schema::TYPE_STRING . '(32)', 'varchar(32)'),
 			array(Schema::TYPE_STRING . ' CHECK (value LIKE "test%")', 'varchar(255) CHECK (value LIKE "test%")'),
@@ -40,19 +41,18 @@ class SqliteQueryBuilderTest extends QueryBuilderTest
 			array(Schema::TYPE_BIGINT . ' CHECK (value > 5)', 'bigint CHECK (value > 5)'),
 			array(Schema::TYPE_BIGINT . '(8) CHECK (value > 5)', 'bigint CHECK (value > 5)'),
 			array(Schema::TYPE_BIGINT . ' NOT NULL', 'bigint NOT NULL'),
-			array(Schema::TYPE_FLOAT, 'float'),
-			array(Schema::TYPE_FLOAT . '(16,5)', 'float'),
-			array(Schema::TYPE_FLOAT . ' CHECK (value > 5.6)', 'float CHECK (value > 5.6)'),
-			array(Schema::TYPE_FLOAT . '(16,5) CHECK (value > 5.6)', 'float CHECK (value > 5.6)'),
-			array(Schema::TYPE_FLOAT . ' NOT NULL', 'float NOT NULL'),
-			array(Schema::TYPE_DECIMAL, 'decimal(10,0)'),
-			array(Schema::TYPE_DECIMAL . '(12,4)', 'decimal(12,4)'),
-			array(Schema::TYPE_DECIMAL . ' CHECK (value > 5.6)', 'decimal(10,0) CHECK (value > 5.6)'),
-			array(Schema::TYPE_DECIMAL . '(12,4) CHECK (value > 5.6)', 'decimal(12,4) CHECK (value > 5.6)'),
-			array(Schema::TYPE_DECIMAL . ' NOT NULL', 'decimal(10,0) NOT NULL'),
-			array(Schema::TYPE_DATETIME, 'datetime'),
-			array(Schema::TYPE_DATETIME . " CHECK(value BETWEEN '2011-01-01' AND '2013-01-01')", "datetime CHECK(value BETWEEN '2011-01-01' AND '2013-01-01')"),
-			array(Schema::TYPE_DATETIME . ' NOT NULL', 'datetime NOT NULL'),
+			array(Schema::TYPE_FLOAT, 'double precision'),
+			array(Schema::TYPE_FLOAT . ' CHECK (value > 5.6)', 'double precision CHECK (value > 5.6)'),
+			array(Schema::TYPE_FLOAT . '(16,5) CHECK (value > 5.6)', 'double precision CHECK (value > 5.6)'),
+			array(Schema::TYPE_FLOAT . ' NOT NULL', 'double precision NOT NULL'),
+			array(Schema::TYPE_DECIMAL, 'numeric(10,0)'),
+			array(Schema::TYPE_DECIMAL . '(12,4)', 'numeric(12,4)'),
+			array(Schema::TYPE_DECIMAL . ' CHECK (value > 5.6)', 'numeric(10,0) CHECK (value > 5.6)'),
+			array(Schema::TYPE_DECIMAL . '(12,4) CHECK (value > 5.6)', 'numeric(12,4) CHECK (value > 5.6)'),
+			array(Schema::TYPE_DECIMAL . ' NOT NULL', 'numeric(10,0) NOT NULL'),
+			array(Schema::TYPE_DATETIME, 'timestamp'),
+			array(Schema::TYPE_DATETIME . " CHECK(value BETWEEN '2011-01-01' AND '2013-01-01')", "timestamp CHECK(value BETWEEN '2011-01-01' AND '2013-01-01')"),
+			array(Schema::TYPE_DATETIME . ' NOT NULL', 'timestamp NOT NULL'),
 			array(Schema::TYPE_TIMESTAMP, 'timestamp'),
 			array(Schema::TYPE_TIMESTAMP . " CHECK(value BETWEEN '2011-01-01' AND '2013-01-01')", "timestamp CHECK(value BETWEEN '2011-01-01' AND '2013-01-01')"),
 			array(Schema::TYPE_TIMESTAMP . ' NOT NULL', 'timestamp NOT NULL'),
@@ -62,21 +62,15 @@ class SqliteQueryBuilderTest extends QueryBuilderTest
 			array(Schema::TYPE_DATE, 'date'),
 			array(Schema::TYPE_DATE . " CHECK(value BETWEEN '2011-01-01' AND '2013-01-01')", "date CHECK(value BETWEEN '2011-01-01' AND '2013-01-01')"),
 			array(Schema::TYPE_DATE . ' NOT NULL', 'date NOT NULL'),
-			array(Schema::TYPE_BINARY, 'blob'),
+			array(Schema::TYPE_BINARY, 'bytea'),
 			array(Schema::TYPE_BOOLEAN, 'boolean'),
 			array(Schema::TYPE_BOOLEAN . ' NOT NULL DEFAULT 1', 'boolean NOT NULL DEFAULT 1'),
-			array(Schema::TYPE_MONEY, 'decimal(19,4)'),
-			array(Schema::TYPE_MONEY . '(16,2)', 'decimal(16,2)'),
-			array(Schema::TYPE_MONEY . ' CHECK (value > 0.0)', 'decimal(19,4) CHECK (value > 0.0)'),
-			array(Schema::TYPE_MONEY . '(16,2) CHECK (value > 0.0)', 'decimal(16,2) CHECK (value > 0.0)'),
-			array(Schema::TYPE_MONEY . ' NOT NULL', 'decimal(19,4) NOT NULL'),
+			array(Schema::TYPE_MONEY, 'numeric(19,4)'),
+			array(Schema::TYPE_MONEY . '(16,2)', 'numeric(16,2)'),
+			array(Schema::TYPE_MONEY . ' CHECK (value > 0.0)', 'numeric(19,4) CHECK (value > 0.0)'),
+			array(Schema::TYPE_MONEY . '(16,2) CHECK (value > 0.0)', 'numeric(16,2) CHECK (value > 0.0)'),
+			array(Schema::TYPE_MONEY . ' NOT NULL', 'numeric(19,4) NOT NULL'),
 		);
-	}
-	
-	public function testAddDropPrimayKey()
-	{
-		$this->setExpectedException('yii\base\NotSupportedException');
-		parent::testAddDropPrimayKey();
 	}
 
 }


### PR DESCRIPTION
- Updated code styling and added braces.
  - Added drop/add primary key methods to Command.php
  - Added drop/add primary key methods to QueryBuilder.php
  - Added mysql specific dropPrimarykey method
  - Added sqlite specific dropPrimarykey and addPrimaryKey methods
  - Added uint testing for dropPrimarykey and addPrimaryKey methods
  - Corrected postgresql column types, by adding length and precision
