### PR TITLE
[doc]Composer is not a package manager.

### DIFF
--- a/docs/guide/composer.md
+++ b/docs/guide/composer.md
@@ -1,7 +1,7 @@
 Composer
 ========
 
-Yii2 uses Composer as its package manager. Composer is a PHP utility that can automatically handle the installation of needed libraries and
+Yii2 uses Composer as its dependency management tool. Composer is a PHP utility that can automatically handle the installation of needed libraries and
 extensions, thereby keeping those third-party resources up to date while absolving you of the need to manually manage the project's dependencies.
 
 Installing Composer


### PR DESCRIPTION
It is a issue i found when I translate the composer.md file.
**Composer is not a package manager, It's a tool for dependency management.**

According to their [doc](https://getcomposer.org/doc/00-intro.md)

> **Composer is a tool for dependency management in PHP.** It allows you to declare the dependent libraries your project needs and it will install them in your project for you.

and 

> **Composer is not a package manager.** Yes, it deals with "packages" or libraries, but it manages > them on a per-project basis, installing them in a directory (e.g. vendor) inside your project. By > default it will never install anything globally. Thus, it is a dependency manager.

So i think, It would be better, if we remain their offical appellation. What do you think?
