### PR TITLE
Update start-gii.md

### DIFF
--- a/docs/guide/start-gii.md
+++ b/docs/guide/start-gii.md
@@ -43,6 +43,8 @@ Thanks to that line, your application is in development mode, and will have alre
 http://hostname/index.php?r=gii
 ```
 
+> Info: By default (for security reasons) yii will restrict the access to gii so that it is only accessible from localhost. Trying to access the URL as any other address will give a 403-error ("You are not allowed to access this page"). The address from which gii can be accessed can be modified by adding a proper ipFilter statement in the configuration as described in the [yii Wiki](http://www.yiiframework.com/wiki/115/why-do-i-get-a-403-error-when-trying-to-use-gii/) 
+
 ![Gii](images/start-gii.png)
 
 


### PR DESCRIPTION
Since the default ipfilter setting will only allow access to gii as address "localhost" (or 127.0.0.1) this should be stated. I have added a short info note with that affect and directed to a longer wiki article describing how to modify the ipFilter setting. This type of information is vital for developers just starting to learn about yii.
