### PR TITLE
Remove the focus on the search field

### DIFF
--- a/extensions/apidoc/templates/bootstrap/layouts/main.php
+++ b/extensions/apidoc/templates/bootstrap/layouts/main.php
@@ -93,9 +93,6 @@ JS
 
 var searchBox = $('#searchbox');
 
-// focus the search field
-searchBox.focus();
-
 // search when typing in search field
 searchBox.on("keyup", function(event) {
     var query = $(this).val();


### PR DESCRIPTION
I think to remove the auto focus. For example, it is very uncomfortable when page opens and immediately need to use the `Ctrl + F` combination.
