### PR TITLE
I have add new line in methods that render code in the head and for body

### DIFF
--- a/framework/yii/base/View.php
+++ b/framework/yii/base/View.php
@@ -730,7 +730,7 @@ class View extends Component
 		if (!empty($this->js[self::POS_HEAD])) {
 			$lines[] = Html::script(implode("\n", $this->js[self::POS_HEAD]), array('type' => 'text/javascript'));
 		}
-		return empty($lines) ? '' : implode("\n", $lines) . "\n";
+		return empty($lines) ? '' : "\n" . implode("\n", $lines) . "\n";
 	}
 
 	/**
@@ -747,7 +747,7 @@ class View extends Component
 		if (!empty($this->js[self::POS_BEGIN])) {
 			$lines[] = Html::script(implode("\n", $this->js[self::POS_BEGIN]), array('type' => 'text/javascript'));
 		}
-		return empty($lines) ? '' : implode("\n", $lines) . "\n";
+		return empty($lines) ? '' : "\n" . implode("\n", $lines) . "\n";
 	}
 
 	/**
@@ -768,6 +768,6 @@ class View extends Component
 			$js = "jQuery(document).ready(function(){\n" . implode("\n", $this->js[self::POS_READY]) . "\n});";
 			$lines[] = Html::script($js, array('type' => 'text/javascript'));
 		}
-		return empty($lines) ? '' : implode("\n", $lines) . "\n";
+		return empty($lines) ? '' : "\n" . implode("\n", $lines) . "\n";
 	}
 }


### PR DESCRIPTION
I have add a new line before any html-code that generated in head, after &lt;body> tag and befor &lt;/body> tag. Without new line the code is ugly and attached to the end of other tags like that:
&lt;/script>&lt;script src="...">&lt;/script>
Now it looks like:
&lt;/script>
&lt;script src="...">&lt;/script>
