### PR TITLE
Minor edits Nginx configuration

### DIFF
--- a/docs/guide-ru/start-installation.md
+++ b/docs/guide-ru/start-installation.md
@@ -148,7 +148,6 @@ server {
 
     server_name mysite.local;
     root        /path/to/basic/web;
-    index       index.php;
 
     access_log  /path/to/project/log/access.log main;
     error_log   /path/to/project/log/error.log;
@@ -162,13 +161,15 @@ server {
     #location ~ \.(js|css|png|jpg|gif|swf|ico|pdf|mov|fla|zip|rar)$ {
     #    try_files $uri =404;
     #}
-    #error_page 404 /404.html;
 
     location ~ \.php$ {
+        try_files $uri =403;
+
         include fastcgi.conf;
         fastcgi_pass   127.0.0.1:9000;
         #fastcgi_pass unix:/var/run/php5-fpm.sock;
     }
+    #error_page 403 404 /40x.html;
 
     location ~ /\.(ht|svn|git) {
         deny all;

--- a/docs/guide-ru/start-installation.md
+++ b/docs/guide-ru/start-installation.md
@@ -163,13 +163,13 @@ server {
     #}
 
     location ~ \.php$ {
-        try_files $uri =403;
+        try_files $uri =404;
 
         include fastcgi.conf;
         fastcgi_pass   127.0.0.1:9000;
         #fastcgi_pass unix:/var/run/php5-fpm.sock;
     }
-    #error_page 403 404 /40x.html;
+    #error_page 404 /404.html;
 
     location ~ /\.(ht|svn|git) {
         deny all;

--- a/docs/guide/start-installation.md
+++ b/docs/guide/start-installation.md
@@ -174,13 +174,13 @@ server {
     #}
 
     location ~ \.php$ {
-        try_files $uri =403;
+        try_files $uri =404;
 
         include fastcgi.conf;
         fastcgi_pass   127.0.0.1:9000;
         #fastcgi_pass unix:/var/run/php5-fpm.sock;
     }
-    #error_page 403 404 /40x.html;
+    #error_page 404 /404.html;
 
     location ~ /\.(ht|svn|git) {
         deny all;

--- a/docs/guide/start-installation.md
+++ b/docs/guide/start-installation.md
@@ -159,7 +159,6 @@ server {
 
     server_name mysite.local;
     root        /path/to/basic/web;
-    index       index.php;
 
     access_log  /path/to/basic/log/access.log main;
     error_log   /path/to/basic/log/error.log;
@@ -173,13 +172,15 @@ server {
     #location ~ \.(js|css|png|jpg|gif|swf|ico|pdf|mov|fla|zip|rar)$ {
     #    try_files $uri =404;
     #}
-    #error_page 404 /404.html;
 
     location ~ \.php$ {
+        try_files $uri =403;
+
         include fastcgi.conf;
         fastcgi_pass   127.0.0.1:9000;
         #fastcgi_pass unix:/var/run/php5-fpm.sock;
     }
+    #error_page 403 404 /40x.html;
 
     location ~ /\.(ht|svn|git) {
         deny all;


### PR DESCRIPTION
The `index` directive is not required, as later we specify the entry point using `try_files`. It also should specify `try_files $uri =403;` in the location for processing `.php` files to avoid the `No input file specified` error if they do not exist.
