### PR TITLE
Login url fix when called from a module [skip ci]

### DIFF
--- a/framework/yii/web/User.php
+++ b/framework/yii/web/User.php
@@ -45,12 +45,12 @@ class User extends Component
 	 * the name-value pairs are GET parameters used to construct the login URL. For example,
 	 *
 	 * ~~~
-	 * array('site/login', 'ref' => 1)
+	 * array('/site/login', 'ref' => 1)
 	 * ~~~
 	 *
 	 * If this property is null, a 403 HTTP exception will be raised when [[loginRequired()]] is called.
 	 */
-	public $loginUrl = array('site/login');
+	public $loginUrl = array('/site/login');
 	/**
 	 * @var array the configuration of the identity cookie. This property is used only when [[enableAutoLogin]] is true.
 	 * @see Cookie


### PR DESCRIPTION
If a request is denied (with access control behavior) in a module called for example `admin`, the login page fails because it tries to get, for example: `http://localhost/yii-app/index.php/admin/site/login`.
