### PR TITLE
Add support for VersionEye dependency tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you are looking for a production-ready PHP framework, please use
 Yii 2.0 is still under heavy development. We may make significant changes
 without prior notices. **Yii 2.0 is not ready for production use yet.**
 
-[![Build Status](https://secure.travis-ci.org/yiisoft/yii2.png)](http://travis-ci.org/yiisoft/yii2)
+[![Build Status](https://secure.travis-ci.org/yiisoft/yii2.png)](http://travis-ci.org/yiisoft/yii2)[![Dependency Status](https://www.versioneye.com/php/yiisoft:yii2/dev-master/badge.png)](https://www.versioneye.com/php/yiisoft:yii2/dev-master)
 
 
 DIRECTORY STRUCTURE

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you are looking for a production-ready PHP framework, please use
 Yii 2.0 is still under heavy development. We may make significant changes
 without prior notices. **Yii 2.0 is not ready for production use yet.**
 
-[![Build Status](https://secure.travis-ci.org/yiisoft/yii2.png)](http://travis-ci.org/yiisoft/yii2)[![Dependency Status](https://www.versioneye.com/php/yiisoft:yii2/dev-master/badge.png)](https://www.versioneye.com/php/yiisoft:yii2/dev-master)
+[![Build Status](https://secure.travis-ci.org/yiisoft/yii2.png)](http://travis-ci.org/yiisoft/yii2) [![Dependency Status](https://www.versioneye.com/php/yiisoft:yii2/dev-master/badge.png)](https://www.versioneye.com/php/yiisoft:yii2/dev-master)
 
 
 DIRECTORY STRUCTURE


### PR DESCRIPTION
This pr adds support for the [VersionEye](https://www.versioneye.com/) dependency tracking service. It'll show as a button in the readme quite similar to Travis CI. VersionEye builds dependency graphs via found composer.json files in this very case, so no further steps are required on the side of Yii devs.
