### PR TITLE
Update composer.json

### DIFF
--- a/extensions/gii/generators/extension/default/composer.json
+++ b/extensions/gii/generators/extension/default/composer.json
@@ -2,7 +2,7 @@
 	"name": "<?= $generator->vendorName ?>/<?= $generator->packageName ?>",
 	"description": "<?= $generator->description ?>",
 	"type": "<?= $generator->type ?>",
-	"keywords": <?= $generator->keywordsArrayJson ?>,
+	"keywords": "<?= $generator->keywordsArrayJson ?>",
 	"license": "<?= $generator->license ?>",
 	"authors": [
 		{


### PR DESCRIPTION
String Quotes Missing
       "keywords": <?= $generator->keywordsArrayJson ?>,
it should be
       "keywords": "<?= $generator->keywordsArrayJson ?>",
