### PR TITLE
fix js asset position conflict

### DIFF
--- a/framework/yii/base/View.php
+++ b/framework/yii/base/View.php
@@ -622,6 +622,7 @@ class View extends Component
 			} elseif ($pos > $position) {
 				throw new InvalidConfigException("An asset bundle that depends on '$name' has a higher javascript file position configured than '$name'.");
 			}
+			// update position for all dependencies
 			foreach ($bundle->depends as $dep) {
 				$this->registerAssetBundle($dep, $pos);
 			}

--- a/framework/yii/base/View.php
+++ b/framework/yii/base/View.php
@@ -620,7 +620,7 @@ class View extends Component
 			if ($pos === null) {
 				$bundle->jsOptions['position'] = $pos = $position;
 			} elseif ($pos > $position) {
-				throw new InvalidConfigException("A dependend AssetBundle of '$name' requires a higher position but it conflicts with the position set for '$name'!");
+				throw new InvalidConfigException("An asset bundle that depends on '$name' has a higher javascript file position configured than '$name'.");
 			}
 			foreach ($bundle->depends as $dep) {
 				$this->registerAssetBundle($dep, $pos);

--- a/framework/yii/base/View.php
+++ b/framework/yii/base/View.php
@@ -142,8 +142,8 @@ class View extends Component
 	 */
 	public $dynamicPlaceholders = array();
 	/**
-	 * @var array list of the registered asset bundles. The keys are the bundle names, and the values
-	 * are booleans indicating whether the bundles have been registered.
+	 * @var AssetBundle[] list of the registered asset bundles. The keys are the bundle names, and the values
+	 * are the registered [[AssetBundle]] objects.
 	 * @see registerAssetBundle
 	 */
 	public $assetBundles;

--- a/framework/yii/base/View.php
+++ b/framework/yii/base/View.php
@@ -543,6 +543,24 @@ class View extends Component
 	}
 
 	/**
+	 * Registers all files provided by an asset bundle including depending bundles files.
+	 * Removes a bundle from [[assetBundles]] once registered.
+	 * @param string $name name of the bundle to register
+	 */
+	private function registerAssetFiles($name)
+	{
+		if (!isset($this->assetBundles[$name])) {
+			return;
+		}
+		$bundle = $this->assetBundles[$name];
+		foreach($bundle->depends as $dep) {
+			$this->registerAssetFiles($dep);
+		}
+		$bundle->registerAssets($this);
+		unset($this->assetBundles[$name]);
+	}
+
+	/**
 	 * Marks the beginning of an HTML body section.
 	 */
 	public function beginBody()
@@ -568,25 +586,14 @@ class View extends Component
 		echo self::PH_HEAD;
 	}
 
-	protected function registerAssetFiles($name)
-	{
-		if (!isset($this->assetBundles[$name])) {
-			return;
-		}
-		$bundle = $this->assetBundles[$name];
-		foreach($bundle->depends as $depName) {
-			$this->registerAssetFiles($depName);
-		}
-		$bundle->registerAssets($this);
-		unset($this->assetBundles[$name]);
-	}
-
 	/**
 	 * Registers the named asset bundle.
 	 * All dependent asset bundles will be registered.
 	 * @param string $name the name of the asset bundle.
-	 * @param integer|null $position optional parameter to force a minimum Javascript position TODO link to relevant method
-	 * Null means to register on default position.
+	 * @param integer|null $position if set, this forces a minimum position for javascript files.
+	 * This will adjust depending assets javascript file position or fail if requirement can not be met.
+	 * If this is null, asset bundles position settings will not be changed.
+	 * See [[registerJsFile]] for more details on javascript position.
 	 * @return AssetBundle the registered asset bundle instance
 	 * @throws InvalidConfigException if the asset bundle does not exist or a circular dependency is detected
 	 */

