### PR TITLE
Fix #3358 CSRF meta tags specification

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -30,6 +30,7 @@ Yii Framework 2 Change Log
 - Bug #3436: Fixed the issue that `ServiceLocator` still returns the old component after calling `set()` with a new definition (qiangxue)
 - Bug #3458: Fixed the bug that the image rendered by `CaptchaAction` was using a wrong content type (MDMunir, qiangxue)
 - Bug #3473: Allow postgreSQL to specify timestamp precision via abstract types in QueryBuilder (cebe)
+- Bug #3478: Fixed yii\console\Controller::select accept empty input as '0' value (lynicidn)
 - Bug #3522: Fixed BaseFileHelper::normalizePath to allow a (.) for the current path. (skotos)
 - Bug #3548: Fixed the bug that X-Rate-Limit-Remaining header is always zero when using RateLimiter (qiangxue)
 - Bug #3564: Fixed the bug that primary key columns should not take default values from schema (qiangxue)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -24,6 +24,7 @@ Yii Framework 2 Change Log
 - Bug #3268: Fixed the bug that the schema name in a table name was not respected by `yii\db\mysql\Schema` (terazoid, qiangxue)
 - Bug #3311: Fixed the bug that `yii\di\Container::has()` did not return correct value (mgrechanik, qiangxue)
 - Bug #3327: Fixed "Unable to find debug data" when logging objects with circular references (jarekkozak, samdark)
+- Bug #3358: Fixed CSRF meta tags rendered in the mail view layout (klimov-paul)
 - Bug #3368: Fix for comparing numeric attributes in JavaScript (technixp)
 - Bug #3393: Fix `yii\helpers\FileHelper::copyDirectory()` pattern not working (klimov-paul)
 - Bug #3431: Allow using extended ErrorHandler class from the app namespace (cebe)

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -161,11 +161,12 @@ class Request extends \yii\base\Request
     private $_headers;
 
     /**
-     * @inheritdoc
+     * Resolves the current request into a route and the associated parameters.
+     * @return array the first element is the route, and the second is the associated parameters.
+     * @throws HttpException if the request cannot be resolved.
      */
-    public function init()
+    public function resolve()
     {
-        parent::init();
         if ($this->enableCsrfValidation) {
             $view = Yii::$app->getView();
             if ($view instanceof View) {
@@ -173,15 +174,7 @@ class Request extends \yii\base\Request
                 $view->registerMetaTag(['name' => 'csrf-token', 'content' => $this->getCsrfToken()], __CLASS__ . '::csrfToken');
             }
         }
-    }
 
-    /**
-     * Resolves the current request into a route and the associated parameters.
-     * @return array the first element is the route, and the second is the associated parameters.
-     * @throws HttpException if the request cannot be resolved.
-     */
-    public function resolve()
-    {
         $result = Yii::$app->getUrlManager()->parseRequest($this);
         if ($result !== false) {
             list ($route, $params) = $result;

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -161,6 +161,21 @@ class Request extends \yii\base\Request
     private $_headers;
 
     /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+        if ($this->enableCsrfValidation) {
+            $view = Yii::$app->getView();
+            if ($view instanceof View) {
+                $view->registerMetaTag(['name' => 'csrf-param', 'content' => $this->csrfParam], __CLASS__ . '::csrfParam');
+                $view->registerMetaTag(['name' => 'csrf-token', 'content' => $this->getCsrfToken()], __CLASS__ . '::csrfToken');
+            }
+        }
+    }
+
+    /**
      * Resolves the current request into a route and the associated parameters.
      * @return array the first element is the route, and the second is the associated parameters.
      * @throws HttpException if the request cannot be resolved.

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -459,13 +459,6 @@ class View extends \yii\base\View
         if (!empty($this->metaTags)) {
             $lines[] = implode("\n", $this->metaTags);
         }
-
-        $request = Yii::$app->getRequest();
-        if ($request instanceof \yii\web\Request && $request->enableCsrfValidation && !$request->getIsAjax()) {
-            $lines[] = Html::tag('meta', '', ['name' => 'csrf-param', 'content' => $request->csrfParam]);
-            $lines[] = Html::tag('meta', '', ['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
-        }
-
         if (!empty($this->linkTags)) {
             $lines[] = implode("\n", $this->linkTags);
         }


### PR DESCRIPTION
Fix #3358 unnesessary meta tags in email html

CSRF meta tags specification reworked to be triggered by `Request` instead of `View`
