### PR TITLE
Set input options in ActiveField.widget() method

### DIFF
--- a/framework/yii/widgets/ActiveField.php
+++ b/framework/yii/widgets/ActiveField.php
@@ -579,6 +579,7 @@ class ActiveField extends Component
 		$config['model'] = $this->model;
 		$config['attribute'] = $this->attribute;
 		$config['view'] = $this->form->getView();
+		$config['options'] = $this->inputOptions;
 		$this->parts['{input}'] = $class::widget($config);
 		return $this;
 	}


### PR DESCRIPTION
Issue: captcha widget doesn't render text field with class "form-control" when calling it via ActiveForm.field() method.
