### PR TITLE
Fix #3358 CSRF meta tags specification

### DIFF
--- a/apps/advanced/backend/views/layouts/main.php
+++ b/apps/advanced/backend/views/layouts/main.php
@@ -10,12 +10,7 @@ use yii\widgets\Breadcrumbs;
  * @var string $content
  */
 AppAsset::register($this);
-
-$request = Yii::$app->getRequest();
-if ($request->enableCsrfValidation) {
-    $this->registerMetaTag(['name' => 'csrf-param', 'content' => $request->csrfParam]);
-    $this->registerMetaTag(['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
-}
+$this->registerCsrfTags(Yii::$app->getRequest());
 ?>
 <?php $this->beginPage() ?>
 <!DOCTYPE html>

--- a/apps/advanced/backend/views/layouts/main.php
+++ b/apps/advanced/backend/views/layouts/main.php
@@ -10,6 +10,12 @@ use yii\widgets\Breadcrumbs;
  * @var string $content
  */
 AppAsset::register($this);
+
+$request = Yii::$app->getRequest();
+if ($request->enableCsrfValidation) {
+    $this->registerMetaTag(['name' => 'csrf-param', 'content' => $request->csrfParam]);
+    $this->registerMetaTag(['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
+}
 ?>
 <?php $this->beginPage() ?>
 <!DOCTYPE html>

--- a/apps/advanced/frontend/views/layouts/main.php
+++ b/apps/advanced/frontend/views/layouts/main.php
@@ -11,6 +11,12 @@ use frontend\widgets\Alert;
  * @var string $content
  */
 AppAsset::register($this);
+
+$request = Yii::$app->getRequest();
+if ($request->enableCsrfValidation) {
+    $this->registerMetaTag(['name' => 'csrf-param', 'content' => $request->csrfParam]);
+    $this->registerMetaTag(['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
+}
 ?>
 <?php $this->beginPage() ?>
 <!DOCTYPE html>

--- a/apps/advanced/frontend/views/layouts/main.php
+++ b/apps/advanced/frontend/views/layouts/main.php
@@ -11,12 +11,7 @@ use frontend\widgets\Alert;
  * @var string $content
  */
 AppAsset::register($this);
-
-$request = Yii::$app->getRequest();
-if ($request->enableCsrfValidation) {
-    $this->registerMetaTag(['name' => 'csrf-param', 'content' => $request->csrfParam]);
-    $this->registerMetaTag(['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
-}
+$this->registerCsrfTags(Yii::$app->getRequest());
 ?>
 <?php $this->beginPage() ?>
 <!DOCTYPE html>

--- a/apps/basic/views/layouts/main.php
+++ b/apps/basic/views/layouts/main.php
@@ -10,6 +10,12 @@ use app\assets\AppAsset;
  * @var string $content
  */
 AppAsset::register($this);
+
+$request = Yii::$app->getRequest();
+if ($request->enableCsrfValidation) {
+    $this->registerMetaTag(['name' => 'csrf-param', 'content' => $request->csrfParam]);
+    $this->registerMetaTag(['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
+}
 ?>
 <?php $this->beginPage() ?>
 <!DOCTYPE html>

--- a/apps/basic/views/layouts/main.php
+++ b/apps/basic/views/layouts/main.php
@@ -10,12 +10,7 @@ use app\assets\AppAsset;
  * @var string $content
  */
 AppAsset::register($this);
-
-$request = Yii::$app->getRequest();
-if ($request->enableCsrfValidation) {
-    $this->registerMetaTag(['name' => 'csrf-param', 'content' => $request->csrfParam]);
-    $this->registerMetaTag(['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
-}
+$this->registerCsrfTags(Yii::$app->getRequest());
 ?>
 <?php $this->beginPage() ?>
 <!DOCTYPE html>

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -24,6 +24,7 @@ Yii Framework 2 Change Log
 - Bug #3268: Fixed the bug that the schema name in a table name was not respected by `yii\db\mysql\Schema` (terazoid, qiangxue)
 - Bug #3311: Fixed the bug that `yii\di\Container::has()` did not return correct value (mgrechanik, qiangxue)
 - Bug #3327: Fixed "Unable to find debug data" when logging objects with circular references (jarekkozak, samdark)
+- Bug #3358: Fixed CSRF meta tags rendered in the mail view layout (klimov-paul)
 - Bug #3368: Fix for comparing numeric attributes in JavaScript (technixp)
 - Bug #3393: Fix `yii\helpers\FileHelper::copyDirectory()` pattern not working (klimov-paul)
 - Bug #3431: Allow using extended ErrorHandler class from the app namespace (cebe)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -44,3 +44,5 @@ Upgrade from Yii 2.0 Beta
   in this release.
 
 * `yii\console\controllers\AssetController` is now using hashes instead of timestamps. Replace all `{ts}` with `{hash}`.
+
+* If you are using CSRF protection feature, you should add corresponding meta tags manually into your page HTML.

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -46,3 +46,4 @@ Upgrade from Yii 2.0 Beta
 * `yii\console\controllers\AssetController` is now using hashes instead of timestamps. Replace all `{ts}` with `{hash}`.
 
 * If you are using CSRF protection feature, you should add corresponding meta tags manually into your page HTML.
+  This can be done via `yii\web\View::registerCsrfTags()`.

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -98,9 +98,19 @@ class Request extends \yii\base\Request
      * When CSRF validation is enabled, forms submitted to an Yii Web application must be originated
      * from the same application. If not, a 400 HTTP exception will be raised.
      *
-     * Note, this feature requires that the user client accepts cookie. Also, to use this feature,
-     * forms submitted via POST method must contain a hidden input whose name is specified by [[csrfParam]].
-     * You may use [[\yii\helpers\Html::beginForm()]] to generate his hidden input.
+     * Note, this feature requires that the user client accepts cookie.
+     *
+     * Attention, to use this feature, forms submitted via POST method must contain a hidden input whose name
+     * is specified by [[csrfParam]]. You may use [[\yii\helpers\Html::beginForm()]] to generate his hidden input.
+     * Also, CSRF meta tags should be manually added to page. You may add them in the main layout file:
+     *
+     * ~~~
+     * $request = Yii::$app->getRequest();
+     * if ($request->enableCsrfValidation) {
+     *     $this->registerMetaTag(['name' => 'csrf-param', 'content' => $request->csrfParam]);
+     *     $this->registerMetaTag(['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
+     * }
+     * ~~~
      *
      * In JavaScript, you may get the values of [[csrfParam]] and [[csrfToken]] via `yii.getCsrfParam()` and
      * `yii.getCsrfToken()`, respectively. The [[\yii\web\YiiAsset]] asset must be registered.

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -102,15 +102,7 @@ class Request extends \yii\base\Request
      *
      * Attention, to use this feature, forms submitted via POST method must contain a hidden input whose name
      * is specified by [[csrfParam]]. You may use [[\yii\helpers\Html::beginForm()]] to generate his hidden input.
-     * Also, CSRF meta tags should be manually added to page. You may add them in the main layout file:
-     *
-     * ~~~
-     * $request = Yii::$app->getRequest();
-     * if ($request->enableCsrfValidation) {
-     *     $this->registerMetaTag(['name' => 'csrf-param', 'content' => $request->csrfParam]);
-     *     $this->registerMetaTag(['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
-     * }
-     * ~~~
+     * Also, CSRF meta tags should be manually added to page. You may do this via [[\yii\web\View::registerCsrfTags()]].
      *
      * In JavaScript, you may get the values of [[csrfParam]] and [[csrfToken]] via `yii.getCsrfParam()` and
      * `yii.getCsrfToken()`, respectively. The [[\yii\web\YiiAsset]] asset must be registered.

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -459,13 +459,6 @@ class View extends \yii\base\View
         if (!empty($this->metaTags)) {
             $lines[] = implode("\n", $this->metaTags);
         }
-
-        $request = Yii::$app->getRequest();
-        if ($request instanceof \yii\web\Request && $request->enableCsrfValidation && !$request->getIsAjax()) {
-            $lines[] = Html::tag('meta', '', ['name' => 'csrf-param', 'content' => $request->csrfParam]);
-            $lines[] = Html::tag('meta', '', ['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
-        }
-
         if (!empty($this->linkTags)) {
             $lines[] = implode("\n", $this->linkTags);
         }

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -550,7 +550,7 @@ class View extends \yii\base\View
      */
     public function registerCsrfTags(Request $request)
     {
-        if ($request->enableCsrfValidation) {
+        if ($request->enableCsrfValidation && !$request->getIsAjax()) {
             $this->registerMetaTag(['name' => 'csrf-param', 'content' => $request->csrfParam]);
             $this->registerMetaTag(['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
         }

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -542,4 +542,17 @@ class View extends \yii\base\View
 
         return empty($lines) ? '' : implode("\n", $lines);
     }
+
+    /**
+     * Registers all necessary meta tags to support CSRF protection specified by request.
+     * Note, this method should be called before [[head()]].
+     * @param Request $request request instance.
+     */
+    public function registerCsrfTags(Request $request)
+    {
+        if ($request->enableCsrfValidation) {
+            $this->registerMetaTag(['name' => 'csrf-param', 'content' => $request->csrfParam]);
+            $this->registerMetaTag(['name' => 'csrf-token', 'content' => $request->getCsrfToken()]);
+        }
+    }
 }


### PR DESCRIPTION
Fix #3358 unnesessary meta tags in email html

Automatic setup of CSRF meta tags removed.
