### PR TITLE
Better Secure Connection detection

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -777,7 +777,8 @@ class Request extends \yii\base\Request
     public function getIsSecureConnection()
     {
         return isset($_SERVER['HTTPS']) && (strcasecmp($_SERVER['HTTPS'], 'on') === 0 || $_SERVER['HTTPS'] == 1)
-            || isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strcasecmp($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') === 0;
+            || isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strcasecmp($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') === 0
+            || isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == '443';
     }
 
     /**


### PR DESCRIPTION
In PHP-FPM + nginx there is no such env $_SERVER['HTTPS'] and `Yii::$app->request->isSecureConnection` is always false.
So checking server port (what is not perfect) seems as ultimate way.
