### PR TITLE
Default search behavior in gii-generated CRUD is case insensitive now. Can be forced to be case-sensitive.

### DIFF
--- a/extensions/gii/generators/crud/templates/search.php
+++ b/extensions/gii/generators/crud/templates/search.php
@@ -67,15 +67,20 @@ class <?= $searchModelClass ?> extends Model
 		return $dataProvider;
 	}
 
-	protected function addCondition($query, $attribute, $partialMatch = false)
+	protected function addCondition($query, $attribute, $partialMatch = false, $caseSensitive = false)
 	{
 		$value = $this->$attribute;
 		if (trim($value) === '') {
 			return;
 		}
 		if ($partialMatch) {
-			$value = '%' . strtr($value, ['%'=>'\%', '_'=>'\_', '\\'=>'\\\\']) . '%';
-			$query->andWhere(['like', $attribute, $value]);
+            if ($caseSensitive) {
+                $value = '%' . strtr($value, ['%'=>'\%', '_'=>'\_', '\\'=>'\\\\']) . '%';
+                $query->andWhere(['like', $attribute , $value]);
+            } else {
+                $value = '%' . strtolower(strtr($value, ['%'=>'\%', '_'=>'\_', '\\'=>'\\\\'])) . '%';
+                $query->andWhere(['like', 'lower('.$attribute.')', $value]);
+            }
 		} else {
 			$query->andWhere([$attribute => $value]);
 		}


### PR DESCRIPTION
Hello, just a quick enhancement for the default CRUD generator. It adds case insensitive search behavior to gii-generated CRUD's. It's also possible to fall back to the original case sensitiive method by setting the $caseSensitive parameter to false.
