### PR TITLE
Add wait() to login test with wrong credentials to fix WebDriver test

### DIFF
--- a/apps/basic/tests/acceptance/LoginCept.php
+++ b/apps/basic/tests/acceptance/LoginCept.php
@@ -17,6 +17,9 @@ $I->see('Password cannot be blank.');
 
 $I->amGoingTo('try to login with wrong credentials');
 $loginPage->login('admin', 'wrong');
+if (method_exists($I, 'wait')) {
+    $I->wait(3); // only for selenium
+}
 $I->expectTo('see validations errors');
 $I->see('Incorrect username or password.');
 


### PR DESCRIPTION
Based on earlier discussion in #2949, an extra `wait(3)` is necessary for the LoginCept acceptance test when running in WebDriver. This is because otherwise the the login request hasn't processed yet. 
