### PR TITLE
Update sqlite/QueryBuilder.php: batchInsert() limit

### DIFF
--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -62,6 +62,11 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     public function batchInsert($table, $columns, $rows)
     {
+        // Limit of 500 terms http://www.sqlite.org/limits.html#max_compound_select
+        if (count($rows) > 500) { 
+            throw new InvalidParamException("SQLite can insert a maximum of 500 rows at a time"); 
+        }
+
         if (($tableSchema = $this->db->getTableSchema($table)) !== null) {
             $columnSchemas = $tableSchema->columns;
         } else {


### PR DESCRIPTION
Using `UNION SELECT` to perform batch inserts in SQLite is [limited to a maximum of 500](http://www.sqlite.org/limits.html#max_compound_select) rows at a time, so add a `$row` length check.

Also, as of [3.7.11 (2012-03-20)](http://www.sqlite.org/releaselog/3_7_11.html),

> the INSERT syntax to allow multiple rows to be inserted via the VALUES clause.

I haven't changed the code to use that format because I don't know if you are supporting the legacy format intentionally or not.

Ideally the SQLite QueryBuilder should check for the version of SQLite in use and make use of newer features if they are available.
