### PR TITLE
Fix function argument

### DIFF
--- a/framework/yii/widgets/Menu.php
+++ b/framework/yii/widgets/Menu.php
@@ -250,7 +250,7 @@ class Menu extends Widget
 			}
 			$hasActiveChild = false;
 			if (isset($item['items'])) {
-				$items[$i]['items'] = $this->normalizeItems($item['items'], $route, $hasActiveChild);
+				$items[$i]['items'] = $this->normalizeItems($item['items'], $hasActiveChild);
 				if (empty($items[$i]['items']) && $this->hideEmptyItems) {
 					unset($items[$i]['items']);
 					if (!isset($item['url'])) {


### PR DESCRIPTION
``` php
normalizeItems($items, &$active)
```

Qiang use 

``` php
$items[$i]['items'] = $this->normalizeItems($item['items'], $route, $hasActiveChild);
```

So $hasActiveChild not assign value and parent item not set activated

Plz, review and approval

Thanks
