### PR TITLE
Rename method createAbsoluteUrl to createCanonicalUrl

### DIFF
--- a/apps/advanced/common/mails/passwordResetToken.php
+++ b/apps/advanced/common/mails/passwordResetToken.php
@@ -6,7 +6,7 @@ use yii\helpers\Html;
  * @var common\models\User $user;
  */
 
-$resetLink = Yii::$app->urlManager->createAbsoluteUrl('site/reset-password', ['token' => $user->password_reset_token]);
+$resetLink = Yii::$app->urlManager->createCanonicalUrl('site/reset-password', ['token' => $user->password_reset_token]);
 ?>
 
 Hello <?= Html::encode($user->username) ?>,

--- a/docs/guide/url.md
+++ b/docs/guide/url.md
@@ -18,9 +18,9 @@ application component with the `urlManager` ID. This component is accessible bot
 `\Yii::$app->urlManager`. The component makes availabe the two following URL creation methods:
 
 - `createUrl($route, $params = [])`
-- `createAbsoluteUrl($route, $params = [])`
+- `createCanonicalUrl($route, $params = [])`
 
-The `createUrl` method creates a URL relative to the application root, such as `/index.php/site/index/`. The `createAbsoluteUrl` method creates URL prefixed with the proper protocol and
+The `createUrl` method creates a URL relative to the application root, such as `/index.php/site/index/`. The `createCanonicalUrl` method creates URL prefixed with the proper protocol and
 hostname: `http://www.example.com/index.php/site/index`. The former is suitable for internal application URLs, while the latter is used when you need to create rules for outside the website, such as when sending emails or generating an RSS feed.
 
 Some examples:
@@ -28,7 +28,7 @@ Some examples:
 ```php
 echo \Yii::$app->urlManager->createUrl('site/page', ['id' => 'about']);
 // /index.php/site/page/id/about/
-echo \Yii::$app->urlManager->createAbsoluteUrl('blog/post/index');
+echo \Yii::$app->urlManager->createCanonicalUrl('blog/post/index');
 // http://www.example.com/index.php/blog/post/index/
 ```
 

--- a/framework/yii/web/Controller.php
+++ b/framework/yii/web/Controller.php
@@ -143,7 +143,7 @@ class Controller extends \yii\base\Controller
 	 */
 	public function getCanonicalUrl()
 	{
-		return Yii::$app->getUrlManager()->createAbsoluteUrl($this->getRoute(), $this->actionParams);
+		return Yii::$app->getUrlManager()->createCanonicalUrl($this->getRoute(), $this->actionParams);
 	}
 
 	/**

--- a/framework/yii/web/UrlManager.php
+++ b/framework/yii/web/UrlManager.php
@@ -32,7 +32,7 @@ use yii\caching\Cache;
  *
  * @property string $baseUrl The base URL that is used by [[createUrl()]] to prepend URLs it creates.
  * @property string $hostInfo The host info (e.g. "http://www.example.com") that is used by
- * [[createAbsoluteUrl()]] to prepend URLs it creates.
+ * [[createCanonicalUrl()]] to prepend URLs it creates.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -227,7 +227,7 @@ class UrlManager extends Component
 
 	/**
 	 * Creates a URL using the given route and parameters.
-	 * The URL created is a relative one. Use [[createAbsoluteUrl()]] to create an absolute URL.
+	 * The URL created is a relative one. Use [[createCanonicalUrl()]] to create an absolute URL.
 	 * @param string $route the route
 	 * @param array $params the parameters (name-value pairs)
 	 * @return string the created URL
@@ -273,14 +273,14 @@ class UrlManager extends Component
 	}
 
 	/**
-	 * Creates an absolute URL using the given route and parameters.
+	 * Creates an canonical URL using the given route and parameters.
 	 * This method prepends the URL created by [[createUrl()]] with the [[hostInfo]].
 	 * @param string $route the route
 	 * @param array $params the parameters (name-value pairs)
 	 * @return string the created URL
 	 * @see createUrl()
 	 */
-	public function createAbsoluteUrl($route, $params = [])
+	public function createCanonicalUrl($route, $params = [])
 	{
 		$url = $this->createUrl($route, $params);
 		if (strpos($url, '://') !== false) {
@@ -316,8 +316,8 @@ class UrlManager extends Component
 	}
 
 	/**
-	 * Returns the host info that is used by [[createAbsoluteUrl()]] to prepend URLs it creates.
-	 * @return string the host info (e.g. "http://www.example.com") that is used by [[createAbsoluteUrl()]] to prepend URLs it creates.
+	 * Returns the host info that is used by [[createCanonicalUrl()]] to prepend URLs it creates.
+	 * @return string the host info (e.g. "http://www.example.com") that is used by [[createCanonicalUrl()]] to prepend URLs it creates.
 	 */
 	public function getHostInfo()
 	{
@@ -328,8 +328,8 @@ class UrlManager extends Component
 	}
 
 	/**
-	 * Sets the host info that is used by [[createAbsoluteUrl()]] to prepend URLs it creates.
-	 * @param string $value the host info (e.g. "http://www.example.com") that is used by [[createAbsoluteUrl()]] to prepend URLs it creates.
+	 * Sets the host info that is used by [[createCanonicalUrl()]] to prepend URLs it creates.
+	 * @param string $value the host info (e.g. "http://www.example.com") that is used by [[createCanonicalUrl()]] to prepend URLs it creates.
 	 */
 	public function setHostInfo($value)
 	{

--- a/tests/unit/framework/web/UrlManagerTest.php
+++ b/tests/unit/framework/web/UrlManagerTest.php
@@ -115,14 +115,14 @@ class UrlManagerTest extends TestCase
 		$this->assertEquals('/test/post/index?page=1', $url);
 	}
 
-	public function testCreateAbsoluteUrl()
+	public function testCreateCanonicalUrl()
 	{
 		$manager = new UrlManager([
 			'baseUrl' => '/',
 			'hostInfo' => 'http://www.example.com',
 			'cache' => null,
 		]);
-		$url = $manager->createAbsoluteUrl('post/view', ['id' => 1, 'title' => 'sample post']);
+		$url = $manager->createCanonicalUrl('post/view', ['id' => 1, 'title' => 'sample post']);
 		$this->assertEquals('http://www.example.com?r=post/view&id=1&title=sample+post', $url);
 	}
 


### PR DESCRIPTION
Rename method, because 

``` php
echo \Yii::$app->urlManager->createUrl('site/page', ['id' => 'about']);
```

It is generate absolute url too (`/index.php/site/page/id/about/`).
