### PR TITLE
Better params replacement

### DIFF
--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -121,13 +121,14 @@ class Command extends \yii\base\Component
         } else {
             $params = [];
             foreach ($this->params as $name => $value) {
-                if (is_string($value)) {
-                    $params[$name] = $this->db->quoteValue($value);
-                } elseif ($value === null) {
-                    $params[$name] = 'NULL';
-                } else {
-                    $params[$name] = $value;
-                }
+				$name = ':' . $name;
+				if (is_string($value)) {
+					$params[$name] = ':' . $this->db->quoteValue($value);
+				} elseif ($value === null) {
+					$params[$name] = ':NULL';
+				} else {
+					$params[$name] = ':' . $value;
+				}
             }
             if (isset($params[1])) {
                 $sql = '';

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -121,7 +121,7 @@ class Command extends \yii\base\Component
         } else {
             $params = [];
             foreach ($this->params as $name => $value) {
-				$name = ':' . $name;
+				$name = strpos($name, ':')===0 ? $name : ':' . $name;
 				if (is_string($value)) {
 					$params[$name] = ':' . $this->db->quoteValue($value);
 				} elseif ($value === null) {


### PR DESCRIPTION
More useful db query in logs
before:

``` sql
...
and pu.'miramir' = UPPER(:'miramir')),
... 
```

after:

``` sql
...
and pu.login = UPPER(:'miramir')),
... 
```
