### PR TITLE
Fix Menu bug when using `template` with `encodeLabel` => false

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -45,6 +45,7 @@ Yii Framework 2 Change Log
 - Bug: Fixed inconsistent return of `\yii\console\Application::runAction()` (samdark)
 - Bug: URL encoding for the route parameter added to `\yii\web\UrlManager` (klimov-paul)
 - Bug: Fixed the bug that requesting protected or private action methods would cause 500 error instead of 404 (qiangxue)
+- Bug #3843: Fixed Menu bug when using `template` with `encodeLabel` => false (creocoder, umneeq)
 - Enh #2264: `CookieCollection::has()` will return false for expired or removed cookies (qiangxue)
 - Enh #2435: `yii\db\IntegrityException` is now thrown on database integrity errors instead of general `yii\db\Exception` (samdark)
 - Enh #2837: Error page now shows arguments in stack trace method calls (samdark)

--- a/framework/widgets/Menu.php
+++ b/framework/widgets/Menu.php
@@ -255,9 +255,7 @@ class Menu extends Widget
             if (!isset($item['label'])) {
                 $item['label'] = '';
             }
-            if ($this->encodeLabels) {
-                $items[$i]['label'] = Html::encode($item['label']);
-            }
+            $items[$i]['label'] = $this->encodeLabels ? Html::encode($item['label']) : $item['label'];
             $hasActiveChild = false;
             if (isset($item['items'])) {
                 $items[$i]['items'] = $this->normalizeItems($item['items'], $hasActiveChild);


### PR DESCRIPTION
``` php
Menu::widget([
        'encodeLabels' => false,
        'items' => [
            ['template' => '<div class="sidebar-toggler"></div>'],
            ['label' => 'Articles', 'url' => ['/article/index']],
        ],
    ])
```

Lead to exception: 

```
PHP Notice – yii\base\ErrorException
Undefined index: label
```
