### PR TITLE
Refactor UrlManager, bootstrap Gii to add its own routes.

### DIFF
--- a/apps/advanced/environments/dev/backend/config/main-local.php
+++ b/apps/advanced/environments/dev/backend/config/main-local.php
@@ -4,9 +4,11 @@ $config = [];
 
 if (!YII_ENV_TEST) {
     // configuration adjustments for 'dev' environment
-    $config['bootstrap'][] = 'debug';
     $config['modules']['debug'] = 'yii\debug\Module';
     $config['modules']['gii'] = 'yii\gii\Module';
+
+    $config['bootstrap'][] = 'debug';
+    $config['bootstrap'][] = 'gii';
 }
 
 return $config;

--- a/apps/advanced/environments/dev/frontend/config/main-local.php
+++ b/apps/advanced/environments/dev/frontend/config/main-local.php
@@ -4,9 +4,11 @@ $config = [];
 
 if (!YII_ENV_TEST) {
     // configuration adjustments for 'dev' environment
-    $config['bootstrap'][] = 'debug';
     $config['modules']['debug'] = 'yii\debug\Module';
     $config['modules']['gii'] = 'yii\gii\Module';
+
+    $config['bootstrap'][] = 'debug';
+    $config['bootstrap'][] = 'gii';
 }
 
 return $config;

