### PR TITLE
Update Config.php to support Simplified Chinese

### DIFF
--- a/framework/messages/config.php
+++ b/framework/messages/config.php
@@ -7,7 +7,7 @@ return [
 	'messagePath' => __DIR__,
 	// array, required, list of language codes that the extracted messages
 	// should be translated to. For example, ['zh-CN', 'de'].
-	'languages' => ['da', 'de', 'ru', 'pl', 'pt-BR', 'it', 'es', 'ro', 'ja'],
+	'languages' => ['da', 'de', 'ru', 'pl', 'pt-BR', 'it', 'es', 'ro', 'ja'，'zh_cn'],
 	// string, the name of the function for translating messages.
 	// Defaults to 'Yii::t'. This is used as a mark to find the messages to be
 	// translated. You may use a string for single function name or an array for


### PR DESCRIPTION
Hi, @samdark

I think you forget to put zh_cn inside. Is it zh_cn or zh-cn. My folder named as `zh_cn`, it is the common way I guess. But is it suitable for Yii2 naming convention? I do found `pt-BR` here. 
