### PR TITLE
Allow rules with optional parameters

### DIFF
--- a/framework/web/UrlRule.php
+++ b/framework/web/UrlRule.php
@@ -161,6 +161,8 @@ class UrlRule extends Object implements UrlRuleInterface
             ']' => '\\]',
             '(' => '\\(',
             ')' => '\\)',
+            '{' => '(?:',
+            '}?' => ')?',
         ];
         $tr2 = [];
         if (preg_match_all('/<(\w+):?([^>]+)?>/', $this->pattern, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {


### PR DESCRIPTION
Today UrlRule not allow to create rules with optional parameters. Often they can be useful.

As the method escapes the parentheses, I thought of making the optional parameters using brackets. A rule might look like this:

``` PHP
'urlManager' => [
    'rules' => [
        'agenda/<formato:json|xml>{/p/<person:\d+>}?{/a/<agenda:\d+>}?' => 'agenda/init',
    ]
],
```
