### PR TITLE
Don't required BaseYii manual

### DIFF
--- a/framework/yii/Yii.php
+++ b/framework/yii/Yii.php
@@ -7,8 +7,6 @@
  * @license http://www.yiiframework.com/license/
  */
 
-require(__DIR__ . '/BaseYii.php');
-
 /**
  * Yii is a helper class serving common framework functionalities.
  *


### PR DESCRIPTION
Let Composer doing his job.

Because I need the BaseYii class before importing Yii, it cause redeclare class error.

If you insist on imports, for users which don't use Composer, please check if class exists before import file.

``` php
if (class_exists('\yii\BaseYii', false)) {
    require(__DIR__ . '/BaseYii.php');
}
```
