### PR TITLE
Update logging.md

### DIFF
--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -32,9 +32,8 @@ There are multiple severity levels and corresponding methods available:
 Log targets
 -----------
 
-When one of the logging methods is called, message is passed to [[yii\log\Logger]] component also accessible as
-`Yii::$app->log`. Logger accumulates messages in memory and then when there are enough messages or when current
-request finishes, sends them to different log targets, such as file or email.
+When one of the logging methods is called, message is passed to [[yii\log\Logger]] component accessible as
+`Yii::$app->log->logger` or `Yii::getLogger()`. Logger accumulates messages in memory and then when there are enough messages or when current request finishes, sends them to different log targets, such as file or email.
 
 You may configure the targets in application configuration, like the following:
 


### PR DESCRIPTION
Currently `Yii::$app->log` is not the `yii\log\Logger`, but the `yii\log\Dispatcher`. Logger is transient component used indirectly and separately by the dispatcher and helper methods for logging.
