### PR TITLE
issue #1659: released buildLimitOffset() for MSSQL

### DIFF
--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -49,10 +49,22 @@ class QueryBuilder extends \yii\db\QueryBuilder
 //		return '';
 //	}
 
-//	public function buildLimit($limit, $offset)
-//	{
-//		return '';
-//	}
+	/**
+	 * @param integer $limit
+	 * @param integer $offset
+	 * @return string the LIMIT and OFFSET clauses built from [[query]].
+	 */
+	public function buildLimit($limit, $offset = 0)
+	{
+		$sql = '';
+		if ($offset !== null && $offset >= 0) {
+			$sql = 'OFFSET ' . (int)$offset . ' ROWS';
+			if ($limit !== null && $limit >= 0) {
+				$sql .= ' FETCH NEXT ' . (int)$limit . ' ROWS ONLY';
+			}
+		}
+		return $sql;
+	}
 
 //	public function resetSequence($table, $value = null)
 //	{

--- a/tests/unit/framework/db/mssql/MssqlQueryBuilderTest.php
+++ b/tests/unit/framework/db/mssql/MssqlQueryBuilderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace yiiunit\framework\db\mssql;
+
+use yiiunit\framework\db\QueryBuilderTest;
+use yii\db\Query;
+
+/**
+ * @group db
+ * @group mssql
+ */
+class MSSQLQueryBuilderTest extends QueryBuilderTest
+{
+	public $driverName = 'sqlsrv';
+        
+        public function testOffsetLimit() {
+                $expectedQuerySql = 'SELECT `id` FROM `exapmle` OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY';
+                $expectedQueryParams = null;
+                
+                $query = new Query();
+                $query->select('id')
+                        ->from('example')
+                        ->limit(10)->offset(5);
+                
+                list($actualQuerySql, $actualQueryParams) = $this->getQueryBuilder()->build($query);
+                
+                $this->assertEquals($expectedQuerySql, $actualQuerySql);
+                $this->assertEquals($expectedQueryParams, $actualQueryParams);
+        }
+        
+        public function testLimit() {
+                $expectedQuerySql = 'SELECT `id` FROM `exapmle` OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY';
+                $expectedQueryParams = null;
+                
+                $query = new Query();
+                $query->select('id')
+                        ->from('example')
+                        ->limit(10);
+                
+                list($actualQuerySql, $actualQueryParams) = $this->getQueryBuilder()->build($query);
+                
+                $this->assertEquals($expectedQuerySql, $actualQuerySql);
+                $this->assertEquals($expectedQueryParams, $actualQueryParams);
+        }
+        
+        public function testOffset() {
+                $expectedQuerySql = 'SELECT `id` FROM `exapmle` OFFSET 10 ROWS';
+                $expectedQueryParams = null;
+                
+                $query = new Query();
+                $query->select('id')
+                        ->from('example')
+                        ->offset(10);
+                
+                list($actualQuerySql, $actualQueryParams) = $this->getQueryBuilder()->build($query);
+                
+                $this->assertEquals($expectedQuerySql, $actualQuerySql);
+                $this->assertEquals($expectedQueryParams, $actualQueryParams);
+        }
+}


### PR DESCRIPTION
released buildLimitOffset method for MSSQL. Returns query part like `OFFSET x ROWS FETCH NEXT y ROWS`. `OFFSET x ROWS` part is required permanently, but `x` may be 0. This clause performed by 2012 or later versions of server. In earlier versions should use `SELECT TOP x` clause instead `LIMIT`. `OFFSET` can be emulated only.