--- a/apps/basic/config/web.php
+++ b/apps/basic/config/web.php
@@ -39,9 +39,11 @@ $config = [
 
 if (YII_ENV_DEV) {
     // configuration adjustments for 'dev' environment
-    $config['bootstrap'][] = 'debug';
     $config['modules']['debug'] = 'yii\debug\Module';
     $config['modules']['gii'] = 'yii\gii\Module';
+
+    $config['bootstrap'][] = 'debug';
+    $config['bootstrap'][] = 'gii';
 }
 
 return $config;

--- a/extensions/gii/Module.php
+++ b/extensions/gii/Module.php
@@ -1,14 +1,16 @@
 <?php
 /**
- * @link http://www.yiiframework.com/
+ * @link      http://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
- * @license http://www.yiiframework.com/license/
+ * @license   http://www.yiiframework.com/license/
  */
 
 namespace yii\gii;
 
 use Yii;
+use yii\base\BootstrapInterface;
 use yii\web\ForbiddenHttpException;
+use yii\web\UrlManager;
 
 /**
  * This is the main module class for the Gii module.
@@ -49,10 +51,10 @@ use yii\web\ForbiddenHttpException;
  * You can then access Gii via URL: `http://localhost/path/to/index.php/gii`
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
- * @since 2.0
+ * @since  2.0
  */
-class Module extends \yii\base\Module
-{
+class Module extends \yii\base\Module implements BootstrapInterface {
+
     /**
      * @inheritdoc
      */
@@ -93,8 +95,7 @@ class Module extends \yii\base\Module
     /**
      * @inheritdoc
      */
-    public function init()
-    {
+    public function init() {
         parent::init();
         foreach (array_merge($this->coreGenerators(), $this->generators) as $id => $config) {
             $this->generators[$id] = Yii::createObject($config);
@@ -104,8 +105,7 @@ class Module extends \yii\base\Module
     /**
      * @inheritdoc
      */
-    public function beforeAction($action)
-    {
+    public function beforeAction($action) {
         if ($this->checkAccess()) {
             return parent::beforeAction($action);
         } else {
@@ -114,13 +114,30 @@ class Module extends \yii\base\Module
     }
 
     /**
+     * @inheritdoc
+     */
+    public function bootstrap($app) {
+        $app->urlManager->addRules(
+            [
+                'gii'                               => 'gii',
+                'gii/<controller:\w+>'              => 'gii/<controller>',
+                'gii/<controller:\w+>/<action:\w+>' => 'gii/<controller>/<action>',
+            ]
+        );
+    }
+
+    /**
      * @return boolean whether the module can be accessed by the current user
      */
-    protected function checkAccess()
-    {
+    protected function checkAccess() {
         $ip = Yii::$app->getRequest()->getUserIP();
         foreach ($this->allowedIPs as $filter) {
-            if ($filter === '*' || $filter === $ip || (($pos = strpos($filter, '*')) !== false && !strncmp($ip, $filter, $pos))) {
+            if ($filter === '*' || $filter === $ip || (($pos = strpos($filter, '*')) !== false && !strncmp(
+                $ip,
+                $filter,
+                $pos
+            ))
+            ) {
                 return true;
             }
         }
@@ -131,17 +148,17 @@ class Module extends \yii\base\Module
 
     /**
      * Returns the list of the core code generator configurations.
+     *
      * @return array the list of the core code generator configurations.
      */
-    protected function coreGenerators()
-    {
+    protected function coreGenerators() {
         return [
-            'model' => ['class' => 'yii\gii\generators\model\Generator'],
-            'crud' => ['class' => 'yii\gii\generators\crud\Generator'],
+            'model'      => ['class' => 'yii\gii\generators\model\Generator'],
+            'crud'       => ['class' => 'yii\gii\generators\crud\Generator'],
             'controller' => ['class' => 'yii\gii\generators\controller\Generator'],
-            'form' => ['class' => 'yii\gii\generators\form\Generator'],
-            'module' => ['class' => 'yii\gii\generators\module\Generator'],
-            'extension' => ['class' => 'yii\gii\generators\extension\Generator'],
+            'form'       => ['class' => 'yii\gii\generators\form\Generator'],
+            'module'     => ['class' => 'yii\gii\generators\module\Generator'],
+            'extension'  => ['class' => 'yii\gii\generators\extension\Generator'],
         ];
     }
 }

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @link http://www.yiiframework.com/
+ * @link      http://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
- * @license http://www.yiiframework.com/license/
+ * @license   http://www.yiiframework.com/license/
  */
 
 namespace yii\web;
@@ -31,15 +31,15 @@ use yii\caching\Cache;
  * ]
  * ~~~
  *
- * @property string $baseUrl The base URL that is used by [[createUrl()]] to prepend URLs it creates.
+ * @property string $baseUrl  The base URL that is used by [[createUrl()]] to prepend URLs it creates.
  * @property string $hostInfo The host info (e.g. "http://www.example.com") that is used by
  * [[createAbsoluteUrl()]] to prepend URLs it creates.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
- * @since 2.0
+ * @since  2.0
  */
-class UrlManager extends Component
-{
+class UrlManager extends Component {
+
     /**
      * @var boolean whether to enable pretty URLs. Instead of putting all parameters in the query
      * string part of a URL, pretty URLs allow using path info to represent some of the parameters
@@ -127,11 +127,14 @@ class UrlManager extends Component
     private $_baseUrl;
     private $_hostInfo;
 
+    const VERBS = 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS';
+    const AFTER = 0;
+    const BEFORE = 1;
+
     /**
      * Initializes UrlManager.
      */
-    public function init()
-    {
+    public function init() {
         parent::init();
         $this->compileRules();
     }
@@ -139,17 +142,17 @@ class UrlManager extends Component
     /**
      * Parses the URL rules.
      */
-    protected function compileRules()
-    {
+    protected function compileRules() {
         if (!$this->enablePrettyUrl || empty($this->rules)) {
             return;
         }
+
         if (is_string($this->cache)) {
             $this->cache = Yii::$app->get($this->cache, false);
         }
         if ($this->cache instanceof Cache) {
             $cacheKey = __CLASS__;
-            $hash = md5(json_encode($this->rules));
+            $hash     = md5(json_encode($this->rules));
             if (($data = $this->cache->get($cacheKey)) !== false && isset($data[1]) && $data[1] === $hash) {
                 $this->rules = $data[0];
 
@@ -157,25 +160,7 @@ class UrlManager extends Component
             }
         }
 
-        $rules = [];
-        $verbs = 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS';
-        foreach ($this->rules as $key => $rule) {
-            if (!is_array($rule)) {
-                $rule = ['route' => $rule];
-                if (preg_match("/^((?:($verbs),)*($verbs))\\s+(.*)$/", $key, $matches)) {
-                    $rule['verb'] = explode(',', $matches[1]);
-                    $rule['mode'] = UrlRule::PARSING_ONLY;
-                    $key = $matches[4];
-                }
-                $rule['pattern'] = $key;
-            }
-            $rule = Yii::createObject(array_merge($this->ruleConfig, $rule));
-            if (!$rule instanceof UrlRuleInterface) {
-                throw new InvalidConfigException('URL rule class must implement UrlRuleInterface.');
-            }
-            $rules[] = $rule;
-        }
-        $this->rules = $rules;
+        $this->addRules($this->rules, true);
 
         if (isset($cacheKey, $hash)) {
             $this->cache->set($cacheKey, [$this->rules, $hash]);
@@ -183,13 +168,63 @@ class UrlManager extends Component
     }
 
     /**
+     * Parse a pattern and create a UrlRule object.
+     * Refactored from compileRules().
+     *
+     * @param $pattern
+     * @param $route
+     *
+     * @return UrlRule
+     * @throws \yii\base\InvalidConfigException
+     */
+    public function parseRule($pattern, $route) {
+        if (!is_array($route)) {
+            $route = ['route' => $route];
+            if (preg_match('/^((?:(' . self::VERBS . '),)*(' . self::VERBS . '))\\s+(.*)$/', $pattern, $matches)) {
+                $route['verb'] = explode(',', $matches[1]);
+                $route['mode'] = UrlRule::PARSING_ONLY;
+                $pattern      = $matches[4];
+            }
+            $route['pattern'] = $pattern;
+        }
+        $route = Yii::createObject(array_merge($this->ruleConfig, $route));
+        if (!$route instanceof UrlRuleInterface) {
+            throw new InvalidConfigException('URL rule class must implement UrlRuleInterface.');
+        }
+
+        return $route;
+    }
+
+    /**
+     * Adds rules to the UrlManager.
+     *
+     * Refactored from compileRules() to allow simple addition of rules by modules
+     * after the configuration has been loaded.
+     *
+     * @param array $rules
+     * @param bool  $addToBottom
+     */
+    public function addRules($rules, $addToBottom = false) {
+        $newRules = [];
+        foreach ($rules as $pattern => $rule) {
+            $newRules[] = $this->parseRule($pattern, $rule);
+        }
+        if ($addToBottom) {
+            $this->rules = \yii\helpers\ArrayHelper::merge($this->rules, $newRules);
+        } else {
+            $this->rules = \yii\helpers\ArrayHelper::merge($newRules, $this->rules);
+        }
+    }
+
+    /**
      * Parses the user request.
+     *
      * @param Request $request the request component
+     *
      * @return array|boolean the route and the associated parameters. The latter is always empty
      * if [[enablePrettyUrl]] is false. False is returned if the current request cannot be successfully parsed.
      */
-    public function parseRequest($request)
-    {
+    public function parseRequest($request) {
         if ($this->enablePrettyUrl) {
             $pathInfo = $request->getPathInfo();
             /** @var UrlRule $rule */
@@ -205,7 +240,7 @@ class UrlManager extends Component
 
             Yii::trace('No matching URL rules. Using default URL parsing logic.', __METHOD__);
 
-            $suffix = (string) $this->suffix;
+            $suffix = (string)$this->suffix;
             if ($suffix !== '' && $pathInfo !== '') {
                 $n = strlen($this->suffix);
                 if (substr($pathInfo, -$n) === $this->suffix) {
@@ -228,7 +263,7 @@ class UrlManager extends Component
                 $route = '';
             }
 
-            return [(string) $route, []];
+            return [(string)$route, []];
         }
     }
 
@@ -258,12 +293,12 @@ class UrlManager extends Component
      * as an absolute route.
      *
      * @param string|array $params use a string to represent a route (e.g. `site/index`),
-     * or an array to represent a route with query parameters (e.g. `['site/index', 'param1' => 'value1']`).
+     *                             or an array to represent a route with query parameters (e.g. `['site/index', 'param1' => 'value1']`).
+     *
      * @return string the created URL
      */
-    public function createUrl($params)
-    {
-        $params = (array) $params;
+    public function createUrl($params) {
+        $params = (array)$params;
         $anchor = isset($params['#']) ? '#' . $params['#'] : '';
         unset($params['#'], $params[$this->routeParam]);
 
@@ -314,16 +349,16 @@ class UrlManager extends Component
      * as an absolute route.
      *
      * @param string|array $params use a string to represent a route (e.g. `site/index`),
-     * or an array to represent a route with query parameters (e.g. `['site/index', 'param1' => 'value1']`).
-     * @param string $scheme the scheme to use for the url (either `http` or `https`). If not specified
-     * the scheme of the current request will be used.
+     *                             or an array to represent a route with query parameters (e.g. `['site/index', 'param1' => 'value1']`).
+     * @param string       $scheme the scheme to use for the url (either `http` or `https`). If not specified
+     *                             the scheme of the current request will be used.
+     *
      * @return string the created URL
      * @see createUrl()
      */
-    public function createAbsoluteUrl($params, $scheme = null)
-    {
-        $params = (array) $params;
-        $url = $this->createUrl($params);
+    public function createAbsoluteUrl($params, $scheme = null) {
+        $params = (array)$params;
+        $url    = $this->createUrl($params);
         if (strpos($url, '://') === false) {
             $url = $this->getHostInfo() . $url;
         }
@@ -338,15 +373,16 @@ class UrlManager extends Component
      * Returns the base URL that is used by [[createUrl()]] to prepend URLs it creates.
      * It defaults to [[Request::scriptUrl]] if [[showScriptName]] is true or [[enablePrettyUrl]] is false;
      * otherwise, it defaults to [[Request::baseUrl]].
+     *
      * @return string the base URL that is used by [[createUrl()]] to prepend URLs it creates.
      * @throws InvalidConfigException if running in console application and [[baseUrl]] is not configured.
      */
-    public function getBaseUrl()
-    {
+    public function getBaseUrl() {
         if ($this->_baseUrl === null) {
             $request = Yii::$app->getRequest();
             if ($request instanceof \yii\web\Request) {
-                $this->_baseUrl = $this->showScriptName || !$this->enablePrettyUrl ? $request->getScriptUrl() : $request->getBaseUrl();
+                $this->_baseUrl = $this->showScriptName || !$this->enablePrettyUrl ? $request->getScriptUrl(
+                ) : $request->getBaseUrl();
             } else {
                 throw new InvalidConfigException('Please configure UrlManager::baseUrl correctly as you are running a console application.');
             }
@@ -357,20 +393,20 @@ class UrlManager extends Component
 
     /**
      * Sets the base URL that is used by [[createUrl()]] to prepend URLs it creates.
+     *
      * @param string $value the base URL that is used by [[createUrl()]] to prepend URLs it creates.
      */
-    public function setBaseUrl($value)
-    {
+    public function setBaseUrl($value) {
         $this->_baseUrl = rtrim($value, '/');
     }
 
     /**
      * Returns the host info that is used by [[createAbsoluteUrl()]] to prepend URLs it creates.
+     *
      * @return string the host info (e.g. "http://www.example.com") that is used by [[createAbsoluteUrl()]] to prepend URLs it creates.
      * @throws InvalidConfigException if running in console application and [[hostInfo]] is not configured.
      */
-    public function getHostInfo()
-    {
+    public function getHostInfo() {
         if ($this->_hostInfo === null) {
             $request = Yii::$app->getRequest();
             if ($request instanceof \yii\web\Request) {
@@ -385,10 +421,10 @@ class UrlManager extends Component
 
     /**
      * Sets the host info that is used by [[createAbsoluteUrl()]] to prepend URLs it creates.
+     *
      * @param string $value the host info (e.g. "http://www.example.com") that is used by [[createAbsoluteUrl()]] to prepend URLs it creates.
      */
-    public function setHostInfo($value)
-    {
+    public function setHostInfo($value) {
         $this->_hostInfo = rtrim($value, '/');
     }
 }

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -160,7 +160,10 @@ class UrlManager extends Component {
             }
         }
 
-        $this->addRules($this->rules, true);
+        $rules = $this->rules;
+        $this->rules = [];
+
+        $this->addRules($rules, true);
 
         if (isset($cacheKey, $hash)) {
             $this->cache->set($cacheKey, [$this->rules, $hash]);


### PR DESCRIPTION
These changes refactor UrlManager to allow Gii and other modules to add routes to UrlManager during the bootstrap process, after the main app has been initialized.

Also sets up Gii to add routes to UrlManager if bootstrapped. This saves users from having to manually add extra routes to their config file to get Gii to work when custom routes are set in their apps.
