### PR TITLE
Console controller generator

### DIFF
--- a/extensions/gii/generators/controller/Generator.php
+++ b/extensions/gii/generators/controller/Generator.php
@@ -235,7 +235,13 @@ class Generator extends \yii\gii\Generator
     {
         $module = $this->getModule();
 
-        return $module->getControllerPath() . '/' . $this->getControllerClass() . '.php';
+        if( $module instanceof \yii\base\Application ) {
+            $controllerPath = Yii::getAlias('@' . str_replace('\\', '/', $this->ns));
+        } else {
+            $controllerPath = $module->getControllerPath();
+        }
+
+        return $controllerPath . '/' . $this->getControllerClass() . '.php';
     }
 
     /**


### PR DESCRIPTION
Hi.

I think that we have some bug and I have a possible way to fix it.

I want to generate from terminal web controller (child of \yii\web\Controller). By default while using `yii gii/controller --controller=default --actions=index,details` we have a controller under app/commands folder which extends \yii\web\Controller.

First of all I tryied to get help from yii help gii/controller and what i see (http://puu.sh/bCuPr/3d7182d851.png): default ns=app\commands, but baseClass is \yii\web\Controller.

Must ns parameter change the folder of generated file?

After my changes I can generate web-controller while using
`yii gii/controller --controller=test --actions=index,details --ns=app\\controllers`

But also I want to generate a console controller. We have no generator included in gii for now. I can use something like this:
`yii gii/controller --controller=parser --baseClass=app\\console\\Application --actions=`
Its a _hard_ way to generate command, but it works fine for me. Would we write some code for command generator?

In RoR we can generate controllers and commands by using different cli commands if I remember clear.
