### PR TITLE
`yii\widgets\Breadcrumbs` enhacement

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -99,7 +99,7 @@ Yii Framework 2 Change Log
 - Enh: Added param `hideOnSinglePage` to `yii\widgets\LinkPager` (arturf)
 - Enh: Added support for array attributes in `in` validator (creocoder)
 - Enh: Improved `yii\helpers\Inflector::slug` to support more cases for Russian, Hebrew and special characters (samdark)
-- Enh: `yii\widgets\Breadcrumbs::$links`. Allows individual link to have its `ownTemplate` (creocoder|umneeq)
+- Enh #3926: `yii\widgets\Breadcrumbs::$links`. Allows individual link to have its `ownTemplate` (creocoder, umneeq)
 - Chg #2898: `yii\console\controllers\AssetController` is now using hashes instead of timestamps (samdark)
 - Chg #2913: RBAC `DbManager` is now initialized via migration (samdark)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -99,6 +99,7 @@ Yii Framework 2 Change Log
 - Enh: Added param `hideOnSinglePage` to `yii\widgets\LinkPager` (arturf)
 - Enh: Added support for array attributes in `in` validator (creocoder)
 - Enh: Improved `yii\helpers\Inflector::slug` to support more cases for Russian, Hebrew and special characters (samdark)
+- Enh: `yii\widgets\Breadcrumbs::$links`. Allows individual link to have its `ownTemplate` (creocoder|umneeq)
 - Chg #2898: `yii\console\controllers\AssetController` is now using hashes instead of timestamps (samdark)
 - Chg #2913: RBAC `DbManager` is now initialized via migration (samdark)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -99,7 +99,7 @@ Yii Framework 2 Change Log
 - Enh: Added param `hideOnSinglePage` to `yii\widgets\LinkPager` (arturf)
 - Enh: Added support for array attributes in `in` validator (creocoder)
 - Enh: Improved `yii\helpers\Inflector::slug` to support more cases for Russian, Hebrew and special characters (samdark)
-- Enh #3926: `yii\widgets\Breadcrumbs::$links`. Allows individual link to have its `ownTemplate` (creocoder, umneeq)
+- Enh #3926: `yii\widgets\Breadcrumbs::$links`. Allows individual link to have its own `template` (creocoder, umneeq)
 - Chg #2898: `yii\console\controllers\AssetController` is now using hashes instead of timestamps (samdark)
 - Chg #2913: RBAC `DbManager` is now initialized via migration (samdark)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)

--- a/framework/widgets/Breadcrumbs.php
+++ b/framework/widgets/Breadcrumbs.php
@@ -29,7 +29,7 @@ use yii\helpers\Html;
  *         [
  *             'label' => 'Post Category',
  *             'url' => ['post-category/view', 'id' => 10],
- *             'ownTemplate' => '<li><b>{link}</b></li>\n', // template for this link only
+ *             'template' => '<li><b>{link}</b></li>\n', // template for this link only
  *         ],
  *         ['label' => 'Sample Post', 'url' => ['post/edit', 'id' => 1]],
  *         'Edit',
@@ -82,7 +82,7 @@ class Breadcrumbs extends Widget
      * [
      *     'label' => 'label of the link',  // required
      *     'url' => 'url of the link',      // optional, will be processed by Url::to()
-     *     'ownTemplate' => 'own template of the current item', // optional, if not set $this->itemTemplate will be used
+     *     'template' => 'own template of the item', // optional, if not set $this->itemTemplate will be used
      * ]
      * ~~~
      *
@@ -142,9 +142,9 @@ class Breadcrumbs extends Widget
             throw new InvalidConfigException('The "label" element is required for each link.');
         }
         if (isset($link['url'])) {
-            return strtr(isset($link['ownTemplate']) ? $link['ownTemplate'] : $template, ['{link}' => Html::a($label, $link['url'])]);
+            return strtr(isset($link['template']) ? $link['ownTemplate'] : $template, ['{link}' => Html::a($label, $link['url'])]);
         } else {
-            return strtr(isset($link['ownTemplate']) ? $link['ownTemplate'] : $template, ['{link}' => $label]);
+            return strtr(isset($link['template']) ? $link['ownTemplate'] : $template, ['{link}' => $label]);
         }
     }
 }

