### PR TITLE
Update grid ActionColumn for controlling HTML options of buttons

### DIFF
--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -34,42 +34,10 @@ class ActionColumn extends Column
 	/* Options for delete button */
 	public $deleteOptions = [];
 	
-	/* Default view button options */
-	private static $_defaultView = [
-		'label' => '<span class="glyphicon glyphicon-eye-open"></span>',
-		'title' => 'View'
-	];
-
-	/* Default update button options */
-	private static $_defaultUpdate = [
-		'label' => '<span class="glyphicon glyphicon-pencil"></span>',
-		'title' => 'Update'
-	];
-
-	/* Default delete button options */
-	private static $_defaultDelete = [
-		'label' => '<span class="glyphicon glyphicon-trash"></span>',
-		'title' => 'Delete',
-		'data-confirm' => 'Are you sure to delete this item?',
-		'data-method' => 'post'
-	];
-	
 	public function init()
 	{
 		parent::init();
 		$this->initDefaultButtons();
-	}
-	
-	protected function renderButton($options, $default, $url) {
-		$options = array_replace($default, $options);
-		$label = ArrayHelper::remove($options, 'label', '');
-		if (!empty($options['title'])) {
-			$options['title'] = Yii::t('yii', $options['title']);
-		}
-		if (!empty($options['data-confirm'])) {
-			$options['data-confirm'] = Yii::t('yii', $options['data-confirm']);
-		}		
-		return Html::a($label, $url, $options);
 	}
 
 	protected function initDefaultButtons()
@@ -78,21 +46,31 @@ class ActionColumn extends Column
 			$this->buttons['view'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'view');
-				return $this->renderButton($this->viewOptions, self::$_defaultView, $url);
+				$label = ArrayHelper::remove($this->viewOptions, 'label', '<span class="glyphicon glyphicon-eye-open"></span>'); 
+				$options = array_replace(['title' => Yii::t('yii', 'View')], $this->viewOptions); 
+				return Html::a($label, $url, $options);
 			};
 		}
 		if (!isset($this->buttons['update'])) {
 			$this->buttons['update'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'update');
-				return $this->renderButton($this->updateOptions, self::$_defaultUpdate, $url);
+				$label = ArrayHelper::remove($this->updateOptions, 'label', '<span class="glyphicon glyphicon-pencil"></span>'); 
+				$options = array_replace(['title' => Yii::t('yii', 'Update')], $this->updateOptions); 
+				return Html::a($label, $url, $options);
 			};
 		}
 		if (!isset($this->buttons['delete'])) {
 			$this->buttons['delete'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'delete');
-				return $this->renderButton($this->deleteOptions, self::$_defaultDelete, $url);
+				$label = ArrayHelper::remove($this->deleteOptions, 'label', '<span class="glyphicon glyphicon-trash"></span>'); 
+				$options = array_replace([
+					'title' => Yii::t('yii', 'Delete'),
+					'data-confirm' => Yii::t('yii', 'Are you sure to delete this item?'),
+					'data-method' => 'post'
+				], $this->deleteOptions); 
+				return Html::a($label, $url, $options);
 			};
 		}
 	}

--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -53,7 +53,6 @@ class ActionColumn extends Column
 		'data-method' => 'post'
 	];
 	
