### PR TITLE
Fixes #4188: API exceptions are now exposing less data when YII_DEBUG is false

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -230,6 +230,7 @@ Yii Framework 2 Change Log
 - Chg #4051: Renamed `yii\caching\GroupDependency` to `TagDependency` and added support for associating multiple tags to a single cached data item (qiangxue)
 - Chg #4071: `mail` component renamed to `mailer`, `yii\log\EmailTarget::$mail` renamed to `yii\log\EmailTarget::$mailer` (samdark)
 - Chg #4147: `BaseMailer::compose()` will not overwrite the `message` parameter if it is explicitly provided (qiangxue)
+- Chg #4188: API exceptions are now exposing less data when YII_DEBUG is false (samdark)
 - Chg #4201: change default value of `SyslogTarget::facility` from LOG_SYSLOG to LOG_USER (dizews)
 - Chg #4211: BaseActiveRecord::populateRecord now silently hide selected columns that are not defined in AR instead of failing with an error (miramir)
 - Chg #4227: `\yii\widgets\LinkPager::$hideOnSinglePage` is now `true` by default (samdark)

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -117,8 +117,11 @@ class ErrorHandler extends \yii\base\ErrorHandler
      */
     protected function convertExceptionToArray($exception)
     {
+        if (!YII_DEBUG && !$exception instanceof UserException && !$exception instanceof HttpException) {
+            $exception = new HttpException(500, 'There was an error at the server.');
+        }
+
         $array = [
-            'type' => get_class($exception),
             'name' => ($exception instanceof Exception || $exception instanceof ErrorException) ? $exception->getName() : 'Exception',
             'message' => $exception->getMessage(),
             'code' => $exception->getCode(),
@@ -126,12 +129,15 @@ class ErrorHandler extends \yii\base\ErrorHandler
         if ($exception instanceof HttpException) {
             $array['status'] = $exception->statusCode;
         }
-        if (YII_DEBUG && !$exception instanceof UserException) {
-            $array['file'] = $exception->getFile();
-            $array['line'] = $exception->getLine();
-            $array['stack-trace'] = explode("\n", $exception->getTraceAsString());
-            if ($exception instanceof \yii\db\Exception) {
-                $array['error-info'] = $exception->errorInfo;
+        if (YII_DEBUG) {
+            $array['type'] = get_class($exception);
+            if (!$exception instanceof UserException) {
+                $array['file'] = $exception->getFile();
+                $array['line'] = $exception->getLine();
+                $array['stack-trace'] = explode("\n", $exception->getTraceAsString());
+                if ($exception instanceof \yii\db\Exception) {
+                    $array['error-info'] = $exception->errorInfo;
+                }
             }
         }
         if (($prev = $exception->getPrevious()) !== null) {


### PR DESCRIPTION
- If exception is internal it's always returned as HTTP 500 general purpose one.
- Type isn't exposed anymore.

Fixes #4188
