### PR TITLE
Use array_replace_recursive instead of array_merge

### DIFF
--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -156,7 +156,7 @@ class Container extends Component
             $concrete = $definition['class'];
             unset($definition['class']);
 
-            $config = array_merge($definition, $config);
+            $config = array_replace_recursive($definition, $config);
             $params = $this->mergeParams($class, $params);
 
             if ($concrete === $class) {


### PR DESCRIPTION
Use `array_replace_recursive` instead of `array_merge` for `$config`

e.g.
I had this in with the config to set the `ActiveField` class for forms.

```
Yii::$container->set('yii\bootstrap\ActiveForm', [
    'fieldConfig' => [
        'class' => 'common\components\ActiveField',
    ],
]);
```

When using the form I wanted to change some css classes.

```
<?php $form = ActiveForm::begin([
    'layout' => 'horizontal',
    'fieldConfig' => [
        'horizontalCssClasses' => [
            'label' => 'col-sm-2',
            'wrapper' => 'col-sm-8',
            'hint' => 'col-sm-2'
        ]
    ]
]) ?>
```

This would overwrite the initial config falling back to the default `ActiveField` class

If it's OK I will update the changelog.
