### PR TITLE
Rename `\yii\web\User` component param for consistency

### DIFF
--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -131,7 +131,7 @@ class User extends Component
      * @var string the session variable name used to store the value of absolute expiration timestamp of the authenticated state.
      * This is used when [[absoluteAuthTimeout]] is set.
      */
-    public $absoluteAuthTimeoutParam = '__absolute_expire';
+    public $absoluteAuthTimeoutParam = '__absoluteExpire';
     /**
      * @var string the session variable name used to store the value of [[returnUrl]].
      */


### PR DESCRIPTION
For example we have `__returnUrl` name for param. Its not consistent that we use name `__absolute_expire` instead of `__absoluteExpire`.
