### PR TITLE
A simple patch to get AspectMock and Go Aop working with Yii2

### DIFF
--- a/framework/yii/helpers/SecurityBase.php
+++ b/framework/yii/helpers/SecurityBase.php
@@ -120,7 +120,10 @@ class SecurityBase
 		static $keys;
 		$keyFile = Yii::$app->getRuntimePath() . '/keys.php';
 		if ($keys === null) {
-			$keys = is_file($keyFile) ? require($keyFile) : array();
+            		$keys = array();
+			if (is_file($keyFile)) {
+                		$keys = require($keyFile);
+            		}
 		}
 		if (!isset($keys[$name])) {
 			$keys[$name] = static::generateRandomKey($length);

--- a/framework/yii/helpers/SecurityBase.php
+++ b/framework/yii/helpers/SecurityBase.php
@@ -120,10 +120,10 @@ class SecurityBase
 		static $keys;
 		$keyFile = Yii::$app->getRuntimePath() . '/keys.php';
 		if ($keys === null) {
-            $keys = array();
+			$keys = array();
 			if (is_file($keyFile)) {
-             	$keys = require($keyFile);
-            }
+				$keys = require($keyFile);
+			}
 		}
 		if (!isset($keys[$name])) {
 			$keys[$name] = static::generateRandomKey($length);

--- a/framework/yii/helpers/SecurityBase.php
+++ b/framework/yii/helpers/SecurityBase.php
@@ -120,10 +120,10 @@ class SecurityBase
 		static $keys;
 		$keyFile = Yii::$app->getRuntimePath() . '/keys.php';
 		if ($keys === null) {
-            		$keys = array();
+            $keys = array();
 			if (is_file($keyFile)) {
-                		$keys = require($keyFile);
-            		}
+             	$keys = require($keyFile);
+            }
 		}
 		if (!isset($keys[$name])) {
 			$keys[$name] = static::generateRandomKey($length);


### PR DESCRIPTION
This is a very tiny patch that changes nothing in code logic, but is required to get [AspectMock](https://github.com/Codeception/AspectMock) and Go Aop working with Yii2. 

Go Aop is processing all `include` and `require` directives, replacing them with its filters. Unfortunately it doesn't play well with one-liners. So I had to break the code into few lines to get that working. 

I was trying to fix this issue in [Go Aop](https://github.com/lisachenko/go-aop-php/pull/78) but looks like, the only option is to fix that in Yii2.

AspectMock can dramaticly improve unit testing in Yii2, and I plan to do a blogpost with tutorial about it.
