### PR TITLE
use toRoute instead of createUrl in ActionColumn

### DIFF
--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -10,6 +10,7 @@ namespace yii\grid;
 use Yii;
 use Closure;
 use yii\helpers\Html;
+use yii\helpers\Url;
 
 /**
  * ActionColumn is a column for the [[GridView]] widget that displays buttons for viewing and manipulating the items.
@@ -128,7 +129,7 @@ class ActionColumn extends Column
 		} else {
 			$params = is_array($key) ? $key : ['id' => (string)$key];
 			$params[0] = $this->controller ? $this->controller . '/' . $action : $action;
-			return Yii::$app->controller->createUrl($params);
+			return Url::toRoute($params);
 		}
 	}
 


### PR DESCRIPTION
use toRoute() instead of createUrl() in ActionColumn.
createUrl will trigger an UnknownMethodException when using ActionColumn in a view.
