### PR TITLE
Html::error() disable encode

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1122,7 +1122,10 @@ class BaseHtml
         $error = $model->getFirstError($attribute);
         $tag = isset($options['tag']) ? $options['tag'] : 'div';
         unset($options['tag']);
-        return Html::tag($tag, Html::encode($error), $options);
+        if (!isset($options['encode']) || $options['encode'] === true) {
+            $error = Html::encode($error);
+        }
+        return Html::tag($tag, $error, $options);
     }
 
     /**


### PR DESCRIPTION
Need option to disable encode for error text. For example, if the error contains a link (<a href="">...</a>)
I'm not sure that the code is correct, fix it if necessary.
