### PR TITLE
Add icons support to bootstrap widgets.

### DIFF
--- a/extensions/bootstrap/Button.php
+++ b/extensions/bootstrap/Button.php
@@ -33,11 +33,15 @@ class Button extends Widget
     /**
      * @var string the button label
      */
-    public $label = 'Button';
+    public $label = '';
     /**
      * @var boolean whether the label should be HTML-encoded.
      */
     public $encodeLabel = true;
+    /**
+     * @var string the button icon
+     */
+    public $icon;
 
 
     /**
@@ -56,7 +60,11 @@ class Button extends Widget
      */
     public function run()
     {
-        echo Html::tag($this->tagName, $this->encodeLabel ? Html::encode($this->label) : $this->label, $this->options);
+        $label = $this->encodeLabel ? Html::encode($this->label) : $this->label;
+        if (!empty($this->icon)) {
+            $label = $this->icon . ' ' . $label;
+        }
+        echo Html::tag($this->tagName, $label, $this->options);
         $this->registerPlugin('button');
     }
 }

--- a/extensions/bootstrap/ButtonDropdown.php
+++ b/extensions/bootstrap/ButtonDropdown.php
@@ -37,7 +37,7 @@ class ButtonDropdown extends Widget
     /**
      * @var string the button label
      */
-    public $label = 'Button';
+    public $label = '';
     /**
      * @var array the HTML attributes for the container tag. The following special options are recognized:
      *
@@ -68,6 +68,10 @@ class ButtonDropdown extends Widget
      * @var boolean whether the label should be HTML-encoded.
      */
     public $encodeLabel = true;
+    /**
+     * @var string the button icon
+     */
+    public $icon;
 
 
     /**
@@ -93,9 +97,9 @@ class ButtonDropdown extends Widget
     protected function renderButton()
     {
         Html::addCssClass($this->options, 'btn');
-        $label = $this->label;
-        if ($this->encodeLabel) {
-            $label = Html::encode($label);
+        $label = $this->encodeLabel ? Html::encode($this->label) : $this->label;
+        if (!empty($this->icon)) {
+            $label = $this->icon . ' ' . $label;
         }
         if ($this->split) {
             $options = $this->options;

--- a/extensions/bootstrap/ButtonGroup.php
+++ b/extensions/bootstrap/ButtonGroup.php
@@ -42,7 +42,8 @@ class ButtonGroup extends Widget
      * @var array list of buttons. Each array element represents a single button
      * which can be specified as a string or an array of the following structure:
      *
-     * - label: string, required, the button label.
+     * - label: string, optional, the button label.
+     * - icon: string, optional, html for the button icon.
      * - options: array, optional, the HTML attributes of the button.
      */
     public $buttons = [];

--- a/extensions/bootstrap/CHANGELOG.md
+++ b/extensions/bootstrap/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 bootstrap extension Change Log
 2.0.2 under development
 -----------------------
 
-- no changes in this release.
+- Enh #5207: Added icon option to widgets and Icon class (nkovacs)
 
 
 2.0.1 December 07, 2014

--- a/extensions/bootstrap/Collapse.php
+++ b/extensions/bootstrap/Collapse.php
@@ -53,6 +53,7 @@ class Collapse extends Widget
      * - content: string, required, the content (HTML) of the group
      * - options: array, optional, the HTML attributes of the group
      * - contentOptions: optional, the HTML attributes of the group's content
+     * - icon: optional, icon for the header
      */
     public $items = [];
 
