### PR TITLE
memcache value compression

### DIFF
--- a/framework/caching/MemCache.php
+++ b/framework/caching/MemCache.php
@@ -69,7 +69,12 @@ class MemCache extends Cache
 	 * Defaults to false.
 	 */
 	public $useMemcached = false;
-	/**
+    /**
+     * @var bool whether to use memcache value compression
+     * Defaults to false.
+     */
+    public $useCompression = false;
+    /**
 	 * @var \Memcache|\Memcached the Memcache instance
 	 */
 	private $_cache = null;
@@ -198,7 +203,9 @@ class MemCache extends Cache
 			$expire = 0;
 		}
 
-		return $this->useMemcached ? $this->_cache->set($key, $value, $expire) : $this->_cache->set($key, $value, 0, $expire);
+        $flag = $this->useCompression ? MEMCACHE_COMPRESSED : 0;
+
+		return $this->useMemcached ? $this->_cache->set($key, $value, $expire) : $this->_cache->set($key, $value, $flag, $expire);
 	}
 
 	/**

--- a/framework/caching/MemCache.php
+++ b/framework/caching/MemCache.php
@@ -69,12 +69,11 @@ class MemCache extends Cache
 	 * Defaults to false.
 	 */
 	public $useMemcached = false;
-    /**
-     * @var bool whether to use memcache value compression
-     * Defaults to false.
-     */
-    public $useCompression = false;
-    /**
+	/**
+	 * @var boolean whether to use memcache value compression
+	 */
+	public $useCompression = false;
+	/**
 	 * @var \Memcache|\Memcached the Memcache instance
 	 */
 	private $_cache = null;
@@ -203,7 +202,7 @@ class MemCache extends Cache
 			$expire = 0;
 		}
 
-        $flag = $this->useCompression ? MEMCACHE_COMPRESSED : 0;
+		$flag = $this->useCompression ? MEMCACHE_COMPRESSED : 0;
 
 		return $this->useMemcached ? $this->_cache->set($key, $value, $expire) : $this->_cache->set($key, $value, $flag, $expire);
 	}

--- a/framework/caching/MemCache.php
+++ b/framework/caching/MemCache.php
@@ -202,9 +202,13 @@ class MemCache extends Cache
 			$expire = 0;
 		}
 
-		$flag = $this->useCompression ? MEMCACHE_COMPRESSED : 0;
-
-		return $this->useMemcached ? $this->_cache->set($key, $value, $expire) : $this->_cache->set($key, $value, $flag, $expire);
+		if ($this->useMemcached) {
+			$this->_cache->setOption(Memcached::OPT_COMPRESSION, $this->useCompression);
+			return $this->_cache->set($key, $value, $expire);
+		} else {
+			$flag = $this->useCompression ? MEMCACHE_COMPRESSED : 0;
+			$this->_cache->set($key, $value, $flag, $expire);
+		}
 	}
 
 	/**


### PR DESCRIPTION
The maximum size of a value you can store in memcached is 1 megabyte. If your data is larger, consider clientside compression or splitting the value up into multiple keys.
