### PR TITLE
Fix path to gii assets 

### DIFF
--- a/extensions/gii/GiiAsset.php
+++ b/extensions/gii/GiiAsset.php
@@ -20,7 +20,7 @@ class GiiAsset extends AssetBundle
 	/**
 	 * @inheritdoc
 	 */
-	public $sourcePath = '@yii/gii/assets';
+	public $sourcePath = '@gii/assets';
 	/**
 	 * @inheritdoc
 	 */

--- a/extensions/gii/Module.php
+++ b/extensions/gii/Module.php
@@ -97,6 +97,7 @@ class Module extends \yii\base\Module
 	public function init()
 	{
 		parent::init();
+		yii::$aliases['@gii'] = __DIR__ ;
 		foreach (array_merge($this->coreGenerators(), $this->generators) as $id => $config) {
 			$this->generators[$id] = Yii::createObject($config);
 		}

--- a/extensions/gii/views/layouts/generator.php
+++ b/extensions/gii/views/layouts/generator.php
@@ -10,7 +10,7 @@ use yii\helpers\Html;
 $generators = Yii::$app->controller->module->generators;
 $activeGenerator = Yii::$app->controller->generator;
 ?>
-<?php $this->beginContent('@yii/gii/views/layouts/main.php'); ?>
+<?php $this->beginContent('@gii/views/layouts/main.php'); ?>
 <div class="row">
 	<div class="col-lg-3">
 		<div class="list-group">


### PR DESCRIPTION
```
Invalid Parameter – yii\base\InvalidParamException

The file or directory to be published does not exist: /home/lav45/www/advanced/vendor/yiisoft/yii2/yii/gii/assets
1. in /home/lav45/www/advanced/vendor/yiisoft/yii2/yii/web/AssetManager.php at line 207
```
