### PR TITLE
Gii `*Search` model generator fix

### DIFF
--- a/extensions/gii/generators/crud/default/search.php
+++ b/extensions/gii/generators/crud/default/search.php
@@ -60,7 +60,7 @@ class <?= $searchModelClass ?> extends <?= isset($modelAlias) ? $modelAlias : $m
      */
     public function search($params)
     {
-        $query = <?= isset($modelAlias) ? $modelAlias : $modelClass ?>::find();
+        $query = static::find();
 
         $dataProvider = new ActiveDataProvider([
             'query' => $query,


### PR DESCRIPTION
Without that fix `*Search` model approach is broken. You can't use virtual attributes defined in `*Search` model inside `*DataProvider` sort, etc. Example:

``` php
class ProductSearch extends Product
{
    public $price_from;
    public $price_to;

    public function attributeLabels() {
        return array_merge(parent::attributeLabels(), [
            'price_from' => 'Price From',
            'price_to' => 'Price To',
        ]);
    }

    public function search($params) {
        $query = static::find();

        $dataProvider = new ActiveDataProvider([
            'query' => $query,
            'sort' => [
                'attributes' => [
                    'price_from' => [
                        ...
                    ],
                    'price_to' => [
                        ...
                    ],
                ],
            ],
        ]);

        $query->andFilterWhere([
            'product.price' => $this->price,
        ]);

        $query->andFilterWhere([
            'product.price > :price_from',
            [':price_from' => $this->price_from],
        ]);

        $query->andFilterWhere([
            'product.price < :price_to',
            [':price_to' => $this->price_to],
        ]);
    }
}

```
