### PR TITLE
Fix exception hierarchy

### DIFF
--- a/extensions/twig/CHANGELOG.md
+++ b/extensions/twig/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 twig extension Change Log
 2.0.0-rc under development
 --------------------------
 
-- no changes in this release.
+- Bug #2925: Fixed throwing exception when accessing AR property with null value (samdark)
 
 
 2.0.0-beta April 13, 2014

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -20,6 +20,7 @@ Yii Framework 2 Change Log
 - Enh: Added support for using sub-queries when building a DB query with `IN` condition (qiangxue)
 - Enh: Supported adding a new response formatter without the need to reconfigure existing formatters (qiangxue)
 - Enh: Added `yii\web\UrlManager::addRules()` to simplify adding new URL rules (qiangxue)
+- Chg #3175: InvalidCallException, InvalidParamException, UnknownMethodException are now extended from SPL BadMethodCallException (samdark)
 - Chg: Replaced `clearAll()` and `clearAllAssignments()` in `yii\rbac\ManagerInterface` with `removeAll()`, `removeAllRoles()`, `removeAllPermissions()`, `removeAllRules()` and `removeAllAssignments()` (qiangxue)
 - Chg: Added `$user` as the first parameter of `yii\rbac\Rule::execute()` (qiangxue)
 

--- a/framework/base/InvalidCallException.php
+++ b/framework/base/InvalidCallException.php
@@ -13,7 +13,7 @@ namespace yii\base;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-class InvalidCallException extends Exception
+class InvalidCallException extends \BadMethodCallException
 {
     /**
      * @return string the user-friendly name of this exception

--- a/framework/base/InvalidParamException.php
+++ b/framework/base/InvalidParamException.php
@@ -13,7 +13,7 @@ namespace yii\base;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-class InvalidParamException extends Exception
+class InvalidParamException extends \BadMethodCallException
 {
     /**
      * @return string the user-friendly name of this exception

--- a/framework/base/Object.php
+++ b/framework/base/Object.php
@@ -214,7 +214,7 @@ class Object
      */
     public function __call($name, $params)
     {
-        throw new UnknownMethodException('Unknown method: ' . get_class($this) . "::$name()");
+        throw new UnknownMethodException('Calling unknown method: ' . get_class($this) . "::$name()");
     }
 
     /**

--- a/framework/base/UnknownMethodException.php
+++ b/framework/base/UnknownMethodException.php
@@ -13,7 +13,7 @@ namespace yii\base;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-class UnknownMethodException extends Exception
+class UnknownMethodException extends \BadMethodCallException
 {
     /**
      * @return string the user-friendly name of this exception


### PR DESCRIPTION
This one fixes #2925 is a standard way to represent exceptions in these cases.
