### PR TITLE
fix rules type

### DIFF
--- a/framework/web/AccessRule.php
+++ b/framework/web/AccessRule.php
@@ -133,6 +133,9 @@ class AccessRule extends Component
      */
     protected function matchRole($user)
     {
+        if (!is_array($this->roles)) {
+            $this->roles = (array) $this->roles;
+        }
         if (empty($this->roles)) {
             return true;
         }


### PR DESCRIPTION
For example (MainController):

``` php
namespace app\modules\users\controllers;

use yii\web\VerbFilter;
use yii\web\AccessControl;
use app\modules\core\components\Controller;

class MainController extends Controller
{

    /**
     * @inheritdoc
     */
    public function behaviors()
    {
        return [
            'access' => [
                'class' => AccessControl::class,
                'rules' => [
                    ['allow' => true, 'actions' => ['join', 'login', 'restore'], 'roles' => '?'],
                    ['allow' => true, 'actions' => ['logout'], 'roles' => '@']
                ]
            ],
            'verbs'  => [
                'class'   => VerbFilter::class,
                'actions' => [
                    'logout' => ['post']
                ]
            ]
        ];
    }

    public function actionJoin()
    {
        return __METHOD__;
    }

    public function actionLogin()
    {
        return __METHOD__;
    }

    public function actionLogout()
    {
        return __METHOD__;
    }

    public function actionRestore()
    {
        return __METHOD__;
    }

}
```

Called:

```
PHP Warning – yii\base\ErrorException
Invalid argument supplied for foreach()
```

Stack trace:

```
1. in /home/diserver.com/public_html/www/vendor/yiisoft/yii2/web/AccessRule.php at line 139
protected function matchRole($user)
    {
        if (empty($this->roles)) {
            return true;
        }
        foreach ($this->roles as $role) {
            if ($role === '?' && $user->getIsGuest()) {
                return true;
            } elseif ($role === '@' && !$user->getIsGuest()) {
                return true;
            } elseif ($user->checkAccess($role)) {
2. in /home/diserver.com/public_html/www/vendor/yiisoft/yii2/web/AccessControl.php – yii\web\AccessRule::allows() at line 107
3. in /home/diserver.com/public_html/www/vendor/yiisoft/yii2/base/ActionFilter.php – yii\web\AccessControl::beforeAction() at line 53
4. in /home/diserver.com/public_html/www/vendor/yiisoft/yii2/base/Component.php – yii\base\ActionFilter::beforeFilter() at line 540
5. in /home/diserver.com/public_html/www/vendor/yiisoft/yii2/base/Component.php – call_user_func() at line 540
6. in /home/diserver.com/public_html/www/vendor/yiisoft/yii2/base/Controller.php – yii\base\Component::trigger() at line 219
7. in /home/diserver.com/public_html/www/vendor/yiisoft/yii2/web/Controller.php – yii\base\Controller::beforeAction() at line 107
8. in /home/diserver.com/public_html/www/vendor/yiisoft/yii2/base/Controller.php – yii\web\Controller::beforeAction() at line 126
9. in /home/diserver.com/public_html/www/vendor/yiisoft/yii2/base/Module.php – yii\base\Controller::runAction() at line 581
10. in /home/diserver.com/public_html/www/vendor/yiisoft/yii2/web/Application.php – yii\base\Module::runAction() at line 84
11. in /home/diserver.com/public_html/www/vendor/yiisoft/yii2/base/Application.php – yii\web\Application::handleRequest() at line 289
12. in /home/diserver.com/public_html/www/web/index.php – yii\base\Application::run() at line 13

$config = require(__DIR__ . '/../app/config/web.php');

$application = new yii\web\Application($config);
$application->setVendorPath('@app/../vendor');
$application->run();
```
