### PR TITLE
Several \yii\bootstrap\NavBar fixes

### DIFF
--- a/extensions/yii/bootstrap/CHANGELOG.md
+++ b/extensions/yii/bootstrap/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Chg #1459: Update Collapse to use bootstrap 3 classes (tonydspaniard)
 - Chg #1820: Update Progress to use bootstrap 3 markup (samdark)
 - Chg #1881: NavBar padded renamed to renderInnerContainer (creocoder)
+- Chg #1881: NavBar collapseOptions added (creocoder)
 
 2.0.0 alpha, December 1, 2013
 -----------------------------

--- a/extensions/yii/bootstrap/CHANGELOG.md
+++ b/extensions/yii/bootstrap/CHANGELOG.md
@@ -7,8 +7,11 @@ Yii Framework 2 bootstrap extension Change Log
 - Enh #1474: Added option to make NavBar 100% width (cebe)
 - Enh #1553: Only add navbar-default class to NavBar when no other class is specified (cebe)
 - Enh #1601: Added support for tagName and encodeLabel parameters in ButtonDropdown (omnilight)
+- Enh #1881: innerContainerOptions added to NavBar (creocoder)
+- Enh #1881: special tag attribute added to NavBar options (creocoder)
 - Chg #1459: Update Collapse to use bootstrap 3 classes (tonydspaniard)
 - Chg #1820: Update Progress to use bootstrap 3 markup (samdark)
+- Chg #1881: NavBar padded renamed to renderInnerContainer (creocoder)
 
 2.0.0 alpha, December 1, 2013
 -----------------------------

--- a/extensions/yii/bootstrap/CHANGELOG.md
+++ b/extensions/yii/bootstrap/CHANGELOG.md
@@ -12,7 +12,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Chg #1459: Update Collapse to use bootstrap 3 classes (tonydspaniard)
 - Chg #1820: Update Progress to use bootstrap 3 markup (samdark)
 - Chg #1881: NavBar padded renamed to renderInnerContainer (creocoder)
-- Chg #1881: NavBar collapseOptions added (creocoder)
+- Chg #1881: NavBar containerOptions added (creocoder)
 
 2.0.0 alpha, December 1, 2013
 -----------------------------

--- a/extensions/yii/bootstrap/NavBar.php
+++ b/extensions/yii/bootstrap/NavBar.php
@@ -41,9 +41,15 @@ class NavBar extends Widget
 	/**
 	 * @var array the HTML attributes for the widget container tag. The following special options are recognized:
 	 *
-	 * - tag: string, defaults to "nav", the tag name of the container tag of this widget
+	 * - tag: string, defaults to "nav", the name of the container tag
 	 */
 	public $options = [];
