### PR TITLE
Cant use textInput without a wrapping tag.

### DIFF
--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -193,26 +193,26 @@ class ActiveField extends Component
      */
     public function begin()
     {
-      $clientOptions = $this->getClientOptions();
-      if (!empty($clientOptions)) {
-        $this->form->attributes[$this->attribute] = $clientOptions;
-      }
+        $clientOptions = $this->getClientOptions();
+        if (!empty($clientOptions)) {
+            $this->form->attributes[$this->attribute] = $clientOptions;
+        }
 
-      $inputID = Html::getInputId($this->model, $this->attribute);
-      $attribute = Html::getAttributeName($this->attribute);
-      $options = $this->options;
-      $class = isset($options['class']) ? [$options['class']] : [];
-      $class[] = "field-$inputID";
-      if ($this->model->isAttributeRequired($attribute)) {
-        $class[] = $this->form->requiredCssClass;
-      }
-      if ($this->model->hasErrors($attribute)) {
-        $class[] = $this->form->errorCssClass;
-      }
-      $options['class'] = implode(' ', $class);
-      $tag = ArrayHelper::remove($options, 'tag', 'div');
+        $inputID = Html::getInputId($this->model, $this->attribute);
+        $attribute = Html::getAttributeName($this->attribute);
+        $options = $this->options;
+        $class = isset($options['class']) ? [$options['class']] : [];
+        $class[] = "field-$inputID";
+        if ($this->model->isAttributeRequired($attribute)) {
+            $class[] = $this->form->requiredCssClass;
+        }
+        if ($this->model->hasErrors($attribute)) {
+            $class[] = $this->form->errorCssClass;
+        }
+        $options['class'] = implode(' ', $class);
+        $tag = ArrayHelper::remove($options, 'tag', 'div');
 
-      return (empty($tag) ? "" : Html::beginTag($tag, $options));
+        return (empty($tag) ? "" : Html::beginTag($tag, $options));
     }
 
     /**
@@ -221,8 +221,8 @@ class ActiveField extends Component
      */
     public function end()
     {
-      $tag = ArrayHelper::remove($this->options, 'tag', 'div');
-      return (empty($tag) ? "" : Html::endTag($tag));
+        $tag = ArrayHelper::remove($this->options, 'tag', 'div');
+        return (empty($tag) ? "" : Html::endTag($tag));
     }
 
     /**

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -189,39 +189,40 @@ class ActiveField extends Component
 
     /**
      * Renders the opening tag of the field container.
-     * @return string the rendering result.
+     * @return string the rendering result or if tag is NULL then returns an empty string.
      */
     public function begin()
     {
-        $clientOptions = $this->getClientOptions();
-        if (!empty($clientOptions)) {
-            $this->form->attributes[$this->attribute] = $clientOptions;
-        }
+      $clientOptions = $this->getClientOptions();
+      if (!empty($clientOptions)) {
+        $this->form->attributes[$this->attribute] = $clientOptions;
+      }
 
-        $inputID = Html::getInputId($this->model, $this->attribute);
-        $attribute = Html::getAttributeName($this->attribute);
-        $options = $this->options;
-        $class = isset($options['class']) ? [$options['class']] : [];
-        $class[] = "field-$inputID";
-        if ($this->model->isAttributeRequired($attribute)) {
-            $class[] = $this->form->requiredCssClass;
-        }
-        if ($this->model->hasErrors($attribute)) {
-            $class[] = $this->form->errorCssClass;
-        }
-        $options['class'] = implode(' ', $class);
-        $tag = ArrayHelper::remove($options, 'tag', 'div');
+      $inputID = Html::getInputId($this->model, $this->attribute);
+      $attribute = Html::getAttributeName($this->attribute);
+      $options = $this->options;
+      $class = isset($options['class']) ? [$options['class']] : [];
+      $class[] = "field-$inputID";
+      if ($this->model->isAttributeRequired($attribute)) {
+        $class[] = $this->form->requiredCssClass;
+      }
+      if ($this->model->hasErrors($attribute)) {
+        $class[] = $this->form->errorCssClass;
+      }
+      $options['class'] = implode(' ', $class);
+      $tag = ArrayHelper::remove($options, 'tag', 'div');
 
-        return Html::beginTag($tag, $options);
+      return (empty($tag) ? "" : Html::beginTag($tag, $options));
     }
 
     /**
      * Renders the closing tag of the field container.
-     * @return string the rendering result.
+     * @return string the rendering result or if tag is NULL then returns an empty string.
      */
     public function end()
     {
-        return Html::endTag(isset($this->options['tag']) ? $this->options['tag'] : 'div');
+      $tag = ArrayHelper::remove($this->options, 'tag', 'div');
+      return (empty($tag) ? "" : Html::endTag($tag));
     }
 
     /**


### PR DESCRIPTION
added an option to set tag to NULL so that elements are not always wrapped in a tag, makes it easier to apply bootstrap styles.
