### PR TITLE
Update Html Helper to include bootstrap icon generation.

### DIFF
--- a/framework/yii/helpers/BaseHtml.php
+++ b/framework/yii/helpers/BaseHtml.php
@@ -378,7 +378,8 @@ class BaseHtml
 	 */
 	public static function icon($icon, $options = [], $tag = 'span', $prefix = 'glyphicon glyphicon-')
 	{
-		static::addCssClass($options, $prefix . $icon);
+		$class = isset($options['class']) ? ' ' . $options['class'] : '';
+		$options['class'] = $prefix . $icon . $class;
 		return static::tag($tag, '', $options);
 	}
 	

--- a/framework/yii/helpers/BaseHtml.php
+++ b/framework/yii/helpers/BaseHtml.php
@@ -372,11 +372,11 @@ class BaseHtml
 	 * Generates a bootstrap icon tag.
 	 * @param string $icon the bootstrap icon name without prefix (e.g. 'plus', 'pencil', 'trash')
 	 * @param array $options html options for the icon container
-	 * @param string $tag the icon container tag (usually 'span' or 'i') - defaults to 'i'
+	 * @param string $tag the icon container tag (usually 'span' or 'i') - defaults to 'span'
 	 * @param string $prefix the css class prefix - defaults to 'glyphicon glyphicon-'
 	 * @author Kartik Visweswaran <kartikv2@gmail.com>
 	 */
-	public static function icon($icon, $options = [], $tag = 'i', $prefix = 'glyphicon glyphicon-')
+	public static function icon($icon, $options = [], $tag = 'span', $prefix = 'glyphicon glyphicon-')
 	{
 		static::addCssClass($options, $prefix . $icon);
 		return static::tag($tag, '', $options);

--- a/framework/yii/helpers/BaseHtml.php
+++ b/framework/yii/helpers/BaseHtml.php
@@ -376,7 +376,7 @@ class BaseHtml
 	 * @param string $prefix the css class prefix - defaults to 'glyphicon glyphicon-'
 	 * @author Kartik Visweswaran <kartikv2@gmail.com>
 	 */
-	public static function icon($icon, $options = [], $tag = 'span', $prefix = 'glyphicon glyphicon-')
+	public static function icon($icon, $options = [], $prefix = 'glyphicon glyphicon-', $tag = 'span')
 	{
 		$class = isset($options['class']) ? ' ' . $options['class'] : '';
 		$options['class'] = $prefix . $icon . $class;

--- a/framework/yii/helpers/BaseHtml.php
+++ b/framework/yii/helpers/BaseHtml.php
@@ -377,8 +377,8 @@ class BaseHtml
 	 */
 	public static function icon($icon, $options = [], $tag = 'i', $prefix = 'glyphicon glyphicon-')
 	{
-		Html::addCssClass($options, $prefix . $icon);
-		return Html::tag($tag, '', $options);
+		static::addCssClass($options, $prefix . $icon);
+		return static::tag($tag, '', $options);
 	}
 	
 	/**

--- a/framework/yii/helpers/BaseHtml.php
+++ b/framework/yii/helpers/BaseHtml.php
@@ -370,10 +370,11 @@ class BaseHtml
 	
 	/**
 	 * Generates a bootstrap icon tag.
-	 * @param string $icon the name of the bootstrap icon (without any prefix)
+	 * @param string $icon the bootstrap icon name without prefix (e.g. 'plus', 'pencil', 'trash')
 	 * @param array $options html options for the icon container
-	 * @param string $tag the icon container tag - defaults to 'i'
+	 * @param string $tag the icon container tag (usually 'span' or 'i') - defaults to 'i'
 	 * @param string $prefix the css class prefix - defaults to 'glyphicon glyphicon-'
+	 * @author Kartik Visweswaran <kartikv2@gmail.com>
 	 */
 	public static function icon($icon, $options = [], $tag = 'i', $prefix = 'glyphicon glyphicon-')
 	{

--- a/framework/yii/helpers/BaseHtml.php
+++ b/framework/yii/helpers/BaseHtml.php
@@ -367,7 +367,20 @@ class BaseHtml
 	{
 		return static::tag('button', $content, $options);
 	}
-
+	
+	/**
+	 * Generates a bootstrap icon tag.
+	 * @param string $icon the name of the bootstrap icon (without any prefix)
+	 * @param array $options html options for the icon container
+	 * @param string $tag the icon container tag - defaults to 'i'
+	 * @param string $prefix the css class prefix - defaults to 'glyphicon glyphicon-'
+	 */
+	public static function icon($icon, $options = [], $tag = 'i', $prefix = 'glyphicon glyphicon-')
+	{
+		Html::addCssClass($options, $prefix . $icon);
+		return Html::tag($tag, '', $options);
+	}
+	
 	/**
 	 * Generates a submit button tag.
 	 * @param string $content the content enclosed within the button tag. It will NOT be HTML-encoded.


### PR DESCRIPTION
Not sure where to put this. Since Twitter Bootstrap is built into yii framework - proposing this in the `BaseHtml` class. The bootstrap glyphicon is potentially used in a lot of places (in views, grids, navs, menus, buttons), and its a lot easier to use it like the following:

``` php
echo Html::icon('pencil');
```

The prefix `glyphicon glyphicon-` and tag `i` or `span` can be customized as parameters. So this can work even if we have something like `FontAwesome` or  `Jquery UI icons` to be generated by changing the prefix.
