### PR TITLE
Fixes #4080, FileHelper::removeDirectory() symlinks handling enhancements

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -119,6 +119,7 @@ Yii Framework 2 Change Log
     - Improved overall slug results.
     - Added note about the fact that intl is required for non-latin languages to requirements checker.
 - Enh #4028: Added ability to `yii\widgets\Menu` to encode each item's label separately (creocoder, umneeq)
+- Enh #4080: Added proper handling and support of the symlinked directories in `FileHelper`, added $options parameter in `FileHelper::removeDirectory()` (resurtm)
 - Enh: Added support for using sub-queries when building a DB query with `IN` condition (qiangxue)
 - Enh: Supported adding a new response formatter without the need to reconfigure existing formatters (qiangxue)
 - Enh: Added `yii\web\UrlManager::addRules()` to simplify adding new URL rules (qiangxue)


### PR DESCRIPTION
Fixes #4080:
1. Added proper handling and support of the symlinked directories.
2. Added $options parameter.
