### PR TITLE
Added ability to `yii\bootstrap\Tabs` to encode each `Tabs::items['label']` separately

### DIFF
--- a/extensions/bootstrap/CHANGELOG.md
+++ b/extensions/bootstrap/CHANGELOG.md
@@ -7,9 +7,8 @@ Yii Framework 2 bootstrap extension Change Log
 - Bug #3292: Fixed dropdown widgets rendering incorrect HTML (it3rmit)
 - Bug #3740: Fixed duplicate error message when client validation is enabled (tadaszelvys)
 - Bug #3749: Fixed invalid plugin registration and ensure clickable links in dropdown (kartik-v)
+- Enh #4024: Added ability to `yii\bootstrap\Tabs` to encode each `Tabs::items['label']` separately (creocoder, umneeq)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)
-- Enh: Added ability to `yii\bootstrap\Tabs` to encode each `Tabs::items['label']` separately (creocoder, umneeq)
-
 
 2.0.0-beta April 13, 2014
 -------------------------

--- a/extensions/bootstrap/CHANGELOG.md
+++ b/extensions/bootstrap/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Bug #3740: Fixed duplicate error message when client validation is enabled (tadaszelvys)
 - Bug #3749: Fixed invalid plugin registration and ensure clickable links in dropdown (kartik-v)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)
+- Enh: Added ability to `yii\bootstrap\Tabs` to encode each `Tabs::items['label']` separately (creocoder, umneeq)
 
 
 2.0.0-beta April 13, 2014

--- a/extensions/bootstrap/Tabs.php
+++ b/extensions/bootstrap/Tabs.php
@@ -58,7 +58,8 @@ class Tabs extends Widget
      * tab with the following structure:
      *
      * - label: string, required, the tab header label.
-     * - encode: boolean, optional, whether this label should be HTML-encoded.
+     * - encode: boolean, optional, whether this label should be HTML-encoded. This param will override
+     *   global `$this->encodeLabels` param.
      * - headerOptions: array, optional, the HTML attributes of the tab header.
      * - linkOptions: array, optional, the HTML attributes of the tab header link tags.
      * - content: string, required if `items` is not set. The content (HTML) of the tab pane.

--- a/extensions/bootstrap/Tabs.php
+++ b/extensions/bootstrap/Tabs.php
@@ -60,11 +60,11 @@ class Tabs extends Widget
      * - label: string, required, the tab header label.
      * - headerOptions: array, optional, the HTML attributes of the tab header.
      * - linkOptions: array, optional, the HTML attributes of the tab header link tags.
-     * - content: array, required if `items` is not set. The content (HTML) of the tab pane.
+     * - content: string, required if `items` is not set. The content (HTML) of the tab pane.
      * - options: array, optional, the HTML attributes of the tab pane container.
      * - active: boolean, optional, whether the item tab header and pane should be visible or not.
      * - items: array, optional, if not set then `content` will be required. The `items` specify a dropdown items
-     *   configuration array. Each item can hold two extra keys, besides the above ones:
+     *   configuration array. Each item can hold three extra keys, besides the above ones:
      *     * active: boolean, optional, whether the item tab header and pane should be visible or not.
      *     * content: string, required if `items` is not set. The content (HTML) of the tab pane.
      *     * contentOptions: optional, array, the HTML attributes of the tab content container.

--- a/extensions/bootstrap/Tabs.php
+++ b/extensions/bootstrap/Tabs.php
@@ -58,6 +58,7 @@ class Tabs extends Widget
      * tab with the following structure:
      *
      * - label: string, required, the tab header label.
+     * - encode: boolean, optional, whether this label should be HTML-encoded.
      * - headerOptions: array, optional, the HTML attributes of the tab header.
      * - linkOptions: array, optional, the HTML attributes of the tab header link tags.
      * - content: string, required if `items` is not set. The content (HTML) of the tab pane.
@@ -136,7 +137,8 @@ class Tabs extends Widget
             if (!isset($item['label'])) {
                 throw new InvalidConfigException("The 'label' option is required.");
             }
-            $label = $this->encodeLabels ? Html::encode($item['label']) : $item['label'];
+            $encodeLabel = $this->encodeLabels || isset($item['encode']) && $item['encode'] === true;
+            $label = $encodeLabel ? Html::encode($item['label']) : $item['label'];
             $headerOptions = array_merge($this->headerOptions, ArrayHelper::getValue($item, 'headerOptions', []));
             $linkOptions = array_merge($this->linkOptions, ArrayHelper::getValue($item, 'linkOptions', []));
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -114,6 +114,7 @@ Yii Framework 2 Change Log
 - Enh: Added support for array attributes in `in` validator (creocoder)
 - Enh: Improved `yii\helpers\Inflector::slug` to support more cases for Russian, Hebrew and special characters (samdark)
 - Enh #3926: `yii\widgets\Breadcrumbs::$links`. Allows individual link to have its own `template` (creocoder, umneeq)
+- Enh: Added ability to `yii\bootstrap\Tabs` to encode each `Tabs::items['label']` separately (creocoder, umneeq)
 - Chg #2898: `yii\console\controllers\AssetController` is now using hashes instead of timestamps (samdark)
 - Chg #2913: RBAC `DbManager` is now initialized via migration (samdark)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -114,7 +114,6 @@ Yii Framework 2 Change Log
 - Enh: Added support for array attributes in `in` validator (creocoder)
 - Enh: Improved `yii\helpers\Inflector::slug` to support more cases for Russian, Hebrew and special characters (samdark)
 - Enh #3926: `yii\widgets\Breadcrumbs::$links`. Allows individual link to have its own `template` (creocoder, umneeq)
-- Enh: Added ability to `yii\bootstrap\Tabs` to encode each `Tabs::items['label']` separately (creocoder, umneeq)
 - Chg #2898: `yii\console\controllers\AssetController` is now using hashes instead of timestamps (samdark)
 - Chg #2913: RBAC `DbManager` is now initialized via migration (samdark)
 - Chg #3036: Upgraded Twitter Bootstrap to 3.1.x (qiangxue)


### PR DESCRIPTION
Suppose we have 10 tabs. In one I want to add checkbox input. This feature allows us do it with beauty.
