### PR TITLE
Update ActiveRecord.php

### DIFF
--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -40,6 +40,11 @@ class ActiveRecord extends BaseActiveRecord
 	 * This is a shortcut of the expression: OP_INSERT | OP_UPDATE | OP_DELETE.
 	 */
 	const OP_ALL = 0x07;
+	/**
+	 * Keep a count of related aliases.
+	 * @var array
+	 */
+	private static $_relationAlias = [];
 
 	/**
 	 * Returns the database connection used by this AR class.
@@ -272,6 +277,17 @@ class ActiveRecord extends BaseActiveRecord
 	public static function createRelation($config = [])
 	{
 		return new ActiveRelation($config);
+	}
+	
+	/**
+	 * Return the table name affixed with the numbered alias.
+	 * @param string $alias
+	 * @return string
+	 */
+	protected static function relationAlias($alias)
+	{
+		$alias = static::tableName() . ' ' . $alias;
+		return $alias . (self::$_relationAlias[$alias] = \yii\helpers\ArrayHelper::getValue(self::$_relationAlias, $alias, 0) + 1);
 	}
 
 	/**


### PR DESCRIPTION
New method "relationAlias".
For use with multiple self joining relations (Table with parent-child relations).

So a relation like,

```
public function getParent()
{
    return $this->hasOne(self::className(), ['id' => 'parent_id'])
        ->from(self::relationAlias('p'));
}
```

Can be used like,

```
->joinWith('parent.parent.parent')
```

Without needing to set the `from` manually for each one.
