### PR TITLE
add missing return to module template

### DIFF
--- a/framework/yii/gii/generators/module/templates/controller.php
+++ b/framework/yii/gii/generators/module/templates/controller.php
@@ -16,6 +16,6 @@ class DefaultController extends Controller
 {
 	public function actionIndex()
 	{
-		$this->render('index');
+		return $this->render('index');
 	}
 }


### PR DESCRIPTION
I think according to the framework it should return the render and otherwise the browser will stay blank...
