### PR TITLE
Blowfish cost must be in range 4…31, not 4…30

### DIFF
--- a/framework/yii/helpers/SecurityBase.php
+++ b/framework/yii/helpers/SecurityBase.php
@@ -262,7 +262,7 @@ class SecurityBase
 	protected static function generateSalt($cost = 13)
 	{
 		$cost = (int)$cost;
-		if ($cost < 4 || $cost > 30) {
+		if ($cost < 4 || $cost > 31) {
 			throw new InvalidParamException('Cost must be between 4 and 31.');
 		}
 


### PR DESCRIPTION
`generateSalt` parameter validation fix.
