### PR TITLE
Grid action column actions url [skip ci]

### DIFF
--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -72,7 +72,8 @@ class ActionColumn extends Column
 		if ($this->urlCreator instanceof Closure) {
 			return call_user_func($this->urlCreator, $model, $action);
 		} else {
-			$route = Inflector::camel2id(StringHelper::basename(get_class($model))) . '/' . $action;
+			$controller = $this->grid->view->context;
+			$route = $controller->getUniqueId() . '/' . $action;
 			$params = $model->getPrimaryKey(true);
 			if (count($params) === 1) {
 				$params = array('id' => reset($params));


### PR DESCRIPTION
Default grid column actions were created based on model classname, instead of current controller url.
