### PR TITLE
added total queries monitoring

### DIFF
--- a/extensions/debug/Module.php
+++ b/extensions/debug/Module.php
@@ -11,6 +11,7 @@ use Yii;
 use yii\base\Application;
 use yii\web\View;
 use yii\web\ForbiddenHttpException;
+use yii\helpers\ArrayHelper;
 
 /**
  * The Yii Debug Module provides the debug toolbar and debugger
@@ -63,7 +64,7 @@ class Module extends \yii\base\Module
 			Yii::$app->getView()->on(View::EVENT_END_BODY, [$this, 'renderToolbar']);
 		});
 
-		$this->panels = array_merge($this->corePanels(), $this->panels);
+		$this->panels = ArrayHelper::merge($this->corePanels(), $this->panels);
 		foreach ($this->panels as $id => $config) {
 			$config['module'] = $this;
 			$config['id'] = $id;

--- a/extensions/debug/panels/DbPanel.php
+++ b/extensions/debug/panels/DbPanel.php
@@ -21,6 +21,11 @@ use yii\debug\models\search\Db;
 class DbPanel extends Panel
 {
 	/**
+	 *
+	 * @var integer total queries critical count
+	 */
+	public $criticalQueriesCount;
+	/**
 	 * @var array db queries info extracted to array as models, to use with data provider.
 	 */
 	private $_models;
@@ -147,4 +152,15 @@ class DbPanel extends Panel
 		preg_match('/^([a-zA-z]*)/', $timing, $matches);
 		return count($matches) ? $matches[0] : '';
 	}
+
+	/**
+	 * Check if given queries count is critical according settings.
+	 * @param queries count $count
+	 * @return boolean
+	 */
+	public function isQueriesCountCritical($count)
+	{
+		return (($this->criticalQueriesCount !== null) && ($count > $this->criticalQueriesCount));
+	}
+
 }

