### PR TITLE
Change data-confirm dialog implementation to callback style.

### DIFF
--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -72,27 +72,16 @@ yii = (function ($) {
         },
 
         /**
-         * Displays a confirmation dialog.
+         * Displays a confirmation dialog and may execute an action if confirmed to do it.
          * The default implementation simply displays a js confirmation dialog.
          * You may override this by setting `yii.confirm`.
          * @param message the confirmation message.
-         * @return boolean whether the user confirms with the message in the dialog
+         * @param action the action if user may allow.
          */
-        confirm: function (message) {
-            return confirm(message);
-        },
-
-        /**
-         * Returns a value indicating whether to allow executing the action defined for the specified element.
-         * This method recognizes the `data-confirm` attribute of the element and uses it
-         * as the message in a confirmation dialog. The method will return true if this special attribute
-         * is not defined or if the user confirms the message.
-         * @param $e the jQuery representation of the element
-         * @return boolean whether to allow executing the action defined for the specified element.
-         */
-        allowAction: function ($e) {
-            var message = $e.data('confirm');
-            return message === undefined || pub.confirm(message);
+        confirm: function (message, action) {
+            if (confirm(message)) {
+                action();
+            }
         },
 
         /**
@@ -107,14 +96,12 @@ yii = (function ($) {
          * If the `data-method` attribute is not defined, the default element action will be performed.
          *
          * @param $e the jQuery representation of the element
-         * @return boolean whether to execute the default action for the element.
          */
         handleAction: function ($e) {
             var method = $e.data('method');
             if (method === undefined) {
-                return true;
+                return;
             }
-
             var $form = $e.closest('form');
             var action = $e.prop('href');
             var newForm = !$form.length || action;
@@ -156,8 +143,6 @@ yii = (function ($) {
             if (newForm) {
                 $form.remove();
             }
-
-            return false;
         },
 
         getQueryParams: function (url) {
@@ -215,27 +200,28 @@ yii = (function ($) {
 
     function initDataMethods() {
         var $document = $(document);
-        // handle data-confirm and data-method for clickable elements
-        $document.on('click.yii', pub.clickableSelector, function (event) {
+        var handler = function (event) {
             var $this = $(this);
-            if (pub.allowAction($this)) {
-                return pub.handleAction($this);
-            } else {
-                event.stopImmediatePropagation();
-                return false;
+            if ($this.data('method') === undefined) {
+                return true;
             }
-        });
+            var message = $this.data('confirm');
+            if (message === undefined) {
+                pub.handleAction($this);
+            } else {
+                pub.confirm(message, function() {
+                    pub.handleAction($this);
+                });
+                event.stopImmediatePropagation();
+            }
+            return false;
+        };
+
+        // handle data-confirm and data-method for clickable elements
+        $document.on('click.yii', pub.clickableSelector, handler);
 
         // handle data-confirm and data-method for changeable elements
-        $document.on('change.yii', pub.changeableSelector, function (event) {
-            var $this = $(this);
-            if (pub.allowAction($this)) {
-                return pub.handleAction($this);
-            } else {
-                event.stopImmediatePropagation();
-                return false;
-            }
-        });
+        $document.on('change.yii', pub.changeableSelector, handler);
     }
 
     function initScriptFilter() {


### PR DESCRIPTION
To create custom dialog for `yii.confirm`, current design is so inconvenient.

JSe's standard `confirm()` function can block event handling until user input. But most of custom modal UI (for example using Bootbox.js http://bootboxjs.com/) can't control script processing. I suggest to change handling `data-confirm` and `data-method` from return-style to callback-style.

I've succeeded to create my dialog box using Bootstrap's Modal component by my callback version.

``` html
<div id="my-confirm" class="modal fade">
    <div class="modal-dialog">
        <div class="modal-content">
            <div class="modal-body">
                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                <p></p>
            </div>
            <div class="modal-footer">
                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                <button type="button" class="btn btn-primary confirm-ok">OK</button>
            </div>
        </div>
    </div>
</div>
```

``` javascript
var $confirmModal = jQuery("#my-confirm");

$confirmModal.find(".confirm-ok").on("click", function() {
    var action = $confirmModal.data("ok-action");
    if (action !== undefined) {
        $confirmModal.on("hidden.bs.modal", function() {
            $confirmModal.off("hidden.bs.modal", arguments.callee);
            action();
        });
    }
    $confirmModal.modal("hide");
});

yii.confirm = function(message, action) {
    $confirmModal.find(".modal-body p").text(message);
    $confirmModal.data("ok-action", action);
    $confirmModal.modal("show");
};
```
