### PR TITLE
[WIP] Html::$ignoreTagAttributes

### DIFF
--- a/framework/yii/helpers/base/Html.php
+++ b/framework/yii/helpers/base/Html.php
@@ -124,6 +124,20 @@ class Html
 	);
 
 	/**
+	 * @var array @todo comment
+	 *
+	 * For example:
+	 * ```
+	 * array(
+	 *     'script' => array('type'),
+	 *     'link' => array('type'),
+	 * )
+	 * ```
+	 */
+	public $ignoreTagAttributes = array();
+
+
+	/**
 	 * Encodes special characters into HTML entities.
 	 * The [[yii\base\Application::charset|application charset]] will be used for encoding.
 	 * @param string $content the content to be encoded


### PR DESCRIPTION
For example HTML5 specification tell us we do NOT need render `type` for `link` and `script` tags. This new option can be used to set ignored attributes for concrete tags before rendering.
