### PR TITLE
Added stacktrace for sub-exceptions

### DIFF
--- a/framework/views/errorHandler/exception.php
+++ b/framework/views/errorHandler/exception.php
@@ -247,8 +247,13 @@ html,body{
     }
 }
 
+/* prevous callstack */
+.previous .call-stack {
+    background: #fff;
+}
+
 /* request */
-.request{
+.request {
     background-color: #fafafa;
     padding-top: 40px;
     padding-bottom: 40px;

--- a/framework/views/errorHandler/previousException.php
+++ b/framework/views/errorHandler/previousException.php
@@ -19,5 +19,16 @@
     <?php if ($exception instanceof \yii\db\Exception && !empty($exception->errorInfo)) {
         echo '<pre>Error Info: ' . print_r($exception->errorInfo, true) . '</pre>';
     } ?>
+
+    <div class="call-stack">
+        <ul>
+            <?= $handler->renderCallStackItem($exception->getFile(), $exception->getLine(), null, null, [], 1) ?>
+            <?php for ($i = 0, $trace = $exception->getTrace(), $length = count($trace); $i < $length; ++$i): ?>
+                <?= $handler->renderCallStackItem(@$trace[$i]['file'] ?: null, @$trace[$i]['line'] ?: null,
+                    @$trace[$i]['class'] ?: null, @$trace[$i]['function'] ?: null, $trace[$i]['args'], $i + 2) ?>
+            <?php endfor; ?>
+        </ul>
+    </div>
+
     <?= $handler->renderPreviousExceptions($exception) ?>
 </div>


### PR DESCRIPTION
Work in progress. Should fix #4224 

TODO:
- [ ] When there are sub-exceptions it's not clear which traces are for which exceptions.
- [ ] Adjust JavaScript to work with traces for multiple exceptions.
- [ ] Fix line-highlighting for sub-exceptions (currently it's slightly off).
