### PR TITLE
Wrong typecast for boolean value

### DIFF
--- a/framework/db/ColumnSchema.php
+++ b/framework/db/ColumnSchema.php
@@ -99,7 +99,7 @@ class ColumnSchema extends Object
             case 'integer':
                 return (integer) $value;
             case 'boolean':
-                return (boolean) $value;
+                return filter_var($value, FILTER_VALIDATE_BOOLEAN);
             case 'double':
                 return (double) $value;
         }


### PR DESCRIPTION
return (boolean)"false" always returns true. 
filter_var($value, FILTER_VALIDATE_BOOLEAN) returns right cast
