### PR TITLE
Load minified assets in PROD environment

### DIFF
--- a/extensions/bootstrap/BootstrapAsset.php
+++ b/extensions/bootstrap/BootstrapAsset.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link http://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -13,10 +14,13 @@ use yii\web\AssetBundle;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-class BootstrapAsset extends AssetBundle
-{
-	public $sourcePath = '@vendor/twbs/bootstrap/dist';
-	public $css = [
-		'css/bootstrap.css',
-	];
+class BootstrapAsset extends AssetBundle {
+
+    public $sourcePath = '@vendor/twbs/bootstrap/dist';
+
+    public function init() {
+        $this->css = YII_DEBUG ? ['css/bootstrap.css'] : ['css/bootstrap.min.css'];
+        parent::init();
+    }
+
 }

--- a/extensions/bootstrap/BootstrapAsset.php
+++ b/extensions/bootstrap/BootstrapAsset.php
@@ -14,7 +14,8 @@ use yii\web\AssetBundle;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-class BootstrapAsset extends AssetBundle {
+class BootstrapAsset extends AssetBundle
+{
 
     public $sourcePath = '@vendor/twbs/bootstrap/dist';
 

--- a/extensions/bootstrap/BootstrapPluginAsset.php
+++ b/extensions/bootstrap/BootstrapPluginAsset.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link http://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -14,14 +15,18 @@ use yii\web\AssetBundle;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-class BootstrapPluginAsset extends AssetBundle
+class BootstrapPluginAsset extends AssetBundle 
 {
-	public $sourcePath = '@vendor/twbs/bootstrap/dist';
-	public $js = [
-		'js/bootstrap.js',
-	];
-	public $depends = [
-		'yii\web\JqueryAsset',
-		'yii\bootstrap\BootstrapAsset',
-	];
+
+    public $sourcePath = '@vendor/twbs/bootstrap/dist';
+    public $depends = [
+        'yii\web\JqueryAsset',
+        'yii\bootstrap\BootstrapAsset',
+    ];
+
+    public function init() {
+        $this->css = YII_DEBUG ? ['js/bootstrap.js'] : ['js/bootstrap.min.js'];
+        parent::init();
+    }
+
 }

--- a/extensions/bootstrap/BootstrapPluginAsset.php
+++ b/extensions/bootstrap/BootstrapPluginAsset.php
@@ -25,7 +25,7 @@ class BootstrapPluginAsset extends AssetBundle
     ];
 
     public function init() {
-        $this->css = YII_DEBUG ? ['js/bootstrap.js'] : ['js/bootstrap.min.js'];
+        $this->js = YII_DEBUG ? ['js/bootstrap.js'] : ['js/bootstrap.min.js'];
         parent::init();
     }
 

--- a/extensions/bootstrap/BootstrapThemeAsset.php
+++ b/extensions/bootstrap/BootstrapThemeAsset.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link http://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -17,11 +18,12 @@ use yii\web\AssetBundle;
  */
 class BootstrapThemeAsset extends AssetBundle
 {
-	public $sourcePath = '@vendor/twbs/bootstrap/dist';
-	public $css = [
-		'css/bootstrap-theme.css',
-	];
-	public $depends = [
-		'yii\bootstrap\BootstrapAsset',
-	];
+
+    public $sourcePath = '@vendor/twbs/bootstrap/dist';
+
+    public function init() {
+        $this->css = YII_DEBUG ? ['js/bootstrap-theme.css'] : ['js/bootstrap-theme.min.css'];
+        parent::init();
+    }
+
 }

--- a/extensions/bootstrap/BootstrapThemeAsset.php
+++ b/extensions/bootstrap/BootstrapThemeAsset.php
@@ -22,7 +22,7 @@ class BootstrapThemeAsset extends AssetBundle
     public $sourcePath = '@vendor/twbs/bootstrap/dist';
 
     public function init() {
-        $this->css = YII_DEBUG ? ['js/bootstrap-theme.css'] : ['js/bootstrap-theme.min.css'];
+        $this->css = YII_DEBUG ? ['css/bootstrap-theme.css'] : ['css/bootstrap-theme.min.css'];
         parent::init();
     }
 


### PR DESCRIPTION
Load minified assets by default for all extensions in the production environment (based on `YII_DEBUG` which is usually set to false for PROD). Though you can edit this using the asset bundle settings in config - this can be a default functionality in `PROD` for all Yii inbuilt extensions.
