### PR TITLE
Allow add a condition telling the table to avoid ambiguity error.

### DIFF
--- a/extensions/gii/generators/crud/templates/search.php
+++ b/extensions/gii/generators/crud/templates/search.php
@@ -69,7 +69,13 @@ class <?= $searchModelClass ?> extends Model
 
 	protected function addCondition($query, $attribute, $partialMatch = false)
 	{
-		$value = $this->$attribute;
+		if (($pos = strrpos($attribute, '.')) !== false) {
+			$modelAttribute = substr($attribute, $pos + 1);
+		} else {
+			$modelAttribute = $attribute;
+		}
+
+		$value = $this->$modelAttribute;
 		if (trim($value) === '') {
 			return;
 		}


### PR DESCRIPTION
When the joinWith() is being used in the search, may happen to have fields with the same name found in the tables. 
I suggest a change to the function that adds the conditions understand disambiguation. 

Thus, the following code could be used:

``` php
$this->addCondition($query, 'tbl_Customer.id');
```
