### PR TITLE
db: Empty dates should be returned as null by typecast

### DIFF
--- a/framework/yii/db/ColumnSchema.php
+++ b/framework/yii/db/ColumnSchema.php
@@ -87,12 +87,12 @@ class ColumnSchema extends Object
 	 */
 	public function typecast($value)
 	{
-		if ($value === null || gettype($value) === $this->phpType || $value instanceof Expression) {
-			return $value;
-		}
-		if ($value === '' && $this->type !== Schema::TYPE_TEXT && $this->type !== Schema::TYPE_STRING) {
-			return null;
-		}
+        if ($value === '' && $this->type !== Schema::TYPE_TEXT && $this->type !== Schema::TYPE_STRING) {
+            return null;
+        }
+        if ($value === null || gettype($value) === $this->phpType || $value instanceof Expression) {
+            return $value;
+        }
 		switch ($this->phpType) {
 			case 'string':
 				return (string)$value;


### PR DESCRIPTION
If a date value is an empty string (''), the typecast should return null because e.g. pgsql dismiss empty strings. Swapping the if statements does this.

Please review!

Thanks
Sascha
