### PR TITLE
ADD METHOD: \yii\db\Schema::createColumnSchema()

### DIFF
--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -56,13 +56,6 @@ abstract class Schema extends Object
     const TYPE_MONEY = 'money';
 
     /**
-     * @var array options to create ColumnSchema for every column of table
-     */
-    public $columnSchemaOpts = [
-        'class'=>'yii\db\ColumnSchema',
-    ];
-
-    /**
      * @var Connection the database connection
      */
     public $db;
@@ -92,12 +85,11 @@ abstract class Schema extends Object
     private $_builder;
 
     /**
-     * @param array $options
      * @return \yii\db\ColumnSchema
      * @throws \yii\base\InvalidConfigException
      */
-    protected function createColumnSchema(array $options = array()) {
-        return \Yii::createObject( (!empty($options) ? $options : $this->columnSchemaOpts) );
+    protected function createColumnSchema() {
+        return Yii::createObject('yii\db\ColumnSchema');
     }
 
     /**

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -56,6 +56,13 @@ abstract class Schema extends Object
     const TYPE_MONEY = 'money';
 
     /**
+     * @var array options to create ColumnSchema for every column of table
+     */
+    public $columnSchemaOpts = [
+        'class'=>'yii\db\ColumnSchema',
+    ];
+
+    /**
      * @var Connection the database connection
      */
     public $db;
@@ -84,6 +91,14 @@ abstract class Schema extends Object
      */
     private $_builder;
 
+    /**
+     * @param array $options
+     * @return \yii\db\ColumnSchema
+     * @throws \yii\base\InvalidConfigException
+     */
+    protected function createColumnSchema(array $options = array()) {
+        return \Yii::createObject( (!empty($options) ? $options : $this->columnSchemaOpts) );
+    }
 
     /**
      * Loads the metadata for the specified table.

--- a/framework/db/cubrid/Schema.php
+++ b/framework/db/cubrid/Schema.php
@@ -195,7 +195,7 @@ class Schema extends \yii\db\Schema
      */
     protected function loadColumnSchema($info)
     {
-        $column = new ColumnSchema();
+        $column = $this->createColumnSchema();
 
         $column->name = $info['Field'];
         $column->allowNull = $info['Null'] === 'YES';

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -176,7 +176,7 @@ class Schema extends \yii\db\Schema
      */
     protected function loadColumnSchema($info)
     {
-        $column = new ColumnSchema();
+        $column = $this->createColumnSchema();
 
         $column->name = $info['column_name'];
         $column->allowNull = $info['is_nullable'] == 'YES';

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -127,7 +127,7 @@ class Schema extends \yii\db\Schema
      */
     protected function loadColumnSchema($info)
     {
-        $column = new ColumnSchema;
+        $column = $this->createColumnSchema();
 
         $column->name = $info['Field'];
         $column->allowNull = $info['Null'] === 'YES';

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -200,7 +200,7 @@ EOD;
      */
     protected function createColumn($column)
     {
-        $c = new ColumnSchema();
+        $c = $this->createColumnSchema();
         $c->name = $column['COLUMN_NAME'];
         $c->allowNull = $column['NULLABLE'] === 'Y';
         $c->isPrimaryKey = strpos($column['KEY'], 'P') !== false;

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -434,7 +434,7 @@ SQL;
      */
     protected function loadColumnSchema($info)
     {
-        $column = new ColumnSchema();
+        $column = $this->createColumnSchema();
         $column->allowNull = $info['is_nullable'];
         $column->autoIncrement = $info['is_autoinc'];
         $column->comment = $info['column_comment'];

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -212,7 +212,7 @@ class Schema extends \yii\db\Schema
      */
     protected function loadColumnSchema($info)
     {
-        $column = new ColumnSchema;
+        $column = $this->createColumnSchema();
         $column->name = $info['name'];
         $column->allowNull = !$info['notnull'];
         $column->isPrimaryKey = $info['pk'] != 0;


### PR DESCRIPTION
Now i am creating MySQL application what will work with UUID's, so i need to override `ColumnSchema::{db,php}Typecast` to convert it between string and binary. But in `\yii\db\mysql\Schema::loadColumnSchema` it's [hardcoded](https://github.com/yiisoft/yii2/blob/master/framework/db/mysql/Schema.php#L130), and no way to override w/o overriding and copypasting long method !

P.S.. Also see #1221
