### PR TITLE
workflow.md: fixed invalid upstream url

### DIFF
--- a/docs/internals/git-workflow.md
+++ b/docs/internals/git-workflow.md
@@ -158,7 +158,7 @@ Doing so will save travis from commencing testruns on changes that are not cover
 
 ```
 git clone git@github.com:YOUR-GITHUB-USERNAME/yii.git
-git remote add upstream git://github.com/yiisoft/yii.github
+git remote add upstream git://github.com/yiisoft/yii.git
 ```
 
 ```


### PR DESCRIPTION
In the "Command overview (for advanced contributors)" section there is a hub too much.

adding this remote will lead into a

``` bash
fatal: remote error:
  Repository not found.
```

error.
