### PR TITLE
renamed ActiveRecord::create() to populateRecord()

### DIFF
--- a/extensions/elasticsearch/ActiveQuery.php
+++ b/extensions/elasticsearch/ActiveQuery.php
@@ -152,7 +152,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 		} else {
 			/** @var ActiveRecord $class */
 			$class = $this->modelClass;
-			$model = $class::create($result);
+			$model = $class::instantiate($result);
+			$class::populateRecord($model, $result);
 		}
 		if (!empty($this->with)) {
 			$models = [$model];

--- a/extensions/elasticsearch/CHANGELOG.md
+++ b/extensions/elasticsearch/CHANGELOG.md
@@ -5,9 +5,11 @@ Yii Framework 2 elasticsearch extension Change Log
 ----------------------------
 
 - Bug #1993: afterFind event in AR is now called after relations have been populated (cebe, creocoder)
+- Enh #1313: made index and type available in `ActiveRecord::instantiate()` to allow creating records based on elasticsearch type when doing cross index/type search (cebe)
 - Enh #1382: Added a debug toolbar panel for elasticsearch (cebe)
 - Enh #1765: Added support for primary key path mapping, pk can now be part of the attributes when mapping is defined (cebe)
 - Chg #1765: Changed handling of ActiveRecord primary keys, removed getId(), use getPrimaryKey() instead (cebe)
+- Chg #2281: Renamed `ActiveRecord::create()` to `populateRecord()` and changed signature. This method will not call instantiate() anymore (cebe)
 
 2.0.0 alpha, December 1, 2013
 -----------------------------

--- a/extensions/mongodb/ActiveQuery.php
+++ b/extensions/mongodb/ActiveQuery.php
@@ -81,7 +81,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 			} else {
 				/** @var ActiveRecord $class */
 				$class = $this->modelClass;
-				$model = $class::create($row);
+				$model = $class::instantiate($row);
+				$class::populateRecord($model, $row);
 			}
 			if (!empty($this->with)) {
 				$models = [$model];

--- a/extensions/mongodb/file/ActiveQuery.php
+++ b/extensions/mongodb/file/ActiveQuery.php
@@ -81,7 +81,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 			} else {
 				/** @var ActiveRecord $class */
 				$class = $this->modelClass;
-				$model = $class::create($row);
+				$model = $class::instantiate($row);
+				$class::populateRecord($model, $row);
 			}
 			if (!empty($this->with)) {
 				$models = [$model];

--- a/extensions/redis/ActiveQuery.php
+++ b/extensions/redis/ActiveQuery.php
@@ -112,7 +112,8 @@ class ActiveQuery extends \yii\base\Component implements ActiveQueryInterface
 		} else {
 			/** @var ActiveRecord $class */
 			$class = $this->modelClass;
-			$model = $class::create($row);
+			$model = $class::instantiate($row);
+			$class::populateRecord($model, $row);
 		}
 		if (!empty($this->with)) {
 			$models = [$model];

--- a/extensions/redis/CHANGELOG.md
+++ b/extensions/redis/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 redis extension Change Log
 
 - Bug #1993: afterFind event in AR is now called after relations have been populated (cebe, creocoder)
 - Enh #1773: keyPrefix property of Session and Cache is not restricted to alnum characters anymore (cebe)
+- Chg #2281: Renamed `ActiveRecord::create()` to `populateRecord()` and changed signature. This method will not call instantiate() anymore (cebe)
 
 2.0.0 alpha, December 1, 2013
 -----------------------------

--- a/extensions/sphinx/ActiveQuery.php
+++ b/extensions/sphinx/ActiveQuery.php
@@ -139,7 +139,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 			} else {
 				/** @var $class ActiveRecord */
 				$class = $this->modelClass;
-				$model = $class::create($row);
+				$model = $class::instantiate($row);
+				$class::populateRecord($model, $row);
 			}
 			if (!empty($this->with)) {
 				$models = [$model];

--- a/extensions/sphinx/ActiveRecord.php
+++ b/extensions/sphinx/ActiveRecord.php
@@ -623,20 +623,13 @@ abstract class ActiveRecord extends BaseActiveRecord
 	 */
 	public static function populateRecord($record, $row)
 	{
-		// TODO refactor to call parent
 		$columns = static::getIndexSchema()->columns;
 		foreach ($row as $name => $value) {
-			if (isset($columns[$name])) {
-				$column = $columns[$name];
-				if ($column->isMva) {
-					$value = explode(',', $value);
-				}
-				$record->setAttribute($name, $value);
-			} else {
-				$record->$name = $value;
+			if (isset($columns[$name]) && $columns[$name]->isMva) {
+				$row[$name] = explode(',', $value);
 			}
 		}
-		$record->setOldAttributes($record->getAttributes());
+		parent::populateRecord($record, $row);
 	}
 
 	/**

--- a/extensions/sphinx/ActiveRecord.php
+++ b/extensions/sphinx/ActiveRecord.php
@@ -619,15 +619,11 @@ abstract class ActiveRecord extends BaseActiveRecord
 	}
 
 	/**
-	 * Creates an active record object using a row of data.
-	 * This method is called by [[ActiveQuery]] to populate the query results
-	 * into Active Records. It is not meant to be used to create new records.
-	 * @param array $row attribute values (name => value)
-	 * @return ActiveRecord the newly created active record.
+	 * @inheritdoc
 	 */
-	public static function create($row)
+	public static function populateRecord($record, $row)
 	{
-		$record = static::instantiate($row);
+		// TODO refactor to call parent
 		$columns = static::getIndexSchema()->columns;
 		foreach ($row as $name => $value) {
 			if (isset($columns[$name])) {
@@ -641,7 +637,6 @@ abstract class ActiveRecord extends BaseActiveRecord
 			}
 		}
 		$record->setOldAttributes($record->getAttributes());
-		return $record;
 	}
 
 	/**

--- a/extensions/sphinx/CHANGELOG.md
+++ b/extensions/sphinx/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 sphinx extension Change Log
 - Bug #1993: afterFind event in AR is now called after relations have been populated (cebe, creocoder)
 - Bug #2160: SphinxQL does not support OFFSET (qiangxue, romeo7)
 - Enh #1398: Refactor ActiveRecord to use BaseActiveRecord class of the framework (klimov-paul)
+- Chg #2281: Renamed `ActiveRecord::create()` to `populateRecord()` and changed signature. This method will not call instantiate() anymore (cebe)
 
 2.0.0 alpha, December 1, 2013
 -----------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -142,6 +142,7 @@ Yii Framework 2 Change Log
 - Chg #2175: QueryBuilder will now append UNION statements at the end of the primary SQL (qiangxue)
 - Chg #2210: Mysql driver will now treat `tinyint(1)` as integer instead of boolean (qiangxue)
 - Chg #2248: Renamed `yii\base\Model::DEFAULT_SCENARIO` to `yii\base\Model::SCENARIO_DEFAULT` (samdark)
+- Chg #2281: Renamed `ActiveRecord::create()` to `populateRecord()` and changed signature. This method will not call instantiate() anymore (cebe)
 - Chg: Renamed `yii\jui\Widget::clientEventsMap` to `clientEventMap` (qiangxue)
 - Chg: Renamed `ActiveRecord::getPopulatedRelations()` to `getRelatedRecords()` (qiangxue)
 - Chg: Renamed `attributeName` and `className` to `targetAttribute` and `targetClass` for `UniqueValidator` and `ExistValidator` (qiangxue)

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -144,7 +144,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 			} else {
 				/** @var ActiveRecord $class */
 				$class = $this->modelClass;
-				$model = $class::create($row);
+				$model = $class::instantiate($row);
+				$class::populateRecord($model, $row);
 			}
 			if (!empty($this->with)) {
 				$models = [$model];

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -128,11 +128,14 @@ trait ActiveQueryTrait
 			$class = $this->modelClass;
 			if ($this->indexBy === null) {
 				foreach ($rows as $row) {
-					$models[] = $class::create($row);
+					$model = $class::instantiate($row);
+					$class::populateRecord($model, $row);
+					$models[] = $model;
 				}
 			} else {
 				foreach ($rows as $row) {
-					$model = $class::create($row);
+					$model = $class::instantiate($row);
+					$class::populateRecord($model, $row);
 					if (is_string($this->indexBy)) {
 						$key = $model->{$this->indexBy};
 					} else {

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -277,9 +277,9 @@ class ActiveRecord extends BaseActiveRecord
 	/**
 	 * @inheritdoc
 	 */
-	public static function create($row)
+	public static function populateRecord($record, $row)
 	{
-		$record = static::instantiate($row);
+		// TODO refactor to call parent
 		$attributes = array_flip($record->attributes());
 		$columns = static::getTableSchema()->columns;
 		foreach ($row as $name => $value) {
@@ -293,7 +293,6 @@ class ActiveRecord extends BaseActiveRecord
 			}
 		}
 		$record->setOldAttributes($record->getAttributes());
-		return $record;
 	}
 
 	/**

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -279,20 +279,13 @@ class ActiveRecord extends BaseActiveRecord
 	 */
 	public static function populateRecord($record, $row)
 	{
-		// TODO refactor to call parent
-		$attributes = array_flip($record->attributes());
 		$columns = static::getTableSchema()->columns;
 		foreach ($row as $name => $value) {
 			if (isset($columns[$name])) {
-				$value = $columns[$name]->typecast($value);
-			}
-			if (isset($attributes[$name])) {
-				$record->setAttribute($name, $value);
-			} else {
-				$record->$name = $value;
+				$row[$name] = $columns[$name]->typecast($value);
 			}
 		}
-		$record->setOldAttributes($record->getAttributes());
+		parent::populateRecord($record, $row);
 	}
 
 	/**

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -984,23 +984,21 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
 	}
 
 	/**
-	 * Creates an active record object using a row of data from the database/storage.
+	 * Populates an active record object using a row of data from the database/storage.
 	 *
-	 * This method is *not* meant to be used to create new records.
-	 *
-	 * It is an internal method meant to be called to create active record objects after
+	 * This is an internal method meant to be called to create active record objects after
 	 * fetching data from the database. It is mainly used by [[ActiveQuery]] to populate
-	 * the query results into Active Records.
+	 * the query results into active records.
 	 *
 	 * When calling this method manually you should call [[afterFind()]] on the created
 	 * record to trigger the [[EVENT_AFTER_FIND|afterFind Event]].
 	 *
+	 * @param BaseActiveRecord $record the record to be populated. In most cases this will be an instance
+	 * created by [[instantiate()]] beforehand.
 	 * @param array $row attribute values (name => value)
-	 * @return static the newly created active record.
 	 */
-	public static function create($row)
+	public static function populateRecord($record, $row)
 	{
-		$record = static::instantiate($row);
 		$columns = array_flip($record->attributes());
 		foreach ($row as $name => $value) {
 			if (isset($columns[$name])) {
@@ -1010,12 +1008,13 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
 			}
 		}
 		$record->_oldAttributes = $record->_attributes;
-		return $record;
 	}
 
 	/**
 	 * Creates an active record instance.
-	 * This method is called by [[create()]].
+	 *
+	 * This method is called together with [[populateRecord()]] by [[ActiveQuery]].
+	 *
 	 * You may override this method if the instance being created
 	 * depends on the row data to be populated into the record.
 	 * For example, by creating a record based on the value of a column,


### PR DESCRIPTION
- renamed ActiveRecord::create() to populateRecord()
- refactored elasticsearch AR to make type and index available in
  instantiate(), issue #1313

fixes #2281
