### PR TITLE
corrected path normalizer

### DIFF
--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -39,7 +39,7 @@ class BaseFileHelper
      */
     public static function normalizePath($path, $ds = DIRECTORY_SEPARATOR)
     {
-        return rtrim(strtr($path, ['/' => $ds, '\\' => $ds]), $ds);
+        return realpath(rtrim(strtr($path, ['/' => $ds, '\\' => $ds]), $ds));
     }
 
     /**


### PR DESCRIPTION
for example. 
if we used path /home/projects/payprocessing.eve/accountant/views/site/../include/menu.html
and /home/projects/payprocessing.eve/accountant/views/site does not exist, but
/home/projects/payprocessing.eve/accountant/views/include/menu.html exist.
Unix doesn't find the file. Normalize them
