### PR TITLE
Using only arrays in rules instead comma-separated string

### DIFF
--- a/apps/advanced/common/models/LoginForm.php
+++ b/apps/advanced/common/models/LoginForm.php
@@ -23,9 +23,9 @@ class LoginForm extends Model
 			// username and password are both required
 			[['username', 'password'], 'required'],
 			// password is validated by validatePassword()
-			[['password'], 'validatePassword'],
+			['password', 'validatePassword'],
 			// rememberMe must be a boolean value
-			[['rememberMe'], 'boolean'],
+			['rememberMe', 'boolean'],
 		];
 	}
 

--- a/apps/advanced/common/models/LoginForm.php
+++ b/apps/advanced/common/models/LoginForm.php
@@ -21,11 +21,11 @@ class LoginForm extends Model
 	{
 		return [
 			// username and password are both required
-			['username, password', 'required'],
+			[['username', 'password'], 'required'],
 			// password is validated by validatePassword()
-			['password', 'validatePassword'],
+			[['password'], 'validatePassword'],
 			// rememberMe must be a boolean value
-			['rememberMe', 'boolean'],
+			[['rememberMe'], 'boolean'],
 		];
 	}
 

--- a/apps/advanced/common/models/User.php
+++ b/apps/advanced/common/models/User.php
@@ -104,18 +104,18 @@ class User extends ActiveRecord implements IdentityInterface
 	public function rules()
 	{
 		return [
-			[['username'], 'filter', 'filter' => 'trim'],
-			[['username'], 'required'],
-			[['username'], 'string', 'min' => 2, 'max' => 255],
+			['username', 'filter', 'filter' => 'trim'],
+			['username', 'required'],
+			['username', 'string', 'min' => 2, 'max' => 255],
 
-			[['email'], 'filter', 'filter' => 'trim'],
-			[['email'], 'required'],
-			[['email'], 'email'],
-			[['email'], 'unique', 'message' => 'This email address has already been taken.', 'on' => 'signup'],
-			[['email'], 'exist', 'message' => 'There is no user with such email.', 'on' => 'requestPasswordResetToken'],
+			['email', 'filter', 'filter' => 'trim'],
+			['email', 'required'],
+			['email', 'email'],
+			['email', 'unique', 'message' => 'This email address has already been taken.', 'on' => 'signup'],
+			['email', 'exist', 'message' => 'There is no user with such email.', 'on' => 'requestPasswordResetToken'],
 
-			[['password'], 'required'],
-			[['password'], 'string', 'min' => 6],
+			['password', 'required'],
+			['password', 'string', 'min' => 6],
 		];
 	}
 

--- a/apps/advanced/common/models/User.php
+++ b/apps/advanced/common/models/User.php
@@ -104,18 +104,18 @@ class User extends ActiveRecord implements IdentityInterface
 	public function rules()
 	{
 		return [
-			['username', 'filter', 'filter' => 'trim'],
-			['username', 'required'],
-			['username', 'string', 'min' => 2, 'max' => 255],
+			[['username'], 'filter', 'filter' => 'trim'],
+			[['username'], 'required'],
+			[['username'], 'string', 'min' => 2, 'max' => 255],
 
-			['email', 'filter', 'filter' => 'trim'],
-			['email', 'required'],
-			['email', 'email'],
-			['email', 'unique', 'message' => 'This email address has already been taken.', 'on' => 'signup'],
-			['email', 'exist', 'message' => 'There is no user with such email.', 'on' => 'requestPasswordResetToken'],
+			[['email'], 'filter', 'filter' => 'trim'],
+			[['email'], 'required'],
+			[['email'], 'email'],
+			[['email'], 'unique', 'message' => 'This email address has already been taken.', 'on' => 'signup'],
+			[['email'], 'exist', 'message' => 'There is no user with such email.', 'on' => 'requestPasswordResetToken'],
 
-			['password', 'required'],
-			['password', 'string', 'min' => 6],
+			[['password'], 'required'],
+			[['password'], 'string', 'min' => 6],
 		];
 	}
 

--- a/apps/advanced/frontend/models/ContactForm.php
+++ b/apps/advanced/frontend/models/ContactForm.php
@@ -25,9 +25,9 @@ class ContactForm extends Model
 			// name, email, subject and body are required
 			[['name', 'email', 'subject', 'body'], 'required'],
 			// email has to be a valid email address
