### PR TITLE
fixed unit tests config

### DIFF
--- a/apps/basic/tests/unit/_bootstrap.php
+++ b/apps/basic/tests/unit/_bootstrap.php
@@ -4,5 +4,5 @@
 
 yii\codeception\TestCase::$appConfig = yii\helpers\ArrayHelper::merge(
 	require(__DIR__ . '/../../config/web.php'),
-	require(__DIR__ . '/../../config/codeception/unit.php')
+	require(__DIR__ . '/_config.php')
 );

--- a/apps/basic/tests/unit/_config.php
+++ b/apps/basic/tests/unit/_config.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+	'components' => [
+		'db' => [
+			'dsn' => 'mysql:host=localhost;dbname=yii2_basic_unit',
+		],
+	],
+];


### PR DESCRIPTION
There was a problem about configs for unit tests, because of there is no more configs under `config/codeception`. Fixed it.
