### PR TITLE
type parameter added for MaskedInput

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.0-rc under development
 --------------------------
-
+- Enh #5045: Type parameter added for MaskedInput to set the `input` field's type attribute  (albertborsos)
 - Bug #1263: Fixed the issue that Gii and Debug modules might be affected by incompatible asset manager configuration (qiangxue)
 - Bug #2314: Gii model generator does not generate correct relation type in some special case (qiangxue)
 - Bug #2563: Theming is not working if the path map of the theme contains ".." or "." in the paths (qiangxue)

--- a/framework/widgets/MaskedInput.php
+++ b/framework/widgets/MaskedInput.php
@@ -43,6 +43,11 @@ class MaskedInput extends InputWidget
     const PLUGIN_NAME = 'inputmask';
 
     /**
+     * @var string the type attribute for the input field. `text` is the default value
+     */
+    public $type = 'text';
+
+    /**
      * @var string|array|JsExpression the input mask (e.g. '99/99/9999' for date input). The following characters
      * can be used in the mask and are predefined:
      *
@@ -109,9 +114,9 @@ class MaskedInput extends InputWidget
     public function run()
     {
         if ($this->hasModel()) {
-            echo Html::activeTextInput($this->model, $this->attribute, $this->options);
+            echo Html::activeInput($this->type, $this->model, $this->attribute, $this->options);
         } else {
-            echo Html::textInput($this->name, $this->value, $this->options);
+            echo Html::input($this->type, $this->name, $this->value, $this->options);
         }
         $this->registerClientScript();
     }


### PR DESCRIPTION
It is a useful enhancement for mobile devices.

If I would like to fill a `MaskedInput` only with numbers and I set the `MaskedInput` field's type attribute to `number` then a numeric keyboard shows up if I am using the app on a mobile device.
