### PR TITLE
[WIP] ActiveRecord::saveMultiple() and corresponding methods needed for batch inserts/updates for AR

### DIFF
--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -338,6 +338,18 @@ class ActiveRecord extends BaseActiveRecord
 	}
 
 	/**
+	 * TBD.
+	 * @param ActiveRecord[] $models
+	 * @param bool $runValidation
+	 * @param null $attributes
+	 * @return bool|void
+	 */
+	public static function insertMultiple($models, $runValidation = true, $attributes = null)
+	{
+
+	}
+
+	/**
 	 * @see ActiveRecord::insert()
 	 */
 	private function insertInternal($attributes = null)
@@ -447,6 +459,18 @@ class ActiveRecord extends BaseActiveRecord
 			$result = $this->updateInternal($attributes);
 		}
 		return $result;
+	}
+
+	/**
+	 * TBD.
+	 * @param ActiveRecord[] $models
+	 * @param bool $runValidation
+	 * @param null $attributes
+	 * @return bool|void
+	 */
+	public static function updateMultiple($models, $runValidation = true, $attributes = null)
+	{
+
 	}
 
 	/**

--- a/framework/db/ActiveRecordInterface.php
+++ b/framework/db/ActiveRecordInterface.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * 
- * 
+ *
+ *
  * @author Carsten Brandt <mail@cebe.cc>
  */
 
@@ -191,6 +191,33 @@ interface ActiveRecordInterface
 	public function save($runValidation = true, $attributes = null);
 
 	/**
+	 * Saves the multiple records.
+	 *
+	 * For example, to save a multiple records:
+	 *
+	 * ```php
+	 * $customer1 = new Customer;
+	 * $customer1->name = $name1;
+	 * $customer1->email = $email1;
+	 * $customer2 = new Customer;
+	 * $customer2->name = $name2;
+	 * $customer2->email = $email2;
+	 * $customer3 = new Customer;
+	 * $customer3->name = $name3;
+	 * $customer3->email = $email3;
+	 * ActiveRecord::saveMultiple([$customer1, $customer2, $customer3]);
+	 * ```
+	 *
+	 * @param ActiveRecord[] $models the models to be saved.
+	 * @param bool $runValidation whether to perform validation before saving the records.
+	 * If the validation fails, the records will not be saved to database.
+	 * @param null $attributes list of attributes that need to be saved. Defaults to null,
+	 * meaning all attributes that are loaded from DB will be saved.
+	 * @return boolean whether the saving succeeds
+	 */
+	public static function saveMultiple($models, $runValidation = true, $attributes = null);
+
+	/**
 	 * Inserts the record into the database using the attribute values of this record.
 	 *
 	 * Usage example:
@@ -209,6 +236,33 @@ interface ActiveRecordInterface
 	 * @return boolean whether the attributes are valid and the record is inserted successfully.
 	 */
 	public function insert($runValidation = true, $attributes = null);
+
+	/**
+	 * Inserts the record into the database using the attribute values of this record.
+	 *
+	 * Usage example:
+	 *
+	 * ~~~
+	 * $customer1 = new Customer;
+	 * $customer1->name = $name1;
+	 * $customer1->email = $email1;
+	 * $customer2 = new Customer;
+	 * $customer2->name = $name2;
+	 * $customer2->email = $email2;
+	 * $customer3 = new Customer;
+	 * $customer3->name = $name3;
+	 * $customer3->email = $email3;
+	 * ActiveRecord::insertMultiple([$customer1, $customer2, $customer3]);
+	 * ~~~
+	 *
+	 * @param ActiveRecord[] $models the models to be inserted.
+	 * @param boolean $runValidation whether to perform validation before saving the records.
+	 * If the validation fails, the records will not be inserted into the database.
+	 * @param array $attributes list of attributes that need to be saved. Defaults to null,
+	 * meaning all attributes that are loaded from DB will be saved.
+	 * @return boolean whether the attributes are valid and the records is inserted successfully.
+	 */
+	public static function insertMultiple($models, $runValidation = true, $attributes = null);
 
 	/**
 	 * Saves the changes to this active record into the database.
@@ -232,6 +286,31 @@ interface ActiveRecordInterface
 	 * update execution is successful.
 	 */
 	public function update($runValidation = true, $attributes = null);
