### PR TITLE
Improved array support for "data" attribute in renderTagAttributes()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -60,6 +60,7 @@ Yii Framework 2 Change Log
 - Enh #3542: Removed requirement to specify `extensions` in application config (samdark)
 - Enh #3562: Adding rotateByCopy to yii\log\FileTarget (pawzar)
 - Enh #3574: Add integrity check support for SQLite (zeeke)
+- Enh #3597: Nested array support for HTML5 custom "data-*" attributes (armab)
 - Enh: Added support for using sub-queries when building a DB query with `IN` condition (qiangxue)
 - Enh: Supported adding a new response formatter without the need to reconfigure existing formatters (qiangxue)
 - Enh: Added `yii\web\UrlManager::addRules()` to simplify adding new URL rules (qiangxue)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1569,6 +1569,8 @@ class BaseHtml
      * the array will be "expanded" and a list data attributes will be rendered. For example,
      * if `'data' => ['id' => 1, 'name' => 'yii']`, then this will be rendered:
      * `data-id="1" data-name="yii"`.
+     * Additionally `'data' => ['params' => ['id' => 1, 'name' => 'yii'], 'status' => 'ok']` will be rendered as:
+     * `data-params='{"id":1,"name":"yii"}' data-status="ok"`.
      *
      * @param array $attributes attributes to be rendered. The attribute values will be HTML-encoded using [[encode()]].
      * @return string the rendering result. If the attributes are not empty, they will be rendered
@@ -1595,7 +1597,11 @@ class BaseHtml
                 }
             } elseif (is_array($value) && $name === 'data') {
                 foreach ($value as $n => $v) {
-                    $html .= " $name-$n=\"" . static::encode($v) . '"';
+                    if (is_array($v)) {
+                        $html .= " $name-$n='" . Json::encode($v) . "'";
+                    } else {
+                        $html .= " $name-$n=\"" . static::encode($v) . '"';
+                    }
                 }
             } elseif ($value !== null) {
                 $html .= " $name=\"" . static::encode($value) . '"';


### PR DESCRIPTION
I suggest to add more advanced support to render nested arrays in "data" attribute of tag (HTML5).

Here is example: 
http://api.jquery.com/data/#data-html5

This: 

``` php
echo Html::tag('div', '', [
    'data' => [
        'role' => 'page',
        'last-value' => 43,
        'options' => [ // nested array
            'name' => 'John',
        ],
    ],
]);
```

will be rendered as: 

``` html
<div data-role="page" data-last-value="43" data-options='{"name":"John"}'></div>
```
