### PR TITLE
BaseMailer: Use textLayout for text version of Email when possible

### DIFF
--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -186,7 +186,12 @@ abstract class BaseMailer extends Component implements MailerInterface, ViewCont
             if (isset($text)) {
                 $message->setTextBody($text);
             } elseif (isset($html)) {
-                $message->setTextBody(strip_tags($html));
+                try {
+                    $text = $this->render($view, $params, $this->textLayout);
+                    $message->setTextBody(strip_tags($text));
+                } catch (\Exception $e) { // textLayout doesn't exist
+                    $message->setTextBody(strip_tags($html));
+                }
             }
         }
         return $message;


### PR DESCRIPTION
For the moment even if `$textLayout` file exists it isn't used for rendering Text version of Email in this example: 

``` php
Yii::$app->mail->compose('confirm');
```

Only this construction will use `$textLayout` for rendering Text version of Email:

``` php
Yii::$app->mail->compose([
    'html' => 'confirm-html', // $htmlLayout
    'text' => 'confirm-text', // $textLayout
]);
```

---

The suggestion is:
When `$textLayout` file exists, use that template by default for generating Email Text Body, instead of `$htmlLayout`.

The change provided for BaseMailer.php is just to show the point.

Thanks.
