### PR TITLE
ActiveForm validationComplete callback

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -168,6 +168,7 @@ Yii Framework 2 Change Log
 - Enh #4436: Added callback functions to AJAX-based form validation (thiagotalma)
 - Enh #4485: Added support for deferred validation in `ActiveForm` (Alex-Code)
 - Enh #4520: Added sasl support to `yii\caching\MemCache` (xjflyttp)
+- Enh #4559: Added `beforeValidateAll` and `afterValidateAll` callbacks to `ActiveForm` (Alex-Code)
 - Enh: Added support for using sub-queries when building a DB query with `IN` condition (qiangxue)
 - Enh: Supported adding a new response formatter without the need to reconfigure existing formatters (qiangxue)
 - Enh: Added `yii\web\UrlManager::addRules()` to simplify adding new URL rules (qiangxue)

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -44,6 +44,9 @@
         // a callback that is called after an attribute is validated. The signature of the callback should be:
         // function ($form, attribute, messages)
         afterValidate: undefined,
+        // a callback that is called after all validation has run. The signature of the callback should be:
+        // function ($form, data, messages)
+        validationComplete: undefined,
         // a pre-request callback function on AJAX-based validation. The signature of the callback should be:
         // function ($form, jqXHR, textStatus)
         ajaxBeforeSend: undefined,
@@ -159,6 +162,11 @@
                         errors.push(this.input);
                     }
                 });
+                
+                if (data.settings.validationComplete) {
+                    data.settings.validationComplete($form, data, messages);
+                }
+                
                 updateSummary($form, messages);
                 if (errors.length) {
                     var top = $form.find(errors.join(',')).first().offset().top;

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -46,7 +46,7 @@
         afterValidate: undefined,
         // a callback that is called after all validation has run. The signature of the callback should be:
         // function ($form, data, messages)
-        validationComplete: undefined,
+        afterValidateAll: undefined,
         // a pre-request callback function on AJAX-based validation. The signature of the callback should be:
         // function ($form, jqXHR, textStatus)
         ajaxBeforeSend: undefined,
@@ -163,8 +163,8 @@
                     }
                 });
                 
-                if (data.settings.validationComplete) {
-                    data.settings.validationComplete($form, data, messages);
+                if (data.settings.afterValidateAll) {
+                    data.settings.afterValidateAll($form, data, messages);
                 }
                 
                 updateSummary($form, messages);

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -41,6 +41,9 @@
         // a callback that is called before validating each attribute. The signature of the callback should be:
         // function ($form, attribute, messages) { ...return false to cancel the validation...}
         beforeValidate: undefined,
+        // a callback that is called before validation starts (This callback is only called when the form is submitted). This signature of the callback should be:
+        // function($form, data) { ...return false to cancel the validation...}
+        beforeValidateAll: undefined,
         // a callback that is called after an attribute is validated. The signature of the callback should be:
         // function ($form, attribute, messages)
         afterValidate: undefined,
@@ -155,6 +158,10 @@
                 clearTimeout(data.settings.timer);
             }
             data.submitting = true;
