### PR TITLE
Use Connection tablePrefix in tableName()

### DIFF
--- a/framework/yii/db/ActiveRecord.php
+++ b/framework/yii/db/ActiveRecord.php
@@ -183,7 +183,7 @@ class ActiveRecord extends BaseActiveRecord
 	 */
 	public static function tableName()
 	{
-		return 'tbl_' . Inflector::camel2id(StringHelper::basename(get_called_class()), '_');
+		return static::getDb()->tablePrefix . Inflector::camel2id(StringHelper::basename(get_called_class()), '_');
 	}
 
 	/**

--- a/framework/yii/helpers/BaseSecurity.php
+++ b/framework/yii/helpers/BaseSecurity.php
@@ -178,7 +178,7 @@ class BaseSecurity
 	/**
 	 * Returns a secret key associated with the specified name.
 	 * If the secret key does not exist, a random key will be generated
-	 * and saved in the file "keys.data" under the application's runtime directory
+	 * and saved in the file "keys.json" under the application's runtime directory
 	 * so that the same secret key can be returned in future requests.
 	 * @param string $name the name that is associated with the secret key
 	 * @param integer $length the length of the key that should be generated if not exists


### PR DESCRIPTION
To not force a user to override tableName or use the prefix "tbl_" in most cases.