@@ -123,6 +124,10 @@ class Collapse extends Widget
             $encodeLabel = isset($item['encode']) ? $item['encode'] : $this->encodeLabels;
             if ($encodeLabel) {
                 $header = Html::encode($header);
+            }
+            $icon = ArrayHelper::getValue($item, 'icon');
+            if (!empty($icon)) {
+                $header = $icon . ' ' . $header;
             }
 
             $headerToggle = Html::a($header, '#' . $id, [

--- a/extensions/bootstrap/Dropdown.php
+++ b/extensions/bootstrap/Dropdown.php
@@ -26,6 +26,7 @@ class Dropdown extends Widget
      * or an array representing a single menu with the following structure:
      *
      * - label: string, required, the label of the item link
+     * - icon: string, optional, html for the item icon.
      * - url: string|array, optional, the url of the item link. This will be processed by [[Url::to()]].
      *   If not set, the item will be treated as a menu header when the item has no sub-menu.
      * - visible: boolean, optional, whether this menu item is visible. Defaults to true.
@@ -81,11 +82,17 @@ class Dropdown extends Widget
                 $lines[] = $item;
                 continue;
             }
-            if (!array_key_exists('label', $item)) {
-                throw new InvalidConfigException("The 'label' option is required.");
+            if (!array_key_exists('label', $item) && !array_key_exists('icon', $item)) {
+                throw new InvalidConfigException("The 'label' or 'icon' option is required.");
             }
             $encodeLabel = isset($item['encode']) ? $item['encode'] : $this->encodeLabels;
-            $label = $encodeLabel ? Html::encode($item['label']) : $item['label'];
+            $label = ArrayHelper::getValue($item, 'label', '');
+            $label = $encodeLabel ? Html::encode($label) : $label;
+            $icon = ArrayHelper::getValue($item, 'icon');
+            if (!empty($icon)) {
+                $label = $icon . ' ' . $label;
+            }
+
             $itemOptions = ArrayHelper::getValue($item, 'options', []);
             $linkOptions = ArrayHelper::getValue($item, 'linkOptions', []);
             $linkOptions['tabindex'] = '-1';

--- a/extensions/bootstrap/Icon.php
+++ b/extensions/bootstrap/Icon.php
@@ -45,6 +45,7 @@ class Icon extends \yii\base\Widget
      */
     public function init()
     {
+        parent::init();
         Html::addCssClass($this->options, 'glyphicon glyphicon-' . $this->icon);
     }
 

--- a/extensions/bootstrap/Icon.php
+++ b/extensions/bootstrap/Icon.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\bootstrap;
+
+use yii\helpers\Html;
+
+/**
+ * Icon renders a glyphicon icon.
+ *
+ * For example:
+ *
+ * ```php
+ * echo Button::widget([
+ *     'label' => 'Action',
+ *     'options' => ['class' => 'btn-lg btn-primary'],
+ *     'icon' => Icon::icon('user'),
+ * ]);
+ * ```
+ */
+class Icon extends \yii\base\Widget
+{
+    /**
+     * @var string the tag to use to render the icon
+     */
+    public $tagName = 'span';
+
+    /**
+     * @var string the icon name
+     */
+    public $icon;
+
+    /**
+     * @var array the HTML attributes for the icon tag.
+     * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
+     */
+    public $options = [];
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        Html::addCssClass($this->options, 'glyphicon glyphicon-' . $this->icon);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function run()
+    {
+        return Html::tag($this->tagName, '', $this->options);
+    }
+
+    /**
+     * Render an icon.
+     *
+     * @param string $icon the icon name
+     * @return string the rendering result.
+     */
+    public static function icon($icon)
+    {
+        return static::widget(['icon' => $icon]);
+    }
+}

--- a/extensions/bootstrap/Nav.php
+++ b/extensions/bootstrap/Nav.php
@@ -53,6 +53,7 @@ class Nav extends Widget
      * menu item which can be either a string or an array with the following structure:
      *
      * - label: string, required, the nav item label.
+     * - icon: string, optional, html for the item icon.
      * - url: optional, the item's URL. Defaults to "#".
      * - visible: boolean, optional, whether this menu item is visible. Defaults to true.
      * - linkOptions: array, optional, the HTML attributes of the item's link.
@@ -146,11 +147,17 @@ class Nav extends Widget
         if (is_string($item)) {
             return $item;
         }
-        if (!isset($item['label'])) {
-            throw new InvalidConfigException("The 'label' option is required.");
+        if (!isset($item['label']) && !isset($item['icon'])) {
+            throw new InvalidConfigException("The 'label' or 'icon' option is required.");
         }
         $encodeLabel = isset($item['encode']) ? $item['encode'] : $this->encodeLabels;
-        $label = $encodeLabel ? Html::encode($item['label']) : $item['label'];
+        $label = ArrayHelper::getValue($item, 'label', '');
+        $label = $encodeLabel ? Html::encode($label) : $label;
+        $icon = ArrayHelper::getValue($item, 'icon');
+        if (!empty($icon)) {
+            $label = $icon . ' ' . $label;
+        }
+
         $options = ArrayHelper::getValue($item, 'options', []);
         $items = ArrayHelper::getValue($item, 'items');
         $url = ArrayHelper::getValue($item, 'url', '#');

--- a/extensions/bootstrap/Tabs.php
+++ b/extensions/bootstrap/Tabs.php
@@ -58,6 +58,7 @@ class Tabs extends Widget
      * tab with the following structure:
      *
      * - label: string, required, the tab header label.
+     * - icon: string, optional, html for the tab header icon.
      * - encode: boolean, optional, whether this label should be HTML-encoded. This param will override
      *   global `$this->encodeLabels` param.
      * - headerOptions: array, optional, the HTML attributes of the tab header.
@@ -142,11 +143,17 @@ class Tabs extends Widget
         }
 
         foreach ($this->items as $n => $item) {
-            if (!array_key_exists('label', $item)) {
-                throw new InvalidConfigException("The 'label' option is required.");
+            if (!array_key_exists('label', $item) && !array_key_exists('icon', $item)) {
+                throw new InvalidConfigException("The 'label' or 'icon' option is required.");
             }
             $encodeLabel = isset($item['encode']) ? $item['encode'] : $this->encodeLabels;
-            $label = $encodeLabel ? Html::encode($item['label']) : $item['label'];
+            $label = ArrayHelper::getValue($item, 'label', '');
+            $label = $encodeLabel ? Html::encode($label) : $label;
+            $icon = ArrayHelper::getValue($item, 'icon');
+            if (!empty($icon)) {
+                $label = $icon . ' ' . $label;
+            }
+
             $headerOptions = array_merge($this->headerOptions, ArrayHelper::getValue($item, 'headerOptions', []));
             $linkOptions = array_merge($this->linkOptions, ArrayHelper::getValue($item, 'linkOptions', []));
 


### PR DESCRIPTION
see #5207 
- Button, ButtonDropdown have `icon` property
- ButtonGroup supports `icon` element in the `buttons` property
- Button and ButtonDropdown `label` defaults to empty string (more convenient for making icon-only buttons)
- Collapse item can have `icon` element, which is applied to header
- Dropdown, Nav and Tabs item can have `icon` element (applied to tab header in Tabs)
  - The `label` option is not required if `icon` is specified.
- `icon` should be a full html tag, not an icon name like in yiistrap, to make it possible to use any other icon plugin, e.g. font awesome.
- Icon class added to make rendering icons more convenient and similar to yiistrap in Yii 1.
  - extends from \yii\base\Widget instead of yii\bootstrap\Widget because the latter adds an id attribute
  - You can extend it if you want to use another icon plugin, or just use plain html.
  - You can even use your class to map from glyphicons to the other plugin, so you only need to change one `use` statement in the view to change your icons.
  - static method `icon` is less verbose than `widget`, but still stuttery. `Icon::widget(['icon' => 'user'])` vs `Icon::icon('user')`. I could change it to `Glyph::icon('user')`, and then you could have `Fa::icon('user')` for font awesome etc.
