### PR TITLE
Option to give parameter values for Yii::t as a Closure.

### DIFF
--- a/framework/BaseYii.php
+++ b/framework/BaseYii.php
@@ -499,6 +499,9 @@ class BaseYii
         } else {
             $p = [];
             foreach ((array) $params as $name => $value) {
+                if($value instanceof \Closure) {
+                    $value = $value();
+                }
                 $p['{' . $name . '}'] = $value;
             }
 

--- a/framework/i18n/I18N.php
+++ b/framework/i18n/I18N.php
@@ -124,6 +124,9 @@ class I18N extends Component
 
         $p = [];
         foreach ($params as $name => $value) {
+            if($value instanceof \Closure) {
+                $value = $value();
+            }
             $p['{' . $name . '}'] = $value;
         }
 


### PR DESCRIPTION
Option to give parameter values for Yii::t as a Closure. e.x.:

``` php
public function rules() {
    return [
        [
            'item_name',
            'unique',
            'targetAttribute' => [ 'item_name' ],
            'filter' => function ( $query ) {

                /** @var \yii\db\Query $query */
                // Check for complex Primary Key [item_name, user_id]
                $query->andWhere( [ 'user_id' => $this->user_id ] );
            },
            'message' => Yii::t('application',
                'Specified auth item "{value}" already assigned for user "{login}".',
                [
                    'login' => function () { return $this->user->login; },
                ]
            )
    ]
    ];
}
```
