### PR TITLE
Expand abnormally used ternary operator to if

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -120,7 +120,11 @@ class BaseArrayHelper
             $next = array_shift($args);
             foreach ($next as $k => $v) {
                 if (is_integer($k)) {
-                    isset($res[$k]) ? $res[] = $v : $res[$k] = $v;
+                    if (isset($res[$k])) {
+                        $res[] = $v;
+                    } else {
+                        $res[$k] = $v;
+                    }
                 } elseif (is_array($v) && isset($res[$k]) && is_array($res[$k])) {
                     $res[$k] = self::merge($res[$k], $v);
                 } else {


### PR DESCRIPTION
IMO constructs like these should be avoided for better clarity.
