### PR TITLE
BootstrapThemeAsset comment fix

### DIFF
--- a/extensions/bootstrap/BootstrapThemeAsset.php
+++ b/extensions/bootstrap/BootstrapThemeAsset.php
@@ -10,7 +10,7 @@ namespace yii\bootstrap;
 use yii\web\AssetBundle;
 
 /**
- * Bootstrap 2 theme for Bootstrap 3.
+ * Asset bundle for the Twitter bootstrap default theme.
  *
  * @author Alexander Makarov <sam@rmcreative.ru>
  * @since 2.0


### PR DESCRIPTION
Bootstrap theme has nothing related to Bootstrap 2, its just **default** theme distributed with Bootstrap. Also description construction was changed to be consistent with other Bootstrap asset bundles description constructions.
