### PR TITLE
fix typo in define $flavors['gfm-comment']

### DIFF
--- a/framework/helpers/BaseMarkdown.php
+++ b/framework/helpers/BaseMarkdown.php
@@ -33,7 +33,7 @@ class BaseMarkdown
             'html5' => true,
         ],
         'gfm-comment' => [
-            'class' => 'cebe\markdown\Markdown',
+            'class' => 'cebe\markdown\GithubMarkdown',
             'html5' => true,
             'enableNewlines' => true,
         ],


### PR DESCRIPTION
fix typo Markdown->GithubMarkdown in $flavors['gfm-comment']
