### PR TITLE
added view options so that each client can have custom parameters.

### DIFF
--- a/extensions/authclient/AuthAction.php
+++ b/extensions/authclient/AuthAction.php
@@ -362,7 +362,7 @@ class AuthAction extends Action
                 return $this->redirectCancel();
             }
         } else {
-            $url = $client->buildAuthUrl();
+            $url = $client->buildAuthUrl($client->getViewOptions());
             return Yii::$app->getResponse()->redirect($url);
         }
     }


### PR DESCRIPTION
Not so sure if this is the best solution but I have trouble setting options for GoogleOAuth and Facebook clients.
e.g.
in my config I have 

```
'authClientCollection' => [
            'class' => 'yii\authclient\Collection',
            'clients' => [
                'google' => [
                    'class' => 'yii\authclient\clients\GoogleOAuth',
                    'clientId' => 'xxx',
                    'clientSecret' => 'xxx',
                    'viewOptions' => [
                        'prompt' => 'select_account'
                    ]
                ],
                'facebook' => [
                    'class' => 'yii\authclient\clients\Facebook',
                    'clientId' => 'xxx',
                    'clientSecret' => 'xxx',
                    'viewOptions' => [
                        'display' => 'popup'
                    ]
                ],
            ],
        ]
```

What I need is for the viewOptions to be set on the client as I want to force account selection for google and for facebook to open as a popup instead of full screen which gives an error that the screen is too small. I could not see a way to do this directly in the AuthChoice widget.
