### PR TITLE
Fixing wrong paths for RBAC PHPManager docs and comments

### DIFF
--- a/docs/guide/security-authorization.md
+++ b/docs/guide/security-authorization.md
@@ -202,8 +202,9 @@ return [
 
 The `authManager` can now be accessed via `\Yii::$app->authManager`.
 
-> Tip: By default, [[yii\rbac\PhpManager]] stores RBAC data in the file `@app/data/rbac.php`.
-  Sometime you need to create this file manually.
+> Tip: By default, [[yii\rbac\PhpManager]] stores RBAC data in three files: `@app/rbac/items.php`, `@app/rbac/assignments.php` and `@app/rbac/rules.php`.
+  Make sure these files are writable by the Web server process if the authorization needs to be changed online.
+  Sometimes you will need to create these files manually.
 
 
 ### Building Authorization Data
@@ -301,8 +302,9 @@ For applications that require complex access control with dynamically updated au
 (i.e. admin panel) may need to be developed using APIs offered by `authManager`.
 
 
-> Tip: By default, [[yii\rbac\PhpManager]] stores RBAC data in the file `@app/data/rbac.php`.
-  Sometimes when you want to make some minor changes to the RBAC data, you may directly edit this file.
+> Tip: By default, [[yii\rbac\PhpManager]] stores RBAC data in three files: `@app/rbac/items.php`, `@app/rbac/assignments.php` and `@app/rbac/rules.php`.
+  Make sure these files are writable by the Web server process if the authorization needs to be changed online.
+  Sometimes you will need to create these files manually.
 
 
 ### Using Rules

--- a/framework/rbac/PhpManager.php
+++ b/framework/rbac/PhpManager.php
@@ -16,8 +16,8 @@ use yii\helpers\VarDumper;
  * PhpManager represents an authorization manager that stores authorization
  * information in terms of a PHP script file.
  *
- * The authorization data will be saved to and loaded from a file
- * specified by [[authFile]], which defaults to 'protected/data/rbac.php'.
+ * The authorization data will be saved to and loaded from three files
+ * specified by [[itemFile]], [[assignmentFile]] and [[ruleFile]].
  *
  * PhpManager is mainly suitable for authorization data that is not too big
  * (for example, the authorization data for a personal blog system).


### PR DESCRIPTION
Fixing wrong docs in RBAC PHPManager and wrong paths in security-authorization.md
