### PR TITLE
Use text/plain part of multipart message for text body and charset in debug mail panel.

### DIFF
--- a/extensions/debug/CHANGELOG.md
+++ b/extensions/debug/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 debug extension Change Log
 - Bug #1263: Fixed the issue that Gii and Debug modules might be affected by incompatible asset manager configuration (qiangxue)
 - Bug #3956: Debug toolbar was affecting flash message removal (samdark)
 - Bug #4812: Fixed search filter (samdark)
+- Bug #5126: Fixed text body and charset not being set for multipart mail (nkovacs)
 - Enh #2299: Date and time in request list is now never wrapped (samdark)
 - Enh #3088: The debug module will manage their own URL rules now (qiangxue)
 - Enh #3103: debugger panel is now not displayed when printing a page (githubjeka)

--- a/extensions/debug/panels/MailPanel.php
+++ b/extensions/debug/panels/MailPanel.php
@@ -62,7 +62,22 @@ class MailPanel extends Panel
                 /* @var $swiftMessage \Swift_Message */
                 $swiftMessage = $message->getSwiftMessage();
 
-                $messageData['body'] = $swiftMessage->getBody();
+                $body = $swiftMessage->getBody();
+                if (empty($body)) {
+                    $parts = $swiftMessage->getChildren();
+                    foreach ($parts as $part) {
+                        if (!($part instanceof \Swift_Mime_Attachment)) {
+                            /* @var $part \Swift_Mime_MimePart */
+                            if ($part->getContentType() == 'text/plain') {
+                                $messageData['charset'] = $part->getCharset();
+                                $body = $part->getBody();
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                $messageData['body'] = $body;
                 $messageData['time'] = $swiftMessage->getDate();
                 $messageData['headers'] = $swiftMessage->getHeaders();
 


### PR DESCRIPTION
Fixes #5126
