### PR TITLE
Missing SemiKolon in module generator module template

### DIFF
--- a/framework/yii/gii/generators/module/templates/module.php
+++ b/framework/yii/gii/generators/module/templates/module.php
@@ -13,7 +13,7 @@ $className = substr($className, $pos + 1);
 echo "<?php\n";
 ?>
 
-namespace <?php echo $ns; ?>
+namespace <?php echo $ns; ?>;
 
 
 class <?php echo $className; ?> extends \yii\web\Module


### PR DESCRIPTION
missing semikolon after namespace in module template
