### PR TITLE
Bug in XML format

### DIFF
--- a/framework/yii/web/Response.php
+++ b/framework/yii/web/Response.php
@@ -771,7 +771,7 @@ class Response extends \yii\base\Response
 					}
 					break;
 				case self::FORMAT_XML:
-					$this->content = Yii::createObject(XmlResponseFormatter::className())->format($this);
+					Yii::createObject(XmlResponseFormatter::className())->format($this);
 					break;
 				default:
 					throw new InvalidConfigException("Unsupported response format: {$this->format}");


### PR DESCRIPTION
Variable $this->content is empty, because method XmlResponseFormatter::format() does not return a result.
