### PR TITLE
Update Alert.php to display multiple flash messages for the session.

### DIFF
--- a/apps/advanced/frontend/widgets/Alert.php
+++ b/apps/advanced/frontend/widgets/Alert.php
@@ -36,10 +36,10 @@ class Alert extends Widget
 			if (in_array($type, $this->allowedTypes)) {
 				$class = ($type === 'error') ? 'alert-danger' : 'alert-' . $type;
 				Html::addCssClass($this->options, $class);
-				echo BsAlert::widget(array(
+				echo BsAlert::widget([
 					'body' => $message,
 					'options' => $this->options
-				));	
+				]);	
 				$session->removeFlash($type);
 				$this->_doNotRender = false;
 			}

--- a/apps/advanced/frontend/widgets/Alert.php
+++ b/apps/advanced/frontend/widgets/Alert.php
@@ -24,8 +24,17 @@ use yii\bootstrap\Alert as BsAlert;
  */
 class Alert extends Widget
 {
-	private $_doNotRender = true;
+	/**
+	 * @var array the allowed bootstrap alert types.
+	 */
 	public $allowedTypes = ['error', 'danger', 'success', 'info', 'warning'];
+	 
+	/**
+	 * @var array the options for rendering the close button tag.
+	 */
+	public $closeButton = [];
+	
+	private $_doNotRender = true;
 	
 	public function init()
 	{
@@ -35,11 +44,12 @@ class Alert extends Widget
 		foreach ($flashes as $type => $message) {
 			if (in_array($type, $this->allowedTypes)) {
 				$class = ($type === 'error') ? 'alert-danger' : 'alert-' . $type;
-				Html::addCssClass($this->options, $class);
+				$this->options['class'] = $class;
 				echo BsAlert::widget([
 					'body' => $message,
+					'closeButton' => $this->closeButton,
 					'options' => $this->options
-				]);	
+				]);
 				$session->removeFlash($type);
 				$this->_doNotRender = false;
 			}

--- a/apps/advanced/frontend/widgets/Alert.php
+++ b/apps/advanced/frontend/widgets/Alert.php
@@ -44,12 +44,13 @@ class Alert extends Widget
 		foreach ($flashes as $type => $message) {
 			if (in_array($type, $this->allowedTypes)) {
 				$class = ($type === 'error') ? 'alert-danger' : 'alert-' . $type;
-				$this->options['class'] = $class;
+				Html::addCssClass($this->options, $class);
 				echo BsAlert::widget([
 					'body' => $message,
 					'closeButton' => $this->closeButton,
 					'options' => $this->options
 				]);
+				Html::removeCssClass($this->options, $class);
 				$session->removeFlash($type);
 				$this->_doNotRender = false;
 			}

--- a/apps/advanced/frontend/widgets/Alert.php
+++ b/apps/advanced/frontend/widgets/Alert.php
@@ -7,10 +7,6 @@
 
 namespace frontend\widgets;
 
-use yii\helpers\Html;
-use yii\bootstrap\Widget;
-use yii\bootstrap\Alert as BsAlert;
-
 /**
  * Alert widget renders a message from session flash. All flash messages are displayed
  * in the sequence they were assigned using setFlash. You can set message as following:
@@ -22,7 +18,7 @@ use yii\bootstrap\Alert as BsAlert;
  * @author Alexander Makarov <sam@rmcerative.ru>
  * @author Kartik Visweswaran <kartikv2@gmail.com>
  */
-class Alert extends Widget
+class Alert extends \yii\bootstrap\Widget
 {
 	/**
 	 * @var array the allowed bootstrap alert types.
@@ -34,38 +30,23 @@ class Alert extends Widget
 	 */
 	public $closeButton = [];
 	
-	private $_doNotRender = true;
-	
 	public function init()
 	{
-		$this->_doNotRender = true;
 		$session = \Yii::$app->getSession();
-		$flashes = $session->getAllFlashes();
-		$baseCssClass = isset($this->options['class']) ? $this->options['class'] : '';
+		$appendCss = isset($this->options['class']) ? $this->options['class'] : '';
 
 		foreach ($flashes as $type => $message) {
 			if (in_array($type, $this->allowedTypes)) {
-				$this->options['class'] = (($type === 'error') ? "alert-danger" : "alert-{$type}") . ' ' . $baseCssClass;
-				echo BsAlert::widget([
+				$this->options['class'] = (($type === 'error') ? 'alert-danger' : 'alert-' . $type) . ' ' . $appendCss;
+				echo \yii\bootstrap\Alert::widget([
 					'body' => $message,
 					'closeButton' => $this->closeButton,
 					'options' => $this->options
 				]);
-				Html::removeCssClass($this->options, $class);
 				$session->removeFlash($type);
 				$this->_doNotRender = false;
 			}
 		}
-		
-		if (!$this->_doNotRender) {
-			parent::init();
-		}
-	}
-
-	public function run()
-	{
-		if (!$this->_doNotRender) {
-			parent::run();
-		}
+		parent::init();
 	}
 }

--- a/apps/advanced/frontend/widgets/Alert.php
+++ b/apps/advanced/frontend/widgets/Alert.php
@@ -33,18 +33,18 @@ class Alert extends \yii\bootstrap\Widget
 	public function init()
 	{
 		$session = \Yii::$app->getSession();
-		$appendCss = isset($this->options['class']) ? $this->options['class'] : '';
+		$flashes = $session->getAllFlashes();
+		$appendCss = isset($this->options['class']) ? ' ' . $this->options['class'] : '';
 
 		foreach ($flashes as $type => $message) {
 			if (in_array($type, $this->allowedTypes)) {
-				$this->options['class'] = (($type === 'error') ? 'alert-danger' : 'alert-' . $type) . ' ' . $appendCss;
+				$this->options['class'] = (($type === 'error') ? 'alert-danger' : 'alert-' . $type) . $appendCss;
 				echo \yii\bootstrap\Alert::widget([
 					'body' => $message,
 					'closeButton' => $this->closeButton,
 					'options' => $this->options
 				]);
 				$session->removeFlash($type);
-				$this->_doNotRender = false;
 			}
 		}
 		parent::init();

--- a/apps/advanced/frontend/widgets/Alert.php
+++ b/apps/advanced/frontend/widgets/Alert.php
@@ -21,9 +21,18 @@ namespace frontend\widgets;
 class Alert extends \yii\bootstrap\Widget
 {
 	/**
-	 * @var array the allowed bootstrap alert types.
+	 * @var array the alert types configuration for the flash messages.
+	 * This array is setup as $key => $value, where:
+	 * - $key is the name of the session flash variable
+	 * - $value is the bootstrap alert type (i.e. danger, success, info, warning)
 	 */
-	public $allowedTypes = ['error', 'danger', 'success', 'info', 'warning'];
+	public $alertTypes = [
+		'error'   => 'danger', 
+		'danger'  => 'danger', 
+		'success' => 'success', 
+		'info'    => 'info', 
+		'warning' => 'warning'
+	];
 	 
 	/**
 	 * @var array the options for rendering the close button tag.
@@ -37,15 +46,13 @@ class Alert extends \yii\bootstrap\Widget
 		$appendCss = isset($this->options['class']) ? ' ' . $this->options['class'] : '';
 
 		foreach ($flashes as $type => $message) {
-			if (in_array($type, $this->allowedTypes)) {
-				$this->options['class'] = (($type === 'error') ? 'alert-danger' : 'alert-' . $type) . $appendCss;
-				echo \yii\bootstrap\Alert::widget([
-					'body' => $message,
-					'closeButton' => $this->closeButton,
-					'options' => $this->options
-				]);
-				$session->removeFlash($type);
-			}
+			$this->options['class'] = 'alert-' . $this->alertTypes[$type] . $appendCss;
+			echo \yii\bootstrap\Alert::widget([
+				'body' => $message,
+				'closeButton' => $this->closeButton,
+				'options' => $this->options
+			]);
+			$session->removeFlash($type);
 		}
 		parent::init();
 	}

--- a/apps/advanced/frontend/widgets/Alert.php
+++ b/apps/advanced/frontend/widgets/Alert.php
@@ -41,10 +41,11 @@ class Alert extends Widget
 		$this->_doNotRender = true;
 		$session = \Yii::$app->getSession();
 		$flashes = $session->getAllFlashes();
+		$baseCssClass = isset($this->options['class']) ? $this->options['class'] : '';
+
 		foreach ($flashes as $type => $message) {
 			if (in_array($type, $this->allowedTypes)) {
-				$class = ($type === 'error') ? 'alert-danger' : 'alert-' . $type;
-				Html::addCssClass($this->options, $class);
+				$this->options['class'] = (($type === 'error') ? "alert-danger" : "alert-{$type}") . ' ' . $baseCssClass;
 				echo BsAlert::widget([
 					'body' => $message,
 					'closeButton' => $this->closeButton,

--- a/apps/advanced/frontend/widgets/Alert.php
+++ b/apps/advanced/frontend/widgets/Alert.php
@@ -48,10 +48,10 @@ class Alert extends \yii\bootstrap\Widget
 		$appendCss = isset($this->options['class']) ? ' ' . $this->options['class'] : '';
 		
 		foreach ($flashes as $type => $message) {
-			/* initialize css class for each alert box in loop */
+			/* initialize css class for each alert box */
 			$this->options['class'] = 'alert-' . $this->alertTypes[$type] . $appendCss; 
 
-			/* assign unique id to each alert box in the loop */
+			/* assign unique id to each alert box */
 			$this->options['id'] = $this->getId() . '-' . $type;
 
 			echo \yii\bootstrap\Alert::widget([

--- a/apps/advanced/frontend/widgets/Alert.php
+++ b/apps/advanced/frontend/widgets/Alert.php
@@ -37,7 +37,7 @@ class Alert extends \yii\bootstrap\Widget
 	/**
 	 * @var array the options for rendering the close button tag.
 	 */
-	public $closeButtonOptions = [];
+	public $closeButton = [];
 	
 	public function init()
 	{
@@ -56,7 +56,7 @@ class Alert extends \yii\bootstrap\Widget
 
 			echo \yii\bootstrap\Alert::widget([
 				'body' => $message,
-				'closeButton' => $this->closeButtonOptions,
+				'closeButton' => $this->closeButton,
 				'options' => $this->options
 			]);
 

--- a/apps/advanced/frontend/widgets/Alert.php
+++ b/apps/advanced/frontend/widgets/Alert.php
@@ -15,8 +15,8 @@ namespace frontend\widgets;
  * - \Yii::$app->getSession()->setFlash('success', 'This is the message');
  * - \Yii::$app->getSession()->setFlash('info', 'This is the message');
  *
- * @author Alexander Makarov <sam@rmcerative.ru>
  * @author Kartik Visweswaran <kartikv2@gmail.com>
+ * @author Alexander Makarov <sam@rmcerative.ru>
  */
 class Alert extends \yii\bootstrap\Widget
 {
@@ -37,23 +37,30 @@ class Alert extends \yii\bootstrap\Widget
 	/**
 	 * @var array the options for rendering the close button tag.
 	 */
-	public $closeButton = [];
+	public $closeButtonOptions = [];
 	
 	public function init()
 	{
+		parent::init();
+
 		$session = \Yii::$app->getSession();
 		$flashes = $session->getAllFlashes();
 		$appendCss = isset($this->options['class']) ? ' ' . $this->options['class'] : '';
-
+		
 		foreach ($flashes as $type => $message) {
-			$this->options['class'] = 'alert-' . $this->alertTypes[$type] . $appendCss;
+			/* initialize css class for each alert box in loop */
+			$this->options['class'] = 'alert-' . $this->alertTypes[$type] . $appendCss; 
+
+			/* assign unique id to each alert box in the loop */
+			$this->options['id'] = $this->getId() . '-' . $type;
+
 			echo \yii\bootstrap\Alert::widget([
 				'body' => $message,
-				'closeButton' => $this->closeButton,
+				'closeButton' => $this->closeButtonOptions,
 				'options' => $this->options
 			]);
+
 			$session->removeFlash($type);
 		}
-		parent::init();
 	}
 }


### PR DESCRIPTION
The alert widget within the advanced app (frontend) does not render multiple flash messages. This updated implementation of the Alert widget allows display of all flash messages assigned through setFlash. In addition, the flash variables can be configured and mapped to specific bootstrap alert types.
