### PR TITLE
Allow Travis to be run not only for YiiSoft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_script:
   - composer self-update && composer --version
   - composer require satooshi/php-coveralls 0.6.* --dev --prefer-dist
   - mysql -e 'CREATE DATABASE yiitest;';
-  - mysql -D yiitest -u travis < /home/travis/build/yiisoft/yii2/tests/unit/data/sphinx/source.sql
   - psql -U postgres -c 'CREATE DATABASE yiitest;';
   - echo 'elasticsearch version ' && curl http://localhost:9200/
   - tests/unit/data/travis/apc-setup.sh

--- a/tests/unit/data/travis/sphinx-setup.sh
+++ b/tests/unit/data/travis/sphinx-setup.sh
@@ -22,6 +22,9 @@ sudo chmod 777 /var/lib/sphinx # ugly (for travis)
 sudo mkdir /var/run/sphinx
 sudo chmod 777 /var/run/sphinx # ugly (for travis)
 
+# Setup source database
+mysql -D yiitest -u travis < $CWD/../sphinx/source.sql
+
 # setup test Sphinx indexes:
 indexer --config $CWD/../sphinx/sphinx.conf --all
 


### PR DESCRIPTION
Resent change #1341 disallow using Travis for any user except “yiisoft”. This PR fixes that.
