### PR TITLE
I have changed names of 'mark'-method of View.php

### DIFF
--- a/framework/yii/base/View.php
+++ b/framework/yii/base/View.php
@@ -507,7 +507,7 @@ class View extends Component
 	/**
 	 * Marks the beginning of an HTML page.
 	 */
-	public function beginPage()
+	public function beginPageMark()
 	{
 		ob_start();
 		ob_implicit_flush(false);
@@ -518,7 +518,7 @@ class View extends Component
 	/**
 	 * Marks the ending of an HTML page.
 	 */
-	public function endPage()
+	public function endPageMark()
 	{
 		$this->trigger(self::EVENT_END_PAGE);
 
@@ -543,7 +543,7 @@ class View extends Component
 	/**
 	 * Marks the beginning of an HTML body section.
 	 */
-	public function beginBody()
+	public function beginBodyMark()
 	{
 		echo self::PH_BODY_BEGIN;
 		$this->trigger(self::EVENT_BEGIN_BODY);
@@ -552,7 +552,7 @@ class View extends Component
 	/**
 	 * Marks the ending of an HTML body section.
 	 */
-	public function endBody()
+	public function endBodyMark()
 	{
 		$this->trigger(self::EVENT_END_BODY);
 		echo self::PH_BODY_END;
@@ -561,7 +561,7 @@ class View extends Component
 	/**
 	 * Marks the position of an HTML head section.
 	 */
-	public function head()
+	public function headMark()
 	{
 		echo self::PH_HEAD;
 	}


### PR DESCRIPTION
It is my another attempt to find a good solution for 'mark'-methods of yii\base\View class. May be it will be more  appropriate. Methods like beginBody(), endBody(), head() etc. in View class are for special purpose. I think they begin look similarly if they have the same postfix 'Mark'.