--- a/framework/yii/web/AssetBundle.php
+++ b/framework/yii/web/AssetBundle.php
@@ -130,7 +130,6 @@ class AssetBundle extends Object
 
 	/**
 	 * Registers the CSS and JS files with the given view.
-	 * This method will first register all dependent asset bundles.
 	 * It will then try to convert non-CSS or JS files (e.g. LESS, Sass) into the corresponding
 	 * CSS or JS files using [[AssetManager::converter|asset converter]].
 	 * @param \yii\base\View $view the view that the asset files to be registered with.
@@ -139,10 +138,6 @@ class AssetBundle extends Object
 	 */
 	public function registerAssets($view)
 	{
-		foreach ($this->depends as $name) {
-			$view->registerAssetBundle($name);
-		}
-
 		$this->publish($view->getAssetManager());
 
 		foreach ($this->js as $js) {

--- a/tests/unit/data/views/layout.php
+++ b/tests/unit/data/views/layout.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @var $this \yii\base\View
+ * @var $content string
+ */
+?>
+<?php $this->beginPage(); ?>
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Test</title>
+	<?php $this->head(); ?>
+</head>
+<body>
+<?php $this->beginBody(); ?>
+
+<?php echo $content; ?>
+
+<?php $this->endBody(); ?>
+</body>
+</html>
+<?php $this->endPage(); ?>

--- a/tests/unit/data/views/rawlayout.php
+++ b/tests/unit/data/views/rawlayout.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * @var $this \yii\base\View
+ */
+?><?php $this->beginPage(); ?>1<?php $this->head(); ?>2<?php $this->beginBody(); ?>3<?php $this->endBody(); ?>4<?php $this->endPage(); ?>

--- a/tests/unit/data/views/simple.php
+++ b/tests/unit/data/views/simple.php
@@ -1,0 +1,1 @@
+This is a damn simple view file.

--- a/tests/unit/data/web/assets/.gitignore
+++ b/tests/unit/data/web/assets/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/unit/framework/web/AssetBundleTest.php
+++ b/tests/unit/framework/web/AssetBundleTest.php
@@ -42,10 +42,10 @@ class AssetBundleTest extends \yiiunit\TestCase
 		$view = $this->getView();
 
 		$this->assertEmpty($view->assetBundles);
-		TestJqueryAsset::register($view);
+		TestSimpleAsset::register($view);
 		$this->assertEquals(1, count($view->assetBundles));
-		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
-		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset'] instanceof AssetBundle);
+		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestSimpleAsset', $view->assetBundles);
+		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestSimpleAsset'] instanceof AssetBundle);
 
 		$expected = <<<EOF
 123<script src="/js/jquery.js"></script>
@@ -60,11 +60,13 @@ EOF;
 
 		$this->assertEmpty($view->assetBundles);
 		TestAssetBundle::register($view);
-		$this->assertEquals(2, count($view->assetBundles));
+		$this->assertEquals(3, count($view->assetBundles));
 		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetBundle', $view->assetBundles);
 		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
+		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetLevel3', $view->assetBundles);
 		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle'] instanceof AssetBundle);
 		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset'] instanceof AssetBundle);
+		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3'] instanceof AssetBundle);
 
 		$expected = <<<EOF
 1<link href="/files/cssFile.css" rel="stylesheet">
@@ -105,17 +107,21 @@ EOF;
 			TestJqueryAsset::register($view);
 		}
 		TestAssetBundle::register($view);
-		$this->assertEquals(2, count($view->assetBundles));
+		$this->assertEquals(3, count($view->assetBundles));
 		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetBundle', $view->assetBundles);
 		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
+		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetLevel3', $view->assetBundles);
 
 		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle'] instanceof AssetBundle);
 		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset'] instanceof AssetBundle);
+		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3'] instanceof AssetBundle);
 
 		$this->assertArrayHasKey('position', $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']->jsOptions);
 		$this->assertEquals($pos, $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']->jsOptions['position']);
 		$this->assertArrayHasKey('position', $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']->jsOptions);
 		$this->assertEquals($pos, $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']->jsOptions['position']);
+		$this->assertArrayHasKey('position', $view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3']->jsOptions);
+		$this->assertEquals($pos, $view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3']->jsOptions['position']);
 
 		switch($pos)
 		{
@@ -183,6 +189,21 @@ EOF;
 		$this->setExpectedException('yii\\base\\InvalidConfigException');
 		TestAssetBundle::register($view);
 	}
+
+	public function testCircularDependency()
+	{
+		$this->setExpectedException('yii\\base\\InvalidConfigException');
+		TestAssetCircleA::register($this->getView());
+	}
+}
+
+class TestSimpleAsset extends AssetBundle
+{
+	public $basePath = '@testWebRoot/js';
+	public $baseUrl = '@testWeb/js';
+	public $js = array(
+		'jquery.js',
+	);
 }
 
 class TestAssetBundle extends AssetBundle
@@ -206,5 +227,38 @@ class TestJqueryAsset extends AssetBundle
 	public $baseUrl = '@testWeb/js';
 	public $js = array(
 		'jquery.js',
+	);
+	public $depends = array(
+		'yiiunit\\framework\\web\\TestAssetLevel3'
+	);
+}
+
+class TestAssetLevel3 extends AssetBundle
+{
+	public $basePath = '@testWebRoot/js';
+	public $baseUrl = '@testWeb/js';
+}
+
+class TestAssetCircleA extends AssetBundle
+{
+	public $basePath = '@testWebRoot/js';
+	public $baseUrl = '@testWeb/js';
+	public $js = array(
+		'jquery.js',
+	);
+	public $depends = array(
+		'yiiunit\\framework\\web\\TestAssetCircleB'
+	);
+}
+
+class TestAssetCircleB extends AssetBundle
+{
+	public $basePath = '@testWebRoot/js';
+	public $baseUrl = '@testWeb/js';
+	public $js = array(
+		'jquery.js',
+	);
+	public $depends = array(
+		'yiiunit\\framework\\web\\TestAssetCircleA'
 	);
 }

--- a/tests/unit/framework/web/AssetBundleTest.php
+++ b/tests/unit/framework/web/AssetBundleTest.php
@@ -45,6 +45,13 @@ class AssetBundleTest extends \yiiunit\TestCase
 		TestJqueryAsset::register($view);
 		$this->assertEquals(1, count($view->assetBundles));
 		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
+		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset'] instanceof AssetBundle);
+
+		$expected = <<<EOF
+123<script src="/js/jquery.js"></script>
+4
+EOF;
+		$this->assertEquals($expected, $view->renderFile('@yiiunit/data/views/rawlayout.php'));
 	}
 
 	public function testSimpleDependency()
@@ -56,6 +63,125 @@ class AssetBundleTest extends \yiiunit\TestCase
 		$this->assertEquals(2, count($view->assetBundles));
 		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetBundle', $view->assetBundles);
 		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
+		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle'] instanceof AssetBundle);
+		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset'] instanceof AssetBundle);
+
+		$expected = <<<EOF
+1<link href="/files/cssFile.css" rel="stylesheet">
+23<script src="/js/jquery.js"></script>
+<script src="/files/jsFile.js"></script>
+4
+EOF;
+		$this->assertEquals($expected, $view->renderFile('@yiiunit/data/views/rawlayout.php'));
+	}
+
+	public function positionProvider()
+	{
+		return array(
+			array(View::POS_HEAD, true),
+			array(View::POS_HEAD, false),
+			array(View::POS_BEGIN, true),
+			array(View::POS_BEGIN, false),
+			array(View::POS_END, true),
+			array(View::POS_END, false),
+		);
+	}
+
+	/**
+	 * @dataProvider positionProvider
+	 */
+	public function testPositionDependency($pos, $jqAlreadyRegistered)
+	{
+		$view = $this->getView();
+
+		$view->getAssetManager()->bundles['yiiunit\\framework\\web\\TestAssetBundle'] = array(
+			'jsOptions' => array(
+				'position' => $pos,
+			),
+		);
+
+		$this->assertEmpty($view->assetBundles);
+		if ($jqAlreadyRegistered) {
+			TestJqueryAsset::register($view);
+		}
+		TestAssetBundle::register($view);
+		$this->assertEquals(2, count($view->assetBundles));
+		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetBundle', $view->assetBundles);
+		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
+
+		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle'] instanceof AssetBundle);
+		$this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset'] instanceof AssetBundle);
+
+		$this->assertArrayHasKey('position', $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']->jsOptions);
+		$this->assertEquals($pos, $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']->jsOptions['position']);
+		$this->assertArrayHasKey('position', $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']->jsOptions);
+		$this->assertEquals($pos, $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']->jsOptions['position']);
+
+		switch($pos)
+		{
+			case View::POS_HEAD:
+				$expected = <<<EOF
+1<link href="/files/cssFile.css" rel="stylesheet">
+<script src="/js/jquery.js"></script>
+<script src="/files/jsFile.js"></script>
+234
+EOF;
+			break;
+			case View::POS_BEGIN:
+				$expected = <<<EOF
+1<link href="/files/cssFile.css" rel="stylesheet">
+2<script src="/js/jquery.js"></script>
+<script src="/files/jsFile.js"></script>
+34
+EOF;
+			break;
+			default:
+			case View::POS_END:
+				$expected = <<<EOF
+1<link href="/files/cssFile.css" rel="stylesheet">
+23<script src="/js/jquery.js"></script>
+<script src="/files/jsFile.js"></script>
+4
+EOF;
+			break;
+		}
+		$this->assertEquals($expected, $view->renderFile('@yiiunit/data/views/rawlayout.php'));
+	}
+
+	public function positionProvider2()
+	{
+		return array(
+			array(View::POS_BEGIN, true),
+			array(View::POS_BEGIN, false),
+			array(View::POS_END, true),
+			array(View::POS_END, false),
+		);
+	}
+
+	/**
+	 * @dataProvider positionProvider
+	 */
+	public function testPositionDependencyConflict($pos, $jqAlreadyRegistered)
+	{
+		$view = $this->getView();
+
+		$view->getAssetManager()->bundles['yiiunit\\framework\\web\\TestAssetBundle'] = array(
+			'jsOptions' => array(
+				'position' => $pos - 1,
+			),
+		);
+		$view->getAssetManager()->bundles['yiiunit\\framework\\web\\TestJqueryAsset'] = array(
+			'jsOptions' => array(
+				'position' => $pos,
+			),
+		);
+
+		$this->assertEmpty($view->assetBundles);
+		if ($jqAlreadyRegistered) {
+			TestJqueryAsset::register($view);
+		}
+		$this->setExpectedException('yii\\base\\InvalidConfigException');
+		TestAssetBundle::register($view);
 	}
 }
 

--- a/tests/unit/framework/web/AssetBundleTest.php
+++ b/tests/unit/framework/web/AssetBundleTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * 
+ * 
+ * @author Carsten Brandt <mail@cebe.cc>
+ */
+
+namespace yiiunit\framework\web;
+
+use Yii;
+use yii\base\View;
+use yii\web\AssetBundle;
+use yii\web\AssetManager;
+
+/**
+ * @group web
+ */
+class AssetBundleTest extends \yiiunit\TestCase
+{
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+
+		Yii::setAlias('@testWeb', '/');
+		Yii::setAlias('@testWebRoot', '@yiiunit/data/web');
+	}
+
+	protected function getView()
+	{
+		$view = new View();
+		$view->setAssetManager(new AssetManager(array(
+			'basePath' => '@testWebRoot/assets',
+			'baseUrl' => '@testWeb/assets',
+		)));
+
+		return $view;
+	}
+
+	public function testRegister()
+	{
+		$view = $this->getView();
+
+		$this->assertEmpty($view->assetBundles);
+		TestJqueryAsset::register($view);
+		$this->assertEquals(1, count($view->assetBundles));
+		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
+	}
+
+	public function testSimpleDependency()
+	{
+		$view = $this->getView();
+
+		$this->assertEmpty($view->assetBundles);
+		TestAssetBundle::register($view);
+		$this->assertEquals(2, count($view->assetBundles));
+		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetBundle', $view->assetBundles);
+		$this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
+	}
+}
+
+class TestAssetBundle extends AssetBundle
+{
+	public $basePath = '@testWebRoot/files';
+	public $baseUrl = '@testWeb/files';
+	public $css = array(
+		'cssFile.css',
+	);
+	public $js = array(
+		'jsFile.js',
+	);
+	public $depends = array(
+		'yiiunit\\framework\\web\\TestJqueryAsset'
+	);
+}
+
+class TestJqueryAsset extends AssetBundle
+{
+	public $basePath = '@testWebRoot/js';
+	public $baseUrl = '@testWeb/js';
+	public $js = array(
+		'jquery.js',
+	);
+}


### PR DESCRIPTION
fixes #700

If an asset bundle does not explicitly configure a position and another asset bundle depends on it, position will be adjusted.
When position is explicitly configured and positions do not match an exception will be thrown.
