### PR TITLE
Add Path To Items

### DIFF
--- a/extensions/bootstrap/Nav.php
+++ b/extensions/bootstrap/Nav.php
@@ -222,6 +222,17 @@ class Nav extends Widget
             if ($route[0] !== '/' && Yii::$app->controller) {
                 $route = Yii::$app->controller->module->getUniqueId() . '/' . $route;
             }
+
+            /** 
+             * add path to items for force active a item when action different than url but in one Controller
+             */
+            if(isset($item['path']) && !empty($item['path'])){
+                $pos = strpos($route, $item['path']);
+                if ($pos !== false) {
+                    return true; 
+                }
+            }
+
             if (ltrim($route, '/') !== $this->route) {
                 return false;
             }


### PR DESCRIPTION
For Yii\bootstrap\nav
When menu nav point to CRUD, sure we should point url to a action.. for example : employee/index, but when we to action create employee/create.. the menu not active.. 

```
 * echo Nav::widget([
 *     'items' => [
 *         [
 *             'label' => 'Employee',
 *             'url' => ['anyurl/employee/index'],
 *             'path' => 'anyurl/employee',
 *             
 *         ],
```
