### PR TITLE
Update rest-quick-start.md: highlight automatic pluralization

### DIFF
--- a/docs/guide/rest-quick-start.md
+++ b/docs/guide/rest-quick-start.md
@@ -75,7 +75,7 @@ for accessing the user data. The APIs you have created include:
 * `OPTIONS /users`: show the supported verbs regarding endpoint `/users`;
 * `OPTIONS /users/123`: show the supported verbs regarding endpoint `/users/123`.
 
-Note that Yii automatically pluralizes controller IDs for them to use in endpoints. 
+Note that Yii automatically pluralizes controller names for use in endpoints. 
 You may access your APIs with the `curl` command like the following,
 
 ```

--- a/docs/guide/rest-quick-start.md
+++ b/docs/guide/rest-quick-start.md
@@ -75,6 +75,7 @@ for accessing the user data. The APIs you have created include:
 * `OPTIONS /users`: show the supported verbs regarding endpoint `/users`;
 * `OPTIONS /users/123`: show the supported verbs regarding endpoint `/users/123`.
 
+Note that Yii automatically pluralizes controller IDs for them to use in endpoints. 
 You may access your APIs with the `curl` command like the following,
 
 ```


### PR DESCRIPTION
This is probably not expected given the other naming conventions within Yii, so highlight this feature for beginners.
