### PR TITLE
Display database exceptions with SQL formatted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,8 @@
 		"smarty/smarty": "required by yii2-smarty extension",
 		"swiftmailer/swiftmailer": "required by yii2-swiftmailer extension",
 		"twig/twig": "required by yii2-twig extension",
-		"yiisoft/yii2-coding-standards": "you can use this package to check for code style issues when contributing to yii"
+		"yiisoft/yii2-coding-standards": "you can use this package to check for code style issues when contributing to yii",
+		"nilportugues/sql-query-formatter": "to view database exceptions with SQL formatted"
 	},
 	"autoload": {
 		"psr-4": {

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -515,6 +515,11 @@ abstract class Schema extends Object
                 $exceptionClass = $class;
             }
         }
+
+        if (class_exists("\\NilPortugues\\SqlQueryFormatter\\Formatter")) {
+            $rawSql = "\n" . (new \NilPortugues\SqlQueryFormatter\Formatter())->format($rawSql);
+        }
+
         $message = $e->getMessage()  . "\nThe SQL being executed was: $rawSql";
         $errorInfo = $e instanceof \PDOException ? $e->errorInfo : null;
         return new $exceptionClass($message, $errorInfo, (int) $e->getCode(), $e);


### PR DESCRIPTION
It helps a lot to find the error quickly, especially in queries with multiple joins.

I suggested the simplest and lightest class I found in packagist.org
