### PR TITLE
[WIP] Default messages for \yii\web\*HttpException

### DIFF
--- a/extensions/authclient/AuthAction.php
+++ b/extensions/authclient/AuthAction.php
@@ -167,7 +167,7 @@ class AuthAction extends Action
             /** @var \yii\authclient\Collection $collection */
             $collection = Yii::$app->get($this->clientCollection);
             if (!$collection->hasClient($clientId)) {
-                throw new NotFoundHttpException("Unknown auth client '{$clientId}'.");
+                throw new NotFoundHttpException("Unknown auth client '$clientId'.");
             }
             $client = $collection->getClient($clientId);
 

--- a/extensions/authclient/AuthAction.php
+++ b/extensions/authclient/AuthAction.php
@@ -167,7 +167,7 @@ class AuthAction extends Action
             /** @var \yii\authclient\Collection $collection */
             $collection = Yii::$app->get($this->clientCollection);
             if (!$collection->hasClient($clientId)) {
-                throw new NotFoundHttpException("Unknown auth client '{$clientId}'");
+                throw new NotFoundHttpException("Unknown auth client '{$clientId}'.");
             }
             $client = $collection->getClient($clientId);
 

--- a/extensions/debug/controllers/DefaultController.php
+++ b/extensions/debug/controllers/DefaultController.php
@@ -101,7 +101,7 @@ class DefaultController extends Controller
         $filePath = Yii::getAlias($this->module->panels['mail']->mailPath) . '/' . basename($file);
 
         if ((mb_strpos($file, '\\') !== false || mb_strpos($file, '/') !== false) || !is_file($filePath)) {
-            throw new NotFoundHttpException('Mail file not found');
+            throw new NotFoundHttpException('Mail file not found.');
         }
 
         Yii::$app->response->sendFile($filePath);

--- a/extensions/gii/controllers/DefaultController.php
+++ b/extensions/gii/controllers/DefaultController.php
@@ -70,7 +70,7 @@ class DefaultController extends Controller
                 }
             }
         }
-        throw new NotFoundHttpException("Code file not found: $file");
+        throw new NotFoundHttpException("Code file '$file' not found.");
     }
 
     public function actionDiff($id, $file)
@@ -85,7 +85,7 @@ class DefaultController extends Controller
                 }
             }
         }
-        throw new NotFoundHttpException("Code file not found: $file");
+        throw new NotFoundHttpException("Code file '$file' not found.");
     }
 
     /**
@@ -104,7 +104,7 @@ class DefaultController extends Controller
         if (method_exists($generator, $method)) {
             return $generator->$method();
         } else {
-            throw new NotFoundHttpException("Unknown generator action: $name");
+            throw new NotFoundHttpException("Unknown generator action '$name'.");
         }
     }
 
@@ -123,7 +123,7 @@ class DefaultController extends Controller
 
             return $this->generator;
         } else {
-            throw new NotFoundHttpException("Code generator not found: $id");
+            throw new NotFoundHttpException("Code generator '$id' not found.");
         }
     }
 }

--- a/extensions/gii/generators/crud/default/controller.php
+++ b/extensions/gii/generators/crud/default/controller.php
@@ -167,7 +167,7 @@ if (count($pks) === 1) {
         if (($model = <?= $modelClass ?>::findOne(<?= $condition ?>)) !== null) {
             return $model;
         } else {
-            throw new NotFoundHttpException('The requested page does not exist.');
+            throw new NotFoundHttpException();
         }
     }
 }

--- a/framework/rest/Action.php
+++ b/framework/rest/Action.php
@@ -99,7 +99,7 @@ class Action extends \yii\base\Action
         if (isset($model)) {
             return $model;
         } else {
-            throw new NotFoundHttpException("Object not found: $id");
+            throw new NotFoundHttpException("Object '$id' not found.");
         }
     }
 }

--- a/framework/web/BadRequestHttpException.php
+++ b/framework/web/BadRequestHttpException.php
@@ -7,6 +7,8 @@
 
 namespace yii\web;
 
+use Yii;
+
 /**
  * BadRequestHttpException represents a "Bad Request" HTTP exception with status code 400.
  *
@@ -29,6 +31,10 @@ class BadRequestHttpException extends HttpException
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {
+        if ($message = null) {
+            $message = Yii::t('yii', 'Bad request.');
+        }
+
         parent::__construct(400, $message, $code, $previous);
     }
 }

--- a/framework/web/NotFoundHttpException.php
+++ b/framework/web/NotFoundHttpException.php
@@ -7,6 +7,8 @@
 
 namespace yii\web;
 
+use Yii;
+
 /**
  * NotFoundHttpException represents a "Not Found" HTTP exception with status code 404.
  *
@@ -23,6 +25,10 @@ class NotFoundHttpException extends HttpException
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {
+        if ($message === null) {
+            $message = Yii::t('yii', 'The requested page does not exist.');
+        }
+
         parent::__construct(404, $message, $code, $previous);
     }
 }

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -174,7 +174,7 @@ class Request extends \yii\base\Request
 
             return [$route, $_GET];
         } else {
-            throw new NotFoundHttpException(Yii::t('yii', 'Page not found.'));
+            throw new NotFoundHttpException();
         }
     }
 

--- a/framework/web/ViewAction.php
+++ b/framework/web/ViewAction.php
@@ -123,7 +123,7 @@ class ViewAction extends Action
 
         if (!is_string($viewName) || !preg_match('/^\w[\w\/\-\.]*$/', $viewName)) {
             if (YII_DEBUG) {
-                throw new NotFoundHttpException("The requested view \"$viewName\" must start with a word character and can contain only word characters, forward slashes, dots and dashes.");
+                throw new NotFoundHttpException("The requested view '$viewName' must start with a word character and can contain only word characters, forward slashes, dots and dashes.");
             } else {
                 throw new NotFoundHttpException(Yii::t('yii', 'The requested view "{name}" was not found.', ['name' => $viewName]));
             }


### PR DESCRIPTION
Guys it really boring to write every time same messages for exceptions. For example inside controller:

``` php
public function actionIndex($categoryId)
{
    $category = Category::findOne($categoryId);

    if ($category === null) {
        throw new NotFoundHttpException(Yii::t('app', 'The requested page does not exist.'));
    }
    ...
}
```

Lets create default localizable messages for every `\yii\web\*HttpException` class. With that feature we can forget about writing messages manually in 90% cases. Controller code will look like:

``` php
public function actionIndex($categoryId)
{
    $category = Category::findOne($categoryId);

    if ($category === null) {
        throw new NotFoundHttpException();
    }
    ...
}
```
