### PR TITLE
Prevent csrf meta tags rendering in html emails

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,6 @@ Yii Framework 2 Change Log
 2.0.0-rc under development
 --------------------------
 
-- Bug #3358: Fixed the issue of csrf tags being rendered in html emails (mbman)
 - Bug #1263: Fixed the issue that Gii and Debug modules might be affected by incompatible asset manager configuration (qiangxue)
 - Bug #2563: Theming is not working if the path map of the theme contains ".." or "." in the paths (qiangxue)
 - Bug #2801: Fixed the issue that GridView gets footer content before data cells content (ElisDN)
@@ -25,6 +24,7 @@ Yii Framework 2 Change Log
 - Bug #3268: Fixed the bug that the schema name in a table name was not respected by `yii\db\mysql\Schema` (terazoid, qiangxue)
 - Bug #3311: Fixed the bug that `yii\di\Container::has()` did not return correct value (mgrechanik, qiangxue)
 - Bug #3327: Fixed "Unable to find debug data" when logging objects with circular references (jarekkozak, samdark)
+- Bug #3358: Fixed the issue of csrf tags being rendered in html emails (mbman)
 - Bug #3368: Fix for comparing numeric attributes in JavaScript (technixp)
 - Bug #3431: Allow using extended ErrorHandler class from the app namespace (cebe)
 - Bug #3436: Fixed the issue that `ServiceLocator` still returns the old component after calling `set()` with a new definition (qiangxue)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.0-rc under development
 --------------------------
 
+- Bug #3358: Fixed the issue of csrf tags being rendered in html emails (mbman)
 - Bug #1263: Fixed the issue that Gii and Debug modules might be affected by incompatible asset manager configuration (qiangxue)
 - Bug #2563: Theming is not working if the path map of the theme contains ".." or "." in the paths (qiangxue)
 - Bug #2801: Fixed the issue that GridView gets footer content before data cells content (ElisDN)

--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -276,12 +276,17 @@ abstract class BaseMailer extends Component implements MailerInterface, ViewCont
      */
     public function render($view, $params = [], $layout = false)
     {
+        // Temporary disable Csrf Validation since it's not needed in emails
+        $request = Yii::$app->getRequest();
+        $enableCsrfValidation = $request->enableCsrfValidation;
+        $request->enableCsrfValidation = false;
+
         $output = $this->getView()->render($view, $params, $this);
         if ($layout !== false) {
-            return $this->getView()->render($layout, ['content' => $output], $this);
-        } else {
-            return $output;
+            $output = $this->getView()->render($layout, ['content' => $output], $this);
         }
+        $request->enableCsrfValidation = $enableCsrfValidation;
+        return $output;
     }
 
     /**

--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -278,14 +278,19 @@ abstract class BaseMailer extends Component implements MailerInterface, ViewCont
     {
         // Temporary disable Csrf Validation since it's not needed in emails
         $request = Yii::$app->getRequest();
-        $enableCsrfValidation = $request->enableCsrfValidation;
-        $request->enableCsrfValidation = false;
+        $isWebRequest = $request instanceof yii\web\Request;
+        if ($isWebRequest) {
+            $enableCsrfValidation = $request->enableCsrfValidation;
+            $request->enableCsrfValidation = false;
+        }
 
         $output = $this->getView()->render($view, $params, $this);
         if ($layout !== false) {
             $output = $this->getView()->render($layout, ['content' => $output], $this);
         }
-        $request->enableCsrfValidation = $enableCsrfValidation;
+        if ($isWebRequest) {
+            $request->enableCsrfValidation = $enableCsrfValidation;
+        }
         return $output;
     }
 


### PR DESCRIPTION
`BaseMailer->reneder()` temporary disables `Yii::$app->getRequest()->enableCsrfValidation` to prevent Csrf meta tags from being rendered in html email. Fixes #3358
