### PR TITLE
Patch for Memcache versions that do not support timeoutms parameter

### DIFF
--- a/framework/yii/caching/MemCache.php
+++ b/framework/yii/caching/MemCache.php
@@ -97,11 +97,19 @@ class MemCache extends Cache
 				} else {
 					// $timeout is used for memcache versions that do not have timeoutms parameter
 					$timeout = (int) ($server->timeout / 1000) + (($server->timeout % 1000 > 0) ? 1 : 0);
-					$cache->addServer(
+					try {
+						$cache->addServer(
 						$server->host, $server->port, $server->persistent,
 						$server->weight, $timeout, $server->retryInterval,
 						$server->status, $server->failureCallback, $server->timeout
-					);
+						);
+					} catch (ErrorException $e) {
+						$cache->addServer(
+						$server->host, $server->port, $server->persistent,
+						$server->weight, $timeout, $server->retryInterval,
+						$server->status, $server->failureCallback
+						);
+					}
 				}
 			}
 		} else {

--- a/framework/yii/caching/MemCache.php
+++ b/framework/yii/caching/MemCache.php
@@ -99,15 +99,15 @@ class MemCache extends Cache
 					$timeout = (int) ($server->timeout / 1000) + (($server->timeout % 1000 > 0) ? 1 : 0);
 					try {
 						$cache->addServer(
-						$server->host, $server->port, $server->persistent,
-						$server->weight, $timeout, $server->retryInterval,
-						$server->status, $server->failureCallback, $server->timeout
+							$server->host, $server->port, $server->persistent,
+							$server->weight, $timeout, $server->retryInterval,
+							$server->status, $server->failureCallback, $server->timeout
 						);
 					} catch (ErrorException $e) {
 						$cache->addServer(
-						$server->host, $server->port, $server->persistent,
-						$server->weight, $timeout, $server->retryInterval,
-						$server->status, $server->failureCallback
+							$server->host, $server->port, $server->persistent,
+							$server->weight, $timeout, $server->retryInterval,
+							$server->status, $server->failureCallback
 						);
 					}
 				}


### PR DESCRIPTION
As reported on issue #898, there is an ErrorException thrown if the 9th parameter (timeoutms) is not supported in the deployed memcached version. 
