### PR TITLE
Update Module.php: `$controllerNamespace` documentation

### DIFF
--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -89,7 +89,8 @@ class Module extends ServiceLocator
      * @var string the namespace that controller classes are in. If not set,
      * it will use the "controllers" sub-namespace under the namespace of this module.
      * For example, if the namespace of this module is "foo\bar", then the default
-     * controller namespace would be "foo\bar\controllers".
+     * controller namespace would be "foo\bar\controllers". You must define
+     * an alias for "foo" or [[Yii::getControllerPath()] will fail.
      */
     public $controllerNamespace;
     /**

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -90,7 +90,7 @@ class Module extends ServiceLocator
      * it will use the "controllers" sub-namespace under the namespace of this module.
      * For example, if the namespace of this module is "foo\bar", then the default
      * controller namespace would be "foo\bar\controllers". You must define
-     * an alias for "foo" or [[Yii::getControllerPath()] will fail.
+     * an alias for "foo" or [[Yii::getControllerPath()]] will fail.
      */
     public $controllerNamespace;
     /**


### PR DESCRIPTION
It took me a while to figure out why my custom `$controllerNamespace` was not working. The requirement for setting up an alias should be in its documentation rather than, or in addition to, the method which uses the value.
