### PR TITLE
ActiveRelationTrait:: __clone() doesn't call parent (Component::__clone())

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -57,6 +57,7 @@ Yii Framework 2 Change Log
 - Bug: Fixed `HelpController::getModuleCommands` issue where it attempts to scan a module's controller directory when it doesn't exist (jom)
 - Bug: Fixed an issue with Filehelper and not accessable directories which resulted in endless loop (cebe)
 - Bug: Fixed `$model->load($data)` returned `true` if `$data` and `formName` were empty (samdark)
+- Bug: Fixed issue with `ActiveRelationTrait` preventing `ActiveQuery` from clearing events and behaviors on clone (jom)
 - Enh #46: Added Image extension based on [Imagine library](http://imagine.readthedocs.org) (tonydspaniard)
 - Enh #364: Improve Inflector::slug with `intl` transliteration. Improved transliteration char map. (tonydspaniard)
 - Enh #797: Added support for validating multiple columns by `UniqueValidator` and `ExistValidator` (qiangxue)

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -64,6 +64,7 @@ trait ActiveRelationTrait
 	 */
 	public function __clone()
 	{
+		parent::__clone();
 		// make a clone of "via" object so that the same query object can be reused multiple times
 		if (is_object($this->via)) {
 			$this->via = clone $this->via;


### PR DESCRIPTION
Fixes issue with `ActiveRelationTrait` preventing `ActiveQuery` from clearing events and behaviors on clone
