### PR TITLE
fixed readme

### DIFF
--- a/apps/basic/tests/README.md
+++ b/apps/basic/tests/README.md
@@ -3,15 +3,9 @@ These tests are developed with [Codeception PHP Testing Framework](http://codece
 
 After creating the basic application, follow these steps to prepare for the tests:
 
-1. To install `Codeception` and its dependencies through composer, run the following commands:
-
-   ```
-   php composer.phar require --dev "codeception/codeception *" "codeception/specify *"
-   ```
-
-2. In the file `_bootstrap.php`, modify the definition of the constant `TEST_ENTRY_URL` so
+1. In the file `_bootstrap.php`, modify the definition of the constant `TEST_ENTRY_URL` so
    that it points to the correct entry script URL.
-3. Go to the application base directory and build the test suites:
+2. Go to the application base directory and build the test suites:
 
    ```
    vendor/bin/codecept build


### PR DESCRIPTION
Fixed `README.md` according last changes that `Codeception` and its extensions are now under `require-dev`.
