### PR TITLE
Fixed storing and loading nulls and booleans in Redis

### DIFF
--- a/extensions/redis/ActiveQuery.php
+++ b/extensions/redis/ActiveQuery.php
@@ -124,14 +124,6 @@ class ActiveQuery extends Component implements ActiveQueryInterface
                 $row[$dataRow[$i++]] = $dataRow[$i++];
             }
 
-            $class = $this->modelClass;
-            $modelInstance = $class::instantiate($row);
-            foreach ($modelInstance->attributes() as $attribute) {
-                if (!isset($row[$attribute])) {
-                    $row[$attribute] = null;
-                }
-            }
-
             $rows[] = $row;
         }
         if (!empty($rows)) {
@@ -173,14 +165,6 @@ class ActiveQuery extends Component implements ActiveQueryInterface
         }
         if ($this->asArray) {
             $model = $row;
-
-            $class = $this->modelClass;
-            $modelInstance = $class::instantiate($row);
-            foreach($modelInstance->attributes() as $attribute) {
-                if (!isset($model[$attribute])) {
-                    $model[$attribute] = null;
-                }
-            }
         } else {
             /* @var $class ActiveRecord */
             $class = $this->modelClass;

--- a/extensions/redis/ActiveQuery.php
+++ b/extensions/redis/ActiveQuery.php
@@ -123,6 +123,15 @@ class ActiveQuery extends Component implements ActiveQueryInterface
             for ($i = 0; $i < $c;) {
                 $row[$dataRow[$i++]] = $dataRow[$i++];
             }
+
+            $class = $this->modelClass;
+            $modelInstance = $class::instantiate($row);
+            foreach ($modelInstance->attributes() as $attribute) {
+                if (!isset($row[$attribute])) {
+                    $row[$attribute] = null;
+                }
+            }
+
             $rows[] = $row;
         }
         if (!empty($rows)) {
@@ -164,6 +173,14 @@ class ActiveQuery extends Component implements ActiveQueryInterface
         }
         if ($this->asArray) {
             $model = $row;
+
+            $class = $this->modelClass;
+            $modelInstance = $class::instantiate($row);
+            foreach($modelInstance->attributes() as $attribute) {
+                if (!isset($model[$attribute])) {
+                    $model[$attribute] = null;
+                }
+            }
         } else {
             /* @var $class ActiveRecord */
             $class = $this->modelClass;

--- a/extensions/redis/ActiveRecord.php
+++ b/extensions/redis/ActiveRecord.php
@@ -123,6 +123,9 @@ class ActiveRecord extends BaseActiveRecord
         $delArgs = [$key];
         foreach ($values as $attribute => $value) {
             if ($value !== null) {
+                if (is_bool($value)) {
+                    $value = (int)$value;
+                }
                 $setArgs[] = $attribute;
                 $setArgs[] = $value;
             } else {
@@ -177,6 +180,9 @@ class ActiveRecord extends BaseActiveRecord
                     $newPk[$attribute] = $value;
                 }
                 if ($value !== null) {
+                    if (is_bool($value)) {
+                        $value = (int)$value;
+                    }
                     $setArgs[] = $attribute;
                     $setArgs[] = $value;
                 } else {

--- a/extensions/redis/ActiveRecord.php
+++ b/extensions/redis/ActiveRecord.php
@@ -120,25 +120,19 @@ class ActiveRecord extends BaseActiveRecord
         $key = static::keyPrefix() . ':a:' . static::buildKey($pk);
         // save attributes
         $setArgs = [$key];
-        $delArgs = [$key];
         foreach ($values as $attribute => $value) {
+            // only insert attributes that are not null
             if ($value !== null) {
                 if (is_bool($value)) {
                     $value = (int)$value;
                 }
                 $setArgs[] = $attribute;
                 $setArgs[] = $value;
-            } else {
-                $delArgs[] = $attribute;
             }
         }
 
         if (count($setArgs) > 1) {
             $db->executeCommand('HMSET', $setArgs);
-        }
-
-        if (count($delArgs) > 1) {
-            $db->executeCommand('HDEL', $delArgs);
         }
 
         $changedAttributes = array_fill_keys(array_keys($values), null);

--- a/extensions/redis/CHANGELOG.md
+++ b/extensions/redis/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 redis extension Change Log
 2.0.0-rc under development
 --------------------------
 
+- Bug #1311: Fixed storage and finding of `null` and boolean values (samdark, cebe)
 - Enh #3520: Added `unlinkAll()`-method to active record to remove all records of a model relation (NmDimas, samdark, cebe)
 - Enh #4048: Added `init` event to `ActiveQuery` classes (qiangxue)
 - Enh #4086: changedAttributes of afterSave Event now contain old values (dizews)

--- a/extensions/redis/LuaScriptBuilder.php
+++ b/extensions/redis/LuaScriptBuilder.php
@@ -268,6 +268,9 @@ EOF;
             if (is_array($value)) { // IN condition
                 $parts[] = $this->buildInCondition('in', [$column, $value], $columns);
             } else {
+                if (is_bool($value)) {
+                    $value = (int)$value;
+                }
                 $column = $this->addColumn($column, $columns);
                 if ($value === null) {
                     $parts[] = "$column==nil";

--- a/tests/unit/data/ar/redis/Order.php
+++ b/tests/unit/data/ar/redis/Order.php
@@ -33,6 +33,17 @@ class Order extends ActiveRecord
             ->via('orderItems')->indexBy('id');
     }
 
+    public function getItemsWithNullFK()
+    {
+        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+            ->via('orderItemsWithNullFK');
+    }
+
+    public function getOrderItemsWithNullFK()
+    {
+        return $this->hasMany(OrderItemWithNullFK::className(), ['order_id' => 'id']);
+    }
+
     public function getItemsInOrder1()
     {
         return $this->hasMany(Item::className(), ['id' => 'item_id'])
@@ -52,8 +63,15 @@ class Order extends ActiveRecord
     public function getBooks()
     {
         return $this->hasMany(Item::className(), ['id' => 'item_id'])
-            ->via('orderItems', ['order_id' => 'id']);
-            //->where(['category_id' => 1]);
+            ->via('orderItems')
+            ->where(['category_id' => 1]);
+    }
+
+    public function getBooksWithNullFK()
+    {
+        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+            ->via('orderItemsWithNullFK')
+            ->where(['category_id' => 1]);
     }
 
     public function beforeSave($insert)

--- a/tests/unit/extensions/redis/ActiveRecordTest.php
+++ b/tests/unit/extensions/redis/ActiveRecordTest.php
@@ -161,12 +161,6 @@ class ActiveRecordTest extends RedisTestCase
         $this->markTestSkipped('Redis does not store/find null values correctly.');
     }
 
-    public function testBooleanAttribute()
-    {
-        // https://github.com/yiisoft/yii2/issues/1311
-        $this->markTestSkipped('Redis does not store/find boolean values correctly.');
-    }
-
     public function testFindEagerViaRelationPreserveOrder()
     {
         $this->markTestSkipped('Redis does not support orderBy.');

--- a/tests/unit/extensions/redis/ActiveRecordTest.php
+++ b/tests/unit/extensions/redis/ActiveRecordTest.php
@@ -143,24 +143,6 @@ class ActiveRecordTest extends RedisTestCase
 
     }
 
-    public function testFindNullValues()
-    {
-        // https://github.com/yiisoft/yii2/issues/1311
-        $this->markTestSkipped('Redis does not store/find null values correctly.');
-    }
-
-    public function testUnlinkAll()
-    {
-        // https://github.com/yiisoft/yii2/issues/1311
-        $this->markTestSkipped('Redis does not store/find null values correctly.');
-    }
-
-    public function testUnlink()
-    {
-        // https://github.com/yiisoft/yii2/issues/1311
-        $this->markTestSkipped('Redis does not store/find null values correctly.');
-    }
-
     public function testFindEagerViaRelationPreserveOrder()
     {
         $this->markTestSkipped('Redis does not support orderBy.');
@@ -267,6 +249,7 @@ class ActiveRecordTest extends RedisTestCase
 
     public function testFindColumn()
     {
+        // TODO this test is duplicated because of missing orderBy support in redis
         $this->assertEquals(['user1', 'user2', 'user3'], Customer::find()->column('name'));
         // TODO $this->assertEquals(['user3', 'user2', 'user1'], Customer::find()->orderBy(['name' => SORT_DESC])->column('name'));
     }

--- a/tests/unit/extensions/redis/ActiveRecordTest.php
+++ b/tests/unit/extensions/redis/ActiveRecordTest.php
@@ -153,6 +153,44 @@ class ActiveRecordTest extends RedisTestCase
         $this->markTestSkipped('Redis does not support orderBy.');
     }
 
+    /**
+     * overridden because null values are not part of the asArray result in redis
+     */
+    public function testFindAsArray()
+    {
+        /* @var $customerClass \yii\db\ActiveRecordInterface */
+        $customerClass = $this->getCustomerClass();
+
+        // asArray
+        $customer = $customerClass::find()->where(['id' => 2])->asArray()->one();
+        $this->assertEquals([
+            'id' => 2,
+            'email' => 'user2@example.com',
+            'name' => 'user2',
+            'address' => 'address2',
+            'status' => 1,
+        ], $customer);
+
+        // find all asArray
+        $customers = $customerClass::find()->asArray()->all();
+        $this->assertEquals(3, count($customers));
+        $this->assertArrayHasKey('id', $customers[0]);
+        $this->assertArrayHasKey('name', $customers[0]);
+        $this->assertArrayHasKey('email', $customers[0]);
+        $this->assertArrayHasKey('address', $customers[0]);
+        $this->assertArrayHasKey('status', $customers[0]);
+        $this->assertArrayHasKey('id', $customers[1]);
+        $this->assertArrayHasKey('name', $customers[1]);
+        $this->assertArrayHasKey('email', $customers[1]);
+        $this->assertArrayHasKey('address', $customers[1]);
+        $this->assertArrayHasKey('status', $customers[1]);
+        $this->assertArrayHasKey('id', $customers[2]);
+        $this->assertArrayHasKey('name', $customers[2]);
+        $this->assertArrayHasKey('email', $customers[2]);
+        $this->assertArrayHasKey('address', $customers[2]);
+        $this->assertArrayHasKey('status', $customers[2]);
+    }
+
     public function testStatisticalFind()
     {
         // find count, sum, average, min, max, scalar


### PR DESCRIPTION
See #1311 
- [x] Fix `LuaScriptBuilder` to use `HEXISTS` in case of `null` values instead of comparison.
- [x] Fix `LuaScriptBuilder` to cast booleans to 0 or 1 before using these in conditions.