-			[['email'], 'email'],
+			['email', 'email'],
 			// verifyCode needs to be entered correctly
-			[['verifyCode'], 'captcha'],
+			['verifyCode', 'captcha'],
 		];
 	}
 

--- a/apps/advanced/frontend/models/ContactForm.php
+++ b/apps/advanced/frontend/models/ContactForm.php
@@ -23,11 +23,11 @@ class ContactForm extends Model
 	{
 		return [
 			// name, email, subject and body are required
-			['name, email, subject, body', 'required'],
+			[['name', 'email', 'subject', 'body'], 'required'],
 			// email has to be a valid email address
-			['email', 'email'],
+			[['email'], 'email'],
 			// verifyCode needs to be entered correctly
-			['verifyCode', 'captcha'],
+			[['verifyCode'], 'captcha'],
 		];
 	}
 

--- a/apps/basic/models/ContactForm.php
+++ b/apps/basic/models/ContactForm.php
@@ -25,9 +25,9 @@ class ContactForm extends Model
 			// name, email, subject and body are required
 			[['name', 'email', 'subject', 'body'], 'required'],
 			// email has to be a valid email address
-			[['email'], 'email'],
+			['email', 'email'],
 			// verifyCode needs to be entered correctly
-			[['verifyCode'], 'captcha'],
+			['verifyCode', 'captcha'],
 		];
 	}
 

--- a/apps/basic/models/ContactForm.php
+++ b/apps/basic/models/ContactForm.php
@@ -23,11 +23,11 @@ class ContactForm extends Model
 	{
 		return [
 			// name, email, subject and body are required
-			['name, email, subject, body', 'required'],
+			[['name', 'email', 'subject', 'body'], 'required'],
 			// email has to be a valid email address
-			['email', 'email'],
+			[['email'], 'email'],
 			// verifyCode needs to be entered correctly
-			['verifyCode', 'captcha'],
+			[['verifyCode'], 'captcha'],
 		];
 	}
 

--- a/apps/basic/models/LoginForm.php
+++ b/apps/basic/models/LoginForm.php
@@ -23,9 +23,9 @@ class LoginForm extends Model
 			// username and password are both required
 			[['username', 'password'], 'required'],
 			// password is validated by validatePassword()
-			[['password'], 'validatePassword'],
+			['password', 'validatePassword'],
 			// rememberMe must be a boolean value
-			[['rememberMe'], 'boolean'],
+			['rememberMe', 'boolean'],
 		];
 	}
 

--- a/apps/basic/models/LoginForm.php
+++ b/apps/basic/models/LoginForm.php
@@ -21,11 +21,11 @@ class LoginForm extends Model
 	{
 		return [
 			// username and password are both required
-			['username, password', 'required'],
+			[['username', 'password'], 'required'],
 			// password is validated by validatePassword()
-			['password', 'validatePassword'],
+			[['password'], 'validatePassword'],
 			// rememberMe must be a boolean value
-			['rememberMe', 'boolean'],
+			[['rememberMe'], 'boolean'],
 		];
 	}
 

--- a/extensions/gii/Generator.php
+++ b/extensions/gii/Generator.php
@@ -178,8 +178,8 @@ abstract class Generator extends Model
 	public function rules()
 	{
 		return [
-			['template', 'required', 'message' => 'A code template must be selected.'],
-			['template', 'validateTemplate'],
+			[['template'], 'required', 'message' => 'A code template must be selected.'],
+			[['template'], 'validateTemplate'],
 		];
 	}
 

