### PR TITLE
[READY] Improve `exist` validator to support array attributes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -48,6 +48,7 @@ Yii Framework 2 Change Log
 - Enh: Added support to insert an event handler at the beginning of class-level event handler queue (qiangxue)
 - Enh: Added `yii\console\Controller::EXIT_CODE_NORMAL` and `yii\console\Controller::EXIT_CODE_ERROR` constants (samdark)
 - Enh: `yii\console\MigrateController` now returns `yii\console\Controller::EXIT_CODE_ERROR` in case of failed migration (samdark)
+- Enh: Added support for arrays for `exist` validator (creocoder)
 - Chg #2913: RBAC `DbManager` is now initialized via migration (samdark)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)
 - Chg #3175: InvalidCallException, InvalidParamException, UnknownMethodException are now extended from SPL BadMethodCallException (samdark)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -48,7 +48,7 @@ Yii Framework 2 Change Log
 - Enh: Added support to insert an event handler at the beginning of class-level event handler queue (qiangxue)
 - Enh: Added `yii\console\Controller::EXIT_CODE_NORMAL` and `yii\console\Controller::EXIT_CODE_ERROR` constants (samdark)
 - Enh: `yii\console\MigrateController` now returns `yii\console\Controller::EXIT_CODE_ERROR` in case of failed migration (samdark)
-- Enh: Added support for arrays for `exist` validator (creocoder)
+- Enh: Added support for array attributes in `exist` validator (creocoder)
 - Chg #2913: RBAC `DbManager` is now initialized via migration (samdark)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)
 - Chg #3175: InvalidCallException, InvalidParamException, UnknownMethodException are now extended from SPL BadMethodCallException (samdark)

--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -97,11 +97,13 @@ class ExistValidator extends Validator
             $params = [$targetAttribute => $object->$attribute];
         }
 
