### PR TITLE
Validator message format

### DIFF
--- a/framework/yii/i18n/I18N.php
+++ b/framework/yii/i18n/I18N.php
@@ -64,7 +64,7 @@ class I18N extends Component
 	 * Translates a message to the specified language.
 	 *
 	 * After translation the message will be formatted using [[MessageFormatter]] if it contains
-	 * ITU message format and `$params` are not empty.
+	 * ICU message format and `$params` are not empty.
 	 *
 	 * @param string $category the message category.
 	 * @param string $message the message to be translated.

--- a/framework/yii/i18n/I18N.php
+++ b/framework/yii/i18n/I18N.php
@@ -63,7 +63,7 @@ class I18N extends Component
 	/**
 	 * Translates a message to the specified language.
 	 *
-	 * After translation the message will be parsed using [[MessageFormatter]] if it contains
+	 * After translation the message will be formatted using [[MessageFormatter]] if it contains
 	 * ITU message format and `$params` are not empty.
 	 *
 	 * @param string $category the message category.

--- a/framework/yii/validators/BooleanValidator.php
+++ b/framework/yii/validators/BooleanValidator.php
@@ -58,8 +58,8 @@ class BooleanValidator extends Validator
 		$value = $object->$attribute;
 		if (!$this->validateValue($value)) {
 			$this->addError($object, $attribute, $this->message, [
-				'{true}' => $this->trueValue,
-				'{false}' => $this->falseValue,
+				'true' => $this->trueValue,
+				'false' => $this->falseValue,
 			]);
 		}
 	}

--- a/framework/yii/validators/CompareValidator.php
+++ b/framework/yii/validators/CompareValidator.php
@@ -143,8 +143,8 @@ class CompareValidator extends Validator
 		}
 		if (!$valid) {
 			$this->addError($object, $attribute, $this->message, [
-				'{compareAttribute}' => $compareLabel,
-				'{compareValue}' => $compareValue,
+				'compareAttribute' => $compareLabel,
+				'compareValue' => $compareValue,
 			]);
 		}
 	}

--- a/framework/yii/validators/FileValidator.php
+++ b/framework/yii/validators/FileValidator.php
@@ -144,7 +144,7 @@ class FileValidator extends Validator
 				$this->addError($object, $attribute, $this->uploadRequired);
 			}
 			if (count($files) > $this->maxFiles) {
-				$this->addError($object, $attribute, $this->tooMany, ['{attribute}' => $attribute, '{limit}' => $this->maxFiles]);
+				$this->addError($object, $attribute, $this->tooMany, ['limit' => $this->maxFiles]);
 			} else {
 				foreach ($files as $file) {
 					$this->validateFile($object, $attribute, $file);
@@ -171,18 +171,18 @@ class FileValidator extends Validator
 		switch ($file->error) {
 			case UPLOAD_ERR_OK:
 				if ($this->maxSize !== null && $file->size > $this->maxSize) {
-					$this->addError($object, $attribute, $this->tooBig, ['{file}' => $file->name, '{limit}' => $this->getSizeLimit()]);
+					$this->addError($object, $attribute, $this->tooBig, ['file' => $file->name, 'limit' => $this->getSizeLimit()]);
 				}
 				if ($this->minSize !== null && $file->size < $this->minSize) {
-					$this->addError($object, $attribute, $this->tooSmall, ['{file}' => $file->name, '{limit}' => $this->minSize]);
+					$this->addError($object, $attribute, $this->tooSmall, ['file' => $file->name, 'limit' => $this->minSize]);
 				}
 				if (!empty($this->types) && !in_array(strtolower(pathinfo($file->name, PATHINFO_EXTENSION)), $this->types, true)) {
-					$this->addError($object, $attribute, $this->wrongType, ['{file}' => $file->name, '{extensions}' => implode(', ', $this->types)]);
+					$this->addError($object, $attribute, $this->wrongType, ['file' => $file->name, 'extensions' => implode(', ', $this->types)]);
 				}
 				break;
 			case UPLOAD_ERR_INI_SIZE:
 			case UPLOAD_ERR_FORM_SIZE:
-				$this->addError($object, $attribute, $this->tooBig, ['{file}' => $file->name, '{limit}' => $this->getSizeLimit()]);
+				$this->addError($object, $attribute, $this->tooBig, ['file' => $file->name, 'limit' => $this->getSizeLimit()]);
 				break;
 			case UPLOAD_ERR_PARTIAL:
 				$this->addError($object, $attribute, $this->message);

--- a/framework/yii/validators/NumberValidator.php
+++ b/framework/yii/validators/NumberValidator.php
@@ -91,10 +91,10 @@ class NumberValidator extends Validator
 			$this->addError($object, $attribute, $this->message);
 		}
 		if ($this->min !== null && $value < $this->min) {
-			$this->addError($object, $attribute, $this->tooSmall, ['{min}' => $this->min]);
+			$this->addError($object, $attribute, $this->tooSmall, ['min' => $this->min]);
 		}
 		if ($this->max !== null && $value > $this->max) {
-			$this->addError($object, $attribute, $this->tooBig, ['{max}' => $this->max]);
+			$this->addError($object, $attribute, $this->tooBig, ['max' => $this->max]);
 		}
 	}
 

--- a/framework/yii/validators/RequiredValidator.php
+++ b/framework/yii/validators/RequiredValidator.php
@@ -75,7 +75,7 @@ class RequiredValidator extends Validator
 				$this->addError($object, $attribute, $this->message);
 			} else {
 				$this->addError($object, $attribute, $this->message, [
-					'{requiredValue}' => $this->requiredValue,
+					'requiredValue' => $this->requiredValue,
 				]);
 			}
 		}

--- a/framework/yii/validators/StringValidator.php
+++ b/framework/yii/validators/StringValidator.php
@@ -112,13 +112,13 @@ class StringValidator extends Validator
 		$length = mb_strlen($value, $this->encoding);
 
 		if ($this->min !== null && $length < $this->min) {
-			$this->addError($object, $attribute, $this->tooShort, ['{min}' => $this->min]);
+			$this->addError($object, $attribute, $this->tooShort, ['min' => $this->min]);
 		}
 		if ($this->max !== null && $length > $this->max) {
-			$this->addError($object, $attribute, $this->tooLong, ['{max}' => $this->max]);
+			$this->addError($object, $attribute, $this->tooLong, ['max' => $this->max]);
 		}
 		if ($this->length !== null && $length !== $this->length) {
-			$this->addError($object, $attribute, $this->notEqual, ['{length}' => $this->length]);
+			$this->addError($object, $attribute, $this->notEqual, ['length' => $this->length]);
 		}
 	}
 

--- a/framework/yii/validators/Validator.php
+++ b/framework/yii/validators/Validator.php
@@ -251,9 +251,9 @@ abstract class Validator extends Component
 	public function addError($object, $attribute, $message, $params = [])
 	{
 		$value = $object->$attribute;
-		$params['{attribute}'] = $object->getAttributeLabel($attribute);
-		$params['{value}'] = is_array($value) ? 'array()' : $value;
-		$object->addError($attribute, strtr($message, $params));
+		$params['attribute'] = $object->getAttributeLabel($attribute);
+		$params['value'] = is_array($value) ? 'array()' : $value;
+		$object->addError($attribute, Yii::$app->getI18n()->format($message, $params, Yii::$app->language));
 	}
 
 	/**

--- a/framework/yii/widgets/BaseListView.php
+++ b/framework/yii/widgets/BaseListView.php
@@ -131,30 +131,32 @@ abstract class BaseListView extends Widget
 	public function renderSummary()
 	{
 		$count = $this->dataProvider->getCount();
-		if (($pagination = $this->dataProvider->getPagination()) !== false && $count > 0) {
+		if (($pagination = $this->dataProvider->getPagination()) !== false) {
 			$totalCount = $this->dataProvider->getTotalCount();
 			$begin = $pagination->getPage() * $pagination->pageSize + 1;
 			$end = $begin + $count - 1;
 			$page = $pagination->getPage() + 1;
 			$pageCount = $pagination->pageCount;
 			if (($summaryContent = $this->summary) === null) {
-				$summaryContent = '<div class="summary">' . Yii::t('yii', 'Showing <b>{begin}-{end}</b> of <b>{totalCount}</b> {0, plural, =1{item} other{items}}.', $totalCount) . '</div>';
+				$summaryContent = '<div class="summary">'
+					. Yii::t('yii', 'Showing <b>{totalCount, plural, =0{0} other{{begin}-{end}}}</b> of <b>{totalCount}</b> {totalCount, plural, one{item} other{items}}.')
+					. '</div>';
 			}
 		} else {
 			$begin = $page = $pageCount = 1;
 			$end = $totalCount = $count;
 			if (($summaryContent = $this->summary) === null) {
-				$summaryContent = '<div class="summary">' . Yii::t('yii', 'Total <b>{count}</b> {0, plural, =1{item} other{items}}.', $count) . '</div>';
+				$summaryContent = '<div class="summary">' . Yii::t('yii', 'Total <b>{count}</b> {count, plural, one{item} other{items}}.') . '</div>';
 			}
 		}
-		return strtr($summaryContent, [
-			'{begin}' => $begin,
-			'{end}' => $end,
-			'{count}' => $count,
-			'{totalCount}' => $totalCount,
-			'{page}' => $page,
-			'{pageCount}' => $pageCount,
-		]);
+		return Yii::$app->getI18n()->format($summaryContent, [
+			'begin' => $begin,
+			'end' => $end,
+			'count' => $count,
+			'totalCount' => $totalCount,
+			'page' => $page,
+			'pageCount' => $pageCount,
+		], Yii::$app->language);
 	}
 
 	/**

--- a/tests/unit/framework/validators/BooleanValidatorTest.php
+++ b/tests/unit/framework/validators/BooleanValidatorTest.php
@@ -10,6 +10,12 @@ use yiiunit\TestCase;
  */
 class BooleanValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
