### PR TITLE
Allow instance of Column in grid config

### DIFF
--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -478,6 +478,8 @@ class GridView extends BaseListView
         foreach ($this->columns as $i => $column) {
             if (is_string($column)) {
                 $column = $this->createDataColumn($column);
+            } elseif ($column instanceof Column) {
+                $column->grid = $this;
             } else {
                 $column = Yii::createObject(array_merge([
                     'class' => $this->dataColumnClass ? : DataColumn::className(),


### PR DESCRIPTION
Need to use container

``` php
echo GridView::widget(
    [
        'dataProvider' => $dataProvider,
        'filterModel'  => $searchModel,
        'columns'      => [
            'id',
            Yii::$app->get('yii\grid\ActionColumn'),
        ],
    ]
);
```
