### PR TITLE
Twig extensions were added twice

### DIFF
--- a/extensions/twig/CHANGELOG.md
+++ b/extensions/twig/CHANGELOG.md
@@ -6,7 +6,7 @@ Yii Framework 2 twig extension Change Log
 
 - Bug #2925: Fixed throwing exception when accessing AR property with null value (samdark)
 - Enh #1799: Added `form_begin`, `form_end` to twig extension (samdark)
-
+- Fixed multiple adding of extensions from the config, added support for the instantiated extensions (grachov)
 
 2.0.0-beta April 13, 2014
 -------------------------

--- a/extensions/twig/ViewRenderer.php
+++ b/extensions/twig/ViewRenderer.php
@@ -56,7 +56,7 @@ class ViewRenderer extends BaseViewRenderer
     public $filters = [];
     /**
      * @var array Custom extensions.
-     * Example: `['Twig_Extension_Sandbox', 'Twig_Extension_Text']`
+     * Example: `['Twig_Extension_Sandbox', new \Twig_Extension_Text()]`
      */
     public $extensions = [];
     /**
@@ -83,13 +83,6 @@ class ViewRenderer extends BaseViewRenderer
             'cache' => Yii::getAlias($this->cachePath),
             'charset' => Yii::$app->charset,
         ], $this->options));
-
-        // Adding custom extensions
-        if (!empty($this->extensions)) {
-            foreach ($this->extensions as $extension) {
-                $this->twig->addExtension(new $extension());
-            }
-        }
 
         // Adding custom globals (objects or static classes)
         if (!empty($this->globals)) {
@@ -198,7 +191,7 @@ class ViewRenderer extends BaseViewRenderer
     public function addExtensions($extensions)
     {
         foreach ($extensions as $extName) {
-            $this->twig->addExtension(new $extName());
+            $this->twig->addExtension(is_object($extName) ? $extName : new $extName());
         }
     }
 


### PR DESCRIPTION
Custom extensions were added twice. And also in config it should be possible to pass the objects, because some extensions can have params that should be passed to the constructor.
