### PR TITLE
Fixed incorrect js selector for `\yii\widgets\ActiveForm::errorSummaryCssClass`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -46,6 +46,7 @@ Yii Framework 2 Change Log
 - Bug: Fixed inconsistent return of `\yii\console\Application::runAction()` (samdark)
 - Bug: URL encoding for the route parameter added to `\yii\web\UrlManager` (klimov-paul)
 - Bug: Fixed the bug that requesting protected or private action methods would cause 500 error instead of 404 (qiangxue)
+- Bug: Fixed incorrect js selector for `\yii\widgets\ActiveForm::errorSummaryCssClass` (creocoder, umneeq)
 - Enh #2264: `CookieCollection::has()` will return false for expired or removed cookies (qiangxue)
 - Enh #2435: `yii\db\IntegrityException` is now thrown on database integrity errors instead of general `yii\db\Exception` (samdark)
 - Enh #2837: Error page now shows arguments in stack trace method calls (samdark)

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -197,7 +197,7 @@ class ActiveForm extends Widget
     protected function getClientOptions()
     {
         $options = [
-            'errorSummary' => '.' . implode('.', explode(' ', $this->errorSummaryCssClass)),
+            'errorSummary' => '.' . implode('.', preg_split('/\s+/', $this->errorSummaryCssClass, -1, PREG_SPLIT_NO_EMPTY)),
             'validateOnSubmit' => $this->validateOnSubmit,
             'errorCssClass' => $this->errorCssClass,
             'successCssClass' => $this->successCssClass,

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -197,7 +197,7 @@ class ActiveForm extends Widget
     protected function getClientOptions()
     {
         $options = [
-            'errorSummary' => '.' . $this->errorSummaryCssClass,
+            'errorSummary' => '.' . implode('.', explode(' ', $this->errorSummaryCssClass)),
             'validateOnSubmit' => $this->validateOnSubmit,
             'errorCssClass' => $this->errorCssClass,
             'successCssClass' => $this->successCssClass,


### PR DESCRIPTION
Example:

``` php
$form = ActiveForm::begin([
    'errorSummaryCssClass' => 'some-class',
]);
```

Works fine! While:

``` php
$form = ActiveForm::begin([
    'errorSummaryCssClass' => 'some-class-1 some-class-2',
]);
```

Does not works. PR fix that.
