### PR TITLE
Enh #4581: Added ability to disable url encoding in `UrlRule`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -169,6 +169,7 @@ Yii Framework 2 Change Log
 - Enh #4485: Added support for deferred validation in `ActiveForm` (Alex-Code)
 - Enh #4520: Added sasl support to `yii\caching\MemCache` (xjflyttp)
 - Enh #4566: Added client validation support for image validator (Skysplit, qiangxue)
+- Enh #4581: Added ability to disable url encoding in `UrlRule` (tadaszelvys)
 - Enh: Added support for using sub-queries when building a DB query with `IN` condition (qiangxue)
 - Enh: Supported adding a new response formatter without the need to reconfigure existing formatters (qiangxue)
 - Enh: Added `yii\web\UrlManager::addRules()` to simplify adding new URL rules (qiangxue)

--- a/framework/web/UrlRule.php
+++ b/framework/web/UrlRule.php
@@ -83,6 +83,10 @@ class UrlRule extends Object implements UrlRuleInterface
      * If it is [[CREATION_ONLY]], the rule is for URL creation only.
      */
     public $mode;
+    /**
+     * @var bool a value indicating if parameters should be url encoded.
+     */
+    public $encodeParams = true;
 
     /**
      * @var string the template for generating a new URL. This is derived from [[pattern]] and is used in generating URL.
@@ -310,7 +314,7 @@ class UrlRule extends Object implements UrlRuleInterface
         // match params in the pattern
         foreach ($this->_paramRules as $name => $rule) {
             if (isset($params[$name]) && !is_array($params[$name]) && ($rule === '' || preg_match($rule, $params[$name]))) {
-                $tr["<$name>"] = urlencode($params[$name]);
+                $tr["<$name>"] = $this->encodeParams ? urlencode($params[$name]) : $params[$name];
                 unset($params[$name]);
             } elseif (!isset($this->defaults[$name]) || isset($params[$name])) {
                 return false;


### PR DESCRIPTION
example of url rule with disabled url encoding for parameters:

```
[
    'pattern' => '<lang:en>/file<path:(.*)?>',
    'route' => ['file/download'],
    'encodeParams' => false,
]
```
