### PR TITLE
BaseMailer: strip <style> content from TextBody fix

### DIFF
--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -186,6 +186,7 @@ abstract class BaseMailer extends Component implements MailerInterface, ViewCont
             if (isset($text)) {
                 $message->setTextBody($text);
             } elseif (isset($html)) {
+                $html = preg_replace('|<style[^>]*>(.*)</style>|is', '', $html);
                 $message->setTextBody(strip_tags($html));
             }
         }

--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -186,7 +186,7 @@ abstract class BaseMailer extends Component implements MailerInterface, ViewCont
             if (isset($text)) {
                 $message->setTextBody($text);
             } elseif (isset($html)) {
-                $html = preg_replace('|<style[^>]*>(.*)</style>|is', '', $html);
+                $html = preg_replace('|<style[^>]*>(.*?)</style>|is', '', $html);
                 $message->setTextBody(strip_tags($html));
             }
         }

--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -186,6 +186,9 @@ abstract class BaseMailer extends Component implements MailerInterface, ViewCont
             if (isset($text)) {
                 $message->setTextBody($text);
             } elseif (isset($html)) {
+                if (preg_match('|<body[^>]*>(.*?)</body>|is', $html, $match)) {
+                    $html = $match[1];
+                }
                 $html = preg_replace('|<style[^>]*>(.*?)</style>|is', '', $html);
                 $message->setTextBody(strip_tags($html));
             }


### PR DESCRIPTION
If  `$htmlLayout` or `$view` contain `<style>` tags with CSS,
`strip_tags()` here: https://github.com/yiisoft/yii2/blob/master/framework/mail/BaseMailer.php#L189
won't clean those CSS rules.

Actual html: 

``` html
<html>
    <head>
        <style>
            .text-secondary {color: #93959A;}
            .gray-text{color:#aaa}
            .green-text{color:#2CB200}
            .red-text{color:#E92C13}
            [...]
        </style>
    </head>
    <body>
        <div>Content Block</div>
    </body>
</html>
```

Will look this way in TEXT version of Email: 

```
.text-secondary {color: #93959A;}
.text-secondary {color: #93959A;}
.gray-text{color:#aaa}
.green-text{color:#2CB200}
.red-text{color:#E92C13}
[...]
Content Block
```

---

When TEXT version of Email differs drastically from visible content of HTML version,
it can be result that some penalty points will apply to such mails: 
http://wiki.apache.org/spamassassin/Rules/MPART_ALT_DIFF_COUNT

Since it's default behaviour for both yii2-app-advanced and yii2-app-basic (where stripped from tags html used for TextBody),
I believe people will stumble in this for sure, without even knowing that their emails can be penalized.

You can reproduce it by placing CSS <style> blocks in email view or layout
and test it here: http://www.mail-tester.com/ (SpamAssassin section).
