### PR TITLE
Get gridview footer content after cells content

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 --------------------------
 
 - Bug #2563: Theming is not working if the path map of the theme contains ".." or "." in the paths (qiangxue)
+- Bug #2801: Fixed the issue that GridView gets footer content before data cells content (ElisDN)
 - Bug #3042: `yii\widgets\Pjax` should end application right after it finishes responding to a pjax request (qiangxue)
 - Bug #3066: `yii\db\mssql\Schema::getTableSchema()` should return null when the table does not exist (qiangxue)
 - Bug #3091: Fixed inconsistent treatment of `Widget::run()` when a widget is used as a container and as a self-contained object (qiangxue)

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -241,8 +241,8 @@ class GridView extends BaseListView
             $this->renderCaption(),
             $this->renderColumnGroup(),
             $this->showHeader ? $this->renderTableHeader() : false,
-            $this->showFooter ? $this->renderTableFooter() : false,
             $this->renderTableBody(),
+            $this->showFooter ? $this->renderTableFooter() : false,
         ]);
 
         return Html::tag('table', implode("\n", $content), $this->tableOptions);

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -237,12 +237,17 @@ class GridView extends BaseListView
      */
     public function renderItems()
     {
+        $caption = $this->renderCaption();
+        $columnGroup = $this->renderColumnGroup();
+        $tableHeader = $this->showHeader ? $this->renderTableHeader() : false;
+        $tableBody = $this->renderTableBody();
+        $tableFooter = $this->showFooter ? $this->renderTableFooter() : false;
         $content = array_filter([
-            $this->renderCaption(),
-            $this->renderColumnGroup(),
-            $this->showHeader ? $this->renderTableHeader() : false,
-            $this->renderTableBody(),
-            $this->showFooter ? $this->renderTableFooter() : false,
+            $caption,
+            $columnGroup,
+            $tableHeader,
+            $tableFooter,
+            $tableBody,
         ]);
 
         return Html::tag('table', implode("\n", $content), $this->tableOptions);


### PR DESCRIPTION
I override Column::renderDataCellContent with own counter implementation, but as a result it returns zero in Column::renderFooterCellContent, because it calls by GridView before data cells loop.
