### PR TITLE
Ensure that the table prefix is used when generating the class name.

### DIFF
--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -543,6 +543,8 @@ class Generator extends \yii\gii\Generator
 
 		$db = $this->getDbConnection();
 		$patterns = [];
+		$patterns[] = "/^{$db->tablePrefix}(.*?)$/";
+		$patterns[] = "/^(.*?){$db->tablePrefix}$/";
 		if (strpos($this->tableName, '*') !== false) {
 			$pattern = $this->tableName;
 			if (($pos = strrpos($pattern, '.')) !== false) {
@@ -550,8 +552,6 @@ class Generator extends \yii\gii\Generator
 			}
 			$patterns[] = '/^' . str_replace('*', '(\w+)', $pattern) . '$/';
 		}
-		$patterns[] = "/^{$db->tablePrefix}(.*?)$/";
-		$patterns[] = "/^(.*?){$db->tablePrefix}$/";
 		$className = $tableName;
 		foreach ($patterns as $pattern) {
 			if (preg_match($pattern, $tableName, $matches)) {


### PR DESCRIPTION
Fix to https://github.com/yiisoft/yii2/issues/2096

The verification of the first pattern will always be true and the pattern with the prefix will never be tested.
