### PR TITLE
setting writable folders in init-script

### DIFF
--- a/apps/advanced/composer.json
+++ b/apps/advanced/composer.json
@@ -43,9 +43,6 @@
 			"backend/runtime",
 			"backend/web/assets",
 
-			"console/runtime",
-			"console/migrations",
-
 			"frontend/runtime",
 			"frontend/web/assets"
 		]

--- a/apps/advanced/environments/index.php
+++ b/apps/advanced/environments/index.php
@@ -20,7 +20,12 @@ return [
     'Development' => [
         'path' => 'dev',
         'writable' => [
-            // handled by composer.json already
+            'backend/runtime',
+            'backend/web/assets',
+            'console/runtime',
+            'console/migrations',
+            'frontend/runtime',
+            'frontend/web/assets',
         ],
         'executable' => [
             'yii',
@@ -29,7 +34,12 @@ return [
     'Production' => [
         'path' => 'prod',
         'writable' => [
-            // handled by composer.json already
+            'backend/runtime',
+            'backend/web/assets',
+            'console/runtime',
+            'console/migrations',
+            'frontend/runtime',
+            'frontend/web/assets',
         ],
         'executable' => [
             'yii',

--- a/apps/advanced/environments/index.php
+++ b/apps/advanced/environments/index.php
@@ -22,8 +22,6 @@ return [
         'writable' => [
             'backend/runtime',
             'backend/web/assets',
-            'console/runtime',
-            'console/migrations',
             'frontend/runtime',
             'frontend/web/assets',
         ],
@@ -36,8 +34,6 @@ return [
         'writable' => [
             'backend/runtime',
             'backend/web/assets',
-            'console/runtime',
-            'console/migrations',
             'frontend/runtime',
             'frontend/web/assets',
         ],


### PR DESCRIPTION
It is said, that these folders are handled already by composer.json, what is definitely true. But if I can't (or don't want to) call composer create-project command, I have to run post-create-project-cmd manually like `composer run-script post-create-project-cmd`. IMHO, it's consistent to make such preparations in init script.
