### PR TITLE
typo fix in contoller.md

### DIFF
--- a/docs/guide/controller.md
+++ b/docs/guide/controller.md
@@ -53,7 +53,7 @@ class SiteController extends Controller
 
 	public function actionIndex()
 	{
-		#CSRF validation will no be applied on this and other actions
+		#CSRF validation will not be applied on this and other actions
 	}
 
 }


### PR DESCRIPTION
Is that a typo?
Or
shall it be `no longer`?
