### PR TITLE
Consistent after save and updateAttributes

### DIFF
--- a/extensions/elasticsearch/ActiveRecord.php
+++ b/extensions/elasticsearch/ActiveRecord.php
@@ -395,35 +395,31 @@ class ActiveRecord extends BaseActiveRecord
         if ($runValidation && !$this->validate($attributes)) {
             return false;
         }
-        if ($this->beforeSave(true)) {
-            $values = $this->getDirtyAttributes($attributes);
-
-            $response = static::getDb()->createCommand()->insert(
-                static::index(),
-                static::type(),
-                $values,
-                $this->getPrimaryKey(),
-                $options
-            );
-
-//            if (!isset($response['ok'])) {
-//                return false;
-//            }
-            $pk = static::primaryKey()[0];
-            $this->$pk = $response['_id'];
-            if ($pk != '_id') {
-                $values[$pk] = $response['_id'];
-            }
-            $this->_version = $response['_version'];
-            $this->_score = null;
-
-            $this->afterSave(true);
-            $this->setOldAttributes($values);
-
-            return true;
+        if (!$this->beforeSave(true)) {
+            return false;
         }
+        $values = $this->getDirtyAttributes($attributes);
 
-        return false;
+        $response = static::getDb()->createCommand()->insert(
+            static::index(),
+            static::type(),
+            $values,
+            $this->getPrimaryKey(),
+            $options
+        );
+
+        $pk = static::primaryKey()[0];
+        $this->$pk = $response['_id'];
+        if ($pk != '_id') {
+            $values[$pk] = $response['_id'];
+        }
+        $this->_version = $response['_version'];
+        $this->_score = null;
+
+        $this->setOldAttributes($values);
+        $this->afterSave(true, $values);
+
+        return true;
     }
 
     /**

--- a/extensions/mongodb/ActiveRecord.php
+++ b/extensions/mongodb/ActiveRecord.php
@@ -224,8 +224,8 @@ abstract class ActiveRecord extends BaseActiveRecord
         $this->setAttribute('_id', $newId);
         $values['_id'] = $newId;
 
-        $this->afterSave(true);
         $this->setOldAttributes($values);
+        $this->afterSave(true, $values);
 
         return true;
     }
@@ -241,7 +241,7 @@ abstract class ActiveRecord extends BaseActiveRecord
         }
         $values = $this->getDirtyAttributes($attributes);
         if (empty($values)) {
-            $this->afterSave(false);
+            $this->afterSave(false, $values);
             return 0;
         }
         $condition = $this->getOldPrimaryKey(true);
@@ -260,10 +260,10 @@ abstract class ActiveRecord extends BaseActiveRecord
             throw new StaleObjectException('The object being updated is outdated.');
         }
 
-        $this->afterSave(false);
         foreach ($values as $name => $value) {
             $this->setOldAttribute($name, $this->getAttribute($name));
         }
+        $this->afterSave(false, $values);
 
         return $rows;
     }

--- a/extensions/mongodb/file/ActiveRecord.php
+++ b/extensions/mongodb/file/ActiveRecord.php
@@ -127,8 +127,8 @@ abstract class ActiveRecord extends \yii\mongodb\ActiveRecord
         $this->setAttribute('_id', $newId);
         $values['_id'] = $newId;
 
-        $this->afterSave(true);
         $this->setOldAttributes($values);
+        $this->afterSave(true, $values);
 
         return true;
     }
@@ -144,7 +144,7 @@ abstract class ActiveRecord extends \yii\mongodb\ActiveRecord
         }
         $values = $this->getDirtyAttributes($attributes);
         if (empty($values)) {
-            $this->afterSave(false);
+            $this->afterSave(false, $values);
             return 0;
         }
 
@@ -196,10 +196,10 @@ abstract class ActiveRecord extends \yii\mongodb\ActiveRecord
             }
         }
 
-        $this->afterSave(false);
         foreach ($values as $name => $value) {
             $this->setOldAttribute($name, $this->getAttribute($name));
         }
+        $this->afterSave(false, $values);
 
         return $rows;
     }

--- a/extensions/sphinx/ActiveRecord.php
+++ b/extensions/sphinx/ActiveRecord.php
@@ -395,8 +395,8 @@ abstract class ActiveRecord extends BaseActiveRecord
             return false;
         }
 
-        $this->afterSave(true);
         $this->setOldAttributes($values);
+        $this->afterSave(true, $values);
 
         return true;
     }
@@ -488,7 +488,7 @@ abstract class ActiveRecord extends BaseActiveRecord
         }
         $values = $this->getDirtyAttributes($attributes);
         if (empty($values)) {
-            $this->afterSave(false);
+            $this->afterSave(false, $values);
             return 0;
         }
 
@@ -530,10 +530,10 @@ abstract class ActiveRecord extends BaseActiveRecord
             }
         }
 
-        $this->afterSave(false);
         foreach ($values as $name => $value) {
             $this->setOldAttribute($name, $this->getAttribute($name));
         }
+        $this->afterSave(false, $values);
 
         return $rows;
     }

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -21,6 +21,7 @@ Yii Framework 2 Change Log
 - Bug #3194: Date formatter works only for timestamps in the year range 1970 to 2038 (kartik-v)
 - Bug #3204: `yii\di\Container` did not handle the `$config` parameter well in case when it does not have a default value (qiangxue)
 - Bug #3216: Fixed the bug that `yii.activeForm.destroy()` did not remove `submit` event handlers (qiangxue)
+- Bug #3233: Ensure consistent behavior in ActiveRecord::afterSave() (cebe, qiangxue)
 - Bug #3236: Return value for DateTime->format('U') casted to double to allow correct date formatting (pgaultier)
 - Bug #3268: Fixed the bug that the schema name in a table name was not respected by `yii\db\mysql\Schema` (terazoid, qiangxue)
 - Bug #3311: Fixed the bug that `yii\di\Container::has()` did not return correct value (mgrechanik, qiangxue)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -55,3 +55,7 @@ Upgrade from Yii 2.0 Beta
   This change is needed because `yii\web\View` no longer automatically generates CSRF meta tags due to issue #3358.
 
 * If your model code is using the `file` validation rule, you should rename its `types` option to `extensions`.
+
+* The behavior and signature of `ActiveRecord::afterSave()` has changed. `ActiveRecord::$isNewRecord` will now always be
+  false in afterSave and also dirty attributes are not available. This change has been made to have a more consistent and
+  expected behavior. The changed attributes are now available in the new parameter of afterSave() `$changedAttributes`.

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -59,3 +59,7 @@ Upgrade from Yii 2.0 Beta
 * The behavior and signature of `ActiveRecord::afterSave()` has changed. `ActiveRecord::$isNewRecord` will now always be
   false in afterSave and also dirty attributes are not available. This change has been made to have a more consistent and
   expected behavior. The changed attributes are now available in the new parameter of afterSave() `$changedAttributes`.
+
+* `ActiveRecord::updateAttributes()` has been changed to not trigger events and not respect optimistic locking anymore to
+  differentiate it more from calling `update(false)` and to ensure it can be used in `afterSave()` without triggering infinite
+  loops.

--- a/framework/base/ModelEvent.php
+++ b/framework/base/ModelEvent.php
@@ -8,9 +8,7 @@
 namespace yii\base;
 
 /**
- * ModelEvent class.
- *
- * ModelEvent represents the parameter needed by model events.
+ * ModelEvent represents the parameter needed by [[Model]] events.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -88,6 +88,7 @@ return [
   'yii\db\ActiveRecord' => YII_PATH . '/db/ActiveRecord.php',
   'yii\db\ActiveRecordInterface' => YII_PATH . '/db/ActiveRecordInterface.php',
   'yii\db\ActiveRelationTrait' => YII_PATH . '/db/ActiveRelationTrait.php',
+  'yii\db\AfterSaveEvent' => YII_PATH . '/db/AfterSaveEvent.php',
   'yii\db\BaseActiveRecord' => YII_PATH . '/db/BaseActiveRecord.php',
   'yii\db\BatchQueryResult' => YII_PATH . '/db/BatchQueryResult.php',
   'yii\db\ColumnSchema' => YII_PATH . '/db/ColumnSchema.php',

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -431,8 +431,8 @@ class ActiveRecord extends BaseActiveRecord
             }
         }
 
-        $this->afterSave(true);
         $this->setOldAttributes($values);
+        $this->afterSave(true, $values);
 
         return true;
     }

--- a/framework/db/AfterSaveEvent.php
+++ b/framework/db/AfterSaveEvent.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db;
+
+use yii\base\Event;
+
+/**
+ * AfterSaveEvent represents the information available in [[ActiveRecord::EVENT_AFTER_INSERT]] and [[ActiveRecord::EVENT_AFTER_UPDATE]].
+ *
+ * @author Carsten Brandt <mail@cebe.cc>
+ * @since 2.0
+ */
+class AfterSaveEvent extends Event
+{
+    /**
+     * @var array The attribute values that had changed and were saved.
+     */
+    public $changedAttributes;
+}

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -667,7 +667,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
             }
         }
 