--- a/framework/widgets/Breadcrumbs.php
+++ b/framework/widgets/Breadcrumbs.php
@@ -24,7 +24,13 @@ use yii\helpers\Html;
  * ~~~
  * // $this is the view object currently being used
  * echo Breadcrumbs::widget([
+ *     'itemTemplate' => "<li><i>{link}</i></li>\n", // template for all links
  *     'links' => [
+ *         [
+ *             'label' => 'Post Category',
+ *             'url' => ['post-category/view', 'id' => 10],
+ *             'ownTemplate' => '<li><b>{link}</b></li>\n', // template for this link only
+ *         ],
  *         ['label' => 'Sample Post', 'url' => ['post/edit', 'id' => 1]],
  *         'Edit',
  *     ],
@@ -76,6 +82,7 @@ class Breadcrumbs extends Widget
      * [
      *     'label' => 'label of the link',  // required
      *     'url' => 'url of the link',      // optional, will be processed by Url::to()
+     *     'ownTemplate' => 'own template of the current item', // optional, if not set $this->itemTemplate will be used
      * ]
      * ~~~
      *
@@ -135,9 +142,9 @@ class Breadcrumbs extends Widget
             throw new InvalidConfigException('The "label" element is required for each link.');
         }
         if (isset($link['url'])) {
-            return strtr($template, ['{link}' => Html::a($label, $link['url'])]);
+            return strtr(isset($link['ownTemplate']) ? $link['ownTemplate'] : $template, ['{link}' => Html::a($label, $link['url'])]);
         } else {
-            return strtr($template, ['{link}' => $label]);
+            return strtr(isset($link['ownTemplate']) ? $link['ownTemplate'] : $template, ['{link}' => $label]);
         }
     }
 }

--- a/framework/widgets/Breadcrumbs.php
+++ b/framework/widgets/Breadcrumbs.php
@@ -142,9 +142,9 @@ class Breadcrumbs extends Widget
             throw new InvalidConfigException('The "label" element is required for each link.');
         }
         if (isset($link['url'])) {
-            return strtr(isset($link['template']) ? $link['ownTemplate'] : $template, ['{link}' => Html::a($label, $link['url'])]);
+            return strtr(isset($link['template']) ? $link['template'] : $template, ['{link}' => Html::a($label, $link['url'])]);
         } else {
-            return strtr(isset($link['template']) ? $link['ownTemplate'] : $template, ['{link}' => $label]);
+            return strtr(isset($link['template']) ? $link['template'] : $template, ['{link}' => $label]);
         }
     }
 }

--- a/framework/widgets/Breadcrumbs.php
+++ b/framework/widgets/Breadcrumbs.php
@@ -141,10 +141,11 @@ class Breadcrumbs extends Widget
         } else {
             throw new InvalidConfigException('The "label" element is required for each link.');
         }
+        $issetTemplate = isset($link['template']);
         if (isset($link['url'])) {
-            return strtr(isset($link['template']) ? $link['template'] : $template, ['{link}' => Html::a($label, $link['url'])]);
+            return strtr($issetTemplate ? $link['template'] : $template, ['{link}' => Html::a($label, $link['url'])]);
         } else {
-            return strtr(isset($link['template']) ? $link['template'] : $template, ['{link}' => $label]);
+            return strtr($issetTemplate ? $link['template'] : $template, ['{link}' => $label]);
         }
     }
 }


### PR DESCRIPTION
I have markup:

``` html
<ul class="page-breadcrumb breadcrumb">
    <li>
        <i class="fa fa-home"></i>
        <a href="index.html">Home</a>
        <i class="fa fa-angle-right"></i>
    </li>
    <li>
        <a href="#">Dashboard</a>
    </li>
</ul>
```

And I want to use template for individual link. Now I can`t use it. This PR will allow to do this.
