### PR TITLE
Allow multilevel dropdown.

### DIFF
--- a/extensions/bootstrap/Dropdown.php
+++ b/extensions/bootstrap/Dropdown.php
@@ -84,6 +84,10 @@ class Dropdown extends Widget
 			$linkOptions = ArrayHelper::getValue($item, 'linkOptions', []);
 			$linkOptions['tabindex'] = '-1';
 			$content = Html::a($label, ArrayHelper::getValue($item, 'url', '#'), $linkOptions);
+			if (isset($item['items']) && is_array($item['items'])) {
+				$content .= $this->renderItems($item['items']);
+				Html::addCssClass($options, 'dropdown-submenu');
+			}
 			$lines[] = Html::tag('li', $content, $options);
 		}
 

--- a/extensions/bootstrap/Dropdown.php
+++ b/extensions/bootstrap/Dropdown.php
@@ -84,7 +84,7 @@ class Dropdown extends Widget
 			$linkOptions = ArrayHelper::getValue($item, 'linkOptions', []);
 			$linkOptions['tabindex'] = '-1';
 			$content = Html::a($label, ArrayHelper::getValue($item, 'url', '#'), $linkOptions);
-			if (isset($item['items']) && is_array($item['items'])) {
+			if (!empty($item['items'])) {
 				$content .= $this->renderItems($item['items']);
 				Html::addCssClass($options, 'dropdown-submenu');
 			}


### PR DESCRIPTION
Although the Bootstrap not support natively, there are already several ways around this problem. 
Like this:

``` CSS
.dropdown-submenu{position:relative;}
.dropdown-submenu>.dropdown-menu{top:0;left:100%;margin-top:-6px;margin-left:-1px;-webkit-border-radius:0 6px 6px 6px;-moz-border-radius:0 6px 6px 6px;border-radius:0 6px 6px 6px;}
.dropdown-submenu:hover>.dropdown-menu{display:block;}
.dropdown-submenu>a:after{display:block;content:" ";float:right;width:0;height:0;border-color:transparent;border-style:solid;border-width:5px 0 5px 5px;border-left-color:#cccccc;margin-top:5px;margin-right:-10px;}
.dropdown-submenu:hover>a:after{border-left-color:#ffffff;}
.dropdown-submenu.pull-left{float:none;}
.dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px;-webkit-border-radius:6px 0 6px 6px;-moz-border-radius:6px 0 6px 6px;border-radius:6px 0 6px 6px;}
```
