### PR TITLE
use uniqid() to generate widget IDs

### DIFF
--- a/framework/base/Widget.php
+++ b/framework/base/Widget.php
@@ -25,11 +25,6 @@ use ReflectionClass;
 class Widget extends Component implements ViewContextInterface
 {
     /**
-     * @var integer a counter used to generate [[id]] for widgets.
-     * @internal
-     */
-    public static $counter = 0;
-    /**
      * @var string the prefix to the automatically generated widget IDs.
      * @see getId()
      */
@@ -108,7 +103,7 @@ class Widget extends Component implements ViewContextInterface
     public function getId($autoGenerate = true)
     {
         if ($autoGenerate && $this->_id === null) {
-            $this->_id = static::$autoIdPrefix . static::$counter++;
+            $this->_id = uniqid(static::$autoIdPrefix);
         }
 
         return $this->_id;


### PR DESCRIPTION
Problem:
Rendering Widget within an AJAX-Request can result in duplicate HTML-ID's. Yii and Yii2 using a simple count method to generate new ID's.

Solution:
Use microtime() or better uniqid() to generate an ID's which is dependent from the current time. No more ID conflicts will get in your way.
