### PR TITLE
[WIP?] Let ArrayHelper::getColumn behave like array_column

### DIFF
--- a/tests/unit/framework/helpers/ArrayHelperTest.php
+++ b/tests/unit/framework/helpers/ArrayHelperTest.php
@@ -2,141 +2,206 @@
 
 namespace yiiunit\framework\helpers;
 
+use yii\data\Sort;
 use yii\helpers\ArrayHelper;
 use yii\test\TestCase;
-use yii\data\Sort;
 
 class ArrayHelperTest extends TestCase
 {
 
-    protected function getDataForColumnTest()
-    {
-        return array(
-            array(
-                'id' => 2135,
-                'first_name' => 'John',
-                'last_name' => 'Doe',
-            ),
-            array(
-                'id' => 3245,
-                'first_name' => 'Sally',
-                'last_name' => 'Smith',
-            ),
-            array(
-                'id' => 5342,
-                'first_name' => 'Jane',
-                'last_name' => 'Jones',
-            ),
-            array(
-                'id' => 5623,
-                'first_name' => 'Peter',
-                'last_name' => 'Doe',
-            )
-        );
-    }
-    
-    public function testMerge()
-    {
+	public function testMerge()
+	{
 
 
-    }
+	}
 
-    public function testGetColumn()
-    {
-        $result = ArrayHelper::getColumn($this->getDataForColumnTest(), 'first_name');
-        $this->assertEquals(array('John', 'Sally', 'Jane', 'Peter'), $result, "Documented behaviour on php.net");
-        /* Missing functionality:
-        $result = ArrayHelper::getColumn($this->getDataForColumnTest(), 'first_name', 'id');
-        $this->assertEquals(array(2135 => 'John', 3245 => 'Sally', 5342 => 'Jane', 5623 => 'Peter'));
-        */
-    }
+	public function testGetColumn()
+	{
+		$this->assertEmpty(ArrayHelper::getColumn($this->getDataForColumnTest(), null)); //todo WIP
+		$result = ArrayHelper::getColumn($this->getDataForColumnTest(), 'first_name');
+		// default
+		$this->assertEquals(
+			array('John', 'Sally', 'Jane'),
+			$result,
+			"Documented behaviour on php.net / array_column_basic.phpt in php source"
+		);
+		// yii-specific
+		$result = ArrayHelper::getColumn($this->getDataForColumnTest2(), 'first_name', true);
+		$this->assertEquals(
+			array(2 => 'John', 3 => 'Sally', 4 => 'Jane'),
+			$result
+		);
+		/* Missing functionality: */
+		$result = ArrayHelper::getColumn($this->getDataForColumnTest(), 'first_name', 'id');
+		$this->assertEquals(array(1 => 'John', 2 => 'Sally', 3 => 'Jane'), $result);
+		$data = $this->getDataForColumnTest();
+		$result = ArrayHelper::getColumn($data, null, 'id');
+		$this->assertEquals(
+			array(1 => $data[0], 2 => $data[1], 3 => $data[2]),
+			$result,
+			"name: null behaviour => return full array"
+		);
+		if (version_compare(phpversion(), '5.5.0', '>=')) {
+			$should = array_column($this->getDataForColumnTest(), 'first_name');
+			$is = ArrayHelper::getColumn($this->getDataForColumnTest(), 'first_name');
+			$this->assertEquals($should, $is, "Comparing with official php implementation: default behaviour");
+			$should = array_column($this->getDataForColumnTest(), 'first_name', 'id');
+			$is = ArrayHelper::getColumn($this->getDataForColumnTest(), 'first_name', 'id');
+			$this->assertEquals($should, $is, "Comparing with official php implementation: index by field");
+			$should = array_column($this->getDataForColumnTest(), null, 'id');
+			$is = ArrayHelper::getColumn($this->getDataForColumnTest(), null, 'id');
+			$this->assertEquals($should, $is, "Comparing with official php implementation: nulled name");
+		}
 
-    public function testRemove()
-    {
-        $array = array('name' => 'b', 'age' => 3);
-        $name = ArrayHelper::remove($array, 'name');
+		// yii-specific: anonymous
+		$is = ArrayHelper::getColumn(
+			$this->getDataForColumnTest(),
+			function ($element) {
+				return $element['first_name'];
+			}
+		);
+		$should = array('John', 'Sally', 'Jane');
+		$this->assertEquals($should, $is);
+		// mixed together
+		$is = ArrayHelper::getColumn(
+			$this->getDataForColumnTest(),
+			function ($element) {
+				return $element['first_name'];
+			},
+			'id'
+		);
+		$should = array(1 => 'John', 2 => 'Sally', 3 => 'Jane');
+		$this->assertEquals($should, $is);
+	}
 
-        $this->assertEquals($name, 'b');
-        $this->assertEquals($array, array('age' => 3));
-    }
+	protected function getDataForColumnTest()
+	{
+		return array(
+			array(
+				'id' => 1,
+				'first_name' => 'John',
+				'last_name' => 'Doe'
+			),
+			array(
+				'id' => 2,
+				'first_name' => 'Sally',
+				'last_name' => 'Smith'
+			),
+			array(
+				'id' => 3,
+				'first_name' => 'Jane',
+				'last_name' => 'Jones'
+			)
+		);
+	}
 
-    public function testMultisort()
-    {
-        // single key
-        $array = array(
-            array('name' => 'b', 'age' => 3),
-            array('name' => 'a', 'age' => 1),
-            array('name' => 'c', 'age' => 2),
-        );
-        ArrayHelper::multisort($array, 'name');
-        $this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
-        $this->assertEquals(array('name' => 'b', 'age' => 3), $array[1]);
-        $this->assertEquals(array('name' => 'c', 'age' => 2), $array[2]);
+	protected function getDataForColumnTest2()
+	{
+		return array(
+			2 => array(
+				'id' => 1,
+				'first_name' => 'John',
+				'last_name' => 'Doe'
+			),
+			3 => array(
+				'id' => 2,
+				'first_name' => 'Sally',
+				'last_name' => 'Smith'
+			),
+			4 => array(
+				'id' => 3,
+				'first_name' => 'Jane',
+				'last_name' => 'Jones'
+			)
+		);
+	}
 
-        // multiple keys
-        $array = array(
-            array('name' => 'b', 'age' => 3),
-            array('name' => 'a', 'age' => 2),
-            array('name' => 'a', 'age' => 1),
-        );
-        ArrayHelper::multisort($array, array('name', 'age'));
-        $this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
-        $this->assertEquals(array('name' => 'a', 'age' => 2), $array[1]);
-        $this->assertEquals(array('name' => 'b', 'age' => 3), $array[2]);
+	public function testRemove()
+	{
+		$array = array('name' => 'b', 'age' => 3);
+		$name = ArrayHelper::remove($array, 'name');
 
-        // case-insensitive
-        $array = array(
-            array('name' => 'a', 'age' => 3),
-            array('name' => 'b', 'age' => 2),
-            array('name' => 'B', 'age' => 4),
-            array('name' => 'A', 'age' => 1),
-        );
+		$this->assertEquals($name, 'b');
+		$this->assertEquals($array, array('age' => 3));
+	}
 
-        ArrayHelper::multisort($array, array('name', 'age'), false, array(SORT_STRING, SORT_REGULAR));
-        $this->assertEquals(array('name' => 'A', 'age' => 1), $array[0]);
-        $this->assertEquals(array('name' => 'B', 'age' => 4), $array[1]);
-        $this->assertEquals(array('name' => 'a', 'age' => 3), $array[2]);
-        $this->assertEquals(array('name' => 'b', 'age' => 2), $array[3]);
+	public function testMultisort()
+	{
+		// single key
+		$array = array(
+			array('name' => 'b', 'age' => 3),
+			array('name' => 'a', 'age' => 1),
+			array('name' => 'c', 'age' => 2),
+		);
+		ArrayHelper::multisort($array, 'name');
+		$this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
+		$this->assertEquals(array('name' => 'b', 'age' => 3), $array[1]);
+		$this->assertEquals(array('name' => 'c', 'age' => 2), $array[2]);
 
-        ArrayHelper::multisort($array, array('name', 'age'), false, array(SORT_STRING, SORT_REGULAR), false);
-        $this->assertEquals(array('name' => 'A', 'age' => 1), $array[0]);
-        $this->assertEquals(array('name' => 'a', 'age' => 3), $array[1]);
-        $this->assertEquals(array('name' => 'b', 'age' => 2), $array[2]);
-        $this->assertEquals(array('name' => 'B', 'age' => 4), $array[3]);
-    }
+		// multiple keys
+		$array = array(
+			array('name' => 'b', 'age' => 3),
+			array('name' => 'a', 'age' => 2),
+			array('name' => 'a', 'age' => 1),
+		);
+		ArrayHelper::multisort($array, array('name', 'age'));
+		$this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
+		$this->assertEquals(array('name' => 'a', 'age' => 2), $array[1]);
+		$this->assertEquals(array('name' => 'b', 'age' => 3), $array[2]);
 
-    public function testMultisortUseSort()
-    {
-        // single key
-        $sort = new Sort();
-        $sort->attributes = array('name', 'age');
-        $sort->defaults = array('name' => Sort::ASC);
-        $orders = $sort->getOrders();
+		// case-insensitive
+		$array = array(
+			array('name' => 'a', 'age' => 3),
+			array('name' => 'b', 'age' => 2),
+			array('name' => 'B', 'age' => 4),
+			array('name' => 'A', 'age' => 1),
+		);
 
-        $array = array(
-            array('name' => 'b', 'age' => 3),
-            array('name' => 'a', 'age' => 1),
-            array('name' => 'c', 'age' => 2),
-        );
-        ArrayHelper::multisort($array, array_keys($orders), array_values($orders));
-        $this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
-        $this->assertEquals(array('name' => 'b', 'age' => 3), $array[1]);
-        $this->assertEquals(array('name' => 'c', 'age' => 2), $array[2]);
+		ArrayHelper::multisort($array, array('name', 'age'), false, array(SORT_STRING, SORT_REGULAR));
+		$this->assertEquals(array('name' => 'A', 'age' => 1), $array[0]);
+		$this->assertEquals(array('name' => 'B', 'age' => 4), $array[1]);
+		$this->assertEquals(array('name' => 'a', 'age' => 3), $array[2]);
+		$this->assertEquals(array('name' => 'b', 'age' => 2), $array[3]);
 
-        // multiple keys
-        $sort = new Sort();
-        $sort->attributes = array('name', 'age');
-        $sort->defaults = array('name' => Sort::ASC, 'age' => Sort::DESC);
-        $orders = $sort->getOrders();
+		ArrayHelper::multisort($array, array('name', 'age'), false, array(SORT_STRING, SORT_REGULAR), false);
+		$this->assertEquals(array('name' => 'A', 'age' => 1), $array[0]);
+		$this->assertEquals(array('name' => 'a', 'age' => 3), $array[1]);
+		$this->assertEquals(array('name' => 'b', 'age' => 2), $array[2]);
+		$this->assertEquals(array('name' => 'B', 'age' => 4), $array[3]);
+	}
 
-        $array = array(
-            array('name' => 'b', 'age' => 3),
-            array('name' => 'a', 'age' => 2),
-            array('name' => 'a', 'age' => 1),
-        );
-        ArrayHelper::multisort($array, array_keys($orders), array_values($orders));
-        $this->assertEquals(array('name' => 'a', 'age' => 2), $array[0]);
-        $this->assertEquals(array('name' => 'a', 'age' => 1), $array[1]);
-        $this->assertEquals(array('name' => 'b', 'age' => 3), $array[2]);
-    }
+	public function testMultisortUseSort()
+	{
+		// single key
+		$sort = new Sort();
+		$sort->attributes = array('name', 'age');
+		$sort->defaults = array('name' => Sort::ASC);
+		$orders = $sort->getOrders();
+
+		$array = array(
+			array('name' => 'b', 'age' => 3),
+			array('name' => 'a', 'age' => 1),
+			array('name' => 'c', 'age' => 2),
+		);
+		ArrayHelper::multisort($array, array_keys($orders), array_values($orders));
+		$this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
+		$this->assertEquals(array('name' => 'b', 'age' => 3), $array[1]);
+		$this->assertEquals(array('name' => 'c', 'age' => 2), $array[2]);
+
+		// multiple keys
+		$sort = new Sort();
+		$sort->attributes = array('name', 'age');
+		$sort->defaults = array('name' => Sort::ASC, 'age' => Sort::DESC);
+		$orders = $sort->getOrders();
+
+		$array = array(
+			array('name' => 'b', 'age' => 3),
+			array('name' => 'a', 'age' => 2),
+			array('name' => 'a', 'age' => 1),
+		);
+		ArrayHelper::multisort($array, array_keys($orders), array_values($orders));
+		$this->assertEquals(array('name' => 'a', 'age' => 2), $array[0]);
+		$this->assertEquals(array('name' => 'a', 'age' => 1), $array[1]);
+		$this->assertEquals(array('name' => 'b', 'age' => 3), $array[2]);
+	}
 }

