### PR TITLE
Treat integer indexed attributes as boolean attributes

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1512,7 +1512,9 @@ class BaseHtml
 
 		$html = '';
 		foreach ($attributes as $name => $value) {
-			if (is_bool($value)) {
+			if (is_int($name)) {
+				$html .= " $value";
+			} elseif (is_bool($value)) {
 				if ($value) {
 					$html .= " $name";
 				}


### PR DESCRIPTION
Related to #2566

Just to avoid invalid html markup like:

``` html
<input name="name" 0="readonly" />
```

It's not supposed to encourage people to use ['readonly'] insteadof ['readonly' => true].
