### PR TITLE
Fixes #2204

### DIFF
--- a/extensions/imagine/BaseImage.php
+++ b/extensions/imagine/BaseImage.php
@@ -14,7 +14,6 @@ use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\ManipulatorInterface;
 use Imagine\Image\Point;
-use Imagine\Image\Palette\RGB;
 use yii\base\InvalidConfigException;
 use yii\base\InvalidParamException;
 use yii\helpers\ArrayHelper;
@@ -156,8 +155,7 @@ class BaseImage
 		$img = $img->thumbnail($box, $mode);
 
 		// create empty image to preserve aspect ratio of thumbnail
-		$color = (new RGB())->color('#FFF', 100);
-		$thumb = static::getImagine()->create($box, $color);
+		$thumb = static::getImagine()->create($box, new Color('FFF', 100));
 
 		// calculate points
 		$size = $img->getSize();

--- a/extensions/imagine/BaseImage.php
+++ b/extensions/imagine/BaseImage.php
@@ -14,6 +14,7 @@ use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\ManipulatorInterface;
 use Imagine\Image\Point;
+use Imagine\Image\Palette\RGB;
 use yii\base\InvalidConfigException;
 use yii\base\InvalidParamException;
 use yii\helpers\ArrayHelper;
@@ -155,7 +156,8 @@ class BaseImage
 		$img = $img->thumbnail($box, $mode);
 
 		// create empty image to preserve aspect ratio of thumbnail
-		$thumb = static::getImagine()->create($box);
+		$color = (new RGB())->color('#FFF', 100);
+		$thumb = static::getImagine()->create($box, $color);
 
 		// calculate points
 		$size = $img->getSize();


### PR DESCRIPTION
Hello

Quick fix for #2204, tested with :
- png, gif : transparent background ok
- jpg : white background ok

But here my thoughts about this extension :
-  there should be an options param, instead of $mode, e.g. : 

``` php
public static function thumbnail($filename, $width, $height, $options = [])
{
}
```
- I don't see the meaning of `frame` function
- there should be an `open` function to quickly create an ImageInterface
