### PR TITLE
Correct `yii\base\Theme::pathMap` generation when its not provided

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -40,6 +40,7 @@ Yii Framework 2 Change Log
 - Bug: Fixed inconsistent return of `\yii\console\Application::runAction()` (samdark)
 - Bug: URL encoding for the route parameter added to `\yii\web\UrlManager` (klimov-paul)
 - Bug: Fixed the bug that requesting protected or private action methods would cause 500 error instead of 404 (qiangxue)
+- Bug: Correct `yii\base\Theme::pathMap` generation when its not provided (creocoder)
 - Enh #2264: `CookieCollection::has()` will return false for expired or removed cookies (qiangxue)
 - Enh #2435: `yii\db\IntegrityException` is now thrown on database integrity errors instead of general `yii\db\Exception` (samdark)
 - Enh #2837: Error page now shows arguments in stack trace method calls (samdark)

--- a/framework/base/Theme.php
+++ b/framework/base/Theme.php
@@ -91,7 +91,7 @@ class Theme extends Component
             if (($basePath = $this->getBasePath()) === null) {
                 throw new InvalidConfigException('The "basePath" property must be set.');
             }
-            $this->pathMap = [Yii::$app->getBasePath() . DIRECTORY_SEPARATOR . 'views' => [$basePath]];
+            $this->pathMap = [Yii::$app->getViewPath() => [$basePath]];
         }
     }
 

--- a/framework/base/Theme.php
+++ b/framework/base/Theme.php
@@ -91,7 +91,7 @@ class Theme extends Component
             if (($basePath = $this->getBasePath()) === null) {
                 throw new InvalidConfigException('The "basePath" property must be set.');
             }
-            $this->pathMap = [Yii::$app->getBasePath() => [$basePath]];
+            $this->pathMap = [Yii::$app->getBasePath() . DIRECTORY_SEPARATOR . 'views' => [$basePath]];
         }
     }
 


### PR DESCRIPTION
This allow not provide `pathMap` in 90% cases. So theme configuring become simplier, like:

```
'components' => [
    'view' => [
        'theme' => [
            'basePath' => '@app/themes/basic',
            'baseUrl' => '@web/themes/basic',
        ],
    ],
],
```