-
 	public function init()
 	{
 		parent::init();

--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -24,26 +24,35 @@ class ActionColumn extends Column
 	public $buttons = [];
 	public $urlCreator;
 	
-	/* Action button options */
+	/* Options for view button */
 	public $viewOptions = [];
+
+	/* Options for update button */
 	public $updateOptions = [];
+
+	/* Options for delete button */
 	public $deleteOptions = [];
 	
-	/* Default button options */
-	private $_viewOptions = [
+	/* Default view button options */
+	private static $_defaultView = [
 		'label' => '<span class="glyphicon glyphicon-eye-open"></span>',
 		'title' => 'View'
 	];
-	private $_updateOptions = [
+
+	/* Default update button options */
+	private static $_defaultUpdate = [
 		'label' => '<span class="glyphicon glyphicon-pencil"></span>',
 		'title' => 'Update'
 	];
-	private $_deleteOptions = [
+
+	/* Default delete button options */
+	private static $_defaultDelete = [
 		'label' => '<span class="glyphicon glyphicon-trash"></span>',
 		'title' => 'Delete',
 		'data-confirm' => 'Are you sure to delete this item?',
 		'data-method' => 'post'
 	];
+	
 
 	public function init()
 	{
@@ -64,21 +73,21 @@ class ActionColumn extends Column
 			$this->buttons['view'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'view');
-				return $this->renderButton($this->viewOptions, $this->_viewOptions, $url);
+				return $this->renderButton($this->viewOptions, static::$_defaultView, $url);
 			};
 		}
 		if (!isset($this->buttons['update'])) {
 			$this->buttons['update'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'update');
-				return $this->renderButton($this->updateOptions, $this->_updateOptions, $url);
+				return $this->renderButton($this->updateOptions, static::$_defaultUpdate, $url);
 			};
 		}
 		if (!isset($this->buttons['delete'])) {
 			$this->buttons['delete'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'delete');
-				return $this->renderButton($this->deleteOptions, $this->_deleteOptions, $url);
+				return $this->renderButton($this->deleteOptions, static::$_defaultDelete, $url);
 			};
 		}
 	}

--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -10,6 +10,7 @@ namespace yii\grid;
 use Yii;
 use Closure;
 use yii\helpers\Html;
+use yii\helpers\ArrayHelper;
 
 /**
  * ActionColumn is a column for the [[GridView]] widget that displays buttons for viewing and manipulating the items.

--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -15,6 +15,7 @@ use yii\helpers\Html;
  * ActionColumn is a column for the [[GridView]] widget that displays buttons for viewing and manipulating the items.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
+ * @author Kartik Visweswaran <kartikv2@gmail.com>
  * @since 2.0
  */
 class ActionColumn extends Column
@@ -22,11 +23,39 @@ class ActionColumn extends Column
 	public $template = '{view} {update} {delete}';
 	public $buttons = [];
 	public $urlCreator;
+	
+	/* Action button options */
+	public $viewOptions = [];
+	public $updateOptions = [];
+	public $deleteOptions = [];
+	
+	/* Default button options */
+	private $_viewOptions = [
+		'label' => '<span class="glyphicon glyphicon-eye-open"></span>',
+		'title' => 'View'
+	];
+	private $_updateOptions = [
+		'label' => '<span class="glyphicon glyphicon-pencil"></span>',
+		'title' => 'Update'
+	];
+	private $_deleteOptions = [
+		'label' => '<span class="glyphicon glyphicon-trash"></span>',
+		'title' => 'Delete',
+		'data-confirm' => 'Are you sure to delete this item?',
+		'data-method' => 'post'
+	];
 
 	public function init()
 	{
 		parent::init();
 		$this->initDefaultButtons();
+	}
+	
+	protected function renderButton($options, $default, $url) {
+		$options = array_replace($default, $options);
+		$label = $options['label'];
+		unset($options['label']);
+		return Html::a($label, $url, $options);
 	}
 
 	protected function initDefaultButtons()
@@ -35,29 +64,21 @@ class ActionColumn extends Column
 			$this->buttons['view'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'view');
