### PR TITLE
Corrected sample in data-grid.md

### DIFF
--- a/docs/guide/data-grid.md
+++ b/docs/guide/data-grid.md
@@ -50,12 +50,10 @@ echo GridView::widget([
 		'username',
 		// More complex one.
 		[
-			'class' => 'DataColumn', // can be omitted, default
-			'name' => 'column1',
+			'class' => 'yii\grid\DataColumn', // can be omitted, default
 			'value' => function ($data) {
 				return $data->name;
 			},
-			'type'=>'raw',
 		],
 	],
 ]);


### PR DESCRIPTION
DataColumn doesn't have "name" & "type" fields, and should have fully qualified name if not omitted