-        $values = $this->getDirtyAttributes($attributes);
+        $values = $this->getDirtyAttributes($attrs);
         if (empty($values)) {
             return 0;
         }

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -867,17 +867,17 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
     /**
      * This method is called at the end of inserting or updating a record.
      * The default implementation will trigger an [[EVENT_AFTER_INSERT]] event when `$insert` is true,
-     * or an [[EVENT_AFTER_UPDATE]] event if `$insert` is false.
+     * or an [[EVENT_AFTER_UPDATE]] event if `$insert` is false. The event class used is [[AfterSaveEvent]].
      * When overriding this method, make sure you call the parent implementation so that
      * the event is triggered.
      * @param boolean $insert whether this method called while inserting a record.
-     * @param array $changedAttributes the attribute values that have changed during save.
      * If false, it means the method is called while updating a record.
+     * @param array $changedAttributes The attribute values that had changed and were saved.
      */
     public function afterSave($insert, $changedAttributes)
     {
-        $this->trigger($insert ? self::EVENT_AFTER_INSERT : self::EVENT_AFTER_UPDATE, new ModelEvent([
-            'data' => ['changedAttributes' => $changedAttributes]
+        $this->trigger($insert ? self::EVENT_AFTER_INSERT : self::EVENT_AFTER_UPDATE, new AfterSaveEvent([
+            'changedAttributes' => $changedAttributes
         ]));
     }
 

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -680,7 +680,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
         }
         $values = $this->getDirtyAttributes($attributes);
         if (empty($values)) {
-            $this->afterSave(false);
+            $this->afterSave(false, $values);
             return 0;
         }
         $condition = $this->getOldPrimaryKey(true);
@@ -699,10 +699,10 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
             throw new StaleObjectException('The object being updated is outdated.');
         }
 
-        $this->afterSave(false);
         foreach ($values as $name => $value) {
             $this->_oldAttributes[$name] = $this->_attributes[$name];
         }
+        $this->afterSave(false, $values);
 
         return $rows;
     }
