### PR TITLE
limit applied to migration

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -61,6 +61,7 @@ Yii Framework 2 Change Log
 - Enh #3562: Adding rotateByCopy to yii\log\FileTarget (pawzar)
 - Enh #3574: Add integrity check support for SQLite (zeeke)
 - Enh #3597: Nested array support for HTML5 custom "data-*" attributes (armab)
+- Enh #3607: Added support for limit in migrations actions: history, new, redo (Ragazzo)
 - Enh: Added support for using sub-queries when building a DB query with `IN` condition (qiangxue)
 - Enh: Supported adding a new response formatter without the need to reconfigure existing formatters (qiangxue)
 - Enh: Added `yii\web\UrlManager::addRules()` to simplify adding new URL rules (qiangxue)

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -204,10 +204,7 @@ class MigrateController extends Controller
      */
     public function actionDown($limit = 1)
     {
-
-        $downAll = ($limit === 'all');
-
-        if ($downAll) {
+        if ($limit === 'all') {
             $limit = null;
         } else {
             $limit = (int) $limit;
@@ -265,9 +262,7 @@ class MigrateController extends Controller
      */
     public function actionRedo($limit = 1)
     {
-        $redoAll = ($limit === 'all');
-
-        if ($redoAll) {
+        if ($limit === 'all') {
             $limit = null;
         } else {
             $limit = (int) $limit;
@@ -432,9 +427,7 @@ class MigrateController extends Controller
      */
     public function actionHistory($limit = 10)
     {
-        $showAll = ($limit === 'all');
-
-        if ($showAll) {
+        if ($limit === 'all') {
             $limit = null;
         } else {
             $limit = (int) $limit;
@@ -477,9 +470,7 @@ class MigrateController extends Controller
      */
     public function actionNew($limit = 10)
     {
-        $showAll = ($limit === 'all');
-
-        if ($showAll) {
+        if ($limit === 'all') {
             $limit = null;
         } else {
             $limit = (int) $limit;

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -204,7 +204,10 @@ class MigrateController extends Controller
      */
     public function actionDown($limit = 1)
     {
-        if ($limit === 'all') {
+
+        $downAll = ($limit === 'all');
+
+        if ($downAll) {
             $limit = null;
         } else {
             $limit = (int) $limit;
@@ -214,11 +217,13 @@ class MigrateController extends Controller
         }
 
         $migrations = $this->getMigrationHistory($limit);
+
         if (empty($migrations)) {
             echo "No migration has been done before.\n";
 
             return self::EXIT_CODE_NORMAL;
         }
+
         $migrations = array_keys($migrations);
 
         $n = count($migrations);
@@ -249,6 +254,7 @@ class MigrateController extends Controller
      * ~~~
      * yii migrate/redo     # redo the last applied migration
      * yii migrate/redo 3   # redo the last 3 applied migrations
+     * yii migrate/redo all # redo all migrations
      * ~~~
      *
      * @param integer $limit the number of migrations to be redone. Defaults to 1,
@@ -259,17 +265,25 @@ class MigrateController extends Controller
      */
     public function actionRedo($limit = 1)
     {
-        $limit = (int) $limit;
-        if ($limit < 1) {
-            throw new Exception("The step argument must be greater than 0.");
+        $redoAll = ($limit === 'all');
+
+        if ($redoAll) {
+            $limit = null;
+        } else {
+            $limit = (int) $limit;
+            if ($limit < 1) {
+                throw new Exception("The step argument must be greater than 0.");
+            }
         }
 
         $migrations = $this->getMigrationHistory($limit);
+
         if (empty($migrations)) {
             echo "No migration has been done before.\n";
 
             return self::EXIT_CODE_NORMAL;
         }
+
         $migrations = array_keys($migrations);
 
         $n = count($migrations);
@@ -410,7 +424,7 @@ class MigrateController extends Controller
      * ~~~
      * yii migrate/history     # showing the last 10 migrations
      * yii migrate/history 5   # showing the last 5 migrations
-     * yii migrate/history 0   # showing the whole history
+     * yii migrate/history all # showing the whole history
      * ~~~
      *
      * @param integer $limit the maximum number of migrations to be displayed.
@@ -418,8 +432,19 @@ class MigrateController extends Controller
      */
     public function actionHistory($limit = 10)
     {
-        $limit = (int) $limit;
+        $showAll = ($limit === 'all');
+
+        if ($showAll) {
+            $limit = null;
+        } else {
+            $limit = (int) $limit;
+            if ($limit < 1) {
+                throw new Exception("The step argument must be greater than 0.");
+            }
+        }
+
         $migrations = $this->getMigrationHistory($limit);
+
         if (empty($migrations)) {
             echo "No migration has been done before.\n";
         } else {
@@ -444,7 +469,7 @@ class MigrateController extends Controller
      * ~~~
      * yii migrate/new     # showing the first 10 new migrations
      * yii migrate/new 5   # showing the first 5 new migrations
-     * yii migrate/new 0   # showing all new migrations
+     * yii migrate/new all # showing all new migrations
      * ~~~
      *
      * @param integer $limit the maximum number of new migrations to be displayed.
@@ -452,13 +477,24 @@ class MigrateController extends Controller
      */
     public function actionNew($limit = 10)
     {
-        $limit = (int) $limit;
+        $showAll = ($limit === 'all');
+
+        if ($showAll) {
+            $limit = null;
+        } else {
+            $limit = (int) $limit;
+            if ($limit < 1) {
+                throw new Exception("The step argument must be greater than 0.");
+            }
+        }
+
         $migrations = $this->getNewMigrations();
+
         if (empty($migrations)) {
             echo "No new migrations found. Your system is up-to-date.\n";
         } else {
             $n = count($migrations);
-            if ($limit > 0 && $n > $limit) {
+            if ($limit && $n > $limit) {
                 $migrations = array_slice($migrations, 0, $limit);
                 echo "Showing $limit out of $n new " . ($n === 1 ? 'migration' : 'migrations') . ":\n";
             } else {


### PR DESCRIPTION
This PR related with this [issue](https://github.com/yiisoft/yii2/issues/3594). I also think that such enh. should be done:
- [x] `getNewMigrations` should support `$limit` param;
- [x] introducing new 2 methods `isValidLimit()` and `needToApplyAll`.
