### PR TITLE
Inform the class that generated the error

### DIFF
--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -567,8 +567,9 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      * Adds a new error to the specified attribute.
      * @param string $attribute attribute name
      * @param string $error new error message
+     * @param string $className the fully qualified class name that generated the error
      */
-    public function addError($attribute, $error = '')
+    public function addError($attribute, $error = '', $className = '')
     {
         $this->_errors[$attribute][] = $error;
     }

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -351,7 +351,7 @@ class Validator extends Component
         $value = $object->$attribute;
         $params['attribute'] = $object->getAttributeLabel($attribute);
         $params['value'] = is_array($value) ? 'array()' : $value;
-        $object->addError($attribute, Yii::$app->getI18n()->format($message, $params, Yii::$app->language));
+        $object->addError($attribute, Yii::$app->getI18n()->format($message, $params, Yii::$app->language), $this->className());
     }
 
     /**


### PR DESCRIPTION
Thus better control the error display, for example, displaying elements on the page when a particular type of error. 

I am suggesting a modification of minimal impact, which takes effect only when the Model is extended and the method is overridden to treat it. 

However, I believe that this information can be useful and incorporated into the framework, changing the format of the array of errors, indicating which class generated particular error.
