### PR TITLE
Http status codes are hardcoded in filter in debug

### DIFF
--- a/extensions/debug/CHANGELOG.md
+++ b/extensions/debug/CHANGELOG.md
@@ -6,12 +6,12 @@ Yii Framework 2 debug extension Change Log
 
 - Bug #1263: Fixed the issue that Gii and Debug modules might be affected by incompatible asset manager configuration (qiangxue)
 - Bug #3956: Debug toolbar was affecting flash message removal (samdark) 
-- Bug #4031: Http status codes were hardcoded in filter (sdkiller)
 - Enh #2299: Date and time in request list is now never wrapped (samdark)
 - Enh #3088: The debug module will manage their own URL rules now (qiangxue)
 - Enh #3103: debugger panel is now not displayed when printing a page (githubjeka)
 - Enh #3108: Added `yii\debug\Module::enableDebugLogs` to disable logging debug logs by default (qiangxue)
 - Enh #3810: Added "Latest" button on panels page (thiagotalma)
+- Enh #4031: Http status codes were hardcoded in filter (sdkiller)
 
 2.0.0-beta April 13, 2014
 -------------------------

--- a/extensions/debug/CHANGELOG.md
+++ b/extensions/debug/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 debug extension Change Log
 
 - Bug #1263: Fixed the issue that Gii and Debug modules might be affected by incompatible asset manager configuration (qiangxue)
 - Bug #3956: Debug toolbar was affecting flash message removal (samdark) 
+- Bug #4031: Http status codes were hardcoded in filter (sdkiller)
 - Enh #2299: Date and time in request list is now never wrapped (samdark)
 - Enh #3088: The debug module will manage their own URL rules now (qiangxue)
 - Enh #3103: debugger panel is now not displayed when printing a page (githubjeka)

--- a/extensions/debug/controllers/DefaultController.php
+++ b/extensions/debug/controllers/DefaultController.php
@@ -60,6 +60,7 @@ class DefaultController extends Controller
             'panels' => $this->module->panels,
             'dataProvider' => $dataProvider,
             'searchModel' => $searchModel,
+            'manifest' => $this->getManifest(),
         ]);
     }
 

--- a/extensions/debug/views/default/index.php
+++ b/extensions/debug/views/default/index.php
@@ -41,7 +41,7 @@ if (isset($this->context->module->panels['db']) && isset($this->context->module-
         }
     }
     $codes = array_unique($codes, SORT_NUMERIC);
-    $status_codes = (!empty($codes)) ? array_combine($codes, $codes) : true;
+    $statusCodes = (!empty($codes)) ? array_combine($codes, $codes) : true;
 
     echo GridView::widget([
         'dataProvider' => $dataProvider,
@@ -113,7 +113,7 @@ if (isset($this->context->module->panels['db']) && isset($this->context->module-
             ],
             [
                 'attribute' => 'statusCode',
-                'filter' => $status_codes,
+                'filter' => $statusCodes,
                 'label' => 'Status code'
             ],
         ],

--- a/extensions/debug/views/default/index.php
+++ b/extensions/debug/views/default/index.php
@@ -34,6 +34,15 @@ if (isset($this->context->module->panels['db']) && isset($this->context->module-
     echo "			<h1>Available Debug Data</h1>";
     $timeFormatter = extension_loaded('intl') ? Yii::createObject(['class' => 'yii\i18n\Formatter']) : Yii::$app->formatter;
 
+    $codes = [];
+    foreach ($manifest as $tag => $vals) {
+        if (!empty($vals['statusCode'])) {
+            $codes[] = $vals['statusCode'];
+        }
+    }
+    $codes = array_unique($codes, SORT_NUMERIC);
+    $status_codes = (!empty($codes)) ? array_combine($codes, $codes) : true;
+
     echo GridView::widget([
         'dataProvider' => $dataProvider,
         'filterModel' => $searchModel,
@@ -104,7 +113,7 @@ if (isset($this->context->module->panels['db']) && isset($this->context->module-
             ],
             [
                 'attribute' => 'statusCode',
-                'filter' => [200 => 200, 404 => 404, 403 => 403, 500 => 500],
+                'filter' => $status_codes,
                 'label' => 'Status code'
             ],
         ],


### PR DESCRIPTION
Arbitrary http status codes are hardcoded in filter so it is impossible to search by status code if it is not present in select.

![aaaa](https://cloud.githubusercontent.com/assets/2150916/3368172/726f9802-fb70-11e3-97d9-5a429eed47b4.png)
