### PR TITLE
Fixed file validation

### DIFF
--- a/framework/yii/validators/FileValidator.php
+++ b/framework/yii/validators/FileValidator.php
@@ -178,6 +178,7 @@ class FileValidator extends Validator
 				} elseif (!empty($this->types) && !in_array(strtolower(pathinfo($file->name, PATHINFO_EXTENSION)), $this->types, true)) {
 					return [$this->wrongType, ['file' => $file->name, 'extensions' => implode(', ', $this->types)]];
 				}
+				return [];
 				break;
 			case UPLOAD_ERR_INI_SIZE:
 			case UPLOAD_ERR_FORM_SIZE:
@@ -197,7 +198,7 @@ class FileValidator extends Validator
 			default:
 				break;
 		}
-		return null;
+		return [$this->message, []];
 	}
 
 	/**


### PR DESCRIPTION
I think the only situation when file is correct is in case UPLOAD_ERR_OK. If any other state then there is an error. If php developers will introduce new constant then in default state validation will always pass. But validation have to pass in UPLOAD_ERR_OK case only.
