### PR TITLE
Disallow indexing backend by default

### DIFF
--- a/apps/advanced/backend/web/robots.txt
+++ b/apps/advanced/backend/web/robots.txt
@@ -1,0 +1,2 @@
+User-Agent: *
+Disallow: /


### PR DESCRIPTION
Backend should be always totally closed for indexing by search engine robots
