### PR TITLE
fix the _only_ option in calls to FileHelper::findFiles()

### DIFF
--- a/build/controllers/ClassmapController.php
+++ b/build/controllers/ClassmapController.php
@@ -42,10 +42,10 @@ class ClassmapController extends Controller
 				}
 				return null;
 			},
-			'only' => ['.php'],
+			'only' => ['*.php'],
 			'except' => [
-				'Yii.php',
-				'BaseYii.php',
+				'/Yii.php',
+				'/BaseYii.php',
 				'/console/',
 			],
 		];

--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -71,10 +71,10 @@ class PhpDocController extends Controller
 				}
 				return null;
 			},
-			'only' => ['.php'],
+			'only' => ['*.php'],
 			'except' => array_merge($except, [
-				'BaseYii.php',
-				'Yii.php',
+				'/BaseYii.php',
+				'/Yii.php',
 				'/views/',
 				'/requirements/',
 				'/gii/generators/',

--- a/extensions/apidoc/commands/RenderController.php
+++ b/extensions/apidoc/commands/RenderController.php
@@ -137,7 +137,7 @@ class RenderController extends Controller
 				}
 				return null;
 			},
-			'only' => ['.php'],
+			'only' => ['*.php'],
 			'except' => $except,
 		];
 		return FileHelper::findFiles($path, $options);
@@ -147,7 +147,7 @@ class RenderController extends Controller
 	{
 		$path = FileHelper::normalizePath($path);
 		$options = [
-			'only' => ['.md'],
+			'only' => ['*.md'],
 			'except' => $except,
 		];
 		return FileHelper::findFiles($path, $options);

--- a/extensions/faker/FixtureController.php
+++ b/extensions/faker/FixtureController.php
@@ -204,7 +204,7 @@ class FixtureController extends \yii\console\controllers\FixtureController
 		$fixturePath = Yii::getAlias($this->fixturePath);
 
 		if ($this->needToGenerateAll($file[0])) {
-			$files = FileHelper::findFiles($templatePath, ['only' => ['.php']]);
+			$files = FileHelper::findFiles($templatePath, ['only' => ['*.php']]);
 		} else {
 			$filesToSearch = [];
 			foreach ($file as $fileName) {

--- a/framework/console/controllers/FixtureController.php
+++ b/framework/console/controllers/FixtureController.php
@@ -314,7 +314,7 @@ class FixtureController extends Controller
 	{
 		$fixturesPath = Yii::getAlias($this->fixturePath);
 
-		$filesToSearch = ['.php'];
+		$filesToSearch = ['*.php'];
 		if (!$this->needToApplyAll($fixtures[0])) {
 			$filesToSearch = [];
 			foreach ($fixtures as $fileName) {

--- a/framework/views/messageConfig.php
+++ b/framework/views/messageConfig.php
@@ -30,7 +30,7 @@ return [
 	// and the '.svn' will match all files and directories named exactly '.svn'.
 	// Note, the '/' characters in a pattern matches both '/' and '\'.
 	// See helpers/FileHelper::findFiles() description for more details on pattern matching rules.
-	'only' => ['.php'],
+	'only' => ['*.php'],
 	// array, list of patterns that specify which files (not directories) should be processed.
 	// If empty or not set, all files will be processed.
 	// Please refer to "except" for details about the patterns.


### PR DESCRIPTION
Resolves #2184.

BTW I've noticed that _framework/views/messageConfig.php_ is not updated along _framework/messages/config.php_. Should it be exactly the same?
