### PR TITLE
Decoupling View class and AssetBundle class

### DIFF
--- a/framework/yii/web/AssetBundle.php
+++ b/framework/yii/web/AssetBundle.php
@@ -139,25 +139,21 @@ class AssetBundle extends Object
 	}
 
 	/**
-	 * Registers the CSS and JS files with the given view.
-	 * @param \yii\web\View $view the view that the asset files are to be registered with.
+	 * Get the list of JavaScript files that this bundle contains
+	 * @return array the list of JavaScript files
 	 */
-	public function registerAssetFiles($view)
+	public function getJsFiles()
 	{
-		foreach ($this->js as $js) {
-			if (strpos($js, '/') !== 0 && strpos($js, '://') === false) {
-				$view->registerJsFile($this->baseUrl . '/' . $js, $this->jsOptions);
-			} else {
-				$view->registerJsFile($js, $this->jsOptions);
-			}
-		}
-		foreach ($this->css as $css) {
-			if (strpos($css, '/') !== 0 && strpos($css, '://') === false) {
-				$view->registerCssFile($this->baseUrl . '/' . $css, $this->cssOptions);
-			} else {
-				$view->registerCssFile($css, $this->cssOptions);
-			}
-		}
+		return $this->js;
+	}
+
+	/**
+	 * Get the list of CSS files that this bundle contains
+	 * @return array the list of CSS files
+	 */
+	public function getCssFiles()
+	{
+		return $this->css;
 	}
 
 	/**

--- a/framework/yii/web/View.php
+++ b/framework/yii/web/View.php
@@ -188,7 +188,22 @@ class View extends \yii\base\View
 			foreach ($bundle->depends as $dep) {
 				$this->registerAssetFiles($dep);
 			}
-			$bundle->registerAssetFiles($this);
+			$jsFiles = $bundle->getJsFiles();
+			foreach ($jsFiles as $js) {
+				if (strpos($js, '/') !== 0 && strpos($js, '://') === false) {
+					$this->registerJsFile($bundle->baseUrl . '/' . $js, $bundle->jsOptions);
+				} else {
+					$this->registerJsFile($js, $bundle->jsOptions);
+				}
+			}
+			$cssFiles = $bundle->getCssFiles();
+			foreach ($cssFiles as $css) {
+				if (strpos($css, '/') !== 0 && strpos($css, '://') === false) {
+					$view->registerCssFile($bundle->baseUrl . '/' . $css, $bundle->cssOptions);
+				} else {
+					$view->registerCssFile($css, $bundle->cssOptions);
+				}
+			}
 		}
 		unset($this->assetBundles[$name]);
 	}


### PR DESCRIPTION
I have try to decouple yii\web\View class and yii\web\AssetBundle class. There was two way dependence: View class depended AssetBundle class and vise versa. Now there is one way dependency: View class dependes AssetBundle only.

I don't know how it is useful may be but I my thought is to lead the design principles I have study recently.
@qiangxue what do you think?
