### PR TITLE
Fixed constant UTF-8 encoding in Response::FORMAT_JSON

### DIFF
--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -848,7 +848,7 @@ class Response extends \yii\base\Response
 					$this->content = $this->data;
 					break;
 				case self::FORMAT_JSON:
-					$this->getHeaders()->set('Content-Type', 'application/json; charset=UTF-8');
+					$this->getHeaders()->set('Content-Type', 'application/json; charset=' . $this->charset);
 					$this->content = Json::encode($this->data);
 					break;
 				case self::FORMAT_JSONP:


### PR DESCRIPTION
Isn’t that an error?
