### PR TITLE
PHPDocs: "app\models" changed to "common\models"

### DIFF
--- a/apps/advanced/backend/views/site/login.php
+++ b/apps/advanced/backend/views/site/login.php
@@ -5,7 +5,7 @@ use yii\widgets\ActiveForm;
 /**
  * @var yii\web\View $this
  * @var yii\widgets\ActiveForm $form
- * @var app\models\LoginForm $model
+ * @var common\models\LoginForm $model
  */
 $this->title = 'Login';
 $this->params['breadcrumbs'][] = $this->title;


### PR DESCRIPTION
Just a minor PHPDocs change. In the advanced application there is no such thing as "app\models".
