### PR TITLE
Grid view ActionColumn buttons names like `{controller/action}`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -57,6 +57,7 @@ Yii Framework 2 Change Log
 - Enh #1773: keyPrefix property of Cache is not restricted to alnum characters anymore, however it is still recommended (cebe)
 - Enh #1809: Added support for building "EXISTS" and "NOT EXISTS" query conditions (abdrasulov)
 - Enh #1852: ActiveRecord::tableName() now returns table name using DbConnection::tablePrefix (creocoder)
+- Enh #1921: Grid view ActionColumn now allow to name buttons like `{controller/action}` (creocoder)
 - Enh: Added `favicon.ico` and `robots.txt` to default application templates (samdark)
 - Enh: Added `Widget::autoIdPrefix` to support prefixing automatically generated widget IDs (qiangxue)
 - Enh: Support for file aliases in console command 'message' (omnilight)

--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -122,7 +122,7 @@ class ActionColumn extends Column
 	 */
 	protected function renderDataCellContent($model, $key, $index)
 	{
-		return preg_replace_callback('/\\{([\w\-]+)\\}/', function ($matches) use ($model, $key, $index) {
+		return preg_replace_callback('/\\{([\w\-\/]+)\\}/', function ($matches) use ($model, $key, $index) {
 			$name = $matches[1];
 			if (isset($this->buttons[$name])) {
 				$url = $this->createUrl($name, $model, $key, $index);


### PR DESCRIPTION
For example:

``` php
<?= GridView::widget([
    'dataProvider' => $dataProvider,
    'filterModel' => $searchModel,
    'columns' => [
        [
            'class' => 'yii\grid\ActionColumn',
            'template' => '{answer/index}',
            'buttons' => [
                'answer/index' => function ($url, $model) {
                    return Html::a('<span class="glyphicon glyphicon-folder-open"></span>', $url, [
                        'title' => Yii::t('yii', 'Go to answers grid'),
                    ]);
                },
            ],
        ],
        'id',
        'title',
        'body:ntext',
        'create_time:datetime',
        'update_time:datetime',
        ['class' => 'yii\grid\ActionColumn'],
    ],
]) ?>
```
