### PR TITLE
terminate console command with error code

### DIFF
--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -87,7 +87,7 @@ class ErrorHandler extends Component
 	{
 		if (Yii::$app instanceof \yii\console\Application || YII_ENV_TEST) {
 			echo Yii::$app->renderException($exception);
-			return;
+			exit(1);
 		}
 
 		$useErrorView = !YII_DEBUG || $exception instanceof UserException;


### PR DESCRIPTION
if the script has caught an error, it must be terminated with an error code
