### PR TITLE
Optional encoding of validation error strings

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -181,6 +181,7 @@ Yii Framework 2 Change Log
 - Enh #4630: Added automatic generating of unique slug value to `yii\behaviors\Sluggable` (klimov-paul)
 - Enh #4644: Added `\yii\db\Schema::createColumnSchema()` to be able to customize column schema used (mcd-php)
 - Enh #4656: HtmlPurifier helper config can now be a closure to change the purifier config object after it was created (Alex-Code)
+- Enh #4691: Encoding on `ActiveForm` and `ActiveField` validation errors is now configurable (Alex-Code)
 - Enh: Added support for using sub-queries when building a DB query with `IN` condition (qiangxue)
 - Enh: Supported adding a new response formatter without the need to reconfigure existing formatters (qiangxue)
 - Enh: Added `yii\web\UrlManager::addRules()` to simplify adding new URL rules (qiangxue)

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -23,6 +23,8 @@
     };
 
     var defaults = {
+        // whether to encode the error summary
+        encodeErrorSummary: true,
         // the jQuery selector for the error summary
         errorSummary: undefined,
         // whether to perform validation before submitting the form.
@@ -73,6 +75,8 @@
         input: undefined,
         // the jQuery selector of the error tag
         error: undefined,
+        // whether to encode the error
+        encode: true,
         // whether to perform validation when a change is detected on the input
         validateOnChange: false,
         // whether to perform validation when the user is typing.
@@ -404,11 +408,15 @@
             var $container = $form.find(attribute.container);
             var $error = $container.find(attribute.error);
             if (hasError) {
-                $error.text(messages[attribute.id][0]);
+                if (attribute.encode) {
+                    $error.text(messages[attribute.id][0]);
+                } else {
+                    $error.html(messages[attribute.id][0]);
+                }
                 $container.removeClass(data.settings.validatingCssClass + ' ' + data.settings.successCssClass)
                     .addClass(data.settings.errorCssClass);
             } else {
-                $error.text('');
+                $error.empty();
                 $container.removeClass(data.settings.validatingCssClass + ' ' + data.settings.errorCssClass + ' ')
                     .addClass(data.settings.successCssClass);
             }
@@ -425,12 +433,18 @@
     var updateSummary = function ($form, messages) {
         var data = $form.data('yiiActiveForm'),
             $summary = $form.find(data.settings.errorSummary),
-            $ul = $summary.find('ul').html('');
+            $ul = $summary.find('ul').empty();
 
         if ($summary.length && messages) {
             $.each(data.attributes, function () {
                 if ($.isArray(messages[this.id]) && messages[this.id].length) {
-                    $ul.append($('<li/>').text(messages[this.id][0]));
+                    var error = $('<li/>');
+                    if (data.settings.encodeErrorSummary) {
+                        error.text(messages[this.id][0]);
+                    } else {
+                        error.html(messages[this.id][0]);
+                    }
+                    $ul.append(error);
                 }
             });
             $summary.toggle($ul.find('li').length > 0);

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -63,6 +63,7 @@ class ActiveField extends Component
      * The following special options are recognized:
      *
      * - tag: the tag name of the container element. Defaults to "div".
+     * - encode: whether to encode the error output. Defaults to true.
      *
      * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
      */

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -726,6 +726,7 @@ class ActiveField extends Component
             } else {
                 $options['error'] = isset($this->errorOptions['tag']) ? $this->errorOptions['tag'] : 'span';
             }
+            $options['encode'] = isset($this->errorOptions['encode']) ? $this->errorOptions['encode'] : true;
 
             return $options;
         } else {

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -726,7 +726,7 @@ class ActiveField extends Component
             } else {
                 $options['error'] = isset($this->errorOptions['tag']) ? $this->errorOptions['tag'] : 'span';
             }
-            $options['encode'] = isset($this->errorOptions['encode']) ? $this->errorOptions['encode'] : true;
+            $options['encode'] = isset($this->errorOptions['encode']) && $this->errorOptions['encode'] !== false;
 
             return $options;
         } else {

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -54,6 +54,10 @@ class ActiveForm extends Widget
      */
     public $fieldConfig;
     /**
+     * @var boolean whether to perform encoding on the error summary.
+     */
+    public $encodeErrorSummary = true;
+    /**
      * @var string the default CSS class for the error summary container.
      * @see errorSummary()
      */
@@ -239,6 +243,7 @@ class ActiveForm extends Widget
     protected function getClientOptions()
     {
         $options = [
+            'encodeErrorSummary' => $this->encodeErrorSummary,
             'errorSummary' => '.' . implode('.', preg_split('/\s+/', $this->errorSummaryCssClass, -1, PREG_SPLIT_NO_EMPTY)),
             'validateOnSubmit' => $this->validateOnSubmit,
             'errorCssClass' => $this->errorCssClass,
@@ -276,6 +281,7 @@ class ActiveForm extends Widget
     public function errorSummary($models, $options = [])
     {
         Html::addCssClass($options, $this->errorSummaryCssClass);
+        $options['encode'] = $this->encodeErrorSummary;
         return Html::errorSummary($models, $options);
     }
 


### PR DESCRIPTION
Updated `yii.activeform.js` to use the `encode` option introduced in #4663.
Updated `ActiveForm` with new option `encodeErrorSummary`
#4690
