### PR TITLE
Fixes #3101: Improved handling of log target failures

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -73,6 +73,7 @@ Yii Framework 2 Change Log
 - Enh #2942: Added truncate and truncateWord methods (Alex-Code, samdark)
 - Enh #3008: Added `Html::errorSummary()` (qiangxue)
 - Enh #3088: The debug and gii modules will manage their own URL rules now (hiltonjanfield, qiangxue)
+- Enh #3101: Improved handling of log target failures. It will now skip target and log reason instead of going into infinite cycle (samdark)
 - Enh #3103: debugger panel is now not displayed when printing a page (githubjeka)
 - Enh #3108: Added `yii\debug\Module::enableDebugLogs` to disable logging debug logs by default (qiangxue)
 - Enh #3132: `yii\rbac\PhpManager` now supports more compact data file format (qiangxue)

--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -105,13 +105,7 @@ abstract class Target extends Component
             if (($context = $this->getContextMessage()) !== '') {
                 $this->messages[] = [$context, Logger::LEVEL_INFO, 'application', YII_BEGIN_TIME];
             }
-            try {
-                $this->export();
-            } catch (\Exception $e) {
-                $this->enabled = false;
-                \Yii::warning('Unable to send log via '.  get_class($this) .': ' . $e->getMessage(), __METHOD__);
-                \Yii::getLogger()->flush(true);
-            }
+            $this->export();
             $this->messages = [];
         }
     }

--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -105,7 +105,13 @@ abstract class Target extends Component
             if (($context = $this->getContextMessage()) !== '') {
                 $this->messages[] = [$context, Logger::LEVEL_INFO, 'application', YII_BEGIN_TIME];
             }
-            $this->export();
+            try {
+                $this->export();
+            } catch (\Exception $e) {
+                $this->enabled = false;
+                \Yii::warning('Unable to send log via '.  get_class($this) .': ' . $e->getMessage(), __METHOD__);
+                \Yii::getLogger()->flush(true);
+            }
             $this->messages = [];
         }
     }


### PR DESCRIPTION
This one is to fix #3101, many debug toolbar failures and improve logging in general. It will now skip target and log reason instead of going into infinite cycle.
