### PR TITLE
Multiple flash messages per type support

### DIFF
--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -717,13 +717,35 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
     {
         $counters = $this->get($this->flashParam, []);
         $counters[$key] = $removeAfterAccess ? -1 : 0;
+        $_SESSION[$key] = $value;
+        $_SESSION[$this->flashParam] = $counters;
+    }
 
+    /**
+     * Appends new flash message to the specified key.
+     * @param string $key the key identifying the flash message.
+     * @param mixed $value flash message
+     * @param boolean $removeAfterAccess whether the flash message should be automatically removed only if
+     * it is accessed. If false, the flash message will be automatically removed after the next request,
+     * regardless if it is accessed or not. If true (default value), the flash message will remain until after
+     * it is accessed.
+     * @throws InvalidParamException if exising session variable is not array.
+     * @see getFlash()
+     * @see removeFlash()
+     */
+    public function addFlash($key, $value = true, $removeAfterAccess = true)
+    {
+        $counters = $this->get($this->flashParam, []);
+        $counters[$key] = $removeAfterAccess ? -1 : 0;
         if (!empty($_SESSION[$key])) {
+            // If it's not an array, convert it to array 
+            if (!is_array($_SESSION[$key])) {
+                $_SESSION[$key] = [$_SESSION[$key]];
+            }
             $_SESSION[$key][] = $value;
         } else {
             $_SESSION[$key] = [$value];
         }
-
         $_SESSION[$this->flashParam] = $counters;
     }
 

--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -717,7 +717,13 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
     {
         $counters = $this->get($this->flashParam, []);
         $counters[$key] = $removeAfterAccess ? -1 : 0;
-        $_SESSION[$key] = $value;
+
+        if (!empty($_SESSION[$key])) {
+            $_SESSION[$key][] = $value;
+        } else {
+            $_SESSION[$key] = [$value];
+        }
+
         $_SESSION[$this->flashParam] = $counters;
     }
 
@@ -760,9 +766,9 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
     }
 
     /**
-     * Returns a value indicating whether there is a flash message associated with the specified key.
-     * @param string $key key identifying the flash message
-     * @return boolean whether the specified flash message exists
+     * Returns a value indicating whether there are flash messages associated with the specified key.
+     * @param string $key key identifying the flash message type
+     * @return boolean whether any flash messages exist under specified key
      */
     public function hasFlash($key)
     {


### PR DESCRIPTION
Basic support for multiple flash messages per type, as per discussion
https://github.com/yiisoft/yii2/pull/1250#issuecomment-52454763

Tested in advanced and basic app use cases.

It turned out that advanced template alert widget already works fine with array of messages.

The approach used in basic app:

```
 Yii::$app->session->setFlash('contactFormSubmitted');
```

is also not broken.

The remove-after-access and remove-on-the-next page logic should work fine but I did not test it thoroughly.