--- a/extensions/gii/generators/controller/Generator.php
+++ b/extensions/gii/generators/controller/Generator.php
@@ -69,12 +69,12 @@ class Generator extends \yii\gii\Generator
 	public function rules()
 	{
 		return array_merge(parent::rules(), [
-			['controller, actions, baseClass, ns', 'filter', 'filter' => 'trim'],
-			['controller, baseClass', 'required'],
-			['controller', 'match', 'pattern' => '/^[a-z\\-\\/]*$/', 'message' => 'Only a-z, dashes (-) and slashes (/) are allowed.'],
-			['actions', 'match', 'pattern' => '/^[a-z\\-,\\s]*$/', 'message' => 'Only a-z, dashes (-), spaces and commas are allowed.'],
-			['baseClass', 'match', 'pattern' => '/^[\w\\\\]*$/', 'message' => 'Only word characters and backslashes are allowed.'],
-			['ns', 'match', 'pattern' => '/^[\w\\\\]*$/', 'message' => 'Only word characters and backslashes are allowed.'],
+			[['controller', 'actions', 'baseClass', 'ns'], 'filter', 'filter' => 'trim'],
+			[['controller', 'baseClass'], 'required'],
+			[['controller'], 'match', 'pattern' => '/^[a-z\\-\\/]*$/', 'message' => 'Only a-z, dashes (-) and slashes (/) are allowed.'],
+			[['actions'], 'match', 'pattern' => '/^[a-z\\-,\\s]*$/', 'message' => 'Only a-z, dashes (-), spaces and commas are allowed.'],
+			[['baseClass'], 'match', 'pattern' => '/^[\w\\\\]*$/', 'message' => 'Only word characters and backslashes are allowed.'],
+			[['ns'], 'match', 'pattern' => '/^[\w\\\\]*$/', 'message' => 'Only word characters and backslashes are allowed.'],
 		]);
 	}
 

--- a/extensions/gii/generators/crud/Generator.php
+++ b/extensions/gii/generators/crud/Generator.php
@@ -42,17 +42,17 @@ class Generator extends \yii\gii\Generator
 	public function rules()
 	{
 		return array_merge(parent::rules(), [
-			['moduleID, controllerClass, modelClass, searchModelClass, baseControllerClass', 'filter', 'filter' => 'trim'],
-			['modelClass, searchModelClass, controllerClass, baseControllerClass, indexWidgetType', 'required'],
-			['searchModelClass', 'compare', 'compareAttribute' => 'modelClass', 'operator' => '!==', 'message' => 'Search Model Class must not be equal to Model Class.'],
-			['modelClass, controllerClass, baseControllerClass, searchModelClass', 'match', 'pattern' => '/^[\w\\\\]*$/', 'message' => 'Only word characters and backslashes are allowed.'],
-			['modelClass', 'validateClass', 'params' => ['extends' => ActiveRecord::className()]],
-			['baseControllerClass', 'validateClass', 'params' => ['extends' => Controller::className()]],
-			['controllerClass', 'match', 'pattern' => '/Controller$/', 'message' => 'Controller class name must be suffixed with "Controller".'],
-			['controllerClass, searchModelClass', 'validateNewClass'],
-			['indexWidgetType', 'in', 'range' => ['grid', 'list']],
-			['modelClass', 'validateModelClass'],
-			['moduleID', 'validateModuleID'],
+			[['moduleID', 'controllerClass', 'modelClass', 'searchModelClass', 'baseControllerClass'], 'filter', 'filter' => 'trim'],
+			[['modelClass', 'searchModelClass', 'controllerClass', 'baseControllerClass', 'indexWidgetType'], 'required'],
+			[['searchModelClass'], 'compare', 'compareAttribute' => 'modelClass', 'operator' => '!==', 'message' => 'Search Model Class must not be equal to Model Class.'],
+			[['modelClass', 'controllerClass', 'baseControllerClass', 'searchModelClass'], 'match', 'pattern' => '/^[\w\\\\]*$/', 'message' => 'Only word characters and backslashes are allowed.'],
+			[['modelClass'], 'validateClass', 'params' => ['extends' => ActiveRecord::className()]],
+			[['baseControllerClass'], 'validateClass', 'params' => ['extends' => Controller::className()]],
+			[['controllerClass'], 'match', 'pattern' => '/Controller$/', 'message' => 'Controller class name must be suffixed with "Controller".'],
+			[['controllerClass', 'searchModelClass'], 'validateNewClass'],
+			[['indexWidgetType'], 'in', 'range' => ['grid', 'list']],
+			[['modelClass'], 'validateModelClass'],
+			[['moduleID'], 'validateModuleID'],
 		]);
 	}
 

