### PR TITLE
fixed model generation (no pivot table models)

### DIFF
--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -296,6 +296,11 @@ class Generator extends \yii\gii\Generator
             $tableName = $table->name;
             $className = $this->generateClassName($tableName);
             foreach ($table->foreignKeys as $refs) {
+                // We don't need to create models for pivot tables
+                if ($this->checkPivotTable($table)) {
+                    continue 1;
+                }
+
                 $refTable = $refs[0];
                 unset($refs[0]);
                 $fks = array_keys($refs);


### PR DESCRIPTION
Found no good reason why the pivot tables need models by default.
