### PR TITLE
Facebook Auth - Indicate that the window is a popup.

### DIFF
--- a/extensions/authclient/clients/Facebook.php
+++ b/extensions/authclient/clients/Facebook.php
@@ -78,6 +78,17 @@ class Facebook extends OAuth2
     /**
      * @inheritdoc
      */
+    protected function defaultViewOptions()
+    {
+        return [
+            'popupWidth' => 450,
+            'popupHeight' => 380,
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
     protected function defaultName()
     {
         return 'facebook';

--- a/extensions/authclient/clients/Facebook.php
+++ b/extensions/authclient/clients/Facebook.php
@@ -68,6 +68,16 @@ class Facebook extends OAuth2
     /**
      * @inheritdoc
      */
+    public function buildAuthUrl(array $params = [])
+    {
+        $params['display'] = 'popup';
+
+        return parent::buildAuthUrl($params);
+    }
+
+    /**
+     * @inheritdoc
+     */
     protected function defaultName()
     {
         return 'facebook';


### PR DESCRIPTION
Without this parameter is showing a full page, which results in the display of a warning message, as the following images.

![](http://i.imgur.com/2stbUir.png)

> _Your pop-up is too small to view this page. Extend it to continue._

![](http://i.imgur.com/DuAkkLp.png)

> _You are using a display type of "page" in a small navigation window or in a popup window. For a better experience, view this dialogue with our JavaScript SDK without specifying an explicit type of display. The SDK will choose the best display type for each environment. Alternatively, use the display type "pop-up" if you have special circumstances that prevent you from using the SDK. This message is only visible to the developers of your application._

Whith display=popup:

![](http://i.imgur.com/zxwMuyI.png)
