### PR TITLE
added highlighting into debug module

### DIFF
--- a/extensions/debug/DebugAsset.php
+++ b/extensions/debug/DebugAsset.php
@@ -17,13 +17,17 @@ use yii\web\AssetBundle;
  */
 class DebugAsset extends AssetBundle
 {
+
     public $sourcePath = '@yii/debug/assets';
+
     public $css = [
         'main.css',
         'toolbar.css',
     ];
+
     public $depends = [
         'yii\web\YiiAsset',
         'yii\bootstrap\BootstrapAsset',
     ];
+
 }

--- a/extensions/debug/HighlightAsset.php
+++ b/extensions/debug/HighlightAsset.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\debug;
+
+use yii\web\AssetBundle;
+
+/**
+ * Highlight asset bundle
+ * 
+ * @author Mark Jebri <mark.github@yandex.ru>
+ * @since 2.0
+ */
+class HighlightAsset extends AssetBundle
+{
+
+    public $sourcePath = '@app/vendor/scrivo/highlight.php/styles';
+
+    public $css = [
+        'github.css',
+    ];
+
+}

--- a/extensions/debug/Module.php
+++ b/extensions/debug/Module.php
@@ -13,6 +13,7 @@ use yii\base\BootstrapInterface;
 use yii\helpers\Url;
 use yii\web\View;
 use yii\web\ForbiddenHttpException;
+use Highlight\Highlighter;
 
 /**
  * The Yii Debug Module provides the debug toolbar and debugger
@@ -60,7 +61,10 @@ class Module extends \yii\base\Module implements BootstrapInterface
      * You may want to enable the debug logs if you want to investigate how the debug module itself works.
      */
     public $enableDebugLogs = false;
-
+    /**
+     * @var \Highlight\Highlighter highlighter instance
+     */
+    private $_highlighter;
 
     /**
      * Returns Yii logo ready to use in `<img src="`
@@ -213,4 +217,18 @@ class Module extends \yii\base\Module implements BootstrapInterface
             'mail' => ['class' => 'yii\debug\panels\MailPanel'],
         ];
     }
+
+    /**
+     * Returns current module highlighter instance
+     * @return \Highlight\Highlighter
+     */
+    public function getHighlighter()
+    {
+        if ($this->_highlighter == null) {
+            $this->_highlighter = new Highlighter();
+        }
+
+        return $this->_highlighter;
+    }
+
 }