@@ -859,11 +859,14 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * When overriding this method, make sure you call the parent implementation so that
      * the event is triggered.
      * @param boolean $insert whether this method called while inserting a record.
+     * @param array $changedAttributes the attribute values that have changed during save.
      * If false, it means the method is called while updating a record.
      */
-    public function afterSave($insert)
+    public function afterSave($insert, $changedAttributes)
     {
-        $this->trigger($insert ? self::EVENT_AFTER_INSERT : self::EVENT_AFTER_UPDATE);
+        $this->trigger($insert ? self::EVENT_AFTER_INSERT : self::EVENT_AFTER_UPDATE, new ModelEvent([
+            'data' => ['changedAttributes' => $changedAttributes]
+        ]));
     }
 
     /**

--- a/tests/unit/data/ar/Customer.php
+++ b/tests/unit/data/ar/Customer.php
@@ -58,11 +58,11 @@ class Customer extends ActiveRecord
         })->orderBy('id');
     }
 
-    public function afterSave($insert)
+    public function afterSave($insert, $changedAttributes)
     {
         ActiveRecordTest::$afterSaveInsert = $insert;
         ActiveRecordTest::$afterSaveNewRecord = $this->isNewRecord;
-        parent::afterSave($insert);
+        parent::afterSave($insert, $changedAttributes);
     }
 
     /**

--- a/tests/unit/data/ar/elasticsearch/Customer.php
+++ b/tests/unit/data/ar/elasticsearch/Customer.php
@@ -40,11 +40,11 @@ class Customer extends ActiveRecord
         return $this->hasMany(OrderWithNullFK::className(), ['customer_id' => 'id'])->orderBy('created_at');
     }
 
-    public function afterSave($insert)
+    public function afterSave($insert, $changedAttributes)
     {
         ActiveRecordTest::$afterSaveInsert = $insert;
         ActiveRecordTest::$afterSaveNewRecord = $this->isNewRecord;
-        parent::afterSave($insert);
+        parent::afterSave($insert, $changedAttributes);
     }
 
     /**

--- a/tests/unit/data/ar/redis/Customer.php
+++ b/tests/unit/data/ar/redis/Customer.php
@@ -38,11 +38,11 @@ class Customer extends ActiveRecord
     /**
      * @inheritdoc
      */
