### PR TITLE
RBAC assignments that only apply to the current request

### DIFF
--- a/framework/rbac/BaseManager.php
+++ b/framework/rbac/BaseManager.php
@@ -94,14 +94,7 @@ abstract class BaseManager extends Component implements ManagerInterface
     abstract protected function updateRule($name, $rule);
 
     /**
-     * Assigns a temporary role to a user, which will only exist for the current request. If any
-     * temporary assignments exist for a user, they will override all regular assignments.
-     *
-     * @param Role $role
-     * @param string|integer $userId the user ID (see [[\yii\web\User::id]])
-     * @param Rule $rule the rule to be associated with this assignment. If not null, the rule
-     * will be executed when [[allow()]] is called to check the user permission.
-     * @return Assignment the role assignment information.
+     * @inheritdoc
      */
     public function tempAssign($role, $userId, $rule = null)
     {

--- a/framework/rbac/BaseManager.php
+++ b/framework/rbac/BaseManager.php
@@ -25,6 +25,11 @@ abstract class BaseManager extends Component implements ManagerInterface
     public $defaultRoles = [];
 
     /**
+     * @var Assignment[] a list of temporary assignments that will override the regular assignments for a user if set
+     */
+    protected $tempAssignments = []; // userId, itemName => assignment
+
+    /**
      * Returns the named auth item.
      * @param string $name the auth item name.
      * @return Item the auth item corresponding to the specified name. Null is returned if no such item.
@@ -87,6 +92,29 @@ abstract class BaseManager extends Component implements ManagerInterface
      * @throws \Exception if data validation or saving fails (such as the name of the rule is not unique)
      */
     abstract protected function updateRule($name, $rule);
+
+    /**
+     * Assigns a temporary role to a user, which will only exist for the current request. If any
+     * temporary assignments exist for a user, they will override all regular assignments.
+     *
+     * @param Role $role
+     * @param string|integer $userId the user ID (see [[\yii\web\User::id]])
+     * @param Rule $rule the rule to be associated with this assignment. If not null, the rule
+     * will be executed when [[allow()]] is called to check the user permission.
+     * @return Assignment the role assignment information.
+     */
+    public function tempAssign($role, $userId, $rule = null)
+    {
+        $assignment = new Assignment([
+            'userId'    => $userId,
+            'roleName'  => $role->name,
+            'createdAt' => time(),
+        ]);
+
+        $this->tempAssignments[$userId][$role->name] = $assignment;
+
+        return $assignment;
+    }
 
     /**
      * @inheritdoc

--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -494,6 +494,10 @@ class DbManager extends BaseManager
      */
     public function getAssignments($userId)
     {
+        if (isset($this->tempAssignments[$userId])) {
+            return $this->tempAssignments[$userId];
+        }
+
         $query = (new Query)
             ->from($this->assignmentTable)
             ->where(['user_id' => $userId]);

--- a/framework/rbac/ManagerInterface.php
+++ b/framework/rbac/ManagerInterface.php
@@ -173,6 +173,18 @@ interface ManagerInterface
     public function assign($role, $userId, $rule = null);
 
     /**
+     * Assigns a role to a user temporarily, which will only last for the current request. If any
+     * temporary assignments exist for a user, they will override all regular assignments.
+     *
+     * @param Role $role
+     * @param string|integer $userId the user ID (see [[\yii\web\User::id]])
+     * @param Rule $rule the rule to be associated with this assignment. If not null, the rule
+     * will be executed when [[allow()]] is called to check the user permission.
+     * @return Assignment the role assignment information.
+     */
+    public function tempAssign($role, $userId, $rule = null);
+
+    /**
      * Revokes a role from a user.
      * @param Role $role
      * @param string|integer $userId the user ID (see [[\yii\web\User::id]])

--- a/framework/rbac/PhpManager.php
+++ b/framework/rbac/PhpManager.php
@@ -102,6 +102,10 @@ class PhpManager extends BaseManager
      */
     public function getAssignments($userId)
     {
+        if (isset($this->tempAssignments[$userId])) {
+            return $this->tempAssignments[$userId];
+        }
+
         return isset($this->assignments[$userId]) ? $this->assignments[$userId] : [];
     }
 


### PR DESCRIPTION
Relates to #4430

This allows you to create RBAC assignments that won't persist to the database or file backend, but which only apply to the current request.

For example, you can develop your application while logged in as a regular user that doesn't have any special roles; then make a call to `authManager->assign($persistent = false)` (based on a cookie/post/get value) to view that page as administrator/moderator/whatever - without having to regenerate your RBAC rules or create/remove assignments every time you want to switch between roles.
