### PR TITLE
Gii codestyle fixes #2

### DIFF
--- a/extensions/gii/generators/model/default/model.php
+++ b/extensions/gii/generators/model/default/model.php
@@ -14,12 +14,15 @@
 
 echo "<?php\n";
 $baseClass = new \ReflectionClass($generator->baseClass);
+$classNs = '\\' . ltrim($generator->ns, '\\');
+$baseClassNs = '\\' . ltrim($baseClass->getNamespaceName(), '\\');
+$baseClassShortName = $baseClass->getShortName();
 ?>
 
 namespace <?= $generator->ns ?>;
 
 use Yii;
-<?php if ($className !== $baseClass->getShortName() && '\\' . ltrim($generator->ns, '\\') !== '\\' . ltrim($baseClass->getNamespaceName(), '\\')): ?>
+<?php if ($className !== $baseClassShortName && $classNs !== $baseClassNs && !class_exists($classNs . '\\' . $baseClassShortName)): ?>
 use <?= ltrim($generator->baseClass, '\\') ?>;
 <?php endif; ?>
 
@@ -36,7 +39,7 @@ use <?= ltrim($generator->baseClass, '\\') ?>;
 <?php endforeach; ?>
 <?php endif; ?>
  */
-class <?= $className ?> extends <?= $className === $baseClass->getShortName() ? '\\' . ltrim($baseClass->getNamespaceName(), '\\') : $baseClass->getShortName() . "\n" ?>
+class <?= $className ?> extends <?= $className === $baseClassShortName || class_exists($classNs . '\\' . $baseClassShortName) ? $baseClass : $baseClassShortName . "\n" ?>
 {
     /**
      * @inheritdoc

--- a/extensions/gii/generators/model/default/model.php
+++ b/extensions/gii/generators/model/default/model.php
@@ -13,11 +13,15 @@
  */
 
 echo "<?php\n";
+$class = new \ReflectionClass($generator->baseClass);
 ?>
 
 namespace <?= $generator->ns ?>;
 
 use Yii;
+<?php if ('\\' . ltrim($generator->ns, '\\') !== '\\' . ltrim($class->getNamespaceName(), '\\')): ?>
+use <?= ltrim($generator->baseClass, '\\') ?>;
+<?php endif; ?>
 
 /**
  * This is the model class for table "<?= $tableName ?>".
@@ -32,7 +36,7 @@ use Yii;
 <?php endforeach; ?>
 <?php endif; ?>
  */
-class <?= $className ?> extends <?= '\\' . ltrim($generator->baseClass, '\\') . "\n" ?>
+class <?= $className ?> extends <?= $class->getShortName() . "\n" ?>
 {
     /**
      * @inheritdoc

--- a/extensions/gii/generators/model/default/model.php
+++ b/extensions/gii/generators/model/default/model.php
@@ -13,13 +13,13 @@
  */
 
 echo "<?php\n";
-$class = new \ReflectionClass($generator->baseClass);
+$baseClass = new \ReflectionClass($generator->baseClass);
 ?>
 
 namespace <?= $generator->ns ?>;
 
 use Yii;
-<?php if ('\\' . ltrim($generator->ns, '\\') !== '\\' . ltrim($class->getNamespaceName(), '\\')): ?>
+<?php if ($className !== $baseClass->getShortName() && '\\' . ltrim($generator->ns, '\\') !== '\\' . ltrim($baseClass->getNamespaceName(), '\\')): ?>
 use <?= ltrim($generator->baseClass, '\\') ?>;
 <?php endif; ?>
 
@@ -36,7 +36,7 @@ use <?= ltrim($generator->baseClass, '\\') ?>;
 <?php endforeach; ?>
 <?php endif; ?>
  */
-class <?= $className ?> extends <?= $class->getShortName() . "\n" ?>
+class <?= $className ?> extends <?= $className === $baseClass->getShortName() ? '\\' . ltrim($baseClass->getNamespaceName(), '\\') : $baseClass->getShortName() . "\n" ?>
 {
     /**
      * @inheritdoc


### PR DESCRIPTION
Improve Gii model generator to:
1. Not use unnecessary fully qualified class name;
2. Not use `use` mechanism when extended class in the same namespace.
