### PR TITLE
Model::formName() and ActiveRecord::getNamespacedClass() PHP 5.3 way

### DIFF
--- a/framework/yii/base/Model.php
+++ b/framework/yii/base/Model.php
@@ -186,9 +186,8 @@ class Model extends Component implements \IteratorAggregate, \ArrayAccess, Jsona
 	 */
 	public function formName()
 	{
-		$class = get_class($this);
-		$pos = strrpos($class, '\\');
-		return $pos === false ? $class : substr($class, $pos + 1);
+		$reflector = new \ReflectionClass($this);
+		return $reflector->getShortName();
 	}
 
 	/**

--- a/framework/yii/db/ActiveRecord.php
+++ b/framework/yii/db/ActiveRecord.php
@@ -1393,12 +1393,11 @@ class ActiveRecord extends Model
 	protected function getNamespacedClass($class)
 	{
 		if (strpos($class, '\\') === false) {
-			$primaryClass = get_class($this);
-			if (($pos = strrpos($primaryClass, '\\')) !== false) {
-				return substr($primaryClass, 0, $pos + 1) . $class;
-			}
+			$reflector = new \ReflectionClass($this);
+			return $reflector->getNamespaceName() . '\\' . $class;
+		} else {
+			return $class;
 		}
-		return $class;
 	}
 
 	/**


### PR DESCRIPTION
This code do same things, but much more cleaner and understandable.

P. S. If someone think this will lead to perfomance degradation please forget all you know about reflections before PHP 5.3. You can make tests and compare ;)
