### PR TITLE
added resolving of symlinks for recursive directories creation

### DIFF
--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -439,6 +439,9 @@ class BaseFileHelper
      */
     public static function createDirectory($path, $mode = 0775, $recursive = true)
     {
+        if(is_link($path)) {
+            $path = readlink($path);
+        }
         if (is_dir($path)) {
             return true;
         }


### PR DESCRIPTION
Example of bug:
If you have a symlink for directory
/var/www/site.com/storage->/media/data
then this code will cause a exception:

```
FileHelper::createDirectory(Yii::getAlias('@app/storage/images'), true);
```

```
PHP Warning – yii\base\ErrorException
mkdir(): File exists
```
