### PR TITLE
Add slash after dirname for fixture paths - advanced application template

### DIFF
--- a/apps/advanced/tests/codeception/bin/yii_acceptance
+++ b/apps/advanced/tests/codeception/bin/yii_acceptance
@@ -20,8 +20,8 @@ $config = yii\helpers\ArrayHelper::merge(
         'controllerMap' => [
             'fixture' => [
                 'class' => 'yii\faker\FixtureController',
-                'fixtureDataPath' => dirname(__DIR__) . 'common/fixtures',
-                'templatePath' => dirname(__DIR__) . 'common/templates'
+                'fixtureDataPath' => dirname(__DIR__) . '/common/fixtures',
+                'templatePath' => dirname(__DIR__) . '/common/templates'
             ],
         ],
     ]

--- a/apps/advanced/tests/codeception/bin/yii_functional
+++ b/apps/advanced/tests/codeception/bin/yii_functional
@@ -20,8 +20,8 @@ $config = yii\helpers\ArrayHelper::merge(
         'controllerMap' => [
             'fixture' => [
                 'class' => 'yii\faker\FixtureController',
-                'fixtureDataPath' => dirname(__DIR__) . 'common/fixtures',
-                'templatePath' => dirname(__DIR__) . 'common/templates'
+                'fixtureDataPath' => dirname(__DIR__) . '/common/fixtures',
+                'templatePath' => dirname(__DIR__) . '/common/templates'
             ],
         ],
     ]

--- a/apps/advanced/tests/codeception/bin/yii_unit
+++ b/apps/advanced/tests/codeception/bin/yii_unit
@@ -20,8 +20,8 @@ $config = yii\helpers\ArrayHelper::merge(
         'controllerMap' => [
             'fixture' => [
                 'class' => 'yii\faker\FixtureController',
-                'fixtureDataPath' => dirname(__DIR__) . 'common/fixtures',
-                'templatePath' => dirname(__DIR__) . 'common/templates'
+                'fixtureDataPath' => dirname(__DIR__) . '/common/fixtures',
+                'templatePath' => dirname(__DIR__) . '/common/templates'
             ],
         ],
     ]

--- a/extensions/faker/FixtureController.php
+++ b/extensions/faker/FixtureController.php
@@ -258,7 +258,7 @@ class FixtureController extends \yii\console\controllers\FixtureController
         $path = Yii::getAlias($this->templatePath);
 
         if (!is_dir($path)) {
-            throw new Exception("The template path \"{$this->templatePath}\" not exist");
+            throw new Exception("The template path \"{$this->templatePath}\" does not exist");
         }
     }
 


### PR DESCRIPTION
When I attempted to run `codeception/bin/yii_functional fixture user` I received the error message `Error: The template path "/path/to/yii2-app-advanced/tests/codeceptioncommon/templates" not exist`. 

In my tests, `dirname(__DIR__)` does not result in a trailing slash, so I think it's necessary to add the slash to the beginning of the appended path. Same for yii_acceptance and yii_unit. I'm using Ubuntu 14.04 and PHP 5.5.9.

I also suggest a grammar change to the wording of the related error message.
