### PR TITLE
Add getIsPjax method to Request, and add X-PJAX-URL header when redirect from pjax request

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -292,6 +292,15 @@ class Request extends \yii\base\Request
 	}
 
 	/**
+	 * Returns wheter this is a PJAX request
+	 * @return boolean wether this is a PJAX request
+	 */
+	public function getIsPjax ()
+	{
+		return $this->getIsAjax() && isset($_SERVER['HTTP_X_PJAX']) && $_SERVER['HTTP_X_PJAX']==true;
+	}
+	
+	/**
 	 * Returns whether this is an Adobe Flash or Flex request.
 	 * @return boolean whether this is an Adobe Flash or Adobe Flex request.
 	 */

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -678,7 +678,9 @@ class Response extends \yii\base\Response
 			$url = Yii::$app->getRequest()->getHostInfo() . $url;
 		}
 
-		if (Yii::$app->getRequest()->getIsAjax()) {
+		if (Yii::$app->getRequest()->getIsPjax()) {
+			$this->getHeaders()->set('X-PJAX-URL', $url);
+		} elseif (Yii::$app->getRequest()->getIsAjax()) {
 			$this->getHeaders()->set('X-Redirect', $url);
 		} else {
 			$this->getHeaders()->set('Location', $url);


### PR DESCRIPTION
When redirecting from a pjax request, we should send a x-pjax-url header, with the redirected url. Therefore, pjax will push this url in state, instead of the original url.
