### PR TITLE
Add missing InvalidConfigException when wrong model validator is used

### DIFF
--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -10,6 +10,7 @@ namespace yii\validators;
 use Yii;
 use yii\base\Component;
 use yii\base\NotSupportedException;
+use yii\base\InvalidConfigException;
 
 /**
  * Validator is the base class for all validators.


### PR DESCRIPTION
When you add a model validator that is missing or for example you have a typo you currently get:

```
PHP Fatal Error 'yii\base\ErrorException' with message 'Class 'yii\validators\InvalidConfigException' not found'
```

Fixed this by adding the correct InvalidConfigException
