### PR TITLE
fixes initializing attributes in Sort class

### DIFF
--- a/framework/yii/data/Sort.php
+++ b/framework/yii/data/Sort.php
@@ -203,6 +203,8 @@ class Sort extends Object
 					'desc' => array($name => self::DESC),
 					'label' => Inflector::camel2words($name),
 				), $attribute);
+			} else {
+				$attributes[$name] = $attribute;
 			}
 		}
 		$this->attributes = $attributes;


### PR DESCRIPTION
If you set all the parameters of sorting...

``` php
 'age' => array(
     'asc' => array('age' => Sort::ASC),
     'desc' => array('age' => Sort::DESC),
     'default' => Sort::ASC,
     'label' => Inflector::camel2words('age'),
 )
```

then this element will not get into the final configuration array
