### PR TITLE
Fixes Twig lexerOptions throwing exception (#3877) 

### DIFF
--- a/extensions/twig/ViewRenderer.php
+++ b/extensions/twig/ViewRenderer.php
@@ -111,11 +111,6 @@ class ViewRenderer extends BaseViewRenderer
             $this->addExtensions($this->extensions);
         }
 
-        // Change lexer syntax
-        if (!empty($this->lexerOptions)) {
-            $this->setLexerOptions($this->lexerOptions);
-        }
-
         // Adding global 'void' function (usage: {{void(App.clientScript.registerScriptFile(...))}})
         $this->twig->addFunction('void', new \Twig_Function_Function(function ($argument) {
         }));
@@ -137,6 +132,11 @@ class ViewRenderer extends BaseViewRenderer
         }));
 
         $this->twig->addGlobal('app', \Yii::$app);
+
+        // Change lexer syntax (must be set after other settings)
+        if (!empty($this->lexerOptions)) {
+            $this->setLexerOptions($this->lexerOptions);
+        }
     }
 
     /**

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -50,6 +50,7 @@ Yii Framework 2 Change Log
 - Bug: Fixed inconsistent return of `\yii\console\Application::runAction()` (samdark)
 - Bug: URL encoding for the route parameter added to `\yii\web\UrlManager` (klimov-paul)
 - Bug: Fixed the bug that requesting protected or private action methods would cause 500 error instead of 404 (qiangxue)
+- Bug #3877 : Fixed Twig lexerOptions throwing exception
 - Enh #2264: `CookieCollection::has()` will return false for expired or removed cookies (qiangxue)
 - Enh #2435: `yii\db\IntegrityException` is now thrown on database integrity errors instead of general `yii\db\Exception` (samdark)
 - Enh #2837: Error page now shows arguments in stack trace method calls (samdark)

--- a/tests/unit/extensions/twig/ViewRendererTest.php
+++ b/tests/unit/extensions/twig/ViewRendererTest.php
@@ -52,6 +52,9 @@ class ViewRendererTest extends TestCase
                     'functions' => [
                         't' => '\Yii::t',
                         'json_encode' => '\yii\helpers\Json::encode'
+                    ],
+                    'lexerOptions' => [
+                        'tag_comment' => [ '{*', '*}' ],
                     ]
                 ],
             ],

--- a/tests/unit/extensions/twig/ViewRendererTest.php
+++ b/tests/unit/extensions/twig/ViewRendererTest.php
@@ -35,6 +35,18 @@ class ViewRendererTest extends TestCase
         $this->assertEquals(1, preg_match('#<script src="/assets/[0-9a-z]+/jquery\\.js"></script>\s*</body>#', $content), 'content does not contain the jquery js:' . $content);
     }
 
+    /**
+     * https://github.com/yiisoft/yii2/issues/3877
+     */
+    public function testLexerOptions()
+    {
+        $view = $this->mockView();
+        $content = $view->renderFile('@yiiunit/extensions/twig/views/layout.twig');
+
+        $this->assertFalse(strpos($content, 'CUSTOM_LEXER_TWIG_COMMENT') , 'custom comment lexerOption is not applied');
+        $this->assertTrue(0 < strpos($content, 'DEFAULT_TWIG_COMMENT') , 'default comment style not modified via lexerOptions');
+    }
+
     protected function mockView()
     {
         return new View([

--- a/tests/unit/extensions/twig/views/layout.twig
+++ b/tests/unit/extensions/twig/views/layout.twig
@@ -8,6 +8,8 @@
 </head>
 <body>
 {{ this.beginBody() }}
+    {# DEFAULT_TWIG_COMMENT #}
+    {* CUSTOM_LEXER_TWIG_COMMENT *}
     body
 {{ this.endBody() }}
 </body>


### PR DESCRIPTION
First commit only adds lexerOptions to config to make test fail and demonstrate the error.

Although rearranging the order of applying Twig options obviously fixes this bug, it rather seems like a quickfix because there are no tests to ensure that Twig will always behave as we expect it.

Maybe we should write more tests before applying this fix.

fixes #3877
