### PR TITLE
Deferred validation

### DIFF
--- a/docs/guide/input-validation.md
+++ b/docs/guide/input-validation.md
@@ -580,11 +580,12 @@ deferred.push($.get("/check", {value: value}).done(function(data) {
 
 The ```deferred``` array also has a shortcut method ```add```.
 ```
-deferred.add(function() {
+deferred.add(function(def) {
     //Asynchronous Validation here
-    //The context of this function is the Deferred object where resolve can be called.
+    //The context of this function and the first argument is the Deferred object where resolve can be called.
 });
 ```
+>   Note: `resolve` must be called on any deferred objects after the attribute has been validated or the main form validation will not complete.
 
 ### Ajax validation
 

--- a/docs/guide/input-validation.md
+++ b/docs/guide/input-validation.md
@@ -487,6 +487,7 @@ predefined variables:
 - `attribute`: the name of the attribute being validated.
 - `value`: the value being validated.
 - `messages`: an array used to hold the validation error messages for the attribute.
+- `deferred`: an array which deferred objects can be pushed into.
 
 In the following example, we create a `StatusValidator` which validates if an input is a valid status input
 against the existing status data. The validator supports both server side and client side validation.
@@ -533,6 +534,56 @@ JS;
 [
     ['status', 'in', 'range' => Status::find()->select('id')->asArray()->column()],
 ]
+```
+
+### Deferred validation
+
+If you need to perform any asynchronous validation you can use a [deferred object](http://api.jquery.com/category/deferred-object/).
+
+deferred objects must be pushed to the ```deferred``` array for validation to use them.
+Once any asynchronous validation has finished you must call ```resolve()``` on the Deferred object for it to complete.
+
+This example shows reading an image to check the dimensions client side (```file``` will be from an input of type=file).
+```php
+...
+public function clientValidateAttribute($model, $attribute, $view)
+{
+    return <<<JS
+    var def = $.Deferred();
+    var img = new Image();
+    img.onload = function() {
+        if (this.width > 150) {
+            messages.push('Image too wide!!');
+        }
+        def.resolve();
+    }
+    var reader = new FileReader();
+    reader.onloadend = function() {
+        img.src = reader.result;
+    }
+    reader.readAsDataURL(file);
+
+    deferred.push(def);
+JS;
+}
+...
+```
+
+Ajax can also be used and pushed straight into the deferred array.
+```
+deferred.push($.get("/check", {value: value}).done(function(data) {
+    if ('' !== data) {
+        messages.push(data);
+    }
+}));
+```
+
+The ```deferred``` array also has a shortcut method ```add```.
+```
+deferred.add(function() {
+    //Asynchronous Validation here
+    //The context of this function is the Deferred object where resolve can be called.
+});
 ```
 
 ### Ajax validation

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -161,7 +161,7 @@ Yii Framework 2 Change Log
 - Enh #4317: Added `absoluteAuthTimeout` to yii\web\User (ivokund, nkovacs)
 - Enh #4360: Added client validation support for file validator (Skysplit)
 - Enh #4436: Added callback functions to AJAX-based form validation (thiagotalma)
-- Enh #4485: Added support for deferred validation in `ActiveForm`
+- Enh #4485: Added support for deferred validation in `ActiveForm` (Alex-Code)
 - Enh: Added support for using sub-queries when building a DB query with `IN` condition (qiangxue)
 - Enh: Supported adding a new response formatter without the need to reconfigure existing formatters (qiangxue)
 - Enh: Added `yii\web\UrlManager::addRules()` to simplify adding new URL rules (qiangxue)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -161,6 +161,7 @@ Yii Framework 2 Change Log
 - Enh #4317: Added `absoluteAuthTimeout` to yii\web\User (ivokund, nkovacs)
 - Enh #4360: Added client validation support for file validator (Skysplit)
 - Enh #4436: Added callback functions to AJAX-based form validation (thiagotalma)
+- Enh #4485: Added support for deferred validation in `ActiveForm`
 - Enh: Added support for using sub-queries when building a DB query with `IN` condition (qiangxue)
 - Enh: Supported adding a new response formatter without the need to reconfigure existing formatters (qiangxue)
 - Enh: Added `yii\web\UrlManager::addRules()` to simplify adding new URL rules (qiangxue)

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -270,7 +270,22 @@
             });
         }, data.settings.validationDelay);
     };
-
+    
+    /**
+     * Returns an array prototype with a shortcut method for adding a new deferred.
+     * The context of the callback will be the deferred object so it can be resolved like ```this.resolve()```
+     * @returns Array
+     */
+    var deferredArray = function () {
+        var array = [];
+        array.add = function(callback) {
+            var deferred = new $.Deferred();
+            callback.call(deferred);
+            this.push(deferred);
+        };
+        return array;
+    };
+    
     /**
      * Performs validation.
      * @param $form jQuery the jquery representation of the form
@@ -281,7 +296,7 @@
         var data = $form.data('yiiActiveForm'),
             needAjaxValidation = false,
             messages = {},
-            deferreds = [];
+            deferreds = deferredArray();
 
         $.each(data.attributes, function () {
             if (data.submitting || this.status === 2 || this.status === 3) {

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -279,9 +279,7 @@
     var deferredArray = function () {
         var array = [];
         array.add = function(callback) {
-            var deferred = new $.Deferred();
-            callback.call(deferred);
-            this.push(deferred);
+            this.push(new $.Deferred(callback));
         };
         return array;
     };

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -299,6 +299,12 @@
         });
 
         $.when.apply(this, deferreds).always(function() {
+            //Remove empty message arrays
+            for (var i in messages) {
+                if (0 === messages[i].length) {
+                    delete messages[i];
+                }
+            }
             if (needAjaxValidation && (!data.submitting || $.isEmptyObject(messages))) {
                 // Perform ajax validation when at least one input needs it.
                 // If the validation is triggered by form submission, ajax validation

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -703,7 +703,7 @@ class ActiveField extends Component
                 }
             }
             if (!empty($validators)) {
-                $options['validate'] = new JsExpression("function (attribute, value, messages) {" . implode('', $validators) . '}');
+                $options['validate'] = new JsExpression("function (attribute, value, messages, deferred) {" . implode('', $validators) . '}');
             }
         }
 


### PR DESCRIPTION
Added support of deferred validation in `ActiveForm`

The `validate` option in `ActiveField` `getClientOptions` now has a forth parameter, `deferred`.
This is an array which `Deferred` objects can be pushed into.

e.g.
An inline validator can do something like

```
['attribute', 'method', 'clientValidate' => function() {
    return 'deferred.push($.ajax("/check").done(function(data) { messages.push(data); }));';
}],
```

An image could be checked client side.

```
var def = $.Deferred();
var img = new Image();
img.onload = function() {
    if (this.width > 150) {
        messages.push('Image too wide!!');
    }
    def.resolve();
}
var reader = new FileReader();
reader.onloadend = function() {
    img.src = reader.result;
}
reader.readAsDataURL(file);

deferred.push(def);
```

Thoughts?
