### PR TITLE
Added encodeLabel param to \yii\grid\DataColumn

### DIFF
--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -50,6 +50,10 @@ class DataColumn extends Column
      */
     public $label;
     /**
+     * @var boolean whether the label should be HTML-encoded.
+     */
+    public $encodeLabel = true;
+    /**
      * @var string|\Closure an anonymous function that returns the value to be displayed for every data model.
      * The signature of this function is `function ($model, $key, $index, $column)`.
      * If this is not set, `$model[$attribute]` will be used to obtain the value.
@@ -128,9 +132,9 @@ class DataColumn extends Column
 
         if ($this->attribute !== null && $this->enableSorting &&
             ($sort = $provider->getSort()) !== false && $sort->hasAttribute($this->attribute)) {
-            return $sort->link($this->attribute, array_merge($this->sortLinkOptions, ['label' => Html::encode($label)]));
+            return $sort->link($this->attribute, array_merge($this->sortLinkOptions, ['label' => ($this->encodeLabel ? Html::encode($label) : $label)]));
         } else {
-            return Html::encode($label);
+            return $this->encodeLabel ? Html::encode($label) : $label;
         }
     }
 


### PR DESCRIPTION
Use case:

```
    echo GridView::widget([
        ...
        'columns' => [
            ...
            [
                'attribute' => 'created_at',
                'label' => '<span data-toggle="tooltip" class="glyphicon glyphicon-time" title="'.Yii::t('app', 'Created At').'"></span>',
                'encodeLabel' => false,
                ...
            ],
```
