### PR TITLE
Added StringHelper::parseUri

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -81,6 +81,7 @@ Yii Framework 2 Change Log
 - Enh: Added support for using path alias with `FileDependency::fileName` (qiangxue)
 - Enh: Added param `hideOnSinglePage` to `yii\widgets\LinkPager` (arturf)
 - Enh: Added support for array attributes in `in` validator (creocoder)
+- Enh: Added `yii\helpers\StringHelper::parseUri` (suralc)
 - Chg #2898: `yii\console\controllers\AssetController` is now using hashes instead of timestamps (samdark)
 - Chg #2913: RBAC `DbManager` is now initialized via migration (samdark)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -87,7 +87,7 @@ class BaseStringHelper
             return '';
         }
     }
-    
+
     /**
      * Truncates a string to the number of characters specified.
      *
@@ -99,13 +99,13 @@ class BaseStringHelper
      */
     public static function truncate($string, $length, $suffix = '...', $encoding = null)
     {
-        if (mb_strlen($string, $encoding ?: \Yii::$app->charset) > $length) {
-            return trim(mb_substr($string, 0, $length, $encoding ?: \Yii::$app->charset)) . $suffix;
+        if (mb_strlen($string, $encoding ? : \Yii::$app->charset) > $length) {
+            return trim(mb_substr($string, 0, $length, $encoding ? : \Yii::$app->charset)) . $suffix;
         } else {
             return $string;
         }
     }
-    
+
     /**
      * Truncates a string to the number of words specified.
      *
@@ -122,5 +122,46 @@ class BaseStringHelper
         } else {
             return $string;
         }
+    }
+
+    /**
+     * Parse a uri to components
+     *
+     * This function can be used to parse a given uri string to the scheme, authority, path, query and fragment
+     * components. The string is split according to rfc 2396 Appendix B.
+     * This function should not be used to validate a given uri-string as it tries to get every component possible.
+     * One may use this function to parse URIs that are not parsable by PHPs own parse_url (E.g. 'assets:///path').
+     * Note: The authority component equals parse_urls host result. 'Authority' is however used in URI contexts in the
+     * already named rfc.
+     * @param string $uri The uri to be parsed
+     * @param bool $appendMatches Determent if the original result from the regular expression used to parse the uri string
+     * should be returned in a 'matches' key of the result array.
+     * @return array The result array. This array **may** contain the following keys: ´scheme´, ´authority´, ´path´, ´query´,
+     * and ´fragment´. None of this keys is guaranteed to be present.
+     */
+    public static function parseUri($uri, $appendMatches = false)
+    {
+        static $regex, $components;
+        if ($regex === null) {
+            // rfc 2396 Page 28 Appendix B
+            $regex = '/^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/';
+            $components = ['scheme' => 2, 'authority' => 4, 'path' => 5, 'query' => 7, 'fragment' => 9];
+        }
+
+        $matches = [];
+        preg_match($regex, $uri, $matches);
+        $result = [];
+
+        foreach ($components as $componentName => $componentPosition) {
+            if (!empty($matches[$componentPosition])) {
+                $result[$componentName] = $matches[$componentPosition];
+            }
+        }
+
+        if ($appendMatches) {
+            $result['matches'] = $matches;
+        }
+
+        return $result;
     }
 }

--- a/tests/unit/framework/helpers/StringHelperTest.php
+++ b/tests/unit/framework/helpers/StringHelperTest.php
@@ -86,4 +86,24 @@ class StringHelperTest extends TestCase
         $this->assertEquals('это тестовая multibyte!!!', StringHelper::truncateWords('это тестовая multibyte строка', 3, '!!!'));
         $this->assertEquals('это строка с          неожиданными...', StringHelper::truncateWords('это строка с          неожиданными пробелами', 4));
     }
+	
+    public function testParseUri()
+    {
+        $r = StringHelper::parseUri('http://google.de/search?q=yii2');
+        $this->assertArrayNotHasKey('fragment', $r);
+        $this->assertEquals(['scheme' => 'http', 'authority' => 'google.de', 'path' => '/search', 'query' => 'q=yii2'], $r);
+        $r = StringHelper::parseUri('assets://my/path/file.css');
+        $this->assertArrayNotHasKey('query', $r);
+        $this->assertEquals(['scheme' => 'assets', 'authority' => 'my', 'path' => '/path/file.css'], $r);
+        $this->assertEquals(['scheme' => 'assets', 'path' => '/my/path/file.css'], $r = StringHelper::parseUri('assets:///my/path/file.css'));
+        $this->assertArrayNotHasKey('authority', $r);
+        $this->assertArrayNotHasKey('matches', $r);
+        $this->assertArrayHasKey('matches', StringHelper::parseUri('assets://localhost/path', true));
+		$this->assertEmpty(StringHelper::parseUri(''));
+		$this->assertEquals(['authority' => 'abc', 'path' => '/fdg'], StringHelper::parseUri('//abc/fdg'));
+		$this->assertEquals(['path' => 'testfile.php'], StringHelper::parseUri('testfile.php'));
+		$this->assertEquals(['path' => '/file'], StringHelper::parseUri('///file'));
+		$this->assertEquals(['scheme' => 'file', 'path' =>'/'], StringHelper::parseUri('file:///'));
+		
+	}
 }

--- a/tests/unit/framework/helpers/StringHelperTest.php
+++ b/tests/unit/framework/helpers/StringHelperTest.php
@@ -99,11 +99,10 @@ class StringHelperTest extends TestCase
         $this->assertArrayNotHasKey('authority', $r);
         $this->assertArrayNotHasKey('matches', $r);
         $this->assertArrayHasKey('matches', StringHelper::parseUri('assets://localhost/path', true));
-		$this->assertEmpty(StringHelper::parseUri(''));
-		$this->assertEquals(['authority' => 'abc', 'path' => '/fdg'], StringHelper::parseUri('//abc/fdg'));
-		$this->assertEquals(['path' => 'testfile.php'], StringHelper::parseUri('testfile.php'));
-		$this->assertEquals(['path' => '/file'], StringHelper::parseUri('///file'));
-		$this->assertEquals(['scheme' => 'file', 'path' =>'/'], StringHelper::parseUri('file:///'));
-		
-	}
+        $this->assertEmpty(StringHelper::parseUri(''));
+        $this->assertEquals(['authority' => 'abc', 'path' => '/fdg'], StringHelper::parseUri('//abc/fdg'));
+        $this->assertEquals(['path' => 'testfile.php'], StringHelper::parseUri('testfile.php'));
+        $this->assertEquals(['path' => '/file'], StringHelper::parseUri('///file'));
+        $this->assertEquals(['scheme' => 'file', 'path' =>'/'], StringHelper::parseUri('file:///'));
+    }
 }


### PR DESCRIPTION
This pr adds StringHelper::parseUri.

PHPs default parse_url is as noted in the official docs not meant to spit/parse all variants of URIs. 

URIs that are to some extend valid like `assets:///ae823jss/js/compact.js` (and in my case delivered by an external api) result in `false` using parse_url. The added function is however capable of parsing this string into the correct output (omitting the non-exsistant parts):

```
array(2) {
  'scheme' =>
  string(6) "assets"
  'path' =>
  string(23) "/ae823jss/js/compact.js"
}
```

The regex used is exemplified in rfc 2396 Appendix B.
