### PR TITLE
Add support for elasticsearch suggestions

### DIFF
--- a/extensions/elasticsearch/Command.php
+++ b/extensions/elasticsearch/Command.php
@@ -69,6 +69,28 @@ class Command extends Component
     }
 
     /**
+     * @param array $options
+     * @return mixed
+     */
+    public function suggest($options = [])
+    {
+        $query = $this->queryParts;
+        if (empty($query)) {
+            throw new InvalidParamException('No query specified');
+        }
+        if (is_array($query)) {
+            unset($query['size']);
+            $query = Json::encode($query);
+        }
+        $url = [
+            $this->index !== null ? $this->index : '_all',
+            '_suggest'
+        ];
+
+        return $this->db->post($url, array_merge($this->options, $options), $query);
+    }
+
+    /**
      * Inserts a document into an index
      * @param string $index
      * @param string $type

--- a/extensions/elasticsearch/Query.php
+++ b/extensions/elasticsearch/Query.php
@@ -245,6 +245,22 @@ class Query extends Component implements QueryInterface
         return $result;
     }
 
+    /**
+     * Executes the suggest query and returns the suggestion options, if any
+     * @return array the query results.
+     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-suggesters.html
+     */
+    public function suggest($db = null, $options = [])
+    {
+        $result = $this->createCommand($db)->suggest($options);
+
+        if (isset($result['query'])) {
+            return $result['query'][0]['options'];
+        } else {
+            return [];
+        }
+    }
+
     // TODO add query stats http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search.html#stats-groups
 
     // TODO add scroll/scan http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-search-type.html#scan
@@ -471,8 +487,6 @@ class Query extends Component implements QueryInterface
     {
         return $this->addFacet($name, 'geo_distance', $options);
     }
-
-    // TODO add suggesters http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-suggesters.html
 
     // TODO add validate query http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-validate.html
 


### PR DESCRIPTION
Example usage:

``` php
$suggests = SearchModel::find()->query(['text' => $query, 'completion' => ['field' => 'suggest']])->suggest();
```
