### PR TITLE
BaseHtml::checkbox() and BaseHtml::radio() fixes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -50,6 +50,7 @@ Yii Framework 2 Change Log
 - Bug: Fixed inconsistent return of `\yii\console\Application::runAction()` (samdark)
 - Bug: URL encoding for the route parameter added to `\yii\web\UrlManager` (klimov-paul)
 - Bug: Fixed the bug that requesting protected or private action methods would cause 500 error instead of 404 (qiangxue)
+- Bug: Fixed `BaseHtml::checkbox()` and `BaseHtml::radio()` `labelOptions` option lead to undefined index error in some cases (creocoder)
 - Enh #2264: `CookieCollection::has()` will return false for expired or removed cookies (qiangxue)
 - Enh #2435: `yii\db\IntegrityException` is now thrown on database integrity errors instead of general `yii\db\Exception` (samdark)
 - Enh #2837: Error page now shows arguments in stack trace method calls (samdark)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -640,11 +640,12 @@ class BaseHtml
         } else {
             $hidden = '';
         }
+        $labelOptions = isset($options['labelOptions']) ? $options['labelOptions'] : [];
+        unset($options['labelOptions']);
         if (isset($options['label'])) {
             $label = $options['label'];
-            $labelOptions = isset($options['labelOptions']) ? $options['labelOptions'] : [];
             $container = isset($options['container']) ? $options['container'] : ['class' => 'radio'];
-            unset($options['label'], $options['labelOptions'], $options['container']);
+            unset($options['label'], $options['container']);
             $content = static::label(static::input('radio', $name, $value, $options) . ' ' . $label, null, $labelOptions);
             if (is_array($container)) {
                 return $hidden . static::tag('div', $content, $container);
@@ -690,11 +691,12 @@ class BaseHtml
         } else {
             $hidden = '';
         }
+        $labelOptions = isset($options['labelOptions']) ? $options['labelOptions'] : [];
+        unset($options['labelOptions']);
         if (isset($options['label'])) {
             $label = $options['label'];
-            $labelOptions = isset($options['labelOptions']) ? $options['labelOptions'] : [];
             $container = isset($options['container']) ? $options['container'] : ['class' => 'checkbox'];
-            unset($options['label'], $options['labelOptions'], $options['container']);
+            unset($options['label'], $options['container']);
             $content = static::label(static::input('checkbox', $name, $value, $options) . ' ' . $label, null, $labelOptions);
             if (is_array($container)) {
                 return $hidden . static::tag('div', $content, $container);
@@ -1550,7 +1552,7 @@ class BaseHtml
         $groups = isset($tagOptions['groups']) ? $tagOptions['groups'] : [];
         unset($tagOptions['prompt'], $tagOptions['options'], $tagOptions['groups']);
         $options['encodeSpaces'] = ArrayHelper::getValue($options, 'encodeSpaces', $encodeSpaces);
-        
+
         foreach ($items as $key => $value) {
             if (is_array($value)) {
                 $groupAttrs = isset($groups[$key]) ? $groups[$key] : [];


### PR DESCRIPTION
Code:

``` php
use yii\helpers\Html;
echo Html::checkbox('test', false, ['labelOptions' => ['class' => 'test']]);
echo Html::radio('test', false, ['labelOptions' => ['class' => 'test']]);
```

lead to undefined index errors.
