### PR TITLE
Fix scrollbar in the Debug module when viewing PHP info output

### DIFF
--- a/extensions/debug/assets/main.css
+++ b/extensions/debug/assets/main.css
@@ -34,6 +34,10 @@ td, th {
 	word-break: break-all;
 }
 
+.config-php-info-table td.v {
+	word-break: break-all;
+}
+
 .detail-grid-view th {
     white-space: nowrap;
 }

--- a/extensions/debug/panels/ConfigPanel.php
+++ b/extensions/debug/panels/ConfigPanel.php
@@ -68,7 +68,7 @@ class ConfigPanel extends Panel
 		$pinfo = ob_get_contents();
 		ob_end_clean();
 		$phpinfo = preg_replace('%^.*<body>(.*)</body>.*$%ms', '$1', $pinfo);
-		$phpinfo = str_replace('<table ', '<table class="table table-condensed table-bordered table-striped table-hover"', $phpinfo);
+		$phpinfo = str_replace('<table ', '<table class="table table-condensed table-bordered table-striped table-hover config-php-info-table"', $phpinfo);
 
 		return $phpinfo;
 	}


### PR DESCRIPTION
Fix scrollbar in the Debug module when viewing PHP info output. Here's screenshot of this issue:

![debug-config-horiz-scroll-bar](https://f.cloud.github.com/assets/100198/2209412/a726484e-998b-11e3-81d3-92f4560b77c5.png)
