### PR TITLE
Enhance kind of values accepted in $className of ExistValidator and UniqueValidator

### DIFF
--- a/framework/yii/validators/ExistValidator.php
+++ b/framework/yii/validators/ExistValidator.php
@@ -26,6 +26,9 @@ class ExistValidator extends Validator
 	 * that should be used to look for the attribute value being validated.
 	 * Defaults to null, meaning using the ActiveRecord class of
 	 * the attribute being validated.
+	 * If the given class name is not namespaced, it will be changed to use
+	 * the same namespace as the AR class of the currently validated object.
+	 * Note, this rule only applies to [[validateAttribute()]] method.
 	 * @see attributeName
 	 */
 	public $className;
@@ -66,7 +69,14 @@ class ExistValidator extends Validator
 		}
 
 		/** @var $className \yii\db\ActiveRecord */
-		$className = $this->className === null ? get_class($object) : $this->className;
+		if ($this->className === null) {
+			$className = get_class($object);
+		} elseif (strpos($this->className, '\\') === false) {
+			$reflector = new \ReflectionClass($object::className());
+			$className = $reflector->getNamespaceName() . '\\' . $this->className;
+		} else {
+			$className = $this->className;
+		}
 		$attributeName = $this->attributeName === null ? $attribute : $this->attributeName;
 		$query = $className::find();
 		$query->where([$attributeName => $value]);

--- a/framework/yii/validators/UniqueValidator.php
+++ b/framework/yii/validators/UniqueValidator.php
@@ -23,6 +23,9 @@ class UniqueValidator extends Validator
 	 * @var string the ActiveRecord class name or alias of the class
 	 * that should be used to look for the attribute value being validated.
 	 * Defaults to null, meaning using the ActiveRecord class of the attribute being validated.
+	 * If the given class name is not namespaced, it will be changed to use
+	 * the same namespace as the AR class of the currently validated object.
+	 * Note, this rule only applies to [[validateAttribute()]] method.
 	 * @see attributeName
 	 */
 	public $className;
@@ -61,7 +64,14 @@ class UniqueValidator extends Validator
 		}
 
 		/** @var $className \yii\db\ActiveRecord */
-		$className = $this->className === null ? get_class($object) : $this->className;
+		if ($this->className === null) {
+			$className = get_class($object);
+		} elseif (strpos($this->className, '\\') === false) {
+			$reflector = new \ReflectionClass($object::className());
+			$className = $reflector->getNamespaceName() . '\\' . $this->className;
+		} else {
+			$className = $this->className;
+		}
 		$attributeName = $this->attributeName === null ? $attribute : $this->attributeName;
 
 		$table = $className::getTableSchema();

--- a/tests/unit/framework/validators/ExistValidatorTest.php
+++ b/tests/unit/framework/validators/ExistValidatorTest.php
@@ -54,7 +54,13 @@ class ExistValidatorTest extends DatabaseTestCase
 	public function testValidateAttribute()
 	{
 		// existing value on different table
+		// 1. fully qualified name of the class
 		$val = new ExistValidator(['className' => ValidatorTestMainModel::className(), 'attributeName' => 'id']);
+		$m = ValidatorTestRefModel::find(['id' => 1]);
+		$val->validateAttribute($m, 'ref');
+		$this->assertFalse($m->hasErrors());
+		// 2. short name of the class without namespace
+		$val = new ExistValidator(['className' => 'ValidatorTestMainModel', 'attributeName' => 'id']);
 		$m = ValidatorTestRefModel::find(['id' => 1]);
 		$val->validateAttribute($m, 'ref');
 		$this->assertFalse($m->hasErrors());

--- a/tests/unit/framework/validators/UniqueValidatorTest.php
+++ b/tests/unit/framework/validators/UniqueValidatorTest.php
@@ -58,7 +58,15 @@ class UniqueValidatorTest extends DatabaseTestCase
 
 	public function testValidateAttributeOfNonARModel()
 	{
+		// 1. fully qualified name of the class
 		$val = new UniqueValidator(['className' => ValidatorTestRefModel::className(), 'attributeName' => 'ref']);
+		$m = FakedValidationModel::createWithAttributes(['attr_1' => 5, 'attr_2' => 1313]);
+		$val->validateAttribute($m, 'attr_1');
+		$this->assertTrue($m->hasErrors('attr_1'));
+		$val->validateAttribute($m, 'attr_2');
+		$this->assertFalse($m->hasErrors('attr_2'));
+		// 2. short name of the class without namespace
+		$val = new UniqueValidator(['className' => 'ValidatorTestRefModel', 'attributeName' => 'ref']);
 		$m = FakedValidationModel::createWithAttributes(['attr_1' => 5, 'attr_2' => 1313]);
 		$val->validateAttribute($m, 'attr_1');
 		$this->assertTrue($m->hasErrors('attr_1'));


### PR DESCRIPTION
Usage sample:

``` php
namespace frontend\models;

class User extends \common\models\User
{
    public function rules()
    {
        return [
            ['group_id', 'unique', 'className' => 'Group',
                'attributeName' => 'id'],

            ['region_id', 'unique', 'className' => '\common\models\Region',
                'attributeName' => 'id'],

            ['username', 'unique'],
        ];
    }
}

class Group extends \common\models\Group
{
}

namespace common\models;

class Region extends \yii\db\ActiveRecord
{
}
```