+
 	public function testValidateValue()
 	{
 		$val = new BooleanValidator;

--- a/tests/unit/framework/validators/CompareValidatorTest.php
+++ b/tests/unit/framework/validators/CompareValidatorTest.php
@@ -10,6 +10,11 @@ use yiiunit\TestCase;
 
 class CompareValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
 
 	public function testValidateValueException()
 	{

--- a/tests/unit/framework/validators/DateValidatorTest.php
+++ b/tests/unit/framework/validators/DateValidatorTest.php
@@ -10,6 +10,12 @@ use yiiunit\TestCase;
 
 class DateValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
+
 	public function testEnsureMessageIsSet()
 	{
 		$val = new DateValidator;

--- a/tests/unit/framework/validators/DefaultValueValidatorTest.php
+++ b/tests/unit/framework/validators/DefaultValueValidatorTest.php
@@ -8,6 +8,12 @@ use yiiunit\TestCase;
  */
 class DefaultValueValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
+
 	public function testValidateAttribute()
 	{
 		$val = new DefaultValueValidator;

--- a/tests/unit/framework/validators/EmailValidatorTest.php
+++ b/tests/unit/framework/validators/EmailValidatorTest.php
@@ -11,6 +11,12 @@ use yiiunit\TestCase;
  */
 class EmailValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
+
 	public function testValidateValue()
 	{
 		$validator = new EmailValidator();

--- a/tests/unit/framework/validators/ExistValidatorTest.php
+++ b/tests/unit/framework/validators/ExistValidatorTest.php
@@ -18,6 +18,7 @@ class ExistValidatorTest extends DatabaseTestCase
 	public function setUp()
 	{
 		parent::setUp();
+		$this->mockApplication();
 		ActiveRecord::$db = $this->getConnection();
 	}
 

--- a/tests/unit/framework/validators/FilterValidatorTest.php
+++ b/tests/unit/framework/validators/FilterValidatorTest.php
@@ -9,6 +9,12 @@ use yiiunit\TestCase;
 
 class FilterValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
+
 	public function testAssureExceptionOnInit()
 	{
 		$this->setExpectedException('yii\base\InvalidConfigException');

--- a/tests/unit/framework/validators/NumberValidatorTest.php
+++ b/tests/unit/framework/validators/NumberValidatorTest.php
@@ -9,6 +9,12 @@ use yiiunit\TestCase;
 
 class NumberValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
+
 	public function testEnsureMessageOnInit()
 	{
 		$val = new NumberValidator;

--- a/tests/unit/framework/validators/RangeValidatorTest.php
+++ b/tests/unit/framework/validators/RangeValidatorTest.php
@@ -9,6 +9,12 @@ use yiiunit\TestCase;
 
 class RangeValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
+
 	public function testInitException()
 	{
 		$this->setExpectedException('yii\base\InvalidConfigException', 'The "range" property must be set.');

--- a/tests/unit/framework/validators/RegularExpressionValidatorTest.php
+++ b/tests/unit/framework/validators/RegularExpressionValidatorTest.php
@@ -9,6 +9,12 @@ use yiiunit\TestCase;
 
 class RegularExpressionValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
+
 	public function testValidateValue()
 	{
 		$val = new RegularExpressionValidator(['pattern' => '/^[a-zA-Z0-9](\.)?([^\/]*)$/m']);

--- a/tests/unit/framework/validators/RequiredValidatorTest.php
+++ b/tests/unit/framework/validators/RequiredValidatorTest.php
@@ -8,6 +8,12 @@ use yiiunit\TestCase;
 
 class RequiredValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
+
 	public function testValidateValueWithDefaults()
 	{
 		$val = new RequiredValidator();

--- a/tests/unit/framework/validators/UniqueValidatorTest.php
+++ b/tests/unit/framework/validators/UniqueValidatorTest.php
@@ -19,6 +19,7 @@ class UniqueValidatorTest extends DatabaseTestCase
 	public function setUp()
 	{
 		parent::setUp();
+		$this->mockApplication();
 		ActiveRecord::$db = $this->getConnection();
 	}
 

--- a/tests/unit/framework/validators/UrlValidatorTest.php
+++ b/tests/unit/framework/validators/UrlValidatorTest.php
@@ -9,6 +9,12 @@ use yiiunit\TestCase;
  */
 class UrlValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
+
 	public function testValidateValue()
 	{
 		$val = new UrlValidator;

--- a/tests/unit/framework/validators/ValidatorTest.php
+++ b/tests/unit/framework/validators/ValidatorTest.php
@@ -12,6 +12,11 @@ use yiiunit\TestCase;
 
 class ValidatorTest extends TestCase
 {
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockApplication();
+	}
 
 	protected function getTestModel($additionalAttributes = [])
 	{

--- a/tests/unit/framework/validators/ValidatorTest.php
+++ b/tests/unit/framework/validators/ValidatorTest.php
@@ -220,7 +220,7 @@ class ValidatorTest extends TestCase
 		$errors = $m->getErrors('attr_msg_val');
 		$this->assertEquals('attr_msg_val::array()', $errors[0]);
 		$m = $this->getTestModel(['attr_msg_val' => 'abc']);
-		$val->addError($m, 'attr_msg_val', '{attribute}::{value}::{param}', ['{param}' => 'param_value']);
+		$val->addError($m, 'attr_msg_val', '{attribute}::{value}::{param}', ['param' => 'param_value']);
 		$errors = $m->getErrors('attr_msg_val');
 		$this->assertEquals('attr_msg_val::abc::param_value', $errors[0]);
 	}


### PR DESCRIPTION
Fixes #991.
ICU message format is now available for gridview summary and all validator messages.
It is not available for client validation as some params are added in JS.
