### PR TITLE
Tests composer

### DIFF
--- a/apps/basic/composer.json
+++ b/apps/basic/composer.json
@@ -20,9 +20,7 @@
 		"yiisoft/yii2-codeception": "*",
 		"yiisoft/yii2-debug": "*",
 		"yiisoft/yii2-gii": "*",
-		"yiisoft/yii2-swiftmailer": "*",
-		"codeception/codeception": "*",
-		"codeception/specify": "*"
+		"yiisoft/yii2-swiftmailer": "*"
 	},
 	"scripts": {
 		"post-create-project-cmd": [

--- a/apps/basic/tests/README.md
+++ b/apps/basic/tests/README.md
@@ -4,10 +4,12 @@ These tests are developed with [Codeception PHP Testing Framework](http://codece
 After creating the basic application, follow these steps to prepare for the tests:
 
 1. To install `Codeception` and its dependencies through composer, run commands:
+
    ```
    php composer.phar require "codeception/codeception": "*"
    php composer.phar require "codeception/specify": "*"
    ```
+
 2. In the file `_bootstrap.php`, modify the definition of the constant `TEST_ENTRY_URL` so
    that it points to the correct entry script URL.
 3. Go to the application base directory and build the test suites:

--- a/apps/basic/tests/README.md
+++ b/apps/basic/tests/README.md
@@ -3,9 +3,14 @@ These tests are developed with [Codeception PHP Testing Framework](http://codece
 
 After creating the basic application, follow these steps to prepare for the tests:
 
-1. In the file `_bootstrap.php`, modify the definition of the constant `TEST_ENTRY_URL` so
+1. To install `Codeception` and its dependencies through composer, run commands:
+   ```
+   php composer.phar require "codeception/codeception": "*"
+   php composer.phar require "codeception/specify": "*"
+   ```
+2. In the file `_bootstrap.php`, modify the definition of the constant `TEST_ENTRY_URL` so
    that it points to the correct entry script URL.
-2. Go to the application base directory and build the test suites:
+3. Go to the application base directory and build the test suites:
 
    ```
    vendor/bin/codecept build


### PR DESCRIPTION
Since some `Codeception` dependencies can take some time to load, i think it is better by default exclude it from `composer.json` file, because of user may just want to have brief look to the application. If needed he goes to the tests seciton and see `README.md` and follows all this steps.
