### PR TITLE
[WIP] Improve `in` validator to properly support array attributes

### DIFF
--- a/framework/validators/RangeValidator.php
+++ b/framework/validators/RangeValidator.php
@@ -55,8 +55,14 @@ class RangeValidator extends Validator
      */
     protected function validateValue($value)
     {
-        $valid = !$this->not && in_array($value, $this->range, $this->strict)
-            || $this->not && !in_array($value, $this->range, $this->strict);
+        $valid = false;
+
+        foreach ((array)$value as $v) {
+            if (!($valid = !$this->not && in_array($v, $this->range, $this->strict)
+                || $this->not && !in_array($v, $this->range, $this->strict))) {
+                break;
+            }
+        }
 
         return $valid ? null : [$this->message, []];
     }

--- a/framework/validators/RangeValidator.php
+++ b/framework/validators/RangeValidator.php
@@ -35,6 +35,10 @@ class RangeValidator extends Validator
      * the attribute value should NOT be among the list of values defined via [[range]].
      */
     public $not = false;
+    /**
+     * @var boolean whether to allow array type attribute.
+     */
+    public $allowArray = false;
 
     /**
      * @inheritdoc
@@ -55,6 +59,10 @@ class RangeValidator extends Validator
      */
     protected function validateValue($value)
     {
+        if (!$this->allowArray && is_array($value)) {
+            return [$this->message, []];
+        }
+
         $valid = false;
 
         foreach ((array)$value as $v) {

--- a/tests/unit/framework/helpers/HtmlTest.php
+++ b/tests/unit/framework/helpers/HtmlTest.php
@@ -289,7 +289,7 @@ EOD;
 <option value="value2">text2</option>
 </select>
 EOD;
-        $this->assertEqualsWithoutLE($expected, Html::listBox('test', null, $this->getDataItems(), ['size' => 5]));
+        $this->assertEqualsWithoutLE($expected, Html::listBox('test', null, $this->getDataItems(), ['size' => 5, 'encodeSpaces' => true]));
         $expected = <<<EOD
 <select name="test" size="4">
 <option value="value1&lt;&gt;">text1&lt;&gt;</option>
@@ -495,8 +495,12 @@ EOD;
             'groups' => [
                 'group12' => ['class' => 'group'],
             ],
+            'encodeSpaces' => true,
         ];
         $this->assertEqualsWithoutLE($expected, Html::renderSelectOptions(['value111', 'value1'], $data, $attributes));
+
+        $attributes['encodeSpaces'] = false;
+        $this->assertEqualsWithoutLE(str_replace('&nbsp;', ' ', $expected), Html::renderSelectOptions(['value111', 'value1'], $data, $attributes));
     }
 
     public function testRenderAttributes()


### PR DESCRIPTION
Use case:

``` php
public function rules()
{
    return [
        [['sectionIds'], 'in', 'range' => [Section::BOOKING, Section::REPRESENTATIVE, Section::CREATIVE],
    ];
}
```
