### PR TITLE
Change ActiveField.hintOptions

### DIFF
--- a/framework/yii/widgets/ActiveField.php
+++ b/framework/yii/widgets/ActiveField.php
@@ -70,7 +70,7 @@ class ActiveField extends Component
 	 *
 	 * - tag: the tag name of the container element. Defaults to "div".
 	 */
-	public $hintOptions = ['class' => 'hint-block'];
+	public $hintOptions = ['class' => 'help-block'];
 	/**
 	 * @var boolean whether to enable client-side data validation.
 	 * If not set, it will take the value of [[ActiveForm::enableClientValidation]].


### PR DESCRIPTION
Twitter Bootstrap has the "help-block" class for hint text: http://getbootstrap.com/css/#forms-help-text

There is no "hint-block" class and thus hint text doesn't look pretty. Another option could be to add custom style for "hint-block" class into site.css.
