### PR TITLE
Fix #3749: Ensure clickable links for Bootstrap Dropdown

### DIFF
--- a/extensions/bootstrap/CHANGELOG.md
+++ b/extensions/bootstrap/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 bootstrap extension Change Log
 --------------------------
 
 - Bug #3292: Fixed dropdown widgets rendering incorrect HTML (it3rmit)
+- Bug #3749: Fixed invalid plugin registration and ensure clickable links in dropdown (kartik-v)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)
 
 

--- a/extensions/bootstrap/Dropdown.php
+++ b/extensions/bootstrap/Dropdown.php
@@ -57,7 +57,6 @@ class Dropdown extends Widget
     public function run()
     {
         echo $this->renderItems($this->items);
-        $this->registerPlugin('dropdown');
     }
 
     /**


### PR DESCRIPTION
The registerPlugin is not required.
