### PR TITLE
Fix bug in `yii\db\mysql\Schema`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -26,6 +26,7 @@ Yii Framework 2 Change Log
 - Bug #3327: Fixed "Unable to find debug data" when logging objects with circular references (jarekkozak, samdark)
 - Bug #3368: Fix for comparing numeric attributes in JavaScript (technixp)
 - Bug: Fixed inconsistent return of `\yii\console\Application::runAction()` (samdark)
+- Bug: Fixed bug where schema name was not used in ’SHOW CREATE TABLE’ query in `yii\db\mysql\Schema` (stevekr)
 - Enh #2264: `CookieCollection::has()` will return false for expired or removed cookies (qiangxue)
 - Enh #2435: `yii\db\IntegrityException` is now thrown on database integrity errors instead of general `yii\db\Exception` (samdark)
 - Enh #2837: Error page now shows arguments in stack trace method calls (samdark)

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -215,7 +215,7 @@ class Schema extends \yii\db\Schema
      */
     protected function getCreateTableSql($table)
     {
-        $row = $this->db->createCommand('SHOW CREATE TABLE ' . $this->quoteSimpleTableName($table->name))->queryOne();
+        $row = $this->db->createCommand('SHOW CREATE TABLE ' . $this->quoteTableName($table->fullName))->queryOne();
         if (isset($row['Create Table'])) {
             $sql = $row['Create Table'];
         } else {


### PR DESCRIPTION
Schema name was not used in ’SHOW CREATE TABLE’ query
