### PR TITLE
Correct classname typo

### DIFF
--- a/extensions/authclient/BaseOAuth.php
+++ b/extensions/authclient/BaseOAuth.php
@@ -13,7 +13,7 @@ use Yii;
 use yii\helpers\Json;
 
 /**
- * BaseClient is a base class for the OAuth clients.
+ * BaseOAuth is a base class for the OAuth clients.
  *
  * @see http://oauth.net/
  *


### PR DESCRIPTION
Correct classname to `BaseOAuth` instead of `BaseClient` in PHP Doc.
