### PR TITLE
Update ActiveField.php

### DIFF
--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -195,7 +195,7 @@ class ActiveField extends Component
     {
         $clientOptions = $this->getClientOptions();
         if (!empty($clientOptions)) {
-            $this->form->attributes[$this->attribute] = $clientOptions;
+            $this->form->attributes[Html::getInputId($this->model, $this->attribute)] = $clientOptions;
         }
 
         $inputID = Html::getInputId($this->model, $this->attribute);


### PR DESCRIPTION
When rendering multiple models in the same ActiveForm if any of the field names in the two models is the same then the clientOptions of the last rendered attribute will overwrite those of the previous attribute causing the client-side validation for the overwritten field not to run at all. Example: given two models Car and Owner with attributes {make, age} and {name, age} then if the Car is rendered first its age attribute will not have any client validation.
