### PR TITLE
Json::encode did not handle JsonSerializable objects

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Bug #1545: It was not possible to execute db Query twice, params where missing (cebe)
 - Bug: Fixed `Call to a member function registerAssetFiles() on a non-object` in case of wrong `sourcePath` for an asset bundle (samdark)
 - Bug: Fixed incorrect event name for `yii\jui\Spinner` (samdark)
+- Bug: Json::encode() did not handle objects that implement JsonSerializable interface correctly (cebe)
 - Enh #1293: Replaced Console::showProgress() with a better approach. See Console::startProgress() for details (cebe)
 - Enh #1406: DB Schema support for Oracle Database (p0larbeer, qiangxue)
 - Enh #1437: Added ListView::viewParams (qiangxue)

--- a/framework/yii/helpers/BaseJson.php
+++ b/framework/yii/helpers/BaseJson.php
@@ -81,6 +81,10 @@ class BaseJson
 	 */
 	protected static function processData($data, &$expressions, $expPrefix)
 	{
+		if ($data instanceof \JsonSerializable) {
+			return $data;
+		}
+
 		if (is_object($data)) {
 			if ($data instanceof JsExpression) {
 				$token = "!{[$expPrefix=" . count($expressions) . ']}!';


### PR DESCRIPTION
it checks for ArrayAble and calls toArray() but that should not be done if JsonSerializable is implemented.
