### PR TITLE
Removed compatibility code for PHP < 5.4 in yii\web\Session

### DIFF
--- a/framework/yii/web/Session.php
+++ b/framework/yii/web/Session.php
@@ -179,13 +179,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
 	 */
 	public function getIsActive()
 	{
-		if (function_exists('session_status')) {
-			// available in PHP 5.4.0+
-			return session_status() == PHP_SESSION_ACTIVE;
-		} else {
-			// this is not very reliable
-			return $this->_opened && session_id() !== '';
-		}
+		return session_status() == PHP_SESSION_ACTIVE;
 	}
 
 	/**


### PR DESCRIPTION
I don't think this has been necessary anymore :smile: 
