### PR TITLE
Using VarDumper::dumpAsString() instead var_export() in the Request pane...

### DIFF
--- a/extensions/debug/CHANGELOG.md
+++ b/extensions/debug/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.0 beta under development
 ----------------------------
 
+- Bug #1783: Using VarDumper::dumpAsString() instead var_export(), because var_export() does not handle circular references. (djagya)
 - Bug #1504: Debug toolbar isn't loaded successfully in some environments when xdebug is enabled (qiangxue)
 - Bug #1747: Fixed problems with displaying toolbar on small screens (cebe)
 - Bug #1827: Debugger toolbar is loaded twice if an action is calling `run()` to execute another action (qiangxue)

--- a/extensions/debug/views/default/panels/request/table.php
+++ b/extensions/debug/views/default/panels/request/table.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\VarDumper;
 
 /**
  * @var string $caption
@@ -25,7 +26,7 @@ use yii\helpers\Html;
 		<?php foreach($values as $name => $value): ?>
 			<tr>
 				<th style="width: 200px;"><?= Html::encode($name) ?></th>
-				<td><?= htmlspecialchars(var_export($value, true), ENT_QUOTES|ENT_SUBSTITUTE, \Yii::$app->charset, true) ?></td>
+				<td><?= htmlspecialchars(VarDumper::dumpAsString($value), ENT_QUOTES|ENT_SUBSTITUTE, \Yii::$app->charset, true) ?></td>
 			</tr>
 		<?php endforeach; ?>
 		</tbody>


### PR DESCRIPTION
#1783
