### PR TITLE
csrf docs added

### DIFF
--- a/docs/guide/controller.md
+++ b/docs/guide/controller.md
@@ -39,6 +39,26 @@ The output of an action is what the method returns. The return value will be han
 component which can convert the output to differnet formats such as JSON for example. The default behavior
 is to output the value unchanged though.
 
+You also can disable CSRF validation per controller, by setting its property:
+
+```php
+namespace app\controllers;
+
+use yii\web\Controller;
+
+class SiteController extends Controller
+{
+
+	public $enableCsrfValidation = false;
+
+	public function actionIndex()
+	{
+		#CSRF validation will no be applied on this and other actions
+	}
+
+}
+```
+
 Routes
 ------
 

--- a/docs/guide/controller.md
+++ b/docs/guide/controller.md
@@ -39,7 +39,7 @@ The output of an action is what the method returns. The return value will be han
 component which can convert the output to differnet formats such as JSON for example. The default behavior
 is to output the value unchanged though.
 
-You also can disable CSRF validation per controller, by setting its property:
+You also can disable CSRF validation per controller and/or action, by setting its property:
 
 ```php
 namespace app\controllers;
@@ -56,6 +56,24 @@ class SiteController extends Controller
 		#CSRF validation will no be applied on this and other actions
 	}
 
+}
+```
+
+To disable CSRF validation per custom actions you can do:
+
+```php
+namespace app\controllers;
+
+use yii\web\Controller;
+
+class SiteController extends Controller
+{
+	public function beforeAction($action)
+	{
+		// ...set `$this->enableCsrfValidation` here based on some conditions...
+		// call parent method that will check CSRF if such property is true.
+		return parent::beforeAction($action);
+	}
 }
 ```
 


### PR DESCRIPTION
Added small docs about csrf validation in controller. 
Also @qiangxue i think it would be better if this property also can be an array or we need `$excludeCsrfValidate = []` this array will hold actions that should be excluded from csrf validation of the current request. 
Can be helpful for example for upload action (usually it is standalone `Upload < Action`), anyway currently there is no way to cansell csrf validation per some actions. Can submit PR if needed. Only small modifications here are needed: https://github.com/yiisoft/yii2/blob/master/framework/yii/web/Controller.php#L93
