### PR TITLE
File validator adjusted

### DIFF
--- a/framework/validators/ImageValidator.php
+++ b/framework/validators/ImageValidator.php
@@ -9,7 +9,6 @@ namespace yii\validators;
 
 use Yii;
 use yii\web\UploadedFile;
-use yii\helpers\FileHelper;
 
 /**
  * ImageValidator verifies if an attribute is receiving a valid image.
@@ -52,15 +51,6 @@ class ImageValidator extends FileValidator
      */
     public $maxHeight;
     /**
-     * @var array|string a list of file MIME types that are allowed to be uploaded.
-     * This can be either an array or a string consisting of file MIME types
-     * separated by space or comma (e.g. "image/jpeg, image/png").
-     * Mime type names are case-insensitive. Defaults to null, meaning all MIME types
-     * are allowed.
-     * @see wrongMimeType
-     */
-    public $mimeTypes;
-    /**
      * @var string the error message used when the image is under [[minWidth]].
      * You may use the following tokens in the message:
      *
@@ -96,16 +86,7 @@ class ImageValidator extends FileValidator
      * - {limit}: the value of [[maxHeight]]
      */
     public $overHeight;
-    /**
-     * @var string the error message used when the file has an mime type
-     * that is not listed in [[mimeTypes]].
-     * You may use the following tokens in the message:
-     *
-     * - {attribute}: the attribute name
-     * - {file}: the uploaded file name
-     * - {mimeTypes}: the value of [[mimeTypes]]
-     */
-    public $wrongMimeType;
+
 
     /**
      * @inheritdoc
@@ -129,12 +110,6 @@ class ImageValidator extends FileValidator
         if ($this->overHeight === null) {
             $this->overHeight = Yii::t('yii', 'The image "{file}" is too large. The height cannot be larger than {limit, number} {limit, plural, one{pixel} other{pixels}}.');
         }
-        if ($this->wrongMimeType === null) {
-            $this->wrongMimeType = Yii::t('yii', 'Only files with these MIME types are allowed: {mimeTypes}.');
-        }
-        if (!is_array($this->mimeTypes)) {
-            $this->mimeTypes = preg_split('/[\s,]+/', strtolower($this->mimeTypes), -1, PREG_SPLIT_NO_EMPTY);
-        }
     }
 
     /**
@@ -155,10 +130,6 @@ class ImageValidator extends FileValidator
      */
     protected function validateImage($image)
     {
-        if (!empty($this->mimeTypes) && !in_array(FileHelper::getMimeType($image->tempName), $this->mimeTypes, true)) {
-            return [$this->wrongMimeType, ['file' => $image->name, 'mimeTypes' => implode(', ', $this->mimeTypes)]];
-        }
-
         if (false === ($imageInfo = getimagesize($image->tempName))) {
             return [$this->notImage, ['file' => $image->name]];
         }

--- a/tests/unit/framework/validators/FileValidatorTest.php
+++ b/tests/unit/framework/validators/FileValidatorTest.php
@@ -21,7 +21,7 @@ class FileValidatorTest extends TestCase
     public function testAssureMessagesSetOnInit()
     {
         $val = new FileValidator();
-        foreach (['message', 'uploadRequired', 'tooMany', 'wrongType', 'tooBig', 'tooSmall'] as $attr) {
+        foreach (['message', 'uploadRequired', 'tooMany', 'wrongType', 'tooBig', 'tooSmall', 'wrongMimeType'] as $attr) {
             $this->assertTrue(is_string($val->$attr));
         }
     }
@@ -30,16 +30,42 @@ class FileValidatorTest extends TestCase
     {
         $val = new FileValidator(['types' => 'jpeg, jpg, gif']);
         $this->assertEquals(['jpeg', 'jpg', 'gif'], $val->types);
+
         $val = new FileValidator(['types' => 'jpeg']);
         $this->assertEquals(['jpeg'], $val->types);
+
         $val = new FileValidator(['types' => '']);
         $this->assertEquals([], $val->types);
+
         $val = new FileValidator(['types' => []]);
         $this->assertEquals([], $val->types);
+
         $val = new FileValidator();
         $this->assertEquals([], $val->types);
+
         $val = new FileValidator(['types' => ['jpeg', 'exe']]);
         $this->assertEquals(['jpeg', 'exe'], $val->types);
+    }
+
+    public function testMimeTypeSplitOnInit()
+    {
+        $val = new FileValidator(['mimeTypes' => 'text/plain, image/png']);
+        $this->assertEquals(['text/plain', 'image/png'], $val->mimeTypes);
+
+        $val = new FileValidator(['mimeTypes' => 'text/plain']);
+        $this->assertEquals(['text/plain'], $val->mimeTypes);
+
+        $val = new FileValidator(['mimeTypes' => '']);
+        $this->assertEquals([], $val->mimeTypes);
+
+        $val = new FileValidator(['mimeTypes' => []]);
+        $this->assertEquals([], $val->mimeTypes);
+
+        $val = new FileValidator();
+        $this->assertEquals([], $val->mimeTypes);
+
+        $val = new FileValidator(['mimeTypes' => ['text/plain', 'image/png']]);
+        $this->assertEquals(['text/plain', 'image/png'], $val->mimeTypes);
     }
 
     public function testGetSizeLimit()


### PR DESCRIPTION
File validator mime - types added, also image validator adjusted. This PR is related with this [issue](https://github.com/yiisoft/yii2/issues/3743).
Should we also drop `types` here or not ? As for me i almost always use `mimeTypes` , but for other developers it can be annoing to specify all mimeTypes that can be matched by file extensions, so they will like to make simple `types`. 
However i think `types` can be adjusted with mime-types check, so we will compare pathinfo extension + extension that is determined on mime - type, what do you think ? If so, then we will need some additional method in `BaseFileHelper` called `getExtensionByMimeType`, simple `return isset()` .
