### PR TITLE
Fix json format in gii/generators/extension/default

### DIFF
--- a/extensions/gii/generators/extension/default/composer.json
+++ b/extensions/gii/generators/extension/default/composer.json
@@ -2,7 +2,7 @@
 	"name": "<?= $generator->vendorName ?>/<?= $generator->packageName ?>",
 	"description": "<?= $generator->description ?>",
 	"type": "<?= $generator->type ?>",
-	"keywords": <?= $generator->keywordsArrayJson ?>,
+	"keywords": "<?= $generator->keywordsArrayJson ?>",
 	"license": "<?= $generator->license ?>",
 	"authors": [
 		{


### PR DESCRIPTION
A little quick fix in json format for composer.json in gii/generators/extension/default
