### PR TITLE
Fixed #4754: BaseActiveFixture internal models cache isn't cleared on fixture unload

### DIFF
--- a/framework/test/BaseActiveFixture.php
+++ b/framework/test/BaseActiveFixture.php
@@ -105,11 +105,11 @@ abstract class BaseActiveFixture extends DbFixture implements \IteratorAggregate
             throw new InvalidConfigException("Fixture data file does not exist: {$this->dataFile}");
         }
     }
-	
-	public function unload()
+
+    public function unload()
     {
         parent::unload();
-		$this->data = [];
+        $this->data = [];
         $this->_models = [];
     }
 }

--- a/framework/test/BaseActiveFixture.php
+++ b/framework/test/BaseActiveFixture.php
@@ -105,4 +105,11 @@ abstract class BaseActiveFixture extends DbFixture implements \IteratorAggregate
             throw new InvalidConfigException("Fixture data file does not exist: {$this->dataFile}");
         }
     }
+	
+	public function unload()
+    {
+        parent::unload();
+		$this->data = [];
+        $this->_models = [];
+    }
 }


### PR DESCRIPTION
Fixes #4754
