### PR TITLE
fix view->theme support className as string.

### DIFF
--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -113,8 +113,8 @@ class View extends Component
             if (!isset($this->theme['class'])) {
                 $this->theme['class'] = 'yii\base\Theme';
             }
-            $this->theme = Yii::createObject($this->theme);
         }
+        $this->theme = Yii::createObject($this->theme);
     }
 
     /**

--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -113,8 +113,8 @@ class View extends Component
             if (!isset($this->theme['class'])) {
                 $this->theme['class'] = 'yii\base\Theme';
             }
-            $this->theme = Yii::createObject($this->theme);
         }
+		$this->theme = Yii::createObject($this->theme);
     }
 
     /**


### PR DESCRIPTION
According to Configure Convention. Theme can be className as string , reference line 28 in yii\web\View
