### PR TITLE
Basic app: DB configuration in separated file

### DIFF
--- a/apps/basic/config/console.php
+++ b/apps/basic/config/console.php
@@ -3,6 +3,8 @@
 Yii::setAlias('@tests', dirname(__DIR__) . '/tests');
 
 $params = require(__DIR__ . '/params.php');
+$db = require(__DIR__ . '/db.php');
+
 return [
 	'id' => 'basic-console',
 	'basePath' => dirname(__DIR__),
@@ -22,13 +24,7 @@ return [
 				],
 			],
 		],
-		'db' => [
-			'class' => 'yii\db\Connection',
-			'dsn' => 'mysql:host=localhost;dbname=yii2basic',
-			'username' => 'root',
-			'password' => '',
-			'charset' => 'utf8',
-		],
+		'db' => $db,
 		'fixture' => [
 			'class' => 'yii\test\DbFixtureManager',
 			'basePath' => '@tests/unit/fixtures',

--- a/apps/basic/config/db.php
+++ b/apps/basic/config/db.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+	'class' => 'yii\db\Connection',
+	'dsn' => 'mysql:host=localhost;dbname=yii2basic',
+	'username' => 'root',
+	'password' => '',
+	'charset' => 'utf8',
+];

--- a/apps/basic/config/web.php
+++ b/apps/basic/config/web.php
@@ -1,6 +1,7 @@
 <?php
 
 $params = require(__DIR__ . '/params.php');
+$db = require(__DIR__ . '/db.php');
 
 $config = [
 	'id' => 'basic',
@@ -29,13 +30,7 @@ $config = [
 				],
 			],
 		],
-		'db' => [
-			'class' => 'yii\db\Connection',
-			'dsn' => 'mysql:host=localhost;dbname=yii2basic',
-			'username' => 'root',
-			'password' => '',
-			'charset' => 'utf8',
-		],
+		'db' => $db,
 	],
 	'params' => $params,
 ];


### PR DESCRIPTION
As discussed in https://github.com/yiisoft/yii2/pull/1759#discussion_r8646284.
Actually, in a real app there would be normal having a `db.php.dist` ignored by **CVS** and copy that file for the local configuration.
