### PR TITLE
Cache console controller adjustments

### DIFF
--- a/framework/console/controllers/CacheController.php
+++ b/framework/console/controllers/CacheController.php
@@ -45,8 +45,6 @@ class CacheController extends Controller
         } else {
             $this->notifyNoCachesFound();
         }
-
-        return static::EXIT_CODE_NORMAL;
     }
 
     /**
@@ -118,8 +116,6 @@ class CacheController extends Controller
         }
 
         $this->notifyFlushed($cachesInfo);
-        
-        return static::EXIT_CODE_NORMAL;
     }
 
     /**

--- a/framework/console/controllers/CacheController.php
+++ b/framework/console/controllers/CacheController.php
@@ -95,8 +95,6 @@ class CacheController extends Controller
         }
 
         $this->notifyFlushed($cachesInfo);
-        
-        return static::EXIT_CODE_NORMAL;
     }
 
     /**
@@ -144,7 +142,7 @@ class CacheController extends Controller
      */
     private function notifyNoCachesFound()
     {
-        $this->stdout("No caches were found in the system.\n", Console::FG_RED);
+        $this->stdout("No cache components were found in the system.\n", Console::FG_RED);
     }
 
     /**
@@ -153,7 +151,7 @@ class CacheController extends Controller
      */
     private function notifyNotFoundCaches($cachesNames)
     {
-        $this->stdout("Following cache components were NOT found in the system:\n\n", Console::FG_RED);
+        $this->stdout("The following cache components were NOT found:\n\n", Console::FG_RED);
 
         foreach ($cachesNames as $name) {
             $this->stdout("\t * $name \n", Console::FG_GREEN);
@@ -168,7 +166,7 @@ class CacheController extends Controller
      */
     private function notifyFlushed($caches)
     {
-        $this->stdout("Following caches were found and flushed, or not flushed due any error: \n\n", Console::FG_YELLOW);
+        $this->stdout("The following cache components were processed:\n\n", Console::FG_YELLOW);
 
         foreach ($caches as $cache) {
             $this->stdout("\t* " . $cache['name'] ." (" . $cache['class'] . ")", Console::FG_GREEN);
@@ -189,7 +187,7 @@ class CacheController extends Controller
      */
     private function confirmFlush($cachesNames)
     {
-        $this->stdout("Following cache components will be flushed:\n\n", Console::FG_YELLOW);
+        $this->stdout("The following cache components will be flushed:\n\n", Console::FG_YELLOW);
 
         foreach ($cachesNames as $name) {
             $this->stdout("\t * $name \n", Console::FG_GREEN);

--- a/framework/console/controllers/CacheController.php
+++ b/framework/console/controllers/CacheController.php
@@ -9,59 +9,217 @@ namespace yii\console\controllers;
 
 use Yii;
 use yii\console\Controller;
-use yii\console\Exception;
 use yii\caching\Cache;
+use yii\helpers\Console;
+use yii\console\Exception;
 
 /**
  * Allows you to flush cache.
  *
+ * ~~~
+ * #see list of available components to flush
+ * yii cache
+ * 
+ * #flush particular components specified by their names
+ * yii cache/flush first second third
+ * 
+ * #flush all cache components that can be found in the system
+ * yii cache/flush-all
+ * ~~~
+ * 
  * @author Alexander Makarov <sam@rmcreative.ru>
  * @since 2.0
  */
 class CacheController extends Controller
 {
+
     /**
      * Lists the caches that can be flushed.
      */
     public function actionIndex()
     {
+        $caches = $this->findCaches();
+
+        if (!empty($caches)) {
+            $this->notifyCachesCanBeFlushed($caches);
+        } else {
+            $this->notifyNoCachesFound();
+        }
+
+        return static::EXIT_CODE_NORMAL;
+    }
+
+    /**
+     * Flushes given cache components.
+     * For example,
+     *
+     * ~~~
+     * # flushes caches specified by their id: "first", "second", "third"
+     * yii cache/flush first second third
+     * ~~~
+     * 
+     */
+    public function actionFlush()
+    {
+        $cachesInput = func_get_args();
+        
+        if (empty($cachesInput)) {
+            throw new Exception("You should specify cache components names");
+        }
+
+        $caches = $this->findCaches($cachesInput);
+        $cachesInfo = [];
+
+        $foundCaches = array_keys($caches);
+
+        $notFoundCaches = array_diff($cachesInput, array_keys($caches));
+
+        if ($notFoundCaches) {
+            $this->notifyNotFoundCaches($notFoundCaches);
+        }
+        
+        if (!$this->confirmFlush($foundCaches)) {
+            return static::EXIT_CODE_NORMAL;
+        }
+
+        foreach ($caches as $name => $class) {
+            $cachesInfo[] = [
+                'name' => $name,
+                'class' => $class,
+                'is_flushed' =>  Yii::$app->get($name)->flush(),
+            ];
+        }
+
+        $this->notifyFlushed($cachesInfo);
+        
+        return static::EXIT_CODE_NORMAL;
+    }
+
+    /**
+     * Flushes all caches registered in the system.
+     */
+    public function actionFlushAll()
+    {
+        $caches = $this->findCaches();
+        $cachesInfo = [];
+
+        if (empty($caches)) {
+            $this->notifyNoCachesFound();
+        }
+
+        foreach ($caches as $name => $class) {
+            $cachesInfo[] = [
+                'name' => $name,
+                'class' => $class,
+                'is_flushed' =>  Yii::$app->get($name)->flush(),
+            ];
+        }
+
+        $this->notifyFlushed($cachesInfo);
+        
+        return static::EXIT_CODE_NORMAL;
+    }
+
+    /**
+     * Notifies user that given caches are found and can be flushed.
+     * @param array $caches array of cache component classes
+     */
+    private function notifyCachesCanBeFlushed($caches)
+    {
+        $this->stdout("Following caches were found in the system: \n\n", Console::FG_YELLOW);
+
+        foreach ($caches as $name => $class) {
+            $this->stdout("\t* $name ($class)\n", Console::FG_GREEN);
+        }
+
+        $this->stdout("\n");
+    }
+
+    /**
+     * Notifies user that there was not found any cache in the system.
+     */
+    private function notifyNoCachesFound()
+    {
+        $this->stdout("No caches were found in the system.\n", Console::FG_RED);
+    }
+
+    /**
+     * Notifies user that given cache components were not found in the system.
+     * @param array $cachesNames
+     */
+    private function notifyNotFoundCaches($cachesNames)
+    {
+        $this->stdout("Following cache components were NOT found in the system:\n\n", Console::FG_RED);
+
+        foreach ($cachesNames as $name) {
+            $this->stdout("\t * $name \n", Console::FG_GREEN);
+        }
+
+        $this->stdout("\n");
+    }
+
+    /**
+     * 
+     * @param array $caches
+     */
+    private function notifyFlushed($caches)
+    {
+        $this->stdout("Following caches were found and flushed, or not flushed due any error: \n\n", Console::FG_YELLOW);
+
+        foreach ($caches as $cache) {
+            $this->stdout("\t* " . $cache['name'] ." (" . $cache['class'] . ")", Console::FG_GREEN);
+
+            if (!$cache['is_flushed']) {
+                $this->stdout(" - not flushed\n", Console::FG_RED);
+            } else {
+                $this->stdout("\n");
+            }
+        }
+
+        $this->stdout("\n");
+    }
+
+    /**
+     * Prompts user with confirmation if caches should be flushed.
+     * @param array $cachesNames
+     */
+    private function confirmFlush($cachesNames)
+    {
+        $this->stdout("Following cache components will be flushed:\n\n", Console::FG_YELLOW);
+
+        foreach ($cachesNames as $name) {
+            $this->stdout("\t * $name \n", Console::FG_GREEN);
+        }
+
+        return $this->confirm("\nFlush above cache components?");
+    }
+
+    /**
+     * Returns array of caches in the system, keys are cache components names, values are class names.
+     * @param array $cachesNames caches to be found
+     * @return array
+     */
+    private function findCaches(array $cachesNames = [])
+    {
         $caches = [];
         $components = Yii::$app->getComponents();
+        $findAll = ($cachesNames == []);
+
         foreach ($components as $name => $component) {
+            if (!$findAll && !in_array($name, $cachesNames)) {
+                continue;
+            }
+
             if ($component instanceof Cache) {
                 $caches[$name] = get_class($component);
             } elseif (is_array($component) && isset($component['class']) && strpos($component['class'], 'Cache') !== false) {
                 $caches[$name] = $component['class'];
+            } elseif (is_string($component) && strpos($component, 'Cache') !== false) {
+                $caches[$name] = $component;
             }
         }
-        if (!empty($caches)) {
-            echo "The following caches can be flushed:\n\n";
-            foreach ($caches as $name => $class) {
-                echo " * $name: $class\n";
-            }
-        } else {
-            echo "No cache is used.\n";
-        }
+
+        return $caches;
     }
 
-    /**
-     * Flushes cache.
-     * @param string $component Name of the cache application component to use.
-     *
-     * @throws \yii\console\Exception
-     */
-    public function actionFlush($component = 'cache')
-    {
-        /* @var $cache Cache */
-        $cache = Yii::$app->get($component, false);
-        if (!$cache || !$cache instanceof Cache) {
-            throw new Exception('Application component "'.$component.'" is not defined or not a cache.');
-        }
-
-        if (!$cache->flush()) {
-            throw new Exception('Unable to flush cache.');
-        }
-
-        echo "\nDone.\n";
-    }
 }

--- a/framework/console/controllers/CacheController.php
+++ b/framework/console/controllers/CacheController.php
@@ -71,13 +71,17 @@ class CacheController extends Controller
         $cachesInfo = [];
 
         $foundCaches = array_keys($caches);
-
         $notFoundCaches = array_diff($cachesInput, array_keys($caches));
 
         if ($notFoundCaches) {
             $this->notifyNotFoundCaches($notFoundCaches);
         }
-        
+
+        if (!$foundCaches) {
+            $this->notifyNoCachesFound();
+            return static::EXIT_CODE_NORMAL;
+        }
+
         if (!$this->confirmFlush($foundCaches)) {
             return static::EXIT_CODE_NORMAL;
         }

--- a/tests/unit/framework/console/controllers/CacheControllerTest.php
+++ b/tests/unit/framework/console/controllers/CacheControllerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace yiiunit\framework\console\controllers;
+
+use Yii;
+use yiiunit\TestCase;
+use yii\console\controllers\CacheController;
+
+class CacheControllerTest extends TestCase
+{
+
+    /**
+     * @var \yiiunit\framework\console\controllers\CacheConsoledController
+     */
+    private $_cacheController;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->_cacheController = Yii::createObject([
+            'class' => 'yiiunit\framework\console\controllers\CacheConsoledController',
+            'interactive' => false,
+        ],[null, null]); //id and module are null
+
+        $this->mockApplication([
+            'components' => [
+                'firstCache' => 'yii\caching\ArrayCache',
+                'secondCache' => 'yii\caching\ArrayCache',
+            ],
+        ]);
+    }
+
+    public function testFlushOne()
+    {
+        Yii::$app->firstCache->set('firstKey', 'firstValue');
+        Yii::$app->firstCache->set('secondKey', 'secondValue');
+        Yii::$app->secondCache->set('thirdKey', 'thirdValue');
+
+        $this->_cacheController->actionFlush('firstCache');
+
+        $this->assertFalse(Yii::$app->firstCache->get('firstKey'),'first cache data should be flushed');
+        $this->assertFalse(Yii::$app->firstCache->get('secondKey'),'first cache data should be flushed');
+        $this->assertEquals('thirdValue', Yii::$app->secondCache->get('thirdKey'), 'second cache data should not be flushed');
+    }
+
+    public function testFlushBoth()
+    {
+        Yii::$app->firstCache->set('firstKey', 'firstValue');
+        Yii::$app->firstCache->set('secondKey', 'secondValue');
+        Yii::$app->secondCache->set('thirdKey', 'secondValue');
+
+        $this->_cacheController->actionFlush('firstCache', 'secondCache');
+
+        $this->assertFalse(Yii::$app->firstCache->get('firstKey'),'first cache data should be flushed');
+        $this->assertFalse(Yii::$app->firstCache->get('secondKey'),'first cache data should be flushed');
+        $this->assertFalse(Yii::$app->secondCache->get('thirdKey'), 'second cache data should be flushed');
+    }
+
+    /**
+     * @expectedException yii\console\Exception
+     */
+    public function testNothingToFlushException()
+    {
+        $this->_cacheController->actionFlush();
+    }
+
+    public function testFlushAll()
+    {
+        Yii::$app->firstCache->set('firstKey', 'firstValue');
+        Yii::$app->secondCache->set('thirdKey', 'secondValue');
+
+        $this->_cacheController->actionFlushAll();
+
+        $this->assertFalse(Yii::$app->firstCache->get('firstKey'),'first cache data should be flushed');
+        $this->assertFalse(Yii::$app->secondCache->get('thirdKey'), 'second cache data should be flushed');
+
+    }
+
+}
+
+class CacheConsoledController extends CacheController
+{
+
+    public function stdout($string)
+    {
+    }
+
+}
+

--- a/tests/unit/framework/console/controllers/CacheControllerTest.php
+++ b/tests/unit/framework/console/controllers/CacheControllerTest.php
@@ -57,6 +57,15 @@ class CacheControllerTest extends TestCase
         $this->assertFalse(Yii::$app->secondCache->get('thirdKey'), 'second cache data should be flushed');
     }
 
+    public function testNotFoundFlush()
+    {
+        Yii::$app->firstCache->set('firstKey', 'firstValue');
+
+        $this->_cacheController->actionFlush('notExistingCache');
+
+        $this->assertEquals('firstValue', Yii::$app->firstCache->get('firstKey'), 'first cache data should not be flushed');
+    }
+
     /**
      * @expectedException yii\console\Exception
      */
@@ -87,4 +96,3 @@ class CacheConsoledController extends CacheController
     }
 
 }
-


### PR DESCRIPTION
Related with https://github.com/yiisoft/yii2/issues/4792

@qiangxue i have not implemented `exclusion` for `flush-all` in cache controller since it will be used very rare, and there will not be too much cache components in system, so user can easily specify them with a  list. 
