### PR TITLE
Update ViewRenderer.php

### DIFF
--- a/extensions/twig/ViewRenderer.php
+++ b/extensions/twig/ViewRenderer.php
@@ -75,11 +75,30 @@ class ViewRenderer extends BaseViewRenderer
     /**
      * @var \Twig_Environment twig environment object that do all rendering twig templates
      */
+     
+
+    public $define_layout = NULL;
+    /**
+     * @var string the directory pointing to where the extra layout template folder.
+     */
+	
     public $twig;
+    
+	public $loader;
 
     public function init()
     {
-        $this->twig = new \Twig_Environment(null, array_merge([
+        // Adding extra template layout
+        if (!empty($this->define_layout)) {
+			
+            $this->loader = new \Twig_Loader_Filesystem($_SERVER['DOCUMENT_ROOT'].$this->define_layout);
+        }
+		else
+		{
+			$this->loader = NULL;
+		}
+		
+        $this->twig = new \Twig_Environment($this->loader, array_merge([
             'cache' => Yii::getAlias($this->cachePath),
             'charset' => Yii::$app->charset,
         ], $this->options));
@@ -154,8 +173,16 @@ class ViewRenderer extends BaseViewRenderer
     public function render($view, $file, $params)
     {
         $this->twig->addGlobal('this', $view);
-        $this->twig->setLoader(new TwigSimpleFileLoader(dirname($file)));
 
+		if($this->loader)
+		{
+			$this->loader->addPath(dirname($file));
+		}
+		else
+		{
+			$this->twig->setLoader(new TwigSimpleFileLoader(dirname($file)));
+		}
+		
         return $this->twig->render(pathinfo($file, PATHINFO_BASENAME), $params);
     }
 


### PR DESCRIPTION
I want to use my layouts in a different folder that calls base or main layout in project and use them every twig files that can be extended.

views
| site
  |index.htm
| layouts
  |main.htm

Now If I call render like this from Sitecontroller I can not extend main.htm, because it is not in site view folder, it is in the layouts folder. 

```
public function actionIndex()
{

    return $this->render('index.htm');
}
```

So from index.htm (inside site folder) want to extend main.htm (inside layouts folder) gives error. Can not find main.htm, because twig only look in to site folder....

{% extends "main.htm" %}

http://stackoverflow.com/questions/24247569/twig-template-layout-yii2-framework

So I change the file and now I can define layouts folder with Twig_Loader_Filesystem and after that in function render, I can addPath my file folder path site/index.htm .. so twig search the files in two folders - layouts and site folders. If you want we can change the $define_layout as an array and from config file we can send more than one folders that can twig search for. If there is another simple way to do this I would be very happy to learn how can I do this .. 

Now I only use it like one variable.

Config : 

'define_layout' => '/views/layouts',

Regards,
