### PR TITLE
[travis-ci] Allow fast finishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 # run build against PHP 5.6 and hhvm but allow them to fail
 # http://docs.travis-ci.com/user/build-configuration/#Rows-That-are-Allowed-To-Fail
 matrix:
+  fast_finish: true
   allow_failures:
     - php: hhvm
     - php: 5.6


### PR DESCRIPTION
With a single test run easily exceeding half an hour of cumulative time, we should be getting build results a bit sooner. This PR allows [fast finishing](http://docs.travis-ci.com/user/build-configuration/#Fast-finishing) in Travis CI. As a result, a build is being marked as "passed" if either:
1. A job that is not allowed to fail has indeed failed
2. all remaining jobs are allowed to fail.

It is important to note that this doesn't actually _skip_ any jobs (cf travis-ci/travis-ci#2260).

See also: http://blog.travis-ci.com/2013-11-27-fast-finishing-builds/
