### PR TITLE
Must be one method to get _GET. 

### DIFF
--- a/framework/yii/web/Request.php
+++ b/framework/yii/web/Request.php
@@ -312,15 +312,6 @@ class Request extends \yii\base\Request
 	}
 
 	/**
-	 * Returns the GET request parameter values.
-	 * @return array the GET request parameter values
-	 */
-	public function getGet()
-	{
-		return $_GET;
-	}
-
-	/**
 	 * Returns the named POST parameter value.
 	 * If the POST parameter does not exist, the second parameter to this method will be returned.
 	 * @param string $name the POST parameter name. If not specified, whole $_POST is returned.


### PR DESCRIPTION
getGet() is just duplication of get(). It is better to put the logic for $_GET management in one place.
