### PR TITLE
Update BaseHtmlPurifier.php

### DIFF
--- a/framework/helpers/BaseHtmlPurifier.php
+++ b/framework/helpers/BaseHtmlPurifier.php
@@ -31,7 +31,7 @@ class BaseHtmlPurifier
         $purifier=\HTMLPurifier::instance($configInstance);
         $purifier->config->set('Cache.SerializerPath', \Yii::$app->getRuntimePath());
                 
-        if (is_callable($config)) {
+        if ($config instanceof \Closure) {
             call_user_func($config, $configInstance);
         }
 

--- a/framework/helpers/BaseHtmlPurifier.php
+++ b/framework/helpers/BaseHtmlPurifier.php
@@ -21,7 +21,7 @@ class BaseHtmlPurifier
      * Passes markup through HTMLPurifier making it safe to output to end user
      *
      * @param string $content
-     * @param array|null $config
+     * @param array|callable|null $config
      * @return string
      */
     public static function process($content, $config = null)
@@ -30,6 +30,10 @@ class BaseHtmlPurifier
         $configInstance->autoFinalize = false;
         $purifier=\HTMLPurifier::instance($configInstance);
         $purifier->config->set('Cache.SerializerPath', \Yii::$app->getRuntimePath());
+                
+        if (is_callable($config)) {
+            call_user_func($config, $configInstance);
+        }
 
         return $purifier->purify($content);
     }

--- a/framework/helpers/BaseHtmlPurifier.php
+++ b/framework/helpers/BaseHtmlPurifier.php
@@ -19,9 +19,21 @@ class BaseHtmlPurifier
 {
     /**
      * Passes markup through HTMLPurifier making it safe to output to end user
+     * 
+     * Anonymous function config example,
+     * 
+     * ~~~
+     * // Allow the HTML5 data attribute `data-type` on `img` elements.
+     * HtmlPurifier::process($content, function($config) {
+     *  $def = $config->getHTMLDefinition(true);
+     *  $def->addAttribute('img', 'data-type', 'Text');
+     * })
+     * ~~~
      *
-     * @param string $content
-     * @param array|callable|null $config
+     * @param string $content The HTML content to purify
+     * @param array|\Closure|null $config if not specified or null the default config will be used.
+     * Use an array or an anonymous function to provide configuration options. The anonymous function signature should be:
+     * `function($config)` where `$config` will be an instance of HTMLPurifier_Config.
      * @return string
      */
     public static function process($content, $config = null)
@@ -30,9 +42,9 @@ class BaseHtmlPurifier
         $configInstance->autoFinalize = false;
         $purifier=\HTMLPurifier::instance($configInstance);
         $purifier->config->set('Cache.SerializerPath', \Yii::$app->getRuntimePath());
-                
+        
         if ($config instanceof \Closure) {
-            call_user_func($config, $configInstance);
+            $config($configInstance);
         }
 
         return $purifier->purify($content);


### PR DESCRIPTION
I needed an HTML5 data attribute to pass through purifying.
Using the `HTML.AllowedAttributes` wouldn't work as it clears the default whitelist.

I tried doing

```
$config = HTMLPurifier_Config::createDefault();
$def = $config->getHTMLDefinition(true);
$def->addAttribute('img', 'data-type', 'Text');

HtmlPurifier::process($content, $config);
```

but calling `getHTMLDefinition` finalizes the config which causes an error with this line.
`$purifier->config->set('Cache.SerializerPath', \Yii::$app->getRuntimePath());`

Using `$config` as a callable you can now do

```
HtmlPurifier::process($content, function($config) {
    $def = $config->getHTMLDefinition(true);
    $def->addAttribute('img', 'data-type', 'Text');
})
```
