### PR TITLE
Code style fix

### DIFF
--- a/framework/base/Formatter.php
+++ b/framework/base/Formatter.php
@@ -442,17 +442,17 @@ class Formatter extends Component
 		
 		switch($position) {
 			case 0:
-				return $verbose ? Yii::t('yii','{n, plural, =1{# byte} other{# bytes}}', $params) : Yii::t('yii', '{n} B', $params);
+				return $verbose ? Yii::t('yii', '{n, plural, =1{# byte} other{# bytes}}', $params) : Yii::t('yii', '{n} B', $params);
 			case 1:
-				return $verbose ? Yii::t('yii','{n, plural, =1{# kilobyte} other{# kilobytes}}', $params) : Yii::t('yii','{n} KB', $params);
+				return $verbose ? Yii::t('yii', '{n, plural, =1{# kilobyte} other{# kilobytes}}', $params) : Yii::t('yii', '{n} KB', $params);
 			case 2:
-				return $verbose ? Yii::t('yii','{n, plural, =1{# megabyte} other{# megabytes}}', $params) : Yii::t('yii','{n} MB', $params);
+				return $verbose ? Yii::t('yii', '{n, plural, =1{# megabyte} other{# megabytes}}', $params) : Yii::t('yii', '{n} MB', $params);
 			case 3:
-				return $verbose ? Yii::t('yii','{n, plural, =1{# gigabyte} other{# gigabytes}}', $params) : Yii::t('yii','{n} GB', $params);
+				return $verbose ? Yii::t('yii', '{n, plural, =1{# gigabyte} other{# gigabytes}}', $params) : Yii::t('yii', '{n} GB', $params);
 			case 4:
-				return $verbose ? Yii::t('yii','{n, plural, =1{# terabyte} other{# terabytes}}', $params) : Yii::t('yii','{n} TB', $params);
+				return $verbose ? Yii::t('yii', '{n, plural, =1{# terabyte} other{# terabytes}}', $params) : Yii::t('yii', '{n} TB', $params);
 			default:
-				return $verbose ? Yii::t('yii','{n, plural, =1{# petabyte} other{# petabytes}}', $params) : Yii::t('yii','{n} PB', $params);
+				return $verbose ? Yii::t('yii', '{n, plural, =1{# petabyte} other{# petabytes}}', $params) : Yii::t('yii', '{n} PB', $params);
 		}
 	}
 }

--- a/framework/base/Request.php
+++ b/framework/base/Request.php
@@ -6,6 +6,7 @@
  */
 
 namespace yii\base;
+
 use Yii;
 
 /**

--- a/framework/caching/FileDependency.php
+++ b/framework/caching/FileDependency.php
@@ -6,6 +6,7 @@
  */
 
 namespace yii\caching;
+
 use yii\base\InvalidConfigException;
 
 /**

--- a/framework/caching/GroupDependency.php
+++ b/framework/caching/GroupDependency.php
@@ -6,6 +6,7 @@
  */
 
 namespace yii\caching;
+
 use yii\base\InvalidConfigException;
 
 /**

--- a/framework/console/controllers/FixtureController.php
+++ b/framework/console/controllers/FixtureController.php
@@ -64,7 +64,7 @@ class FixtureController extends Controller
 	public function globalOptions()
 	{
 		return array_merge(parent::globalOptions(), [
-			'namespace','globalFixtures'
+			'namespace', 'globalFixtures'
 		]);
 	}
 
@@ -100,7 +100,7 @@ class FixtureController extends Controller
 		}
 
 		$filtered = array_diff($foundFixtures, $except);
-		$fixtures = $this->getFixturesConfig(array_merge($this->globalFixtures ,$filtered));
+		$fixtures = $this->getFixturesConfig(array_merge($this->globalFixtures, $filtered));
 
 		if (!$fixtures) {
 			throw new Exception('No fixtures were found in namespace: "' . $this->namespace . '"' . '');

--- a/framework/console/controllers/FixtureController.php
+++ b/framework/console/controllers/FixtureController.php
@@ -318,5 +318,4 @@ class FixtureController extends Controller
 	{
 		return Yii::getAlias('@' . str_replace('\\', '/', $this->namespace));
 	}
-
 }

--- a/framework/console/controllers/FixtureController.php
+++ b/framework/console/controllers/FixtureController.php
@@ -74,6 +74,7 @@ class FixtureController extends Controller
 	 * whitespace between names. Note that if you are loading fixtures to storage, for example: database or nosql,
 	 * storage will not be cleared, data will be appended to already existed.
 	 * @param array $fixtures
+	 * @param array $except
 	 * @throws \yii\console\Exception
 	 */
 	public function actionLoad(array $fixtures, array $except = [])

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -190,7 +190,7 @@ class MessageController extends Controller
 		echo "Inserting new messages...";
 		$savedFlag = false;
 
