### PR TITLE
typo in comments

### DIFF
--- a/framework/di/ServiceLocator.php
+++ b/framework/di/ServiceLocator.php
@@ -42,7 +42,7 @@ use yii\base\InvalidConfigException;
  * Because [[\yii\base\Module]] extends from ServiceLocator, modules and the application are all service locators.
  *
  * @property array $components The list of the component definitions or the loaded component instances (ID =>
- * definition or instance). This property is read-only.
+ * definition or instance).
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0


### PR DESCRIPTION
property can be set via [[setComponents()]]
