### PR TITLE
Added coverage status button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you are looking for a production-ready PHP framework, please use
 Yii 2.0 is still under heavy development. We may make significant changes
 without prior notices. **Yii 2.0 is not ready for production use yet.**
 
-[![Build Status](https://secure.travis-ci.org/yiisoft/yii2.png)](http://travis-ci.org/yiisoft/yii2) [![Dependency Status](https://www.versioneye.com/php/yiisoft:yii2/dev-master/badge.png)](https://www.versioneye.com/php/yiisoft:yii2/dev-master)
+[![Build Status](https://secure.travis-ci.org/yiisoft/yii2.png)](http://travis-ci.org/yiisoft/yii2) [![Coverage Status](https://coveralls.io/repos/yiisoft/yii2/badge.png?branch=master)](https://coveralls.io/r/yiisoft/yii2?branch=master) [![Dependency Status](https://www.versioneye.com/php/yiisoft:yii2/dev-master/badge.png)](https://www.versioneye.com/php/yiisoft:yii2/dev-master)
 
 
 DIRECTORY STRUCTURE


### PR DESCRIPTION
This is a follow-up to #665 and #678, adding the coveralls.io status button to the `readme.md`. As @suralc pointed out, it might be advisable to wait a bit until coverage has been increased before merging this pr in :wink: 

For reference, the current status is this: [![Coverage Status](https://coveralls.io/repos/yiisoft/yii2/badge.png?branch=master)](https://coveralls.io/r/yiisoft/yii2?branch=master)