+            
+            if (data.settings.beforeValidateAll && !data.settings.beforeValidateAll($form, data)) {
+                return false;
+            }
             validate($form, function (messages) {
                 var errors = [];
                 $.each(data.attributes, function () {

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -44,7 +44,7 @@
         // a callback that is called after an attribute is validated. The signature of the callback should be:
         // function ($form, attribute, messages)
         afterValidate: undefined,
-        // a callback that is called after all validation has run. The signature of the callback should be:
+        // a callback that is called after all validation has run (This callback is only called when the form is submitted). The signature of the callback should be:
         // function ($form, data, messages)
         afterValidateAll: undefined,
         // a pre-request callback function on AJAX-based validation. The signature of the callback should be:

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -160,6 +160,7 @@
             data.submitting = true;
             
             if (data.settings.beforeValidateAll && !data.settings.beforeValidateAll($form, data)) {
+                data.submitting = false;
                 return false;
             }
             validate($form, function (messages) {

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -160,7 +160,7 @@ class ActiveForm extends Widget
      * }
      * ~~~
      */
-    public $validationComplete;
+    public $afterValidateAll;
     /**
      * @var string|JsExpression a JS pre-request callback function on AJAX-based validation.
      * The signature of the callback should be:
@@ -239,7 +239,7 @@ class ActiveForm extends Widget
         if ($this->validationUrl !== null) {
             $options['validationUrl'] = Url::to($this->validationUrl);
         }
-        foreach (['beforeSubmit', 'beforeValidate', 'afterValidate', 'ajaxBeforeSend', 'ajaxComplete', 'validationComplete'] as $name) {
+        foreach (['beforeSubmit', 'beforeValidate', 'afterValidate', 'ajaxBeforeSend', 'ajaxComplete', 'afterValidateAll'] as $name) {
             if (($value = $this->$name) !== null) {
                 $options[$name] = $value instanceof JsExpression ? $value : new JsExpression($value);
             }

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -152,6 +152,16 @@ class ActiveForm extends Widget
      */
     public $afterValidate;
     /**
+     * @var string|JsExpression a JS callback that is called after all validation has run.
+     * The signature of the callback should be:
+     *
+     * ~~~
+     * function ($form, data, messages) {
+     * }
+     * ~~~
+     */
+    public $validationComplete;
+    /**
      * @var string|JsExpression a JS pre-request callback function on AJAX-based validation.
      * The signature of the callback should be:
      *
@@ -229,7 +239,7 @@ class ActiveForm extends Widget
         if ($this->validationUrl !== null) {
             $options['validationUrl'] = Url::to($this->validationUrl);
         }
-        foreach (['beforeSubmit', 'beforeValidate', 'afterValidate', 'ajaxBeforeSend', 'ajaxComplete'] as $name) {
+        foreach (['beforeSubmit', 'beforeValidate', 'afterValidate', 'ajaxBeforeSend', 'ajaxComplete', 'validationComplete'] as $name) {
             if (($value = $this->$name) !== null) {
                 $options[$name] = $value instanceof JsExpression ? $value : new JsExpression($value);
             }

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -147,6 +147,7 @@ class ActiveForm extends Widget
      *
      * ~~~
      * function ($form, data) {
+     *     ...return false to cancel the validation...
      * }
      * ~~~
      */

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -142,6 +142,16 @@ class ActiveForm extends Widget
      */
     public $beforeValidate;
     /**
+     * @var string|JsExpression a JS callback that is called before any validation has run (Only called when the form is submitted).
+     * The signature of the callback should be:
+     *
+     * ~~~
+     * function ($form, data) {
+     * }
+     * ~~~
+     */
+    public $beforeValidateAll;
+    /**
      * @var string|JsExpression a JS callback that is called after validating an attribute.
      * The signature of the callback should be:
      *
@@ -239,7 +249,7 @@ class ActiveForm extends Widget
         if ($this->validationUrl !== null) {
             $options['validationUrl'] = Url::to($this->validationUrl);
         }
-        foreach (['beforeSubmit', 'beforeValidate', 'afterValidate', 'ajaxBeforeSend', 'ajaxComplete', 'afterValidateAll'] as $name) {
+        foreach (['beforeSubmit', 'beforeValidate', 'beforeValidateAll', 'afterValidate', 'afterValidateAll', 'ajaxBeforeSend', 'ajaxComplete'] as $name) {
             if (($value = $this->$name) !== null) {
                 $options[$name] = $value instanceof JsExpression ? $value : new JsExpression($value);
             }

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -152,7 +152,7 @@ class ActiveForm extends Widget
      */
     public $afterValidate;
     /**
-     * @var string|JsExpression a JS callback that is called after all validation has run.
+     * @var string|JsExpression a JS callback that is called after all validation has run (Only called when the form is submitted).
      * The signature of the callback should be:
      *
      * ~~~


### PR DESCRIPTION
Now Yii2 supports deferred validation there was no way to know when validation had completed.

I have form fields across some tabs. If a user clicks the submit button and a field fails validation in a non active tab it's not obvious validation has failed.

With the new callback you could do something like, 

```
'validationComplete' => new \yii\web\JsExpression("function(form, data, messages) {
    $('a[role=tab]').removeClass('error');
    if (!$.isEmptyObject(messages)) {
        for (var i in messages) {
            var pane = $('#' + i).closest('.tab-pane');
            $('a[href=\"#' + pane.attr('id') + '\"]').addClass('error');
        }
    }
}"),
```

To add a class to the tab which has failed fields to change it's colour etc.
