### PR TITLE
Support for php namespaces, static methods and yii widgets for Twig

### DIFF
--- a/extensions/twig/ViewRenderer.php
+++ b/extensions/twig/ViewRenderer.php
@@ -124,7 +124,7 @@ class ViewRenderer extends BaseViewRenderer
         }
 
         // Adding global 'void' function (usage: {{void(App.clientScript.registerScriptFile(...))}})
-        $this->twig->addFunction(new \Twig_SimpleFunction('void', function ($argument) {
+        $this->twig->addFunction(new \Twig_SimpleFunction('void', function () {
         }));
 
         $this->twig->addFunction(new \Twig_SimpleFunction('path', function ($path, $args = []) {

--- a/extensions/twig/ViewRenderer.php
+++ b/extensions/twig/ViewRenderer.php
@@ -124,26 +124,26 @@ class ViewRenderer extends BaseViewRenderer
         }
 
         // Adding global 'void' function (usage: {{void(App.clientScript.registerScriptFile(...))}})
-        $this->twig->addFunction('void', new \Twig_Function_Function(function ($argument) {
+        $this->twig->addFunction(new \Twig_SimpleFunction('void', function ($argument) {
         }));
 
-        $this->twig->addFunction('path', new \Twig_Function_Function(function ($path, $args = []) {
+        $this->twig->addFunction(new \Twig_SimpleFunction('path', function ($path, $args = []) {
             return Url::to(array_merge([$path], $args));
         }));
 
-        $this->twig->addFunction('url', new \Twig_Function_Function(function ($path, $args = []) {
+        $this->twig->addFunction(new \Twig_SimpleFunction('url', function ($path, $args = []) {
             return Url::to(array_merge([$path], $args), true);
         }));
 
-        $this->twig->addFunction('form_begin', new \Twig_Function_Function(function ($args = []) {
+        $this->twig->addFunction(new \Twig_SimpleFunction('form_begin', function ($args = []) {
             return ActiveForm::begin($args);
         }));
 
-        $this->twig->addFunction('form_end', new \Twig_Function_Function(function () {
+        $this->twig->addFunction(new \Twig_SimpleFunction('form_end', function () {
             ActiveForm::end();
         }));
 
-        $this->twig->addFunction('use', new \Twig_Function_Function(function($namespaces) {
+        $this->twig->addFunction(new \Twig_SimpleFunction('use', function($namespaces) {
             if(!is_array($namespaces)) {
                 $namespaces = array($namespaces);
             }
@@ -154,35 +154,35 @@ class ViewRenderer extends BaseViewRenderer
             return null;
         }));
 
-        $this->twig->addFunction('static', new \Twig_Function_Function(function($name, $method, $args = []) {
+        $this->twig->addFunction(new \Twig_SimpleFunction('static', function($name, $method, $args = []) {
             if(isset($this->namespaces[$name]))
                 $name = $this->namespaces[$name];
 
             $name::$method($args);
         }));
 
-        $this->twig->addFunction('echo_static', new \Twig_Function_Function(function($name, $method, $args = []) {
+        $this->twig->addFunction(new \Twig_SimpleFunction('echo_static', function($name, $method, $args = []) {
             if(isset($this->namespaces[$name]))
                 $name = $this->namespaces[$name];
 
             return $name::$method($args);
         }),['is_safe' => ['html']]);
 
-        $this->twig->addFunction('widget', new \Twig_Function_Function(function ($name, $args = []) {
+        $this->twig->addFunction(new \Twig_SimpleFunction('widget', function ($name, $args = []) {
             if(isset($this->namespaces[$name]))
                 $name = $this->namespaces[$name];
 
             return $name::widget($args);
         },['is_safe' => ['html']]));
 
-        $this->twig->addFunction('widget_begin', new \Twig_Function_Function(function($name, $args = []) {
+        $this->twig->addFunction(new \Twig_SimpleFunction('widget_begin', function($name, $args = []) {
             if(isset($this->namespaces[$name]))
                 $name = $this->namespaces[$name];
 
             $name::begin($args);
         }));
 
-        $this->twig->addFunction('widget_end', new \Twig_Function_Function(function($name, $args = []){
+        $this->twig->addFunction(new \Twig_SimpleFunction('widget_end', function($name, $args = []){
             if(isset($this->namespaces[$name]))
                 $name = $this->namespaces[$name];
 

--- a/extensions/twig/ViewRenderer.php
+++ b/extensions/twig/ViewRenderer.php
@@ -156,17 +156,27 @@ class ViewRenderer extends BaseViewRenderer
         }));
 
         $this->twig->addFunction(new \Twig_SimpleFunction('static', function($name, $method, $args = []) {
+            $args = func_get_args();
+            $name = $args[0];
+            $method = $args[1];
+            unset($args[0], $args[1]);
+
             if(isset($this->namespaces[$name]))
                 $name = $this->namespaces[$name];
 
-            $name::$method($args);
+            call_user_func_array([$name, $method], $args);
         }));
 
         $this->twig->addFunction(new \Twig_SimpleFunction('echo_static', function($name, $method, $args = []) {
+            $args = func_get_args();
+            $name = $args[0];
+            $method = $args[1];
+            unset($args[0], $args[1]);
+
             if(isset($this->namespaces[$name]))
                 $name = $this->namespaces[$name];
 
-            return $name::$method($args);
+            return call_user_func_array([$name, $method], $args);
         },['is_safe' => ['html']]));
 
         $this->twig->addFunction(new \Twig_SimpleFunction('widget', function ($name, $args = []) {

--- a/extensions/twig/ViewRenderer.php
+++ b/extensions/twig/ViewRenderer.php
@@ -147,9 +147,10 @@ class ViewRenderer extends BaseViewRenderer
             if(!is_array($namespaces)) {
                 $namespaces = array($namespaces);
             }
-            foreach($namespaces as $name) {
-                $class = end(explode('\\', $name));
-                $this->namespaces[ $class ] = $name;
+            foreach($namespaces as $namespace) {
+                $elems = explode('\\', $namespace);
+                $class = end($elems);
+                $this->namespaces[ $class ] = $namespace;
             }
             return null;
         }));
@@ -166,7 +167,7 @@ class ViewRenderer extends BaseViewRenderer
                 $name = $this->namespaces[$name];
 
             return $name::$method($args);
-        }),['is_safe' => ['html']]);
+        },['is_safe' => ['html']]));
 
         $this->twig->addFunction(new \Twig_SimpleFunction('widget', function ($name, $args = []) {
             if(isset($this->namespaces[$name]))
@@ -305,7 +306,8 @@ class ViewRenderer extends BaseViewRenderer
         $namespaces = $this->namespaces;
         $this->namespaces = [];
         foreach($namespaces as $namespace) {
-            $class = end(explode('\\', $namespace));
+            $elems = explode('\\', $namespace);
+            $class = end($elems);
             $this->namespaces[ $class ] = $namespace;
         }
     }


### PR DESCRIPTION
Here is example of using:

in yii we do:

``` php
<?php
use yii\bootstrap\Nav;
use yii\bootstrap\NavBar;
use yii\widgets\Breadcrumbs;
use frontend\assets\AppAsset;
use frontend\widgets\Alert;

AppAsset::register($this);
?>
...
<?php
            NavBar::begin([
                'brandLabel' => 'My Company',
                'brandUrl' => Yii::$app->homeUrl,
                'options' => [
                    'class' => 'navbar-inverse navbar-fixed-top',
                ],
            ]);
...
            echo Nav::widget([
                'options' => ['class' => 'navbar-nav navbar-right'],
                'items' => [...],
            ]);
            NavBar::end();
        ?>
        <div class="container">
        <?= Breadcrumbs::widget([
            'links' => $this->params['breadcrumbs']
        ]) ?>
        <?= Alert::widget() ?>
        </div>
```

With these functions we can do:

``` php
{{ use([
    'yii\\bootstrap\\Nav',
    'yii\\bootstrap\\NavBar',    
    'frontend\\assets\\AppAsset',
    'frontend\\widgets\\Alert'
]) }}
{{ static('AppAsset', 'register', this) }}
...
{{ widget_begin('NavBar', { brandLabel: app.name, brandUrl: app.homeUrl, options: { class: 'navbar-inverse navbar-fixed-top' } }) }}            
...
{{ widget('Nav', {options: { class: 'navbar-nav navbar-right' }, items: ...) }}
...
{{ widget_end('NavBar') }}
...
<div class="container">
    {{ widget('yii\\widgets\\Breadcrumbs', {links: this.params['breadcrumbs']}) }}

    {{ widget('Alert') }}
</div>
```

Also we can define namespaces globally in config files:

``` php
'namespaces' => [
    '\yii\bootstrap\NavBar',    
],
```
