### PR TITLE
fix JS redirect in OAuth callback view

### DIFF
--- a/extensions/authclient/AuthAction.php
+++ b/extensions/authclient/AuthAction.php
@@ -97,6 +97,10 @@ class AuthAction extends Action
 	 * If not set default one will be used.
 	 */
 	public $redirectView;
+	/**
+	 * @var boolean indicates if redirect trigger from popup window or in main window.
+	 */
+	public $popupMode = true;
 
 	/**
 	 * @param string $url successful URL.
@@ -219,7 +223,9 @@ class AuthAction extends Action
 	{
 		$viewFile = $this->redirectView;
 		if ($viewFile === null) {
-			$viewFile = __DIR__ . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR . 'redirect.php';
+			$viewFile = __DIR__ . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR . (
+				$this->popupMode ? 'redirect-popup.php' : 'redirect-in-window.php'
+			);
 		} else {
 			$viewFile = Yii::getAlias($viewFile);
 		}

--- a/extensions/authclient/views/redirect-in-window.php
+++ b/extensions/authclient/views/redirect-in-window.php
@@ -6,20 +6,7 @@ use yii\helpers\Json;
 /* @var $url string */
 /* @var $enforceRedirect boolean */
 
-$redirectJavaScript = <<<EOL
-function popupWindowRedirect(url, enforceRedirect) {
-	if (window.opener && window.name == 'yii_auth_choice') {
-		window.close();
-		if (enforceRedirect === undefined || enforceRedirect) {
-			window.opener.location = url;
-		}
-	} else {
-		window.location = url;
-	}
-}
-EOL;
-
-$redirectJavaScript .= 'popupWindowRedirect(' . Json::encode($url) . ', ' . Json::encode($enforceRedirect) . ');';
+$redirectJavaScript = 'window.location = ' . Json::encode($url) . ';';
 
 ?>
 <!DOCTYPE html>

--- a/extensions/authclient/views/redirect-popup.php
+++ b/extensions/authclient/views/redirect-popup.php
@@ -1,0 +1,34 @@
+<?php
+use yii\helpers\Html;
+use yii\helpers\Json;
+
+/* @var $this \yii\base\View */
+/* @var $url string */
+/* @var $enforceRedirect boolean */
+
+$redirectJavaScript = <<<EOL
+function popupWindowRedirect(url, enforceRedirect) {
+	window.close();
+	if ((enforceRedirect === undefined || enforceRedirect) && window.opener && !window.opener.closed) {
+		window.opener.location = url;
+	}
+}
+EOL;
+
+$redirectJavaScript .= 'popupWindowRedirect(' . Json::encode($url) . ', ' . Json::encode($enforceRedirect) . ');';
+
+?>
+<!DOCTYPE html>
+<html>
+<head>
+	<?= Html::script($redirectJavaScript); ?>
+</head>
+<body>
+<h2 id="title" style="display:none;">Redirecting back to the &quot;<?= Yii::$app->name; ?>&quot;...</h2>
+<h3 id="link"><a href="<?= $url; ?>">Click here to return to the &quot;<?= Yii::$app->name; ?>&quot;.</a></h3>
+<script type="text/javascript">
+	document.getElementById('title').style.display = '';
+	document.getElementById('link').style.display = 'none';
+</script>
+</body>
+</html>

--- a/extensions/authclient/views/redirect.php
+++ b/extensions/authclient/views/redirect.php
@@ -8,7 +8,7 @@ use yii\helpers\Json;
 
 $redirectJavaScript = <<<EOL
 function popupWindowRedirect(url, enforceRedirect) {
-	if (window.opener) {
+	if (window.opener && window.name == 'yii_auth_choice') {
 		window.close();
 		if (enforceRedirect === undefined || enforceRedirect) {
 			window.opener.location = url;


### PR DESCRIPTION
OAuth success/cancel callback shows a view which includes JavaScript redirect back logic.

When my app configured to use this view without popup window, 

``` php
<?php $authChoice = yii\authclient\widgets\Choice::begin([
    'baseAuthUrl' => ['site/auth'],
    'popupMode' => false,
]); ?>
```

but if the main window previously opened via `<a href="..." target="_blank">` or such as in browser tabs, I get no actions in the view.

Because `window.opener` was set something (that might be already closed). Also `window.close()` was ignored tab because it might not be floating window... I guess.

It should be checked correctly if it had been popped up by this component. I think that to add window name assigned by `yii\authclient\widgets\Choice` is safer way here:

https://github.com/yiisoft/yii2/blob/master/extensions/authclient/widgets/assets/authchoice.js#L61
