### PR TITLE
added pdo class feature

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -33,6 +33,7 @@ Yii Framework 2 Change Log
 - Enh #1611: Added `BaseActiveRecord::markAttributeDirty()` (qiangxue)
 - Enh #1634: Use masked CSRF tokens to prevent BREACH exploits (qiangxue)
 - Enh #1641: Added `BaseActiveRecord::updateAttributes()` (qiangxue)
+- Enh #1645: Added `Connection::$pdoClass` property (Ragazzo)
 - Enh: Added `favicon.ico` and `robots.txt` to defauly application templates (samdark)
 - Enh: Added `Widget::autoIdPrefix` to support prefixing automatically generated widget IDs (qiangxue)
 - Enh: Support for file aliases in console command 'message' (omnilight)

--- a/framework/yii/db/Connection.php
+++ b/framework/yii/db/Connection.php
@@ -348,7 +348,7 @@ class Connection extends Component
 			$driver = strtolower(substr($this->dsn, 0, $pos));
 
 			if ($driver === 'mssql' || $driver === 'dblib' || $driver === 'sqlsrv') {
-				$pdoClass = is_null($this->pdoClass) ? 'yii\db\mssql\PDO' : $this->pdoClass;;
+				$pdoClass = is_null($this->pdoClass) ? '\yii\db\mssql\PDO' : $this->pdoClass;;
 			}
 		}
 		return new $pdoClass($this->dsn, $this->username, $this->password, $this->attributes);

--- a/framework/yii/db/Connection.php
+++ b/framework/yii/db/Connection.php
@@ -257,7 +257,7 @@ class Connection extends Component
 	/**
      * @var string Custom PDO wrapper class. If you use mssql|dblib|sqlsrv it should be "yii\db\mssql\PDO".
 	 */
-	public $pdoClass = 'PDO';
+	public $pdoClass;
 
 	/**
 	 * Returns a value indicating whether the DB connection is established.
@@ -342,7 +342,15 @@ class Connection extends Component
 	 */
 	protected function createPdoInstance()
 	{
-		$pdoClass = $this->pdoClass;
+		$pdoClass = is_null($this->pdoClass) ? 'PDO' : $this->pdoClass;
+
+		if (($pos = strpos($this->dsn, ':')) !== false) {
+			$driver = strtolower(substr($this->dsn, 0, $pos));
+
+			if ($driver === 'mssql' || $driver === 'dblib' || $driver === 'sqlsrv') {
+				$pdoClass = is_null($this->pdoClass) ? 'yii\db\mssql\PDO' : $this->pdoClass;;
+			}
+		}
 		return new $pdoClass($this->dsn, $this->username, $this->password, $this->attributes);
 	}
 

--- a/framework/yii/db/Connection.php
+++ b/framework/yii/db/Connection.php
@@ -254,6 +254,10 @@ class Connection extends Component
 	 */
 	private $_schema;
 
+	/**
+     * @var string Custom PDO wrapper class. If you use mssql|dblib|sqlsrv it should be "yii\db\mssql\PDO".
+	 */
+	public $pdoClass = 'PDO';
 
 	/**
 	 * Returns a value indicating whether the DB connection is established.
@@ -338,13 +342,7 @@ class Connection extends Component
 	 */
 	protected function createPdoInstance()
 	{
-		$pdoClass = 'PDO';
-		if (($pos = strpos($this->dsn, ':')) !== false) {
-			$driver = strtolower(substr($this->dsn, 0, $pos));
-			if ($driver === 'mssql' || $driver === 'dblib' || $driver === 'sqlsrv') {
-				$pdoClass = 'yii\db\mssql\PDO';
-			}
-		}
+		$pdoClass = $this->pdoClass;
 		return new $pdoClass($this->dsn, $this->username, $this->password, $this->attributes);
 	}
 


### PR DESCRIPTION
This is a port of Yii1 feature https://github.com/yiisoft/yii/blob/master/framework/db/CDbConnection.php#L251. This will also enable such features like custom `pdoClass` with nested transaction (it is commonly used in Yii1) https://github.com/yiisoft/yii2/issues/1645.  
I also removed check for those three drivers and added a comment to `pdoClass` property about it, because of if this check will be for those db there will be no custom pdo class support as you can see.
