### PR TITLE
Fix #4114: `Security::generateRandomKey()`

### DIFF
--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -312,15 +312,16 @@ class Security extends Component
      * @throws Exception on failure.
      * @return string the generated random key
      */
-    public function generateRandomKey($length = 32)
+    public function generateRandomKey($length = 64)
     {
         if (!extension_loaded('mcrypt')) {
             throw new InvalidConfigException('The mcrypt PHP extension is not installed.');
         }
-        $key = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
-        if ($key === false) {
+        $binaryKey = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
+        if ($binaryKey === false) {
             throw new Exception('Unable to generate random key.');
         }
+        $key = StringHelper::byteSubstr(bin2hex($binaryKey), 0, $length);
         return $key;
     }
 

--- a/tests/unit/framework/base/SecurityTest.php
+++ b/tests/unit/framework/base/SecurityTest.php
@@ -137,5 +137,6 @@ class SecurityTest extends TestCase
         $keyLength = 20;
         $key = $this->security->generateRandomKey($keyLength);
         $this->assertEquals($keyLength, strlen($key));
+        $this->assertRegExp('/^[a-z0-9]+$/is', $key, 'Invalid character set!');
     }
 }


### PR DESCRIPTION
Fix #4114
Method `Security::generateRandomKey()` changed to return ascii string in...stead of binary one.

It should be safe to use bin4hex conversion. Indeed it reduces the entropy of original binary IV, but it returns just what is needed - random string of specified length. It is up to the developer which length he whould use.
I have increased default length to keep the strength, this should be enough.
