### PR TITLE
toolbar UI updates

### DIFF
--- a/extensions/debug/views/default/index.php
+++ b/extensions/debug/views/default/index.php
@@ -15,9 +15,11 @@ $this->title = 'Yii Debugger';
 ?>
 <div class="default-index">
 	<div id="yii-debug-toolbar" class="yii-debug-toolbar-top">
-		<a href="<?= Yii::$app->homeUrl ?>">
-			<span class="glyphicon glyphicon-home"></span>
-		</a>
+		<div class="yii-debug-toolbar-block title">
+			<a href="<?= Yii::$app->homeUrl ?>">
+				<span class="glyphicon glyphicon-home"></span>
+			</a>
+		</div>
 		<div class="yii-debug-toolbar-block title">
 			Yii Debugger
 		</div>

--- a/extensions/debug/views/default/index.php
+++ b/extensions/debug/views/default/index.php
@@ -15,6 +15,9 @@ $this->title = 'Yii Debugger';
 ?>
 <div class="default-index">
 	<div id="yii-debug-toolbar" class="yii-debug-toolbar-top">
+		<a href="<?= Yii::$app->homeUrl ?>">
+			<span class="glyphicon glyphicon-home"></span>
+		</a>
 		<div class="yii-debug-toolbar-block title">
 			Yii Debugger
 		</div>

--- a/extensions/debug/views/default/panels/config/detail.php
+++ b/extensions/debug/views/default/panels/config/detail.php
@@ -7,6 +7,9 @@ use yii\helpers\Html;
 $extensions = $panel->getExtensions();
 ?>
 <h1>Configuration</h1>
+
+<div><?= Html::a('Show phpinfo() »', ['phpinfo'], ['class' => 'btn btn-info', 'target' => 'phpinfo']) ?></div>
+
 <?php
 echo $this->render('panels/config/table', [
 	'caption' => 'Application Configuration',
@@ -35,4 +38,3 @@ echo $this->render('panels/config/table', [
 	],
 ]);
 ?>
-<div><?= Html::a('Show phpinfo() »', ['phpinfo'], ['class' => 'btn btn-primary']) ?></div>

--- a/extensions/debug/views/default/panels/config/summary.php
+++ b/extensions/debug/views/default/panels/config/summary.php
@@ -9,9 +9,6 @@ use yii\helpers\Html;
 <div class="yii-debug-toolbar-block">
 	<a href="<?= $panel->getUrl() ?>">
 		<img width="29" height="30" alt="" src="<?= $panel->getYiiLogo() ?>">
-		<span><?= $panel->data['application']['yii'] ?></span>
+		<span><span class="label"><?= $panel->data['application']['yii'] ?></span> PHP <span class="label"><?= $panel->data['php']['version'] ?></span></span>
 	</a>
-</div>
-<div class="yii-debug-toolbar-block">
-	<?= Html::a('PHP ' . $panel->data['php']['version'], ['phpinfo'], ['title' => 'Show phpinfo()']) ?>
 </div>

--- a/extensions/debug/views/default/panels/config/summary.php
+++ b/extensions/debug/views/default/panels/config/summary.php
@@ -9,6 +9,9 @@ use yii\helpers\Html;
 <div class="yii-debug-toolbar-block">
 	<a href="<?= $panel->getUrl() ?>">
 		<img width="29" height="30" alt="" src="<?= $panel->getYiiLogo() ?>">
-		<span><span class="label"><?= $panel->data['application']['yii'] ?></span> PHP <span class="label"><?= $panel->data['php']['version'] ?></span></span>
+		<span><?= $panel->data['application']['yii'] ?></span>
 	</a>
+</div>
+<div class="yii-debug-toolbar-block">
+	<?= Html::a('PHP ' . $panel->data['php']['version'], ['phpinfo'], ['title' => 'Show phpinfo()', 'target' => 'phpinfo']) ?>
 </div>

--- a/extensions/debug/views/default/panels/request/summary.php
+++ b/extensions/debug/views/default/panels/request/summary.php
@@ -21,7 +21,5 @@ $statusText = Html::encode(isset(Response::$httpStatuses[$statusCode]) ? Respons
 ?>
 <div class="yii-debug-toolbar-block">
 	<a href="<?= $panel->getUrl() ?>" title="Status code: <?= $statusCode ?> <?= $statusText ?>">Status <span class="label <?= $class ?>"><?= $statusCode ?></span></a>
-</div>
-<div class="yii-debug-toolbar-block">
 	<a href="<?= $panel->getUrl() ?>">Action <span class="label"><?= $panel->data['action'] ?></span></a>
 </div>

--- a/extensions/debug/views/default/toolbar.php
+++ b/extensions/debug/views/default/toolbar.php
@@ -26,6 +26,11 @@ EOD;
 $url = $panels['request']->getUrl();
 ?>
 <div id="yii-debug-toolbar" class="yii-debug-toolbar-<?= $position ?>">
+    <div class="yii-debug-toolbar-block">
+        <a href="<?= Yii::$app->homeUrl ?>">
+            <span class="glyphicon glyphicon-home"></span>
+        </a>
+    </div>
 	<?php foreach ($panels as $panel): ?>
 	<?= $panel->getSummary() ?>
 	<?php endforeach; ?>

--- a/extensions/debug/views/default/view.php
+++ b/extensions/debug/views/default/view.php
@@ -17,6 +17,11 @@ $this->title = 'Yii Debugger';
 ?>
 <div class="default-view">
 	<div id="yii-debug-toolbar" class="yii-debug-toolbar-top">
+		<div class="yii-debug-toolbar-block">
+			<a href="<?= Yii::$app->homeUrl ?>">
+				<span class="glyphicon glyphicon-home"></span>
+			</a>
+		</div>
 		<div class="yii-debug-toolbar-block title">
 			<?= Html::a('Yii Debugger', ['index'], ['title' => 'Back to main debug page']) ?>
 		</div>


### PR DESCRIPTION
- added home icon, because there was no way back to the frontend
- removed separators with summary sections to make browsing with the panel more intuitive
- updated version number display, now also shown as label
### Screens

![bildschirmfoto 2014-02-05 um 01 44 16](https://f.cloud.github.com/assets/649031/2083408/93ca560e-8e01-11e3-8f23-a0793f7e5b13.png)

![bildschirmfoto 2014-02-05 um 01 44 24](https://f.cloud.github.com/assets/649031/2083409/93cd2370-8e01-11e3-80f6-9a5eba768952.png)

![bildschirmfoto 2014-02-05 um 01 43 52](https://f.cloud.github.com/assets/649031/2083410/93cf06c2-8e01-11e3-8da2-01c4597d355c.png)
