### PR TITLE
Enhancements to Formatter for parsing dates & numbers

### DIFF
--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -492,7 +492,7 @@ class Formatter extends Component
     ];
 
     /**
-     * @param integer $value normalized datetime value
+     * @param DateTime $value normalized datetime value
      * @param string $format the format used to convert the value into a date string.
      * @param string $type 'date', 'time', or 'datetime'.
      * @throws InvalidConfigException if the date format is invalid.
@@ -529,38 +529,30 @@ class Formatter extends Component
             } else {
                 $format = $this->getPhpDatePattern($format);
             }
-            $date = new DateTime(null, new \DateTimeZone($this->timeZone));
-            $date->setTimestamp($value);
-            return $date->format($format);
+			if ($this->timeZone != null) {
+				$value->setTimezone(new \DateTimeZone($this->timeZone));
+			}
+            return $value->format($format);
         }
     }
 
     /**
-     * Normalizes the given datetime value as a UNIX timestamp that can be taken by various date/time formatting methods.
+     * Normalizes the given datetime value as a DateTime object that can be taken by various date/time formatting methods.
      *
      * @param mixed $value the datetime value to be normalized.
-     * @return float the normalized datetime value (int64)
+     * @return DateTime object the normalized datetime value
      */
-    protected function normalizeDatetimeValue($value)
-    {
-        if ($value === null) {
+	 
+	protected function normalizeDatetimeValue($value) {
+		if ($value === null) {
             return null;
-        } elseif (is_string($value)) {
-            if (is_numeric($value) || $value === '') {
-                $value = (double)$value;
-            } else {
-                $date = new DateTime($value);
-                $value = (double)$date->format('U');
-            }
-            return $value;
-
-        } elseif ($value instanceof DateTime || $value instanceof DateTimeInterface) {
-            return (double)$value->format('U');
-        } else {
-            return (double)$value;
         }
-    }
-
+		if ($value instanceof DateTime) {
+            return $value;
+        }
+		return new DateTime($value);
+	}
+	
     private function getIntlDatePattern($pattern)
     {
         if (strpos($pattern, 'php:') === 0) {
@@ -787,12 +779,10 @@ class Formatter extends Component
                     $dateNow = new DateTime('now', $timezone);
                 } else {
                     $referenceTime = $this->normalizeDatetimeValue($referenceTime);
-                    $dateNow = new DateTime(null, $timezone);
-                    $dateNow->setTimestamp($referenceTime);
+                    $dateNow->setTimezone($timezone);
                 }
 
-                $dateThen = new DateTime(null, $timezone);
-                $dateThen->setTimestamp($timestamp);
+                $dateThen->setTimezone($timezone);
 
                 $interval = $dateThen->diff($dateNow);
             }

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -529,9 +529,9 @@ class Formatter extends Component
             } else {
                 $format = $this->getPhpDatePattern($format);
             }
-			if ($this->timeZone != null) {
-				$value->setTimezone(new \DateTimeZone($this->timeZone));
-			}
+            if ($this->timeZone != null) {
+                $value->setTimezone(new \DateTimeZone($this->timeZone));
+            }
             return $value->format($format);
         }
     }
@@ -541,18 +541,17 @@ class Formatter extends Component
      *
      * @param mixed $value the datetime value to be normalized.
      * @return DateTime object the normalized datetime value
