### PR TITLE
check error level in error handler

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,6 @@ Yii Framework 2 Change Log
 
 2.0.0 beta under development
 ----------------------------
-
 - Bug #1265: AssetController does not override 'js' and 'css' for compressed bundles (klimov-paul)
 - Bug #1326: The `visible` setting for `DetailView` doesn't work as expected (qiangxue)
 - Bug #1412: `FileValidator` and `ImageValidator` still trigger `uploadRequired` error in some case when `skipOnEmpty` is true and no upload is provided (qiangxue)
@@ -123,6 +122,7 @@ Yii Framework 2 Change Log
 - Enh:#2211: Added typecast database types into php types (dizews)
 - Enh #2240: Improved `yii\web\AssetManager::publish()`, `yii\web\AssetManager::getPublishedPath()` and `yii\web\AssetManager::getPublishedUrl()` to support aliases (vova07)
 - Enh #2325: Adding support for the `X-HTTP-Method-Override` header in `yii\web\Request::getMethod()` (pawzar)
+- Enh: Take into account current error reporting level in error handler (gureedo)
 - Chg #1519: `yii\web\User::loginRequired()` now returns the `Response` object instead of exiting the application (qiangxue)
 - Chg #1586: `QueryBuilder::buildLikeCondition()` will now escape special characters and use percentage characters by default (qiangxue)
 - Chg #1610: `Html::activeCheckboxList()` and `Html::activeRadioList()` will submit an empty string if no checkbox/radio is selected (qiangxue)

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -247,7 +247,7 @@ abstract class Application extends Module
 		if (YII_ENABLE_ERROR_HANDLER) {
 			ini_set('display_errors', 0);
 			set_exception_handler([$this, 'handleException']);
-			set_error_handler([$this, 'handleError'], error_reporting());
+			set_error_handler([$this, 'handleError']);
 			if ($this->memoryReserveSize > 0) {
 				$this->_memoryReserve = str_repeat('x', $this->memoryReserveSize);
 			}
@@ -551,7 +551,7 @@ abstract class Application extends Module
 	 */
 	public function handleError($code, $message, $file, $line)
 	{
-		if (error_reporting() !== 0) {
+		if (error_reporting() & $code) {
 			// load ErrorException manually here because autoloading them will not work
 			// when error occurs while autoloading a class
 			if (!class_exists('\\yii\\base\\Exception', false)) {


### PR DESCRIPTION
Yii2 error handler does not take into account current error reporting level.
For example current code will raise error handler and it throw exception, despite of disabling notices.

``` php
error_reporting(error_reporting() & ~E_NOTICE);
$a = ['foo' => 'bar'];
echo $a['baz'];
```

Also I've omit error levels in `set_error_handler` and attach Yii2 handler to all error levels, because at runtime error reporting level can be changed to anything and error will not be handled.
