### PR TITLE
fixed UrlValidator pattern

### DIFF
--- a/framework/yii/validators/UrlValidator.php
+++ b/framework/yii/validators/UrlValidator.php
@@ -26,7 +26,7 @@ class UrlValidator extends Validator
 	 * The pattern may contain a `{schemes}` token that will be replaced
 	 * by a regular expression which represents the [[validSchemes]].
 	 */
-	public $pattern = '/^{schemes}:\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)/i';
+	public $pattern = '/^{schemes}:\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)$/i';
 	/**
 	 * @var array list of URI schemes which should be considered valid. By default, http and https
 	 * are considered to be valid schemes.


### PR DESCRIPTION
urls as 'http://site.com/page space 8' were considered valid.