-     */
-	 
-	protected function normalizeDatetimeValue($value) {
-		if ($value === null) {
+     */ 
+    protected function normalizeDatetimeValue($value) {
+        if ($value === null) {
             return null;
         }
-		if ($value instanceof DateTime) {
+        if ($value instanceof DateTime) {
             return $value;
         }
-		return new DateTime($value);
-	}
-	
+        return new DateTime($value);
+    }
+    
     private function getIntlDatePattern($pattern)
     {
         if (strpos($pattern, 'php:') === 0) {

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -504,9 +504,9 @@ class Formatter extends Component
         if ($timestamp === null) {
             return $this->nullDisplay;
         }
-        if (!$timestamp instanceof DateTime) {
-            // if no valid timestamp found return raw original value
-            return $value;
+        $errors = DateTime::getLastErrors();
+        if (is_array($errors) && !empty($errors['errors'])) {
+            throw new InvalidConfigException(implode("\n", $errors['errors']) . "\n(Value: {$value})");
         }
 
         if ($this->_intlLoaded) {

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -735,7 +735,8 @@ class Formatter extends Component
         if ($value === null) {
             return $this->nullDisplay;
         }
-        return number_format($this->normalizeDatetimeValue($value), 0, '.', '');
+        $timestamp = $this->normalizeDatetimeValue($value);
+        return number_format($timestamp->format('U'), 0, '.', '');
     }
 
     /**

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -544,11 +544,11 @@ class Formatter extends Component
      */ 
     protected function normalizeDatetimeValue($value) {
         if ($value === null || $value instanceof DateTime) {
-            // return as is
+            // skip any processing
             return $value;
         }
         if (is_numeric($value)) {
-            // if numeric assume its a unix timestamp
+            // process as unix timestamp
             return DateTime::createFromFormat('U', $value);
         }
         return new DateTime($value);

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -543,11 +543,13 @@ class Formatter extends Component
      * @return DateTime object the normalized datetime value
      */ 
     protected function normalizeDatetimeValue($value) {
-        if ($value === null) {
-            return null;
-        }
-        if ($value instanceof DateTime) {
+        if ($value === null || $value instanceof DateTime) {
+            // return as is
             return $value;
+        }
+        if (is_numeric($value)) {
+            // if numeric assume its a unix timestamp
+            return DateTime::createFromFormat('U', $value);
         }
         return new DateTime($value);
     }

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -781,7 +781,7 @@ class Formatter extends Component
                     $dateNow->setTimezone($timezone);
                 }
 
-                $dateThen->setTimezone($timezone);
+                $dateThen = $timestamp->setTimezone($timezone);
 
                 $interval = $dateThen->diff($dateNow);
             }

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -777,7 +777,7 @@ class Formatter extends Component
                 if ($referenceTime === null) {
                     $dateNow = new DateTime('now', $timezone);
                 } else {
-                    $referenceTime = $this->normalizeDatetimeValue($referenceTime);
+                    $dateNow = $this->normalizeDatetimeValue($referenceTime);
                     $dateNow->setTimezone($timezone);
                 }
 

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -1181,6 +1181,10 @@ class Formatter extends Component
      */
     protected function normalizeNumericValue($value)
     {
+        if ($value == null) {
+            // prevent exception when converting empty strings
+            return 0;
+        }
         if (is_string($value) && is_numeric($value)) {
             $value = (float) $value;
         }

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -500,9 +500,13 @@ class Formatter extends Component
      */
     private function formatDateTimeValue($value, $format, $type)
     {
-        $value = $this->normalizeDatetimeValue($value);
-        if ($value === null) {
+        $timestamp = $this->normalizeDatetimeValue($value);
+        if ($timestamp === null) {
             return $this->nullDisplay;
+        }
+        if (!$timestamp instanceof DateTime) {
+            // if no valid timestamp found return raw original value
+            return $value;
         }
 
         if ($this->_intlLoaded) {
@@ -521,7 +525,7 @@ class Formatter extends Component
             if ($formatter === null) {
                 throw new InvalidConfigException(intl_get_error_message());
             }
-            return $formatter->format($value);
+            return $formatter->format($timestamp);
         } else {
             // replace short, medium, long and full with real patterns in case intl is not loaded.
             if (isset($this->_phpNameToPattern[$format][$type])) {
@@ -530,9 +534,9 @@ class Formatter extends Component
                 $format = $this->getPhpDatePattern($format);
             }
             if ($this->timeZone != null) {
-                $value->setTimezone(new \DateTimeZone($this->timeZone));
+                $timestamp->setTimezone(new \DateTimeZone($this->timeZone));
             }
-            return $value->format($format);
+            return $timestamp->format($format);
         }
     }
 

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -492,7 +492,7 @@ class Formatter extends Component
     ];
 
     /**
-     * @param DateTime $value normalized datetime value
+     * @param string $value normalized datetime value
      * @param string $format the format used to convert the value into a date string.
      * @param string $type 'date', 'time', or 'datetime'.
      * @throws InvalidConfigException if the date format is invalid.
@@ -540,7 +540,7 @@ class Formatter extends Component
      * Normalizes the given datetime value as a DateTime object that can be taken by various date/time formatting methods.
      *
      * @param mixed $value the datetime value to be normalized.
-     * @return DateTime object the normalized datetime value
+     * @return mixed the normalized datetime value
      */ 
     protected function normalizeDatetimeValue($value) {
         if ($value === null || $value instanceof DateTime) {


### PR DESCRIPTION
Summary of various enhancements incorporated:
- `normalizeDateTimeValue` will parse, convert, and return a `DateTime` object for seamless usage across 32 bit, 64 bit systems or using within `IntlDateFormatter`.The `DateTime` object is supported for input & output across date values by 32 bit, 64 bit, as well as the `IntlDateFormatter` to format all date strings (including fixing of the Y2K38 bug). Fixes issue in #4989.
- `formatDateTimeValue` will now read a `DateTime` object from above method for formatting as needed.
- `InvalidConfigException` handling for date & time formatting to capture `DateTime` parsing errors.
- `asRelativeTime` has been changed to reflect usage of `DateTime` object
- `asTimestamp` has been changed to reflect usage of `DateTime` object
- `normalizeNumericValue` now parses empty strings and returns a zero - so no exception is thrown.
