### PR TITLE
Fixed overriding default message sources

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -60,6 +60,7 @@ Yii Framework 2 Change Log
 - Bug #2739: Fixed the issue that `CreateAction::run()` was using obsolete `Controller::createAbsoluteUrl()` method (tonydspaniard)
 - Bug #2740: Fixed the issue that `CaptchaAction::run()` was using obsolete `Controller::createUrl()` method (tonydspaniard)
 - Bug #2760: Fixed GridView `filterUrl` parameters (qiangxue, AlexGx)
+- Bug #2834: When overriding i18n translation sources from config using `app*` or `yii*` default `app` and `yii` sources were not removed (samdark)
 - Bug: Fixed `Call to a member function registerAssetFiles() on a non-object` in case of wrong `sourcePath` for an asset bundle (samdark)
 - Bug: Fixed incorrect event name for `yii\jui\Spinner` (samdark)
 - Bug: Json::encode() did not handle objects that implement JsonSerializable interface correctly (cebe)

--- a/framework/i18n/I18N.php
+++ b/framework/i18n/I18N.php
@@ -54,14 +54,14 @@ class I18N extends Component
     public function init()
     {
         parent::init();
-        if (!isset($this->translations['yii'])) {
+        if (!isset($this->translations['yii']) && !isset($this->translations['yii*'])) {
             $this->translations['yii'] = [
                 'class' => 'yii\i18n\PhpMessageSource',
                 'sourceLanguage' => 'en',
                 'basePath' => '@yii/messages',
             ];
         }
-        if (!isset($this->translations['app'])) {
+        if (!isset($this->translations['app']) && !isset($this->translations['app*'])) {
             $this->translations['app'] = [
                 'class' => 'yii\i18n\PhpMessageSource',
                 'sourceLanguage' => Yii::$app->sourceLanguage,


### PR DESCRIPTION
When overriding i18n translation sources from config using `app*` or `yii*` default `app` and `yii` sources were not removed resulting in using application source language for messages with `app` category.

``` php
'i18n' => [
    'translations' => [
        'app*' => [
            'class' => 'yii\i18n\PhpMessageSource',
            'sourceLanguage' => 'ru',
            'fileMap' => [
                'app' => 'app.php',
                'app/error' => 'error.php',
            ],
        ],
    ],
],
```
