### PR TITLE
tests improved, verify added

### DIFF
--- a/apps/basic/tests/README.md
+++ b/apps/basic/tests/README.md
@@ -6,7 +6,7 @@ After creating the basic application, follow these steps to prepare for the test
 1. To install `Codeception` and its dependencies through composer, run the following commands:
 
    ```
-   php composer.phar require --dev "codeception/codeception *" "codeception/specify *"
+   php composer.phar require --dev "codeception/codeception *" "codeception/specify *" "codeception/verify *"
    ```
 
 2. In the file `_bootstrap.php`, modify the definition of the constant `TEST_ENTRY_URL` so

--- a/apps/basic/tests/unit/models/ContactFormTest.php
+++ b/apps/basic/tests/unit/models/ContactFormTest.php
@@ -39,15 +39,16 @@ class ContactFormTest extends TestCase
 		$model->contact('admin@example.com');
 
 		$this->specify('email should be send', function () {
-			$this->assertFileExists($this->getMessageFile(), 'email file should exist');
+			expect('email file should exist', file_exists($this->getMessageFile()))->true();
 		});
 
 		$this->specify('message should contain correct data', function () use($model) {
 			$emailMessage = file_get_contents($this->getMessageFile());
-			$this->assertContains($model->name, $emailMessage, 'email should contain user name');
-			$this->assertContains($model->email, $emailMessage, 'email should contain sender email');
-			$this->assertContains($model->subject, $emailMessage, 'email should contain subject');
-			$this->assertContains($model->body, $emailMessage, 'email should contain body');
+
+			expect('email should contain user name', $emailMessage)->contains($model->name);
+			expect('email should contain sender email', $emailMessage)->contains($model->email);
+			expect('email should contain subject', $emailMessage)->contains($model->subject);
+			expect('email should contain body', $emailMessage)->contains($model->body);
 		});
 	}
 

--- a/apps/basic/tests/unit/models/LoginFormTest.php
+++ b/apps/basic/tests/unit/models/LoginFormTest.php
@@ -19,8 +19,8 @@ class LoginFormTest extends TestCase
 		$model->password = 'some_password';
 
 		$this->specify('user should not be able to login, when there is no identity' , function () use ($model) {
-			$this->assertFalse($model->login());
-			$this->assertTrue(Yii::$app->user->isGuest,'user should not be logged in');
+			expect('model should not login user', $model->login())->false();
+			expect('user should not be logged in', Yii::$app->user->isGuest)->true();
 		});
 	}
 
@@ -32,9 +32,9 @@ class LoginFormTest extends TestCase
 		$model->password = 'wrong-password';
 
 		$this->specify('user should not be able to login with wrong password', function () use ($model) {
-			$this->assertFalse($model->login());
-			$this->assertArrayHasKey('password',$model->errors);
-			$this->assertTrue(Yii::$app->user->isGuest,'user should not be logged in');
+			expect('model should not login user', $model->login())->false();
+			expect('error message should be set', $model->errors)->hasKey('password');
+			expect('user should not be logged in', Yii::$app->user->isGuest)->true();
 		});
 	}
 
@@ -46,9 +46,9 @@ class LoginFormTest extends TestCase
 		$model->password = 'demo';
 
 		$this->specify('user should be able to login with correct credentials', function() use ($model) {
-			$this->assertTrue($model->login());
-			$this->assertArrayNotHasKey('password',$model->errors);
-			$this->assertFalse(Yii::$app->user->isGuest,'user should be logged in');
+			expect('model should login user', $model->login())->true();
+			expect('error message should not be set', $model->errors)->hasntKey('password');
+			expect('user should be logged in', Yii::$app->user->isGuest)->false();
 		});
 	}
 


### PR DESCRIPTION
I improved a little bit tests and introduced `codeception/verify` extension. This extension is just simple wrapper against some very used asserts. The main benefits we get:
1. Increases readability of tests, and writing of it.
2. It is more likely and almost often so, that user first think about specification (to be simple, message that goes first), and only then perform some assertions. So users will not be reading first assertions and only after that reading expectation message.
3. As it simple wrapper over some asserts id does not touch some internal logic or smth. like this, and all phpunit assertions can be used by developers as they want. This is just simple syntax sugar.
4. As you would look into ruby rspec/minitest they do it similar: first goes message, then assertions.

I think it can be merged, because for end-user it is more friendly and readable, so they can start playing around with tests with some fun :)
