### PR TITLE
Actualize phpunit usage approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,12 +16,14 @@ Thumbs.db
 /vendor
 
 # composer itself is not needed
-composer.phar
+/composer.phar
 # composer.lock should not be committed as we always want the latest versions
 /composer.lock
 
 # Mac DS_Store Files
 .DS_Store
 
+# phpunit itself is not needed
+/phpunit.phar
 # local phpunit config
 /phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,8 @@
 		"ext-pdo_mysql": "*",
 		"smarty/smarty": "*",
 		"swiftmailer/swiftmailer": "*",
-		"twig/twig": "*"
+		"twig/twig": "*",
+		"phpunit/phpunit": "3.7.*"
 	},
 	"suggest": {
 		"twbs/bootstrap": "required by yii2-bootstrap, yii2-debug, yii2-gii extension",

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -2,11 +2,6 @@
 
 namespace yiiunit;
 
-require_once('PHPUnit/Runner/Version.php');
-spl_autoload_unregister(['Yii', 'autoload']);
-require_once('PHPUnit/Autoload.php');
-spl_autoload_register(['Yii', 'autoload']); // put yii's autoloader at the end
-
 /**
  * This is the base class for all yii framework unit tests.
  */


### PR DESCRIPTION
1) Yii 2 unit tests is not working with `phpunit.phar`
2) Since we are composer guys its better to have `phpunit` under `require-dev` section as recommended at http://phpunit.de/manual/3.7/en/installation.html
3) PEAR is dead a long time ago

After merge there is two ways to run tests:

1) Download `phpunit.phar` and run it
2) `composer update` and run `./vendor/bin/phpunit`
