### PR TITLE
Transfer beforeSubmit function after global validation all fields forms

### DIFF
--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -127,6 +127,13 @@
 			var $form = $(this),
 				data = $form.data('yiiActiveForm');
 			if (data.validated) {
+				if (data.settings.beforeSubmit !== undefined) {
+					if (data.settings.beforeSubmit($form) == false) {
+						data.validated = false;
+						data.submitting = false;
+						return false;
+					}
+				}
 				// continue submitting the form since validation passes
 				return true;
 			}
@@ -135,40 +142,36 @@
 				clearTimeout(data.settings.timer);
 			}
 			data.submitting = true;
-			if (!data.settings.beforeSubmit || data.settings.beforeSubmit($form)) {
-				validate($form, function (messages) {
-					var errors = [];
-					$.each(data.attributes, function () {
-						if (updateInput($form, this, messages)) {
-							errors.push(this.input);
-						}
-					});
-					updateSummary($form, messages);
-					if (errors.length) {
-						var top = $form.find(errors.join(',')).first().offset().top;
-						var wtop = $(window).scrollTop();
-						if (top < wtop || top > wtop + $(window).height) {
-							$(window).scrollTop(top);
-						}
-					} else {
-						data.validated = true;
-						var $button = data.submitObject || $form.find(':submit:first');
-						// TODO: if the submission is caused by "change" event, it will not work
-						if ($button.length) {
-							$button.click();
-						} else {
-							// no submit button in the form
-							$form.submit();
-						}
-						return;
+			validate($form, function (messages) {
+				var errors = [];
+				$.each(data.attributes, function () {
+					if (updateInput($form, this, messages)) {
+						errors.push(this.input);
 					}
-					data.submitting = false;
-				}, function () {
-					data.submitting = false;
 				});
-			} else {
+				updateSummary($form, messages);
+				if (errors.length) {
+					var top = $form.find(errors.join(',')).first().offset().top;
+					var wtop = $(window).scrollTop();
+					if (top < wtop || top > wtop + $(window).height) {
+						$(window).scrollTop(top);
+					}
+				} else {
+					data.validated = true;
+					var $button = data.submitObject || $form.find(':submit:first');
+					// TODO: if the submission is caused by "change" event, it will not work
+					if ($button.length) {
+						$button.click();
+					} else {
+						// no submit button in the form
+						$form.submit();
+					}
+					return;
+				}
 				data.submitting = false;
-			}
+			}, function () {
+				data.submitting = false;
+			});
 			return false;
 		},
 


### PR DESCRIPTION
Transfer function "before Submit" immediately before submitting forms and **after** successful validation form.

This update will resolve this issue: https://github.com/yiisoft/yii2/issues/1950
Example:

``` php
$form = ActiveForm::begin([
            'beforeSubmit' => new \yii\web\JsExpression('function(form) {
                jQuery.ajax({
                    url: "'. $this->context->createUrl('create') .'",
                    type: "POST",
                    dataType: "json",
                    data: form.serialize(),
                    success: function(response) {
                        ...
                        //cancel default submitting form
                        return false;
                    },
                    error: function(response) {
                        ...
                        //continue default submitting form
                        return true;
                    }
                });
            }')
        ]);
```