-				return Html::a('<span class="glyphicon glyphicon-eye-open"></span>', $url, [
-					'title' => Yii::t('yii', 'View'),
-				]);
+				return $this->renderButton($this->viewOptions, $this->_viewOptions, $url);
 			};
 		}
 		if (!isset($this->buttons['update'])) {
 			$this->buttons['update'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'update');
-				return Html::a('<span class="glyphicon glyphicon-pencil"></span>', $url, [
-					'title' => Yii::t('yii', 'Update'),
-				]);
+				return $this->renderButton($this->updateOptions, $this->_updateOptions, $url);
 			};
 		}
 		if (!isset($this->buttons['delete'])) {
 			$this->buttons['delete'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'delete');
-				return Html::a('<span class="glyphicon glyphicon-trash"></span>', $url, [
-					'title' => Yii::t('yii', 'Delete'),
-					'data-confirm' => Yii::t('yii', 'Are you sure to delete this item?'),
-					'data-method' => 'post',
-				]);
+				return $this->renderButton($this->deleteOptions, $this->_deleteOptions, $url);
 			};
 		}
 	}

--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -72,21 +72,21 @@ class ActionColumn extends Column
 			$this->buttons['view'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'view');
-				return $this->renderButton($this->viewOptions, static::$_defaultView, $url);
+				return $this->renderButton($this->viewOptions, self::$_defaultView, $url);
 			};
 		}
 		if (!isset($this->buttons['update'])) {
 			$this->buttons['update'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'update');
-				return $this->renderButton($this->updateOptions, static::$_defaultUpdate, $url);
+				return $this->renderButton($this->updateOptions, self::$_defaultUpdate, $url);
 			};
 		}
 		if (!isset($this->buttons['delete'])) {
 			$this->buttons['delete'] = function ($model, $key, $index, $column) {
 				/** @var ActionColumn $column */
 				$url = $column->createUrl($model, $key, $index, 'delete');
-				return $this->renderButton($this->deleteOptions, static::$_defaultDelete, $url);
+				return $this->renderButton($this->deleteOptions, self::$_defaultDelete, $url);
 			};
 		}
 	}

--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -21,17 +21,34 @@ use yii\helpers\ArrayHelper;
  */
 class ActionColumn extends Column
 {
+	/**
+	 * @var string template for displaying the column content
+	 */
 	public $template = '{view} {update} {delete}';
+	
+	/**
+	 * @var array action buttons configuration
+	 */
 	public $buttons = [];
+	
+	/**
+	 * @var Closure callback for the button url
+	 */
 	public $urlCreator;
 	
-	/* Options for view button */
+	/**
+	 * @var array options for the view button 
+	 */
 	public $viewOptions = [];
 
-	/* Options for update button */
+	/**
+	 * @var array options for the update button 
+	 */
 	public $updateOptions = [];
 
-	/* Options for delete button */
+	/**
+	 * @var array options for the delete button 
+	 */
 	public $deleteOptions = [];
 	
 	public function init()

--- a/framework/yii/grid/ActionColumn.php
+++ b/framework/yii/grid/ActionColumn.php
@@ -61,8 +61,13 @@ class ActionColumn extends Column
 	
 	protected function renderButton($options, $default, $url) {
 		$options = array_replace($default, $options);
-		$label = $options['label'];
-		unset($options['label']);
+		$label = ArrayHelper::remove($options, 'label', '');
+		if (!empty($options['title'])) {
+			$options['title'] = Yii::t('yii', $options['title']);
+		}
+		if (!empty($options['data-confirm'])) {
+			$options['data-confirm'] = Yii::t('yii', $options['data-confirm']);
+		}		
 		return Html::a($label, $url, $options);
 	}
 


### PR DESCRIPTION
The grid action column does have a `buttons` configuration to override default buttons. But in many cases, only few basic HTML rendering changes are needed: e.g. update the button label, or add a css class, or change the delete confirmation message (or probably add a javascript event). With this pull request, button options can be directly configured like:

``` php
// Example 1
[
'class'=>'yii\grid\ActionColumn',
'updateOptions' => ['label'=>\Yii::t('app', 'Edit')],
];

// Example 2
[
'class'=>'yii\grid\ActionColumn',
'viewOptions' => ['class' => 'red-color']
];

// Example 3
[
'class'=>'yii\grid\ActionColumn',
'deleteOptions' => ['data-confirm'=>\Yii::t('app', 'Are you sure to delete this ' . strtolower($title) . '?')],
];
```
