### PR TITLE
Dropdown update, implement simple missing features

### DIFF
--- a/extensions/bootstrap/Dropdown.php
+++ b/extensions/bootstrap/Dropdown.php
@@ -75,6 +75,9 @@ class Dropdown extends Widget
                 continue;
             }
             if (is_string($item)) {
+                if ($item == '---') {
+                    $item = Html::tag('li', '', ['class' => 'divider']);
+                }
                 $lines[] = $item;
                 continue;
             }
@@ -85,8 +88,17 @@ class Dropdown extends Widget
             $options = ArrayHelper::getValue($item, 'options', []);
             $linkOptions = ArrayHelper::getValue($item, 'linkOptions', []);
             $linkOptions['tabindex'] = '-1';
-            $content = Html::a($label, ArrayHelper::getValue($item, 'url', '#'), $linkOptions);
-            if (!empty($item['items'])) {
+            $url = ArrayHelper::getValue($item, 'url', '#');
+            if (empty($item['items'])) {
+                if ($url == '#') {
+                    $content = $label;
+                    Html::addCssClass($options, 'dropdown-header');
+                } else {
+                    $content = Html::a($label, $url, $linkOptions);
+                }
+            } else {
+                $content = Html::a($label, $url, $linkOptions);
+
                 $content .= $this->renderItems($item['items']);
                 Html::addCssClass($options, 'dropdown-submenu');
             }

--- a/extensions/bootstrap/Nav.php
+++ b/extensions/bootstrap/Nav.php
@@ -29,8 +29,8 @@ use yii\helpers\Html;
  *             'label' => 'Dropdown',
  *             'items' => [
  *                  ['label' => 'Level 1 - Dropdown A', 'url' => '#'],
- *                  '<li class="divider"></li>',
- *                  '<li class="dropdown-header">Dropdown Header</li>',
+ *                  '---', // creates a divider
+ *                  ['label' => 'Dropdown Header'], // creaetes a header
  *                  ['label' => 'Level 1 - Dropdown B', 'url' => '#'],
  *             ],
  *         ],
@@ -38,7 +38,9 @@ use yii\helpers\Html;
  * ]);
  * ```
  *
- * Note: Multilevel dropdowns beyond Level 1 are not supported in Bootstrap 3.
+ * Note: Multilevel dropdowns beyond Level 1 are not supported by default in Bootstrap 3.
+ * The internal functionality to generate multi-level menus is available, however custom CSS
+ * is required to make them appear, such as the example at http://www.bootply.com/86684.
  *
  * @see http://getbootstrap.com/components/#dropdowns
  * @see http://getbootstrap.com/components/#nav


### PR DESCRIPTION
Implements headers and dividers in a logical manner similar to Yii 1.1. This allows use of dividers and headers in a more consistent manner (rather than having to manually add HTML), and allows 'visible' and other options to be used.

Items with no URL will become a header. A string with three hyphens will become a divider.

``` php
['label' => 'Secret Areas'],
['label' => 'Nimh', 'url' => 'http://www.imdb.com/title/tt0084649'],
'---'
['label' => 'Not Visible', 'visible' => false],
['label' => 'Yii', 'url' => 'http://www.yiiframework.com']
```

will now become:

``` html
<li class="dropdown-header">Secret Areas</li>
<li><a tabindex="-1" href="http://www.imdb.com/title/tt0084649">Nimh</a></li>
<li class="divider">
<li><a tabindex="-1" href="http://www.yiiframework.com">Yii</a></li>
```

Original code to output submenus (lines 92, 99-104) retained despite lack of support in Bootstrap 3, as functionality can be restored with a few lines of CSS as shown at http://www.bootply.com/86684 .
