### PR TITLE
Add individual SELECT statements in UNION

### DIFF
--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -645,6 +645,19 @@ class Query extends Component implements QueryInterface
 	}
 
 	/**
+	 * Appends a SQL statement using UNION operator as individual SELECT statements.
+	 * e.g. (SELECT ... FROM ...) UNION (SELECT ... FROM ...)
+	 * @param string|Query $sql the SQL statement to be appended using UNION
+	 * @param bool $all TRUE if using UNION ALL and FALSE if using UNION
+	 * @return static the query object itself
+	 */
+	public function unionFull($sql, $all = false)
+	{
+		$this->union[] = ['query' => $sql, 'all' => $all, 'full' => true];
+		return $this;
+	}
+
+	/**
 	 * Sets the parameters to be bound to the query.
 	 * @param array $params list of query parameter values indexed by parameter placeholders.
 	 * For example, `[':name' => 'Dan', ':age' => 31]`.


### PR DESCRIPTION
This pull request must be connected with this: #2175

``` php
Foo::find()
    ->limit(15)
    ->unionFull(
        Bar::find()
        ->limit(16),
        true
    )
    ->createCommand()
    ->getSql();
```

or

``` php
(new Query())
    ->from(['foo'])
    ->limit(15)
    ->unionFull(
        (new Query())
        ->from(['bar'])
        ->limit(16),
        true
    )
    ->createCommand()
    ->getSql();
```

**Output:** 

``` sql
(SELECT * FROM `foo` LIMIT 15) UNION ALL ( SELECT * FROM `bar` LIMIT 16 )
```
