### PR TITLE
Simplify apidoc's RenderController::findRenderer to allow for custom renderers via ext

### DIFF
--- a/extensions/apidoc/commands/RenderController.php
+++ b/extensions/apidoc/commands/RenderController.php
@@ -103,15 +103,11 @@ class RenderController extends Controller
 	 */
 	protected function findRenderer()
 	{
-		$file = Yii::getAlias('@yii/apidoc/templates/' . $this->template . '/Renderer.php');
-		$reflection = new FileReflector($file, true);
-		$reflection->process();
-		$classes = $reflection->getClasses();
-		if (empty($classes)) {
+		$rendererClass = 'yii\\apidoc\\templates\\' . $this->template . '\\Renderer';
+		if (!class_exists($rendererClass)) {
 			$this->stderr('Renderer not found.' . PHP_EOL);
+			exit(0);
 		}
-		$rendererClass = reset($classes)->getName();
-		require($file);
 		return new $rendererClass();
 	}
 


### PR DESCRIPTION
I could be missing something, but I changed apidoc's RenderController::findRenderer to do a simple class_exists check. That way, through Yii's autoloader, I can create an extension to load a custom template renderer. The previous method would not allow me to do this (I would have had to put my custom template inside a cloned version of yii2-apidoc).
