### PR TITLE
Fix #2532: Allow AR behaviors to attach other behaviors to Query

### DIFF
--- a/extensions/elasticsearch/ActiveQuery.php
+++ b/extensions/elasticsearch/ActiveQuery.php
@@ -86,6 +86,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     public function __construct($modelClass, $config = [])
     {
         $this->modelClass = $modelClass;
+        $this->ensureModelBehaviors();
         parent::__construct($config);
     }
 

--- a/extensions/mongodb/ActiveQuery.php
+++ b/extensions/mongodb/ActiveQuery.php
@@ -73,6 +73,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     public function __construct($modelClass, $config = [])
     {
         $this->modelClass = $modelClass;
+        $this->ensureModelBehaviors();
         parent::__construct($config);
     }
 

--- a/extensions/redis/ActiveQuery.php
+++ b/extensions/redis/ActiveQuery.php
@@ -86,6 +86,7 @@ class ActiveQuery extends Component implements ActiveQueryInterface
     public function __construct($modelClass, $config = [])
     {
         $this->modelClass = $modelClass;
+        $this->ensureModelBehaviors();
         parent::__construct($config);
     }
 

--- a/extensions/sphinx/ActiveQuery.php
+++ b/extensions/sphinx/ActiveQuery.php
@@ -100,6 +100,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     public function __construct($modelClass, $config = [])
     {
         $this->modelClass = $modelClass;
+        $this->ensureModelBehaviors();
         parent::__construct($config);
     }
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -52,6 +52,7 @@ Yii Framework 2 Change Log
 - Bug: Fixed the bug that requesting protected or private action methods would cause 500 error instead of 404 (qiangxue)
 - Enh #2264: `CookieCollection::has()` will return false for expired or removed cookies (qiangxue)
 - Enh #2435: `yii\db\IntegrityException` is now thrown on database integrity errors instead of general `yii\db\Exception` (samdark)
+- Enh #2532: Added ability for Active Record behavior to attach behavior to the Active Query (klimov-paul)
 - Enh #2837: Error page now shows arguments in stack trace method calls (samdark)
 - Enh #2906: Added support for using conditional comments for js and css files registered through asset bundles and Html helper (exromany, qiangxue)
 - Enh #2942: Added truncate and truncateWord methods (Alex-Code, samdark)

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -99,6 +99,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     public function __construct($modelClass, $config = [])
     {
         $this->modelClass = $modelClass;
+        $this->ensureModelBehaviors();
         parent::__construct($config);
     }
 

--- a/framework/db/ActiveQueryBehaviorInterface.php
+++ b/framework/db/ActiveQueryBehaviorInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db;
+
+/**
+ * ActiveQueryBehaviorInterface allows behavior declared for the [[ActiveRecord]] attach relative
+ * behavior to the [[ActiveQuery]] once it is created.
+ *
+ * @author Klimov Paul <klimov@zfort.com>
+ * @since 2.0
+ */
+interface ActiveQueryBehaviorInterface
+{
+    /**
+     * Returns definition of the behavior, which should be attached to the [[ActiveQuery]] instance.
+     * @return mixed behavior instance or configuration.
+     */
+    public function queryBehavior();
+}

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -30,6 +30,21 @@ trait ActiveQueryTrait
      */
     public $asArray;
 
+    /**
+     * Makes sure that query behaviors declared by model behaviors are attached to this component.
+     */
+    public function ensureModelBehaviors()
+    {
+        /* @var \yii\base\Model $model */
+        $modelClass = $this->modelClass;
+        $model = new $modelClass();
+        foreach ($model->getBehaviors() as $name => $behavior) {
+            if ($behavior instanceof ActiveQueryBehaviorInterface) {
+                /* @var \yii\base\Component $this */
+                $this->attachBehavior($name, $behavior->queryBehavior());
+            }
+        }
+    }
 
     /**
      * Sets the [[asArray]] property.

--- a/tests/unit/framework/db/ActiveRecordQueryBehaviorTest.php
+++ b/tests/unit/framework/db/ActiveRecordQueryBehaviorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace yiiunit\framework\db;
+
+use yii\base\Behavior;
+use yii\db\ActiveQueryBehaviorInterface;
+use yiiunit\data\ar\ActiveRecord;
+use yiiunit\data\ar\Customer;
+
+/**
+ * @group db
+ */
+class ActiveRecordQueryBehaviorTest extends DatabaseTestCase
+{
+    protected $driverName = 'sqlite';
+
+    protected function setUp()
+    {
+        parent::setUp();
+        ActiveRecord::$db = $this->getConnection();
+    }
+
+    public function testScope()
+    {
+        $models = CustomerEx::find()->whereStatus(2)->all();
+        $this->assertCount(1, $models);
+    }
+}
+
+class CustomerEx extends Customer
+{
+    public function behaviors()
+    {
+        return [
+            'query' => [
+                'class' => ArBehavior::className()
+            ]
+        ];
+    }
+}
+
+class ArBehavior extends Behavior implements ActiveQueryBehaviorInterface
+{
+    public function queryBehavior()
+    {
+        return [
+            'class' => QueryBehavior::className()
+        ];
+    }
+}
+
+class QueryBehavior extends Behavior
+{
+    public function whereStatus($status)
+    {
+        /* @var \yii\db\ActiveQuery $query */
+        $query = $this->owner;
+        $query->andWhere(['status' => $status]);
+        return $query;
+    }
+}


### PR DESCRIPTION
This one attmpts to fix #2532: "Allow AR behaviors to attach other behaviors to Query"

Unit test is attached.

Migrated from #3898
