### PR TITLE
Unit tests to widgets\ActiveField and refactoring.

### DIFF
--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -730,7 +730,7 @@ class ActiveField extends Component
     }
     
     /**
-     * This method will set a JsExpression object from the model validators, if any exists.
+     * This method will build and set a JsExpression to the passed-by-reference parameter.
      * It's used by the [[getClientOptions()]] method.
      * @param   string  $attribute  the attribute
      * @param   array   $options    the Collecting Parameter passed by reference
@@ -757,7 +757,8 @@ class ActiveField extends Component
     }
     
     /**
-     * Add options to the passed-by-reference $options.
+     * Add options to the passed-by-reference parameter.
+     * It's used by the [[getClientOptions()]] method.
      * @param   array $options  the Collecting Parameter passed by reference
      * @return  void
      */

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -724,9 +724,10 @@ class ActiveField extends Component
         if ($this->isClientValidationEnabled() && !empty($options['validate']) || $this->isAjaxValidationEnabled()) { 
             $this->addOptions($options);
             return $options;
-        } else {
-            return [];
         }
+        
+        return [];
+        
     }
     
     /**
@@ -767,16 +768,33 @@ class ActiveField extends Component
         $inputID = Html::getInputId($this->model, $this->attribute);
         $options['id'] = $inputID;
         $options['name'] = $this->attribute;
+        
         foreach (['validateOnChange', 'validateOnType', 'validationDelay'] as $name) {
             $options[$name] = $this->$name === null ? $this->form->$name : $this->$name;
         }
-        $options['container'] = isset($this->selectors['container']) ? $this->selectors['container'] : ".field-$inputID";
-        $options['input'] = isset($this->selectors['input']) ? $this->selectors['input'] : "#$inputID";
+
+        $this->setOptionContainer($options);
+        $this->setOptionInput($options);
+        $this->setOptionError($options);
+    }
+    
+    private function setOptionError(array &$options)
+    {
         if (isset($this->errorOptions['class'])) {
             $options['error'] = '.' . implode('.', preg_split('/\s+/', $this->errorOptions['class'], -1, PREG_SPLIT_NO_EMPTY));
         } else {
             $options['error'] = isset($this->errorOptions['tag']) ? $this->errorOptions['tag'] : 'span';
-        }       
+        }          
+    }
+    
+    private function setOptionContainer(array &$options)
+    {
+       $options['container'] = isset($this->selectors['container']) ? $this->selectors['container'] : ".field-{$options['id']}"; 
+    }
+    
+    private function setOptionInput(array &$options)
+    {
+        $options['input'] = isset($this->selectors['input']) ? $this->selectors['input'] : "#{$options['id']}";
     }
     
     /**

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -167,18 +167,10 @@ class ActiveField extends Component
     public function render($content = null)
     {
         if ($content === null) {
-            if (!isset($this->parts['{input}'])) {
-                $this->parts['{input}'] = Html::activeTextInput($this->model, $this->attribute, $this->inputOptions);
-            }
-            if (!isset($this->parts['{label}'])) {
-                $this->parts['{label}'] = Html::activeLabel($this->model, $this->attribute, $this->labelOptions);
-            }
-            if (!isset($this->parts['{error}'])) {
-                $this->parts['{error}'] = Html::error($this->model, $this->attribute, $this->errorOptions);
-            }
-            if (!isset($this->parts['{hint}'])) {
-                $this->parts['{hint}'] = '';
-            }
+            $this->setInputPart();
+            $this->setLabelPart();
+            $this->setErrorPart();
+            $this->setHintPart();
             $content = strtr($this->template, $this->parts);
         } elseif (!is_string($content)) {
             $content = call_user_func($content, $this);
@@ -186,7 +178,51 @@ class ActiveField extends Component
 
         return $this->begin() . "\n" . $content . "\n" . $this->end();
     }
-
+    
+    /**
+     * Sets the Input HTML element for the rendering field.
+     * @return void
+     */
+    protected function setInputPart()
+    {
+        if (!isset($this->parts['{input}'])) {
+            $this->parts['{input}'] = Html::activeTextInput($this->model, $this->attribute, $this->inputOptions);
+        }        
+    }
+    
+    /**
+     * Sets the Label HTML element for the rendering field.
+     * @return void
+     */    
+    protected function setLabelPart()
+    {
+        if (!isset($this->parts['{label}'])) {
+            $this->parts['{label}'] = Html::activeLabel($this->model, $this->attribute, $this->labelOptions);
+        }        
+    }
+    
+    /**
+     * Sets the Error HTML element for the rendering field.
+     * @return void
+     */    
+    protected function setErrorPart()
+    {
+        if (!isset($this->parts['{error}'])) {
+            $this->parts['{error}'] = Html::error($this->model, $this->attribute, $this->errorOptions);
+        }        
+    }
+    
+    /**
+     * Sets the Hint HTML element to empty for the rendering field if not already set.
+     * @return void
+     */
+    protected function setHintPart()
+    {
+        if (!isset($this->parts['{hint}'])) {
+            $this->parts['{hint}'] = '';
+        }        
+    }
+    
     /**
      * Renders the opening tag of the field container.
      * @return string the rendering result.
@@ -677,11 +713,32 @@ class ActiveField extends Component
         if (!in_array($attribute, $this->model->activeAttributes(), true)) {
             return [];
         }
-
+        
         $options = [];
-
-        $enableClientValidation = $this->enableClientValidation || $this->enableClientValidation === null && $this->form->enableClientValidation;
-        if ($enableClientValidation) {
+        $this->addJsExpression($attribute, $options);
+        
+        if ($this->isAjaxValidationEnabled()) {
+            $options['enableAjaxValidation'] = 1;
+        }
+        
+        if ($this->isClientValidationEnabled() && !empty($options['validate']) || $this->isAjaxValidationEnabled()) { 
+            $this->addOptions($options);
+            return $options;
+        } else {
+            return [];
+        }
+    }
+    
+    /**
+     * This method will set a JsExpression object from the model validators, if any exists.
+     * It's used by the [[getClientOptions()]] method.
+     * @param   string  $attribute  the attribute
+     * @param   array   $options    the Collecting Parameter passed by reference
+     * @return  void    
+     */
+    private function addJsExpression($attribute, &$options)
+    {
+        if ($this->isClientValidationEnabled()) {
             $validators = [];
             foreach ($this->model->getActiveValidators($attribute) as $validator) {
                 /* @var $validator \yii\validators\Validator */
@@ -697,30 +754,45 @@ class ActiveField extends Component
                 $options['validate'] = new JsExpression("function (attribute, value, messages) {" . implode('', $validators) . '}');
             }
         }
-
-        $enableAjaxValidation = $this->enableAjaxValidation || $this->enableAjaxValidation === null && $this->form->enableAjaxValidation;
-        if ($enableAjaxValidation) {
-            $options['enableAjaxValidation'] = 1;
+    }
+    
+    /**
+     * Add options to the passed-by-reference $options.
+     * @param   array $options  the Collecting Parameter passed by reference
+     * @return  void
+     */
+    private function addOptions(&$options)
+    {
+        $inputID = Html::getInputId($this->model, $this->attribute);
+        $options['id'] = $inputID;
+        $options['name'] = $this->attribute;
+        foreach (['validateOnChange', 'validateOnType', 'validationDelay'] as $name) {
+            $options[$name] = $this->$name === null ? $this->form->$name : $this->$name;
         }
-
-        if ($enableClientValidation && !empty($options['validate']) || $enableAjaxValidation) {
-            $inputID = Html::getInputId($this->model, $this->attribute);
-            $options['id'] = $inputID;
-            $options['name'] = $this->attribute;
-            foreach (['validateOnChange', 'validateOnType', 'validationDelay'] as $name) {
-                $options[$name] = $this->$name === null ? $this->form->$name : $this->$name;
-            }
-            $options['container'] = isset($this->selectors['container']) ? $this->selectors['container'] : ".field-$inputID";
-            $options['input'] = isset($this->selectors['input']) ? $this->selectors['input'] : "#$inputID";
-            if (isset($this->errorOptions['class'])) {
-                $options['error'] = '.' . implode('.', preg_split('/\s+/', $this->errorOptions['class'], -1, PREG_SPLIT_NO_EMPTY));
-            } else {
-                $options['error'] = isset($this->errorOptions['tag']) ? $this->errorOptions['tag'] : 'span';
-            }
-
-            return $options;
+        $options['container'] = isset($this->selectors['container']) ? $this->selectors['container'] : ".field-$inputID";
+        $options['input'] = isset($this->selectors['input']) ? $this->selectors['input'] : "#$inputID";
+        if (isset($this->errorOptions['class'])) {
+            $options['error'] = '.' . implode('.', preg_split('/\s+/', $this->errorOptions['class'], -1, PREG_SPLIT_NO_EMPTY));
         } else {
-            return [];
-        }
+            $options['error'] = isset($this->errorOptions['tag']) ? $this->errorOptions['tag'] : 'span';
+        }       
+    }
+    
+    /**
+     * Checks whether client-side data validation is enabled.
+     * @return boolean
+     */    
+    protected function isClientValidationEnabled()
+    {
+        return $this->enableClientValidation || $this->enableClientValidation === null && $this->form->enableClientValidation;        
+    }
+
+    /**
+     * Checks whether AJAX-based data validation is enabled.
+     * @return boolean
+     */      
+    protected function isAjaxValidationEnabled()
+    {
+        return $this->enableAjaxValidation || $this->enableAjaxValidation === null && $this->form->enableAjaxValidation;        
     }
 }

