### PR TITLE
Empty error message in Model::addError().

### DIFF
--- a/framework/yii/base/Model.php
+++ b/framework/yii/base/Model.php
@@ -494,7 +494,7 @@ class Model extends Component implements \IteratorAggregate, \ArrayAccess
 	 *             // IMPORTANT:
 	 *             // mark current model as having error, even if attributes of this model are
 	 *             // all valid; this is needed to preserve main model to be saved since related
-	 *             // visitors are invalid
+	 *             // visitors are invalid; error message is useless and meaningless here
 	 *             $this->addError('visitors');
 	 *         }
 	 *     }

--- a/framework/yii/base/Model.php
+++ b/framework/yii/base/Model.php
@@ -473,10 +473,36 @@ class Model extends Component implements \IteratorAggregate, \ArrayAccess
 
 	/**
 	 * Adds a new error to the specified attribute.
-	 * @param string $attribute attribute name
-	 * @param string $error new error message
+	 *
+	 * Second parameter's default value is `false`, meaning that no error message was given. Missing
+	 * error message could be used in the following situation: assume we're dealing with a model HTML
+	 * form which is not displaying any textual error information (e.g. error fields are highlighted
+	 * by color), and at the same time we're validating some attribute with [[InlineValidator]].
+	 * Our code would look something like this:
+	 *
+	 * ```php
+	 * class Venue extends Model
+	 * {
+	 *     public $address;
+	 *
+	 *     public function validateAddress()
+	 *     {
+	 *         if ($this->addressIsInvalid()) {
+	 *             // no error message specified since we're not displaying textual information about it
+	 *             $this->addError('address');
+	 *         }
+	 *     }
+	 * }
+	 * ```
+	 *
+	 * This feature of empty error message could also be used with relations to mark them
+	 * as having errors.
+	 *
+	 * @param string $attribute attribute name.
+	 * @param string|boolean $error new error message. Defaults to false meaning that no error message
+	 * was provided, i.e. empty message.
 	 */
-	public function addError($attribute, $error)
+	public function addError($attribute, $error = false)
 	{
 		$this->_errors[$attribute][] = $error;
 	}

--- a/framework/yii/base/Model.php
+++ b/framework/yii/base/Model.php
@@ -474,8 +474,7 @@ class Model extends Component implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * Adds a new error to the specified attribute.
 	 * @param string $attribute attribute name.
-	 * @param string|boolean $error new error message. Defaults to empty string meaning that
-	 * no error message was provided.
+	 * @param string $error new error message. Defaults to empty string.
 	 */
 	public function addError($attribute, $error = '')
 	{

--- a/framework/yii/base/Model.php
+++ b/framework/yii/base/Model.php
@@ -475,28 +475,31 @@ class Model extends Component implements \IteratorAggregate, \ArrayAccess
 	 * Adds a new error to the specified attribute.
 	 *
 	 * Second parameter's default value is `false`, meaning that no error message was given. Missing
-	 * error message could be used in the following situation: assume we're dealing with a model HTML
-	 * form which is not displaying any textual error information (e.g. error fields are highlighted
-	 * by color), and at the same time we're validating some attribute with [[InlineValidator]].
-	 * Our code would look something like this:
+	 * error message could be used in the following situation: assume we're dealing with cascade
+	 * validation and saving of related methods. Our sample code would look like as follows:
 	 *
 	 * ```php
-	 * class Venue extends Model
+	 * class Venue extends ActiveRecord
 	 * {
-	 *     public $address;
-	 *
-	 *     public function validateAddress()
+	 *     public function afterValidate()
 	 *     {
-	 *         if ($this->addressIsInvalid()) {
-	 *             // no error message specified since we're not displaying textual information about it
-	 *             $this->addError('address');
+	 *         parent::afterValidate();
+	 *
+	 *         // perform related visitors cascade validation
+	 *         $result = true;
+	 *         foreach ($this->visitors as $visitor) {
+	 *             $result = $visitor->validate() && $result;
+	 *         }
+	 *         if (!$result) {
+	 *             // IMPORTANT:
+	 *             // mark current model as having error, even if attributes of this model are
+	 *             // all valid; this is needed to preserve main model to be saved since related
+	 *             // visitors are invalid
+	 *             $this->addError('visitors');
 	 *         }
 	 *     }
 	 * }
 	 * ```
-	 *
-	 * This feature of empty error message could also be used with relations to mark them
-	 * as having errors.
 	 *
 	 * @param string $attribute attribute name.
 	 * @param string|boolean $error new error message. Defaults to false meaning that no error message

--- a/framework/yii/base/Model.php
+++ b/framework/yii/base/Model.php
@@ -473,39 +473,11 @@ class Model extends Component implements \IteratorAggregate, \ArrayAccess
 
 	/**
 	 * Adds a new error to the specified attribute.
-	 *
-	 * Second parameter's default value is `false`, meaning that no error message was given. Missing
-	 * error message could be used in the following situation: assume we're dealing with cascade
-	 * validation and saving of related methods. Our sample code would look like as follows:
-	 *
-	 * ```php
-	 * class Venue extends ActiveRecord
-	 * {
-	 *     public function afterValidate()
-	 *     {
-	 *         parent::afterValidate();
-	 *
-	 *         // perform related visitors cascade validation
-	 *         $result = true;
-	 *         foreach ($this->visitors as $visitor) {
-	 *             $result = $visitor->validate() && $result;
-	 *         }
-	 *         if (!$result) {
-	 *             // IMPORTANT:
-	 *             // mark current model as having error, even if attributes of this model are
-	 *             // all valid; this is needed to preserve main model to be saved since related
-	 *             // visitors are invalid; error message is useless and meaningless here
-	 *             $this->addError('visitors');
-	 *         }
-	 *     }
-	 * }
-	 * ```
-	 *
 	 * @param string $attribute attribute name.
-	 * @param string|boolean $error new error message. Defaults to false meaning that no error message
-	 * was provided, i.e. empty message.
+	 * @param string|boolean $error new error message. Defaults to empty string meaning that
+	 * no error message was provided.
 	 */
-	public function addError($attribute, $error = false)
+	public function addError($attribute, $error = '')
 	{
 		$this->_errors[$attribute][] = $error;
 	}


### PR DESCRIPTION
This can be useful to make [this sample code](https://gist.github.com/resurtm/5815403) even better. If you look at the `Product::afterValidate()` method you can see `$this->addError('orders', 'Orders are invalid!');` call. With patch provided in this PR it can be rewritten as `$this->addError('orders');`, which looks much better as we don't want/need to specify error message for the `orders` relation—our purpose is to mark main model as having errors.

I and @creocoder thought about introduction of returning boolean value in the `Model::afterValidate()` method but it seems as worse approach.
