### PR TITLE
为ActiveRadio 和 ActiveCheckbox方法添加自动获取$options['label']的功能。

### DIFF
--- a/framework/data/Pagination.php
+++ b/framework/data/Pagination.php
@@ -276,6 +276,44 @@ class Pagination extends Object implements Linkable
             return $urlManager->createUrl($params);
         }
     }
+    
+    /**
+     * Creates the URL suitable for pagination with the specified pageSize number.
+     * This method is mainly called by pagers when creating URLs used to perform pagination.
+     * @param integer $pageSize
+     * @param boolean $absolute whether to create an absolute URL. Defaults to `false`.
+     * @return string the created URL
+     * @see params
+     * @see forcePageParam
+     */
+    public function createPageSizeUrl($pageSize, $absolute = false)
+    {
+        if (($params = $this->params) === null) {
+            $request = Yii::$app->getRequest();
+            $params = $request instanceof Request ? $request->getQueryParams() : [];
+        }
+
+        $page = $this->getPage();
+        if ($page > 0 || $page >= 0 && $this->forcePageParam) {
+            $params[$this->pageParam] = $page + 1;
+        } else {
+            unset($params[$this->pageParam]);
+        }
+
+        $pageSize = ($pageSize > 0) ? (int)$pageSize : $this->getPageSize();
+        if ($pageSize != $this->defaultPageSize) {
+            $params[$this->pageSizeParam] = $pageSize;
+        } else {
+            unset($params[$this->pageSizeParam]);
+        }
+        $params[0] = $this->route === null ? Yii::$app->controller->getRoute() : $this->route;
+        $urlManager = $this->urlManager === null ? Yii::$app->getUrlManager() : $this->urlManager;
+        if ($absolute) {
+            return $urlManager->createAbsoluteUrl($params);
+        } else {
+            return $urlManager->createUrl($params);
+        }
+    }
 
     /**
      * @return integer the offset of the data. This may be used to set the

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1270,6 +1270,10 @@ class BaseHtml
             $options['id'] = static::getInputId($model, $attribute);
         }
 
+        if (!array_key_exists('label', $options) && $label = $model->getAttributeLabel($attribute)) {
+            $options['label'] = $label;
+        }
+
         return static::radio($name, $checked, $options);
     }
 
@@ -1312,6 +1316,10 @@ class BaseHtml
 
         if (!array_key_exists('id', $options)) {
             $options['id'] = static::getInputId($model, $attribute);
+        }
+
+        if (!array_key_exists('label', $options) && $label = $model->getAttributeLabel($attribute)) {
+            $options['label'] = $label;
         }
 
         return static::checkbox($name, $checked, $options);


### PR DESCRIPTION
为ActiveRadio 和 ActiveCheckbox方法添加自动获取$options['label']的功能。
当用户没有指定$options['label']的值时自动获取$model->getAttributeLabel($attribute)
