### PR TITLE
Fix #3429: Incorrect path to AppAssets at docs

### DIFF
--- a/docs/guide/bootstrap-widgets.md
+++ b/docs/guide/bootstrap-widgets.md
@@ -18,7 +18,7 @@ Basics
 Yii doesn't wrap the bootstrap basics into PHP code since HTML is very simple by itself in this case. You can find details
 about using the basics at [bootstrap documentation website](http://getbootstrap.com/css/). Still Yii provides a
 convenient way to include bootstrap assets in your pages with a single line added to `AppAsset.php` located in your
-`config` directory:
+`@app/assets` directory:
 
 ```php
 public $depends = [


### PR DESCRIPTION
Fix #3429: Incorrect path to AppAssets at docs
