### PR TITLE
Sphinx test integration for Travis (from #1341)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_script:
   - composer self-update && composer --version
   - composer require satooshi/php-coveralls 0.6.* --dev --prefer-dist
   - mysql -e 'CREATE DATABASE yiitest;';
+  - mysql -D yiitest -u travis < /home/travis/build/yiisoft/yii2/tests/unit/data/sphinx/source.sql
   - psql -U postgres -c 'CREATE DATABASE yiitest;';
   - echo 'elasticsearch version ' && curl http://localhost:9200/
   - tests/unit/data/travis/apc-setup.sh

--- a/tests/unit/data/sphinx/sphinx.conf
+++ b/tests/unit/data/sphinx/sphinx.conf
@@ -2,7 +2,7 @@
 #
 # Setup test environment:
 # - initialize test database source:
-# mysql -D yii2test -u test < /path/to/yii/tests/unit/data/sphinx/source.sql
+# mysql -D yiitest -u test < /path/to/yii/tests/unit/data/sphinx/source.sql
 # - setup test Sphinx indexes:
 # indexer --config /path/to/yii/tests/unit/data/sphinx/sphinx.conf --all [--rotate]
 # - run the "searchd" daemon:
@@ -39,7 +39,7 @@ source yii2_test_item_src
 	sql_host		= localhost
 	sql_user		= travis
 	sql_pass		=
-	sql_db			= yii2test
+	sql_db			= yiitest
 	sql_port		= 3306	# optional, default is 3306
 
 	sql_query		= \

--- a/tests/unit/data/travis/README.md
+++ b/tests/unit/data/travis/README.md
@@ -10,3 +10,5 @@ The scripts are:
    Compiles and installs the [memcache pecl extension](http://pecl.php.net/package/memcache)
  - [`cubrid-setup.sh`](cubrid-setup.sh)
    Prepares the [CUBRID](http://www.cubrid.org/) server instance by installing the server and PHP PDO driver
+ - [`sphinx-setup.sh`](sphinx-setup.sh)
+   Prepares the [Sphinx](http://sphinxsearch.com/) server instances by installing the server and attaching it to MySQL

--- a/tests/unit/data/travis/sphinx-setup.sh
+++ b/tests/unit/data/travis/sphinx-setup.sh
@@ -18,6 +18,10 @@ sudo chmod -R 777 /var/log/sphinx # ugly (for travis)
 sudo mkdir /var/lib/sphinx
 sudo chmod 777 /var/lib/sphinx # ugly (for travis)
 
+# run dir pid
+sudo mkdir /var/run/sphinx
+sudo chmod 777 /var/run/sphinx # ugly (for travis)
+
 # setup test Sphinx indexes:
 indexer --config $CWD/../sphinx/sphinx.conf --all
 


### PR DESCRIPTION
Was not done with #1341

This PR addresses the PID error for searchd, and switches to yiitest db like the rest of the tests. (uses the yiitest db  to insert fixtures and create tags/indexes)
