### PR TITLE
Fix #87: security helper improvement

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -57,6 +57,7 @@ Yii Framework 2 Change Log
 - Bug: URL encoding for the route parameter added to `\yii\web\UrlManager` (klimov-paul)
 - Bug: Fixed the bug that requesting protected or private action methods would cause 500 error instead of 404 (qiangxue)
 - Bug: Fixed Object of class Imagick could not be converted to string in CaptchaAction (eXprojects, cebe)
+- Enh #87: Cryptographic strength `yii\helpers\Security` improved (klimov-paul)
 - Enh #422: Added Support for BIT(M) data type default values in Schema (cebe)
 - Enh #2264: `CookieCollection::has()` will return false for expired or removed cookies (qiangxue)
 - Enh #2435: `yii\db\IntegrityException` is now thrown on database integrity errors instead of general `yii\db\Exception` (samdark)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -55,3 +55,15 @@ Upgrade from Yii 2.0 Beta
   This change is needed because `yii\web\View` no longer automatically generates CSRF meta tags due to issue #3358.
 
 * If your model code is using the `file` validation rule, you should rename its `types` option to `extensions`.
+
+* If you have used `yii\helpers\Security` for encryption or hash generating, you need to configure it for the
+  legacy code support. To do so you need to declare your own `yii\helpers\Security` extending from `yii\helpers\BaseSecurity`
+  in following way:
+  ```
+  class yii\helpers\Security extends yii\helpers\BaseSecurity
+  {
+      public static $cryptBlockSize = 16;
+      public static $cryptKeySize = 24;
+      public static $derivationIterations = 1000;
+  }
+  ```

--- a/framework/helpers/BaseSecurity.php
+++ b/framework/helpers/BaseSecurity.php
@@ -55,7 +55,7 @@ class BaseSecurity
     {
         $module = static::openCryptModule();
         $data = static::addPadding($data);
-        $iv = mcrypt_create_iv(mcrypt_enc_get_iv_size($module), MCRYPT_RAND);
+        $iv = mcrypt_create_iv(mcrypt_enc_get_iv_size($module), MCRYPT_DEV_URANDOM);
         $key = static::deriveKey($password, $iv);
         mcrypt_generic_init($module, $key, $iv);
         $encrypted = $iv . mcrypt_generic($module, $data);
@@ -174,14 +174,14 @@ class BaseSecurity
             $hash = StringHelper::byteSubstr($data, 0, $hashSize);
             $pureData = StringHelper::byteSubstr($data, $hashSize, $n - $hashSize);
 
-            $calculatedHash = hash_hmac($algorithm, $pureData, $key) ? $pureData : false;
+            $calculatedHash = hash_hmac($algorithm, $pureData, $key);
 
             // timing attack resistant approach:
             $diff = 0;
             for ($i = 0; $i < StringHelper::byteLength($calculatedHash); $i++) {
                 $diff |= (ord($calculatedHash[$i]) ^ ord($hash[$i]));
             }
-            return $diff === 0;
+            return $diff === 0 ? $pureData : false;
         } else {
             return false;
         }

--- a/framework/helpers/BaseSecurity.php
+++ b/framework/helpers/BaseSecurity.php
@@ -172,9 +172,16 @@ class BaseSecurity
         $n = StringHelper::byteLength($data);
         if ($n >= $hashSize) {
             $hash = StringHelper::byteSubstr($data, 0, $hashSize);
-            $data2 = StringHelper::byteSubstr($data, $hashSize, $n - $hashSize);
+            $pureData = StringHelper::byteSubstr($data, $hashSize, $n - $hashSize);
 
-            return $hash === hash_hmac($algorithm, $data2, $key) ? $data2 : false;
+            $calculatedHash = hash_hmac($algorithm, $pureData, $key) ? $pureData : false;
+
+            // timing attack resistant approach:
+            $diff = 0;
+            for ($i = 0; $i < StringHelper::byteLength($calculatedHash); $i++) {
+                $diff |= (ord($calculatedHash[$i]) ^ ord($hash[$i]));
+            }
+            return $diff === 0;
         } else {
             return false;
         }

--- a/framework/helpers/BaseSecurity.php
+++ b/framework/helpers/BaseSecurity.php
@@ -25,9 +25,10 @@ class BaseSecurity
 {
     /**
      * @var integer crypt block size in bytes.
-     * For AES, block size is 128-bit (16 bytes).
+     * For AES-128, AES-192, block size is 128-bit (16 bytes).
+     * For AES-256, block size is 256-bit (32 bytes).
      */
-    public static $cryptBlockSize = 16;
+    public static $cryptBlockSize = 32;
     /**
      * @var integer crypt key size in bytes.
      * For AES-192, key size is 192-bit (24 bytes).

--- a/framework/helpers/BaseSecurity.php
+++ b/framework/helpers/BaseSecurity.php
@@ -221,7 +221,6 @@ class BaseSecurity
      */
     public static function generateRandomKey($length = 32)
     {
-        static::openCryptModule();
         return mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
     }
 
@@ -236,8 +235,9 @@ class BaseSecurity
         if (!extension_loaded('mcrypt')) {
             throw new InvalidConfigException('The mcrypt PHP extension is not installed.');
         }
-        // AES uses a 128-bit block size
-        $module = @mcrypt_module_open('rijndael-128', '', 'cbc', '');
+        // AES version depending on crypt block size
+        $algorithmName = 'rijndael-' . (static::$cryptBlockSize * 8);
+        $module = @mcrypt_module_open($algorithmName, '', 'cbc', '');
         if ($module === false) {
             throw new Exception('Failed to initialize the mcrypt module.');
         }

--- a/framework/helpers/BaseSecurity.php
+++ b/framework/helpers/BaseSecurity.php
@@ -221,15 +221,8 @@ class BaseSecurity
      */
     public static function generateRandomKey($length = 32)
     {
-        if (function_exists('openssl_random_pseudo_bytes')) {
-            $key = strtr(base64_encode(openssl_random_pseudo_bytes($length, $strong)), '+/=', '_-.');
-            if ($strong) {
-                return substr($key, 0, $length);
-            }
-        }
-        $chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-.';
-
-        return substr(str_shuffle(str_repeat($chars, 5)), 0, $length);
+        static::openCryptModule();
+        return mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
     }
 
     /**
@@ -351,15 +344,7 @@ class BaseSecurity
         }
 
         // Get 20 * 8bits of random entropy
-        if (function_exists('openssl_random_pseudo_bytes')) {
-            // https://github.com/yiisoft/yii2/pull/2422
-            $rand = openssl_random_pseudo_bytes(20);
-        } else {
-            $rand = '';
-            for ($i = 0; $i < 20; ++$i) {
-                $rand .= chr(mt_rand(0, 255));
-            }
-        }
+        $rand = static::generateRandomKey(20);
 
         // Add the microtime for a little more entropy.
         $rand .= microtime(true);


### PR DESCRIPTION
Fix #87: security helper improvement

Basic fix to improve cryptographic strength `yii\helpers\Security`. Basic recomendations are applied.
Method `generatePasswordHash()` still requires improvement to be compatbale with `password_hash()` PHP 5.5 function.

Helper structure reworked to support BC (see UPGRADE.md)

Note: from the way I see this class is better to be an application component, then a static helper. I can make such coversion if the rest of the team agree with it.
