### PR TITLE
[WIP] `Html::checkbox()/Html::radio()` unused `container` option removed

### DIFF
--- a/extensions/bootstrap/ActiveField.php
+++ b/extensions/bootstrap/ActiveField.php
@@ -261,6 +261,10 @@ class ActiveField extends \yii\widgets\ActiveField
                     'labelOptions' => ['class' => 'checkbox-inline'],
                 ];
             }
+        } elseif (!isset($options['item'])) {
+            $options['item'] = function($index, $label, $name, $checked, $value) {
+                return '<div class="checkbox">' . Html::checkbox($name, $checked) . '</div>';
+            };
         }
         parent::checkboxList($items, $options);
         return $this;

--- a/extensions/bootstrap/ActiveField.php
+++ b/extensions/bootstrap/ActiveField.php
@@ -263,7 +263,7 @@ class ActiveField extends \yii\widgets\ActiveField
             }
         } elseif (!isset($options['item'])) {
             $options['item'] = function($index, $label, $name, $checked, $value) {
-                return '<div class="checkbox">' . Html::checkbox($name, $checked) . '</div>';
+                return '<div class="checkbox">' . Html::checkbox($name, $checked, ['label' => $label, 'value' => $value]) . '</div>';
             };
         }
         parent::checkboxList($items, $options);
@@ -287,6 +287,10 @@ class ActiveField extends \yii\widgets\ActiveField
                     'labelOptions' => ['class' => 'radio-inline'],
                 ];
             }
+        } elseif (!isset($options['item'])) {
+            $options['item'] = function($index, $label, $name, $checked, $value) {
+                return '<div class="radio">' . Html::radio($name, $checked, ['label' => $label, 'value' => $value]) . '</div>';
+            };
         }
         parent::radioList($items, $options);
         return $this;

--- a/extensions/bootstrap/ActiveField.php
+++ b/extensions/bootstrap/ActiveField.php
@@ -258,7 +258,6 @@ class ActiveField extends \yii\widgets\ActiveField
             }
             if (!isset($options['itemOptions'])) {
                 $options['itemOptions'] = [
-                    'container' => false,
                     'labelOptions' => ['class' => 'checkbox-inline'],
                 ];
             }
@@ -281,7 +280,6 @@ class ActiveField extends \yii\widgets\ActiveField
             }
             if (!isset($options['itemOptions'])) {
                 $options['itemOptions'] = [
-                    'container' => false,
                     'labelOptions' => ['class' => 'radio-inline'],
                 ];
             }

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -119,7 +119,7 @@ Yii Framework 2 Change Log
 - Chg: Removed `yii\rest\ActiveController::$transactional` property and connected functionality (samdark)
 - Chg: Changed the default value of the `keyPrefix` property of cache components to be null (qiangxue)
 - Chg: Added `prefix` column to `yii\log\DbTarget` to have the same amount of information logged as in files and emails (cebe)
-
+- Chg: Removed rudiment `container` option from `Html::checkbox()` and `Html::radio()` (creocoder)
 
 2.0.0-beta April 13, 2014
 -------------------------

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -619,9 +619,6 @@ class BaseHtml
      *   in HTML code such as an image tag. If this is is coming from end users, you should [[encode()]] it to prevent XSS attacks.
      *   When this option is specified, the radio button will be enclosed by a label tag.
      * - labelOptions: array, the HTML attributes for the label tag. This is only used when the "label" option is specified.
-     * - container: array, the HTML attributes for the container tag. This is only used when the "label" option is specified.
-     *   If it is not set, no container will be rendered. If it is an array or not, a "div" container will be rendered
-     *   around the the radio button.
      *
      * The rest of the options will be rendered as the attributes of the resulting radio button tag. The values will
      * be HTML-encoded using [[encode()]]. If a value is null, the corresponding attribute will not be rendered.

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -619,8 +619,8 @@ class BaseHtml
      *   in HTML code such as an image tag. If this is is coming from end users, you should [[encode()]] it to prevent XSS attacks.
      *   When this option is specified, the radio button will be enclosed by a label tag.
      * - labelOptions: array, the HTML attributes for the label tag. This is only used when the "label" option is specified.
