### PR TITLE
Make unit tests cleanup a DB after finish

### DIFF
--- a/extensions/codeception/TestCase.php
+++ b/extensions/codeception/TestCase.php
@@ -80,7 +80,6 @@ class TestCase extends Test
     {
         parent::setUp();
         $this->mockApplication();
-        $this->unloadFixtures();
         $this->loadFixtures();
     }
 
@@ -90,6 +89,7 @@ class TestCase extends Test
     protected function tearDown()
     {
         $this->destroyApplication();
+        $this->unloadFixtures();
         parent::tearDown();
     }
 

--- a/extensions/codeception/TestCase.php
+++ b/extensions/codeception/TestCase.php
@@ -80,6 +80,7 @@ class TestCase extends Test
     {
         parent::setUp();
         $this->mockApplication();
+        $this->unloadFixtures();
         $this->loadFixtures();
     }
 


### PR DESCRIPTION
Unit tests don't cleanup a DB after successful finish.
It is an issue if I use one DB for all kind of tests. Especially with hardcoded primary keys in fixtures.

This fix make tests do a housekeeping after them.