--- a/extensions/gii/generators/form/Generator.php
+++ b/extensions/gii/generators/form/Generator.php
@@ -60,14 +60,14 @@ class Generator extends \yii\gii\Generator
 	public function rules()
 	{
 		return array_merge(parent::rules(), [
-			['modelClass, viewName, scenarioName, viewPath', 'filter', 'filter' => 'trim'],
-			['modelClass, viewName, viewPath', 'required'],
-			['modelClass', 'match', 'pattern' => '/^[\w\\\\]*$/', 'message' => 'Only word characters and backslashes are allowed.'],
-			['modelClass', 'validateClass', 'params' => ['extends' => Model::className()]],
-			['viewName', 'match', 'pattern' => '/^\w+[\\-\\/\w]*$/', 'message' => 'Only word characters, dashes and slashes are allowed.'],
-			['viewPath', 'match', 'pattern' => '/^@?\w+[\\-\\/\w]*$/', 'message' => 'Only word characters, dashes, slashes and @ are allowed.'],
-			['viewPath', 'validateViewPath'],
-			['scenarioName', 'match', 'pattern' => '/^[\w\\-]+$/', 'message' => 'Only word characters and dashes are allowed.'],
+			[['modelClass', 'viewName', 'scenarioName', 'viewPath'], 'filter', 'filter' => 'trim'],
+			[['modelClass', 'viewName', 'viewPath'], 'required'],
+			[['modelClass'], 'match', 'pattern' => '/^[\w\\\\]*$/', 'message' => 'Only word characters and backslashes are allowed.'],
+			[['modelClass'], 'validateClass', 'params' => ['extends' => Model::className()]],
+			[['viewName'], 'match', 'pattern' => '/^\w+[\\-\\/\w]*$/', 'message' => 'Only word characters, dashes and slashes are allowed.'],
+			[['viewPath'], 'match', 'pattern' => '/^@?\w+[\\-\\/\w]*$/', 'message' => 'Only word characters, dashes, slashes and @ are allowed.'],
+			[['viewPath'], 'validateViewPath'],
+			[['scenarioName'], 'match', 'pattern' => '/^[\w\\-]+$/', 'message' => 'Only word characters and dashes are allowed.'],
 		]);
 	}
 

--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -237,10 +237,10 @@ class Generator extends \yii\gii\Generator
 
 		$rules = [];
 		foreach ($types as $type => $columns) {
-			$rules[] = "['" . implode(', ', $columns) . "', '$type']";
+			$rules[] = "[['" . implode(', ', $columns) . "'], '$type']";
 		}
 		foreach ($lengths as $length => $columns) {
-			$rules[] = "['" . implode(', ', $columns) . "', 'string', 'max' => $length]";
+			$rules[] = "[['" . implode(', ', $columns) . "'], 'string', 'max' => $length]";
 		}
 
 		return $rules;

--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -53,17 +53,17 @@ class Generator extends \yii\gii\Generator
 	public function rules()
 	{
 		return array_merge(parent::rules(), [
-			['db, ns, tableName, modelClass, baseClass', 'filter', 'filter' => 'trim'],
-			['db, ns, tableName, baseClass', 'required'],
-			['db, modelClass', 'match', 'pattern' => '/^\w+$/', 'message' => 'Only word characters are allowed.'],
-			['ns, baseClass', 'match', 'pattern' => '/^[\w\\\\]+$/', 'message' => 'Only word characters and backslashes are allowed.'],
-			['tableName', 'match', 'pattern' => '/^(\w+\.)?([\w\*]+)$/', 'message' => 'Only word characters, and optionally an asterisk and/or a dot are allowed.'],
-			['db', 'validateDb'],
-			['ns', 'validateNamespace'],
-			['tableName', 'validateTableName'],
-			['modelClass', 'validateModelClass', 'skipOnEmpty' => false],
-			['baseClass', 'validateClass', 'params' => ['extends' => ActiveRecord::className()]],
-			['generateRelations, generateLabelsFromComments', 'boolean'],
+			[['db', 'ns', 'tableName', 'modelClass', 'baseClass'], 'filter', 'filter' => 'trim'],
+			[['db', 'ns', 'tableName', 'baseClass'], 'required'],
+			[['db', 'modelClass'], 'match', 'pattern' => '/^\w+$/', 'message' => 'Only word characters are allowed.'],
+			[['ns', 'baseClass'], 'match', 'pattern' => '/^[\w\\\\]+$/', 'message' => 'Only word characters and backslashes are allowed.'],
+			[['tableName'], 'match', 'pattern' => '/^(\w+\.)?([\w\*]+)$/', 'message' => 'Only word characters, and optionally an asterisk and/or a dot are allowed.'],
+			[['db'], 'validateDb'],
+			[['ns'], 'validateNamespace'],
+			[['tableName'], 'validateTableName'],
+			[['modelClass'], 'validateModelClass', 'skipOnEmpty' => false],
+			[['baseClass'], 'validateClass', 'params' => ['extends' => ActiveRecord::className()]],
+			[['generateRelations', 'generateLabelsFromComments'], 'boolean'],
 		]);
 	}
 

