### PR TITLE
Add HTML whitespace remover

### DIFF
--- a/framework/yii/helpers/base/Html.php
+++ b/framework/yii/helpers/base/Html.php
@@ -1476,4 +1476,53 @@ class Html
 		$name = strtolower(static::getInputName($model, $attribute));
 		return str_replace(array('[]', '][', '[', ']', ' '), array('', '-', '-', '', '-'), $name);
 	}
+
+	/**
+	 * Removes whitespace characters between HTML tags. Whitespaces within HTML tags or in a plain text
+	 * are always kept untouched. This method must be used in a succession with [[endSpaceless()]].
+	 *
+	 * Usage example:
+	 * ```php
+	 * <body>
+	 *     <?php \yii\helpers\Html::spaceless(); ?>
+	 *         <div class="navbar">
+	 *             <!-- other tags -->
+	 *         </div>
+	 *         <div class="content">
+	 *             <!-- other tags -->
+	 *         </div>
+	 *     <?php \yii\helpers\Html::endSpaceless(); ?>
+	 * </body>
+	 * ```
+	 *
+	 * This example would generate the following HTML:
+	 * ```html
+	 * <body>
+	 *     <div class="navbar"><!-- other tags --></div><div class="content"><!-- other tags --></div></body>
+	 * ```
+	 *
+	 * This method is not designed for content compression (you should use `gzip` output compression to achieve it).
+	 * Main intention is to strip out extra whitespace characters between HTML tags in order to avoid browser
+	 * rendering quirks in some circumstances (e.g. newlines between inline-block elements).
+	 *
+	 * Note, never use this method with `pre` or `textarea` tags. It's not that easy to deal with such tags
+	 * as it may seem at first sight. For this case you should consider using
+	 * [HTML Tidy Project](http://tidy.sourceforge.net/) instead.
+	 *
+	 * @see http://tidy.sourceforge.net/
+	 */
+	public static function spaceless()
+	{
+		ob_start();
+		ob_implicit_flush(false);
+	}
+
+	/**
+	 * Call this method to specify the end of your area to be cleaned from whitespace characters.
+	 * @see spaceless
+	 */
+	public static function endSpaceless()
+	{
+		echo trim(preg_replace('/>\s+</', '><', ob_get_clean()));
+	}
 }

--- a/tests/unit/framework/helpers/HtmlTest.php
+++ b/tests/unit/framework/helpers/HtmlTest.php
@@ -463,4 +463,33 @@ EOD;
 			'value  2' => 'text  2',
 		);
 	}
+
+	public function testSpaceless()
+	{
+		ob_start();
+		ob_implicit_flush(false);
+
+		echo "<body>\n";
+		Html::spaceless();
+		echo "\t<div class='wrapper'>\n";
+
+		Html::spaceless();
+		echo "\t\t<div class='left-column'>\n";
+		echo "\t\t\t<p>This is a left bar!</p>\n";
+		echo "\t\t</div>\n\n";
+		echo "\t\t<div class='right-column'>\n";
+		echo "\t\t\t<p>This is a right bar!</p>\n";
+		echo "\t\t</div>\n";
+		Html::endSpaceless();
+
+		echo "\t</div>\n";
+		Html::endSpaceless();
+		echo "\t<p>Bye!</p>\n";
+		echo "</body>\n";
+
+		$this->assertEquals(
+			"<body>\n<div class='wrapper'><div class='left-column'><p>This is a left bar!</p></div><div class='right-column'><p>This is a right bar!</p></div></div>\t<p>Bye!</p>\n</body>\n",
+			ob_get_clean()
+		);
+	}
 }


### PR DESCRIPTION
Use case:

HTML document 1: http://resurtm.com/yii-stuff/spaceless-use-case-1.html
HTML document 2: http://resurtm.com/yii-stuff/spaceless-use-case-2.html

Diff between them:

```
$ diff spaceless-use-case-1.html spaceless-use-case-2.html
43c43,44
<               </div><div class="right">

---
>               </div>
>               <div class="right">
```

Patch provided in this PR would allow us to solve this problem as follows:

``` html
<?php \yii\helpers\Html::spaceless(); ?>
<body>
    <div class="wrapper">
        <div class="left">
            <ul>
                <li><a href="#">Posts</a></li>
                <li><a href="#">Users</a></li>
                <li><a href="#">Contact Us</a></li>
                <li><a href="#">Legal Notes</a></li>
            </ul>
        </div>

        <div class="right">
            <p>Even when the Xbox One is in sleep mode, its built-in microphone can always listen in. It’s a feature developers say will provide quick voice-command access to games and apps — but that could spook commanders who might worry the always-connected device could also capture more than just idle chit-chat among troops.</p>

            <p>“Microsoft has single handedly alienated the entire military. And not just the U.S. military — the militaries of the entire world,” says naval aviator Jay Johnson.</p>

            <p>The Internet connection requirement is “the single greatest sin Microsoft has committed against all service members,” he writes in a post on the game developers’ site Gamasutra.</p>

            <p>Sample text taken from here:<br/>http://www.navytimes.com/article/20130614/OFFDUTY02/306140030</p>
        </div>
    </div>
</body>
<?php \yii\helpers\Html::endSpaceless(); ?>
```
