### PR TITLE
AutoTimestamp field renaming

### DIFF
--- a/apps/advanced/common/models/User.php
+++ b/apps/advanced/common/models/User.php
@@ -17,8 +17,8 @@ use yii\web\IdentityInterface;
  * @property string $auth_key
  * @property integer $role
  * @property integer $status
- * @property integer $create_time
- * @property integer $update_time
+ * @property integer $created_at
+ * @property integer $updated_at
  */
 class User extends ActiveRecord implements IdentityInterface
 {
@@ -38,8 +38,8 @@ class User extends ActiveRecord implements IdentityInterface
 			'timestamp' => [
 				'class' => 'yii\behaviors\AutoTimestamp',
 				'attributes' => [
-					ActiveRecord::EVENT_BEFORE_INSERT => ['create_time', 'update_time'],
-					ActiveRecord::EVENT_BEFORE_UPDATE => 'update_time',
+					ActiveRecord::EVENT_BEFORE_INSERT => ['created_at', 'updated_at'],
+					ActiveRecord::EVENT_BEFORE_UPDATE => 'updated_at',
 				],
 			],
 		];

--- a/apps/advanced/console/migrations/m130524_201442_init.php
+++ b/apps/advanced/console/migrations/m130524_201442_init.php
@@ -21,8 +21,8 @@ class m130524_201442_init extends \yii\db\Migration
 			'role' => Schema::TYPE_SMALLINT . ' NOT NULL DEFAULT 10',
 
 			'status' => Schema::TYPE_SMALLINT . ' NOT NULL DEFAULT 10',
-			'create_time' => Schema::TYPE_INTEGER.' NOT NULL',
-			'update_time' => Schema::TYPE_INTEGER.' NOT NULL',
+			'created_at' => Schema::TYPE_INTEGER.' NOT NULL',
+			'updated_at' => Schema::TYPE_INTEGER.' NOT NULL',
 		], $tableOptions);
 	}
 

--- a/docs/guide/active-record.md
+++ b/docs/guide/active-record.md
@@ -413,7 +413,7 @@ and you may also join with sub-relations. For example,
 $orders = Order::find()->innerJoinWith([
 	'books',
 	'customer' => function ($query) {
-		$query->where('tbl_customer.create_time > ' . (time() - 24 * 3600));
+		$query->where('tbl_customer.created_at > ' . (time() - 24 * 3600));
 	}
 ])->all();
 // join with sub-relations: join with books and books' authors

--- a/docs/guide/behaviors.md
+++ b/docs/guide/behaviors.md
@@ -23,8 +23,8 @@ class User extends ActiveRecord
 			'timestamp' => [
 				'class' => 'yii\behaviors\AutoTimestamp',
 				'attributes' => [
-					ActiveRecord::EVENT_BEFORE_INSERT => ['create_time', 'update_time'],
-					ActiveRecord::EVENT_BEFORE_UPDATE => 'update_time',
+					ActiveRecord::EVENT_BEFORE_INSERT => ['created_at', 'updated_at'],
+					ActiveRecord::EVENT_BEFORE_UPDATE => 'updated_at',
 				],
 			],
 		];
@@ -39,7 +39,7 @@ Creating your own behaviors
 
 [[NEEDS UPDATING FOR Yii 2]]
 
