### PR TITLE
FIX: Sort separator '.' was breaking deep fields, '~' instead

### DIFF
--- a/framework/yii/data/Sort.php
+++ b/framework/yii/data/Sort.php
@@ -170,9 +170,9 @@ class Sort extends Object
 	 * @var array separators used in the generated URL. This must be an array consisting of
 	 * two elements. The first element specifies the character separating different
 	 * attributes, while the second element specifies the character separating attribute name
-	 * and the corresponding sort direction. Defaults to `['.', '-']`.
+	 * and the corresponding sort direction. Defaults to `['~', '-']`.
 	 */
-	public $separators = ['.', '-'];
+	public $separators = ['~', '-'];
 	/**
 	 * @var array parameters (name => value) that should be used to obtain the current sort directions
 	 * and to create new sort URLs. If not set, $_GET will be used instead.


### PR DESCRIPTION
'~' is 1) Not reserved by http://tools.ietf.org/html/rfc3986 2) Does not mix with namespace/class/name separator in any major programming language