+	/**
+	 * @var array the HTML attributes for the collapse container tag. The following special options are recognized:
+	 *
+	 * - tag: string, defaults to "div", the name of the container tag
+	 */
+	public $collapseOptions = [];
 	/**
 	 * @var string the text of the brand. Note that this is not HTML-encoded.
 	 * @see http://getbootstrap.com/components/#navbar
@@ -79,8 +85,8 @@ class NavBar extends Widget
 	{
 		parent::init();
 		$this->clientOptions = false;
-		if (!isset($this->options['class'])) {
-			Html::addCssClass($this->options, 'navbar');
+		Html::addCssClass($this->options, 'navbar');
+		if ($this->options['class'] === 'navbar') {
 			Html::addCssClass($this->options, 'navbar-default');
 		}
 		if (!isset($this->options['role'])) {
@@ -98,13 +104,18 @@ class NavBar extends Widget
 		echo Html::beginTag('div', ['class' => 'navbar-header']);
 		echo $this->renderToggleButton();
 		if ($this->brandLabel !== null) {
-			if (!isset($this->brandOptions['class'])) {
-				Html::addCssClass($this->brandOptions, 'navbar-brand');
-			}
+			Html::addCssClass($this->brandOptions, 'navbar-brand');
 			echo Html::a($this->brandLabel, $this->brandUrl, $this->brandOptions);
 		}
 		echo Html::endTag('div');
-		echo Html::beginTag('div', ['class' => "collapse navbar-collapse navbar-{$this->options['id']}-collapse"]);
+		$options = $this->collapseOptions;
+		$tag = ArrayHelper::remove($options, 'tag', 'div');
+		Html::addCssClass($options, 'collapse');
+		Html::addCssClass($options, 'navbar-collapse');
+		if (!isset($options['id'])) {
+			$options['id'] = "#{$this->options['id']}-collapse";
+		}
+		echo Html::beginTag($tag, $options);
 	}
 
 	/**
@@ -112,7 +123,8 @@ class NavBar extends Widget
 	 */
 	public function run()
 	{
-		echo Html::endTag('div');
+		$tag = ArrayHelper::remove($this->collapseOptions, 'tag', 'div');
+		echo Html::endTag($tag);
 		if ($this->renderInnerContainer) {
 			echo Html::endTag('div');
 		}
@@ -132,7 +144,7 @@ class NavBar extends Widget
 		return Html::button("{$screenReader}\n{$bar}\n{$bar}\n{$bar}", [
 			'class' => 'navbar-toggle',
 			'data-toggle' => 'collapse',
-			'data-target' => ".navbar-{$this->options['id']}-collapse",
+			'data-target' => "#{$this->options['id']}-collapse",
 		]);
 	}
 }

--- a/extensions/yii/bootstrap/NavBar.php
+++ b/extensions/yii/bootstrap/NavBar.php
@@ -102,19 +102,19 @@ class NavBar extends Widget
 			echo Html::beginTag('div', $this->innerContainerOptions);
 		}
 		echo Html::beginTag('div', ['class' => 'navbar-header']);
+		if (!isset($this->collapseOptions['id'])) {
+			$this->collapseOptions['id'] = "{$this->options['id']}-collapse";
+		}
 		echo $this->renderToggleButton();
 		if ($this->brandLabel !== null) {
 			Html::addCssClass($this->brandOptions, 'navbar-brand');
 			echo Html::a($this->brandLabel, $this->brandUrl, $this->brandOptions);
 		}
 		echo Html::endTag('div');
+		Html::addCssClass($this->collapseOptions, 'collapse');
+		Html::addCssClass($this->collapseOptions, 'navbar-collapse');
 		$options = $this->collapseOptions;
 		$tag = ArrayHelper::remove($options, 'tag', 'div');
-		Html::addCssClass($options, 'collapse');
-		Html::addCssClass($options, 'navbar-collapse');
-		if (!isset($options['id'])) {
-			$options['id'] = "#{$this->options['id']}-collapse";
-		}
 		echo Html::beginTag($tag, $options);
 	}
 
@@ -144,7 +144,7 @@ class NavBar extends Widget
 		return Html::button("{$screenReader}\n{$bar}\n{$bar}\n{$bar}", [
 			'class' => 'navbar-toggle',
 			'data-toggle' => 'collapse',
-			'data-target' => "#{$this->options['id']}-collapse",
+			'data-target' => "#{$this->collapseOptions['id']}",
 		]);
 	}
 }

--- a/extensions/yii/bootstrap/NavBar.php
+++ b/extensions/yii/bootstrap/NavBar.php
@@ -45,11 +45,11 @@ class NavBar extends Widget
 	 */
 	public $options = [];
 	/**
-	 * @var array the HTML attributes for the collapse container tag. The following special options are recognized:
+	 * @var array the HTML attributes for the container tag. The following special options are recognized:
 	 *
 	 * - tag: string, defaults to "div", the name of the container tag
 	 */
