### PR TITLE
Update Grid ActionColumn URL generation for modules

### DIFF
--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -76,7 +76,7 @@ class ActionColumn extends Column
 		} else {
 			$params = is_array($key) ? $key : ['id' => $key];
 			$controller = Yii::$app->controller;
-			if (isset($controller->module) && $controller->module instanceof Application) {
+			if (!isset($controller->module) || $controller->module instanceof Application) {
 				return Yii::$app->controller->createUrl($action, $params);
 			}
 			else {

--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -80,7 +80,7 @@ class ActionColumn extends Column
 				return Yii::$app->controller->createUrl($action, $params);
 			}
 			else {
-				return Yii::$app->controller->createUrl($module->id . '/' . $action, $params);
+				return Yii::$app->controller->createUrl('/' . $module->id . '/' . $action, $params);
 			}
 		}
 	}

--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -75,12 +75,12 @@ class ActionColumn extends Column
 			return call_user_func($this->urlCreator, $model, $key, $index, $action);
 		} else {
 			$params = is_array($key) ? $key : ['id' => $key];
-			$module = Yii::$app->controller->module;
-			if ($module instanceof Application) {
+			$controller = Yii::$app->controller;
+			if (isset($controller->module) && $controller->module instanceof Application) {
 				return Yii::$app->controller->createUrl($action, $params);
 			}
 			else {
-				return Yii::$app->controller->createUrl('/' . $module->id . '/' . $action, $params);
+				return Yii::$app->controller->createUrl('/' . $controller->module->id . '/' . $controller->id . '/' . $action, $params);
 			}
 		}
 	}

--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -75,13 +75,7 @@ class ActionColumn extends Column
 			return call_user_func($this->urlCreator, $model, $key, $index, $action);
 		} else {
 			$params = is_array($key) ? $key : ['id' => $key];
-			$controller = Yii::$app->controller;
-			if (!isset($controller->module) || $controller->module instanceof Application) {
-				return Yii::$app->controller->createUrl($action, $params);
-			}
-			else {
-				return Yii::$app->controller->createUrl('/' . $controller->module->id . '/' . $controller->id . '/' . $action, $params);
-			}
+			return Yii::$app->controller->createUrl('/' . Yii::$app->controller->uniqueId . '/' . $action, $params);
 		}
 	}
 

--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -75,7 +75,13 @@ class ActionColumn extends Column
 			return call_user_func($this->urlCreator, $model, $key, $index, $action);
 		} else {
 			$params = is_array($key) ? $key : ['id' => $key];
-			return Yii::$app->controller->createUrl($action, $params);
+			$module = Yii::$app->controller->module;
+			if ($module instanceof Application) {
+				return Yii::$app->controller->createUrl($action, $params);
+			}
+			else {
+				return Yii::$app->controller->createUrl($module->id . '/' . $action, $params);
+			}
 		}
 	}
 


### PR DESCRIPTION
By default the `createUrl` function within the Yii `ActionColumn` does not consider that grids may be utilized within modules. This change should help generate the right URL for `ActionColumn` url within modules.
