### PR TITLE
Debug panel : change json_encode/decode to serialise/unserialise

### DIFF
--- a/framework/yii/debug/LogTarget.php
+++ b/framework/yii/debug/LogTarget.php
@@ -49,7 +49,7 @@ class LogTarget extends Target
 		if (!is_file($indexFile)) {
 			$manifest = array();
 		} else {
-			$manifest = json_decode(file_get_contents($indexFile), true);
+			$manifest = unserialize(file_get_contents($indexFile));
 		}
 		$request = Yii::$app->getRequest();
 		$manifest[$this->tag] = $summary = array(
@@ -68,8 +68,8 @@ class LogTarget extends Target
 			$data[$id] = $panel->save();
 		}
 		$data['summary'] = $summary;
-		file_put_contents($dataFile, json_encode($data));
-		file_put_contents($indexFile, json_encode($manifest));
+		file_put_contents($dataFile, serialize($data));
+		file_put_contents($indexFile, serialize($manifest));
 	}
 
 	/**

--- a/framework/yii/debug/LogTarget.php
+++ b/framework/yii/debug/LogTarget.php
@@ -45,7 +45,7 @@ class LogTarget extends Target
 		if (!is_dir($path)) {
 			mkdir($path);
 		}
-		$indexFile = "$path/index.json";
+		$indexFile = "$path/index.php";
 		if (!is_file($indexFile)) {
 			$manifest = array();
 		} else {
@@ -62,7 +62,7 @@ class LogTarget extends Target
 		);
 		$this->gc($manifest);
 
-		$dataFile = "$path/{$this->tag}.json";
+		$dataFile = "$path/{$this->tag}.php";
 		$data = array();
 		foreach ($this->module->panels as $id => $panel) {
 			$data[$id] = $panel->save();
@@ -93,7 +93,7 @@ class LogTarget extends Target
 		if (count($manifest) > $this->module->historySize + 10) {
 			$n = count($manifest) - $this->module->historySize;
 			foreach (array_keys($manifest) as $tag) {
-				$file = $this->module->dataPath . "/$tag.json";
+				$file = $this->module->dataPath . "/$tag.php";
 				@unlink($file);
 				unset($manifest[$tag]);
 				if (--$n <= 0) {

--- a/framework/yii/debug/controllers/DefaultController.php
+++ b/framework/yii/debug/controllers/DefaultController.php
@@ -76,7 +76,7 @@ class DefaultController extends Controller
 		if ($this->_manifest === null) {
 			$indexFile = $this->module->dataPath . '/index.json';
 			if (is_file($indexFile)) {
-				$this->_manifest = array_reverse(json_decode(file_get_contents($indexFile), true), true);
+				$this->_manifest = array_reverse(unserialize(file_get_contents($indexFile)), true);
 			} else {
 				$this->_manifest = array();
 			}
@@ -89,7 +89,7 @@ class DefaultController extends Controller
 		$manifest = $this->getManifest();
 		if (isset($manifest[$tag])) {
 			$dataFile = $this->module->dataPath . "/$tag.json";
-			$data = json_decode(file_get_contents($dataFile), true);
+			$data = unserialize(file_get_contents($dataFile));
 			foreach ($this->module->panels as $id => $panel) {
 				if (isset($data[$id])) {
 					$panel->tag = $tag;

--- a/framework/yii/debug/controllers/DefaultController.php
+++ b/framework/yii/debug/controllers/DefaultController.php
@@ -74,7 +74,7 @@ class DefaultController extends Controller
 	protected function getManifest()
 	{
 		if ($this->_manifest === null) {
-			$indexFile = $this->module->dataPath . '/index.json';
+			$indexFile = $this->module->dataPath . '/index.php';
 			if (is_file($indexFile)) {
 				$this->_manifest = array_reverse(unserialize(file_get_contents($indexFile)), true);
 			} else {
@@ -88,7 +88,7 @@ class DefaultController extends Controller
 	{
 		$manifest = $this->getManifest();
 		if (isset($manifest[$tag])) {
-			$dataFile = $this->module->dataPath . "/$tag.json";
+			$dataFile = $this->module->dataPath . "/$tag.php";
 			$data = unserialize(file_get_contents($dataFile));
 			foreach ($this->module->panels as $id => $panel) {
 				if (isset($data[$id])) {

--- a/framework/yii/debug/panels/RequestPanel.php
+++ b/framework/yii/debug/panels/RequestPanel.php
@@ -151,7 +151,7 @@ EOD;
 		}
 		$rows = array();
 		foreach ($values as $name => $value) {
-			$rows[] = '<tr><th style="width: 200px;">' . Html::encode($name) . '</th><td>' . Html::encode(var_export($value, true)) . '</td></tr>';
+			$rows[] = '<tr><th style="width: 200px;">' . Html::encode($name) . '</th><td>' . htmlspecialchars(var_export($value, true), ENT_QUOTES|ENT_SUBSTITUTE, \Yii::$app->charset, TRUE) . '</td></tr>';
 		}
 		$rows = implode("\n", $rows);
 		return <<<EOD


### PR DESCRIPTION
Fixes #933 
To prevent non-UTF characters error
I am not sure as for

>  htmlspecialchars(var_export($value, true), ENT_QUOTES|ENT_SUBSTITUTE, \Yii::$app->charset, TRUE)

but it seems like an overkill to create a separate encode function for single use
