### PR TITLE
add encode option to BaseHtml::error method

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1106,7 +1106,7 @@ class BaseHtml
      * using [[encode()]]. If a value is null, the corresponding attribute will not be rendered.
      *
      * The following options are specially handled:
-     *
+     * - encode: default true, if it's setup as false the message won't be encoded
      * - tag: this specifies the tag name. If not set, "div" will be used.
      *
      * See [[renderTagAttributes()]] for details on how attributes are being rendered.
@@ -1119,7 +1119,12 @@ class BaseHtml
         $error = $model->getFirstError($attribute);
         $tag = isset($options['tag']) ? $options['tag'] : 'div';
         unset($options['tag']);
-        return Html::tag($tag, Html::encode($error), $options);
+        if(!isset($options['encode'])) {
+            return Html::tag($tag, Html::encode($error), $options);
+        } else if($options['encode'] === false) {
+            unset($options['encode']);
+            return  Html::tag($tag, $error, $options);
+        }
     }
 
     /**


### PR DESCRIPTION
Now we can setup 'encode' option for error message. It's very usefully tip: for example i would to add urls to 'login' and 'restore' password to error message if email has been already registered.

http://stackoverflow.com/questions/23594933/yii2-how-to-make-validation-rule-message-not-to-be-encoded