-To create your own behavior, you must define a class that implements the `IBehavior` interface. This can be accomplished by extending `CBehavior`. More specifically, you can extend `CModelBehavior` or `CActiveRecordBehavior` for behaviors to be used specifically with models or with Active Record models. 
+To create your own behavior, you must define a class that implements the `IBehavior` interface. This can be accomplished by extending `CBehavior`. More specifically, you can extend `CModelBehavior` or `CActiveRecordBehavior` for behaviors to be used specifically with models or with Active Record models.
 
 ```php
 class MyBehavior extends CActiveRecordBehavior

--- a/docs/guide/model.md
+++ b/docs/guide/model.md
@@ -238,7 +238,7 @@ Using the same `attributes` property you can massively assign data from associat
 ```php
 $attributes = [
 	'title' => 'Model attributes',
-	'create_time' => time(),
+	'created_at' => time(),
 ];
 $post->attributes = $attributes;
 ```

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -93,7 +93,7 @@ Yii Framework 2 Change Log
 - Chg #1821: Changed default values for yii\db\Connection username and password to null (cebe)
 - Chg #1844: `Response::sendFile()` and other file sending methods will not send the response (qiangxue)
 - Chg #1852: DbConnection::tablePrefix default value now 'tbl_' (creocoder)
-- Cng #2057: AutoTimestamp attributes defaults changed from `create_time` and `update_time` to `created_at` and `updated_at` (creocoder)
+- Chg #2057: AutoTimestamp attributes defaults changed from `create_time` and `update_time` to `created_at` and `updated_at` (creocoder)
 - Chg: Renamed `yii\jui\Widget::clientEventsMap` to `clientEventMap` (qiangxue)
 - Chg: Renamed `ActiveRecord::getPopulatedRelations()` to `getRelatedRecords()` (qiangxue)
 - Chg: Renamed `attributeName` and `className` to `targetAttribute` and `targetClass` for `UniqueValidator` and `ExistValidator` (qiangxue)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -93,6 +93,7 @@ Yii Framework 2 Change Log
 - Chg #1821: Changed default values for yii\db\Connection username and password to null (cebe)
 - Chg #1844: `Response::sendFile()` and other file sending methods will not send the response (qiangxue)
 - Chg #1852: DbConnection::tablePrefix default value now 'tbl_' (creocoder)
+- Cng #2057: AutoTimestamp attributes defaults changed from `create_time` and `update_time` to `created_at` and `updated_at` (creocoder)
 - Chg: Renamed `yii\jui\Widget::clientEventsMap` to `clientEventMap` (qiangxue)
 - Chg: Renamed `ActiveRecord::getPopulatedRelations()` to `getRelatedRecords()` (qiangxue)
 - Chg: Renamed `attributeName` and `className` to `targetAttribute` and `targetClass` for `UniqueValidator` and `ExistValidator` (qiangxue)

--- a/framework/behaviors/AutoTimestamp.php
+++ b/framework/behaviors/AutoTimestamp.php
@@ -27,8 +27,8 @@ use yii\db\ActiveRecord;
  * }
  * ~~~
  *
- * By default, AutoTimestamp will fill the `create_time` attribute with the current timestamp
- * when the associated AR object is being inserted; it will fill the `update_time` attribute
+ * By default, AutoTimestamp will fill the `created_at` attribute with the current timestamp
+ * when the associated AR object is being inserted; it will fill the `updated_at` attribute
  * with the timestamp when the AR object is being updated.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
@@ -41,8 +41,8 @@ class AutoTimestamp extends Behavior
 	 * The array keys are the ActiveRecord events upon which the attributes are to be filled with timestamps,
 	 * and the array values are the corresponding attribute(s) to be updated. You can use a string to represent
 	 * a single attribute, or an array to represent a list of attributes.
-	 * The default setting is to update the `create_time` attribute upon AR insertion,
-	 * and update the `update_time` attribute upon AR updating.
+	 * The default setting is to update the `created_at` attribute upon AR insertion,
+	 * and update the `updated_at` attribute upon AR updating.
 	 */
 	public $attributes = [
 		ActiveRecord::EVENT_BEFORE_INSERT => 'created_at',

--- a/framework/behaviors/AutoTimestamp.php
+++ b/framework/behaviors/AutoTimestamp.php
@@ -45,8 +45,8 @@ class AutoTimestamp extends Behavior
 	 * and update the `update_time` attribute upon AR updating.
 	 */
 	public $attributes = [
-		ActiveRecord::EVENT_BEFORE_INSERT => 'create_time',
-		ActiveRecord::EVENT_BEFORE_UPDATE => 'update_time',
+		ActiveRecord::EVENT_BEFORE_INSERT => 'created_at',
+		ActiveRecord::EVENT_BEFORE_UPDATE => 'updated_at',
 	];
 	/**
 	 * @var \Closure|Expression The expression that will be used for generating the timestamp.

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -145,7 +145,7 @@ class Sort extends Object
 	 * ~~~
 	 * [
 	 *     'name' => SORT_ASC,
-	 *     'create_time' => SORT_DESC,
+	 *     'created_at' => SORT_DESC,
 	 * ]
 	 * ~~~
 	 *

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -33,7 +33,7 @@ class BaseArrayHelper
 	 *         'id',
 	 *         'title',
 	 *         // the key name in array result => property name
-	 *         'createTime' => 'create_time',
+	 *         'createTime' => 'created_at',
 	 *         // the key name in array result => anonymous function
 	 *         'length' => function ($post) {
 	 *             return strlen($post->content);

--- a/tests/unit/data/ar/Order.php
+++ b/tests/unit/data/ar/Order.php
@@ -7,7 +7,7 @@ namespace yiiunit\data\ar;
  *
  * @property integer $id
  * @property integer $customer_id
- * @property integer $create_time
+ * @property integer $created_at
  * @property string $total
  */
 class Order extends ActiveRecord
@@ -68,7 +68,7 @@ class Order extends ActiveRecord
 	public function beforeSave($insert)
 	{
 		if (parent::beforeSave($insert)) {
-			$this->create_time = time();
+			$this->created_at = time();
 			return true;
 		} else {
 			return false;

--- a/tests/unit/data/ar/elasticsearch/Customer.php
+++ b/tests/unit/data/ar/elasticsearch/Customer.php
@@ -32,7 +32,7 @@ class Customer extends ActiveRecord
 
 	public function getOrders()
 	{
-		return $this->hasMany(Order::className(), array('customer_id' => 'id'))->orderBy('create_time');
+		return $this->hasMany(Order::className(), array('customer_id' => 'id'))->orderBy('created_at');
 	}
 
 	public static function active($query)

--- a/tests/unit/data/ar/elasticsearch/Order.php
+++ b/tests/unit/data/ar/elasticsearch/Order.php
@@ -8,7 +8,7 @@ use yii\elasticsearch\Command;
  *
  * @property integer $id
  * @property integer $customer_id
- * @property integer $create_time
+ * @property integer $created_at
  * @property string $total
  */
 class Order extends ActiveRecord
@@ -20,7 +20,7 @@ class Order extends ActiveRecord
 
 	public function attributes()
 	{
-		return ['id', 'customer_id', 'create_time', 'total'];
+		return ['id', 'customer_id', 'created_at', 'total'];
 	}
 
 	public function getCustomer()
@@ -65,7 +65,7 @@ class Order extends ActiveRecord
 	public function beforeSave($insert)
 	{
 		if (parent::beforeSave($insert)) {
-//			$this->create_time = time();
+//			$this->created_at = time();
 			return true;
 		} else {
 			return false;
@@ -84,7 +84,7 @@ class Order extends ActiveRecord
 				"_id" => ["path" => "id", "index" => "not_analyzed", "store" => "yes"],
 				"properties" => [
 					"customer_id" => ["type" => "integer"],
-//					"create_time" => ["type" => "string", "index" => "not_analyzed"],
+//					"created_at" => ["type" => "string", "index" => "not_analyzed"],
 					"total" => ["type" => "integer"],
 				]
 			]

--- a/tests/unit/data/ar/redis/Order.php
+++ b/tests/unit/data/ar/redis/Order.php
@@ -6,7 +6,7 @@ class Order extends ActiveRecord
 {
 	public function attributes()
 	{
-		return ['id', 'customer_id', 'create_time', 'total'];
+		return ['id', 'customer_id', 'created_at', 'total'];
 	}
 
 	public function getCustomer()
@@ -53,7 +53,7 @@ class Order extends ActiveRecord
 	public function beforeSave($insert)
 	{
 		if (parent::beforeSave($insert)) {
-			$this->create_time = time();
+			$this->created_at = time();
 			return true;
 		} else {
 			return false;

--- a/tests/unit/data/cubrid.sql
+++ b/tests/unit/data/cubrid.sql
@@ -46,7 +46,7 @@ CREATE TABLE `tbl_item` (
 CREATE TABLE `tbl_order` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `customer_id` int(11) NOT NULL,
-  `create_time` int(11) NOT NULL,
+  `created_at` int(11) NOT NULL,
   `total` decimal(10,0) NOT NULL,
   PRIMARY KEY (`id`),
   CONSTRAINT `FK_order_customer_id` FOREIGN KEY (`customer_id`) REFERENCES `tbl_customer` (`id`) ON DELETE CASCADE
@@ -107,9 +107,9 @@ INSERT INTO tbl_item (name, category_id) VALUES ('Ice Age', 2);
 INSERT INTO tbl_item (name, category_id) VALUES ('Toy Story', 2);
 INSERT INTO tbl_item (name, category_id) VALUES ('Cars', 2);
 
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (1, 1325282384, 110.0);
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (2, 1325334482, 33.0);
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (2, 1325502201, 40.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (1, 1325282384, 110.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (2, 1325334482, 33.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (2, 1325502201, 40.0);
 
 INSERT INTO tbl_order_item (order_id, item_id, quantity, subtotal) VALUES (1, 1, 1, 30.0);
 INSERT INTO tbl_order_item (order_id, item_id, quantity, subtotal) VALUES (1, 2, 2, 40.0);

--- a/tests/unit/data/mssql.sql
+++ b/tests/unit/data/mssql.sql
@@ -37,7 +37,7 @@ CREATE TABLE [dbo].[tbl_item] (
 CREATE TABLE [dbo].[tbl_order] (
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[customer_id] [int] NOT NULL,
-	[create_time] [int] NOT NULL,
+	[created_at] [int] NOT NULL,
 	[total] [decimal](10,0) NOT NULL,
 	CONSTRAINT [PK_order] PRIMARY KEY CLUSTERED (
 		[id] ASC
@@ -92,9 +92,9 @@ INSERT INTO [dbo].[tbl_item] ([name], [category_id]) VALUES ('Ice Age', 2);
 INSERT INTO [dbo].[tbl_item] ([name], [category_id]) VALUES ('Toy Story', 2);
 INSERT INTO [dbo].[tbl_item] ([name], [category_id]) VALUES ('Cars', 2);
 
-INSERT INTO [dbo].[tbl_order] ([customer_id], [create_time], [total]) VALUES (1, 1325282384, 110.0);
-INSERT INTO [dbo].[tbl_order] ([customer_id], [create_time], [total]) VALUES (2, 1325334482, 33.0);
-INSERT INTO [dbo].[tbl_order] ([customer_id], [create_time], [total]) VALUES (2, 1325502201, 40.0);
+INSERT INTO [dbo].[tbl_order] ([customer_id], [created_at], [total]) VALUES (1, 1325282384, 110.0);
+INSERT INTO [dbo].[tbl_order] ([customer_id], [created_at], [total]) VALUES (2, 1325334482, 33.0);
+INSERT INTO [dbo].[tbl_order] ([customer_id], [created_at], [total]) VALUES (2, 1325502201, 40.0);
 
 INSERT INTO [dbo].[tbl_order_item] ([order_id], [item_id], [quantity], [subtotal]) VALUES (1, 1, 1, 30.0);
 INSERT INTO [dbo].[tbl_order_item] ([order_id], [item_id], [quantity], [subtotal]) VALUES (1, 2, 2, 40.0);

--- a/tests/unit/data/mysql.sql
+++ b/tests/unit/data/mysql.sql
@@ -47,7 +47,7 @@ CREATE TABLE `tbl_item` (
 CREATE TABLE `tbl_order` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `customer_id` int(11) NOT NULL,
-  `create_time` int(11) NOT NULL,
+  `created_at` int(11) NOT NULL,
   `total` decimal(10,0) NOT NULL,
   PRIMARY KEY (`id`),
   CONSTRAINT `FK_order_customer_id` FOREIGN KEY (`customer_id`) REFERENCES `tbl_customer` (`id`) ON DELETE CASCADE
@@ -109,9 +109,9 @@ INSERT INTO tbl_item (name, category_id) VALUES ('Ice Age', 2);
 INSERT INTO tbl_item (name, category_id) VALUES ('Toy Story', 2);
 INSERT INTO tbl_item (name, category_id) VALUES ('Cars', 2);
 
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (1, 1325282384, 110.0);
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (2, 1325334482, 33.0);
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (2, 1325502201, 40.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (1, 1325282384, 110.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (2, 1325334482, 33.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (2, 1325502201, 40.0);
 
 INSERT INTO tbl_order_item (order_id, item_id, quantity, subtotal) VALUES (1, 1, 1, 30.0);
 INSERT INTO tbl_order_item (order_id, item_id, quantity, subtotal) VALUES (1, 2, 2, 40.0);

--- a/tests/unit/data/postgres.sql
+++ b/tests/unit/data/postgres.sql
@@ -43,7 +43,7 @@ CREATE TABLE tbl_item (
 CREATE TABLE tbl_order (
   id serial not null primary key,
   customer_id integer NOT NULL references tbl_customer(id) on UPDATE CASCADE on DELETE CASCADE,
-  create_time integer NOT NULL,
+  created_at integer NOT NULL,
   total decimal(10,0) NOT NULL
 );
 
@@ -92,9 +92,9 @@ INSERT INTO tbl_item (name, category_id) VALUES ('Ice Age', 2);
 INSERT INTO tbl_item (name, category_id) VALUES ('Toy Story', 2);
 INSERT INTO tbl_item (name, category_id) VALUES ('Cars', 2);
 
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (1, 1325282384, 110.0);
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (2, 1325334482, 33.0);
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (2, 1325502201, 40.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (1, 1325282384, 110.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (2, 1325334482, 33.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (2, 1325502201, 40.0);
 
 INSERT INTO tbl_order_item (order_id, item_id, quantity, subtotal) VALUES (1, 1, 1, 30.0);
 INSERT INTO tbl_order_item (order_id, item_id, quantity, subtotal) VALUES (1, 2, 2, 40.0);

--- a/tests/unit/data/sqlite.sql
+++ b/tests/unit/data/sqlite.sql
@@ -37,7 +37,7 @@ CREATE TABLE tbl_item (
 CREATE TABLE tbl_order (
   id INTEGER NOT NULL,
   customer_id INTEGER NOT NULL,
-  create_time INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
   total decimal(10,0) NOT NULL,
   PRIMARY KEY (id)
 );
@@ -94,9 +94,9 @@ INSERT INTO tbl_item (name, category_id) VALUES ('Ice Age', 2);
 INSERT INTO tbl_item (name, category_id) VALUES ('Toy Story', 2);
 INSERT INTO tbl_item (name, category_id) VALUES ('Cars', 2);
 
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (1, 1325282384, 110.0);
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (2, 1325334482, 33.0);
-INSERT INTO tbl_order (customer_id, create_time, total) VALUES (2, 1325502201, 40.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (1, 1325282384, 110.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (2, 1325334482, 33.0);
+INSERT INTO tbl_order (customer_id, created_at, total) VALUES (2, 1325502201, 40.0);
 
 INSERT INTO tbl_order_item (order_id, item_id, quantity, subtotal) VALUES (1, 1, 1, 30.0);
 INSERT INTO tbl_order_item (order_id, item_id, quantity, subtotal) VALUES (1, 2, 2, 40.0);

--- a/tests/unit/extensions/elasticsearch/ActiveRecordTest.php
+++ b/tests/unit/extensions/elasticsearch/ActiveRecordTest.php
@@ -100,15 +100,15 @@ class ActiveRecordTest extends ElasticSearchTestCase
 
 		$order = new Order();
 		$order->id = 1;
-		$order->setAttributes(['customer_id' => 1, 'create_time' => 1325282384, 'total' => 110.0], false);
+		$order->setAttributes(['customer_id' => 1, 'created_at' => 1325282384, 'total' => 110.0], false);
 		$order->save(false);
 		$order = new Order();
 		$order->id = 2;
-		$order->setAttributes(['customer_id' => 2, 'create_time' => 1325334482, 'total' => 33.0], false);
+		$order->setAttributes(['customer_id' => 2, 'created_at' => 1325334482, 'total' => 33.0], false);
 		$order->save(false);
 		$order = new Order();
 		$order->id = 3;
-		$order->setAttributes(['customer_id' => 2, 'create_time' => 1325502201, 'total' => 40.0], false);
+		$order->setAttributes(['customer_id' => 2, 'created_at' => 1325502201, 'total' => 40.0], false);
 		$order->save(false);
 
 		$orderItem = new OrderItem();
@@ -239,14 +239,14 @@ class ActiveRecordTest extends ElasticSearchTestCase
 		$orders = $customer->orders;
 		$this->assertEquals(2, count($orders));
 
-		$orders = $customer->getOrders()->where(['between', 'create_time', 1325334000, 1325400000])->all();
+		$orders = $customer->getOrders()->where(['between', 'created_at', 1325334000, 1325400000])->all();
 		$this->assertEquals(1, count($orders));
 		$this->assertEquals(2, $orders[0]->id);
 	}
 
 	public function testFindEagerViaRelation()
 	{
-		$orders = Order::find()->with('items')->orderBy('create_time')->all();
+		$orders = Order::find()->with('items')->orderBy('created_at')->all();
 		$this->assertEquals(3, count($orders));
 		$order = $orders[0];
 		$this->assertEquals(1, $order->id);

--- a/tests/unit/extensions/redis/ActiveRecordTest.php
+++ b/tests/unit/extensions/redis/ActiveRecordTest.php
@@ -63,13 +63,13 @@ class ActiveRecordTest extends RedisTestCase
 		$item->save(false);
 
 		$order = new Order();
-		$order->setAttributes(['customer_id' => 1, 'create_time' => 1325282384, 'total' => 110.0], false);
+		$order->setAttributes(['customer_id' => 1, 'created_at' => 1325282384, 'total' => 110.0], false);
 		$order->save(false);
 		$order = new Order();
-		$order->setAttributes(['customer_id' => 2, 'create_time' => 1325334482, 'total' => 33.0], false);
+		$order->setAttributes(['customer_id' => 2, 'created_at' => 1325334482, 'total' => 33.0], false);
 		$order->save(false);
 		$order = new Order();
-		$order->setAttributes(['customer_id' => 2, 'create_time' => 1325502201, 'total' => 40.0], false);
+		$order->setAttributes(['customer_id' => 2, 'created_at' => 1325502201, 'total' => 40.0], false);
 		$order->save(false);
 
 		$orderItem = new OrderItem();

--- a/tests/unit/framework/ar/ActiveRecordTestTrait.php
+++ b/tests/unit/framework/ar/ActiveRecordTestTrait.php
@@ -502,7 +502,7 @@ trait ActiveRecordTestTrait
 
 		/*
 		Item (name, category_id)
-		Order (customer_id, create_time, total)
+		Order (customer_id, created_at, total)
 		OrderItem (order_id, item_id, quantity, subtotal)
 
 		Result should be the following:
@@ -530,7 +530,7 @@ trait ActiveRecordTestTrait
 		- itemsInOrder:
 			Item 3: 'Ice Age', 2
 		 */
-		$orders = $this->callOrderFind()->with('itemsInOrder1')->orderBy('create_time')->all();
+		$orders = $this->callOrderFind()->with('itemsInOrder1')->orderBy('created_at')->all();
 		$this->assertEquals(3, count($orders));
 
 		$order = $orders[0];
@@ -558,7 +558,7 @@ trait ActiveRecordTestTrait
 	// different order in via table
 	public function testFindEagerViaRelationPreserveOrderB()
 	{
-		$orders = $this->callOrderFind()->with('itemsInOrder2')->orderBy('create_time')->all();
+		$orders = $this->callOrderFind()->with('itemsInOrder2')->orderBy('created_at')->all();
 		$this->assertEquals(3, count($orders));
 
 		$order = $orders[0];

--- a/tests/unit/framework/behaviors/AutoTimestampTest.php
+++ b/tests/unit/framework/behaviors/AutoTimestampTest.php
@@ -41,8 +41,8 @@ class AutoTimestampTest extends TestCase
 
 		$columns = [
 			'id' => 'pk',
-			'create_time' => 'integer',
-			'update_time' => 'integer',
+			'created_at' => 'integer',
+			'updated_at' => 'integer',
 		];
 		Yii::$app->getDb()->createCommand()->createTable('test_auto_timestamp', $columns)->execute();
 	}
@@ -62,8 +62,8 @@ class AutoTimestampTest extends TestCase
 		$model = new ActiveRecordAutoTimestamp();
 		$model->save(false);
 
-		$this->assertTrue($model->create_time >= $currentTime);
-		$this->assertTrue($model->update_time >= $currentTime);
+		$this->assertTrue($model->created_at >= $currentTime);
+		$this->assertTrue($model->updated_at >= $currentTime);
 	}
 
 	/**
@@ -78,12 +78,12 @@ class AutoTimestampTest extends TestCase
 
 		$enforcedTime = $currentTime - 100;
 
-		$model->create_time = $enforcedTime;
-		$model->update_time = $enforcedTime;
+		$model->created_at = $enforcedTime;
+		$model->updated_at = $enforcedTime;
 		$model->save(false);
 
-		$this->assertEquals($enforcedTime, $model->create_time, 'Create time has been set on update!');
-		$this->assertTrue($model->update_time >= $currentTime, 'Update time has NOT been set on update!');
+		$this->assertEquals($enforcedTime, $model->created_at, 'Create time has been set on update!');
+		$this->assertTrue($model->updated_at >= $currentTime, 'Update time has NOT been set on update!');
 	}
 }
 
@@ -91,8 +91,8 @@ class AutoTimestampTest extends TestCase
  * Test Active Record class with [[AutoTimestamp]] behavior attached.
  *
  * @property integer $id
- * @property integer $create_time
- * @property integer $update_time
+ * @property integer $created_at
+ * @property integer $updated_at
  */
 class ActiveRecordAutoTimestamp extends ActiveRecord
 {
@@ -102,8 +102,8 @@ class ActiveRecordAutoTimestamp extends ActiveRecord
 			'timestamp' => [
 				'class' => AutoTimestamp::className(),
 				'attributes' => [
-					static::EVENT_BEFORE_INSERT => ['create_time', 'update_time'],
-					static::EVENT_BEFORE_UPDATE => 'update_time',
+					static::EVENT_BEFORE_INSERT => ['created_at', 'updated_at'],
+					static::EVENT_BEFORE_UPDATE => 'updated_at',
 				],
 			],
 		];


### PR DESCRIPTION
Pros:
- play well with both date and datetime
- one char less
- correct verb in the past tense
- play well in pair with created_by_id and updated_by_id

Cons:
- no cons at all
