### PR TITLE
Fix #2532: Allow AR behaviors to attach other behaviors to Query

### DIFF
--- a/apps/advanced/backend/controllers/SiteController.php
+++ b/apps/advanced/backend/controllers/SiteController.php
@@ -15,7 +15,7 @@ class SiteController extends Controller
     /**
      * @inheritdoc
      */
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             'access' => [

--- a/apps/advanced/common/models/User.php
+++ b/apps/advanced/common/models/User.php
@@ -31,7 +31,7 @@ class User extends ActiveRecord implements IdentityInterface
     /**
      * @inheritdoc
      */
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             'timestamp' => [

--- a/apps/advanced/frontend/controllers/SiteController.php
+++ b/apps/advanced/frontend/controllers/SiteController.php
@@ -21,7 +21,7 @@ class SiteController extends Controller
     /**
      * @inheritdoc
      */
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             'access' => [

--- a/apps/basic/controllers/SiteController.php
+++ b/apps/basic/controllers/SiteController.php
@@ -11,7 +11,7 @@ use app\models\ContactForm;
 
 class SiteController extends Controller
 {
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             'access' => [

--- a/docs/guide-es/intro-upgrade-from-v1.md
+++ b/docs/guide-es/intro-upgrade-from-v1.md
@@ -311,7 +311,7 @@ al controlador como un comportamiento. Por ejemplo, para utilizar el filtro [[yi
 el siguiente código en el controlador:
 
 ```php
-public function behaviors()
+public static function behaviors()
 {
     return [
         'access' => [

--- a/docs/guide-fr/intro-upgrade-from-v1.md
+++ b/docs/guide-fr/intro-upgrade-from-v1.md
@@ -309,7 +309,7 @@ Les filtres d'action sont maintenant implémentés comme des comportements. Pour
 comme un comportement du contrôleur.  Par exemple, pour utilser le filtre [[yii\filters\AccessControl]], vous aurez le code suivant dans le contrôleur :
 
 ```php
-public function behaviors()
+public static function behaviors()
 {
     return [
         'access' => [

--- a/docs/guide-pt-BR/intro-upgrade-from-v1.md
+++ b/docs/guide-pt-BR/intro-upgrade-from-v1.md
@@ -355,7 +355,7 @@ behavior. Por exemplo, para usar o filtro [[yii\filters\AccessControl]],
 você teria o seguinte código em um controller:
 
 ```php
-public function behaviors()
+public static function behaviors()
 {
     return [
         'access' => [

--- a/docs/guide/caching-http.md
+++ b/docs/guide/caching-http.md
@@ -33,7 +33,7 @@ function ($action, $params)
 The following is an example of making use of the `Last-Modified` header:
 
 ```php
-public function behaviors()
+public static function behaviors()
 {
     return [
         [
@@ -78,7 +78,7 @@ function ($action, $params)
 The following is an example of making use of the `ETag` header:
 
 ```php
-public function behaviors()
+public static function behaviors()
 {
     return [
         [

--- a/docs/guide/caching-page.md
+++ b/docs/guide/caching-page.md
@@ -8,7 +8,7 @@ Page caching is supported by [[yii\filters\PageCache]], an [action filter](runti
 It can be used like the following in a controller class:
 
 ```php
-public function behaviors()
+public static function behaviors()
 {
     return [
         [

--- a/docs/guide/concept-behaviors.md
+++ b/docs/guide/concept-behaviors.md
@@ -71,7 +71,7 @@ use app\components\MyBehavior;
 
 class User extends ActiveRecord
 {
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             // anonymous behavior, behavior class name only
@@ -249,7 +249,7 @@ class User extends ActiveRecord
 {
     // ...
 
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             [

--- a/docs/guide/intro-upgrade-from-v1.md
+++ b/docs/guide/intro-upgrade-from-v1.md
@@ -309,7 +309,7 @@ as a behavior. For example, to use the [[yii\filters\AccessControl]] filter, you
 code in a controller:
 
 ```php
-public function behaviors()
+public static function behaviors()
 {
     return [
         'access' => [

--- a/docs/guide/rest-authentication.md
+++ b/docs/guide/rest-authentication.md
@@ -35,7 +35,7 @@ For example, to use HTTP Basic Auth, you may configure `authenticator` as follow
 ```php
 use yii\filters\auth\HttpBasicAuth;
 
-public function behaviors()
+public static function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
@@ -53,7 +53,7 @@ use yii\filters\auth\HttpBasicAuth;
 use yii\filters\auth\HttpBearerAuth;
 use yii\filters\auth\QueryParamAuth;
 
-public function behaviors()
+public static function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [

--- a/docs/guide/rest-controllers.md
+++ b/docs/guide/rest-controllers.md
@@ -65,7 +65,7 @@ For example, if you only want to use HTTP basic authentication, you may write th
 ```php
 use yii\filters\auth\HttpBasicAuth;
 
-public function behaviors()
+public static function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [

--- a/docs/guide/rest-rate-limiting.md
+++ b/docs/guide/rest-rate-limiting.md
@@ -25,7 +25,7 @@ will thrown a [[yii\web\TooManyRequestsHttpException]] if rate limit is exceeded
 as follows in your REST controller classes,
 
 ```php
-public function behaviors()
+public static function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['rateLimiter']['enableRateLimitHeaders'] = false;

--- a/docs/guide/rest-response-formatting.md
+++ b/docs/guide/rest-response-formatting.md
@@ -69,7 +69,7 @@ the following in your API controller classes:
 ```php
 use yii\web\Response;
 
-public function behaviors()
+public static function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['contentNegotiator']['formats']['text/html'] = Response::FORMAT_HTML;

--- a/docs/guide/security-authorization.md
+++ b/docs/guide/security-authorization.md
@@ -22,7 +22,7 @@ use yii\filters\AccessControl;
 
 class SiteController extends Controller
 {
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             'access' => [
@@ -118,7 +118,7 @@ use yii\filters\AccessControl;
 
 class SiteController extends Controller
 {
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             'access' => [

--- a/docs/guide/structure-filters.md
+++ b/docs/guide/structure-filters.md
@@ -12,7 +12,7 @@ To use an action filter, attach it as a behavior to a controller or a module. Th
 example shows how to enable HTTP caching for the `index` action:
 
 ```php
-public function behaviors()
+public static function behaviors()
 {
     return [
         'httpCache' => [

--- a/docs/guide/tutorial-performance-tuning.md
+++ b/docs/guide/tutorial-performance-tuning.md
@@ -143,7 +143,7 @@ Forming proper headers is time consuming task so Yii provides a shortcut in form
 the following:
 
 ```php
-public function behaviors()
+public static function behaviors()
 {
     return [
         'httpCache' => [

--- a/extensions/gii/generators/crud/default/controller.php
+++ b/extensions/gii/generators/crud/default/controller.php
@@ -45,7 +45,7 @@ use yii\filters\VerbFilter;
  */
 class <?= $controllerClass ?> extends <?= StringHelper::basename($generator->baseControllerClass) . "\n" ?>
 {
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             'verbs' => [

--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -431,7 +431,7 @@ class Component extends Object
      *
      * @return array the behavior configurations.
      */
-    public function behaviors()
+    public static function behaviors()
     {
         return [];
     }
@@ -652,7 +652,7 @@ class Component extends Object
     {
         if ($this->_behaviors === null) {
             $this->_behaviors = [];
-            foreach ($this->behaviors() as $name => $behavior) {
+            foreach (static::behaviors() as $name => $behavior) {
                 $this->attachBehaviorInternal($name, $behavior);
             }
         }

--- a/framework/behaviors/AttributeBehavior.php
+++ b/framework/behaviors/AttributeBehavior.php
@@ -23,7 +23,7 @@ use yii\base\Event;
  * ~~~
  * use yii\behaviors\AttributeBehavior;
  *
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         'attributeStamp' => [

--- a/framework/behaviors/BlameableBehavior.php
+++ b/framework/behaviors/BlameableBehavior.php
@@ -19,7 +19,7 @@ use yii\db\BaseActiveRecord;
  * ```php
  * use yii\behaviors\BlameableBehavior;
  *
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         BlameableBehavior::className(),
@@ -33,7 +33,7 @@ use yii\db\BaseActiveRecord;
  * the [[attributes]] property like the following:
  *
  * ```php
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         [

--- a/framework/behaviors/TimestampBehavior.php
+++ b/framework/behaviors/TimestampBehavior.php
@@ -18,7 +18,7 @@ use yii\db\Expression;
  * ```php
  * use yii\behaviors\TimestampBehavior;
  *
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         TimestampBehavior::className(),
@@ -36,7 +36,7 @@ use yii\db\Expression;
  * ```php
  * use yii\db\Expression;
  *
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         'timestamp' => [

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -99,6 +99,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     public function __construct($modelClass, $config = [])
     {
         $this->modelClass = $modelClass;
+        $this->ensureModelBehaviors();
         parent::__construct($config);
     }
 

--- a/framework/db/ActiveQueryBehaviorInterface.php
+++ b/framework/db/ActiveQueryBehaviorInterface.php
@@ -20,5 +20,5 @@ interface ActiveQueryBehaviorInterface
      * Returns definition of the behavior, which should be attached to the [[ActiveQuery]] instance.
      * @return mixed behavior instance or configuration.
      */
-    public static function queryBehavior();
+    public function queryBehavior();
 }

--- a/framework/db/ActiveQueryBehaviorInterface.php
+++ b/framework/db/ActiveQueryBehaviorInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db;
+
+/**
+ * ActiveQueryBehaviorInterface allows behavior declared for the [[ActiveRecord]] attach relative
+ * behavior to the [[ActiveQuery]] once it is created.
+ *
+ * @author Klimov Paul <klimov@zfort.com>
+ * @since 2.0
+ */
+interface ActiveQueryBehaviorInterface
+{
+    /**
+     * Returns definition of the behavior, which should be attached to the [[ActiveQuery]] instance.
+     * @return mixed behavior instance or configuration.
+     */
+    public static function queryBehavior();
+}

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -6,6 +6,7 @@
  */
 
 namespace yii\db;
+use Yii;
 
 /**
  * ActiveQueryTrait implements the common methods and properties for active record query classes.
@@ -35,7 +36,7 @@ trait ActiveQueryTrait
      */
     public function ensureModelBehaviors()
     {
-        /** @var ActiveRecord $modelClass */
+        /* @var ActiveRecord $modelClass */
         $modelClass = $this->modelClass;
         $behaviors = [];
         foreach ($modelClass::behaviors() as $modelBehavior) {
@@ -46,9 +47,12 @@ trait ActiveQueryTrait
             } else {
                 $behaviorClass = $modelBehavior;
             }
-            // @todo extract special interface
             if (is_subclass_of($behaviorClass, 'yii\db\ActiveQueryBehaviorInterface')) {
-                $behaviors[] = $behaviorClass::queryBehavior();
+                /* @var \yii\db\ActiveQueryBehaviorInterface $modelBehavior */
+                if (!is_object($modelBehavior)) {
+                    $modelBehavior = Yii::createObject($modelBehavior);
+                }
+                $behaviors[] = $modelBehavior->queryBehavior();
             }
         }
         if (!empty($behaviors)) {

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -47,8 +47,8 @@ trait ActiveQueryTrait
                 $behaviorClass = $modelBehavior;
             }
             // @todo extract special interface
-            if (is_subclass_of($behaviorClass, 'yii\base\Behavior')) {
-                $behaviors[] = $modelBehavior;
+            if (is_subclass_of($behaviorClass, 'yii\db\ActiveQueryBehaviorInterface')) {
+                $behaviors[] = $behaviorClass::queryBehavior();
             }
         }
         if (!empty($behaviors)) {

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -30,6 +30,32 @@ trait ActiveQueryTrait
      */
     public $asArray;
 
+    /**
+     * Makes sure that query behaviors declared by model behaviors are attached to this component.
+     */
+    public function ensureModelBehaviors()
+    {
+        /** @var ActiveRecord $modelClass */
+        $modelClass = $this->modelClass;
+        $behaviors = [];
+        foreach ($modelClass::behaviors() as $modelBehavior) {
+            if (is_object($modelBehavior)) {
+                $behaviorClass = get_class($modelBehavior);
+            } elseif (is_array($modelBehavior)) {
+                $behaviorClass = $modelBehavior['class'];
+            } else {
+                $behaviorClass = $modelBehavior;
+            }
+            // @todo extract special interface
+            if (is_subclass_of($behaviorClass, 'yii\base\Behavior')) {
+                $behaviors[] = $modelBehavior;
+            }
+        }
+        if (!empty($behaviors)) {
+            /* @var \yii\base\Component $this */
+            $this->attachBehaviors($behaviors);
+        }
+    }
 
     /**
      * Sets the [[asArray]] property.

--- a/framework/filters/AccessControl.php
+++ b/framework/filters/AccessControl.php
@@ -27,7 +27,7 @@ use yii\web\ForbiddenHttpException;
  * and "update" actions and deny all other users from accessing these two actions.
  *
  * ~~~
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         'access' => [

--- a/framework/filters/ContentNegotiator.php
+++ b/framework/filters/ContentNegotiator.php
@@ -60,7 +60,7 @@ use yii\web\UnsupportedMediaTypeHttpException;
  * ```php
  * use yii\web\Response;
  *
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         [

--- a/framework/filters/HttpCache.php
+++ b/framework/filters/HttpCache.php
@@ -21,7 +21,7 @@ use yii\base\Action;
  * the Last-Modified header will contain the date of the last update to the user table in the database.
  *
  * ~~~
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         'httpCache' => [

--- a/framework/filters/PageCache.php
+++ b/framework/filters/PageCache.php
@@ -24,7 +24,7 @@ use yii\caching\Dependency;
  * the application language and user id.
  *
  * ~~~
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         'pageCache' => [

--- a/framework/filters/RateLimiter.php
+++ b/framework/filters/RateLimiter.php
@@ -19,7 +19,7 @@ use yii\web\TooManyRequestsHttpException;
  * You may use RateLimiter by attaching it as a behavior to a controller or module, like the following,
  *
  * ```php
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         'rateLimiter' => [

--- a/framework/filters/VerbFilter.php
+++ b/framework/filters/VerbFilter.php
@@ -25,7 +25,7 @@ use yii\web\MethodNotAllowedHttpException;
  * request methods for REST CRUD actions.
  *
  * ~~~
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         'verbs' => [

--- a/framework/filters/auth/CompositeAuth.php
+++ b/framework/filters/auth/CompositeAuth.php
@@ -19,7 +19,7 @@ use yii\base\InvalidConfigException;
  * The following example shows how to support three authentication methods:
  *
  * ```php
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         'compositeAuth' => [

--- a/framework/filters/auth/HttpBasicAuth.php
+++ b/framework/filters/auth/HttpBasicAuth.php
@@ -16,7 +16,7 @@ use yii\web\UnauthorizedHttpException;
  * You may use HttpBasicAuth by attaching it as a behavior to a controller or module, like the following:
  *
  * ```php
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         'basicAuth' => [

--- a/framework/filters/auth/HttpBearerAuth.php
+++ b/framework/filters/auth/HttpBearerAuth.php
@@ -16,7 +16,7 @@ use yii\web\UnauthorizedHttpException;
  * You may use HttpBearerAuth by attaching it as a behavior to a controller or module, like the following:
  *
  * ```php
- * public function behaviors()
+ * public static function behaviors()
  * {
  *     return [
  *         'bearerAuth' => [

--- a/framework/rest/Controller.php
+++ b/framework/rest/Controller.php
@@ -43,7 +43,7 @@ class Controller extends \yii\web\Controller
     /**
      * @inheritdoc
      */
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             'contentNegotiator' => [

--- a/framework/rest/Controller.php
+++ b/framework/rest/Controller.php
@@ -55,7 +55,7 @@ class Controller extends \yii\web\Controller
             ],
             'verbFilter' => [
                 'class' => VerbFilter::className(),
-                'actions' => $this->verbs(),
+                'actions' => static::verbs(),
             ],
             'authenticator' => [
                 'class' => CompositeAuth::className(),
@@ -80,7 +80,7 @@ class Controller extends \yii\web\Controller
      * Please refer to [[VerbFilter::actions]] on how to declare the allowed verbs.
      * @return array the allowed HTTP verbs.
      */
-    protected function verbs()
+    protected static function verbs()
     {
         return [];
     }

--- a/tests/unit/framework/base/ActionFilterTest.php
+++ b/tests/unit/framework/base/ActionFilterTest.php
@@ -24,21 +24,29 @@ class ActionFilterTest extends TestCase
         $this->mockApplication();
     }
 
+    /**
+     * @param array $behaviors behaviors to apply.
+     * @return FakeController controller instance.
+     */
+    protected function createFakeController(array $behaviors = [])
+    {
+        FakeController::$behaviors = $behaviors;
+        return new FakeController('fake', Yii::$app);
+    }
+
     public function testFilter()
     {
         // no filters
-        $controller = new FakeController('fake', Yii::$app);
+        $controller = $this->createFakeController();
         $this->assertNull($controller->result);
         $result = $controller->runAction('test');
         $this->assertEquals('x', $result);
         $this->assertNull($controller->result);
 
         // all filters pass
-        $controller = new FakeController('fake', Yii::$app, [
-            'behaviors' => [
-                'filter1' => Filter1::className(),
-                'filter3' => Filter3::className(),
-            ],
+        $controller = $this->createFakeController([
+            'filter1' => Filter1::className(),
+            'filter3' => Filter3::className(),
         ]);
         $this->assertNull($controller->result);
         $result = $controller->runAction('test');
@@ -46,12 +54,10 @@ class ActionFilterTest extends TestCase
         $this->assertEquals([1, 3], $controller->result);
 
         // a filter stops in the middle
-        $controller = new FakeController('fake', Yii::$app, [
-            'behaviors' => [
-                'filter1' => Filter1::className(),
-                'filter2' => Filter2::className(),
-                'filter3' => Filter3::className(),
-            ],
+        $controller = $this->createFakeController([
+            'filter1' => Filter1::className(),
+            'filter2' => Filter2::className(),
+            'filter3' => Filter3::className(),
         ]);
         $this->assertNull($controller->result);
         $result = $controller->runAction('test');
@@ -59,12 +65,10 @@ class ActionFilterTest extends TestCase
         $this->assertEquals([1, 2], $controller->result);
 
         // the first filter stops
-        $controller = new FakeController('fake', Yii::$app, [
-            'behaviors' => [
-                'filter2' => Filter2::className(),
-                'filter1' => Filter1::className(),
-                'filter3' => Filter3::className(),
-            ],
+        $controller = $this->createFakeController([
+            'filter2' => Filter2::className(),
+            'filter1' => Filter1::className(),
+            'filter3' => Filter3::className(),
         ]);
         $this->assertNull($controller->result);
         $result = $controller->runAction('test');
@@ -72,12 +76,10 @@ class ActionFilterTest extends TestCase
         $this->assertEquals([2], $controller->result);
 
         // the last filter stops
-        $controller = new FakeController('fake', Yii::$app, [
-            'behaviors' => [
-                'filter1' => Filter1::className(),
-                'filter3' => Filter3::className(),
-                'filter2' => Filter2::className(),
-            ],
+        $controller = $this->createFakeController([
+            'filter1' => Filter1::className(),
+            'filter3' => Filter3::className(),
+            'filter2' => Filter2::className(),
         ]);
         $this->assertNull($controller->result);
         $result = $controller->runAction('test');
@@ -88,12 +90,12 @@ class ActionFilterTest extends TestCase
 
 class FakeController extends Controller
 {
+    public static $behaviors = [];
     public $result;
-    public $behaviors = [];
 
-    public function behaviors()
+    public static function behaviors()
     {
-        return $this->behaviors;
+        return static::$behaviors;
     }
 
     public function actionTest()

--- a/tests/unit/framework/base/BehaviorTest.php
+++ b/tests/unit/framework/base/BehaviorTest.php
@@ -12,7 +12,7 @@ class BarClass extends Component
 
 class FooClass extends Component
 {
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             'foo' => __NAMESPACE__ . '\BarBehavior',

--- a/tests/unit/framework/behaviors/TimestampBehaviorTest.php
+++ b/tests/unit/framework/behaviors/TimestampBehaviorTest.php
@@ -96,7 +96,7 @@ class TimestampBehaviorTest extends TestCase
  */
 class ActiveRecordTimestamp extends ActiveRecord
 {
-    public function behaviors()
+    public static function behaviors()
     {
         return [
             TimestampBehavior::className(),

--- a/tests/unit/framework/db/ActiveRecordQueryBehaviorTest.php
+++ b/tests/unit/framework/db/ActiveRecordQueryBehaviorTest.php
@@ -41,7 +41,7 @@ class CustomerEx extends Customer
 
 class ArBehavior extends Behavior implements ActiveQueryBehaviorInterface
 {
-    public static function queryBehavior()
+    public function queryBehavior()
     {
         return [
             'class' => QueryBehavior::className()

--- a/tests/unit/framework/db/ActiveRecordQueryBehaviorTest.php
+++ b/tests/unit/framework/db/ActiveRecordQueryBehaviorTest.php
@@ -3,6 +3,7 @@
 namespace yiiunit\framework\db;
 
 use yii\base\Behavior;
+use yii\db\ActiveQueryBehaviorInterface;
 use yiiunit\data\ar\ActiveRecord;
 use yiiunit\data\ar\Customer;
 
@@ -32,8 +33,18 @@ class CustomerEx extends Customer
     {
         return [
             'query' => [
-                'class' => QueryBehavior::className()
+                'class' => ArBehavior::className()
             ]
+        ];
+    }
+}
+
+class ArBehavior extends Behavior implements ActiveQueryBehaviorInterface
+{
+    public static function queryBehavior()
+    {
+        return [
+            'class' => QueryBehavior::className()
         ];
     }
 }

--- a/tests/unit/framework/db/ActiveRecordQueryBehaviorTest.php
+++ b/tests/unit/framework/db/ActiveRecordQueryBehaviorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace yiiunit\framework\db;
+
+use yii\base\Behavior;
+use yiiunit\data\ar\ActiveRecord;
+use yiiunit\data\ar\Customer;
+
+/**
+ * @group db
+ */
+class ActiveRecordQueryBehaviorTest extends DatabaseTestCase
+{
+    protected $driverName = 'sqlite';
+
+    protected function setUp()
+    {
+        parent::setUp();
+        ActiveRecord::$db = $this->getConnection();
+    }
+
+    public function testScope()
+    {
+        $models = CustomerEx::find()->whereStatus(2)->all();
+        $this->assertCount(1, $models);
+    }
+}
+
+class CustomerEx extends Customer
+{
+    public static function behaviors()
+    {
+        return [
+            'query' => [
+                'class' => QueryBehavior::className()
+            ]
+        ];
+    }
+}
+
+class QueryBehavior extends Behavior
+{
+    public function whereStatus($status)
+    {
+        /* @var \yii\db\ActiveQuery $query */
+        $query = $this->owner;
+        $query->andWhere(['status' => $status]);
+        return $query;
+    }
+}


### PR DESCRIPTION
This one attmpts to fix #2532: "Allow AR behaviors to attach other behaviors to Query"

I can not see other solution to do so, but changing `yii\base\Component::behaviors()` to be a static.
This allows `ActiveQuery` to browse behaviors declared for `ActiveRecord` searhing for specific ones implementing `ActiveQueryBehaviorInterface`.
This interface enforces behavior to declare method, which should return definition for the `ActiveQuery` specific behavior.

Unit test is attached.

Warning: this PR breaks a BC!
