### PR TITLE
View. Default empty array value for $params

### DIFF
--- a/framework/yii/base/View.php
+++ b/framework/yii/base/View.php
@@ -96,7 +96,7 @@ class View extends Component
 	/**
 	 * @var mixed custom parameters that are shared among view templates.
 	 */
-	public $params;
+	public $params = array();
 	/**
 	 * @var array a list of available renderers indexed by their corresponding supported file extensions.
 	 * Each renderer may be a view renderer object or the configuration for creating the renderer object.


### PR DESCRIPTION
To prevent Warning "Trying to get property of non-object" in case when nothing set to params, but you try to get some key (check is there something)

ArrayHelper::getValue($this->view->params, 'abc');
