### PR TITLE
Removed redundant code in detachBehaviors()

### DIFF
--- a/framework/yii/base/Component.php
+++ b/framework/yii/base/Component.php
@@ -543,12 +543,9 @@ class Component extends Object
 	public function detachBehaviors()
 	{
 		$this->ensureBehaviors();
-		if ($this->_behaviors !== null) {
-			foreach ($this->_behaviors as $name => $behavior) {
-				$this->detachBehavior($name);
-			}
+		foreach ($this->_behaviors as $name => $behavior) {
+			$this->detachBehavior($name);
 		}
-		$this->_behaviors = [];
 	}
 
 	/**


### PR DESCRIPTION
After ensureBehaviors() call $this->_behaviors is an array already.
And since detachBehavior() unsets elements in $this->_behaviors, $this->_behaviors turns out to be an empty array after all iterations.
