### PR TITLE
ActiveForm error: removed purification attribute brackets

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1050,7 +1050,6 @@ class BaseHtml
      */
     public static function error($model, $attribute, $options = [])
     {
-        $attribute = static::getAttributeName($attribute);
         $error = $model->getFirstError($attribute);
         $tag = isset($options['tag']) ? $options['tag'] : 'div';
         unset($options['tag']);

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -205,7 +205,7 @@ class ActiveField extends Component
         if ($this->model->isAttributeRequired($attribute)) {
             $class[] = $this->form->requiredCssClass;
         }
-        if ($this->model->hasErrors($attribute)) {
+        if ($this->model->hasErrors($this->attribute)) {
             $class[] = $this->form->errorCssClass;
         }
         $options['class'] = implode(' ', $class);


### PR DESCRIPTION
Because of these two lines of code do not appear in the error fields that represent arrays.

Example

``` php
$form->field($FormModel, 'name[en]')->textField();
$form->field($FormModel, 'name[de]')->textField();
$form->field($FormModel, 'name[ru]')->textField();
```