--- a/tests/unit/framework/helpers/ArrayHelperTest.php
+++ b/tests/unit/framework/helpers/ArrayHelperTest.php
@@ -8,99 +8,135 @@ use yii\data\Sort;
 
 class ArrayHelperTest extends TestCase
 {
-	public function testMerge()
-	{
+
+    protected function getDataForColumnTest()
+    {
+        return array(
+            array(
+                'id' => 2135,
+                'first_name' => 'John',
+                'last_name' => 'Doe',
+            ),
+            array(
+                'id' => 3245,
+                'first_name' => 'Sally',
+                'last_name' => 'Smith',
+            ),
+            array(
+                'id' => 5342,
+                'first_name' => 'Jane',
+                'last_name' => 'Jones',
+            ),
+            array(
+                'id' => 5623,
+                'first_name' => 'Peter',
+                'last_name' => 'Doe',
+            )
+        );
+    }
+    
+    public function testMerge()
+    {
 
 
-	}
+    }
 
-	public function testRemove()
-	{
-		$array = array('name' => 'b', 'age' => 3);
-		$name = ArrayHelper::remove($array, 'name');
+    public function testGetColumn()
+    {
+        $result = ArrayHelper::getColumn($this->getDataForColumnTest(), 'first_name');
+        $this->assertEquals(array('John', 'Sally', 'Jane', 'Peter'), $result, "Documented behaviour on php.net");
+        /* Missing functionality:
+        $result = ArrayHelper::getColumn($this->getDataForColumnTest(), 'first_name', 'id');
+        $this->assertEquals(array(2135 => 'John', 3245 => 'Sally', 5342 => 'Jane', 5623 => 'Peter'));
+        */
+    }
 
-		$this->assertEquals($name, 'b');
-		$this->assertEquals($array, array('age' => 3));
-	}
+    public function testRemove()
+    {
+        $array = array('name' => 'b', 'age' => 3);
+        $name = ArrayHelper::remove($array, 'name');
 
+        $this->assertEquals($name, 'b');
+        $this->assertEquals($array, array('age' => 3));
+    }
 
-	public function testMultisort()
-	{
-		// single key
-		$array = array(
-			array('name' => 'b', 'age' => 3),
-			array('name' => 'a', 'age' => 1),
-			array('name' => 'c', 'age' => 2),
-		);
-		ArrayHelper::multisort($array, 'name');
-		$this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
-		$this->assertEquals(array('name' => 'b', 'age' => 3), $array[1]);
-		$this->assertEquals(array('name' => 'c', 'age' => 2), $array[2]);
+    public function testMultisort()
+    {
+        // single key
+        $array = array(
+            array('name' => 'b', 'age' => 3),
+            array('name' => 'a', 'age' => 1),
+            array('name' => 'c', 'age' => 2),
+        );
+        ArrayHelper::multisort($array, 'name');
+        $this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
+        $this->assertEquals(array('name' => 'b', 'age' => 3), $array[1]);
+        $this->assertEquals(array('name' => 'c', 'age' => 2), $array[2]);
 
-		// multiple keys
-		$array = array(
-			array('name' => 'b', 'age' => 3),
-			array('name' => 'a', 'age' => 2),
-			array('name' => 'a', 'age' => 1),
-		);
-		ArrayHelper::multisort($array, array('name', 'age'));
-		$this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
-		$this->assertEquals(array('name' => 'a', 'age' => 2), $array[1]);
-		$this->assertEquals(array('name' => 'b', 'age' => 3), $array[2]);
+        // multiple keys
+        $array = array(
+            array('name' => 'b', 'age' => 3),
+            array('name' => 'a', 'age' => 2),
+            array('name' => 'a', 'age' => 1),
+        );
+        ArrayHelper::multisort($array, array('name', 'age'));
+        $this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
+        $this->assertEquals(array('name' => 'a', 'age' => 2), $array[1]);
+        $this->assertEquals(array('name' => 'b', 'age' => 3), $array[2]);
 
-		// case-insensitive
-		$array = array(
-			array('name' => 'a', 'age' => 3),
-			array('name' => 'b', 'age' => 2),
-			array('name' => 'B', 'age' => 4),
-			array('name' => 'A', 'age' => 1),
-		);
+        // case-insensitive
+        $array = array(
+            array('name' => 'a', 'age' => 3),
+            array('name' => 'b', 'age' => 2),
+            array('name' => 'B', 'age' => 4),
+            array('name' => 'A', 'age' => 1),
+        );
 
-		ArrayHelper::multisort($array, array('name', 'age'), false, array(SORT_STRING, SORT_REGULAR));
-		$this->assertEquals(array('name' => 'A', 'age' => 1), $array[0]);
-		$this->assertEquals(array('name' => 'B', 'age' => 4), $array[1]);
-		$this->assertEquals(array('name' => 'a', 'age' => 3), $array[2]);
-		$this->assertEquals(array('name' => 'b', 'age' => 2), $array[3]);
+        ArrayHelper::multisort($array, array('name', 'age'), false, array(SORT_STRING, SORT_REGULAR));
+        $this->assertEquals(array('name' => 'A', 'age' => 1), $array[0]);
+        $this->assertEquals(array('name' => 'B', 'age' => 4), $array[1]);
+        $this->assertEquals(array('name' => 'a', 'age' => 3), $array[2]);
+        $this->assertEquals(array('name' => 'b', 'age' => 2), $array[3]);
 
-		ArrayHelper::multisort($array, array('name', 'age'), false, array(SORT_STRING, SORT_REGULAR), false);
-		$this->assertEquals(array('name' => 'A', 'age' => 1), $array[0]);
-		$this->assertEquals(array('name' => 'a', 'age' => 3), $array[1]);
-		$this->assertEquals(array('name' => 'b', 'age' => 2), $array[2]);
-		$this->assertEquals(array('name' => 'B', 'age' => 4), $array[3]);
-	}
+        ArrayHelper::multisort($array, array('name', 'age'), false, array(SORT_STRING, SORT_REGULAR), false);
+        $this->assertEquals(array('name' => 'A', 'age' => 1), $array[0]);
+        $this->assertEquals(array('name' => 'a', 'age' => 3), $array[1]);
+        $this->assertEquals(array('name' => 'b', 'age' => 2), $array[2]);
+        $this->assertEquals(array('name' => 'B', 'age' => 4), $array[3]);
+    }
 
-	public function testMultisortUseSort()
-	{
-		// single key
-		$sort = new Sort();
-		$sort->attributes = array('name', 'age');
-		$sort->defaults = array('name' => Sort::ASC);
-		$orders = $sort->getOrders();
+    public function testMultisortUseSort()
+    {
+        // single key
+        $sort = new Sort();
+        $sort->attributes = array('name', 'age');
+        $sort->defaults = array('name' => Sort::ASC);
+        $orders = $sort->getOrders();
 
-		$array = array(
-			array('name' => 'b', 'age' => 3),
-			array('name' => 'a', 'age' => 1),
-			array('name' => 'c', 'age' => 2),
-		);
-		ArrayHelper::multisort($array, array_keys($orders), array_values($orders));
-		$this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
-		$this->assertEquals(array('name' => 'b', 'age' => 3), $array[1]);
-		$this->assertEquals(array('name' => 'c', 'age' => 2), $array[2]);
+        $array = array(
+            array('name' => 'b', 'age' => 3),
+            array('name' => 'a', 'age' => 1),
+            array('name' => 'c', 'age' => 2),
+        );
+        ArrayHelper::multisort($array, array_keys($orders), array_values($orders));
+        $this->assertEquals(array('name' => 'a', 'age' => 1), $array[0]);
+        $this->assertEquals(array('name' => 'b', 'age' => 3), $array[1]);
+        $this->assertEquals(array('name' => 'c', 'age' => 2), $array[2]);
 
-		// multiple keys
-		$sort = new Sort();
-		$sort->attributes = array('name', 'age');
-		$sort->defaults = array('name' => Sort::ASC, 'age' => Sort::DESC);
-		$orders = $sort->getOrders();
+        // multiple keys
+        $sort = new Sort();
+        $sort->attributes = array('name', 'age');
+        $sort->defaults = array('name' => Sort::ASC, 'age' => Sort::DESC);
+        $orders = $sort->getOrders();
 
-		$array = array(
-			array('name' => 'b', 'age' => 3),
-			array('name' => 'a', 'age' => 2),
-			array('name' => 'a', 'age' => 1),
-		);
-		ArrayHelper::multisort($array, array_keys($orders), array_values($orders));
-		$this->assertEquals(array('name' => 'a', 'age' => 2), $array[0]);
-		$this->assertEquals(array('name' => 'a', 'age' => 1), $array[1]);
-		$this->assertEquals(array('name' => 'b', 'age' => 3), $array[2]);
-	}
+        $array = array(
+            array('name' => 'b', 'age' => 3),
+            array('name' => 'a', 'age' => 2),
+            array('name' => 'a', 'age' => 1),
+        );
+        ArrayHelper::multisort($array, array_keys($orders), array_values($orders));
+        $this->assertEquals(array('name' => 'a', 'age' => 2), $array[0]);
+        $this->assertEquals(array('name' => 'a', 'age' => 1), $array[1]);
+        $this->assertEquals(array('name' => 'b', 'age' => 3), $array[2]);
+    }
 }

--- a/tests/unit/framework/helpers/ArrayHelperTest.php
+++ b/tests/unit/framework/helpers/ArrayHelperTest.php
@@ -17,7 +17,7 @@ class ArrayHelperTest extends TestCase
 
 	public function testGetColumn()
 	{
-		$this->assertEmpty(ArrayHelper::getColumn($this->getDataForColumnTest(), null)); //todo WIP
+		$this->assertFalse(ArrayHelper::getColumn($this->getDataForColumnTest(), null)); //todo WIP
 		$result = ArrayHelper::getColumn($this->getDataForColumnTest(), 'first_name');
 		// default
 		$this->assertEquals(


### PR DESCRIPTION
This should ArrayHelper::getColumn behave as the PHP 5.5 function array_column.

However, I'm not sure if php default behaviour should be kept or changed (as we have additional functionality).
Nativly, if second parameter is null and thrid is not set, the entire array is returned. This pr returns false instead.

http://php.net/manual/en/function.array-column.php
