### PR TITLE
Include Schema in new migrations by default

### DIFF
--- a/framework/yii/views/migration.php
+++ b/framework/yii/views/migration.php
@@ -8,6 +8,8 @@
 echo "<?php\n";
 ?>
 
+use yii\db\Schema;
+
 class <?= $className ?> extends \yii\db\Migration
 {
 	public function up()


### PR DESCRIPTION
The most common use of migrations is DB Schema manipulation.
So I think it is better to include `use yii\db\Schema;` into default migration template in console tool.
