### PR TITLE
fix sort constants for correct sorting SQL generation

### DIFF
--- a/framework/yii/data/Sort.php
+++ b/framework/yii/data/Sort.php
@@ -78,12 +78,12 @@ class Sort extends Object
 	/**
 	 * Sort ascending
 	 */
-	const ASC = false;
+	const ASC = SORT_ASC;
 
 	/**
 	 * Sort descending
 	 */
-	const DESC = true;
+	const DESC = SORT_DESC;
 
 	/**
 	 * @var boolean whether the sorting can be applied to multiple attributes simultaneously.


### PR DESCRIPTION
as QueryTrait expect now 
`SORT_ASC, SORT_DESC`
instead 
`Query::SORT_ASC, Query::SORT_DESC`

but Sort class was still using "own" sort constans and SQL was generated without ASC / DESC operators

Maybe  QueryTrait code comments should be also changed from

> (e.g. `['id' => SORT_ASC, 'name' => SORT_DESC]`).

to

> (e.g. `['id' => Sort::ASC, 'name' => Sort::DESC]`). 

to use consistent constant naming all over framework ?
