### PR TITLE
Improve `in` validator to properly support array attributes.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -61,6 +61,7 @@ Yii Framework 2 Change Log
 - Enh: Added support for array attributes in `exist` validator (creocoder)
 - Enh: Added support for using path alias with `FileDependency::fileName` (qiangxue)
 - Enh: Added param `hideOnSinglePage` to `yii\widgets\LinkPager` (arturf)
+- Enh: Added support for array attributes in `in` validator (creocoder)
 - Chg #2913: RBAC `DbManager` is now initialized via migration (samdark)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)
 - Chg #3175: InvalidCallException, InvalidParamException, UnknownMethodException are now extended from SPL BadMethodCallException (samdark)

--- a/framework/validators/RangeValidator.php
+++ b/framework/validators/RangeValidator.php
@@ -35,6 +35,10 @@ class RangeValidator extends Validator
      * the attribute value should NOT be among the list of values defined via [[range]].
      */
     public $not = false;
+    /**
+     * @var boolean whether to allow array type attribute.
+     */
+    public $allowArray = false;
 
     /**
      * @inheritdoc
@@ -55,8 +59,18 @@ class RangeValidator extends Validator
      */
     protected function validateValue($value)
     {
-        $valid = !$this->not && in_array($value, $this->range, $this->strict)
-            || $this->not && !in_array($value, $this->range, $this->strict);
+        if (!$this->allowArray && is_array($value)) {
+            return [$this->message, []];
+        }
+
+        $valid = false;
+
+        foreach ((array)$value as $v) {
+            if (!($valid = !$this->not && in_array($v, $this->range, $this->strict)
+                || $this->not && !in_array($v, $this->range, $this->strict))) {
+                break;
+            }
+        }
 
         return $valid ? null : [$this->message, []];
     }

--- a/framework/validators/RangeValidator.php
+++ b/framework/validators/RangeValidator.php
@@ -66,8 +66,10 @@ class RangeValidator extends Validator
         $valid = false;
 
         foreach ((array)$value as $v) {
-            if (!($valid = !$this->not && in_array($v, $this->range, $this->strict)
-                || $this->not && !in_array($v, $this->range, $this->strict))) {
+            $valid = !$this->not && in_array($v, $this->range, $this->strict)
+                || $this->not && !in_array($v, $this->range, $this->strict);
+
+            if ($valid) {
                 break;
             }
         }

--- a/framework/validators/RangeValidator.php
+++ b/framework/validators/RangeValidator.php
@@ -69,7 +69,7 @@ class RangeValidator extends Validator
             $valid = !$this->not && in_array($v, $this->range, $this->strict)
                 || $this->not && !in_array($v, $this->range, $this->strict);
 
-            if ($valid) {
+            if (!$valid) {
                 break;
             }
         }

--- a/tests/unit/framework/validators/RangeValidatorTest.php
+++ b/tests/unit/framework/validators/RangeValidatorTest.php
@@ -41,6 +41,17 @@ class RangeValidatorTest extends TestCase
         $this->assertTrue($val->validate("5"));
     }
 
+    public function testValidateArrayValue()
+    {
+        $val = new RangeValidator(['range' => range(1, 10, 1)]);
+        $val->allowArray = true;
+        $this->assertTrue($val->validate([1, 2, 3, 4, 5]));
+        $this->assertTrue($val->validate([6, 7, 8, 9, 10]));
+        $this->assertFalse($val->validate([0, 1, 2]));
+        $this->assertFalse($val->validate([10, 11, 12]));
+        $this->assertTrue($val->validate(["1", "2", "3", 4, 5, 6]));
+    }
+
     public function testValidateValueStrict()
     {
         $val = new RangeValidator(['range' => range(1, 10, 1), 'strict' => true]);
@@ -50,6 +61,14 @@ class RangeValidatorTest extends TestCase
         $this->assertFalse($val->validate("1"));
         $this->assertFalse($val->validate("10"));
         $this->assertFalse($val->validate("5.5"));
+    }
+
+    public function testValidateArrayValueStrict()
+    {
+        $val = new RangeValidator(['range' => range(1, 10, 1), 'strict' => true]);
+        $val->allowArray = true;
+        $this->assertFalse($val->validate(["1", "2", "3", "4", "5", "6"]));
+        $this->assertFalse($val->validate(["1", "2", "3", 4, 5, 6]));
     }
 
     public function testValidateValueNot()


### PR DESCRIPTION
Use case:

``` php
public function rules()
{
    return [
        [['sectionIds'], 'in', 'range' => [Section::BOOKING, Section::REPRESENTATIVE, Section::CREATIVE],
    ];
}
```
