### PR TITLE
Fixes #2726: ActiveRecord now fills default values on creating new instance of the model if defaults are available from DB schema

### DIFF
--- a/docs/guide/active-record.md
+++ b/docs/guide/active-record.md
@@ -193,6 +193,15 @@ Customer::updateAllCounters(['age' => 1]);
 > Info: The `save()` method will either perform an `INSERT` or `UPDATE` SQL statement, depending
   on whether the ActiveRecord being saved is new or not by checking `ActiveRecord::isNewRecord`.
 
+In order to load default values from database schema you may call `loadDefaultValues()` method:
+
+```php
+$customer = new Customer();
+$customer->loadDefaultValues();
+$cusomer->name = 'Alexander';
+$customer->save();
+```
+
 
 Data Input and Validation
 -------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -146,6 +146,7 @@ Yii Framework 2 Change Log
 - Enh #2661: Added boolean column type support for SQLite (qiangxue)
 - Enh #2670: Changed `console\Controller::globalOptions()` to `options($actionId)` to (make it possible to) differentiate options per action (hqx)
 - Enh #2714: Added support for formatting time intervals relative to the current time with `yii\base\Formatter` (drenty)
+- Enh #2726: ActiveRecord now fills default values on creating new instance of the model if defaults are available from DB schema (samdark)
 - Enh #2729: Added `FilterValidator::skipOnArray` so that filters like `trim` will not fail for array inputs (qiangxue)
 - Enh #2735: Added support for `DateTimeInterface` in `Formatter` (ivokund)
 - Enh #2756: Added support for injecting custom `isEmpty` check for all validators (qiangxue)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -146,7 +146,7 @@ Yii Framework 2 Change Log
 - Enh #2661: Added boolean column type support for SQLite (qiangxue)
 - Enh #2670: Changed `console\Controller::globalOptions()` to `options($actionId)` to (make it possible to) differentiate options per action (hqx)
 - Enh #2714: Added support for formatting time intervals relative to the current time with `yii\base\Formatter` (drenty)
-- Enh #2726: ActiveRecord now fills default values on creating new instance of the model if defaults are available from DB schema (samdark)
+- Enh #2726: Added `yii\db\ActiveRecord::loadDefaultValues()` that fills default values from DB schema (samdark)
 - Enh #2729: Added `FilterValidator::skipOnArray` so that filters like `trim` will not fail for array inputs (qiangxue)
 - Enh #2735: Added support for `DateTimeInterface` in `Formatter` (ivokund)
 - Enh #2756: Added support for injecting custom `isEmpty` check for all validators (qiangxue)

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -94,15 +94,18 @@ class ActiveRecord extends BaseActiveRecord
     const OP_ALL = 0x07;
 
     /**
-     * @inheritdoc
+     * Loads default values from database table schema
+     *
+     * @return static model instance
      */
-    public function init()
+    public function loadDefaultValues()
     {
         foreach ($this->getTableSchema()->columns as $column) {
             if ($column->defaultValue) {
                 $this->{$column->name} = $column->defaultValue;
             }
         }
+        return $this;
     }
 
     /**

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -94,6 +94,18 @@ class ActiveRecord extends BaseActiveRecord
     const OP_ALL = 0x07;
 
     /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        foreach ($this->getTableSchema()->columns as $column) {
+            if ($column->defaultValue) {
+                $this->{$column->name} = $column->defaultValue;
+            }
+        }
+    }
+
+    /**
      * Returns the database connection used by this AR class.
      * By default, the "db" application component is used as the database connection.
      * You may override this method if you want to use a different database connection.

--- a/tests/unit/data/ar/Type.php
+++ b/tests/unit/data/ar/Type.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace yiiunit\data\ar;
+
+/**
+ * Model representing tbl_type table
+ *
+ * @property int $int_col
+ * @property int $int_col2 DEFAULT 1
+ * @property string $char_col
+ * @property string $char_col2 DEFAULT 'something'
+ * @property string $char_col3
+ * @property float $float_col
+ * @property float $float_col2 DEFAULT '1.23'
+ * @property string $blob_col
+ * @property float $numeric_col DEFAULT '33.22'
+ * @property string $time DEFAULT '2002-01-01 00:00:00'
+ * @property boolean $bool_col
+ * @property boolean $bool_col2 DEFAULT 1
+ */
+class Type extends ActiveRecord
+{
+    /**
+     * @inheritdoc
+     */
+    public static function tableName()
+    {
+        return 'tbl_type';
+    }
+}
+ 

--- a/tests/unit/framework/db/ActiveRecordTest.php
+++ b/tests/unit/framework/db/ActiveRecordTest.php
@@ -491,6 +491,7 @@ class ActiveRecordTest extends DatabaseTestCase
     public function testDefaultValues()
     {
         $model = new Type();
+        $model->loadDefaultValues();
         $this->assertEquals(1, $model->int_col2);
         $this->assertEquals('something', $model->char_col2);
         $this->assertEquals(1.23, $model->float_col2);

--- a/tests/unit/framework/db/ActiveRecordTest.php
+++ b/tests/unit/framework/db/ActiveRecordTest.php
@@ -8,6 +8,7 @@ use yiiunit\data\ar\OrderItem;
 use yiiunit\data\ar\Order;
 use yiiunit\data\ar\Item;
 use yiiunit\data\ar\Profile;
+use yiiunit\data\ar\Type;
 use yiiunit\framework\ar\ActiveRecordTestTrait;
 
 /**
@@ -485,5 +486,16 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertTrue($orders[0]['customer2']['orders2'][1]['id'] === $orders[1]['id']);
         $this->assertTrue($orders[1]['customer2']['orders2'][0]['id'] === $orders[0]['id']);
         $this->assertTrue($orders[1]['customer2']['orders2'][1]['id'] === $orders[1]['id']);
+    }
+
+    public function testDefaultValues()
+    {
+        $model = new Type();
+        $this->assertEquals(1, $model->int_col2);
+        $this->assertEquals('something', $model->char_col2);
+        $this->assertEquals(1.23, $model->float_col2);
+        $this->assertEquals(33.22, $model->numeric_col);
+        $this->assertEquals('2002-01-01 00:00:00', $model->time);
+        $this->assertEquals(true, $model->bool_col2);
     }
 }


### PR DESCRIPTION
Pros of this approach:
- No need to manually fill values.
- Defaults could be changed w/o regenerating model code.
- Consistent with how DB works.
