### PR TITLE
allow rendering ActiveField without surrounding tag

### DIFF
--- a/framework/yii/widgets/ActiveField.php
+++ b/framework/yii/widgets/ActiveField.php
@@ -33,6 +33,7 @@ class ActiveField extends Component
 	public $attribute;
 	/**
 	 * @var string the tag name for the field container.
+	 * When setting this to `false` no tag will be rendered.
 	 */
 	public $tag = 'div';
 	/**
@@ -114,6 +115,10 @@ class ActiveField extends Component
 			$this->form->attributes[$this->attribute] = $options;
 		}
 
+		if ($this->tag === false) {
+			return '';
+		}
+
 		$inputID = Html::getInputId($this->model, $this->attribute);
 		$attribute = Html::getAttributeName($this->attribute);
 		$options = $this->options;
@@ -136,7 +141,11 @@ class ActiveField extends Component
 	 */
 	public function end()
 	{
-		return Html::endTag($this->tag);
+		if ($this->tag === false) {
+			return '';
+		} else {
+			return Html::endTag($this->tag);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Example use case:
In tabular input I want to put two fields in one `td` for example quantity and a dropdown for quantity unit:

``` php
<tr>
    <?php $options = array(
        'tag' => 'td',
        'template' => "{input}\n{error}",
    ); ?>
    <?php echo $form->field($item, "[$i]posNr", $options)->textInput(); ?>
    <td>
        <?php echo $form->field($item, "[$i]quantity", array(
            'tag' => false,
            'template' => "{input}\n{error}",
        ))->textInput();
        echo $form->field($item, "[$i]quantityUnit", array(
            'tag' => false,
            'template' => "{input}\n{error}",
        ))->dropDownList($item->getQuantitiyUnits()); ?>
    </td>
    <?php echo $form->field($item, "[$i]description", $options)->textarea(); ?>
</tr>
```
