### PR TITLE
Move a tests config parameter to a yml file. Remove redundant contants

### DIFF
--- a/apps/basic/codeception.yml
+++ b/apps/basic/codeception.yml
@@ -17,3 +17,7 @@ modules:
             user: ''
             password: ''
             dump: tests/_data/dump.sql
+config:
+    # the entry script URL (without host info) for functional and acceptance tests
+    # PLEASE ADJUST IT TO THE ACTUAL ENTRY SCRIPT URL
+    test_entry_url: /basic/web/index-test.php

--- a/apps/basic/tests/README.md
+++ b/apps/basic/tests/README.md
@@ -8,7 +8,7 @@ After creating the basic application, follow these steps to prepare for the test
    ```
    php composer.phar require --dev "codeception/codeception: 2.0.*" "codeception/specify: *" "codeception/verify: *"
    ```
-2. In the file `_bootstrap.php`, modify the definition of the constant `TEST_ENTRY_URL` so
+2. In the file `codeception.yml`, modify the definition of the config parameter `test_entry_url` so
    that it points to the correct entry script URL.
 3. Go to the application base directory and build the test suites:
 

--- a/apps/basic/tests/_bootstrap.php
+++ b/apps/basic/tests/_bootstrap.php
@@ -1,12 +1,5 @@
 <?php
 
-// the entry script URL (without host info) for functional and acceptance tests
-// PLEASE ADJUST IT TO THE ACTUAL ENTRY SCRIPT URL
-defined('TEST_ENTRY_URL') or define('TEST_ENTRY_URL', '/basic/web/index-test.php');
-
-// the entry script file path for functional and acceptance tests
-defined('TEST_ENTRY_FILE') or define('TEST_ENTRY_FILE', dirname(__DIR__) . '/web/index-test.php');
-
 defined('YII_DEBUG') or define('YII_DEBUG', true);
 
 defined('YII_ENV') or define('YII_ENV', 'test');
@@ -16,8 +9,10 @@ require_once(__DIR__ . '/../vendor/autoload.php');
 require_once(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 
 // set correct script paths
-$_SERVER['SCRIPT_FILENAME'] = TEST_ENTRY_FILE;
-$_SERVER['SCRIPT_NAME'] = TEST_ENTRY_URL;
+
+// the entry script file path for functional and acceptance tests
+$_SERVER['SCRIPT_FILENAME'] = dirname(__DIR__) . '/web/index-test.php';
+$_SERVER['SCRIPT_NAME'] = \Codeception\Configuration::config()['config']['test_entry_url'];
 $_SERVER['SERVER_NAME'] = 'localhost';
 
 Yii::setAlias('@tests', __DIR__);

--- a/apps/basic/tests/functional/_config.php
+++ b/apps/basic/tests/functional/_config.php
@@ -1,8 +1,8 @@
 <?php
 
 // set correct script paths
-$_SERVER['SCRIPT_FILENAME'] = TEST_ENTRY_FILE;
-$_SERVER['SCRIPT_NAME'] = TEST_ENTRY_URL;
+$_SERVER['SCRIPT_FILENAME'] = dirname(dirname(__DIR__)) . '/web/index-test.php';
+$_SERVER['SCRIPT_NAME'] = \Codeception\Configuration::config()['config']['test_entry_url'];
 
 return yii\helpers\ArrayHelper::merge(
     require(__DIR__ . '/../../config/web.php'),


### PR DESCRIPTION
Make the basic app tests configuration similar to the advanced app one. As introduced in #4671. See
https://github.com/yiisoft/yii2/pull/4671#issuecomment-51759414
