### PR TITLE
module should extend \yii\base\Module as \yii\web\Module doesn't exist...

### DIFF
--- a/framework/yii/gii/generators/module/templates/module.php
+++ b/framework/yii/gii/generators/module/templates/module.php
@@ -16,7 +16,7 @@ echo "<?php\n";
 namespace <?php echo $ns; ?>;
 
 
-class <?php echo $className; ?> extends \yii\web\Module
+class <?php echo $className; ?> extends \yii\base\Module
 {
 	public $controllerNamespace = '<?php echo $generator->getControllerNamespace(); ?>';
 


### PR DESCRIPTION
module should extend \yii\base\Module as \yii\web\Module doesn't exist...

If this is outdated, then pls just ignore it!
