### PR TITLE
Events can be used like filters

### DIFF
--- a/framework/yii/base/Component.php
+++ b/framework/yii/base/Component.php
@@ -435,6 +435,7 @@ class Component extends Object
 	 * all attached handlers for the event.
 	 * @param string $name the event name
 	 * @param Event $event the event parameter. If not set, a default [[Event]] object will be created.
+	 * @return mix Result that attached handlers
 	 */
 	public function trigger($name, $event = null)
 	{
@@ -450,14 +451,18 @@ class Component extends Object
 			$event->name = $name;
 			foreach ($this->_events[$name] as $handler) {
 				$event->data = $handler[1];
-				call_user_func($handler[0], $event);
+				$returnedEvent = call_user_func($handler[0], $event);
+				if ($returnedEvent instanceof Event) {
+					$event = $returnedEvent;
+				}
 				// stop further handling if the event is handled
 				if ($event instanceof Event && $event->handled) {
-					return;
+					return $event;
 				}
 			}
 		}
 		Event::trigger($this, $name, $event);
+		return $event;
 	}
 
 	/**


### PR DESCRIPTION
Is it possible to introlduce in Yii2 not simple Events only but Filters?

The defference is that the Event does things only, but Filter can be used for modification of variables. So we do something like:

``` php
$myEvent = new myEvent;
$myEvent->var=$variable; //we have $var and want modify it
$event = $this->trigger('myfilter', $myEvent);
//Now we have modified $event and modified $event->var inside 
$variable = $event->var; 
```

So it is possible to modify variables using Events system. It is like [wordpress filters](http://codex.wordpress.org/Function_Reference/add_filter).

Filters can be used in core Yii2. Suppose we have Response component and want modify it in [yii\web\Application::handleRequest() method](https://github.com/yiisoft/yii2/blob/master/framework/yii/web/Application.php#L63)
Instead simple `return $response;` we can do something like:

``` php
$event = $this->trigger('responseModification', $response);
return $event->data; //In $event->data we have new $responce which have been modified in Event
```
