### PR TITLE
PDO MySQL fix: Named placeholders with Question mark placeholders throw an Exception

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -37,6 +37,7 @@ Yii Framework 2 Change Log
 - Bug #3578: Fixed postgreSQL column type detection, added missing types (MDMunir, cebe)
 - Bug #3591: Fixed incomplete obsolete filling in i18n `MessageController::saveMessagesToDb()` (advsm)
 - Bug #3601: Fixed the bug that the refresh URL was not generated correctly by `Captcha` (qiangxue, klevron)
+- Bug #3653: Fixed the bug when PDO question mark parameters in a prepared statement were not 1-based (armab)
 - Bug: Fixed inconsistent return of `\yii\console\Application::runAction()` (samdark)
 - Bug: URL encoding for the route parameter added to `\yii\web\UrlManager` (klimov-paul)
 - Bug: Fixed the bug that requesting protected or private action methods would cause 500 error instead of 404 (qiangxue)

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -824,7 +824,12 @@ class Query extends Component implements QueryInterface
             } else {
                 foreach ($params as $name => $value) {
                     if (is_integer($name)) {
-                        $this->params[] = $value;
+                        // Question mark parameters are 1-based
+                        if (!array_key_exists(1, $this->params)) {
+                            $this->params[1] = $value;
+                        } else {
+                            $this->params[] = $value;
+                        }
                     } else {
                         $this->params[$name] = $value;
                     }


### PR DESCRIPTION
The issue can be reproduced when question mark placeholders and named placeholders are mixed AND question mark placeholder comes after named: 

``` php
$Query = (new Query())->from('tbl_user');
$Query->where('id < :id', [':id' => 100]);
$Query->orWhere('id > ?', [1 => 500]);
```

**PDOException: SQLSTATE[HY093]: Invalid parameter number: Columns/Parameters are 1-based**

![pdoexception_-_2014-05-31_15 55](https://cloud.githubusercontent.com/assets/1533818/3139046/a033fc6e-e8c5-11e3-9e92-5de54ae446ca.gif)

Another one example will work as expected (without bug), because question mark goes first: 

``` php
$Query = (new Query())->from('tbl_user');
$Query->where('id > ?', [1 => 500]);
$Query->orWhere('id < :id', [':id' => 100]);
```
