### PR TITLE
Fixes #1805 : display validation errors as html instead of text

### DIFF
--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -344,7 +344,7 @@
 			var $container = $form.find(attribute.container);
 			var $error = $container.find(attribute.error);
 			if (hasError) {
-				$error.text(messages[attribute.name][0]);
+				$error.html(messages[attribute.name][0]);
 				$container.removeClass(data.settings.validatingCssClass + ' ' + data.settings.successCssClass)
 					.addClass(data.settings.errorCssClass);
 			} else {


### PR DESCRIPTION
Validators use `Html::encode` on error messages, they should be displayed as html when using client validation.
