### PR TITLE
Fixed getting the count for queries with the union

### DIFF
--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -359,7 +359,7 @@ class Query extends Component implements QueryInterface
         $this->limit = $limit;
         $this->offset = $offset;
 
-        if (empty($this->groupBy) && !$this->distinct) {
+        if (empty($this->groupBy) && empty($this->union) && !$this->distinct) {
             return $command->queryScalar();
         } else {
             return (new Query)->select([$selectExpression])


### PR DESCRIPTION
Fixed sql error 'The used SELECT statements have a different number of columns' when using
$queryTwo->union($queryOne);
$count = $queryTwo->count();
