### PR TITLE
Model::loadDefaults() wrong type value

### DIFF
--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -429,7 +429,6 @@ SQL;
         $column->autoIncrement = $info['is_autoinc'];
         $column->comment = $info['column_comment'];
         $column->dbType = $info['data_type'];
-        $column->defaultValue = $info['column_default'];
         $column->enumValues = ($info['enum_values'] !== null) ? explode(',', str_replace(["''"], ["'"], $info['enum_values'])) : null;
         $column->unsigned = false; // has no meaning in PG
         $column->isPrimaryKey = $info['is_pkey'];
@@ -443,6 +442,7 @@ SQL;
             $column->type = self::TYPE_STRING;
         }
         $column->phpType = $this->getColumnPhpType($column);
+        $column->defaultValue = $column->typecast($info['column_default']);
 
         return $column;
     }


### PR DESCRIPTION
Model::loadDefaults() with PostgreSQL, boolean column and checkbox on form, doesn't let checkbox set in the right way 'cos of $column->defaultValue type