-    public function afterSave($insert)
+    public function afterSave($insert, $changedAttributes)
     {
         ActiveRecordTest::$afterSaveInsert = $insert;
         ActiveRecordTest::$afterSaveNewRecord = $this->isNewRecord;
-        parent::afterSave($insert);
+        parent::afterSave($insert, $changedAttributes);
     }
 
     /**

--- a/tests/unit/framework/ar/ActiveRecordTestTrait.php
+++ b/tests/unit/framework/ar/ActiveRecordTestTrait.php
@@ -867,7 +867,7 @@ trait ActiveRecordTestTrait
         /* @var $customerClass \yii\db\ActiveRecordInterface */
         $customerClass = $this->getCustomerClass();
         /* @var $this TestCase|ActiveRecordTestTrait */
-        // save
+        /* @var $customer Customer */
         $customer = $customerClass::findOne(2);
         $this->assertTrue($customer instanceof $customerClass);
         $this->assertEquals('user2', $customer->name);
@@ -879,8 +879,8 @@ trait ActiveRecordTestTrait
         $this->afterSave();
         $this->assertEquals('user2x', $customer->name);
         $this->assertFalse($customer->isNewRecord);
-        $this->assertFalse(static::$afterSaveNewRecord);
-        $this->assertFalse(static::$afterSaveInsert);
+        $this->assertNull(static::$afterSaveNewRecord);
+        $this->assertNull(static::$afterSaveInsert);
         $customer2 = $customerClass::findOne(2);
         $this->assertEquals('user2x', $customer2->name);
 

--- a/tests/unit/framework/ar/ActiveRecordTestTrait.php
+++ b/tests/unit/framework/ar/ActiveRecordTestTrait.php
@@ -816,7 +816,7 @@ trait ActiveRecordTestTrait
         $this->afterSave();
 
         $this->assertNotNull($customer->id);
-        $this->assertTrue(static::$afterSaveNewRecord);
+        $this->assertFalse(static::$afterSaveNewRecord);
         $this->assertTrue(static::$afterSaveInsert);
         $this->assertFalse($customer->isNewRecord);
     }


### PR DESCRIPTION
-  Ensure consistent behavior in ActiveRecord::afterSave() (fixes #4012)
- changed updateAttributes to be more simple update (fixes #3233)
