### PR TITLE
 Fix for use table name template within generating "viaTable" expression.

### DIFF
--- a/extensions/gii/CHANGELOG.md
+++ b/extensions/gii/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.0-rc under development
 --------------------------
 
+- Bug #4971: Fixed hardcoded table names in 'viaTable' expression in model generator. (stepanselyuk)
 - Bug #1263: Fixed the issue that Gii and Debug modules might be affected by incompatible asset manager configuration (qiangxue)
 - Bug #2314: Gii model generator does not generate correct relation type in some special case (qiangxue)
 - Bug #3265: Fixed incorrect controller class name validation (suralc)

--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -354,7 +354,7 @@ class Generator extends \yii\gii\Generator
             $viaLink = $this->generateRelationLink([$table->primaryKey[0] => $fks[$table->primaryKey[0]][1]]);
             $relationName = $this->generateRelationName($relations, $className0, $db->getTableSchema($table0), $table->primaryKey[1], true);
             $relations[$className0][$relationName] = [
-                "return \$this->hasMany($className1::className(), $link)->viaTable('{".$this->generateTableName($table->name)."}', $viaLink);",
+                "return \$this->hasMany($className1::className(), $link)->viaTable('{" . $this->generateTableName($table->name) . "}', $viaLink);",
                 $className1,
                 true,
             ];
@@ -363,7 +363,7 @@ class Generator extends \yii\gii\Generator
             $viaLink = $this->generateRelationLink([$table->primaryKey[1] => $fks[$table->primaryKey[1]][1]]);
             $relationName = $this->generateRelationName($relations, $className1, $db->getTableSchema($table1), $table->primaryKey[0], true);
             $relations[$className1][$relationName] = [
-                "return \$this->hasMany($className0::className(), $link)->viaTable('{".$this->generateTableName($table->name)."}', $viaLink);",
+                "return \$this->hasMany($className0::className(), $link)->viaTable('{" . $this->generateTableName($table->name) . "}', $viaLink);",
                 $className0,
                 true,
             ];

--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -350,17 +350,11 @@ class Generator extends \yii\gii\Generator
             $className0 = $this->generateClassName($table0);
             $className1 = $this->generateClassName($table1);
 
-            if (( $prefixlen = mb_strlen( $db->tablePrefix ) ) > 0) {
-                $tableNameTpl = '{{%' . mb_substr( $table->name, $prefixlen ) . '}}';
-            } else {
-                $tableNameTpl = $table->name;
-            }
-
             $link = $this->generateRelationLink([$fks[$table->primaryKey[1]][1] => $table->primaryKey[1]]);
             $viaLink = $this->generateRelationLink([$table->primaryKey[0] => $fks[$table->primaryKey[0]][1]]);
             $relationName = $this->generateRelationName($relations, $className0, $db->getTableSchema($table0), $table->primaryKey[1], true);
             $relations[$className0][$relationName] = [
-                "return \$this->hasMany($className1::className(), $link)->viaTable('{$tableNameTpl}', $viaLink);",
+                "return \$this->hasMany($className1::className(), $link)->viaTable('{".$this->generateTableName($table->name)."}', $viaLink);",
                 $className1,
                 true,
             ];
@@ -369,7 +363,7 @@ class Generator extends \yii\gii\Generator
             $viaLink = $this->generateRelationLink([$table->primaryKey[1] => $fks[$table->primaryKey[1]][1]]);
             $relationName = $this->generateRelationName($relations, $className1, $db->getTableSchema($table1), $table->primaryKey[0], true);
             $relations[$className1][$relationName] = [
-                "return \$this->hasMany($className0::className(), $link)->viaTable('{$tableNameTpl}', $viaLink);",
+                "return \$this->hasMany($className0::className(), $link)->viaTable('{".$this->generateTableName($table->name)."}', $viaLink);",
                 $className0,
                 true,
             ];

--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -350,8 +350,8 @@ class Generator extends \yii\gii\Generator
             $className0 = $this->generateClassName($table0);
             $className1 = $this->generateClassName($table1);
 
-            if (( $prefixlen = strlen( $db->tablePrefix ) ) > 0) {
-                $tableNameTpl = '{{%' . substr( $table->name, $prefixlen ) . '}}';
+            if (( $prefixlen = mb_strlen( $db->tablePrefix ) ) > 0) {
+                $tableNameTpl = '{{%' . mb_substr( $table->name, $prefixlen ) . '}}';
             } else {
                 $tableNameTpl = $table->name;
             }

--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -350,11 +350,17 @@ class Generator extends \yii\gii\Generator
             $className0 = $this->generateClassName($table0);
             $className1 = $this->generateClassName($table1);
 
+            if (( $prefixlen = strlen( $db->tablePrefix ) ) > 0) {
+                $tableNameTpl = '{{%' . substr( $table->name, $prefixlen ) . '}}';
+            } else {
+                $tableNameTpl = $table->name;
+            }
+
             $link = $this->generateRelationLink([$fks[$table->primaryKey[1]][1] => $table->primaryKey[1]]);
             $viaLink = $this->generateRelationLink([$table->primaryKey[0] => $fks[$table->primaryKey[0]][1]]);
             $relationName = $this->generateRelationName($relations, $className0, $db->getTableSchema($table0), $table->primaryKey[1], true);
             $relations[$className0][$relationName] = [
-                "return \$this->hasMany($className1::className(), $link)->viaTable('{$table->name}', $viaLink);",
+                "return \$this->hasMany($className1::className(), $link)->viaTable('{$tableNameTpl}', $viaLink);",
                 $className1,
                 true,
             ];
@@ -363,7 +369,7 @@ class Generator extends \yii\gii\Generator
             $viaLink = $this->generateRelationLink([$table->primaryKey[1] => $fks[$table->primaryKey[1]][1]]);
             $relationName = $this->generateRelationName($relations, $className1, $db->getTableSchema($table1), $table->primaryKey[0], true);
             $relations[$className1][$relationName] = [
-                "return \$this->hasMany($className0::className(), $link)->viaTable('{$table->name}', $viaLink);",
+                "return \$this->hasMany($className0::className(), $link)->viaTable('{$tableNameTpl}', $viaLink);",
                 $className0,
                 true,
             ];

--- a/extensions/gii/generators/model/default/model.php
+++ b/extensions/gii/generators/model/default/model.php
@@ -20,7 +20,7 @@ namespace <?= $generator->ns ?>;
 use Yii;
 
 /**
- * This is the model class for table "<?= $tableName ?>".
+ * This is the model class for table "<?= $generator->generateTableName($tableName) ?>".
  *
 <?php foreach ($tableSchema->columns as $column): ?>
  * @property <?= "{$column->phpType} \${$column->name}\n" ?>


### PR DESCRIPTION
Fix for use table name template within generating "viaTable" expressions.
