### PR TITLE
Update usage example in comments of db\DataReader

### DIFF
--- a/framework/db/DataReader.php
+++ b/framework/db/DataReader.php
@@ -17,7 +17,8 @@ use yii\base\InvalidCallException;
  * iterating through the reader. For example,
  *
  * ~~~
- * $reader = $command->setSql('SELECT * FROM tbl_post');
+ * $command = $connection->createCommand('SELECT * FROM tbl_post');
+ * $reader = $command->query();
  *
  * while ($row = $reader->read()) {
  *     $rows[] = $row;

--- a/framework/db/DataReader.php
+++ b/framework/db/DataReader.php
@@ -17,7 +17,7 @@ use yii\base\InvalidCallException;
  * iterating through the reader. For example,
  *
  * ~~~
- * $reader = $command->query('SELECT * FROM tbl_post');
+ * $reader = $command->setSql('SELECT * FROM tbl_post');
  *
  * while ($row = $reader->read()) {
  *     $rows[] = $row;


### PR DESCRIPTION
This is to update the usage example used in the comment documentation for db\DataReader. The old comment referenced $command->query('') with SQL as an argument, while the new ->query function no longer accepts parameters. So changed it and added a line to be consistent with the draft of the definitive guide, which I think shows the appropriate usage.
