### PR TITLE
Fix for checking rules

### DIFF
--- a/framework/rbac/BaseManager.php
+++ b/framework/rbac/BaseManager.php
@@ -199,7 +199,7 @@ abstract class BaseManager extends Component implements ManagerInterface
      */
     protected function executeRule($user, $item, $params)
     {
-        if ($item->ruleName === null) {
+        if (empty($item->ruleName)) {
             return true;
         }
         $rule = $this->getRule($item->ruleName);


### PR DESCRIPTION
`$item->ruleName === null` don't works with `DbManager`.

Generates `yii\base\InvalidConfigException` with message `Rule not found:`, although item is empty

```
yii\rbac\Role#1
(
    [type] => '0'
    [name] => 'projects.index'
    [description] => 'Проекты: список'
    [ruleName] => null
    [data] => null
    [createdAt] => '0'
    [updatedAt] => '0'
)
```
