### PR TITLE
Fix .gitignore for `basic` and `advanced` application templates

### DIFF
--- a/apps/advanced/.gitignore
+++ b/apps/advanced/.gitignore
@@ -15,9 +15,6 @@ nbproject
 # windows thumbnail cache
 Thumbs.db
 
-# composer vendor dir
-/vendor
-
 # composer itself is not needed
 composer.phar
 

--- a/apps/basic/.gitignore
+++ b/apps/basic/.gitignore
@@ -12,9 +12,6 @@ nbproject
 # windows thumbnail cache
 Thumbs.db
 
-# composer vendor dir
-/vendor
-
 # composer itself is not needed
 composer.phar
 


### PR DESCRIPTION
We already have `.gitignore` under `vendor` directory. Having this strings in global project `.gitignore` make those local `.gitignores` excluded from end-user repos who use yii 2 applicaiton templates.
