### PR TITLE
Eliminating $_GET array

### DIFF
--- a/framework/yii/data/Pagination.php
+++ b/framework/yii/data/Pagination.php
@@ -83,7 +83,7 @@ class Pagination extends Object
 	public $route;
 	/**
 	 * @var array parameters (name => value) that should be used to obtain the current page number
-	 * and to create new pagination URLs. If not set, $_GET will be used instead.
+	 * and to create new pagination URLs. If not set, all parameters from $_GET will be used instead.
 	 *
 	 * The array element indexed by [[pageVar]] is considered to be the current page number.
 	 * If the element does not exist, the current page number is considered 0.
@@ -131,7 +131,7 @@ class Pagination extends Object
 	public function getPage($recalculate = false)
 	{
 		if ($this->_page === null || $recalculate) {
-			$params = $this->params === null ? $_GET : $this->params;
+			$params = $this->params === null ? Yii::$app->request->get() : $this->params;
 			if (isset($params[$this->pageVar]) && is_scalar($params[$this->pageVar])) {
 				$this->_page = (int)$params[$this->pageVar] - 1;
 				if ($this->validatePage) {
@@ -169,7 +169,7 @@ class Pagination extends Object
 	 */
 	public function createUrl($page)
 	{
-		$params = $this->params === null ? $_GET : $this->params;
+		$params = $this->params === null ? Yii::$app->request->get() : $this->params;
 		if ($page > 0 || $page >= 0 && $this->forcePageVar) {
 			$params[$this->pageVar] = $page + 1;
 		} else {


### PR DESCRIPTION
It is the best practice to use common wraper for defining the get-parameters. 
