### PR TITLE
Fixed sequence id match for postgresql

### DIFF
--- a/framework/yii/db/pgsql/Schema.php
+++ b/framework/yii/db/pgsql/Schema.php
@@ -299,7 +299,7 @@ SQL;
 			$table->columns[$column->name] = $column;
 			if ($column->isPrimaryKey === true) {
 				$table->primaryKey[] = $column->name;
-				if ($table->sequenceName === null && preg_match("/nextval\\('\"?\\w+\"?'(::regclass)?\\)/", $column->defaultValue) === 1) {
+				if ($table->sequenceName === null && preg_match("/nextval\\('\"?\\w+\"?\.?\"?\\w+\"?'(::regclass)?\\)/", $column->defaultValue) === 1) {
 					$table->sequenceName = preg_replace(['/nextval/', '/::/', '/regclass/', '/\'\)/', '/\(\'/'], '', $column->defaultValue);
 				}
 			}


### PR DESCRIPTION
PgAdmin generates   sequence as  '"Schema"."Table_seq"'::regclass  when
non public schema is used.
