### PR TITLE
change default facility of SyslogTarget

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -168,6 +168,7 @@ Yii Framework 2 Change Log
 - Chg #3989: The default value for `yii\log\FileTarget::$rotateByCopy` now defaults to true to work on windows by default (cebe)
 - Chg #4071: `mail` component renamed to `mailer`, `yii\log\EmailTarget::$mail` renamed to `yii\log\EmailTarget::$mailer` (samdark)
 - Chg #4147: `BaseMailer::compose()` will not overwrite the `message` parameter if it is explicitly provided (qiangxue)
+- Chg #4201: change default value of `SyslogTarget::facility` from LOG_SYSLOG to LOG_USER (dizews)
 - Chg: Replaced `clearAll()` and `clearAllAssignments()` in `yii\rbac\ManagerInterface` with `removeAll()`, `removeAllRoles()`, `removeAllPermissions()`, `removeAllRules()` and `removeAllAssignments()` (qiangxue)
 - Chg: Added `$user` as the first parameter of `yii\rbac\Rule::execute()` (qiangxue)
 - Chg: `yii\grid\DataColumn::getDataCellValue()` visibility is now `public` to allow accessing the value from a GridView directly (cebe)

--- a/framework/log/SyslogTarget.php
+++ b/framework/log/SyslogTarget.php
@@ -26,7 +26,7 @@ class SyslogTarget extends Target
     /**
      * @var integer syslog facility.
      */
-    public $facility = LOG_SYSLOG;
+    public $facility = LOG_USER;
 
     /**
      * @var array syslog levels


### PR DESCRIPTION
LOG_SYSLOG - messages generated internally by syslogd. As we know PHP is not a part of syslogd therefore we should use LOG_USER. (additionaly LOG_USER is the only valid log type under Windows operating systems)
