### PR TITLE
Added support for aliases for config files in console command 'message'

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,6 +15,7 @@ Yii Framework 2 Change Log
 - Enh #1469: ActiveRecord::find() now works with default conditions (default scope) applied by createQuery (cebe)
 - Enh: Added `favicon.ico` and `robots.txt` to defauly application templates (samdark)
 - Enh: Added `Widget::autoIdPrefix` to support prefixing automatically generated widget IDs (qiangxue)
+- Enh: Support for file aliases in console command 'message' (omnilight)
 - New #1438: [MongoDB integration](https://github.com/yiisoft/yii2-mongodb) ActiveRecord and Query (klimov-paul)
 
 2.0.0 alpha, December 1, 2013

--- a/framework/yii/console/controllers/MessageController.php
+++ b/framework/yii/console/controllers/MessageController.php
@@ -43,11 +43,12 @@ class MessageController extends Controller
 	 * how to customize it to fit for your needs. After customization,
 	 * you may use this configuration file with the "extract" command.
 	 *
-	 * @param string $filePath output file name.
+	 * @param string $filePath output file name or alias.
 	 * @throws Exception on failure.
 	 */
 	public function actionConfig($filePath)
 	{
+		$filePath = Yii::getAlias($filePath);
 		if (file_exists($filePath)) {
 			if (!$this->confirm("File '{$filePath}' already exists. Do you wish to overwrite it?")) {
 				return;
@@ -63,13 +64,14 @@ class MessageController extends Controller
 	 * This command will search through source code files and extract
 	 * messages that need to be translated in different languages.
 	 *
-	 * @param string $configFile the path of the configuration file.
+	 * @param string $configFile the path or alias of the configuration file.
 	 * You may use the "yii message/config" command to generate
 	 * this file and then customize it for your needs.
 	 * @throws Exception on failure.
 	 */
 	public function actionExtract($configFile)
 	{
+		$configFile = Yii::getAlias($configFile);
 		if (!is_file($configFile)) {
 			throw new Exception("The configuration file does not exist: $configFile");
 		}


### PR DESCRIPTION
With this change you can use commands yii message/config and yii message/extract with the following way:

```
yii message/config filePath="@somePath/message/config.php"
```
