### PR TITLE
Allow specifying related data in a gridview data column

### DIFF
--- a/framework/yii/helpers/ArrayHelperBase.php
+++ b/framework/yii/helpers/ArrayHelperBase.php
@@ -149,7 +149,15 @@ class ArrayHelperBase
 	{
 		if ($key instanceof \Closure) {
 			return $key($array, $default);
-		} elseif (is_array($array)) {
+		}
+		if (($pos = strrpos($key, '.')) !== false) {
+			$array = static::getValue($array, substr($key, 0, $pos));
+			if ($array === null) {
+				return $default;
+			}
+			$key = substr($key, $pos + 1);
+		}
+		if (is_array($array)) {
 			return isset($array[$key]) || array_key_exists($key, $array) ? $array[$key] : $default;
 		} else {
 			return $array->$key;

--- a/tests/unit/framework/helpers/ArrayHelperTest.php
+++ b/tests/unit/framework/helpers/ArrayHelperTest.php
@@ -150,4 +150,50 @@ class ArrayHelperTest extends TestCase
 		$this->assertEquals(array('name' => 'a', 'age' => 1), $array[1]);
 		$this->assertEquals(array('name' => 'b', 'age' => 3), $array[2]);
 	}
+
+	public function valueProvider()
+	{
+		return array(
+			array('name', 'test'),
+			array('noname', null),
+			array('noname', 'test', 'test'),
+			array('post.id', 5),
+			array('post.id', 5, 'test'),
+			array('nopost.id', null),
+			array('nopost.id', 'test', 'test'),
+			array('post.author.name', 'cebe'),
+			array('post.author.noname', null),
+			array('post.author.noname', 'test', 'test'),
+			array('post.author.profile.title', '1337'),
+			array(function($array, $defaultValue) {
+				return $array['date'] . $defaultValue;
+			}, '31-12-2113test', 'test'),
+		);
+	}
+
+	/**
+	 * @dataProvider valueProvider
+	 *
+	 * @param $key
+	 * @param $expected
+	 * @param null $default
+	 */
+	public function testGetValue($key, $expected, $default=null)
+	{
+		$array = array(
+			'name' => 'test',
+			'date' => '31-12-2113',
+			'post' => array(
+				'id' => 5,
+				'author' => array(
+					'name' => 'cebe',
+					'profile' => array(
+						'title' => '1337',
+					),
+				),
+			),
+		);
+
+		$this->assertEquals($expected, ArrayHelper::getValue($array, $key, $default));
+	}
 }


### PR DESCRIPTION
DataColumn uses ArrayHelper::getValue() which is now able to get related
data via `relation.attribute` syntax.

This feature was available in yii 1.1. and should also be in 2.0 imo

TODO:
- [ ] Documentation (will add docs when we agree to take this)
