### PR TITLE
$alias and Handling $query->joinWith called inside of other $query->joinWith

### DIFF
--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -350,11 +350,17 @@ class Generator extends \yii\gii\Generator
             $className0 = $this->generateClassName($table0);
             $className1 = $this->generateClassName($table1);
 
+            if (( $prefixlen = strlen( $db->tablePrefix ) ) > 0) {
+                $tableNameTpl = '{{%' . substr( $table->name, $prefixlen ) . '}}';
+            } else {
+                $tableNameTpl = $table->name;
+            }
+
             $link = $this->generateRelationLink([$fks[$table->primaryKey[1]][1] => $table->primaryKey[1]]);
             $viaLink = $this->generateRelationLink([$table->primaryKey[0] => $fks[$table->primaryKey[0]][1]]);
             $relationName = $this->generateRelationName($relations, $className0, $db->getTableSchema($table0), $table->primaryKey[1], true);
             $relations[$className0][$relationName] = [
-                "return \$this->hasMany($className1::className(), $link)->viaTable('{$table->name}', $viaLink);",
+                "return \$this->hasMany($className1::className(), $link)->viaTable('{$tableNameTpl}', $viaLink);",
                 $className1,
                 true,
             ];
@@ -363,7 +369,7 @@ class Generator extends \yii\gii\Generator
             $viaLink = $this->generateRelationLink([$table->primaryKey[1] => $fks[$table->primaryKey[1]][1]]);
             $relationName = $this->generateRelationName($relations, $className1, $db->getTableSchema($table1), $table->primaryKey[0], true);
             $relations[$className1][$relationName] = [
-                "return \$this->hasMany($className0::className(), $link)->viaTable('{$table->name}', $viaLink);",
+                "return \$this->hasMany($className0::className(), $link)->viaTable('{$tableNameTpl}', $viaLink);",
                 $className0,
                 true,
             ];

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -94,6 +94,10 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      * @var array a list of relations that this query should be joined with
      */
     public $joinWith;
+    /**
+     * @var string Alias for the [[ActiveQueryTrait::$modelClass]] table name
+     */
+    public $alias;
 
 
     /**
@@ -144,7 +148,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             /* @var $modelClass ActiveRecord */
             $modelClass = $this->modelClass;
             $tableName = $modelClass::tableName();
-            $this->from = [$tableName];
+            $this->from = empty($this->alias)?[$tableName]:[$this->alias => $tableName];
         }
 
         if (empty($this->select) && !empty($this->join)) {
@@ -482,6 +486,9 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 $relations[$fullName] = $relation = $primaryModel->getRelation($name);
                 if ($callback !== null) {
                     call_user_func($callback, $relation);
+                    if(is_array($relation->joinWith)) {
+                        $relation->buildJoinWith();
+                    }
                 }
                 $this->joinWithRelation($parent, $relation, $this->getJoinType($joinType, $fullName));
             }


### PR DESCRIPTION
1. Added property $alias for set the alias for the $modelClass table name.
2. Handling $query->joinWith called inside of other $query->joinWith within Closure (called inside Closure). Ex.:
   
   ``` php
   $query->joinWith( [ 'rel1' => function($query) {
     $query->joinWith( [ 'rel2' => function($query) {
         // ...
     } ] );
   } ] );
   ```
