### PR TITLE
Html::button() type is `button` by default

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -425,6 +425,9 @@ class BaseHtml
      */
     public static function button($content = 'Button', $options = [])
     {
+        if (!isset($options['type'])) {
+            $options['type'] = 'button';
+        }
         return static::tag('button', $content, $options);
     }
 
@@ -1541,7 +1544,7 @@ class BaseHtml
         $groups = isset($tagOptions['groups']) ? $tagOptions['groups'] : [];
         unset($tagOptions['prompt'], $tagOptions['options'], $tagOptions['groups']);
         $options['encodeSpaces'] = ArrayHelper::getValue($options, 'encodeSpaces', $encodeSpaces);
-        
+
         foreach ($items as $key => $value) {
             if (is_array($value)) {
                 $groupAttrs = isset($groups[$key]) ? $groups[$key] : [];


### PR DESCRIPTION
Without that fix and type attribute browsers handle button as button with submit type. But for submit type buttons we have `Html::submitButton()` method.
