### PR TITLE
docs added

### DIFF
--- a/apps/basic/tests/acceptance.suite.yml
+++ b/apps/basic/tests/acceptance.suite.yml
@@ -15,6 +15,8 @@ modules:
         - PhpBrowser
 # you can use WebDriver instead of PhpBrowser to test javascript and ajax.
 # This will require you to install selenium. See http://codeception.com/docs/04-AcceptanceTests#Selenium
+# "restart" option is used by the WebDriver to start each time per test-file new session and cookies, 
+# it is useful if you want to login in your app in each test.
 #        - WebDriver
     config:
         PhpBrowser:
@@ -22,3 +24,4 @@ modules:
 #        WebDriver:
 #            url: 'http://localhost'
 #            browser: firefox
+#            restart: true


### PR DESCRIPTION
Added option to `WebDriver`, in some release it was changed to `false` so currently if user want to use 2 or more ui tests and login in each of them, he will be already logged in after first try, and all other tries will fail, because all tests share same cookie and session id. This option is useful to run tests in isolation.
