### PR TITLE
bug fix fetch record with default value in ActiveRecord

### DIFF
--- a/framework/yii/db/ActiveRecord.php
+++ b/framework/yii/db/ActiveRecord.php
@@ -1216,7 +1216,8 @@ class ActiveRecord extends Model
 		foreach ($row as $name => $value) {
 			if (isset($columns[$name])) {
 				$record->_attributes[$name] = $value;
-			} else {
+			}
+			if (property_exists($record, $name)) {
 				$record->$name = $value;
 			}
 		}

--- a/tests/unit/data/ar/Customer.php
+++ b/tests/unit/data/ar/Customer.php
@@ -17,6 +17,8 @@ class Customer extends ActiveRecord
 
 	public $status2;
 
+	public $default_value = 1;
+
 	public static $afterSaveInsert = null;
 	public static $afterSaveNewRecord = null;
 

--- a/tests/unit/data/cubrid.sql
+++ b/tests/unit/data/cubrid.sql
@@ -26,6 +26,7 @@ CREATE TABLE `tbl_customer` (
   `name` varchar(128) NOT NULL,
   `address` string,
   `status` int (11) DEFAULT 0,
+  `default_value` int(11) DEFAULT 1,
   PRIMARY KEY (`id`)
 );
 
@@ -96,7 +97,7 @@ CREATE TABLE `tbl_composite_fk` (
 
 INSERT INTO tbl_customer (email, name, address, status) VALUES ('user1@example.com', 'user1', 'address1', 1);
 INSERT INTO tbl_customer (email, name, address, status) VALUES ('user2@example.com', 'user2', 'address2', 1);
-INSERT INTO tbl_customer (email, name, address, status) VALUES ('user3@example.com', 'user3', 'address3', 2);
+INSERT INTO tbl_customer (email, name, address, status, default_value) VALUES ('user3@example.com', 'user3', 'address3', 2, 2);
 
 INSERT INTO tbl_category (name) VALUES ('Books');
 INSERT INTO tbl_category (name) VALUES ('Movies');

--- a/tests/unit/data/mssql.sql
+++ b/tests/unit/data/mssql.sql
@@ -12,6 +12,7 @@ CREATE TABLE [dbo].[tbl_customer] (
 	[name] [varchar](128) NOT NULL,
 	[address] [text],
 	[status] [int] DEFAULT 0,
+	[default_value] [int] DEFAULT 1,
 	CONSTRAINT [PK_customer] PRIMARY KEY CLUSTERED (
 		[id] ASC
 	) ON [PRIMARY]
@@ -81,7 +82,7 @@ CREATE TABLE [dbo].[tbl_type] (
 
 INSERT INTO [dbo].[tbl_customer] ([email], [name], [address], [status]) VALUES ('user1@example.com', 'user1', 'address1', 1);
 INSERT INTO [dbo].[tbl_customer] ([email], [name], [address], [status]) VALUES ('user2@example.com', 'user2', 'address2', 1);
-INSERT INTO [dbo].[tbl_customer] ([email], [name], [address], [status]) VALUES ('user3@example.com', 'user3', 'address3', 2);
+INSERT INTO [dbo].[tbl_customer] ([email], [name], [address], [status], [default_value]) VALUES ('user3@example.com', 'user3', 'address3', 2, 2);
 
 INSERT INTO [dbo].[tbl_category] ([name]) VALUES ('Books');
 INSERT INTO [dbo].[tbl_category] ([name]) VALUES ('Movies');

--- a/tests/unit/data/mysql.sql
+++ b/tests/unit/data/mysql.sql
@@ -26,6 +26,7 @@ CREATE TABLE `tbl_customer` (
   `name` varchar(128) NOT NULL,
   `address` text,
   `status` int (11) DEFAULT 0,
+  `default_value` int(11) DEFAULT 1,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -98,7 +99,7 @@ CREATE TABLE `tbl_type` (
 
 INSERT INTO tbl_customer (email, name, address, status) VALUES ('user1@example.com', 'user1', 'address1', 1);
 INSERT INTO tbl_customer (email, name, address, status) VALUES ('user2@example.com', 'user2', 'address2', 1);
-INSERT INTO tbl_customer (email, name, address, status) VALUES ('user3@example.com', 'user3', 'address3', 2);
+INSERT INTO tbl_customer (email, name, address, status, default_value) VALUES ('user3@example.com', 'user3', 'address3', 2, 2);
 
 INSERT INTO tbl_category (name) VALUES ('Books');
 INSERT INTO tbl_category (name) VALUES ('Movies');

--- a/tests/unit/data/postgres.sql
+++ b/tests/unit/data/postgres.sql
@@ -24,7 +24,8 @@ CREATE TABLE tbl_customer (
   email varchar(128) NOT NULL,
   name varchar(128) NOT NULL,
   address text,
-  status integer DEFAULT 0
+  status integer DEFAULT 0,
+  default_value integer DEFAULT 1
 );
 
 comment on column public.tbl_customer.email is 'someone@example.com';
@@ -81,7 +82,7 @@ CREATE TABLE tbl_type (
 
 INSERT INTO tbl_customer (email, name, address, status) VALUES ('user1@example.com', 'user1', 'address1', 1);
 INSERT INTO tbl_customer (email, name, address, status) VALUES ('user2@example.com', 'user2', 'address2', 1);
-INSERT INTO tbl_customer (email, name, address, status) VALUES ('user3@example.com', 'user3', 'address3', 2);
+INSERT INTO tbl_customer (email, name, address, status, default_value) VALUES ('user3@example.com', 'user3', 'address3', 2, 2);
 
 INSERT INTO tbl_category (name) VALUES ('Books');
 INSERT INTO tbl_category (name) VALUES ('Movies');

--- a/tests/unit/data/sqlite.sql
+++ b/tests/unit/data/sqlite.sql
@@ -18,6 +18,7 @@ CREATE TABLE tbl_customer (
   name varchar(128) NOT NULL,
   address text,
   status INTEGER DEFAULT 0,
+  default_value INTEGER DEFAULT 1,
   PRIMARY KEY (id)
 );
 
@@ -83,7 +84,7 @@ CREATE TABLE tbl_type (
 
 INSERT INTO tbl_customer (email, name, address, status) VALUES ('user1@example.com', 'user1', 'address1', 1);
 INSERT INTO tbl_customer (email, name, address, status) VALUES ('user2@example.com', 'user2', 'address2', 1);
-INSERT INTO tbl_customer (email, name, address, status) VALUES ('user3@example.com', 'user3', 'address3', 2);
+INSERT INTO tbl_customer (email, name, address, status, default_value) VALUES ('user3@example.com', 'user3', 'address3', 2, 2);
 
 INSERT INTO tbl_category (name) VALUES ('Books');
 INSERT INTO tbl_category (name) VALUES ('Movies');

--- a/tests/unit/framework/db/ActiveRecordTest.php
+++ b/tests/unit/framework/db/ActiveRecordTest.php
@@ -79,6 +79,7 @@ class ActiveRecordTest extends DatabaseTestCase
 			'name' => 'user2',
 			'address' => 'address2',
 			'status' => '1',
+			'default_value' => '1',
 		], $customer);
 
 		// indexBy
@@ -472,5 +473,47 @@ class ActiveRecordTest extends DatabaseTestCase
 
 		$customers = Customer::find()->where(['status' => false])->all();
 		$this->assertEquals(1, count($customers));
+	}
+
+	public function testDefaultValue()
+	{
+		$customer = new Customer();
+		$customer->name = 'default value customer';
+		$customer->email = 'mail@example.com';
+		$customer->status = true;
+		$customer->save(false);
+
+		$customer->refresh();
+		$this->assertEquals(1, $customer->default_value);
+
+		$customer->default_value = 2;
+		$customer->refresh();
+		$this->assertEquals(2, $customer->default_value);
+
+		$customer = new Customer();
+		$customer->name = 'default value customer';
+		$customer->email = 'mail@example.com';
+		$customer->status = true;
+		$customer->default_value = 2;
+		$customer->save(false);
+
+		$customer->refresh();
+		$this->assertEquals(2, $customer->default_value);
+
+		$customer = new Customer();
+		$customer->setAttributes([
+			'name'          => 'default value customer',
+			'email'         => 'mail@example.com',
+			'status'        => true,
+			'default_value' => 2,
+		], false);
+		$customer->save(false);
+
+		$customer->refresh();
+		$this->assertEquals(2, $customer->default_value);
+
+		/** @var Customer $customer */
+		$customer = Customer::find(array('email' => 'user3@example.com'));
+		$this->assertEquals(2, $customer->default_value);
 	}
 }


### PR DESCRIPTION
Я пробую получить запись из БД со значением по-умолчанию (публичное свойство в ActiveRecord классе, как в [Yii1](http://www.yiiframework.com/doc/guide/1.1/en/database.ar#creating-record)), но получаю значение, которое было объявлено мной по умолчанию, а не то что содержится в БД. Я описал это в unit-тесте:

``` php
/** @var Customer $customer */
$customer = Customer::find(array('email' => 'user3@example.com'));
$this->assertEquals(2, $customer->default_value);
```

Извините, что по-русски.
