### PR TITLE
BaseHtml::listBox() default size settings removed

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -718,9 +718,6 @@ class BaseHtml
 	 */
 	public static function listBox($name, $selection = null, $items = [], $options = [])
 	{
-		if (!isset($options['size'])) {
-			$options['size'] = 4;
-		}
 		if (!empty($options['multiple']) && substr($name, -2) !== '[]') {
 			$name .= '[]';
 		}

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -718,6 +718,9 @@ class BaseHtml
 	 */
 	public static function listBox($name, $selection = null, $items = [], $options = [])
 	{
+		if (!array_key_exists($options, 'size')) {
+			$options['size'] = 4;
+		}
 		if (!empty($options['multiple']) && substr($name, -2) !== '[]') {
 			$name .= '[]';
 		}


### PR DESCRIPTION
This is really disservice to set size attribute by default. If you need any size you can set it. Also this may affect some jquery plugins.
