### PR TITLE
Fixed label attributes in BaseHtml

### DIFF
--- a/framework/yii/helpers/BaseHtml.php
+++ b/framework/yii/helpers/BaseHtml.php
@@ -961,9 +961,9 @@ class BaseHtml
 	 */
 	public static function activeLabel($model, $attribute, $options = [])
 	{
+		$for = array_key_exists('for', $options) ? $options['for'] : static::getInputId($model, $attribute);
 		$attribute = static::getAttributeName($attribute);
 		$label = isset($options['label']) ? $options['label'] : static::encode($model->getAttributeLabel($attribute));
-		$for = array_key_exists('for', $options) ? $options['for'] : static::getInputId($model, $attribute);
 		unset($options['label'], $options['for']);
 		return static::label($label, $for, $options);
 	}


### PR DESCRIPTION
``` php
<?= $form->field($model, '[1]field') ?>
```

This code rendered label tag:

``` html
<label for="model-field">...</label>
```

After fix render:

``` html
<label for="model-1-field">...</label>
```
