### PR TITLE
better not publish assets in assetmanager getter

### DIFF
--- a/framework/yii/base/View.php
+++ b/framework/yii/base/View.php
@@ -605,6 +605,7 @@ class View extends Component
 				$this->registerAssetBundle($dep, $pos);
 			}
 			$this->assetBundles[$name] = $bundle;
+			$bundle->publish($am);
 		} elseif ($this->assetBundles[$name] === false) {
 			throw new InvalidConfigException("A circular dependency is detected for bundle '$name'.");
 		} else {

--- a/framework/yii/web/AssetManager.php
+++ b/framework/yii/web/AssetManager.php
@@ -111,8 +111,6 @@ class AssetManager extends Component
 		} else {
 			$bundle = Yii::createObject($name);
 		}
-		/** @var AssetBundle $bundle */
-		$bundle->publish($this);
 		return $this->bundles[$name] = $bundle;
 	}
 


### PR DESCRIPTION
https://github.com/yiisoft/yii2/commit/602592411df232b01bd483db88ca1d97e6cc4455#commitcomment-4374327

Also just seen that `getBundle` is also used in console AssetController so publish definitively should not be in getter.
