### PR TITLE
[WIP] #4408 unicode characters in attribute names

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -79,6 +79,8 @@ class BaseHtml
         'rel',
         'media',
     ];
+    
+    const ATTRIBUTENAMEREGEX = '/(^|.*\])((?:[\p{L}\p{N}]+[\p{M}]*[\p{Pd}\p{Pc}\p{Po}]*)+)(\[.*|$)/u';
 
     /**
      * Encodes special characters into HTML entities.
@@ -1802,7 +1804,7 @@ class BaseHtml
      */
     public static function getAttributeName($attribute)
     {
-        if (preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/', $attribute, $matches)) {
+        if (preg_match(self::ATTRIBUTENAMEREGEX, $attribute, $matches)) {
             return $matches[2];
         } else {
             throw new InvalidParamException('Attribute name must contain word characters only.');
@@ -1825,7 +1827,7 @@ class BaseHtml
      */
     public static function getAttributeValue($model, $attribute)
     {
-        if (!preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/', $attribute, $matches)) {
+        if (!preg_match(self::ATTRIBUTENAMEREGEX, $attribute, $matches)) {
             throw new InvalidParamException('Attribute name must contain word characters only.');
         }
         $attribute = $matches[2];
@@ -1875,7 +1877,7 @@ class BaseHtml
     public static function getInputName($model, $attribute)
     {
         $formName = $model->formName();
-        if (!preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/', $attribute, $matches)) {
+        if (!preg_match(self::ATTRIBUTENAMEREGEX, $attribute, $matches)) {
             throw new InvalidParamException('Attribute name must contain word characters only.');
         }
         $prefix = $matches[1];

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -80,7 +80,7 @@ class BaseHtml
         'media',
     ];
     
-    const ATTRIBUTENAMEREGEX = '/(^|.*\])((?:[\p{L}\p{N}]+[\p{M}]*[\p{Pd}\p{Pc}\p{Po}]*)+)(\[.*|$)/u';
+    public static $attributeNameRegexPart = '(?:[\p{L}\p{N}]+[\p{M}]*[\p{Pd}\p{Pc}\p{Po}]*)+';
 
     /**
      * Encodes special characters into HTML entities.
@@ -1804,7 +1804,7 @@ class BaseHtml
      */
     public static function getAttributeName($attribute)
     {
-        if (preg_match(self::ATTRIBUTENAMEREGEX, $attribute, $matches)) {
+        if (preg_match("/(^|.*\])(".self::$attributeNameRegexPart.")(\[.*|$)/u", $attribute, $matches)) {
             return $matches[2];
         } else {
             throw new InvalidParamException('Attribute name must contain word characters only.');
@@ -1827,7 +1827,7 @@ class BaseHtml
      */
     public static function getAttributeValue($model, $attribute)
     {
-        if (!preg_match(self::ATTRIBUTENAMEREGEX, $attribute, $matches)) {
+        if (!preg_match("/(^|.*\])(".self::$attributeNameRegexPart.")(\[.*|$)/u", $attribute, $matches)) {
             throw new InvalidParamException('Attribute name must contain word characters only.');
         }
         $attribute = $matches[2];
@@ -1877,7 +1877,7 @@ class BaseHtml
     public static function getInputName($model, $attribute)
     {
         $formName = $model->formName();
-        if (!preg_match(self::ATTRIBUTENAMEREGEX, $attribute, $matches)) {
+        if (!preg_match("/(^|.*\])(".self::$attributeNameRegexPart.")(\[.*|$)/u", $attribute, $matches)) {
             throw new InvalidParamException('Attribute name must contain word characters only.');
         }
         $prefix = $matches[1];

--- a/framework/widgets/DetailView.php
+++ b/framework/widgets/DetailView.php
@@ -176,7 +176,7 @@ class DetailView extends Widget
 
         foreach ($this->attributes as $i => $attribute) {
             if (is_string($attribute)) {
-                if (!preg_match('/^('.BaseHtml::$ATTRIBUTENAMEREGEXPART.')(:(\w*))?(:(.*))?$/', $attribute, $matches)) {
+                if (!preg_match('/^('.BaseHtml::$ATTRIBUTENAMEREGEXPART.')(:(\w*))?(:(.*))?$/u', $attribute, $matches)) {
                     throw new InvalidConfigException('The attribute must be specified in the format of "attribute", "attribute:format" or "attribute:format:label"');
                 }
                 $attribute = [

--- a/framework/widgets/DetailView.php
+++ b/framework/widgets/DetailView.php
@@ -176,7 +176,7 @@ class DetailView extends Widget
 
         foreach ($this->attributes as $i => $attribute) {
             if (is_string($attribute)) {
-                if (!preg_match('/^([\w\.]+)(:(\w*))?(:(.*))?$/', $attribute, $matches)) {
+                if (!preg_match('/^('.BaseHtml::$ATTRIBUTENAMEREGEXPART.')(:(\w*))?(:(.*))?$/', $attribute, $matches)) {
                     throw new InvalidConfigException('The attribute must be specified in the format of "attribute", "attribute:format" or "attribute:format:label"');
                 }
                 $attribute = [

--- a/tests/unit/framework/helpers/BaseHtmlTest.php
+++ b/tests/unit/framework/helpers/BaseHtmlTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+namespace yiiunit\framework\helpers;
+
+use yii\helpers\BaseHtml;
+use yii\base\Model;
+use yiiunit\data\base\Singer;
+use yii\base\InvalidParamException;
+use yiiunit\TestCase;
+
+/**
+ * TestCase for BaseHtml
+ */
+class BaseHtmlTest extends TestCase {
+    
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mockApplication();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+    }
+    
+    public function testGetInputName() {
+        $model = new Singer();
+        $this->assertSame("Singer[0][a]", BaseHtml::getInputName($model, "[0]a"));
+        $this->assertSame("Singer[0][a][0]", BaseHtml::getInputName($model, "[0]a[0]"));
+        // TODO add test for $model->formName === ''
+    }
+    
+    public function testGetAttributeValue() {
+        // TODO implement tests
+    }
+    
+    public function testGetAttributeName() {
+        $this->assertSame("asdf.asdfa", BaseHtml::getAttributeName("asd]asdf.asdfa[asdfa"));
+        $this->assertSame("a", BaseHtml::getAttributeName("a"));
+        $this->assertSame("a", BaseHtml::getAttributeName("[0]a"));
+        $this->assertSame("a", BaseHtml::getAttributeName("a[0]"));
+        $this->assertSame("a", BaseHtml::getAttributeName("[0]a[0]"));
+        $this->assertSame("a.", BaseHtml::getAttributeName("[0]a.[0]"));
+        // unicode checks only work if PCRE is compiled with --enable-unicode-properties
+        $this->assertSame("ä", BaseHtml::getAttributeName("ä"));
+        $this->assertSame("öáöio..,", BaseHtml::getAttributeName("asdf]öáöio..,[asdfasdf"));
+        $this->assertSame("test.ööößß.d", BaseHtml::getAttributeName("[0]test.ööößß.d"));
+        $this->assertSame("ИІК", BaseHtml::getAttributeName("ИІК"));
+        $this->assertSame("ИІК", BaseHtml::getAttributeName("]ИІК["));
+        $this->assertSame("ИІК", BaseHtml::getAttributeName("[0]ИІК[0]"));
+        // test non word characters and expect exception
+        $this->setExpectedException('yii\base\InvalidParamException');
+        BaseHtml::getAttributeName("....");
+    }
+}


### PR DESCRIPTION
This PR is WorkInProgress for the issue: #4408
The request is to support different names for attributes if the columns in the database contain special characters like german umlauts.
Those umlauts lead to an exception in activeTextInput and DetailView::widget "Attribute name must contain word characters only in vendor\yiisoft\yii2\helpers\BaseHtml.php"

---
- [ ] Does yii2 want to support non ASCII-characters in column names/attributes?
  - @samdark: "It's not the best practice to use umlauts in code"
  - @cebe: "we already accept them in gridview":
    There the regular expression accepts any character except ':' for the attribute name. That means "..." is a valid attribute name.
- [ ] Discuss valid attribute names (column names of database can contain Unicode characters?):
  - [MySQL](http://dev.mysql.com/doc/refman/5.0/en/identifiers.html) states that "Permitted characters in quoted identifiers include the full Unicode Basic Multilingual Plane (BMP)"
- [ ] Discuss impact of attribute names in other classes than BaseHtml and DetailView
- [ ] Derive regular expression for valid attribute names
- [ ] Implement regular expression
- [ ] Implement tests
