### PR TITLE
Typo in concept-behaviors.md

### DIFF
--- a/docs/guide/concept-behaviors.md
+++ b/docs/guide/concept-behaviors.md
@@ -210,7 +210,7 @@ You can also call a *public* method of the behavior similarly:
 $component->foo();
 ```
 
-As you can see, although `$component` does not define `prop1` and `bar()`, they can be used as if they are part
+As you can see, although `$component` does not define `prop1` and `foo()`, they can be used as if they are part
 of the component definition due to the attached behavior.
 
 If two behaviors define the same property or method and they are both attached to the same component,


### PR DESCRIPTION
The method 'bar()' does not exist in this context. I believe it should be 'foo().'
