### PR TITLE
Fix #4504: `yii\grid\DataColumn` fixed to use label from grid filter model

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -174,6 +174,7 @@ Yii Framework 2 Change Log
 - Enh #4372: `yii\filters\HttpCache` failed to comply to RFC 7232 (DaSourcerer)
 - Enh #4436: Added callback functions to AJAX-based form validation (thiagotalma)
 - Enh #4485: Added support for deferred validation in `ActiveForm` (Alex-Code)
+- Enh #4504: Added ability for `yii\grid\DataColumn` to use attribute label from grid filter model (klimov-paul)
 - Enh #4520: Added sasl support to `yii\caching\MemCache` (xjflyttp)
 - Enh #4559: Added `beforeValidateAll` and `afterValidateAll` callbacks to `ActiveForm` (Alex-Code)
 - Enh #4566: Added client validation support for image validator (Skysplit, qiangxue)

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -109,7 +109,9 @@ class DataColumn extends Column
         $provider = $this->grid->dataProvider;
 
         if ($this->label === null) {
-            if ($provider instanceof ActiveDataProvider && $provider->query instanceof ActiveQueryInterface) {
+            if ($this->grid->filterModel instanceof Model) {
+                $label = $this->grid->filterModel->getAttributeLabel($this->attribute);
+            } elseif ($provider instanceof ActiveDataProvider && $provider->query instanceof ActiveQueryInterface) {
                 /* @var $model Model */
                 $model = new $provider->query->modelClass;
                 $label = $model->getAttributeLabel($this->attribute);


### PR DESCRIPTION
Fix #4504: `yii\grid\DataColumn` fixed to use label from grid filter model
