### PR TITLE
Fixed autoloader behavior according to leading \

### DIFF
--- a/framework/yii/YiiBase.php
+++ b/framework/yii/YiiBase.php
@@ -341,15 +341,13 @@ class YiiBase
 	 * 4. Search PHP include_path for the actual class file if [[enableIncludePath]] is true;
 	 * 5. Return false so that other autoloaders have chance to include the class file.
 	 *
-	 * @param string $className class name
+	 * @param string $className the fully qualified class name without leading \
 	 * @return boolean whether the class has been loaded successfully
 	 * @throws InvalidConfigException if the class file does not exist
 	 * @throws UnknownClassException if the class does not exist in the class file
 	 */
 	public static function autoload($className)
 	{
-		$className = ltrim($className, '\\');
-
 		if (isset(self::$classMap[$className])) {
 			$classFile = self::$classMap[$className];
 			if ($classFile[0] === '@') {


### PR DESCRIPTION
As of PHP 5.3.2, PHP does not send class names with leading \ to
autoload functions.

Removed ltrim for '/' from autoload because it is
1. not needed: https://bugs.php.net/bug.php?id=50731 and
2. possibly wrong behavior: https://bugs.php.net/bug.php?id=51087
