### PR TITLE
I18n docs fix

### DIFF
--- a/docs/guide/i18n.md
+++ b/docs/guide/i18n.md
@@ -356,7 +356,8 @@ class Module extends \yii\base\Module
 }
 ```
 
-In the example above we are using wildcard for matching and then filtering each category per needed file.
+In the example above we are using wildcard for matching and then filtering each category per needed file. Instead of using `fileMap` you can simply
+use convention of category mapping to the same named file and use `Module::t('validation')` or `Module::t('form)` directly.
 
 ###Translating widgets messages
 
@@ -404,6 +405,8 @@ class Menu extends Widget
 
 }
 ```
+
+Instead of using `fileMap` you can simply use convention of category mapping to the same named file and use `Menu::t('messages')` directly.
 
 > **Note**: For widgets you also can use i18n views, same rules as for controllers are applied to them too.
 

--- a/docs/guide/i18n.md
+++ b/docs/guide/i18n.md
@@ -357,7 +357,7 @@ class Module extends \yii\base\Module
 ```
 
 In the example above we are using wildcard for matching and then filtering each category per needed file. Instead of using `fileMap` you can simply
-use convention of category mapping to the same named file and use `Module::t('validation', 'your custom validation method')` or `Module::t('form', 'some form label')` directly.
+use convention of category mapping to the same named file and use `Module::t('validation', 'your custom validation message')` or `Module::t('form', 'some form label')` directly.
 
 ###Translating widgets messages
 

--- a/docs/guide/i18n.md
+++ b/docs/guide/i18n.md
@@ -357,7 +357,7 @@ class Module extends \yii\base\Module
 ```
 
 In the example above we are using wildcard for matching and then filtering each category per needed file. Instead of using `fileMap` you can simply
-use convention of category mapping to the same named file and use `Module::t('validation')` or `Module::t('form)` directly.
+use convention of category mapping to the same named file and use `Module::t('validation')` or `Module::t('form')` directly.
 
 ###Translating widgets messages
 

--- a/docs/guide/i18n.md
+++ b/docs/guide/i18n.md
@@ -357,7 +357,7 @@ class Module extends \yii\base\Module
 ```
 
 In the example above we are using wildcard for matching and then filtering each category per needed file. Instead of using `fileMap` you can simply
-use convention of category mapping to the same named file and use `Module::t('validation')` or `Module::t('form')` directly.
+use convention of category mapping to the same named file and use `Module::t('validation', 'your custom validation method')` or `Module::t('form', 'some form label')` directly.
 
 ###Translating widgets messages
 
@@ -406,7 +406,7 @@ class Menu extends Widget
 }
 ```
 
-Instead of using `fileMap` you can simply use convention of category mapping to the same named file and use `Menu::t('messages')` directly.
+Instead of using `fileMap` you can simply use convention of category mapping to the same named file and use `Menu::t('messages', 'new messages {messages}', ['{messages}' => 10])` directly.
 
 > **Note**: For widgets you also can use i18n views, same rules as for controllers are applied to them too.
 


### PR DESCRIPTION
Related with https://github.com/yiisoft/yii2/issues/2157#issuecomment-33381375. This is also clarified in docs by message
`Instead of configuring fileMap you can rely on convention which is messages/BasePath/LanguageID/CategoryName.php`
but some example notes will be good too.