-	public $collapseOptions = [];
+	public $containerOptions = [];
 	/**
 	 * @var string the text of the brand. Note that this is not HTML-encoded.
 	 * @see http://getbootstrap.com/components/#navbar
@@ -102,8 +102,8 @@ class NavBar extends Widget
 			echo Html::beginTag('div', $this->innerContainerOptions);
 		}
 		echo Html::beginTag('div', ['class' => 'navbar-header']);
-		if (!isset($this->collapseOptions['id'])) {
-			$this->collapseOptions['id'] = "{$this->options['id']}-collapse";
+		if (!isset($this->containerOptions['id'])) {
+			$this->containerOptions['id'] = "{$this->options['id']}-collapse";
 		}
 		echo $this->renderToggleButton();
 		if ($this->brandLabel !== null) {
@@ -111,9 +111,9 @@ class NavBar extends Widget
 			echo Html::a($this->brandLabel, $this->brandUrl, $this->brandOptions);
 		}
 		echo Html::endTag('div');
-		Html::addCssClass($this->collapseOptions, 'collapse');
-		Html::addCssClass($this->collapseOptions, 'navbar-collapse');
-		$options = $this->collapseOptions;
+		Html::addCssClass($this->containerOptions, 'collapse');
+		Html::addCssClass($this->containerOptions, 'navbar-collapse');
+		$options = $this->containerOptions;
 		$tag = ArrayHelper::remove($options, 'tag', 'div');
 		echo Html::beginTag($tag, $options);
 	}
@@ -123,7 +123,7 @@ class NavBar extends Widget
 	 */
 	public function run()
 	{
-		$tag = ArrayHelper::remove($this->collapseOptions, 'tag', 'div');
+		$tag = ArrayHelper::remove($this->containerOptions, 'tag', 'div');
 		echo Html::endTag($tag);
 		if ($this->renderInnerContainer) {
 			echo Html::endTag('div');
@@ -144,7 +144,7 @@ class NavBar extends Widget
 		return Html::button("{$screenReader}\n{$bar}\n{$bar}\n{$bar}", [
 			'class' => 'navbar-toggle',
 			'data-toggle' => 'collapse',
-			'data-target' => "#{$this->collapseOptions['id']}",
+			'data-target' => "#{$this->containerOptions['id']}",
 		]);
 	}
 }

--- a/extensions/yii/bootstrap/NavBar.php
+++ b/extensions/yii/bootstrap/NavBar.php
@@ -7,6 +7,7 @@
 
 namespace yii\bootstrap;
 
