### PR TITLE
Debug tables wraps content [SKIP CI]

### DIFF
--- a/extensions/yii/debug/assets/main.css
+++ b/extensions/yii/debug/assets/main.css
@@ -148,6 +148,6 @@ ul.trace {
 }
 
 td, th {
-	white-space: pre;
+	white-space: pre-line;
 	word-wrap: break-word;
 }


### PR DESCRIPTION
This small change is to avoid table content overflow when the text hasn't spaces to break words.
For example, this: 

![yii debugger 2013-12-18 23-09-58](https://f.cloud.github.com/assets/374554/1779931/fe6697d2-685b-11e3-950b-ac4804dc6864.png)

becomes:

![yii debugger 2013-12-18 23-12-38](https://f.cloud.github.com/assets/374554/1779932/0868c156-685c-11e3-88a7-dfa7d5a15112.png)
