### PR TITLE
Make selenium acceptance tests work for basic app

### DIFF
--- a/apps/basic/tests/_pages/ContactPage.php
+++ b/apps/basic/tests/_pages/ContactPage.php
@@ -17,6 +17,6 @@ class ContactPage extends BasePage
             $inputType = $field === 'body' ? 'textarea' : 'input';
             $this->guy->fillField($inputType . '[name="ContactForm[' . $field . ']"]', $value);
         }
-        $this->guy->click('contact-button');
+        $this->guy->click('button[name="contact-button"]');
     }
 }

--- a/apps/basic/tests/_pages/LoginPage.php
+++ b/apps/basic/tests/_pages/LoginPage.php
@@ -16,6 +16,6 @@ class LoginPage extends BasePage
     {
         $this->guy->fillField('input[name="LoginForm[username]"]', $username);
         $this->guy->fillField('input[name="LoginForm[password]"]', $password);
-        $this->guy->click('login-button');
+        $this->guy->click('button[name="login-button"]');
     }
 }

--- a/apps/basic/tests/acceptance/LoginCept.php
+++ b/apps/basic/tests/acceptance/LoginCept.php
@@ -18,6 +18,9 @@ $I->see('Password cannot be blank.');
 $I->amGoingTo('try to login with wrong credentials');
 $loginPage->login('admin', 'wrong');
 $I->expectTo('see validations errors');
+if (method_exists($I, 'wait')) {
+    $I->wait(3); // only for selenium
+}
 $I->see('Incorrect username or password.');
 
 $I->amGoingTo('try to login with correct credentials');


### PR DESCRIPTION
The selector used for button clicking would not be trickered by the webdriver as it does not automatically look for button[name="click-var"], only for input[type=submit]. So this improves the selector.

Also, a wait() is required after submitting the wrong user/password.

Does not break PhpBrowser based tests.
