### PR TITLE
use tableprefix on gii model generator

### DIFF
--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -30,6 +30,7 @@ class Generator extends \yii\gii\Generator
     public $baseClass = 'yii\db\ActiveRecord';
     public $generateRelations = true;
     public $generateLabelsFromComments = false;
+    public $useTablePefix=false;
 
     /**
      * @inheritdoc
@@ -65,6 +66,7 @@ class Generator extends \yii\gii\Generator
             [['baseClass'], 'validateClass', 'params' => ['extends' => ActiveRecord::className()]],
             [['generateRelations', 'generateLabelsFromComments'], 'boolean'],
             [['enableI18N'], 'boolean'],
+            [['useTablePefix'], 'boolean'],
             [['messageCategory'], 'validateMessageCategory', 'skipOnEmpty' => false],
         ]);
     }
@@ -531,6 +533,27 @@ class Generator extends \yii\gii\Generator
         }
 
         return $this->_tableNames = $tableNames;
+    }
+
+    /**
+     * Generates a the tablename with tableprefix usage .
+     * @param  string $tableName the table name (which may contain schema prefix)
+     * @return string the generated table name if useTablePefix == true return with {{%}} depending of the position of the prefix
+     */
+    public function generateTablename($tableName)
+    {
+        if (!$this->useTablePefix) {
+            return $tableName;
+        } else {
+            $db = $this->getDbConnection();
+            $patterns = [];
+            if (preg_match("/^{$db->tablePrefix}(.*?)$/", $tableName, $matches)) {
+                $tableName = '{{%'.$matches[1].'}}';
+            } elseif (preg_match("/^(.*?){$db->tablePrefix}$/", $tableName, $matches)) {
+                $tableName = '{{'.$matches[1].'%}}';
+            }
+            return $tableName;
+        }
     }
 
     /**

--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -546,7 +546,6 @@ class Generator extends \yii\gii\Generator
             return $tableName;
         } else {
             $db = $this->getDbConnection();
-            $patterns = [];
             if (preg_match("/^{$db->tablePrefix}(.*?)$/", $tableName, $matches)) {
                 $tableName = '{{%'.$matches[1].'}}';
             } elseif (preg_match("/^(.*?){$db->tablePrefix}$/", $tableName, $matches)) {

--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -30,7 +30,7 @@ class Generator extends \yii\gii\Generator
     public $baseClass = 'yii\db\ActiveRecord';
     public $generateRelations = true;
     public $generateLabelsFromComments = false;
-    public $useTablePefix=false;
+    public $useTablePrefix=false;
 
     /**
      * @inheritdoc
@@ -66,7 +66,7 @@ class Generator extends \yii\gii\Generator
             [['baseClass'], 'validateClass', 'params' => ['extends' => ActiveRecord::className()]],
             [['generateRelations', 'generateLabelsFromComments'], 'boolean'],
             [['enableI18N'], 'boolean'],
-            [['useTablePefix'], 'boolean'],
+            [['useTablePrefix'], 'boolean'],
             [['messageCategory'], 'validateMessageCategory', 'skipOnEmpty' => false],
         ]);
     }
@@ -538,11 +538,11 @@ class Generator extends \yii\gii\Generator
     /**
      * Generates a the tablename with tableprefix usage .
      * @param  string $tableName the table name (which may contain schema prefix)
-     * @return string the generated table name if useTablePefix == true return with {{%}} depending of the position of the prefix
+     * @return string the generated table name if useTablePrefix == true return with {{%}} depending of the position of the prefix
      */
     public function generateTablename($tableName)
     {
-        if (!$this->useTablePefix) {
+        if (!$this->useTablePrefix) {
             return $tableName;
         } else {
             $db = $this->getDbConnection();

--- a/extensions/gii/generators/model/default/model.php
+++ b/extensions/gii/generators/model/default/model.php
@@ -39,7 +39,7 @@ class <?= $className ?> extends <?= '\\' . ltrim($generator->baseClass, '\\') . 
      */
     public static function tableName()
     {
-        return '<?= $tableName ?>';
+        return '<?= $generator->generateTablename($tableName) ?>';
     }
 <?php if ($generator->db !== 'db'): ?>
 

--- a/extensions/gii/generators/model/form.php
+++ b/extensions/gii/generators/model/form.php
@@ -10,6 +10,7 @@ echo $form->field($generator, 'modelClass');
 echo $form->field($generator, 'ns');
 echo $form->field($generator, 'baseClass');
 echo $form->field($generator, 'db');
+echo $form->field($generator, 'useTablePefix')->checkbox();
 echo $form->field($generator, 'generateRelations')->checkbox();
 echo $form->field($generator, 'generateLabelsFromComments')->checkbox();
 echo $form->field($generator, 'enableI18N')->checkbox();

--- a/extensions/gii/generators/model/form.php
+++ b/extensions/gii/generators/model/form.php
@@ -10,7 +10,7 @@ echo $form->field($generator, 'modelClass');
 echo $form->field($generator, 'ns');
 echo $form->field($generator, 'baseClass');
 echo $form->field($generator, 'db');
-echo $form->field($generator, 'useTablePefix')->checkbox();
+echo $form->field($generator, 'useTablePrefix')->checkbox();
 echo $form->field($generator, 'generateRelations')->checkbox();
 echo $form->field($generator, 'generateLabelsFromComments')->checkbox();
 echo $form->field($generator, 'enableI18N')->checkbox();


### PR DESCRIPTION
use tableprefix on gii model generator so that tablenames like {{%tablename_without_prefix}} or {{tablename_without_prefix%}} is generated.
