### PR TITLE
Gii CRUD generator search model class table missing bugfix

### DIFF
--- a/extensions/gii/generators/crud/default/search.php
+++ b/extensions/gii/generators/crud/default/search.php
@@ -1,7 +1,6 @@
 <?php
 
 use yii\helpers\StringHelper;
-use yii\helpers\Inflector;
 
 /**
  * This is the template for generating CRUD search class of the specified model.
@@ -11,6 +10,7 @@ use yii\helpers\Inflector;
  */
 
 $modelClass = StringHelper::basename($generator->modelClass);
+$modelClassNamespaced = $generator->modelClass;
 $searchModelClass = StringHelper::basename($generator->searchModelClass);
 if ($modelClass === $searchModelClass) {
     $modelAlias = $modelClass . 'Model';
@@ -38,7 +38,7 @@ class <?= $searchModelClass ?> extends <?= isset($modelAlias) ? $modelAlias : $m
 {
     public static function tableName()
     {
-        return '{{%<?= Inflector::underscore($modelClass) ?>}}';
+        return '<?= $modelClassNamespaced::tableName() ?>';
     }
 
     public function rules()

--- a/extensions/gii/generators/crud/default/search.php
+++ b/extensions/gii/generators/crud/default/search.php
@@ -1,6 +1,7 @@
 <?php
 
 use yii\helpers\StringHelper;
+use yii\helpers\Inflector;
 
 /**
  * This is the template for generating CRUD search class of the specified model.
@@ -35,6 +36,11 @@ use <?= ltrim($generator->modelClass, '\\') . (isset($modelAlias) ? " as $modelA
 class <?= $searchModelClass ?> extends <?= isset($modelAlias) ? $modelAlias : $modelClass ?>
 
 {
+    public static function tableName()
+    {
+        return '{{%<?= Inflector::underscore($modelClass) ?>}}';
+    }
+
     public function rules()
     {
         return [


### PR DESCRIPTION
Gii CRUD generated Search Model Class would report the table was missing when the search class name was different then the model name. Resolved by adding `tableName()` which returns the parent model class name converted to table name using `yii\helpers\Inflector::underscore()` method.
