### PR TITLE
More usable db cache

### DIFF
--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -295,7 +295,11 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             $params = $this->params;
         }
 
-        return $db->createCommand($sql, $params);
+        $command = $db->createCommand($sql, $params);
+
+        return isset($this->enableQueryCache) && $this->enableQueryCache
+            ? $command->cache($this->queryCacheDuration, $this->queryCacheDependency)
+            : $command;
     }
 
     /**

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -103,15 +103,20 @@ class Command extends \yii\base\Component
      * @return $this
      */
     public function cache($duration, $dependency = null){
-        if($duration !== 0){
-			$this->enableQueryCache = true;
-        	$this->queryCacheDuration = $duration;
-        	$this->queryCacheDependency = $dependency;
-		}else{
-			$this->enableQueryCache = false;
-		}
+		$this->enableQueryCache = true;
+		$this->queryCacheDuration = $duration;
+		$this->queryCacheDependency = $dependency;
         return $this;
     }
+
+	/**
+	 * Turns off query caching for this command
+	 * @return $this
+	 */
+	public function noCache(){
+		$this->enableQueryCache = true;
+		return $this;
+	}
 
     /**
      * Get state of queryCache. If not set in this command, get from $db.

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -80,6 +80,59 @@ class Command extends \yii\base\Component
      * @var string the SQL statement that this command represents
      */
     private $_sql;
+    /**
+     * @var boolean whether to enable caching for this command.
+     * If not set, get value from $this->db
+     */
+    public $enableQueryCache;
+    /**
+     * @var integer number of seconds that query results can remain valid in cache.
+     * If not set, get value from $this->db
+     */
+    public $queryCacheDuration;
+    /**
+     * @var \yii\caching\Dependency the dependency that will be used when saving query results into cache.
+     * If not set, get value from $this->db
+     */
+    public $queryCacheDependency;
+
+    /**
+     * Turns on query caching for this command
+     * @param integer $duration the number of seconds that query results may remain valid in cache.
+     * @param \yii\caching\Dependency $dependency the dependency for the cached query result.
+     * @return $this
+     */
+    public function cache($duration, $dependency = null){
+        $this->enableQueryCache = true;
+        $this->queryCacheDuration = $duration;
+        $this->queryCacheDependency = $dependency;
+        return $this;
+    }
+
+    /**
+     * Get state of queryCache. If not set in this command, get from $db.
+     * @return bool
+     */
+    public function isQueryCacheEnabled(){
+        return isset($this->enableQueryCache)?$this->enableQueryCache:$this->db->enableQueryCache;
+    }
+
+    /**
+     * Get cache duration. If not set in this command, get from $db.
+     * @return integer
+     */
+    public function getQueryCacheDuration(){
+        return isset($this->queryCacheDuration)?$this->queryCacheDuration:$this->db->queryCacheDuration;
+    }
+
+    /**
+     * Get cache dependency. If not set in this command, get from $db.
+     * @return \yii\caching\Dependency
+     */
+    public function getQueryCacheDependency(){
+        return isset($this->queryCacheDependency)?$this->queryCacheDependency:$this->db->queryCacheDependency;
+    }
+
 
     /**
      * Returns the SQL statement for this command.
@@ -408,7 +461,7 @@ class Command extends \yii\base\Component
         Yii::info($rawSql, 'yii\db\Command::query');
 
         /* @var $cache \yii\caching\Cache */
-        if ($db->enableQueryCache && $method !== '') {
+        if ($this->isQueryCacheEnabled() && $method !== '') {
             $cache = is_string($db->queryCache) ? Yii::$app->get($db->queryCache, false) : $db->queryCache;
         }
 
@@ -449,7 +502,7 @@ class Command extends \yii\base\Component
             Yii::endProfile($token, 'yii\db\Command::query');
 
             if (isset($cache, $cacheKey) && $cache instanceof Cache) {
-                $cache->set($cacheKey, $result, $db->queryCacheDuration, $db->queryCacheDependency);
+                $cache->set($cacheKey, $result, $this->getQueryCacheDuration(), $this->getQueryCacheDependency());
                 Yii::trace('Saved query result in cache', 'yii\db\Command::query');
             }
 

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -103,9 +103,13 @@ class Command extends \yii\base\Component
      * @return $this
      */
     public function cache($duration, $dependency = null){
-        $this->enableQueryCache = true;
-        $this->queryCacheDuration = $duration;
-        $this->queryCacheDependency = $dependency;
+        if($duration !== 0){
+			$this->enableQueryCache = true;
+        	$this->queryCacheDuration = $duration;
+        	$this->queryCacheDependency = $dependency;
+		}else{
+			$this->enableQueryCache = false;
+		}
         return $this;
     }
 

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -136,6 +136,16 @@ class Query extends Component implements QueryInterface
         return $this;
     }
 
+	/**
+	 * Turns off query caching for this query
+	 * @return $this
+	 */
+	public function noCache(){
+		$this->enableQueryCache = true;
+		return $this;
+	}
+
+
     /**
      * Creates a DB command that can be used to execute this query.
      * @param Connection $db the database connection used to generate the SQL statement.

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -107,6 +107,34 @@ class Query extends Component implements QueryInterface
      */
     public $params = [];
 
+    /**
+     * @var boolean whether to enable caching for this query.
+     * If not set, then use global param from $db
+     */
+    public $enableQueryCache;
+    /**
+     * @var integer number of seconds that query results can remain valid in cache.
+     * If not set, then use global param from $db
+     */
+    public $queryCacheDuration;
+    /**
+     * @var \yii\caching\Dependency the dependency that will be used when saving query results into cache.
+     * If not set, then use global param from $db
+     */
+    public $queryCacheDependency;
+
+    /**
+     * Turns on query caching for this query
+     * @param integer $duration the number of seconds that query results may remain valid in cache.
+     * @param \yii\caching\Dependency $dependency the dependency for the cached query result.
+     * @return $this
+     */
+    public function cache($duration, $dependency = null){
+        $this->enableQueryCache = true;
+        $this->queryCacheDuration = $duration;
+        $this->queryCacheDependency = $dependency;
+        return $this;
+    }
 
     /**
      * Creates a DB command that can be used to execute this query.
@@ -121,7 +149,11 @@ class Query extends Component implements QueryInterface
         }
         list ($sql, $params) = $db->getQueryBuilder()->build($this);
 
-        return $db->createCommand($sql, $params);
+        $command = $db->createCommand($sql, $params);
+
+        return isset($this->enableQueryCache) && $this->enableQueryCache
+            ? $command->cache($this->queryCacheDuration, $this->queryCacheDependency)
+            : $command;
     }
 
     /**


### PR DESCRIPTION
Added more useful methods for caching db queries. Now you can use global cache settings and also local settings of particular `yii\db\Command`, `yii\db\Query` and `yii\db\ActiveQuery` instances.

For example:

app/config/db.php:

``` php
    return [
        'class' => 'yii\db\Connection',
        ...
        /* Global settings for cache */
        'enableQueryCache' => true,
        'queryCacheDuration' => 86400,
    ];
```

In any code:

``` php
    public function getTestObjects()
    {
        /* Cache query on 10 seconds */
        return Test::find()->cache(10)->where(['status' => 1])->all();
    }

    public function getStatuses()
    {
        /* Cache query on 100000 seconds */
        return Yii::$app->db->createCommand('select * from statuses')->cache(100000)->queryAll();
    }

    public function getAny()
    {
        /* Cache query on 86400 seconds, use global settings */
        return Any::findAll(['any_param' => 'any_value']);
    }
```
