### PR TITLE
Timestamp bug for years before 1970 and after 2038

### DIFF
--- a/framework/base/Formatter.php
+++ b/framework/base/Formatter.php
@@ -23,6 +23,7 @@ use yii\helpers\Html;
  * You can access that instance via `Yii::$app->formatter`.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
+ * @author Kartik Visweswaran <kartikv2@gmail.com>
  * @since 2.0
  */
 class Formatter extends Component


### PR DESCRIPTION
Adds support for timestamps before 1970 and beyond year 2038. Added author name as requested in #3194.
