### PR TITLE
Refactor UrlManager, bootstrap Gii to add its own routes.

### DIFF
--- a/apps/advanced/environments/dev/backend/config/main-local.php
+++ b/apps/advanced/environments/dev/backend/config/main-local.php
@@ -4,9 +4,11 @@ $config = [];
 
 if (!YII_ENV_TEST) {
     // configuration adjustments for 'dev' environment
-    $config['bootstrap'][] = 'debug';
     $config['modules']['debug'] = 'yii\debug\Module';
     $config['modules']['gii'] = 'yii\gii\Module';
+
+    $config['bootstrap'][] = 'debug';
+    $config['bootstrap'][] = 'gii';
 }
 
 return $config;

--- a/apps/advanced/environments/dev/frontend/config/main-local.php
+++ b/apps/advanced/environments/dev/frontend/config/main-local.php
@@ -4,9 +4,11 @@ $config = [];
 
 if (!YII_ENV_TEST) {
     // configuration adjustments for 'dev' environment
-    $config['bootstrap'][] = 'debug';
     $config['modules']['debug'] = 'yii\debug\Module';
     $config['modules']['gii'] = 'yii\gii\Module';
+
+    $config['bootstrap'][] = 'debug';
+    $config['bootstrap'][] = 'gii';
 }
 
 return $config;

--- a/apps/basic/config/web.php
+++ b/apps/basic/config/web.php
@@ -39,9 +39,11 @@ $config = [
 
 if (YII_ENV_DEV) {
     // configuration adjustments for 'dev' environment
-    $config['bootstrap'][] = 'debug';
     $config['modules']['debug'] = 'yii\debug\Module';
     $config['modules']['gii'] = 'yii\gii\Module';
+
+    $config['bootstrap'][] = 'debug';
+    $config['bootstrap'][] = 'gii';
 }
 
 return $config;

--- a/extensions/gii/Module.php
+++ b/extensions/gii/Module.php
@@ -122,9 +122,9 @@ class Module extends \yii\base\Module implements BootstrapInterface
     {
         $app->urlManager->addRules(
             [
-                'gii'                               => 'gii',
-                'gii/<controller:\w+>'              => 'gii/<controller>',
-                'gii/<controller:\w+>/<action:\w+>' => 'gii/<controller>/<action>',
+                $this->id => 'gii',
+                $this->id.'/<controller:\w+>' => 'gii/<controller>',
+                $this->id.'/<controller:\w+>/<action:\w+>' => 'gii/<controller>/<action>',
             ]
         );
     }

--- a/extensions/gii/Module.php
+++ b/extensions/gii/Module.php
@@ -8,6 +8,7 @@
 namespace yii\gii;
 
 use Yii;
+use yii\base\BootstrapInterface;
 use yii\web\ForbiddenHttpException;
 
 /**
@@ -51,7 +52,7 @@ use yii\web\ForbiddenHttpException;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-class Module extends \yii\base\Module
+class Module extends \yii\base\Module implements BootstrapInterface
 {
     /**
      * @inheritdoc
@@ -111,6 +112,20 @@ class Module extends \yii\base\Module
         } else {
             throw new ForbiddenHttpException('You are not allowed to access this page.');
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function bootstrap($app)
+    {
+        $app->urlManager->addRules(
+            [
+                'gii'                               => 'gii',
+                'gii/<controller:\w+>'              => 'gii/<controller>',
+                'gii/<controller:\w+>/<action:\w+>' => 'gii/<controller>/<action>',
+            ]
+        );
     }
 
     /**

--- a/extensions/gii/Module.php
+++ b/extensions/gii/Module.php
@@ -33,10 +33,10 @@ use yii\web\ForbiddenHttpException;
  * With the above configuration, you will be able to access GiiModule in your browser using
  * the URL `http://localhost/path/to/index.php?r=gii`
  *
- * If your application enables [[\yii\web\UrlManager::enablePrettyUrl|pretty URLs]] and you have defined
- * custom URL rules or enabled [[\yii\web\UrlManager::enableStrictParsing], you may need to add
- * the following URL rules at the beginning of your URL rule set in your application configuration
- * in order to access Gii:
+ * In case your application enables [[\yii\web\UrlManager::enablePrettyUrl|pretty URLs]], Gii automatically
+ * registers the following set of routes in addition to those defined in your app. This ensures Gii will always
+ * be accessible, no matter what routes are defined in your config.
+ * It is no longer necessary to define these routes manually.
  *
  * ~~~
  * 'rules' => [
@@ -47,7 +47,8 @@ use yii\web\ForbiddenHttpException;
  * ],
  * ~~~
  *
- * You can then access Gii via URL: `http://localhost/path/to/index.php/gii`
+ * With [[\yii\web\UrlManager::enablePrettyUrl|pretty URLs]], You can access Gii via URL:
+ * `http://localhost/path/to/index.php/gii`
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/extensions/gii/Module.php
+++ b/extensions/gii/Module.php
@@ -98,9 +98,6 @@ class Module extends \yii\base\Module implements BootstrapInterface
     public function init()
     {
         parent::init();
-        foreach (array_merge($this->coreGenerators(), $this->generators) as $id => $config) {
-            $this->generators[$id] = Yii::createObject($config);
-        }
     }
 
     /**
@@ -109,6 +106,9 @@ class Module extends \yii\base\Module implements BootstrapInterface
     public function beforeAction($action)
     {
         if ($this->checkAccess()) {
+            foreach (array_merge($this->coreGenerators(), $this->generators) as $id => $config) {
+                $this->generators[$id] = Yii::createObject($config);
+            }
             return parent::beforeAction($action);
         } else {
             throw new ForbiddenHttpException('You are not allowed to access this page.');


### PR DESCRIPTION
This change refactors UrlManager::compileRules() to expose two public functions to allow modules to create and add their own routes. The intent is for Gii to auto-register routes, however the functions should also be useful for other modules.

This change also adjusts Gii to use BootstrapInterface to automatically register routes to ensure it can be accessed with pretty URLs, no matter what routes are defined in the app config.
