### PR TITLE
Improve functionality

### DIFF
--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -727,8 +727,8 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      * The data to be loaded is `$data[formName]`, where `formName` refers to the value of [[formName()]].
      * If [[formName()]] is empty, the whole `$data` array will be used to populate the model.
      * The data being populated is subject to the safety check by [[setAttributes()]].
-     * @param array $data the data array. This is usually `$_POST` or `$_GET`, but can also be any valid array
-     * supplied by end user.
+     * @param array|string $data the data array. This is usually `$_POST` or `$_GET`, but can also be any valid array
+     * supplied by end user. Also it can be string 'post' or 'get' - in this case data will be loaded from the corresponding request.
      * @param string $formName the form name to be used for loading the data into the model.
      * If not set, [[formName()]] will be used.
      * @return boolean whether the model is successfully populated with some data.
@@ -736,6 +736,13 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
     public function load($data, $formName = null)
     {
         $scope = $formName === null ? $this->formName() : $formName;
+        if(is_string($data)){
+            switch(strtolower($data)){
+                case 'post' : $data = Yii::$app->request->post(); break;
+                case 'get' : $data = Yii::$app->request->get(); break;
+                default: return false;
+            }
+        }
         if ($scope == '' && !empty($data)) {
             $this->setAttributes($data);
 

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1098,7 +1098,7 @@ class BaseHtml
      * @param Model $model the model object
      * @param string $attribute the attribute name or expression. See [[getAttributeName()]] for the format
      * about attribute expression.
-     * @param array $options the tag options in terms of name-value pairs. By default the values will be HTML-encoded
+     * @param array $options the tag options in terms of name-value pairs. The values will be HTML-encoded
      * using [[encode()]]. If a value is null, the corresponding attribute will not be rendered.
      *
      * The following options are specially handled:

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1099,11 +1099,12 @@ class BaseHtml
      * @param string $attribute the attribute name or expression. See [[getAttributeName()]] for the format
      * about attribute expression.
      * @param array $options the tag options in terms of name-value pairs. By default the values will be HTML-encoded
-     * using [[encode()]], you can change it with setting 'encode' option to false. If a value is null, the corresponding attribute will not be rendered.
+     * using [[encode()]]. If a value is null, the corresponding attribute will not be rendered.
      *
      * The following options are specially handled:
      *
      * - tag: this specifies the tag name. If not set, "div" will be used.
+     * - encode: boolean, whether to HTML-encode the error message. Defaults to true.
      *
      * See [[renderTagAttributes()]] for details on how attributes are being rendered.
      *

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1098,8 +1098,8 @@ class BaseHtml
      * @param Model $model the model object
      * @param string $attribute the attribute name or expression. See [[getAttributeName()]] for the format
      * about attribute expression.
-     * @param array $options the tag options in terms of name-value pairs. The values will be HTML-encoded
-     * using [[encode()]]. If a value is null, the corresponding attribute will not be rendered.
+     * @param array $options the tag options in terms of name-value pairs. By default the values will be HTML-encoded
+     * using [[encode()]], you can change it with setting 'encode' option to false. If a value is null, the corresponding attribute will not be rendered.
      *
      * The following options are specially handled:
      *
@@ -1113,10 +1113,12 @@ class BaseHtml
     {
         $attribute = static::getAttributeName($attribute);
         $error = $model->getFirstError($attribute);
+        $encode = !isset($options['encode']) || $options['encode'];
+        unset($options['encode']);
         $tag = isset($options['tag']) ? $options['tag'] : 'div';
         unset($options['tag']);
 
-        return Html::tag($tag, Html::encode($error), $options);
+        return Html::tag($tag, $encode ? Html::encode($error) : $error, $options);
     }
 
     /**


### PR DESCRIPTION
Sometimes it is very usefull to append to error message a link. We can't add it while error message is encoded.