--- a/extensions/gii/generators/module/Generator.php
+++ b/extensions/gii/generators/module/Generator.php
@@ -45,11 +45,11 @@ class Generator extends \yii\gii\Generator
 	public function rules()
 	{
 		return array_merge(parent::rules(), [
-			['moduleID, moduleClass', 'filter', 'filter' => 'trim'],
-			['moduleID, moduleClass', 'required'],
-			['moduleID', 'match', 'pattern' => '/^[\w\\-]+$/', 'message' => 'Only word characters and dashes are allowed.'],
-			['moduleClass', 'match', 'pattern' => '/^[\w\\\\]*$/', 'message' => 'Only word characters and backslashes are allowed.'],
-			['moduleClass', 'validateModuleClass'],
+			[['moduleID', 'moduleClass'], 'filter', 'filter' => 'trim'],
+			[['moduleID', 'moduleClass'], 'required'],
+			[['moduleID'], 'match', 'pattern' => '/^[\w\\-]+$/', 'message' => 'Only word characters and dashes are allowed.'],
+			[['moduleClass'], 'match', 'pattern' => '/^[\w\\\\]*$/', 'message' => 'Only word characters and backslashes are allowed.'],
+			[['moduleClass'], 'validateModuleClass'],
 		]);
 	}
 

--- a/framework/yii/base/Model.php
+++ b/framework/yii/base/Model.php
@@ -91,19 +91,19 @@ class Model extends Component implements IteratorAggregate, ArrayAccess
 	 *
 	 * ~~~
 	 * [
-	 *     'attribute list',
+	 *     ['attribute1', 'attribute2'],
 	 *     'validator type',
-	 *     'on' => 'scenario name',
+	 *     'on' => ['scenario1', 'scenario2'],
 	 *     ...other parameters...
 	 * ]
 	 * ~~~
 	 *
 	 * where
 	 *
-	 *  - attribute list: required, specifies the attributes (separated by commas) to be validated;
+	 *  - attribute list: required, specifies the attributes array to be validated;
 	 *  - validator type: required, specifies the validator to be used. It can be the name of a model
 	 *    class method, the name of a built-in validator, or a validator class name (or its path alias).
-	 *  - on: optional, specifies the [[scenario|scenarios]] (separated by commas) when the validation
+	 *  - on: optional, specifies the [[scenario|scenarios]] array when the validation
 	 *    rule can be applied. If this option is not set, the rule will apply to all scenarios.
 	 *  - additional name-value pairs can be specified to initialize the corresponding validator properties.
 	 *    Please refer to individual validator class API for possible properties.
@@ -128,15 +128,15 @@ class Model extends Component implements IteratorAggregate, ArrayAccess
 	 * ~~~
 	 * [
 	 *     // built-in "required" validator
-	 *     ['username', 'required'],
+	 *     [['username'], 'required'],
 	 *     // built-in "string" validator customized with "min" and "max" properties
-	 *     ['username', 'string', 'min' => 3, 'max' => 12],
+	 *     [['username'], 'string', 'min' => 3, 'max' => 12],
 	 *     // built-in "compare" validator that is used in "register" scenario only
-	 *     ['password', 'compare', 'compareAttribute' => 'password2', 'on' => 'register'],
+	 *     [['password'], 'compare', 'compareAttribute' => 'password2', 'on' => 'register'],
 	 *     // an inline validator defined via the "authenticate()" method in the model class
-	 *     ['password', 'authenticate', 'on' => 'login'],
+	 *     [['password'], 'authenticate', 'on' => 'login'],
 	 *     // a validator of class "DateRangeValidator"
-	 *     ['dateRange', 'DateRangeValidator'],
+	 *     [['dateRange'], 'DateRangeValidator'],
 	 * ];
 	 * ~~~
 	 *

