### PR TITLE
with these changes, YIISOFT which hold vendor folder can easily redirect ...

### DIFF
--- a/apps/advanced/environments/dev/backend/web/index-test.php
+++ b/apps/advanced/environments/dev/backend/web/index-test.php
@@ -8,8 +8,11 @@ if (!in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1'])) {
 defined('YII_DEBUG') or define('YII_DEBUG', true);
 defined('YII_ENV') or define('YII_ENV', 'test');
 
-require(__DIR__ . '/../../vendor/autoload.php');
-require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');
+defined('YIISOFT') or define('YIISOFT', __DIR__ );
+// with the above change, YIISOFT which hold vendor folder can easily redirect to somewhere else like: 'G:\yii2\vendor\yiisoft'
+require(YIISOFT . '/../../vendor/autoload.php');
+require(YIISOFT . '/../../vendor/yiisoft/yii2/Yii.php');
+
 require(__DIR__ . '/../../common/config/aliases.php');
 
 $config = require(__DIR__ . '/../tests/acceptance/_config.php');

--- a/apps/advanced/environments/dev/backend/web/index.php
+++ b/apps/advanced/environments/dev/backend/web/index.php
@@ -2,8 +2,11 @@
 defined('YII_DEBUG') or define('YII_DEBUG', true);
 defined('YII_ENV') or define('YII_ENV', 'dev');
 
-require(__DIR__ . '/../../vendor/autoload.php');
-require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');
+defined('YIISOFT') or define('YIISOFT', __DIR__ );
+// with the above change, YIISOFT which hold vendor folder can easily redirect to somewhere else like: 'G:\yii2\vendor\yiisoft'
+require(YIISOFT . '/../../vendor/autoload.php');
+require(YIISOFT . '/../../vendor/yiisoft/yii2/Yii.php');
+
 require(__DIR__ . '/../../common/config/aliases.php');
 
 $config = yii\helpers\ArrayHelper::merge(

--- a/apps/advanced/environments/dev/frontend/web/index-test.php
+++ b/apps/advanced/environments/dev/frontend/web/index-test.php
@@ -8,8 +8,11 @@ if (!in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1'])) {
 defined('YII_DEBUG') or define('YII_DEBUG', true);
 defined('YII_ENV') or define('YII_ENV', 'test');
 
-require(__DIR__ . '/../../vendor/autoload.php');
-require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');
+defined('YIISOFT') or define('YIISOFT', __DIR__ );
+// with the above change, YIISOFT which hold vendor folder can easily redirect to somewhere else like: 'G:\yii2\vendor\yiisoft'
+require(YIISOFT . '/../../vendor/autoload.php');
+require(YIISOFT . '/../../vendor/yiisoft/yii2/Yii.php');
+
 require(__DIR__ . '/../../common/config/aliases.php');
 
 $config = require(__DIR__ . '/../tests/acceptance/_config.php');

--- a/apps/advanced/environments/dev/frontend/web/index.php
+++ b/apps/advanced/environments/dev/frontend/web/index.php
@@ -2,8 +2,11 @@
 defined('YII_DEBUG') or define('YII_DEBUG', true);
 defined('YII_ENV') or define('YII_ENV', 'dev');
 
-require(__DIR__ . '/../../vendor/autoload.php');
-require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');
+defined('YIISOFT') or define('YIISOFT', __DIR__ );
+// with the above change, YIISOFT which hold vendor folder can easily redirect to somewhere else like: 'G:\yii2\vendor\yiisoft'
+require(YIISOFT . '/../../vendor/autoload.php');
+require(YIISOFT . '/../../vendor/yiisoft/yii2/Yii.php');
+
 require(__DIR__ . '/../../common/config/aliases.php');
 
 $config = yii\helpers\ArrayHelper::merge(


### PR DESCRIPTION
When there is a need to run Yii on a network share which could be slower then Yii run from a local hard drive so these changes will enable the redirect of Yii core into location where it will load faster thus will make Yii site run faster on a network share.
