### PR TITLE
IdentityInterface::findIdentity should return active users

### DIFF
--- a/apps/advanced/common/models/User.php
+++ b/apps/advanced/common/models/User.php
@@ -65,7 +65,7 @@ class User extends ActiveRecord implements IdentityInterface
      */
     public static function findIdentity($id)
     {
-        return static::findOne($id);
+        return static::findOne(['id' => $id, 'status' => self::STATUS_ACTIVE]);
     }
 
     /**


### PR DESCRIPTION
Advanced app `User` model does not take into account user status in `findIdentity()`

```
interface IdentityInterface
{
    /**
     * Finds an identity by the given ID.
     * @param string|integer $id the ID to be looked for
     * @return IdentityInterface the identity object that matches the given ID.
     * Null should be returned if such an identity cannot be found
     * or the identity is not in an active state (disabled, deleted, etc.)
     */
    public static function findIdentity($id);
```
