### PR TITLE
Required validator better message

### DIFF
--- a/framework/validators/RequiredValidator.php
+++ b/framework/validators/RequiredValidator.php
@@ -56,7 +56,7 @@ class RequiredValidator extends Validator
     {
         parent::init();
         if ($this->message === null) {
-            $this->message = $this->requiredValue === null ? Yii::t('yii', '{attribute} cannot be blank.')
+            $this->message = $this->requiredValue === null ? Yii::t('yii', '{attribute} is required.')
                 : Yii::t('yii', '{attribute} must be "{requiredValue}".');
         }
     }


### PR DESCRIPTION
Yes i know that this can be customized. But why not have:

```
Attribute is required.
```

instead of:

```
Attribute cannot be blank.
```

First error variation is more famous on sites and less.
