### PR TITLE
Fixed addind join in db/Query

### DIFF
--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -577,7 +577,10 @@ class Query extends Component implements QueryInterface
 	 */
 	public function join($type, $table, $on = '', $params = [])
 	{
-		$this->join[] = [$type, $table, $on];
+		if (is_array($this->join) && array_key_exists($table, $this->join)) {
+			return;
+		}
+		$this->join[$table] = [$type, $table, $on];
 		return $this->addParams($params);
 	}
 


### PR DESCRIPTION
I was need use joinWith in AR by the some condition, like this:
$query = User::find()->joinWith('posts');
if ($something) {
    $query->joinWith('posts.comments'); 
}
The sql I get is :

SELECT `user`.\* FROM `user` 
LEFT JOIN `post` ON `user`.`id` = `post`.`user_id` 
LEFT JOIN `post` ON `user`.`id` = `post`.`user_id` 
LEFT JOIN `comment` ON `post`.`id` = `comment`.`post_id`

so I get mistake 'SQL Error (1066): Not unique table/alias: 'post''.
Here is my solution for this problem.
