### PR TITLE
Use trait instead of behavior

### DIFF
--- a/framework/yii/base/Component.php
+++ b/framework/yii/base/Component.php
@@ -26,39 +26,6 @@ class Component extends Object
 	private $_behaviors;
 
 	/**
-	 * Returns the value of a component property.
-	 * This method will check in the following order and act accordingly:
-	 *
-	 *  - a property defined by a getter: return the getter result
-	 *  - a property of a behavior: return the behavior property value
-	 *
-	 * Do not call this method directly as it is a PHP magic method that
-	 * will be implicitly called when executing `$value = $component->property;`.
-	 * @param string $name the property name
-	 * @return mixed the property value, event handlers attached to the event,
-	 * the behavior, or the value of a behavior's property
-	 * @throws UnknownPropertyException if the property is not defined
-	 * @see __set
-	 */
-	public function __get($name)
-	{
-		$getter = 'get' . $name;
-		if (method_exists($this, $getter)) {
-			// read property, e.g. getName()
-			return $this->$getter();
-		} else {
-			// behavior property
-			$this->ensureBehaviors();
-			foreach ($this->_behaviors as $behavior) {
-				if ($behavior->canGetProperty($name)) {
-					return $behavior->$name;
-				}
-			}
-		}
-		throw new UnknownPropertyException('Getting unknown property: ' . get_class($this) . '::' . $name);
-	}
-
-	/**
 	 * Sets the value of a component property.
 	 * This method will check in the following order and act accordingly:
 	 *
@@ -91,117 +58,12 @@ class Component extends Object
 			$name = trim(substr($name, 3));
 			$this->attachBehavior($name, $value instanceof Behavior ? $value : Yii::createObject($value));
 			return;
-		} else {
-			// behavior property
-			$this->ensureBehaviors();
-			foreach ($this->_behaviors as $behavior) {
-				if ($behavior->canSetProperty($name)) {
-					$behavior->$name = $value;
-					return;
-				}
-			}
 		}
 		if (method_exists($this, 'get' . $name)) {
 			throw new InvalidCallException('Setting read-only property: ' . get_class($this) . '::' . $name);
 		} else {
 			throw new UnknownPropertyException('Setting unknown property: ' . get_class($this) . '::' . $name);
 		}
-	}
-
-	/**
-	 * Checks if a property value is null.
-	 * This method will check in the following order and act accordingly:
-	 *
-	 *  - a property defined by a setter: return whether the property value is null
-	 *  - a property of a behavior: return whether the property value is null
-	 *
-	 * Do not call this method directly as it is a PHP magic method that
-	 * will be implicitly called when executing `isset($component->property)`.
-	 * @param string $name the property name or the event name
-	 * @return boolean whether the named property is null
-	 */
-	public function __isset($name)
-	{
-		$getter = 'get' . $name;
-		if (method_exists($this, $getter)) {
-			return $this->$getter() !== null;
-		} else {
-			// behavior property
-			$this->ensureBehaviors();
-			foreach ($this->_behaviors as $behavior) {
-				if ($behavior->canGetProperty($name)) {
-					return $behavior->$name !== null;
-				}
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Sets a component property to be null.
-	 * This method will check in the following order and act accordingly:
-	 *
-	 *  - a property defined by a setter: set the property value to be null
-	 *  - a property of a behavior: set the property value to be null
-	 *
-	 * Do not call this method directly as it is a PHP magic method that
-	 * will be implicitly called when executing `unset($component->property)`.
-	 * @param string $name the property name
-	 * @throws InvalidCallException if the property is read only.
-	 */
-	public function __unset($name)
-	{
-		$setter = 'set' . $name;
-		if (method_exists($this, $setter)) {
-			$this->$setter(null);
-			return;
-		} else {
-			// behavior property
-			$this->ensureBehaviors();
-			foreach ($this->_behaviors as $behavior) {
-				if ($behavior->canSetProperty($name)) {
-					$behavior->$name = null;
-					return;
-				}
-			}
-		}
-		if (method_exists($this, 'get' . $name)) {
-			throw new InvalidCallException('Unsetting read-only property: ' . get_class($this) . '.' . $name);
-		}
-	}
-
-	/**
-	 * Calls the named method which is not a class method.
-	 * If the name refers to a component property whose value is
-	 * an anonymous function, the method will execute the function.
-	 * Otherwise, it will check if any attached behavior has
-	 * the named method and will execute it if available.
-	 *
-	 * Do not call this method directly as it is a PHP magic method that
-	 * will be implicitly called when an unknown method is being invoked.
-	 * @param string $name the method name
-	 * @param array $params method parameters
-	 * @return mixed the method return value
-	 * @throws UnknownMethodException when calling unknown method
-	 */
-	public function __call($name, $params)
-	{
-		$getter = 'get' . $name;
-		if (method_exists($this, $getter)) {
-			$func = $this->$getter();
-			if ($func instanceof \Closure) {
-				return call_user_func_array($func, $params);
-			}
-		}
-
-		$this->ensureBehaviors();
-		foreach ($this->_behaviors as $object) {
-			if (method_exists($object, $name)) {
-				return call_user_func_array(array($object, $name), $params);
-			}
-		}
-
-		throw new UnknownMethodException('Calling unknown method: ' . get_class($this) . "::$name()");
 	}
 
 	/**
@@ -212,87 +74,6 @@ class Component extends Object
 	{
 		$this->_events = null;
 		$this->_behaviors = null;
-	}
-
-	/**
-	 * Returns a value indicating whether a property is defined for this component.
-	 * A property is defined if:
-	 *
-	 * - the class has a getter or setter method associated with the specified name
-	 *   (in this case, property name is case-insensitive);
-	 * - the class has a member variable with the specified name (when `$checkVar` is true);
-	 * - an attached behavior has a property of the given name (when `$checkBehavior` is true).
-	 *
-	 * @param string $name the property name
-	 * @param boolean $checkVar whether to treat member variables as properties
-	 * @param boolean $checkBehavior whether to treat behaviors' properties as properties of this component
-	 * @return boolean whether the property is defined
-	 * @see canGetProperty
-	 * @see canSetProperty
-	 */
-	public function hasProperty($name, $checkVar = true, $checkBehavior = true)
-	{
-		return $this->canGetProperty($name, $checkVar, $checkBehavior) || $this->canSetProperty($name, $checkVar, $checkBehavior);
-	}
-
-	/**
-	 * Returns a value indicating whether a property can be read.
-	 * A property can be read if:
-	 *
-	 * - the class has a getter method associated with the specified name
-	 *   (in this case, property name is case-insensitive);
-	 * - the class has a member variable with the specified name (when `$checkVar` is true);
-	 * - an attached behavior has a readable property of the given name (when `$checkBehavior` is true).
-	 *
-	 * @param string $name the property name
-	 * @param boolean $checkVar whether to treat member variables as properties
-	 * @param boolean $checkBehavior whether to treat behaviors' properties as properties of this component
-	 * @return boolean whether the property can be read
-	 * @see canSetProperty
-	 */
-	public function canGetProperty($name, $checkVar = true, $checkBehavior = true)
-	{
-		if (method_exists($this, 'get' . $name) || $checkVar && property_exists($this, $name)) {
-			return true;
-		} else {
-			$this->ensureBehaviors();
-			foreach ($this->_behaviors as $behavior) {
-				if ($behavior->canGetProperty($name, $checkVar)) {
-					return true;
-				}
-			}
-			return false;
-		}
-	}
-
-	/**
-	 * Returns a value indicating whether a property can be set.
-	 * A property can be written if:
-	 *
-	 * - the class has a setter method associated with the specified name
-	 *   (in this case, property name is case-insensitive);
-	 * - the class has a member variable with the specified name (when `$checkVar` is true);
-	 * - an attached behavior has a writable property of the given name (when `$checkBehavior` is true).
-	 *
-	 * @param string $name the property name
-	 * @param boolean $checkVar whether to treat member variables as properties
-	 * @param boolean $checkBehavior whether to treat behaviors' properties as properties of this component
-	 * @return boolean whether the property can be written
-	 * @see canGetProperty
-	 */
-	public function canSetProperty($name, $checkVar = true, $checkBehavior = true)
-	{
-		if (method_exists($this, 'set' . $name) || $checkVar && property_exists($this, $name)) {
-			return true;
-		} else {
-			$this->ensureBehaviors();
-			foreach ($this->_behaviors as $behavior) {
-				if ($behavior->canSetProperty($name, $checkVar)) {
-					return true;
-				}
-			}
-			return false;
-		}
 	}
 
 	/**


### PR DESCRIPTION
Use trait instead of behavior for methods and properties. Use behavior only for events.
