### PR TITLE
added server name, for creating url rules

### DIFF
--- a/apps/basic/tests/_bootstrap.php
+++ b/apps/basic/tests/_bootstrap.php
@@ -18,5 +18,6 @@ require_once(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 // set correct script paths
 $_SERVER['SCRIPT_FILENAME'] = TEST_ENTRY_FILE;
 $_SERVER['SCRIPT_NAME'] = TEST_ENTRY_URL;
+$_SERVER['SERVER_NAME'] = 'localhost';
 
 Yii::setAlias('@tests', __DIR__);


### PR DESCRIPTION
Added server name like in [`yii2-advanced`](https://github.com/yiisoft/yii2/blob/master/apps/advanced/frontend/tests/_bootstrap.php#L23), this can be needed when user creating urls, for example in `yii2-advanced` it is used in mail [message](https://github.com/yiisoft/yii2/blob/master/apps/advanced/common/mail/passwordResetToken.php#L9).