--- a/framework/yii/base/Model.php
+++ b/framework/yii/base/Model.php
@@ -390,7 +390,7 @@ class Model extends Component implements IteratorAggregate, ArrayAccess
 			if ($rule instanceof Validator) {
 				$validators->append($rule);
 			} elseif (is_array($rule) && isset($rule[0], $rule[1])) { // attributes, validator type
-				$validator = Validator::createValidator($rule[1], $this, $rule[0], array_slice($rule, 2));
+				$validator = Validator::createValidator($rule[1], $this, (array) $rule[0], array_slice($rule, 2));
 				$validators->append($validator);
 			} else {
 				throw new InvalidConfigException('Invalid validation rule: a rule must specify both attribute names and validator type.');

--- a/framework/yii/base/Model.php
+++ b/framework/yii/base/Model.php
@@ -100,7 +100,7 @@ class Model extends Component implements IteratorAggregate, ArrayAccess
 	 *
 	 * where
 	 *
-	 *  - attribute list: required, specifies the attributes array to be validated;
+	 *  - attribute list: required, specifies the attributes array to be validated, for single attribute you can pass string;
 	 *  - validator type: required, specifies the validator to be used. It can be the name of a model
 	 *    class method, the name of a built-in validator, or a validator class name (or its path alias).
 	 *  - on: optional, specifies the [[scenario|scenarios]] array when the validation
@@ -128,15 +128,15 @@ class Model extends Component implements IteratorAggregate, ArrayAccess
 	 * ~~~
 	 * [
 	 *     // built-in "required" validator
-	 *     [['username'], 'required'],
+	 *     [['username', 'password'], 'required'],
 	 *     // built-in "string" validator customized with "min" and "max" properties
-	 *     [['username'], 'string', 'min' => 3, 'max' => 12],
+	 *     ['username', 'string', 'min' => 3, 'max' => 12],
 	 *     // built-in "compare" validator that is used in "register" scenario only
-	 *     [['password'], 'compare', 'compareAttribute' => 'password2', 'on' => 'register'],
+	 *     ['password', 'compare', 'compareAttribute' => 'password2', 'on' => 'register'],
 	 *     // an inline validator defined via the "authenticate()" method in the model class
-	 *     [['password'], 'authenticate', 'on' => 'login'],
+	 *     ['password', 'authenticate', 'on' => 'login'],
 	 *     // a validator of class "DateRangeValidator"
-	 *     [['dateRange'], 'DateRangeValidator'],
+	 *     ['dateRange', 'DateRangeValidator'],
 	 * ];
 	 * ~~~
 	 *

--- a/framework/yii/validators/Validator.php
+++ b/framework/yii/validators/Validator.php
@@ -133,17 +133,14 @@ abstract class Validator extends Component
 	 */
 	public static function createValidator($type, $object, $attributes, $params = [])
 	{
-		if (!is_array($attributes)) {
-			$attributes = preg_split('/[\s,]+/', $attributes, -1, PREG_SPLIT_NO_EMPTY);
-		}
-		$params['attributes'] = $attributes;
+		$params['attributes'] = (array) $attributes;
 
-		if (isset($params['on']) && !is_array($params['on'])) {
-			$params['on'] = preg_split('/[\s,]+/', $params['on'], -1, PREG_SPLIT_NO_EMPTY);
+		if (isset($params['on'])) {
+			$params['on'] = (array) $params['on'];
 		}
 
-		if (isset($params['except']) && !is_array($params['except'])) {
-			$params['except'] = preg_split('/[\s,]+/', $params['except'], -1, PREG_SPLIT_NO_EMPTY);
+		if (isset($params['except'])) {
+			$params['except'] = (array) $params['except'];
 		}
 
 		if (method_exists($object, $type)) {

--- a/framework/yii/validators/Validator.php
+++ b/framework/yii/validators/Validator.php
@@ -131,17 +131,9 @@ abstract class Validator extends Component
 	 * @param array $params initial values to be applied to the validator properties
 	 * @return Validator the validator
 	 */
-	public static function createValidator($type, $object, $attributes, $params = [])
+	public static function createValidator($type, $object, array $attributes, $params = [])
 	{
-		$params['attributes'] = (array) $attributes;
-
-		if (isset($params['on'])) {
-			$params['on'] = (array) $params['on'];
-		}
-
-		if (isset($params['except'])) {
-			$params['except'] = (array) $params['except'];
-		}
+		$params['attributes'] = $attributes;
 
 		if (method_exists($object, $type)) {
 			// method-based validator

--- a/tests/unit/data/base/Singer.php
+++ b/tests/unit/data/base/Singer.php
@@ -14,9 +14,9 @@ class Singer extends Model
 	public function rules()
 	{
 		return [
-			['lastName', 'default', 'value' => 'Lennon'],
-			['lastName', 'required'],
-			['underscore_style', 'yii\captcha\CaptchaValidator'],
+			[['lastName'], 'default', 'value' => 'Lennon'],
+			[['lastName'], 'required'],
+			[['underscore_style'], 'yii\captcha\CaptchaValidator'],
 		];
 	}
 }

--- a/tests/unit/data/validators/models/FakedValidationModel.php
+++ b/tests/unit/data/validators/models/FakedValidationModel.php
@@ -28,8 +28,8 @@ class FakedValidationModel extends Model
 	public function rules()
 	{
 		return [
-			['val_attr_a, val_attr_b', 'required', 'on' => 'reqTest'],
-			['val_attr_c', 'integer'],
+			[['val_attr_a', 'val_attr_b'], 'required', 'on' => 'reqTest'],
+			[['val_attr_c'], 'integer'],
 		];
 	}
 

--- a/tests/unit/data/validators/models/FakedValidationModel.php
+++ b/tests/unit/data/validators/models/FakedValidationModel.php
@@ -29,7 +29,7 @@ class FakedValidationModel extends Model
 	{
 		return [
 			[['val_attr_a', 'val_attr_b'], 'required', 'on' => 'reqTest'],
-			[['val_attr_c'], 'integer'],
+			['val_attr_c', 'integer'],
 		];
 	}
 

--- a/tests/unit/framework/validators/ValidatorTest.php
+++ b/tests/unit/framework/validators/ValidatorTest.php
@@ -39,7 +39,7 @@ class ValidatorTest extends TestCase
 		$val = TestValidator::createValidator(
 			'boolean',
 			$model,
-			'attr_test1, attr_test2',
+			['attr_test1', 'attr_test2'],
 			['on' => ['a', 'b']]
 		);
 		$this->assertInstanceOf(BooleanValidator::className(), $val);
@@ -48,8 +48,8 @@ class ValidatorTest extends TestCase
 		$val = TestValidator::createValidator(
 			'boolean',
 			$model,
-			'attr_test1, attr_test2',
-			['on' => 'a, b', 'except' => 'c,d,e']
+			['attr_test1', 'attr_test2'],
+			['on' => ['a', 'b'], 'except' => ['c', 'd', 'e']]
 		);
 		$this->assertInstanceOf(BooleanValidator::className(), $val);
 		$this->assertSame(['a', 'b'], $val->on);

--- a/tests/unit/framework/validators/ValidatorTest.php
+++ b/tests/unit/framework/validators/ValidatorTest.php
@@ -54,7 +54,7 @@ class ValidatorTest extends TestCase
 		$this->assertInstanceOf(BooleanValidator::className(), $val);
 		$this->assertSame(['a', 'b'], $val->on);
 		$this->assertSame(['c', 'd', 'e'], $val->except);
-		$val = TestValidator::createValidator('inlineVal', $model, 'val_attr_a');
+		$val = TestValidator::createValidator('inlineVal', $model, ['val_attr_a']);
 		$this->assertInstanceOf(InlineValidator::className(), $val);
 		$this->assertSame('inlineVal', $val->method);
 	}


### PR DESCRIPTION
I think the short form of array is not difficult to write than a comma separated string. But we gain a little bit in performance when creating each model instance.

``` php
public function rules()
{
    return [
        [['name', 'email', 'subject', 'body'], 'required'],
    ];
}
```

vs

``` php
public function rules()
{
    return [
        ['name, email, subject, body', 'required'],
    ];
}
```