--- a/tests/unit/framework/widgets/ActiveFieldTest.php
+++ b/tests/unit/framework/widgets/ActiveFieldTest.php
@@ -288,6 +288,35 @@ class ActiveFieldTest extends \yiiunit\TestCase
         $this->assertEquals($expectedError, $actualValue['error']);
     }
     
+    
+    public function testGetClientOptionsValidatorWhenClientSet()
+    {
+        $this->activeField->setClientOptionsEmpty(false);
+        $this->activeField->enableAjaxValidation = true;
+        $this->activeField->model->addRule($this->attributeName, 'yiiunit\framework\widgets\TestValidator');
+        
+        foreach($this->activeField->model->validators as $validator) {
+            $validator->whenClient = "function (attribute, value) { return 'yii2' == 'yii2'; }"; // js 
+        }
+        
+        $actualValue = $this->activeField->getClientOptions();
+        $expectedJsExpression = "function (attribute, value, messages) {if (function (attribute, value) "
+            . "{ return 'yii2' == 'yii2'; }(attribute, value)) { return true; }}";
+       
+        $expectedValidateOnChange = true;
+        $expectedValidateOnType = false;
+        $expectedValidationDelay = 200;
+        $expectedError = ".help-block";
+        
+        $actualJsExpression = $actualValue['validate'];
+        $this->assertEquals($expectedJsExpression, $actualJsExpression->expression);
+        $this->assertTrue($expectedValidateOnChange === $actualValue['validateOnChange']);
+        $this->assertTrue($expectedValidateOnType === $actualValue['validateOnType']);
+        $this->assertTrue($expectedValidationDelay === $actualValue['validationDelay']);
+        $this->assertTrue(1 === $actualValue['enableAjaxValidation']);
+        $this->assertEquals($expectedError, $actualValue['error']);
+    }    
+    
     /**
      * Helper methods
      */
