### PR TITLE
Added callable typehints, tests slightly fixed

### DIFF
--- a/apps/basic/tests/acceptance/WebGuy.php
+++ b/apps/basic/tests/acceptance/WebGuy.php
@@ -278,7 +278,7 @@ class WebGuy extends \Codeception\AbstractGuy
      * @see Codeception\Module\PhpBrowser::executeInGuzzle()
      * @return \Codeception\Maybe
      */
-    public function executeInGuzzle($function) {
+    public function executeInGuzzle(callable $function) {
         $this->scenario->addStep(new \Codeception\Step\Action('executeInGuzzle', func_get_args()));
         if ($this->scenario->running()) {
             $result = $this->scenario->runStep();

--- a/extensions/sphinx/Query.php
+++ b/extensions/sphinx/Query.php
@@ -644,7 +644,7 @@ class Query extends Component implements QueryInterface
 	 * @return static the query object itself
 	 * @see snippetCallback
 	 */
-	public function snippetCallback($callback)
+	public function snippetCallback(callable $callback)
 	{
 		$this->snippetCallback = $callback;
 		return $this;

--- a/framework/yii/base/Component.php
+++ b/framework/yii/base/Component.php
@@ -390,7 +390,7 @@ class Component extends Object
 	 * When the event handler is invoked, this data can be accessed via [[Event::data]].
 	 * @see off()
 	 */
-	public function on($name, $handler, $data = null)
+	public function on($name, callable $handler, $data = null)
 	{
 		$this->ensureBehaviors();
 		$this->_events[$name][] = [$handler, $data];
@@ -405,7 +405,7 @@ class Component extends Object
 	 * @return boolean if a handler is found and detached
 	 * @see on()
 	 */
-	public function off($name, $handler = null)
+	public function off($name, callable $handler = null)
 	{
 		$this->ensureBehaviors();
 		if (empty($this->_events[$name])) {

--- a/framework/yii/base/Event.php
+++ b/framework/yii/base/Event.php
@@ -74,7 +74,7 @@ class Event extends Object
 	 * When the event handler is invoked, this data can be accessed via [[Event::data]].
 	 * @see off()
 	 */
-	public static function on($class, $name, $handler, $data = null)
+	public static function on($class, $name, callable $handler, $data = null)
 	{
 		self::$_events[$name][ltrim($class, '\\')][] = [$handler, $data];
 	}
@@ -91,7 +91,7 @@ class Event extends Object
 	 * @return boolean if a handler is found and detached
 	 * @see on()
 	 */
-	public static function off($class, $name, $handler = null)
+	public static function off($class, $name, callable $handler = null)
 	{
 		$class = ltrim($class, '\\');
 		if (empty(self::$_events[$name][$class])) {

--- a/framework/yii/db/ActiveRelation.php
+++ b/framework/yii/db/ActiveRelation.php
@@ -38,7 +38,7 @@ class ActiveRelation extends ActiveQuery implements ActiveRelationInterface
 	 * Its signature should be `function($query)`, where `$query` is the query to be customized.
 	 * @return static
 	 */
-	public function viaTable($tableName, $link, $callable = null)
+	public function viaTable($tableName, $link, callable $callable = null)
 	{
 		$relation = new ActiveRelation([
 			'modelClass' => get_class($this->primaryModel),

--- a/framework/yii/db/ActiveRelationInterface.php
+++ b/framework/yii/db/ActiveRelationInterface.php
@@ -25,5 +25,5 @@ interface ActiveRelationInterface extends ActiveQueryInterface
 	 * Its signature should be `function($query)`, where `$query` is the query to be customized.
 	 * @return static the relation object itself.
 	 */
-	public function via($relationName, $callable = null);
+	public function via($relationName, callable $callable = null);
 }

--- a/framework/yii/db/ActiveRelationTrait.php
+++ b/framework/yii/db/ActiveRelationTrait.php
@@ -61,7 +61,7 @@ trait ActiveRelationTrait
 	 * Its signature should be `function($query)`, where `$query` is the query to be customized.
 	 * @return static the relation object itself.
 	 */
-	public function via($relationName, $callable = null)
+	public function via($relationName, callable $callable = null)
 	{
 		$relation = $this->primaryModel->getRelation($relationName);
 		$this->via = [$relationName, $relation];

--- a/tests/unit/framework/base/ComponentTest.php
+++ b/tests/unit/framework/base/ComponentTest.php
@@ -17,6 +17,8 @@ function globalEventHandler2($event)
 	$event->handled = true;
 }
 
+function globalEventHandler3($event){}
+
 /**
  * @group base
  */
@@ -46,7 +48,7 @@ class ComponentTest extends TestCase
 		$behavior = new NewBehavior();
 		$component->attachBehavior('a', $behavior);
 		$this->assertSame($behavior, $component->getBehavior('a'));
-		$component->on('test', 'fake');
+		$component->on('test', 'yiiunit\framework\base\globalEventHandler');
 		$this->assertTrue($component->hasEventHandlers('test'));
 
 		$clone = clone $component;
@@ -158,28 +160,28 @@ class ComponentTest extends TestCase
 	public function testOn()
 	{
 		$this->assertFalse($this->component->hasEventHandlers('click'));
-		$this->component->on('click', 'foo');
+		$this->component->on('click', 'yiiunit\framework\base\globalEventHandler');
 		$this->assertTrue($this->component->hasEventHandlers('click'));
 
 		$this->assertFalse($this->component->hasEventHandlers('click2'));
 		$p = 'on click2';
-		$this->component->$p = 'foo2';
+		$this->component->$p = 'yiiunit\framework\base\globalEventHandler2';
 		$this->assertTrue($this->component->hasEventHandlers('click2'));
 	}
 
 	public function testOff()
 	{
 		$this->assertFalse($this->component->hasEventHandlers('click'));
-		$this->component->on('click', 'foo');
+		$this->component->on('click', 'yiiunit\framework\base\globalEventHandler');
 		$this->assertTrue($this->component->hasEventHandlers('click'));
-		$this->component->off('click', 'foo');
+		$this->component->off('click', 'yiiunit\framework\base\globalEventHandler');
 		$this->assertFalse($this->component->hasEventHandlers('click'));
 
-		$this->component->on('click2', 'foo');
-		$this->component->on('click2', 'foo2');
-		$this->component->on('click2', 'foo3');
+		$this->component->on('click2', 'yiiunit\framework\base\globalEventHandler');
+		$this->component->on('click2', 'yiiunit\framework\base\globalEventHandler2');
+		$this->component->on('click2', 'yiiunit\framework\base\globalEventHandler3');
 		$this->assertTrue($this->component->hasEventHandlers('click2'));
-		$this->component->off('click2', 'foo3');
+		$this->component->off('click2', 'yiiunit\framework\base\globalEventHandler');
 		$this->assertTrue($this->component->hasEventHandlers('click2'));
 		$this->component->off('click2');
 		$this->assertFalse($this->component->hasEventHandlers('click2'));
@@ -215,7 +217,7 @@ class ComponentTest extends TestCase
 	public function testHasEventHandlers()
 	{
 		$this->assertFalse($this->component->hasEventHandlers('click'));
-		$this->component->on('click', 'foo');
+		$this->component->on('click', 'yiiunit\framework\base\globalEventHandler');
 		$this->assertTrue($this->component->hasEventHandlers('click'));
 	}
 


### PR DESCRIPTION
Now `Component::on()` does'nt require test for non-existent callback — PHP will raise uncatchable error in this case

Fix #1290
