### PR TITLE
Pjax redirect fix

### DIFF
--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -682,7 +682,8 @@ class Response extends \yii\base\Response
 
         if (Yii::$app->getRequest()->getIsPjax()) {
             $this->getHeaders()->set('X-Pjax-Url', $url);
-        } elseif (Yii::$app->getRequest()->getIsAjax()) {
+        }
+	    if (Yii::$app->getRequest()->getIsAjax()) {
             $this->getHeaders()->set('X-Redirect', $url);
         } else {
             $this->getHeaders()->set('Location', $url);

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -683,7 +683,7 @@ class Response extends \yii\base\Response
         if (Yii::$app->getRequest()->getIsPjax()) {
             $this->getHeaders()->set('X-Pjax-Url', $url);
         }
-	    if (Yii::$app->getRequest()->getIsAjax()) {
+        if (Yii::$app->getRequest()->getIsAjax()) {
             $this->getHeaders()->set('X-Redirect', $url);
         } else {
             $this->getHeaders()->set('Location', $url);


### PR DESCRIPTION
I made a mistake in #2531. 
In case of a redirect in a pjax response, we need to send X-Pjax-Url header (to push this url into browser state), but we also need the X-Redirect (since pjax is actually a ajax request) to redirect browser. 