--- a/extensions/debug/composer.json
+++ b/extensions/debug/composer.json
@@ -19,7 +19,8 @@
 	],
 	"require": {
 		"yiisoft/yii2": "*",
-		"yiisoft/yii2-bootstrap": "*"
+		"yiisoft/yii2-bootstrap": "*",
+		"scrivo/highlight.php": "8.*"
 	},
 	"autoload": {
 		"psr-4": { "yii\\debug\\": "" }

--- a/extensions/debug/views/default/panels/db/detail.php
+++ b/extensions/debug/views/default/panels/db/detail.php
@@ -13,6 +13,8 @@ use yii\grid\GridView;
 
 <?php
 
+$highlighter = $this->context->module->highlighter;
+
 echo GridView::widget([
     'dataProvider' => $dataProvider,
     'id' => 'db-panel-detailed-grid',
@@ -49,24 +51,34 @@ echo GridView::widget([
         [
             'attribute' => 'type',
             'value' => function ($data) {
-                return Html::encode(mb_strtoupper($data['type'], 'utf8'));
+
+                $content = Html::tag('span', Html::encode(mb_strtoupper($data['type'], 'utf8')), [
+                    'class' => 'hljs-variable'
+                ]);
+
+                return Html::tag('pre', $content, [
+                    'class' => 'hljs php'
+                ]);
             },
+            'format' => 'html',
         ],
         [
             'attribute' => 'query',
-            'value' => function ($data) {
-                $query = Html::encode($data['query']);
+            'value' => function ($data) use ($highlighter) {
+                $highlighted = $highlighter->highlight('sql', $data['query']);
+                $text = Html::tag('pre', $highlighted->value, [
+                    'class' => 'hljs sql'
+                ]);
 
                 if (!empty($data['trace'])) {
-                    $query .= Html::ul($data['trace'], [
+                    $text .= Html::ul($data['trace'], [
                         'class' => 'trace',
                         'item' => function ($trace) {
-                            return "<li>{$trace['file']} ({$trace['line']})</li>";
+                            return "<li>" . Html::encode($trace['file']) . " " . Html::encode($trace['line']) . "</li>";
                         },
                     ]);
                 }
-
-                return $query;
+                return $text;
             },
             'format' => 'html',
             'options' => [

--- a/extensions/debug/views/default/panels/profile/detail.php
+++ b/extensions/debug/views/default/panels/profile/detail.php
@@ -14,6 +14,9 @@ use yii\helpers\Html;
 <h1>Performance Profiling</h1>
 <p>Total processing time: <b><?= $time ?></b>; Peak memory: <b><?= $memory ?></b>.</p>
 <?php
+
+$highlighter = $this->context->module->highlighter;
+
 echo GridView::widget([
     'dataProvider' => $dataProvider,
     'id' => 'profile-panel-detailed-grid',
@@ -47,11 +50,32 @@ echo GridView::widget([
                 'class' => 'sort-numerical'
             ]
         ],
-        'category',
+        [
+            'attribute' => 'category',
+            'value' => function ($data) {
+
+                $content = Html::tag('span', Html::encode($data['category']), [
+                    'class' => 'hljs-variable'
+                ]);
+
+                return Html::tag('pre', $content, [
+                    'class' => 'hljs php'
+                ]);
+            },
+            'format' => 'html',
+        ],
         [
             'attribute' => 'info',
-            'value' => function ($data) {
-                return str_repeat('<span class="indent">→</span>', $data['level']) . Html::encode($data['info']);
+            'value' => function ($data) use ($highlighter) {
+
+                $highlighter->setAutodetectLanguages(['php', 'sql']);
+                $highlighted = $highlighter->highlightAuto($data['info']);
+
+                $text = Html::tag('pre', $highlighted->value, [
+                    'class' => 'hljs ' . $highlighted->language,
+                ]);
+
+                return str_repeat('<span class="indent">→</span>', $data['level']) . $text;
             },
             'format' => 'html',
             'options' => [

--- a/extensions/debug/views/layouts/main.php
+++ b/extensions/debug/views/layouts/main.php
@@ -6,6 +6,7 @@
 use yii\helpers\Html;
 
 yii\debug\DebugAsset::register($this);
+yii\debug\HighlightAsset::register($this);
 ?>
 <?php $this->beginPage() ?>
 <!DOCTYPE html>


### PR DESCRIPTION
Added basic highlighting in `Debug` module with [this](https://github.com/scrivo/highlight.php) 3rd party lib. By default css similar to `github`. Since we dont have too particular code to highlight in `Debug` module, i've currently only highlighted sql queries + categories strings. Questions to discuss:
- should we highlight other pages with this one? Or we can skip it and make it later with simple css if needed and not wrapping them into `<pre>` highlight element like it is done for `category` attribute for example.

Also we can apply highlighting later on `Events` debug panel if it will be considered as enh. , there we can highlight json encoded event attributes and data .

Any suggestions on how to highlight better would be very welcome ) Below are screenshots of highlighted pages:

![database_panel_highlight](https://cloud.githubusercontent.com/assets/1748844/3269348/c43f2a40-f2eb-11e3-8f39-c407c41c7e35.png)
![log_panel_highlight](https://cloud.githubusercontent.com/assets/1748844/3269350/ca12029e-f2eb-11e3-84e0-29e7eb8db2d8.png)
![profile_panel_highlight](https://cloud.githubusercontent.com/assets/1748844/3269351/ce932e6a-f2eb-11e3-9111-3d1b6d568d01.png)
