### PR TITLE
Move isOldMssql function to Connection class

### DIFF
--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -841,4 +841,16 @@ class Connection extends Component
 
         return null;
     }
+
+    /**
+     * @return boolean if MSSQL used is old
+     * @throws \yii\base\InvalidConfigException
+     * @throws \yii\db\Exception
+     */
+    protected function isOldMssql()
+    {
+        $pdo = $this->getSlavePdo();
+        $version = preg_split("/\./", $pdo->getAttribute(\PDO::ATTR_SERVER_VERSION));
+        return $version[0] < 11;
+    }
 }

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -143,11 +143,11 @@ class QueryBuilder extends \yii\db\QueryBuilder
             $this->buildGroupBy($query->groupBy),
             $this->buildHaving($query->having, $params),
             $this->buildOrderBy($query->orderBy),
-            $this->isOldMssql() ? '' : $this->buildLimit($query->limit, $query->offset),
+            $this->db->isOldMssql() ? '' : $this->buildLimit($query->limit, $query->offset),
         ];
 
         $sql = implode($this->separator, array_filter($clauses));
-        if ($this->isOldMssql()) {
+        if ($this->db->isOldMssql()) {
             $sql = $this->applyLimitAndOffset($sql, $query);
         }
         $union = $this->buildUnion($query->union, $params);
@@ -229,17 +229,5 @@ class QueryBuilder extends \yii\db\QueryBuilder
         $schema = $model->getTableSchema();
         $columns = array_keys($schema->columns);
         return $columns;
-    }
-
-    /**
-     * @return boolean if MSSQL used is old
-     * @throws \yii\base\InvalidConfigException
-     * @throws \yii\db\Exception
-     */
-    protected function isOldMssql()
-    {
-        $pdo = $this->db->getSlavePdo();
-        $version = preg_split("/\./", $pdo->getAttribute(\PDO::ATTR_SERVER_VERSION));
-        return $version[0] < 11;
     }
 }


### PR DESCRIPTION
`yii\db\mssql\QueryBuilder::isOldMssql()` reads a PDO attribute to get the database version, but some database drivers (e.g. dblib) do not support getting attributes and this causes an error:

```
Uncaught exception 'PDOException' with message 'SQLSTATE[IM001]: Driver does not support this function: driver does not support getting attributes' in ... 
```

Moving `isOldMssql()` to the `Connection` class makes it easier to override in a subclass, allowing a person to simply return true if they know the database involved in the connection is an old version of MSSQL.  I think that  this function is more of an attribute of the connection than the query, so it makes more sense here anyway.
