### PR TITLE
Change AssetBundle.register() return type to static

### DIFF
--- a/framework/web/AssetBundle.php
+++ b/framework/web/AssetBundle.php
@@ -112,7 +112,7 @@ class AssetBundle extends Object
 
 	/**
 	 * @param View $view
-	 * @return AssetBundle the registered asset bundle instance
+	 * @return static the registered asset bundle instance
 	 */
 	public static function register($view)
 	{


### PR DESCRIPTION
Enable IDE typehints for custom AssetBundle properties (related to #2572).