--- a/extensions/debug/panels/DbPanel.php
+++ b/extensions/debug/panels/DbPanel.php
@@ -21,7 +21,9 @@ use yii\debug\models\search\Db;
 class DbPanel extends Panel
 {
 	/**
-	 * @var integer total queries critical count
+	 * @var integer the threshold for determining whether the request has involved 
+	 * critical number of DB queries. If the number of queries exceeds this number, 
+	 * the execution is considered taking critical number of DB queries.
 	 */
 	public $criticalQueryThreshold;
 	/**
@@ -158,7 +160,7 @@ class DbPanel extends Panel
 	 * @param integer $count queries count
 	 * @return boolean
 	 */
-	public function isQueriesCountCritical($count)
+	public function isQueryCountCritical($count)
 	{
 		return (($this->criticalQueryThreshold !== null) && ($count > $this->criticalQueryThreshold));
 	}

--- a/extensions/debug/panels/DbPanel.php
+++ b/extensions/debug/panels/DbPanel.php
@@ -21,10 +21,9 @@ use yii\debug\models\search\Db;
 class DbPanel extends Panel
 {
 	/**
-	 *
 	 * @var integer total queries critical count
 	 */
-	public $criticalQueriesCount;
+	public $criticalQueryThreshold;
 	/**
 	 * @var array db queries info extracted to array as models, to use with data provider.
 	 */
@@ -155,12 +154,13 @@ class DbPanel extends Panel
 
 	/**
 	 * Check if given queries count is critical according settings.
-	 * @param queries count $count
+	 * 
+	 * @param integer $count queries count
 	 * @return boolean
 	 */
 	public function isQueriesCountCritical($count)
 	{
-		return (($this->criticalQueriesCount !== null) && ($count > $this->criticalQueriesCount));
+		return (($this->criticalQueryThreshold !== null) && ($count > $this->criticalQueryThreshold));
 	}
 
 }

--- a/extensions/debug/views/default/index.php
+++ b/extensions/debug/views/default/index.php
@@ -32,7 +32,9 @@ echo GridView::widget([
 	'dataProvider' => $dataProvider,
 	'filterModel' => $searchModel,
 	'rowOptions' => function ($model, $key, $index, $grid) use ($searchModel) {
-		if ($searchModel->isCodeCritical($model['statusCode'])) {
+		$dbPanel = $this->context->module->panels['db'];
+
+		if ($searchModel->isCodeCritical($model['statusCode']) || $dbPanel->isQueriesCountCritical($model['sqlCount'])) {
 			return ['class'=>'danger'];
 		} else {
 			return [];
@@ -58,7 +60,22 @@ echo GridView::widget([
 		'ip',
 		[
 			'attribute' => 'sqlCount',
-			'label' => 'Total queries count'
+			'label' => 'Total queries count',
+			'value' => function ($data) {
+				$dbPanel = $this->context->module->panels['db'];
+
+				if ($dbPanel->isQueriesCountCritical($data['sqlCount'])) {
+
+					$content = Html::tag('b', $data['sqlCount']) . ' ' . Html::tag('span','',['class' => 'glyphicon glyphicon-exclamation-sign']);
+					return Html::a($content, $dbPanel->getUrl(), [
+						'title' => 'Query is slow. Allowed count is ' . $dbPanel->criticalQueriesCount,
+					]);
+
+				} else {
+					return $data['sqlCount'];
+				}
+			},
+			'format' => 'html',
 		],
 		[
 			'attribute' => 'method',

--- a/extensions/debug/views/default/index.php
+++ b/extensions/debug/views/default/index.php
@@ -34,7 +34,7 @@ echo GridView::widget([
 	'rowOptions' => function ($model, $key, $index, $grid) use ($searchModel) {
 		$dbPanel = $this->context->module->panels['db'];
 
-		if ($searchModel->isCodeCritical($model['statusCode']) || $dbPanel->isQueriesCountCritical($model['sqlCount'])) {
+		if ($searchModel->isCodeCritical($model['statusCode']) || $dbPanel->isQueryCountCritical($model['sqlCount'])) {
 			return ['class'=>'danger'];
 		} else {
 			return [];
@@ -64,7 +64,7 @@ echo GridView::widget([
 			'value' => function ($data) {
 				$dbPanel = $this->context->module->panels['db'];
 
-				if ($dbPanel->isQueriesCountCritical($data['sqlCount'])) {
+				if ($dbPanel->isQueryCountCritical($data['sqlCount'])) {
 
 					$content = Html::tag('b', $data['sqlCount']) . ' ' . Html::tag('span','',['class' => 'glyphicon glyphicon-exclamation-sign']);
 					return Html::a($content, $dbPanel->getUrl(), [

--- a/extensions/debug/views/default/index.php
+++ b/extensions/debug/views/default/index.php
@@ -68,7 +68,7 @@ echo GridView::widget([
 
 					$content = Html::tag('b', $data['sqlCount']) . ' ' . Html::tag('span','',['class' => 'glyphicon glyphicon-exclamation-sign']);
 					return Html::a($content, $dbPanel->getUrl(), [
-						'title' => 'Query is slow. Allowed count is ' . $dbPanel->criticalQueriesCount,
+						'title' => 'Too many queries. Allowed count is ' . $dbPanel->criticalQueryThreshold,
 					]);
 
 				} else {


### PR DESCRIPTION
Related with this issue - https://github.com/yiisoft/yii2/issues/2006

config example:

``` php
if (YII_ENV_DEV) {
    // configuration adjustments for 'dev' environment
    $config['preload'][] = 'debug';
    $config['modules']['debug'] = [
        'class'     =>  'yii\debug\Module',
        'panels'    => [
            'db' => [
                'criticalQueriesCount' => 2,
            ],
        ],
    ];
    $config['modules']['gii'] = 'yii\gii\Module';
}
```

Screenshot is below, there is also a title about that query is slow in `a` tag, but it is not seen on the screenshot.

![total_queries_count_screenshot](https://f.cloud.github.com/assets/1748844/2060681/75ef0d76-8c28-11e3-8e44-2edc8a82d4d6.png)
