### PR TITLE
Addition of `afterPublish` callback

### DIFF
--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -353,6 +353,7 @@ class AssetManager extends Component
      * - forceCopy: boolean, whether the directory being published should be copied even if
      *   it is found in the target directory. This option is used only when publishing a directory.
      *   This overrides [[forceCopy]] if set.
+     * - afterPublish: callback, a PHP callback that is called after all files and directories have been copied.
      *
      * @return array the path (directory or file path) and the URL that the asset is published as.
      * @throws InvalidParamException if the asset to be published does not exist.
@@ -420,6 +421,7 @@ class AssetManager extends Component
      * - forceCopy: boolean, whether the directory being published should be copied even if
      *   it is found in the target directory. This option is used only when publishing a directory.
      *   This overrides [[forceCopy]] if set.
+     * - afterPublish: callback, a PHP callback that is called after all files and directories have been copied.
      *
      * @return array the path directory and the URL that the asset is published as.
      * @throws InvalidParamException if the asset to be published does not exist.
@@ -452,6 +454,9 @@ class AssetManager extends Component
                 $opts['afterCopy'] = $this->afterCopy;
             }
             FileHelper::copyDirectory($src, $dstDir, $opts);
+            if (isset($options['afterPublish'])) {
+                call_user_func($options['afterPublish'], $this, $dstDir);
+            }
         }
 
         return [$dstDir, $this->baseUrl . '/' . $dir];


### PR DESCRIPTION
Addition of `afterPublish` callback, Will be called after all files and directories have been copied.

I needed this to simplify using CKEditor via bower with some custom plugins.
After CKEditor's files have been copied my custom plugins will be copied too.

e.g.

```
class CKEditorAsset extends \yii\web\AssetBundle
{
    public $sourcePath = '@vendor/bower/ckeditor';
    public $sourcePathExtra = '@common/widgets/ckeditor';
    ...
    public function init()
    {
        parent::init();
        $this->publishOptions['afterPublish'] = [$this, 'afterPublish'];
    }

    public function afterPublish($am, $dst)
    {
        \yii\helpers\FileHelper::copyDirectory(\Yii::getAlias($this->sourcePathExtra), $dst, [
            'dirMode' => $am->dirMode,
            'fileMode' => $am->fileMode,
        ]);
    }
}
```
