### PR TITLE
#1616-HTML helper->listBox select short_tag working_now

### DIFF
--- a/framework/yii/helpers/BaseHtml.php
+++ b/framework/yii/helpers/BaseHtml.php
@@ -721,7 +721,7 @@ class BaseHtml
 		if (!isset($options['size'])) {
 			$options['size'] = 4;
 		}
-		if (!empty($options['multiple']) && substr($name, -2) !== '[]') {
+		if (isset($options['multiple']) && substr($name, -2) !== '[]') {
 			$name .= '[]';
 		}
 		$options['name'] = $name;


### PR DESCRIPTION
According to html5 short tags can be used like `<select multiple>` so little fix in `\yii\helpers\Html::listBox` where is using empty function for checking `multiple`'s existence in `$options`

so replaced it with `isset`
https://github.com/yiisoft/yii2/issues/1616
