### PR TITLE
DetailView example usage consistent with other widgets [skip ci]

### DIFF
--- a/framework/yii/widgets/DetailView.php
+++ b/framework/yii/widgets/DetailView.php
@@ -30,7 +30,7 @@ use yii\helpers\Inflector;
  * A typical usage of DetailView is as follows:
  *
  * ~~~
- * \yii\widgets\DetailView::widget(array(
+ * echo DetailView::widget(array(
  *     'model' => $model,
  *     'attributes' => array(
  *         'title',             // title attribute (in plain text)
@@ -90,7 +90,7 @@ class DetailView extends Widget
 	 * @var array the HTML attributes for the container tag of this widget. The "tag" option specifies
 	 * what container tag should be used. It defaults to "table" if not set.
 	 */
-	public $options = array('class' => 'table table-striped');
+	public $options = array('class' => 'table table-striped table-bordered');
 	/**
 	 * @var array|Formatter the formatter used to format model attribute values into displayable texts.
 	 * This can be either an instance of [[Formatter]] or an configuration array for creating the [[Formatter]]


### PR DESCRIPTION
Also added table-bordered class to default classes, because I think a detailed view works as a unit and it helps to separate it to other blocks in the page...
