### PR TITLE
YII DEBUGGER: Replace double backslashes with one in action [skip ci]

### DIFF
--- a/framework/yii/debug/panels/RequestPanel.php
+++ b/framework/yii/debug/panels/RequestPanel.php
@@ -151,7 +151,7 @@ EOD;
 		}
 		$rows = array();
 		foreach ($values as $name => $value) {
-			$rows[] = '<tr><th style="width: 200px;">' . Html::encode($name) . '</th><td>' . Html::encode(var_export($value, true)) . '</td></tr>';
+			$rows[] = '<tr><th style="width: 200px;">' . Html::encode($name) . '</th><td>' . Html::encode(stripslashes(var_export($value, true))) . '</td></tr>';
 		}
 		$rows = implode("\n", $rows);
 		return <<<EOD


### PR DESCRIPTION
In Routing table, `action` shows with two backslashes (because var_export).
Same in other places.
Not sure if this change affects negatively other values.

Also, there is an overflow problem with the COOKIES table when cookie name is long (200px can't seem enough).

![yii debugger 2013-08-24 15-37-38](https://f.cloud.github.com/assets/374554/1021217/4deee50a-0cec-11e3-934f-ef8b2114c3fb.png)