-		foreach ($new  as $category => $msgs) {
+		foreach ($new as $category => $msgs) {
 			foreach ($msgs as $m) {
 				$savedFlag = true;
 
@@ -268,7 +268,7 @@ class MessageController extends Controller
 	{
 		echo "Saving messages to $fileName...";
 		if (is_file($fileName)) {
-			if($format === 'po'){
+			if ($format === 'po') {
 				$translated = file_get_contents($fileName);
 				preg_match_all('/(?<=msgid ").*(?="\n(#*)msgstr)/', $translated, $keys);
 				preg_match_all('/(?<=msgstr ").*(?="\n\n)/', $translated, $values);
@@ -285,7 +285,7 @@ class MessageController extends Controller
 			$merged = [];
 			$untranslated = [];
 			foreach ($messages as $message) {
-				if($format === 'po'){
+				if ($format === 'po') {
 					$message = preg_replace('/\"/', '\"', $message);
 				}
 				if (array_key_exists($message, $translated) && strlen($translated[$message]) > 0) {
@@ -317,9 +317,9 @@ class MessageController extends Controller
 			if (false === $overwrite) {
 				$fileName .= '.merged';
 			}
-			if ($format === 'po'){
+			if ($format === 'po') {
 				$output = '';
-				foreach ($merged as $k => $v){
+				foreach ($merged as $k => $v) {
 					$k = preg_replace('/(\")|(\\\")/', "\\\"", $k);
 					$v = preg_replace('/(\")|(\\\")/', "\\\"", $v);
 					if (substr($v, 0, 2) === '@@' && substr($v, -2) === '@@') {
@@ -338,7 +338,7 @@ class MessageController extends Controller
 			if ($format === 'po') {
 				$merged = '';
 				sort($messages);
-				foreach($messages as $message) {
+				foreach ($messages as $message) {
 					$message = preg_replace('/(\")|(\\\")/', '\\\"', $message);
 					$merged .= "msgid \"$message\"\n";
 					$merged .= "msgstr \"\"\n";

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -120,7 +120,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 			$this->findWith($this->with, $models);
 		}
 		if (!$this->asArray) {
-			foreach($models as $model) {
+			foreach ($models as $model) {
 				$model->afterFind();
 			}
 		}

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -288,7 +288,7 @@ trait ActiveRelationTrait
 				foreach ($primaryModels as $i => $primaryModel) {
 					if ($primaryModels[$i][$primaryName] instanceof ActiveRecordInterface) {
 						$primaryModels[$i][$primaryName]->populateRelation($name, $primaryModel);
-					} elseif  (!empty($primaryModels[$i][$primaryName])) {
+					} elseif (!empty($primaryModels[$i][$primaryName])) {
 						$primaryModels[$i][$primaryName][$name] = $primaryModel;
 					}
 				}

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -599,7 +599,7 @@ class QueryBuilder extends \yii\base\Object
 				if (strpos($column, '(') === false) {
 					$column = $this->db->quoteColumnName($column);
 				}
-				$columns[$i] = "$column AS " . $this->db->quoteColumnName($i);;
+				$columns[$i] = "$column AS " . $this->db->quoteColumnName($i);
 			} elseif (strpos($column, '(') === false) {
 				if (preg_match('/^(.*?)(?i:\s+as\s+|\s+)([\w\-_\.]+)$/', $column, $matches)) {
 					$columns[$i] = $this->db->quoteColumnName($matches[1]) . ' AS ' . $this->db->quoteColumnName($matches[2]);

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -152,7 +152,7 @@ class DataColumn extends Column
 			return parent::getDataCellContent($model, $key, $index);
 		}
 		return $value;
-	}	 
+	}
 
 	/**
 	 * @inheritdoc

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -514,8 +514,9 @@ class BaseFileHelper
 			'flags' => 0,
 			'firstWildcard' => false,
 		);
-		if (!isset($pattern[0]))
+		if (!isset($pattern[0])) {
 			return $result;
+		}
 
 		if ($pattern[0] == '!') {
 			$result['flags'] |= self::PATTERN_NEGATIVE;
@@ -527,11 +528,13 @@ class BaseFileHelper
 			$len--;
 			$result['flags'] |= self::PATTERN_MUSTBEDIR;
 		}
-		if (strpos($pattern, '/') === false)
+		if (strpos($pattern, '/') === false) {
 			$result['flags'] |= self::PATTERN_NODIR;
+		}
 		$result['firstWildcard'] = self::firstWildcardInPattern($pattern);
-		if ($pattern[0] == '*' && self::firstWildcardInPattern(StringHelper::byteSubstr($pattern, 1, StringHelper::byteLength($pattern))) === false)
+		if ($pattern[0] == '*' && self::firstWildcardInPattern(StringHelper::byteSubstr($pattern, 1, StringHelper::byteLength($pattern))) === false) {
 			$result['flags'] |= self::PATTERN_ENDSWITH;
+		}
 		$result['pattern'] = $pattern;
 		return $result;
 	}

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -509,11 +509,11 @@ class BaseFileHelper
 		if (!is_string($pattern)) {
 			throw new InvalidParamException('Exclude/include pattern must be a string.');
 		}
-		$result = array(
+		$result = [
 			'pattern' => $pattern,
 			'flags' => 0,
 			'firstWildcard' => false,
-		);
+		];
 		if (!isset($pattern[0])) {
 			return $result;
 		}
@@ -546,7 +546,7 @@ class BaseFileHelper
 	 */
 	private static function firstWildcardInPattern($pattern)
 	{
-		$wildcards = array('*','?','[','\\');
+		$wildcards = ['*', '?', '[', '\\'];
 		$wildcardSearch = function ($r, $c) use ($pattern) {
 			$p = strpos($pattern, $c);
 			return $r===false ? $p : ($p===false ? $r : min($r, $p));

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -147,6 +147,7 @@ class BaseFileHelper
 	 * @param string $src the source directory
 	 * @param string $dst the destination directory
 	 * @param array $options options for directory copy. Valid options are:
+	 * @throws \yii\base\InvalidParamException if unable to open directory
 	 *
 	 * - dirMode: integer, the permission to be set for newly copied directories. Defaults to 0775.
 	 * - fileMode:  integer, the permission to be set for newly copied files. Defaults to the current environment setting.

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -281,14 +281,14 @@ class BaseFileHelper
 			$options['basePath'] = realpath($dir);
 			// this should also be done only once
 			if (isset($options['except'])) {
-				foreach($options['except'] as $key=>$value) {
+				foreach ($options['except'] as $key => $value) {
 					if (is_string($value)) {
 						$options['except'][$key] = static::parseExcludePattern($value);
 					}
 				}
 			}
 			if (isset($options['only'])) {
-				foreach($options['only'] as $key=>$value) {
+				foreach ($options['only'] as $key => $value) {
 					if (is_string($value)) {
 						$options['only'][$key] = static::parseExcludePattern($value);
 					}
@@ -398,7 +398,7 @@ class BaseFileHelper
 			if ($pattern === $baseName) {
 				return true;
 			}
-		} else if ($flags & self::PATTERN_ENDSWITH) {
+		} elseif ($flags & self::PATTERN_ENDSWITH) {
 			/* "*literal" matching against "fooliteral" */
 			$n = StringHelper::byteLength($pattern);
 			if (StringHelper::byteSubstr($pattern, 1, $n) === StringHelper::byteSubstr($baseName, -$n, $n)) {
@@ -473,7 +473,7 @@ class BaseFileHelper
 	 */
 	private static function lastExcludeMatchingFromList($basePath, $path, $excludes)
 	{
-		foreach(array_reverse($excludes) as $exclude) {
+		foreach (array_reverse($excludes) as $exclude) {
 			if (is_string($exclude)) {
 				$exclude = self::parseExcludePattern($exclude);
 			}

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -544,7 +544,7 @@ class BaseFileHelper
 	private static function firstWildcardInPattern($pattern)
 	{
 		$wildcards = array('*','?','[','\\');
-		$wildcardSearch = function($r, $c) use ($pattern) {
+		$wildcardSearch = function ($r, $c) use ($pattern) {
 			$p = strpos($pattern, $c);
 			return $r===false ? $p : ($p===false ? $r : min($r, $p));
 		};

--- a/framework/helpers/BaseMarkdown.php
+++ b/framework/helpers/BaseMarkdown.php
@@ -86,7 +86,7 @@ class BaseMarkdown
 		/** @var \cebe\markdown\Markdown $parser */
 		if (!isset(static::$flavors[$flavor])) {
 			throw new InvalidParamException("Markdown flavor '$flavor' is not defined.'");
-		} elseif(!is_object($config = static::$flavors[$flavor])) {
+		} elseif (!is_object($config = static::$flavors[$flavor])) {
 			$parser = Yii::createObject($config);
 			if (is_array($config)) {
 				foreach ($config as $name => $value) {

--- a/framework/helpers/BaseSecurity.php
+++ b/framework/helpers/BaseSecurity.php
@@ -107,10 +107,10 @@ class BaseSecurity
 	*/
 	protected static function stripPadding($data)
 	{
-		$end = StringHelper::byteSubstr($data, -1, NULL);
+		$end = StringHelper::byteSubstr($data, -1, null);
 		$last = ord($end);
 		$n = StringHelper::byteLength($data) - $last;
-		if (StringHelper::byteSubstr($data, $n, NULL) == str_repeat($end, $last)) {
+		if (StringHelper::byteSubstr($data, $n, null) == str_repeat($end, $last)) {
 			return StringHelper::byteSubstr($data, 0, $n);
 		}
 		return false;

--- a/framework/i18n/GettextMessageSource.php
+++ b/framework/i18n/GettextMessageSource.php
@@ -70,9 +70,9 @@ class GettextMessageSource extends MessageSource
 
 			if ($messages === null && $fallbackMessages === null && $fallbackLanguage != $this->sourceLanguage) {
 				Yii::error("The message file for category '$category' does not exist: $messageFile Fallback file does not exist as well: $fallbackMessageFile", __METHOD__);
-			} else if (empty($messages)) {
+			} elseif (empty($messages)) {
 				return $fallbackMessages;
-			} else if (!empty($fallbackMessages)) {
+			} elseif (!empty($fallbackMessages)) {
 				foreach ($fallbackMessages as $key => $value) {
 					if (!empty($value) && empty($messages[$key])) {
 						$messages[$key] = $fallbackMessages[$key];

--- a/framework/i18n/I18N.php
+++ b/framework/i18n/I18N.php
@@ -126,7 +126,7 @@ class I18N extends Component
 		}
 
 		$p = [];
-		foreach($params as $name => $value) {
+		foreach ($params as $name => $value) {
 			$p['{' . $name . '}'] = $value;
 		}
 		return strtr($message, $p);

--- a/framework/i18n/MessageFormatter.php
+++ b/framework/i18n/MessageFormatter.php
@@ -143,7 +143,7 @@ class MessageFormatter extends Component
 			return false;
 		}
 		$map = [];
-		foreach($tokens as $i => $token) {
+		foreach ($tokens as $i => $token) {
 			if (is_array($token)) {
 				$param = trim($token[0]);
 				if (!isset($map[$param])) {
@@ -169,7 +169,7 @@ class MessageFormatter extends Component
 			return false;
 		} else {
 			$values = [];
-			foreach($result as $key => $value) {
+			foreach ($result as $key => $value) {
 				$values[$map[$key]] = $value;
 			}
 			return $values;
@@ -190,7 +190,7 @@ class MessageFormatter extends Component
 		if (($tokens = self::tokenizePattern($pattern)) === false) {
 			return false;
 		}
-		foreach($tokens as $i => $token) {
+		foreach ($tokens as $i => $token) {
 			if (!is_array($token)) {
 				continue;
 			}
@@ -210,7 +210,7 @@ class MessageFormatter extends Component
 			}
 			$type = isset($token[1]) ? trim($token[1]) : 'none';
 			// replace plural and select format recursively
-			if ($type == 'plural' || $type == 'select')	{
+			if ($type == 'plural' || $type == 'select') {
 				if (!isset($token[2])) {
 					return false;
 				}
@@ -244,7 +244,7 @@ class MessageFormatter extends Component
 			$this->_errorMessage = "Message pattern is invalid.";
 			return false;
 		}
-		foreach($tokens as $i => $token) {
+		foreach ($tokens as $i => $token) {
 			if (is_array($token)) {
 				if (($tokens[$i] = $this->parseToken($token, $args, $locale)) === false) {
 					$this->_errorCode = -1;

--- a/framework/i18n/PhpMessageSource.php
+++ b/framework/i18n/PhpMessageSource.php
@@ -73,9 +73,9 @@ class PhpMessageSource extends MessageSource
 
 			if ($messages === null && $fallbackMessages === null && $fallbackLanguage != $this->sourceLanguage) {
 				Yii::error("The message file for category '$category' does not exist: $messageFile Fallback file does not exist as well: $fallbackMessageFile", __METHOD__);
-			} else if (empty($messages)) {
+			} elseif (empty($messages)) {
 				return $fallbackMessages;
-			} else if (!empty($fallbackMessages)) {
+			} elseif (!empty($fallbackMessages)) {
 				foreach ($fallbackMessages as $key => $value) {
 					if (!empty($value) && empty($messages[$key])) {
 						$messages[$key] = $fallbackMessages[$key];

--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -348,5 +348,4 @@ abstract class BaseMailer extends Component implements MailerInterface, ViewCont
 		$event = new MailEvent(['message' => $message, 'isSuccessful' => $isSuccessful]);
 		$this->trigger(self::EVENT_AFTER_SEND, $event);
 	}
-
 }

--- a/framework/test/Fixture.php
+++ b/framework/test/Fixture.php
@@ -82,4 +82,3 @@ class Fixture extends Component
 	{
 	}
 }
-

--- a/framework/validators/ImageValidator.php
+++ b/framework/validators/ImageValidator.php
@@ -124,7 +124,7 @@ class ImageValidator extends FileValidator
 		}
 		if ($this->underHeight === null) {
 			$this->underHeight = Yii::t('yii', 'The image "{file}" is too small. The height cannot be smaller than {limit, number} {limit, plural, one{pixel} other{pixels}}.');
-		}		
+		}
 		if ($this->overWidth === null) {
 			$this->overWidth = Yii::t('yii', 'The image "{file}" is too large. The width cannot be larger than {limit, number} {limit, plural, one{pixel} other{pixels}}.');
 		}

--- a/framework/validators/PunycodeAsset.php
+++ b/framework/validators/PunycodeAsset.php
@@ -6,6 +6,7 @@
  */
 
 namespace yii\validators;
+
 use yii\web\AssetBundle;
 
 /**

--- a/framework/validators/ValidationAsset.php
+++ b/framework/validators/ValidationAsset.php
@@ -6,6 +6,7 @@
  */
 
 namespace yii\validators;
+
 use yii\web\AssetBundle;
 
 /**

--- a/framework/web/AssetConverter.php
+++ b/framework/web/AssetConverter.php
@@ -82,7 +82,7 @@ class AssetConverter extends Component implements AssetConverterInterface
 		$proc = proc_open($command, $descriptor, $pipes, $basePath);
 		$stdout = stream_get_contents($pipes[1]);
 		$stderr = stream_get_contents($pipes[2]);
-		foreach($pipes as $pipe) {
+		foreach ($pipes as $pipe) {
 			fclose($pipe);
 		}
 		$status = proc_close($proc);

--- a/framework/widgets/ActiveFormAsset.php
+++ b/framework/widgets/ActiveFormAsset.php
@@ -6,6 +6,7 @@
  */
 
 namespace yii\widgets;
+
 use yii\web\AssetBundle;
 
 /**

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -128,7 +128,7 @@ class LinkPager extends Widget
 	protected function registerLinkTags()
 	{
 		$view = $this->getView();
-		foreach($this->pagination->getLinks() as $rel => $href) {
+		foreach ($this->pagination->getLinks() as $rel => $href) {
 			$view->registerLinkTag(['rel' => $rel, 'href' => $href], $rel);
 		}
 	}


### PR DESCRIPTION
fixed code style:

phpDoc fix

Expected "foreach (...) {\n"; found "foreach(...) {\n"
Usage of ELSE IF is discouraged; use ELSEIF instead
The closing brace for the class must go on the next line after the body
Expected "foreach (...) {\n"; found "foreach(...) {\n"
Expected "if (...) {\n"; found "if (...){\n"
Expected 1 space after "=>"; 0 found
Expected 1 space before "as"; 2 found
Whitespace found at end of line
TRUE, FALSE and NULL must be lowercase; expected "null" but found "NULL"

Expected "foreach (...) {\n"; found "foreach(...) {\n"
Whitespace found at end of line
The closing brace for the class must go on the next line after the body

Inline control structures are not allowed 
PHP5.4 array syntax fix
