### PR TITLE
Filter only active attributes in gridview

### DIFF
--- a/framework/yii/grid/DataColumn.php
+++ b/framework/yii/grid/DataColumn.php
@@ -115,7 +115,9 @@ class DataColumn extends Column
 	{
 		if (is_string($this->filter)) {
 			return $this->filter;
-		} elseif ($this->filter !== false && $this->grid->filterModel instanceof Model && $this->attribute !== null) {
+		} elseif ($this->filter !== false && $this->grid->filterModel instanceof Model &&
+				  $this->attribute !== null && $this->grid->filterModel->isAttributeActive($this->attribute))
+		{
 			if (is_array($this->filter)) {
 				$options = array_merge(array('prompt' => ''), $this->filterInputOptions);
 				return Html::activeDropDownList($this->grid->filterModel, $this->attribute, $this->filter, $options);


### PR DESCRIPTION
When we do not want an attribute to be searched we do not define it in
the filter model, or mark it inctive in the scenario when we use the
original model.
GridView should not try to access the attribute then and automatically
not display the filter field.