-        foreach ($params as $value) {
-            if (!$this->allowArray && is_array($value)) {
-                $this->addError($object, $attribute, Yii::t('yii', '{attribute} is invalid.'));
+        if (!$this->allowArray) {
+            foreach ($params as $value) {
+                if (is_array($value)) {
+                    $this->addError($object, $attribute, Yii::t('yii', '{attribute} is invalid.'));
 
-                return;
+                    return;
+                }
             }
         }
 

--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -111,7 +111,7 @@ class ExistValidator extends Validator
         $query = $this->createQuery($targetClass, $params);
 
         if (is_array($object->$attribute)) {
-            if ($query->count("DISTINCT [[$targetAttribute]]") === count($object->$attribute)) {
+            if ($query->count("DISTINCT [[$targetAttribute]]") == count($object->$attribute)) {
                 return;
             }
         } elseif ($query->exists()) {

--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -96,10 +96,8 @@ class ExistValidator extends Validator
             if ($query->count() !== count($object->$attribute)) {
                 $this->addError($object, $attribute, $this->message);
             }
-        } else {
-            if (!$query->exists()) {
-                $this->addError($object, $attribute, $this->message);
-            }
+        } elseif (!$query->exists()) {
+            $this->addError($object, $attribute, $this->message);
         }
     }
 

--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -89,19 +89,17 @@ class ExistValidator extends Validator
             $params = [$targetAttribute => $object->$attribute];
         }
 
-        foreach ($params as $value) {
-            if (is_array($value)) {
-                $this->addError($object, $attribute, Yii::t('yii', '{attribute} is invalid.'));
-
-                return;
-            }
-        }
-
         $targetClass = $this->targetClass === null ? get_class($object) : $this->targetClass;
         $query = $this->createQuery($targetClass, $params);
 
-        if (!$query->exists()) {
-            $this->addError($object, $attribute, $this->message);
+        if (is_array($object->$attribute)) {
+            if ($query->count() !== count($object->$attribute)) {
+                $this->addError($object, $attribute, $this->message);
+            }
+        } else {
+            if (!$query->exists()) {
+                $this->addError($object, $attribute, $this->message);
+            }
         }
     }
 

--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -93,12 +93,14 @@ class ExistValidator extends Validator
         $query = $this->createQuery($targetClass, $params);
 
         if (is_array($object->$attribute)) {
-            if ($query->count() !== count($object->$attribute)) {
-                $this->addError($object, $attribute, $this->message);
+            if ($query->count() === count($object->$attribute)) {
+                return;
             }
-        } elseif (!$query->exists()) {
-            $this->addError($object, $attribute, $this->message);
+        } elseif ($query->exists()) {
+            return;
         }
+
+        $this->addError($object, $attribute, $this->message);
     }
 
     /**

--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -111,14 +111,12 @@ class ExistValidator extends Validator
         $query = $this->createQuery($targetClass, $params);
 
         if (is_array($object->$attribute)) {
-            if ($query->count("DISTINCT [[$targetAttribute]]") == count($object->$attribute)) {
-                return;
+            if ($query->count("DISTINCT [[$targetAttribute]]") != count($object->$attribute)) {
+                $this->addError($object, $attribute, $this->message);
             }
-        } elseif ($query->exists()) {
-            return;
+        } elseif (!$query->exists()) {
+            $this->addError($object, $attribute, $this->message);
         }
-
-        $this->addError($object, $attribute, $this->message);
     }
 
     /**
@@ -136,6 +134,9 @@ class ExistValidator extends Validator
         $query = $this->createQuery($this->targetClass, [$this->targetAttribute => $value]);
 
         if (is_array($value)) {
+            if (!$this->allowArray) {
+                return [$this->message, []];
+            }
             return $query->count("DISTINCT [[$this->targetAttribute]]") == count($value) ? null : [$this->message, []];
         } else {
             return $query->exists() ? null : [$this->message, []];

--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -93,7 +93,7 @@ class ExistValidator extends Validator
         $query = $this->createQuery($targetClass, $params);
 
         if (is_array($object->$attribute)) {
-            if ($query->count() === count($object->$attribute)) {
+            if ($query->count() >= count($object->$attribute)) {
                 return;
             }
         } elseif ($query->exists()) {

--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -126,9 +126,6 @@ class ExistValidator extends Validator
      */
     protected function validateValue($value)
     {
-        if (is_array($value)) {
-            return [$this->message, []];
-        }
         if ($this->targetClass === null) {
             throw new InvalidConfigException('The "targetClass" property must be set.');
         }
@@ -138,7 +135,11 @@ class ExistValidator extends Validator
 
         $query = $this->createQuery($this->targetClass, [$this->targetAttribute => $value]);
 
-        return $query->exists() ? null : [$this->message, []];
+        if (is_array($value)) {
+            return $query->count("DISTINCT [[$this->targetAttribute]]") == count($value) ? null : [$this->message, []];
+        } else {
+            return $query->exists() ? null : [$this->message, []];
+        }
     }
 
     /**

--- a/tests/unit/framework/validators/ExistValidatorTest.php
+++ b/tests/unit/framework/validators/ExistValidatorTest.php
@@ -89,13 +89,34 @@ class ExistValidatorTest extends DatabaseTestCase
         $m->a_field = 'some new value';
         $val->validateAttribute($m, 'a_field');
         $this->assertTrue($m->hasErrors('a_field'));
-        // check array
+        // existing array
         $val = new ExistValidator(['targetAttribute' => 'ref']);
         $val->allowArray = true;
         $m = new ValidatorTestRefModel();
         $m->test_val = [2, 3, 4, 5];
         $val->validateAttribute($m, 'test_val');
         $this->assertFalse($m->hasErrors('test_val'));
+        // non-existing array
+        $val = new ExistValidator(['targetAttribute' => 'ref']);
+        $val->allowArray = true;
+        $m = new ValidatorTestRefModel();
+        $m->test_val = [95, 96, 97, 98];
+        $val->validateAttribute($m, 'test_val');
+        $this->assertTrue($m->hasErrors('test_val'));
+        // existing array (allowArray = false)
+        $val = new ExistValidator(['targetAttribute' => 'ref']);
+        $val->allowArray = false;
+        $m = new ValidatorTestRefModel();
+        $m->test_val = [2, 3, 4, 5];
+        $val->validateAttribute($m, 'test_val');
+        $this->assertTrue($m->hasErrors('test_val'));
+        // non-existing array (allowArray = false)
+        $val = new ExistValidator(['targetAttribute' => 'ref']);
+        $val->allowArray = false;
+        $m = new ValidatorTestRefModel();
+        $m->test_val = [95, 96, 97, 98];
+        $val->validateAttribute($m, 'test_val');
+        $this->assertTrue($m->hasErrors('test_val'));
     }
 
     public function testValidateCompositeKeys()

--- a/tests/unit/framework/validators/ExistValidatorTest.php
+++ b/tests/unit/framework/validators/ExistValidatorTest.php
@@ -91,8 +91,8 @@ class ExistValidatorTest extends DatabaseTestCase
         $this->assertTrue($m->hasErrors('a_field'));
         // check array
         $val = new ExistValidator(['targetAttribute' => 'ref']);
-        $m = ValidatorTestRefModel::findOne(['id' => 2]);
-        $m->test_val = [1, 2, 3];
+        $m = new ValidatorTestRefModel();
+        $m->test_val = [2, 3, 4, 5];
         $val->validateAttribute($m, 'test_val');
         $this->assertFalse($m->hasErrors('test_val'));
     }

--- a/tests/unit/framework/validators/ExistValidatorTest.php
+++ b/tests/unit/framework/validators/ExistValidatorTest.php
@@ -95,7 +95,6 @@ class ExistValidatorTest extends DatabaseTestCase
         $m = new ValidatorTestRefModel();
         $m->test_val = [2, 3, 4, 5];
         $val->validateAttribute($m, 'test_val');
-        var_dump($m->errors);
         $this->assertFalse($m->hasErrors('test_val'));
     }
 

--- a/tests/unit/framework/validators/ExistValidatorTest.php
+++ b/tests/unit/framework/validators/ExistValidatorTest.php
@@ -92,7 +92,7 @@ class ExistValidatorTest extends DatabaseTestCase
         // check array
         $val = new ExistValidator(['targetAttribute' => 'ref']);
         $m = ValidatorTestRefModel::findOne(['id' => 2]);
-        $m->test_val = [1,2,3];
+        $m->test_val = [1, 2, 3, 4, 5, 6];
         $val->validateAttribute($m, 'test_val');
         $this->assertTrue($m->hasErrors('test_val'));
     }

--- a/tests/unit/framework/validators/ExistValidatorTest.php
+++ b/tests/unit/framework/validators/ExistValidatorTest.php
@@ -91,9 +91,11 @@ class ExistValidatorTest extends DatabaseTestCase
         $this->assertTrue($m->hasErrors('a_field'));
         // check array
         $val = new ExistValidator(['targetAttribute' => 'ref']);
+        $val->allowArray = true;
         $m = new ValidatorTestRefModel();
         $m->test_val = [2, 3, 4, 5];
         $val->validateAttribute($m, 'test_val');
+        var_dump($m->errors);
         $this->assertFalse($m->hasErrors('test_val'));
     }
 

--- a/tests/unit/framework/validators/ExistValidatorTest.php
+++ b/tests/unit/framework/validators/ExistValidatorTest.php
@@ -103,6 +103,13 @@ class ExistValidatorTest extends DatabaseTestCase
         $m->test_val = [95, 96, 97, 98];
         $val->validateAttribute($m, 'test_val');
         $this->assertTrue($m->hasErrors('test_val'));
+        // partial-existing array
+        $val = new ExistValidator(['targetAttribute' => 'ref']);
+        $val->allowArray = true;
+        $m = new ValidatorTestRefModel();
+        $m->test_val = [2, 97, 3, 98];
+        $val->validateAttribute($m, 'test_val');
+        $this->assertTrue($m->hasErrors('test_val'));
         // existing array (allowArray = false)
         $val = new ExistValidator(['targetAttribute' => 'ref']);
         $val->allowArray = false;

--- a/tests/unit/framework/validators/ExistValidatorTest.php
+++ b/tests/unit/framework/validators/ExistValidatorTest.php
@@ -92,9 +92,9 @@ class ExistValidatorTest extends DatabaseTestCase
         // check array
         $val = new ExistValidator(['targetAttribute' => 'ref']);
         $m = ValidatorTestRefModel::findOne(['id' => 2]);
-        $m->test_val = [1, 2, 3, 4, 5, 6];
+        $m->test_val = [1, 2, 3];
         $val->validateAttribute($m, 'test_val');
-        $this->assertTrue($m->hasErrors('test_val'));
+        $this->assertFalse($m->hasErrors('test_val'));
     }
 
     public function testValidateCompositeKeys()


### PR DESCRIPTION
Use case:

``` php
public function rules()
{
    return [
        [['categoryIds'], 'exist', 'targetClass' => Category::className(), 'targetAttribute' => 'id'],
    ];
}
```
