### PR TITLE
Fix #3756: Convert values to float for number formatting

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -42,6 +42,7 @@ Yii Framework 2 Change Log
 - Bug #3716: `DynamicModel::validateData()` does not call `validate()` if the `$rules` parameter is empty (qiangxue)
 - Bug #3751: Fixed postgreSQL schema data for enum values, do not add values if there are none (makroxyz)
 - Bug #3752: `QueryBuilder::batchInsert()` does not typecast input values (qiangxue)
+- Bug #3756: Fix number formatting error for `\yii\base\Formatter` by converting strings to float (kartik-v)
 - Bug: Fixed inconsistent return of `\yii\console\Application::runAction()` (samdark)
 - Bug: URL encoding for the route parameter added to `\yii\web\UrlManager` (klimov-paul)
 - Bug: Fixed the bug that requesting protected or private action methods would cause 500 error instead of 404 (qiangxue)

--- a/framework/base/Formatter.php
+++ b/framework/base/Formatter.php
@@ -436,7 +436,7 @@ class Formatter extends Component
         $ds = isset($this->decimalSeparator) ? $this->decimalSeparator : '.';
         $ts = isset($this->thousandSeparator) ? $this->thousandSeparator : ',';
 
-        return number_format($value, $decimals, $ds, $ts);
+        return number_format((float) $value, $decimals, $ds, $ts);
     }
 
     /**


### PR DESCRIPTION
Convert string values to floating point, so that `number_format` method can properly format values.
