### PR TITLE
session regenerate race condition

### DIFF
--- a/framework/yii/web/Session.php
+++ b/framework/yii/web/Session.php
@@ -209,6 +209,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
 	 */
 	public function regenerateID($deleteOldSession = false)
 	{
+		session_write_close();
 		session_regenerate_id($deleteOldSession);
 	}
 

--- a/framework/yii/web/Session.php
+++ b/framework/yii/web/Session.php
@@ -211,6 +211,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
 	{
 		session_write_close();
 		session_regenerate_id($deleteOldSession);
+		session_start();
 	}
 
 	/**


### PR DESCRIPTION
Hello!
When two scripts simultaneously turning to session data, session id regeneration sometimes fails by "session_regenerate_id (): Session object destruction failed". This is a race condition. Maybe a recording session should be closed before regeneration?
