### PR TITLE
jquery installation and maintance with composer / packagists.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Thumbs.db
 
 # composer vendor dir
 /vendor
+/bower_components
 
 # composer itself is not needed
 composer.phar

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+    "name": "yii2",
+    "private": true,
+    "dependencies": {
+        "jquery": "2.0.3"
+    },
+    "author": "Dimitrios Mengidis <tydeas@peopleperhour.com>"
+}

--- a/composer.json
+++ b/composer.json
@@ -73,10 +73,10 @@
 		"ext-mbstring": "*",
 		"lib-pcre": "*",
 		"yiisoft/yii2-composer": "*",
-		"yiisoft/jquery": "~2.0 | ~1.10",
 		"yiisoft/jquery-pjax": "*",
 		"ezyang/htmlpurifier": "4.6.*",
-		"cebe/markdown": "0.9.*"
+		"cebe/markdown": "0.9.*",
+		"beelab/bowerphp": "0.1.*@alpha"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "3.7.*",

--- a/framework/web/JqueryAsset.php
+++ b/framework/web/JqueryAsset.php
@@ -15,7 +15,7 @@ namespace yii\web;
  */
 class JqueryAsset extends AssetBundle
 {
-    public $sourcePath = '@vendor/yiisoft/jquery';
+    public $sourcePath = '@bower_components/jquery';
     public $js = [
         'jquery.js',
     ];


### PR DESCRIPTION
Quoting from [Packagists](https://packagist.org/)

> Packagist is the main Composer repository. It aggregates all sorts of PHP packages that are installable with Composer.

Under [yiisoft packages](https://packagist.org/packages/yiisoft/) we can find pure javascript packages that should not be exist because they are...javascript.

Not that this brings extra effort in the development team ( maintain extra repo with js and their dependencies), it also brings a "bad" name (imho) to the project.

There are alternatives but this is not `git submodule` of course. It's called [bower](http://bower.io/)

>  Bower is a package manager for the web. It offers a generic, unopinionated solution to the problem of front-end package management.

This is the proper way to maintain the **front-end packages** but bad news is that it's written in node. It is obvious that an extra and particularly this dependency is not good for the a php framework but there is an alternative: [BowerPHP](http://bowerphp.org/#about).

To be honest I have not used this project, but seems to be the solution in this case that can give extra push to the php community around front-end package management.
