### PR TITLE
It is not required by default when you set the property "when"

### DIFF
--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -442,7 +442,7 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
     public function isAttributeRequired($attribute)
     {
         foreach ($this->getActiveValidators($attribute) as $validator) {
-            if ($validator instanceof RequiredValidator) {
+            if ($validator instanceof RequiredValidator && !$validator->when) {
                 return true;
             }
         }


### PR DESCRIPTION
This function is used here:

`ActiveField.php`

``` PHP
if ($this->model->isAttributeRequired($attribute)) {
    $class[] = $this->form->requiredCssClass;
}
```

However, when we condition the validation, I understand that, in principle, the field is not required until such condition is true.

My thinking is correct?