+use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
 
 /**
@@ -30,15 +31,22 @@ use yii\helpers\Html;
  * NavBar::end();
  * ```
  *
- * @see http://twitter.github.io/bootstrap/components.html#navbar
+ * @see http://getbootstrap.com/components/#navbar
  * @author Antonio Ramirez <amigo.cobos@gmail.com>
+ * @author Alexander Kochetov <creocoder@gmail.com>
  * @since 2.0
  */
 class NavBar extends Widget
 {
 	/**
+	 * @var array the HTML attributes for the widget container tag. The following special options are recognized:
+	 *
+	 * - tag: string, defaults to "nav", the tag name of the container tag of this widget
+	 */
+	public $options = [];
+	/**
 	 * @var string the text of the brand. Note that this is not HTML-encoded.
-	 * @see http://twitter.github.io/bootstrap/components.html#navbar
+	 * @see http://getbootstrap.com/components/#navbar
 	 */
 	public $brandLabel;
 	/**
@@ -55,10 +63,14 @@ class NavBar extends Widget
 	 */
 	public $screenReaderToggleText = 'Toggle navigation';
 	/**
-	 * @var bool whether the navbar content should be included in a `container` div which adds left and right padding.
-	 * Set this to false for a 100% width navbar.
+	 * @var bool whether the navbar content should be included in an inner div container which by default
+	 * adds left and right padding. Set this to false for a 100% width navbar.
 	 */
-	public $padded = true;
+	public $renderInnerContainer = true;
+	/**
+	 * @var array the HTML attributes of the inner container.
+	 */
+	public $innerContainerOptions = [];
 
 	/**
 	 * Initializes the widget.
@@ -67,27 +79,31 @@ class NavBar extends Widget
 	{
 		parent::init();
 		$this->clientOptions = false;
-		Html::addCssClass($this->options, 'navbar');
-		if ($this->options['class'] == 'navbar') {
+		if (!isset($this->options['class'])) {
+			Html::addCssClass($this->options, 'navbar');
 			Html::addCssClass($this->options, 'navbar-default');
 		}
-		Html::addCssClass($this->brandOptions, 'navbar-brand');
-		if (empty($this->options['role'])) {
+		if (!isset($this->options['role'])) {
 			$this->options['role'] = 'navigation';
 		}
-
-		echo Html::beginTag('nav', $this->options);
-		if ($this->padded) {
-			echo Html::beginTag('div', ['class' => 'container']);
+		$options = $this->options;
+		$tag = ArrayHelper::remove($options, 'tag', 'nav');
+		echo Html::beginTag($tag, $options);
+		if ($this->renderInnerContainer) {
+			if (!isset($this->innerContainerOptions['class'])) {
+				Html::addCssClass($this->innerContainerOptions, 'container');
+			}
+			echo Html::beginTag('div', $this->innerContainerOptions);
 		}
-
 		echo Html::beginTag('div', ['class' => 'navbar-header']);
 		echo $this->renderToggleButton();
 		if ($this->brandLabel !== null) {
+			if (!isset($this->brandOptions['class'])) {
+				Html::addCssClass($this->brandOptions, 'navbar-brand');
+			}
 			echo Html::a($this->brandLabel, $this->brandUrl, $this->brandOptions);
 		}
 		echo Html::endTag('div');
-
 		echo Html::beginTag('div', ['class' => "collapse navbar-collapse navbar-{$this->options['id']}-collapse"]);
 	}
 
@@ -96,12 +112,12 @@ class NavBar extends Widget
 	 */
 	public function run()
 	{
-
 		echo Html::endTag('div');
-		if ($this->padded) {
+		if ($this->renderInnerContainer) {
 			echo Html::endTag('div');
 		}
-		echo Html::endTag('nav');
+		$tag = ArrayHelper::remove($this->options, 'tag', 'nav');
+		echo Html::endTag($tag, $this->options);
 		BootstrapPluginAsset::register($this->getView());
 	}
 
@@ -112,7 +128,7 @@ class NavBar extends Widget
 	protected function renderToggleButton()
 	{
 		$bar = Html::tag('span', '', ['class' => 'icon-bar']);
-		$screenReader = '<span class="sr-only">'.$this->screenReaderToggleText.'</span>';
+		$screenReader = "<span class=\"sr-only\">{$this->screenReaderToggleText}</span>";
 		return Html::button("{$screenReader}\n{$bar}\n{$bar}\n{$bar}", [
 			'class' => 'navbar-toggle',
 			'data-toggle' => 'collapse',


### PR DESCRIPTION
- links to bootstrap site was actualized
- `padded` renamed to `renderInnerContainer` to be consistent with other "do-something" boolean options
- `innerContainerOptions` added which very important for custom bootstrap assemblies
- special `tag` attribute now recognized inside options, this is very important to get correct html5 markup in several cases. For example if you want make navigation bar as header with role banner like on bootstrap site
- `collapseOptions` added, this is very important to get correct html5 markup in several cases. For example if you want make inner navigation as nav with role navigation like on bootstrap site
- overall refactoring

Why the hell all this needed? :) All simple here is example:

``` php
NavBar::begin([
    'brandLabel' => 'Company label here',
    'options' => ['tag' => 'header', 'role' => 'banner'],
    'collapseOptions' => ['tag' => 'nav', 'role' => 'navigation'],
    'innerContainerOptions' => ['class' => 'container-16'], // this is highly often used while you use bootstrap as framework and have more than 1 grid system
]);
...
NavBar::end();
```