+
+	/**
+	 * Saves the changes to active records into the database.
+	 *
+	 * Usage example:
+	 *
+	 * ```php
+	 * $customers = Customer::find()->where(['in', 'id', [1001, 1002, 1003]])->indexBy('id')->all();
+	 * $customers[1001]->name = $newName1;
+	 * $customers[1002]->name = $newName2;
+	 * $customers[1003]->name = $newName3;
+	 * ActiveRecord::updateMultiple($customers);
+	 * ```
+	 *
+	 * @param ActiveRecord[] $models the models to be updated.
+	 * @param boolean $runValidation whether to perform validation before updating the records.
+	 * If the validation fails, the records will not be updated in the database.
+	 * @param array $attributes list of attributes that need to be updated. Defaults to null,
+	 * meaning all attributes that are loaded from DB will be updated.
+	 * @return integer|boolean the number of rows affected, or false if validation fails
+	 * or updating process is stopped for other reasons.
+	 * Note that it is possible that the number of rows affected is 0, even though the
+	 * update execution is successful.
+	 */
+	public static function updateMultiple($models, $runValidation = true, $attributes = null);
 
 	/**
 	 * Deletes the record from the database.

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -576,6 +576,54 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
 	}
 
 	/**
+	 * Saves the multiple records.
+	 *
+	 * For example, to save a multiple records:
+	 *
+	 * ```php
+	 * $customer1 = new Customer;
+	 * $customer1->name = $name1;
+	 * $customer1->email = $email1;
+	 * $customer2 = new Customer;
+	 * $customer2->name = $name2;
+	 * $customer2->email = $email2;
+	 * $customer3 = new Customer;
+	 * $customer3->name = $name3;
+	 * $customer3->email = $email3;
+	 * ActiveRecord::saveMultiple([$customer1, $customer2, $customer3]);
+	 * ```
+	 *
+	 * @param ActiveRecord[] $models the models to be saved.
+	 * @param bool $runValidation whether to perform validation before saving the records.
+	 * If the validation fails, the records will not be saved to database.
+	 * @param null $attributes list of attributes that need to be saved. Defaults to null,
+	 * meaning all attributes that are loaded from DB will be saved.
+	 * @return boolean whether the saving succeeds
+	 */
+	public static function saveMultiple($models, $runValidation = true, $attributes = null)
+	{
+		if ($runValidation || !static::validateMultiple($models, $attributes)) {
+			return false;
+		}
+
+		$insertModels = [];
+		$updateModels = [];
+
+		foreach ($models as $model) {
+			if ($model->getIsNewRecord()) {
+				$insertModels[] = $model;
+			} else {
+				$updateModels[] = $model;
+			}
+		}
+
+		$result = static::insertMultiple($models, $runValidation, $attributes);
+		$result = static::updateMultiple($models, $runValidation, $attributes) && $result;
+
+		return $result;
+	}
+
+	/**
 	 * Saves the changes to this active record into the associated database table.
 	 *
 	 * This method performs the following steps in order:

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -503,6 +503,31 @@ class Command extends \yii\base\Component
 	}
 
 	/**
+	 * Creates a batch UPDATE command.
+	 * For example,
+	 *
+	 * ~~~
+	 * $connection->createCommand()->batchUpdate('tbl_user', ['name', 'age'], [
+	 *     1001 => ['Tom', 30],
+	 *     1002 => ['Jane', 20],
+	 *     1003 => ['Linda', 25],
+	 * ])->execute();
+	 * ~~~
+	 *
+	 * Note that the values in each row must match the corresponding column names.
+	 *
+	 * @param string $table the table to be updated.
+	 * @param array $columns the column names
+	 * @param array $rows the rows (pk => row) to be batch updated in the table
+	 * @return Command the command object itself
+	 */
+	public function batchUpdate($table, $columns, $rows)
+	{
+		$sql = $this->db->getQueryBuilder()->batchUpdate($table, $columns, $rows);
+		return $this->setSql($sql);
+	}
+
+	/**
 	 * Creates a DELETE command.
 	 * For example,
 	 *

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -217,6 +217,30 @@ class QueryBuilder extends \yii\base\Object
 	}
 
 	/**
+	 * Generates a batch UPDATE SQL statement.
+	 * For example,
+	 *
+	 * ~~~
+	 * $connection->createCommand()->batchUpdate('tbl_user', ['name', 'age'], [
+	 *     1001 => ['Tom', 30],
+	 *     1002 => ['Jane', 20],
+	 *     1003 => ['Linda', 25],
+	 * ])->execute();
+	 * ~~~
+	 *
+	 * Note that the values in each row must match the corresponding column names.
+	 *
+	 * @param string $table the table to be updated.
+	 * @param array $columns the column names
+	 * @param array $rows the rows (pk => row) to be batch updated in the table
+	 * @return string the batch INSERT SQL statement
+	 */
+	public function batchUpdate($table, $columns, $rows)
+	{
+		// implementation http://www.karlrixon.co.uk/writing/update-multiple-rows-with-different-values-and-a-single-sql-query/
+	}
+
+	/**
 	 * Creates a DELETE SQL statement.
 	 * For example,
 	 *


### PR DESCRIPTION
Example:

``` php
$customer1 = new Customer;
$customer1->name = $name1;
$customer1->email = $email1;
$customer2 = new Customer;
$customer2->name = $name2;
$customer2->email = $email2;
$customer3 = new Customer;
$customer3->name = $name3;
$customer3->email = $email3;
ActiveRecord::saveMultiple([$customer1, $customer2, $customer3]);
```

Will be performed in **one** query, instead of **three** queries. Name for this method was choosen to be consistent with `Model::loadMultiple()` and `Model::validateMultiple()` methods. More details and examples for other methods which implemented for `ActiveRecord::saveMultiple()` needs will be given later.

Why this implemented? We have batch save feature at DAO level and this is not use its potential inside Active Record. In 2014 Active Record without batch save/batch update feature lead to lost fw popularity and unjustified expenditure of server resources and electricity. So this feature is must have in AR.

Work for this in progress.
