### PR TITLE
Path to Jquery UI does not match default

### DIFF
--- a/extensions/jui/DatePickerLanguageAsset.php
+++ b/extensions/jui/DatePickerLanguageAsset.php
@@ -15,7 +15,7 @@ use yii\web\AssetBundle;
  */
 class DatePickerLanguageAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/jquery-ui';
+    public $sourcePath = '@bower/jquery.ui';
     /**
      * @var boolean whether to automatically generate the needed language js files.
      * If this is true, the language js files will be determined based on the actual usage of [[DatePicker]]

--- a/extensions/jui/JuiAsset.php
+++ b/extensions/jui/JuiAsset.php
@@ -15,7 +15,7 @@ use yii\web\AssetBundle;
  */
 class JuiAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/jquery-ui';
+    public $sourcePath = '@bower/jquery.ui';
     public $js = [
         'jquery-ui.js',
     ];


### PR DESCRIPTION
I transformed my project for the new asset management, using the composer-asset-plugin to install my bower packages. I noticed that the Jquery UI package is installed in @bower/jquery.ui
