### PR TITLE
resolve path alias for FileHelper::findFiles()

### DIFF
--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -273,6 +273,7 @@ class BaseFileHelper
      */
     public static function findFiles($dir, $options = [])
     {
+        $dir = Yii::getAlias($dir);
         if (!is_dir($dir)) {
             throw new InvalidParamException('The dir argument must be a directory.');
         }


### PR DESCRIPTION
Shouldn't all framework file functions be aware of aliases?
Maybe needed in more places.
