### PR TITLE
HHVM compatibility Fixes for Yii 2 Console Application 

### DIFF
--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -49,7 +49,7 @@ class Controller extends \yii\base\Controller
      * @param resource $stream the stream to check.
      * @return boolean Whether to enable ANSI style in output.
      */
-    public function isColorEnabled($stream = STDOUT)
+    public function isColorEnabled($stream = \STDOUT)
     {
         return $this->color ===  null ? Console::streamSupportsAnsiColors($stream) : $this->color;
     }
@@ -192,13 +192,13 @@ class Controller extends \yii\base\Controller
      */
     public function stderr($string)
     {
-        if ($this->isColorEnabled(STDERR)) {
+        if ($this->isColorEnabled(\STDERR)) {
             $args = func_get_args();
             array_shift($args);
             $string = Console::ansiFormat($string, $args);
         }
 
-        return fwrite(STDERR, $string);
+        return fwrite(\STDERR, $string);
     }
 
     /**

--- a/framework/console/ErrorHandler.php
+++ b/framework/console/ErrorHandler.php
@@ -64,7 +64,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
      */
     protected function formatMessage($message, $format = [Console::FG_RED, Console::BOLD])
     {
-        $stream = (PHP_SAPI === 'cli') ? STDERR : STDOUT;
+        $stream = (PHP_SAPI === 'cli') ? \STDERR : \STDOUT;
         // try controller first to allow check for --color switch
         if (Yii::$app->controller instanceof \yii\console\Controller && Yii::$app->controller->isColorEnabled($stream)
             || Yii::$app instanceof \yii\console\Application && Console::streamSupportsAnsiColors($stream)) {

--- a/framework/helpers/BaseConsole.php
+++ b/framework/helpers/BaseConsole.php
@@ -628,7 +628,7 @@ class BaseConsole
      */
     public static function stdin($raw = false)
     {
-        return $raw ? fgets(STDIN) : rtrim(fgets(STDIN), PHP_EOL);
+        return $raw ? fgets(\STDIN) : rtrim(fgets(\STDIN), PHP_EOL);
     }
 
     /**
@@ -639,7 +639,7 @@ class BaseConsole
      */
     public static function stdout($string)
     {
-        return fwrite(STDOUT, $string);
+        return fwrite(\STDOUT, $string);
     }
 
     /**
@@ -650,7 +650,7 @@ class BaseConsole
      */
     public static function stderr($string)
     {
-        return fwrite(STDERR, $string);
+        return fwrite(\STDERR, $string);
     }
 
     /**


### PR DESCRIPTION
testing Yii 2 in HHVM I came across this issue.

https://github.com/yiisoft/yii2/issues/2926

It seems that the problem that is within HHVM when STDOUT etc. are called in a namespaced file it points to a null instance of STDOUT|STDIN, but you can not redefine it because its it already defined.

This is fixed by calling the global namespace of STDOUT etc. This might be fixed in HHVM but this makes the console application work.
