### PR TITLE
#3522 normalizepath to allow current path

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -132,6 +132,7 @@ Yii Framework 2 Change Log
 - Bug #2848: Individual queries should be enclosed within parenthesis in a UNION query (qiangxue)
 - Bug #2862: Using `DbCache` while enabling schema caching may cause infinite loops (qiangxue)
 - Bug #3052: Fixed the issue that cache dependency data is not reused when `reusable` is set true (qiangxue)
+- Bug #3522: Fixed BaseFileHelper::normalizePath to allow a (.) for the current path.
 - Bug: Fixed `Call to a member function registerAssetFiles() on a non-object` in case of wrong `sourcePath` for an asset bundle (samdark)
 - Bug: Fixed incorrect event name for `yii\jui\Spinner` (samdark)
 - Bug: Json::encode() did not handle objects that implement JsonSerializable interface correctly (cebe)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -28,6 +28,7 @@ Yii Framework 2 Change Log
 - Bug #3431: Allow using extended ErrorHandler class from the app namespace (cebe)
 - Bug #3436: Fixed the issue that `ServiceLocator` still returns the old component after calling `set()` with a new definition (qiangxue)
 - Bug #3458: Fixed the bug that the image rendered by `CaptchaAction` was using a wrong content type (MDMunir, qiangxue)
+- Bug #3522: Fixed BaseFileHelper::normalizePath to allow a (.) for the current path. (skotos)
 - Bug: Fixed inconsistent return of `\yii\console\Application::runAction()` (samdark)
 - Enh #2264: `CookieCollection::has()` will return false for expired or removed cookies (qiangxue)
 - Enh #2435: `yii\db\IntegrityException` is now thrown on database integrity errors instead of general `yii\db\Exception` (samdark)
@@ -132,7 +133,6 @@ Yii Framework 2 Change Log
 - Bug #2848: Individual queries should be enclosed within parenthesis in a UNION query (qiangxue)
 - Bug #2862: Using `DbCache` while enabling schema caching may cause infinite loops (qiangxue)
 - Bug #3052: Fixed the issue that cache dependency data is not reused when `reusable` is set true (qiangxue)
-- Bug #3522: Fixed BaseFileHelper::normalizePath to allow a (.) for the current path.
 - Bug: Fixed `Call to a member function registerAssetFiles() on a non-object` in case of wrong `sourcePath` for an asset bundle (samdark)
 - Bug: Fixed incorrect event name for `yii\jui\Spinner` (samdark)
 - Bug: Json::encode() did not handle objects that implement JsonSerializable interface correctly (cebe)

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -58,7 +58,7 @@ class BaseFileHelper
                 $parts[] = $part;
             }
         }
-        if (count($parts)>1 && $parts[0] === '.') {
+        if (count($parts) > 1 && $parts[0] === '.') {
             array_shift($parts);
         }
         return implode($ds, $parts);

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -49,19 +49,15 @@ class BaseFileHelper
         $parts = [];
         foreach (explode($ds, $path) as $part) {
             if ($part === '..' && !empty($parts) && end($parts) !== '..') {
-                if (array_pop($parts) === ".") {
-                    $parts[] = '..';
-                }
-            } elseif (( $part === '.' || $part === '' ) && !empty($parts)) {
+                array_pop($parts);
+            } elseif ($part === '.' || $part === '' && !empty($parts)) {
                 continue;
             } else {
                 $parts[] = $part;
             }
         }
-        if (count($parts) > 1 && $parts[0] === '.') {
-            array_shift($parts);
-        }
-        return implode($ds, $parts);
+        $path = implode($ds, $parts);
+        return $path === '' ? '.' : $path;
     }
 
     /**

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -49,12 +49,17 @@ class BaseFileHelper
         $parts = [];
         foreach (explode($ds, $path) as $part) {
             if ($part === '..' && !empty($parts) && end($parts) !== '..') {
-                array_pop($parts);
-            } elseif ($part === '.' || $part === '' && !empty($parts)) {
+                if (array_pop($parts) === ".") {
+                    $parts[] = '..';
+                }
+            } elseif (( $part === '.' || $part === '' ) && !empty($parts)) {
                 continue;
             } else {
                 $parts[] = $part;
             }
+        }
+        if (count($parts)>1 && $parts[0] === '.') {
+            array_shift($parts);
         }
         return implode($ds, $parts);
     }

--- a/tests/unit/framework/helpers/FileHelperTest.php
+++ b/tests/unit/framework/helpers/FileHelperTest.php
@@ -369,10 +369,16 @@ class FileHelperTest extends TestCase
         $this->assertEquals("..{$ds}c", FileHelper::normalizePath('//a/.\\b//..//..//../../c'));
 
         // relative paths
+        $this->assertEquals(".", FileHelper::normalizePath('.'));
+        $this->assertEquals(".", FileHelper::normalizePath('./'));
+        $this->assertEquals("a", FileHelper::normalizePath('.\\a'));
+        $this->assertEquals("a/b", FileHelper::normalizePath('./a\\b'));
+        $this->assertEquals(".", FileHelper::normalizePath('./a\\../'));
         $this->assertEquals("..{$ds}..{$ds}a", FileHelper::normalizePath('../..\\a'));
         $this->assertEquals("..{$ds}..{$ds}a", FileHelper::normalizePath('../..\\a/../a'));
         $this->assertEquals("..{$ds}..{$ds}b", FileHelper::normalizePath('../..\\a/../b'));
         $this->assertEquals("..{$ds}a", FileHelper::normalizePath('./..\\a'));
+        $this->assertEquals("..{$ds}a", FileHelper::normalizePath('././..\\a'));
         $this->assertEquals("..{$ds}a", FileHelper::normalizePath('./..\\a/../a'));
         $this->assertEquals("..{$ds}b", FileHelper::normalizePath('./..\\a/../b'));
     }

--- a/tests/unit/framework/helpers/FileHelperTest.php
+++ b/tests/unit/framework/helpers/FileHelperTest.php
@@ -372,7 +372,7 @@ class FileHelperTest extends TestCase
         $this->assertEquals(".", FileHelper::normalizePath('.'));
         $this->assertEquals(".", FileHelper::normalizePath('./'));
         $this->assertEquals("a", FileHelper::normalizePath('.\\a'));
-        $this->assertEquals("a/b", FileHelper::normalizePath('./a\\b'));
+        $this->assertEquals("a{$ds}b", FileHelper::normalizePath('./a\\b'));
         $this->assertEquals(".", FileHelper::normalizePath('./a\\../'));
         $this->assertEquals("..{$ds}..{$ds}a", FileHelper::normalizePath('../..\\a'));
         $this->assertEquals("..{$ds}..{$ds}a", FileHelper::normalizePath('../..\\a/../a'));


### PR DESCRIPTION
The patch for #3522  mainly affects BaseFileHelper.php::normalizePath() in the following ways:
- 55 - Added parentheses so that a . is preserved if it is the first part of the path.
- 52-54 A `..` part will not be cancelled if the preceding part that is popped is `.`  Therefore `./../a` becomes `../a` and not `a`.
- 61-63 Drops the preceeding . if there are more parts. ( `./a` becomes `a`)  This is places after the main logic so that `./a/../` will still be parsed to `.`
