### PR TITLE
Handling $query->joinWith called inside of other $query->joinWith within...

### DIFF
--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -482,6 +482,9 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 $relations[$fullName] = $relation = $primaryModel->getRelation($name);
                 if ($callback !== null) {
                     call_user_func($callback, $relation);
+                    if(is_array($relation->joinWith)) {
+                        $relation->buildJoinWith();
+                    }
                 }
                 $this->joinWithRelation($parent, $relation, $this->getJoinType($joinType, $fullName));
             }

--- a/tests/unit/framework/db/ActiveRecordTest.php
+++ b/tests/unit/framework/db/ActiveRecordTest.php
@@ -410,6 +410,24 @@ class ActiveRecordTest extends DatabaseTestCase
                     ->orderBy('items.id');
             },
         ])->orderBy('order.id')->one();
+
+        // join with sub-relation called inside Closure
+        $orders = Order::find()->joinWith([
+                'items' => function ($q) {
+                    $q->orderBy('item.id');
+                    $q->joinWith([
+                            'category'=> function ($q) {
+                                $q->where('category.id = 2');
+                            }
+                        ]);
+                },
+            ])->orderBy('order.id')->all();
+        $this->assertEquals(1, count($orders));
+        $this->assertTrue($orders[0]->isRelationPopulated('items'));
+        $this->assertEquals(2, $orders[0]->id);
+        $this->assertEquals(3, count($orders[0]->items));
+        $this->assertTrue($orders[0]->items[0]->isRelationPopulated('category'));
+        $this->assertEquals(2, $orders[0]->items[0]->category->id);
     }
 
     public function testJoinWithAndScope()


### PR DESCRIPTION
Handling $query->joinWith called inside of other $query->joinWith within Closure (called inside Closure). Ex.:

``` php
   $query->joinWith( [ 'rel1' => function($query) {
      $query->joinWith( [ 'rel2' => function($query) {
          // ...
      } ] );
   } ] );
```

This is split PR for replace #4570 which I've closed.
So this is important bug in AR. I hope it can be merged ASAP.
