### PR TITLE
MIME for JSONP

### DIFF
--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -852,7 +852,7 @@ class Response extends \yii\base\Response
 					$this->content = Json::encode($this->data);
 					break;
 				case self::FORMAT_JSONP:
-					$this->getHeaders()->set('Content-Type', 'text/javascript; charset=' . $this->charset);
+					$this->getHeaders()->set('Content-Type', 'application/javascript; charset=' . $this->charset);
 					if (is_array($this->data) && isset($this->data['data'], $this->data['callback'])) {
 						$this->content = sprintf('%s(%s);', $this->data['callback'], Json::encode($this->data['data']));
 					} else {


### PR DESCRIPTION
It’s better to use `application/javascript` instead of `text/javascript`.

Also it could be `application/json-p` in future.

See:
- http://en.wikipedia.org/wiki/JSONP#Security_concerns
- http://stackoverflow.com/questions/3128062/is-this-safe-for-providing-jsonp/3128948#3128948
