### PR TITLE
String concatenation in FileTarget::export() function replaced with array join

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Enh: Added `favicon.ico` and `robots.txt` to defauly application templates (samdark)
 - Enh: Widget IDs are now always unique no matter if it's the same request or new one (samdark)
 - New #1438: [MongoDB integration](https://github.com/yiisoft/yii2-mongodb) ActiveRecord and Query (klimov-paul)
+- Enh: #2500 String concatenation in FileTarget::export() function replaced with array join
 
 2.0.0 alpha, December 1, 2013
 ---------------------------

--- a/framework/yii/log/FileTarget.php
+++ b/framework/yii/log/FileTarget.php
@@ -87,7 +87,7 @@ class FileTarget extends Target
 		foreach ($this->messages as $message) {
 			$text[] = $this->formatMessage($message);
 		}
-		$text = implode("\n",$text);
+		$text = implode("\n", $text);
 		if (($fp = @fopen($this->logFile, 'a')) === false) {
 			throw new InvalidConfigException("Unable to append to log file: {$this->logFile}");
 		}

--- a/framework/yii/log/FileTarget.php
+++ b/framework/yii/log/FileTarget.php
@@ -83,10 +83,11 @@ class FileTarget extends Target
 	 */
 	public function export()
 	{
-		$text = '';
+		$text = [];
 		foreach ($this->messages as $message) {
-			$text .= $this->formatMessage($message);
+			$text[] = $this->formatMessage($message);
 		}
+		$text = implode("\n",$text);
 		if (($fp = @fopen($this->logFile, 'a')) === false) {
 			throw new InvalidConfigException("Unable to append to log file: {$this->logFile}");
 		}


### PR DESCRIPTION
This is done to add new line symbols between messages. Otherwise different messages are added to the log file on the same line.
