### PR TITLE
Update travis to exclude packs and display verbose text

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ before_script:
   - tests/unit/data/travis/cubrid-setup.sh
   - tests/unit/data/travis/sphinx-setup.sh
 
-#script:
-#  - phpunit --coverage-clover tests/unit/runtime/coveralls/clover.xml --verbose --exclude-group mssql,oci,wincache,xcache,zenddata,vendor
+script:
+  - phpunit --coverage-text --coverage-clover tests/unit/runtime/coveralls/clover.xml --verbose --exclude-group mssql,oci,wincache,xcache,zenddata,vendor
 
 #after_script:
 #  - php vendor/bin/coveralls


### PR DESCRIPTION
(coveralls.io still excluded)
