### PR TITLE
Update README directory structure [skip ci]

### DIFF
--- a/apps/advanced/README.md
+++ b/apps/advanced/README.md
@@ -19,21 +19,18 @@ common
 	config/				contains shared configurations
 	mail/				contains view files for e-mails
 	models/				contains model classes used in both backend and frontend
-	tests/				contains various tests for objects that are common among applications
 console
 	config/				contains console configurations
 	controllers/		contains console controllers (commands)
 	migrations/			contains database migrations
 	models/				contains console-specific model classes
 	runtime/			contains files generated during runtime
-	tests/				contains various tests for the console application
 backend
 	assets/				contains application assets such as JavaScript and CSS
 	config/				contains backend configurations
 	controllers/		contains Web controller classes
 	models/				contains backend-specific model classes
 	runtime/			contains files generated during runtime
-	tests/				contains various tests for the backend application
 	views/				contains view files for the Web application
 	web/				contains the entry script and Web resources
 frontend
@@ -42,11 +39,13 @@ frontend
 	controllers/		contains Web controller classes
 	models/				contains frontend-specific model classes
 	runtime/			contains files generated during runtime
-	tests/				contains various tests for the frontend application
 	views/				contains view files for the Web application
 	web/				contains the entry script and Web resources
+	widgets/			contains frontend widgets
 vendor/					contains dependent 3rd-party packages
 environments/			contains environment-based overrides
+tests					contains various tests for the advanced application
+	codeception/		contains tests developed with Codeception PHP Testing Framework
 ```
 
 


### PR DESCRIPTION
Something wrong with tabs  on diff preview. 
Looks fine in the file itself: https://github.com/SDKiller/yii2/blob/patch-1/apps/advanced/README.md
