### PR TITLE
fix generateLabels in gii Generator

### DIFF
--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -197,7 +197,7 @@ class Generator extends \yii\gii\Generator
                 $labels[$column->name] = 'ID';
             } else {
                 $label = Inflector::camel2words($column->name);
-                if (!empty($label) && substr_compare($label, ' id', -3, null, true)) {
+                if (!empty($label) && (strlen($label) > 3) && substr_compare($label, ' id', -3, 3, true) === 0) {
                     $label = substr($label, 0, -3) . ' ID';
                 }
                 $labels[$column->name] = $label;


### PR DESCRIPTION
method substr_compare() produces an Exception: "The length must be greater than zero"
when pass "null" as $length param
