### PR TITLE
addSelect method for Query

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -189,6 +189,7 @@ Yii Framework 2 Change Log
 - Enh: Added support to allow an event handler to be inserted at the beginning of the existing event handler list (qiangxue)
 - Enh: Improved action filter and action execution flow by supporting installing action filters at controller, module and application levels (qiangxue)
 - Enh: Added `isAssociative()` and `isIndexed()` to `yii\helpers\ArrayHelper` (qiangxue)
+- Enh: Added `addSelect` to `yii\db\Query` (Alex-Code)
 - Chg #47: Changed Markdown library to cebe/markdown and adjusted Markdown helper API (cebe)
 - Chg #735: Added back `ActiveField::hiddenInput()` (qiangxue)
 - Chg #1186: Changed `Sort` to use comma to separate multiple sort fields and use negative sign to indicate descending sort (qiangxue)

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -409,6 +409,26 @@ class Query extends Component implements QueryInterface
     }
 
     /**
+     * Add more columns to the SELECT part of the query.
+     * @param string|array $columns the columns to add to the select.
+     * @return static the query object itself
+     * @see select()
+     */
+    public function addSelect($columns)
+    {
+        if (!is_array($columns)) {
+            $columns = preg_split('/\s*,\s*/', trim($columns), -1, PREG_SPLIT_NO_EMPTY);
+        }
+        if ($this->select === null) {
+            $this->select = $columns;
+        } else {
+            $this->select = array_merge($this->select, $columns);
+        }
+        
+        return $this;
+    }
+
+    /**
      * Sets the value indicating whether to SELECT DISTINCT or not.
      * @param boolean $value whether to SELECT DISTINCT or not.
      * @return static the query object itself

--- a/tests/unit/framework/db/QueryTest.php
+++ b/tests/unit/framework/db/QueryTest.php
@@ -24,6 +24,11 @@ class QueryTest extends DatabaseTestCase
         $this->assertEquals(['id', 'name'], $query->select);
         $this->assertTrue($query->distinct);
         $this->assertEquals('something', $query->selectOption);
+        
+        $query = new Query();
+        $query->select('id, name');
+        $query->addSelect('email');
+        $this->assertEquals(['id', 'name', 'email'], $query->select);
     }
 
     public function testFrom()


### PR DESCRIPTION
I had some scopes that needed to add to the select part of the query but this meant having to write out a merge every time.
Added a new `addSelect` method to make it simpler for scopes to add columns to select.
