### PR TITLE
Eliminating constant

### DIFF
--- a/framework/yii/base/Application.php
+++ b/framework/yii/base/Application.php
@@ -49,11 +49,6 @@ abstract class Application extends Module
 	 */
 	const EVENT_AFTER_REQUEST = 'afterRequest';
 	/**
-	 * @event ActionEvent an event raised before executing a controller action.
-	 * You may set [[ActionEvent::isValid]] to be false to cancel the action execution.
-	 */
-	const EVENT_BEFORE_ACTION = 'beforeAction';
-	/**
 	 * @event ActionEvent an event raised after executing a controller action.
 	 */
 	const EVENT_AFTER_ACTION = 'afterAction';

--- a/framework/yii/base/Controller.php
+++ b/framework/yii/base/Controller.php
@@ -125,7 +125,7 @@ class Controller extends Component implements ViewContextInterface
 			$this->action = $action;
 			$result = null;
 			$event = new ActionEvent($action);
-			Yii::$app->trigger(Application::EVENT_BEFORE_ACTION, $event);
+			Yii::$app->trigger('beforeAction', $event);
 			if ($event->isValid && $this->module->beforeAction($action) && $this->beforeAction($action)) {
 				$result = $action->runWithParams($params);
 				$this->afterAction($action, $result);


### PR DESCRIPTION
In yii\base\Controller we have `Yii::$app->trigger(Application::EVENT_BEFORE_ACTION, $event);`. It is hard and complicated to look at yii\base\Application.php every time. This event is used only once. There is no need to use constant. It is possible to do the same thing in simple way. So I think we can eliminate redundant information to ease our work.
