### PR TITLE
Add event for coding post filter grid triggers

### DIFF
--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -36,7 +36,7 @@
          * where
          *  - event: an Event object.
          *
-         * If the handler returns a boolean false, it will stop filter form submission after this event. And as
+         * If the handler returns a boolean false, it will stop filter form submission after this event. As
          * a result, afterFilter event will not be triggered.
          */
         beforeFilter: 'beforeFilter.yiiGridView',

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -28,7 +28,6 @@
 
     var gridData = {};
 
-
     var gridEvents = {
         /**
          * beforeFilter event is triggered before filtering the grid.

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -82,6 +82,9 @@
                 $form.append($('<input type="hidden" name="t" value="" />').attr('name', name).val(value));
             });
             $form.submit();
+            
+            // triggers a filter grid event with the filter form as a parameter
+            $grid.trigger('filter.yiiGridView', [$form]);
         },
 
         setSelectionColumn: function (options) {

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -107,7 +107,7 @@
                 $form.append($('<input type="hidden" name="t" value="" />').attr('name', name).val(value));
             });
             
-            // triggers a beforeFilter grid event with the filter form as a parameter
+            // triggers `beforeFilter` grid event with the filter form as a parameter
             event = $.Event(gridEvents.beforeFilter);
             $form.trigger(event, [$form]);
             if (event.result === false) {
@@ -116,7 +116,7 @@
 
             $form.submit();
             
-            // triggers a afterFilter grid event with the filter form as a parameter
+            // triggers `afterFilter` grid event with the filter form as a parameter
             event = $.Event(gridEvents.afterFilter);
             $grid.trigger(event, [$form]);
         },

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -104,7 +104,6 @@
                 $form.append($('<input type="hidden" name="t" value="" />').attr('name', name).val(value));
             });
             
-            // triggers `beforeFilter` grid event with the filter form as a parameter
             event = $.Event(gridEvents.beforeFilter);
             $grid.trigger(event);
             if (event.result === false) {
@@ -113,7 +112,6 @@
 
             $form.submit();
             
-            // triggers `afterFilter` grid event with the filter form as a parameter
             $grid.trigger(gridEvents.afterFilter);
         },
 

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -28,6 +28,31 @@
 
     var gridData = {};
 
+
+    var gridEvents = {
+        /**
+         * beforeFilter event is triggered before filtering the grid.
+         * The signature of the event handler should be:
+         *     function (event, form)
+         * where
+         *  - event: an Event object.
+         *  - form: is the grid filter form that will be submitted
+         *
+         * If the handler returns a boolean false, it will stop further form validation after this event. And as
+         * a result, beforeFilter event will not be triggered.
+         */
+        beforeFilter: 'beforeFilter.yiiGridView',
+        /**
+         * afterFilter event is triggered after filtering the grid and filtered results are fetched.
+         * The signature of the event handler should be:
+         *     function (event, form)
+         * where
+         *  - event: an Event object.
+         *  - form: is the grid filter form that will be submitted
+         */
+        afterFilter: 'afterFilter.yiiGridView'
+    };
+    
     var methods = {
         init: function (options) {
             return this.each(function () {
@@ -60,7 +85,7 @@
         },
 
         applyFilter: function () {
-            var $grid = $(this);
+            var $grid = $(this), event;
             var settings = gridData[$grid.prop('id')].settings;
             var data = {};
             $.each($(settings.filterSelector).serializeArray(), function () {
@@ -81,10 +106,19 @@
             $.each(data, function (name, value) {
                 $form.append($('<input type="hidden" name="t" value="" />').attr('name', name).val(value));
             });
+            
+            // triggers a beforeFilter grid event with the filter form as a parameter
+            event = $.Event(gridEvents.beforeFilter);
+            $form.trigger(event, [$form]);
+            if (event.result === false) {
+                return;
+            }
+
             $form.submit();
             
-            // triggers a filter grid event with the filter form as a parameter
-            $grid.trigger('filter.yiiGridView', [$form]);
+            // triggers a afterFilter grid event with the filter form as a parameter
+            event = $.Event(gridEvents.afterFilter);
+            $grid.trigger(event, [$form]);
         },
 
         setSelectionColumn: function (options) {
@@ -129,4 +163,3 @@
         }
     };
 })(window.jQuery);
-

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -38,8 +38,8 @@
          *  - event: an Event object.
          *  - form: is the grid filter form that will be submitted
          *
-         * If the handler returns a boolean false, it will stop further form validation after this event. And as
-         * a result, beforeFilter event will not be triggered.
+         * If the handler returns a boolean false, it will stop filter form submission after this event. And as
+         * a result, afterFilter event will not be triggered.
          */
         beforeFilter: 'beforeFilter.yiiGridView',
         /**

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -33,10 +33,9 @@
         /**
          * beforeFilter event is triggered before filtering the grid.
          * The signature of the event handler should be:
-         *     function (event, form)
+         *     function (event)
          * where
          *  - event: an Event object.
-         *  - form: is the grid filter form that will be submitted
          *
          * If the handler returns a boolean false, it will stop filter form submission after this event. And as
          * a result, afterFilter event will not be triggered.
@@ -45,10 +44,9 @@
         /**
          * afterFilter event is triggered after filtering the grid and filtered results are fetched.
          * The signature of the event handler should be:
-         *     function (event, form)
+         *     function (event)
          * where
          *  - event: an Event object.
-         *  - form: is the grid filter form that will be submitted
          */
         afterFilter: 'afterFilter.yiiGridView'
     };
@@ -109,7 +107,7 @@
             
             // triggers `beforeFilter` grid event with the filter form as a parameter
             event = $.Event(gridEvents.beforeFilter);
-            $grid.trigger(event, [$form]);
+            $grid.trigger(event);
             if (event.result === false) {
                 return;
             }
@@ -118,7 +116,7 @@
             
             // triggers `afterFilter` grid event with the filter form as a parameter
             event = $.Event(gridEvents.afterFilter);
-            $grid.trigger(event, [$form]);
+            $grid.trigger(event);
         },
 
         setSelectionColumn: function (options) {

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -109,7 +109,7 @@
             
             // triggers `beforeFilter` grid event with the filter form as a parameter
             event = $.Event(gridEvents.beforeFilter);
-            $form.trigger(event, [$form]);
+            $grid.trigger(event, [$form]);
             if (event.result === false) {
                 return;
             }

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -115,8 +115,7 @@
             $form.submit();
             
             // triggers `afterFilter` grid event with the filter form as a parameter
-            event = $.Event(gridEvents.afterFilter);
-            $grid.trigger(event);
+            $grid.trigger(gridEvents.afterFilter);
         },
 
         setSelectionColumn: function (options) {


### PR DESCRIPTION
Trigger a new `filter.yiiGridView` event for yii grid view after grid filters are applied. This will enable developer to code a lot of use cases based on the grid filtering event. The filter `$form` can be accessed as a parameter to the event.
