### PR TITLE
Raw content return for Grid DataColumn & Column

### DIFF
--- a/framework/grid/Column.php
+++ b/framework/grid/Column.php
@@ -114,7 +114,7 @@ class Column extends Object
 	{
 		return trim($this->footer) !== '' ? $this->footer : $this->grid->emptyCell;
 	}
-	
+
 	/**
 	 * Get the raw data cell content.
 	 * @param mixed $model the data model

--- a/framework/grid/Column.php
+++ b/framework/grid/Column.php
@@ -114,6 +114,22 @@ class Column extends Object
 	{
 		return trim($this->footer) !== '' ? $this->footer : $this->grid->emptyCell;
 	}
+	
+	/**
+	 * Get the raw data cell content.
+	 * @param mixed $model the data model
+	 * @param mixed $key the key associated with the data model
+	 * @param integer $index the zero-based index of the data model among the models array returned by [[GridView::dataProvider]].
+	 * @return string the rendering result
+	 */
+	protected function getDataCellContent($model, $key, $index)
+	{
+		if ($this->content !== null) {
+			return call_user_func($this->content, $model, $key, $index, $this);
+		} else {
+			return null;
+		}
+	}
 
 	/**
 	 * Renders the data cell content.
@@ -124,11 +140,7 @@ class Column extends Object
 	 */
 	protected function renderDataCellContent($model, $key, $index)
 	{
-		if ($this->content !== null) {
-			return call_user_func($this->content, $model, $key, $index, $this);
-		} else {
-			return $this->grid->emptyCell;
-		}
+		return ($this->content !== null) ? $this->getDataCellContent : $this->grid->emptyCell;
 	}
 
 	/**

--- a/framework/grid/Column.php
+++ b/framework/grid/Column.php
@@ -140,7 +140,7 @@ class Column extends Object
 	 */
 	protected function renderDataCellContent($model, $key, $index)
 	{
-		return ($this->content !== null) ? $this->getDataCellContent : $this->grid->emptyCell;
+		return ($this->content !== null) ? $this->getDataCellContent($model, $key, $index) : $this->grid->emptyCell;
 	}
 
 	/**

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -134,7 +134,7 @@ class DataColumn extends Column
 			return parent::renderFilterCellContent();
 		}
 	}
-	
+
 	/**
 	 * Return raw content
 	 */

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -134,11 +134,11 @@ class DataColumn extends Column
 			return parent::renderFilterCellContent();
 		}
 	}
-
+	
 	/**
-	 * @inheritdoc
+	 * Return raw content
 	 */
-	protected function renderDataCellContent($model, $key, $index)
+	protected function getDataCellContent($model, $key, $index)
 	{
 		if ($this->value !== null) {
 			if (is_string($this->value)) {
@@ -149,8 +149,16 @@ class DataColumn extends Column
 		} elseif ($this->content === null && $this->attribute !== null) {
 			$value = ArrayHelper::getValue($model, $this->attribute);
 		} else {
-			return parent::renderDataCellContent($model, $key, $index);
+			return parent::getDataCellContent($model, $key, $index);
 		}
-		return $this->grid->formatter->format($value, $this->format);
+		return $value;
+	}	 
+
+	/**
+	 * @inheritdoc
+	 */
+	protected function renderDataCellContent($model, $key, $index)
+	{
+		return $this->grid->formatter->format($this->getDataCellContent, $this->format);
 	}
 }

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -159,6 +159,6 @@ class DataColumn extends Column
 	 */
 	protected function renderDataCellContent($model, $key, $index)
 	{
-		return $this->grid->formatter->format($this->getDataCellContent, $this->format);
+		return $this->grid->formatter->format($this->getDataCellContent($model, $key, $index), $this->format);
 	}
 }


### PR DESCRIPTION
Need to have a method  `getDataCellContent` to return raw parsed data cell content. This is useful when extending these Columns, for processing any other data before formatting via `renderDataCellContent`.
