### PR TITLE
Fixed form with one file input

### DIFF
--- a/framework/yii/widgets/ActiveField.php
+++ b/framework/yii/widgets/ActiveField.php
@@ -333,7 +333,8 @@ class ActiveField extends Component
 		if ($this->inputOptions !== array('class' => 'form-control')) {
 			$options = array_merge($this->inputOptions, $options);
 		}
-		$this->parts['{input}'] = Html::activeFileInput($this->model, $this->attribute, $options);
+		$this->parts['{input}'] = Html::activeFileInput($this->model, $this->attribute, $options)
+            . Html::activeFileInput($this->model, $this->attribute, $options);
 		return $this;
 	}
 


### PR DESCRIPTION
If we have form with one file input,

``` php
$model->load($_POST)
```

will return `false`, because `$_POST` is empty.

I added hidden input like Yii 1.1
