### PR TITLE
Asset Bundle remap feature

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -163,6 +163,7 @@ Yii Framework 2 Change Log
 - Enh: Added support for array attributes in `in` validator (creocoder)
 - Enh: Improved `yii\helpers\Inflector::slug` to support more cases for Russian, Hebrew and special characters (samdark)
 - Enh: ListView now uses the widget ID in the base tag, consistent to gridview (cebe)
+- Enh: Added asset bundle remap via `class` feature (creocoder)
 - Chg #2287: Split `yii\db\ColumnSchema::typecast()` into two methods `phpTypecast()` and `dbTypecast()` to allow specifying PDO type explicitly (cebe)
 - Chg #2898: `yii\console\controllers\AssetController` is now using hashes instead of timestamps (samdark)
 - Chg #2913: RBAC `DbManager` is now initialized via migration (samdark)

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -158,10 +158,11 @@ class AssetManager extends Component
             if ($this->bundles[$name] instanceof AssetBundle) {
                 return $this->bundles[$name];
             } elseif (is_array($this->bundles[$name])) {
-                $bundle = Yii::createObject(array_merge(
-                    ['class' => isset($this->bundles[$name]['class']) ? $this->bundles[$name]['class'] : $name],
-                    $this->bundles[$name]
-                ));
+                $bundle = Yii::createObject(
+                    isset($this->bundles[$name]['class'])
+                        ? $this->bundles[$name]
+                        : array_merge(['class' =>  $name], $this->bundles[$name])
+                );
             } else {
                 throw new InvalidConfigException("Invalid asset bundle: $name");
             }

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -158,7 +158,10 @@ class AssetManager extends Component
             if ($this->bundles[$name] instanceof AssetBundle) {
                 return $this->bundles[$name];
             } elseif (is_array($this->bundles[$name])) {
-                $bundle = Yii::createObject(array_merge(['class' => $name], $this->bundles[$name]));
+                $bundle = Yii::createObject(array_merge(
+                    ['class' => isset($this->bundles[$name]['class']) ? $this->bundles[$name]['class'] : $name],
+                    $this->bundles[$name]
+                ));
             } else {
                 throw new InvalidConfigException("Invalid asset bundle: $name");
             }

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -144,7 +144,8 @@ class AssetManager extends Component
      * Returns the named asset bundle.
      *
      * This method will first look for the bundle in [[bundles]]. If not found,
-     * it will treat `$name` as the class of the asset bundle and create a new instance of it.
+     * it will treat `class` element as the class of the asset bundle and create a new instance of it.
+     * If `class` element not found, it will treat `$name` as the class of asset bundle.
      *
      * @param string $name the class name of the asset bundle
      * @param boolean $publish whether to publish the asset files in the asset bundle before it is returned.


### PR DESCRIPTION
How this can be used:

``` php
'assetManager' => [
    'bundles' => [
        'yii\web\JqueryAsset' => [
            'class' => 'app\assets\JqueryAsset',
        ],
    ],
],
```

By doing this you can fast remap existing asset bundle to another custom class. Without that feature you need override **all classes** which depends on 'yii\web\JqueryAsset'.
