### PR TITLE
Tests improved

### DIFF
--- a/apps/basic/tests/unit/models/LoginFormTest.php
+++ b/apps/basic/tests/unit/models/LoginFormTest.php
@@ -11,7 +11,7 @@ class LoginFormTest extends TestCase
 	
 	use \Codeception\Specify;
 
-	public function tearDown()
+	protected function tearDown()
 	{
 		Yii::$app->user->logout();
 		parent::tearDown();

--- a/apps/basic/tests/unit/models/LoginFormTest.php
+++ b/apps/basic/tests/unit/models/LoginFormTest.php
@@ -11,6 +11,12 @@ class LoginFormTest extends TestCase
 	
 	use \Codeception\Specify;
 
+	public function tearDown()
+	{
+		Yii::$app->user->logout();
+		parent::tearDown();
+	}
+
 	public function testLoginNoUser()
 	{
 		$model = $this->mockUser(null);


### PR DESCRIPTION
Added permanent user logout to avoid different data-collisions. 
Currently per each `login()` or `...session->open()` new session will be started since there is no session id that can be passed from cookies in console, it is ok.

@qiangxue do we need to do some cleanup in `yii\codeception\TestCase` to avoid data-collisions since they all run in one thread in console, or it is fine to mention later in docs so that they can use `@backupGlobals` phpunit [annotation](http://phpunit.de/manual/3.7/en/appendixes.annotations.html) in test? 
However maybe some component should be cleaned - runtime dir, cache, etc?
