### PR TITLE
corrected path normalizer, and simlifier

### DIFF
--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -39,7 +39,22 @@ class BaseFileHelper
      */
     public static function normalizePath($path, $ds = DIRECTORY_SEPARATOR)
     {
-        return rtrim(strtr($path, ['/' => $ds, '\\' => $ds]), $ds);
+		return self::simplifyPath(rtrim(strtr($path, ['/' => $ds, '\\' => $ds]), $ds), $ds);
+    }
+	
+	/**
+     * Silmplify a file/directory path.
+     * @param string $path the file/directory path to be normalized
+     * @param string $ds the directory separator to be used in the normalized result. Defaults to `DIRECTORY_SEPARATOR`.
+     * @return string the normalized file/directory path
+     */
+    public static function simplifyPath($path, $ds = DIRECTORY_SEPARATOR)
+    {
+        return preg_replace_callback('/[\\\\\\/]{1}([\\w\\d\\.\\-_]*)[\\\\\\/]{1}(\\.\\.|\\.)[\\\\\\/]{1}/s', 
+			function ($m)  use ($ds) {
+				return $m[2] === '..' ?  $ds : $ds.$m[1].$ds;
+			},
+			$path);
     }
 
     /**


### PR DESCRIPTION
for example. if we used path /home/projects/payprocessing.eve/accountant/views/site/../include/menu.html
and /home/projects/payprocessing.eve/accountant/views/site does not exist, but
/home/projects/payprocessing.eve/accountant/views/include/menu.html exist.
Unix doesn't find the file. Normalize them
