### PR TITLE
ActiveForm: Trigger `onValidationError` event on input & form

### DIFF
--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -364,7 +364,7 @@
                     }
                 });
                 if (hasError) {
-                    $form.trigger('onValidationError', ['messages'=>messages]);
+                    $form.trigger('onValidationError', {messages:messages});
                 }
             });
         }, data.settings.validationDelay);
@@ -502,7 +502,7 @@
             attribute.value = getValue($form, attribute);
         }
         if (hasError) {
-            $input.trigger('onValidationError', ['messages'=>messages]);
+            $input.trigger('onValidationError', {messages:messages});
         }
         return hasError;
     };

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -364,7 +364,7 @@
                     }
                 });
                 if (hasError) {
-                    $form.trigger('onValidationError', {messages:messages});
+                    $form.trigger('onValidationError', [messages]);
                 }
             });
         }, data.settings.validationDelay);
@@ -502,7 +502,7 @@
             attribute.value = getValue($form, attribute);
         }
         if (hasError) {
-            $input.trigger('onValidationError', {messages:messages});
+            $input.trigger('onValidationError', [messages]);
         }
         return hasError;
     };

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -364,7 +364,7 @@
                     }
                 });
                 if (hasError) {
-                    $form.trigger('onValidationError', [messages]);
+                    $form.trigger('onValidationError', [attribute, messages]);
                 }
             });
         }, data.settings.validationDelay);

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -363,6 +363,9 @@
                         hasError = updateInput($form, this, messages) || hasError;
                     }
                 });
+                if (hasError) {
+                    $form.trigger('onValidationError', ['messages'=>messages]);
+                }
             });
         }, data.settings.validationDelay);
     };
@@ -497,6 +500,9 @@
                     .addClass(data.settings.successCssClass);
             }
             attribute.value = getValue($form, attribute);
+        }
+        if (hasError) {
+            $input.trigger('onValidationError', ['messages'=>messages]);
         }
         return hasError;
     };


### PR DESCRIPTION
Trigger a new `onValidationError` event on both input & form, whenever a validation error is encountered. This can help one to code advanced stuff like:

``` js
$form.on('onValidationError', function(event, attribute, messages) {
    if (messages.length && attribute.id == 'attribute1') {
        // do something
    } else if (messages.length) {
        // do something else
    }
});
// or with each input
$input.on('onValidationError', function(event, messages) {
    if (messages.length) {
        // do something
    }
});
```