@@ -333,9 +362,15 @@ class ActiveFieldExtend extends ActiveField
 
 class TestValidator extends \yii\validators\Validator
 {
+    
     public function clientValidateAttribute($object, $attribute, $view)
     {
         return "return true;";
+    }
+    
+    public function setWhenClient($js)
+    {
+        $this->whenClient = $js;
     }
 }
 

--- a/tests/unit/framework/widgets/ActiveFieldTest.php
+++ b/tests/unit/framework/widgets/ActiveFieldTest.php
@@ -1,0 +1,341 @@
+<?php
+
+namespace yiiunit\framework\widgets;
+
+use Yii;
+use yii\widgets\ActiveField;
+use yii\base\DynamicModel;
+use yii\widgets\ActiveForm;
+use yii\web\View;
+use yii\web\AssetManager;
+
+/**
+ * @author Nelson J Morais <njmorais@gmail.com>
+ * 
+ * @group widgets
+ */
+class ActiveFieldTest extends \yiiunit\TestCase
+{
+    private $activeField;
+    private $helperModel;
+    private $helperForm;
+    private $attributeName = 'attributeName';
+    
+    public function setUp()
+    {
+        // dirty way to have Request object not throwing exception when running testHomeLinkNull()
+        $_SERVER['SCRIPT_FILENAME'] = "index.php";
+        $_SERVER['SCRIPT_NAME'] = "index.php";
+        
+        $this->mockApplication([], 'yii\web\Application');
+        
+        Yii::setAlias('@testWeb', '/');
+        Yii::setAlias('@testWebRoot', '@yiiunit/data/web');
+        
+        $this->helperModel = new DynamicModel(['attributeName']);
+        ob_start();
+        $this->helperForm = new ActiveForm(['action' => '/something']);
+        ob_end_clean();
+     
+        $this->activeField = new ActiveFieldExtend(true);
+        $this->activeField->form = $this->helperForm;
+        $this->activeField->form->setView($this->getView());
+        $this->activeField->model = $this->helperModel;
+        $this->activeField->attribute = $this->attributeName;
+    }
+    
+    public function testRenderNoContent()
+    {
+        $expectedValue = "<div class=\"form-group field-dynamicmodel-attributename\">\n"
+            . "<label class=\"control-label\" for=\"dynamicmodel-attributename\">Attribute Name</label>\n"
+            . "<input type=\"text\" id=\"dynamicmodel-attributename\" class=\"form-control\" "
+            . "name=\"DynamicModel[{$this->attributeName}]\">\n\n"
+            . "<div class=\"help-block\"></div>\n</div>";
+        
+        $actualValue = $this->activeField->render();
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+    
+    /**
+     * @todo    discuss|review  Expected HTML when content is callable shouldn't be the should
+     */
+    public function testRenderWithCallableContent()
+    {
+        // field will be the html of the model's attribute wrapped with the return string below.
+        $field = $this->attributeName;
+        $content = function($field) {
+            return "<div class=\"custom-container\"> $field </div>";
+        };
+        
+        $expectedValue = "<div class=\"form-group field-dynamicmodel-attributename\">\n"
+            . "<div class=\"custom-container\"> "
+            . "<div class=\"form-group field-dynamicmodel-attributename\">\n"
+            . "<label class=\"control-label\" for=\"dynamicmodel-attributename\">Attribute Name</label>\n"
+            . "<input type=\"text\" id=\"dynamicmodel-attributename\" class=\"form-control\" "
+            . "name=\"DynamicModel[{$this->attributeName}]\">\n\n"
+            . "<div class=\"help-block\"></div>\n</div>"
+            . " </div>\n"        
+            . "</div>";
+        
+        $actualValue = $this->activeField->render($content);
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+    
+    public function testBeginHasErros()
+    {
+        $this->helperModel->addError($this->attributeName, "Error Message");
+        
+        $expectedValue = "<div class=\"form-group field-dynamicmodel-attributename has-error\">";
+        $actualValue = $this->activeField->begin();
+        
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+    
+    public function testBeginAttributeIsRequered()
+    {
+        $this->helperModel->addRule($this->attributeName, 'required');
+        
+        $expectedValue = "<div class=\"form-group field-dynamicmodel-attributename required\">";
+        $actualValue = $this->activeField->begin();
+        
+        $this->assertEquals($expectedValue, $actualValue);        
+    }
+    
+    public function testBeginHasErrorAndRequired()
+    {
+        $this->helperModel->addError($this->attributeName, "Error Message");
+        $this->helperModel->addRule($this->attributeName, 'required');
+        
+        $expectedValue = "<div class=\"form-group field-dynamicmodel-attributename required has-error\">";
+        $actualValue = $this->activeField->begin();
+        
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+    
+    public function testEnd()
+    {
+        $expectedValue = '</div>';
+        $actualValue = $this->activeField->end();
+        
+        $this->assertEquals($expectedValue, $actualValue);
+        
+        // other tag
+        $expectedValue = "</article>";
+        $this->activeField->options['tag'] = 'article';
+        $actualValue = $this->activeField->end();
+        
+        $this->assertTrue($actualValue === $expectedValue);
+    }
+    
+    public function testLabel()
+    {
+        $expectedValue = "<label class=\"control-label\" for=\"dynamicmodel-attributename\">Attribute Name</label>";
+        $this->activeField->label();
+        
+        $this->assertEquals($expectedValue, $this->activeField->parts['{label}']);
+        
+        // label = false
+        $expectedValue = '';
+        $this->activeField->label(false);
+        
+        $this->assertEquals($expectedValue, $this->activeField->parts['{label}']);
+        
+        // $label = 'Label Name'
+        $label = 'Label Name';
+        $expectedValue = "<label class=\"control-label\" for=\"dynamicmodel-attributename\">{$label}</label>";
+        $this->activeField->label($label);
+        
+        $this->assertEquals($expectedValue, $this->activeField->parts['{label}']);
+    }
+
+    
+    public function testError()
+    {
+        $expectedValue = "<label class=\"control-label\" for=\"dynamicmodel-attributename\">Attribute Name</label>";
+        $this->activeField->label();
+        
+        $this->assertEquals($expectedValue, $this->activeField->parts['{label}']);
+        
+        // label = false
+        $expectedValue = '';
+        $this->activeField->label(false);
+        
+        $this->assertEquals($expectedValue, $this->activeField->parts['{label}']);
+        
+        // $label = 'Label Name'
+        $label = 'Label Name';
+        $expectedValue = "<label class=\"control-label\" for=\"dynamicmodel-attributename\">{$label}</label>";
+        $this->activeField->label($label);
+        
+        $this->assertEquals($expectedValue, $this->activeField->parts['{label}']);
+    }
+
+    public function testHint()
+    {
+        $expectedValue = "<div class=\"hint-block\">Hint Content</div>";
+        $this->activeField->hint('Hint Content');
+        
+        $this->assertEquals($expectedValue, $this->activeField->parts['{hint}']);
+    }
+    
+    public function testInput()
+    {
+        $expectedValue = "<input type=\"password\" id=\"dynamicmodel-attributename\" class=\"form-control\""
+            . " name=\"DynamicModel[attributeName]\">";
+        $this->activeField->input("password");
+        
+        $this->assertEquals($expectedValue, $this->activeField->parts['{input}']); 
+        
+        // with options
+        $expectedValue = "<input type=\"password\" id=\"dynamicmodel-attributename\" class=\"form-control\""
+            . " name=\"DynamicModel[attributeName]\" weird-attribute=\"weird-value\">";
+        $this->activeField->input("password", ['weird-attribute' => 'weird-value']);
+        
+        $this->assertEquals($expectedValue, $this->activeField->parts['{input}']);         
+    }
+    
+    public function testTextInput()
+    {
+        $expectedValue = "<input type=\"text\" id=\"dynamicmodel-attributename\" class=\"form-control\""
+            . " name=\"DynamicModel[attributeName]\">";
+        $this->activeField->textInput();
+        $this->assertEquals($expectedValue, $this->activeField->parts['{input}']);
+    }
+    
+    public function testHiddenInput()
+    {
+        $expectedValue = "<input type=\"hidden\" id=\"dynamicmodel-attributename\" class=\"form-control\""
+            . " name=\"DynamicModel[attributeName]\">";
+        $this->activeField->hiddenInput();
+        
+        $this->assertEquals($expectedValue, $this->activeField->parts['{input}']);
+    }
+    
+    public function testListBox()
+    {
+        $expectedValue = "<input type=\"hidden\" name=\"DynamicModel[attributeName]\" value=\"\">"
+            . "<select id=\"dynamicmodel-attributename\" class=\"form-control\" name=\"DynamicModel[attributeName]\""
+            . " size=\"4\">\n<option value=\"1\">Item One</option>\n<option value=\"2\">Item 2</option>\n</select>";
+        $this->activeField->listBox(["1" => "Item One", "2" => "Item 2"]);
+        
+        $this->assertEquals($expectedValue, $this->activeField->parts['{input}']);
+    }
+    
+    
+    
+    public function testGetClientOptionsReturnEmpty()
+    {
+        // setup: we want the real deal here!
+        $this->activeField->setClientOptionsEmpty(false);
+        
+        // expected empty
+        $actualValue = $this->activeField->getClientOptions();
+        $this->assertTrue(empty($actualValue) === true);  
+    }
+    
+    public function testGetClientOptionsWithActiveAttributeInScenario()
+    {
+        $this->activeField->setClientOptionsEmpty(false);
+        
+        $this->activeField->model->addRule($this->attributeName, 'yiiunit\framework\widgets\TestValidator');
+        $this->activeField->form->enableClientValidation = false;
+        
+        // expected empty
+        $actualValue = $this->activeField->getClientOptions();
+        $this->assertTrue(empty($actualValue) === true);  
+        
+    }
+    
+    public function testGetClientOptionsClientValidation()
+    {
+        $this->activeField->setClientOptionsEmpty(false);
+        
+        $this->activeField->model->addRule($this->attributeName, 'yiiunit\framework\widgets\TestValidator');
+        $this->activeField->enableClientValidation = true;
+        $actualValue = $this->activeField->getClientOptions();
+        $expectedJsExpression = "function (attribute, value, messages) {return true;}";
+        $expectedValidateOnChange = true;
+        $expectedValidateOnType = false;
+        $expectedValidationDelay = 200;
+        
+        $actualJsExpression = $actualValue['validate'];
+        $this->assertEquals($expectedJsExpression, $actualJsExpression->expression);
+        $this->assertTrue($expectedValidateOnChange === $actualValue['validateOnChange']);
+        $this->assertTrue($expectedValidateOnType === $actualValue['validateOnType']);
+        $this->assertTrue($expectedValidationDelay === $actualValue['validationDelay']);         
+    }
+    
+    public function testGetClientOptionsEnableAjaxValidation()
+    {
+        $this->activeField->setClientOptionsEmpty(false);
+        
+        // expected: enableAjaxValidation
+        $this->activeField->enableAjaxValidation = true;
+        $this->activeField->model->addRule($this->attributeName, 'yiiunit\framework\widgets\TestValidator');
+        $actualValue = $this->activeField->getClientOptions();
+        $expectedJsExpression = "function (attribute, value, messages) {return true;}";
+        $expectedValidateOnChange = true;
+        $expectedValidateOnType = false;
+        $expectedValidationDelay = 200;
+        $expectedError = ".help-block";
+        
+        $actualJsExpression = $actualValue['validate'];
+        $this->assertEquals($expectedJsExpression, $actualJsExpression->expression);
+        $this->assertTrue($expectedValidateOnChange === $actualValue['validateOnChange']);
+        $this->assertTrue($expectedValidateOnType === $actualValue['validateOnType']);
+        $this->assertTrue($expectedValidationDelay === $actualValue['validationDelay']);
+        $this->assertTrue(1 === $actualValue['enableAjaxValidation']);
+        $this->assertEquals($expectedError, $actualValue['error']);
+    }
+    
+    /**
+     * Helper methods
+     */
+    protected function getView()
+    {
+        $view = new View();
+        $view->setAssetManager(new AssetManager([
+            'basePath' => '@testWebRoot/assets',
+            'baseUrl' => '@testWeb/assets',
+        ]));
+
+        return $view;
+    }
+    
+}
+
+/**
+ * Helper Classes
+ */
+class ActiveFieldExtend extends ActiveField
+{
+    private $getClientOptionsEmpty;
+    
+    public function __construct($getClientOptionsEmpty = true)
+    {
+        $this->getClientOptionsEmpty = $getClientOptionsEmpty;
+    }
+    
+    public function setClientOptionsEmpty($value)
+    {
+        $this->getClientOptionsEmpty = (bool) $value;
+    }
+    
+    /**
+     * Usefull to test other methods from ActiveField, that call ActiveField::getClientOptions()
+     * but it's return value is not relevant for the test being run.
+     */
+    public function getClientOptions()
+    {
+        return ($this->getClientOptionsEmpty) ? [] : parent::getClientOptions();
+    }
+}
+
+class TestValidator extends \yii\validators\Validator
+{
+    public function clientValidateAttribute($object, $attribute, $view)
+    {
+        return "return true;";
+    }
+}
+

--- a/tests/unit/framework/widgets/ActiveFieldTest.php
+++ b/tests/unit/framework/widgets/ActiveFieldTest.php
@@ -46,11 +46,14 @@ class ActiveFieldTest extends \yiiunit\TestCase
     
     public function testRenderNoContent()
     {
-        $expectedValue = "<div class=\"form-group field-dynamicmodel-attributename\">\n"
-            . "<label class=\"control-label\" for=\"dynamicmodel-attributename\">Attribute Name</label>\n"
-            . "<input type=\"text\" id=\"dynamicmodel-attributename\" class=\"form-control\" "
-            . "name=\"DynamicModel[{$this->attributeName}]\">\n\n"
-            . "<div class=\"help-block\"></div>\n</div>";
+        $expectedValue = <<<EOD
+<div class="form-group field-dynamicmodel-attributename">
+<label class="control-label" for="dynamicmodel-attributename">Attribute Name</label>
+<input type="text" id="dynamicmodel-attributename" class="form-control" name="DynamicModel[{$this->attributeName}]">
+
+<div class="help-block"></div>
+</div>
+EOD;
         
         $actualValue = $this->activeField->render();
         $this->assertEquals($expectedValue, $actualValue);
@@ -66,16 +69,17 @@ class ActiveFieldTest extends \yiiunit\TestCase
         $content = function($field) {
             return "<div class=\"custom-container\"> $field </div>";
         };
-        
-        $expectedValue = "<div class=\"form-group field-dynamicmodel-attributename\">\n"
-            . "<div class=\"custom-container\"> "
-            . "<div class=\"form-group field-dynamicmodel-attributename\">\n"
-            . "<label class=\"control-label\" for=\"dynamicmodel-attributename\">Attribute Name</label>\n"
-            . "<input type=\"text\" id=\"dynamicmodel-attributename\" class=\"form-control\" "
-            . "name=\"DynamicModel[{$this->attributeName}]\">\n\n"
-            . "<div class=\"help-block\"></div>\n</div>"
-            . " </div>\n"        
-            . "</div>";
+
+        $expectedValue = <<<EOD
+<div class="form-group field-dynamicmodel-attributename">
+<div class="custom-container"> <div class="form-group field-dynamicmodel-attributename">
+<label class="control-label" for="dynamicmodel-attributename">Attribute Name</label>
+<input type="text" id="dynamicmodel-attributename" class="form-control" name="DynamicModel[{$this->attributeName}]">
+
+<div class="help-block"></div>
+</div> </div>
+</div>
+EOD;
         
         $actualValue = $this->activeField->render($content);
         $this->assertEquals($expectedValue, $actualValue);
@@ -85,7 +89,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
     {
         $this->helperModel->addError($this->attributeName, "Error Message");
         
-        $expectedValue = "<div class=\"form-group field-dynamicmodel-attributename has-error\">";
+        $expectedValue = '<div class="form-group field-dynamicmodel-attributename has-error">';
         $actualValue = $this->activeField->begin();
         
         $this->assertEquals($expectedValue, $actualValue);
@@ -95,7 +99,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
     {
         $this->helperModel->addRule($this->attributeName, 'required');
         
-        $expectedValue = "<div class=\"form-group field-dynamicmodel-attributename required\">";
+        $expectedValue = '<div class="form-group field-dynamicmodel-attributename required">';
         $actualValue = $this->activeField->begin();
         
         $this->assertEquals($expectedValue, $actualValue);        
@@ -106,7 +110,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
         $this->helperModel->addError($this->attributeName, "Error Message");
         $this->helperModel->addRule($this->attributeName, 'required');
         
-        $expectedValue = "<div class=\"form-group field-dynamicmodel-attributename required has-error\">";
+        $expectedValue = '<div class="form-group field-dynamicmodel-attributename required has-error">';
         $actualValue = $this->activeField->begin();
         
         $this->assertEquals($expectedValue, $actualValue);
@@ -129,7 +133,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
     
     public function testLabel()
     {
-        $expectedValue = "<label class=\"control-label\" for=\"dynamicmodel-attributename\">Attribute Name</label>";
+        $expectedValue = '<label class="control-label" for="dynamicmodel-attributename">Attribute Name</label>';
         $this->activeField->label();
         
         $this->assertEquals($expectedValue, $this->activeField->parts['{label}']);
@@ -142,7 +146,9 @@ class ActiveFieldTest extends \yiiunit\TestCase
         
         // $label = 'Label Name'
         $label = 'Label Name';
-        $expectedValue = "<label class=\"control-label\" for=\"dynamicmodel-attributename\">{$label}</label>";
+        $expectedValue = <<<EOT
+<label class="control-label" for="dynamicmodel-attributename">{$label}</label>
+EOT;
         $this->activeField->label($label);
         
         $this->assertEquals($expectedValue, $this->activeField->parts['{label}']);
@@ -151,7 +157,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
     
     public function testError()
     {
-        $expectedValue = "<label class=\"control-label\" for=\"dynamicmodel-attributename\">Attribute Name</label>";
+        $expectedValue = '<label class="control-label" for="dynamicmodel-attributename">Attribute Name</label>';
         $this->activeField->label();
         
         $this->assertEquals($expectedValue, $this->activeField->parts['{label}']);
@@ -164,7 +170,9 @@ class ActiveFieldTest extends \yiiunit\TestCase
         
         // $label = 'Label Name'
         $label = 'Label Name';
-        $expectedValue = "<label class=\"control-label\" for=\"dynamicmodel-attributename\">{$label}</label>";
+        $expectedValue = <<<EOT
+<label class="control-label" for="dynamicmodel-attributename">{$label}</label>
+EOT;
         $this->activeField->label($label);
         
         $this->assertEquals($expectedValue, $this->activeField->parts['{label}']);
@@ -172,7 +180,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
 
     public function testHint()
     {
-        $expectedValue = "<div class=\"hint-block\">Hint Content</div>";
+        $expectedValue = '<div class="hint-block">Hint Content</div>';
         $this->activeField->hint('Hint Content');
         
         $this->assertEquals($expectedValue, $this->activeField->parts['{hint}']);
@@ -180,44 +188,49 @@ class ActiveFieldTest extends \yiiunit\TestCase
     
     public function testInput()
     {
-        $expectedValue = "<input type=\"password\" id=\"dynamicmodel-attributename\" class=\"form-control\""
-            . " name=\"DynamicModel[attributeName]\">";
+        $expectedValue = <<<EOD
+<input type="password" id="dynamicmodel-attributename" class="form-control" name="DynamicModel[attributeName]">
+EOD;
         $this->activeField->input("password");
         
         $this->assertEquals($expectedValue, $this->activeField->parts['{input}']); 
         
         // with options
-        $expectedValue = "<input type=\"password\" id=\"dynamicmodel-attributename\" class=\"form-control\""
-            . " name=\"DynamicModel[attributeName]\" weird-attribute=\"weird-value\">";
-        $this->activeField->input("password", ['weird-attribute' => 'weird-value']);
+        $expectedValue = <<<EOD
+<input type="password" id="dynamicmodel-attributename" class="form-control" name="DynamicModel[attributeName]" weird="value">
+EOD;
+        $this->activeField->input("password", ['weird' => 'value']);
         
         $this->assertEquals($expectedValue, $this->activeField->parts['{input}']);         
     }
     
     public function testTextInput()
     {
-        $expectedValue = "<input type=\"text\" id=\"dynamicmodel-attributename\" class=\"form-control\""
-            . " name=\"DynamicModel[attributeName]\">";
+        $expectedValue = <<<EOD
+<input type="text" id="dynamicmodel-attributename" class="form-control" name="DynamicModel[attributeName]">
+EOD;
         $this->activeField->textInput();
         $this->assertEquals($expectedValue, $this->activeField->parts['{input}']);
     }
     
     public function testHiddenInput()
     {
-        $expectedValue = "<input type=\"hidden\" id=\"dynamicmodel-attributename\" class=\"form-control\""
-            . " name=\"DynamicModel[attributeName]\">";
+        $expectedValue = <<<EOD
+<input type="hidden" id="dynamicmodel-attributename" class="form-control" name="DynamicModel[attributeName]">
+EOD;
         $this->activeField->hiddenInput();
-        
         $this->assertEquals($expectedValue, $this->activeField->parts['{input}']);
     }
     
     public function testListBox()
     {
-        $expectedValue = "<input type=\"hidden\" name=\"DynamicModel[attributeName]\" value=\"\">"
-            . "<select id=\"dynamicmodel-attributename\" class=\"form-control\" name=\"DynamicModel[attributeName]\""
-            . " size=\"4\">\n<option value=\"1\">Item One</option>\n<option value=\"2\">Item 2</option>\n</select>";
+        $expectedValue = <<<EOD
+<input type="hidden" name="DynamicModel[attributeName]" value=""><select id="dynamicmodel-attributename" class="form-control" name="DynamicModel[attributeName]" size="4">
+<option value="1">Item One</option>
+<option value="2">Item 2</option>
+</select>
+EOD;
         $this->activeField->listBox(["1" => "Item One", "2" => "Item 2"]);
-        
         $this->assertEquals($expectedValue, $this->activeField->parts['{input}']);
     }
     

--- a/tests/unit/framework/widgets/ActiveFieldTest.php
+++ b/tests/unit/framework/widgets/ActiveFieldTest.php
@@ -57,7 +57,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
     }
     
     /**
-     * @todo    discuss|review  Expected HTML when content is callable shouldn't be the should
+     * @todo    discuss|review  Expected HTML shouldn't be wrapped only by the $content?
      */
     public function testRenderWithCallableContent()
     {


### PR DESCRIPTION
Feel free to review, discuss and even cherry-pick.

I would also call for your attention to the test `testRenderWithCallableContent()`, the `$expectedValue`.
Shouldn't the field be wrapped only around the callable anonymous function, without a call to the `begin()` and `end()` methods when content it's callable?

Refactor applied - Method extraction, Compose method and Accumulation/Collecting parameter.