-     * - container: array|boolean, the HTML attributes for the container tag. This is only used when the "label" option is specified.
-     *   If it is false, no container will be rendered. If it is an array or not, a "div" container will be rendered
+     * - container: array, the HTML attributes for the container tag. This is only used when the "label" option is specified.
+     *   If it is not set, no container will be rendered. If it is an array or not, a "div" container will be rendered
      *   around the the radio button.
      *
      * The rest of the options will be rendered as the attributes of the resulting radio button tag. The values will
@@ -643,14 +643,9 @@ class BaseHtml
         if (isset($options['label'])) {
             $label = $options['label'];
             $labelOptions = isset($options['labelOptions']) ? $options['labelOptions'] : [];
-            $container = isset($options['container']) ? $options['container'] : ['class' => 'radio'];
-            unset($options['label'], $options['labelOptions'], $options['container']);
+            unset($options['label'], $options['labelOptions']);
             $content = static::label(static::input('radio', $name, $value, $options) . ' ' . $label, null, $labelOptions);
-            if (is_array($container)) {
-                return $hidden . static::tag('div', $content, $container);
-            } else {
-                return $hidden . $content;
-            }
+            return $hidden . $content;
         } else {
             return $hidden . static::input('radio', $name, $value, $options);
         }
@@ -669,9 +664,6 @@ class BaseHtml
      *   in HTML code such as an image tag. If this is is coming from end users, you should [[encode()]] it to prevent XSS attacks.
      *   When this option is specified, the checkbox will be enclosed by a label tag.
      * - labelOptions: array, the HTML attributes for the label tag. This is only used when the "label" option is specified.
-     * - container: array|boolean, the HTML attributes for the container tag. This is only used when the "label" option is specified.
-     *   If it is false, no container will be rendered. If it is an array or not, a "div" container will be rendered
-     *   around the the radio button.
      *
      * The rest of the options will be rendered as the attributes of the resulting checkbox tag. The values will
      * be HTML-encoded using [[encode()]]. If a value is null, the corresponding attribute will not be rendered.
@@ -693,14 +685,9 @@ class BaseHtml
         if (isset($options['label'])) {
             $label = $options['label'];
             $labelOptions = isset($options['labelOptions']) ? $options['labelOptions'] : [];
-            $container = isset($options['container']) ? $options['container'] : ['class' => 'checkbox'];
-            unset($options['label'], $options['labelOptions'], $options['container']);
+            unset($options['label'], $options['labelOptions']);
             $content = static::label(static::input('checkbox', $name, $value, $options) . ' ' . $label, null, $labelOptions);
-            if (is_array($container)) {
-                return $hidden . static::tag('div', $content, $container);
-            } else {
-                return $hidden . $content;
-            }
+            return $hidden . $content;
         } else {
             return $hidden . static::input('checkbox', $name, $value, $options);
         }
@@ -1550,7 +1537,7 @@ class BaseHtml
         $groups = isset($tagOptions['groups']) ? $tagOptions['groups'] : [];
         unset($tagOptions['prompt'], $tagOptions['options'], $tagOptions['groups']);
         $options['encodeSpaces'] = ArrayHelper::getValue($options, 'encodeSpaces', $encodeSpaces);
-        
+
         foreach ($items as $key => $value) {
             if (is_array($value)) {
                 $groupAttrs = isset($groups[$key]) ? $groups[$key] : [];


### PR DESCRIPTION
Fix for #3904. We have absoluttely meaningless `container` option for both `checkbox()/radio()`. `yii\bootstrap\ActiveField` already wrap checkboxes and radioboxes in `<div>` with correct classnames. So this option is just rudiment.
