### PR TITLE
Add options for breadcrumbs $link

### DIFF
--- a/framework/widgets/Breadcrumbs.php
+++ b/framework/widgets/Breadcrumbs.php
@@ -144,7 +144,7 @@ class Breadcrumbs extends Widget
         }
         $issetTemplate = isset($link['template']);
         if (isset($link['url'])) {
-            return strtr($issetTemplate ? $link['template'] : $template, ['{link}' => Html::a($label, $link['url'])]);
+            return strtr($issetTemplate ? $link['template'] : $template, ['{link}' => Html::a($label, $link['url'], isset($link['options'])?$link['options']:null)]);
         } else {
             return strtr($issetTemplate ? $link['template'] : $template, ['{link}' => $label]);
         }


### PR DESCRIPTION
Some time we need to set more attribute for the breadcrumbs link, such as <code>title</code>.
