### PR TITLE
Handle invalid code sequences in Html::encode()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -46,6 +46,7 @@ Yii Framework 2 Change Log
 - Enh #3252: Added support for case insensitive matching using ILIKE to PostgreSQL QueryBuilder (cebe)
 - Enh #3298: Supported configuring `View::theme` using a class name (netyum, qiangxue)
 - Enh #3328: `BaseMailer` generates better text body from html body (armab)
+- Enh #3518: `yii\helpers\Html::encode()` now replaces invalid code sequences with "�" (DaSourcerer)
 - Enh: Added support for using sub-queries when building a DB query with `IN` condition (qiangxue)
 - Enh: Supported adding a new response formatter without the need to reconfigure existing formatters (qiangxue)
 - Enh: Added `yii\web\UrlManager::addRules()` to simplify adding new URL rules (qiangxue)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -92,7 +92,7 @@ class BaseHtml
      */
     public static function encode($content, $doubleEncode = true)
     {
-        return htmlspecialchars($content, ENT_QUOTES, Yii::$app->charset, $doubleEncode);
+        return htmlspecialchars($content, ENT_QUOTES | ENT_SUBSTITUTE, Yii::$app->charset, $doubleEncode);
     }
 
     /**

--- a/tests/unit/framework/helpers/HtmlTest.php
+++ b/tests/unit/framework/helpers/HtmlTest.php
@@ -38,7 +38,7 @@ class HtmlTest extends TestCase
 
     public function testEncode()
     {
-        $this->assertEquals("a&lt;&gt;&amp;&quot;&#039;", Html::encode("a<>&\"'"));
+        $this->assertEquals("a&lt;&gt;&amp;&quot;&#039;�", Html::encode("a<>&\"'\x80"));
     }
 
     public function testDecode()


### PR DESCRIPTION
As described in [this blog post](http://nikic.github.io/2012/01/28/htmlspecialchars-improvements-in-PHP-5-4.html), PHP 5.4 introduced a new flag to `htmlspecialchars()` allowing invalid code sequences being replaced by &#xfffd; (REPLACEMENT CHARACTER).

Accepting this PR will highten security of Yii 2 apps and bring the framework closer to the recommendations found in the [Unicode Security Considerations](http://unicode.org/reports/tr36/#Some_Output_For_All_Input).
