### PR TITLE
Convert count() result to integer

### DIFF
--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -277,7 +277,7 @@ class Query extends Component implements QueryInterface
      */
     public function count($q = '*', $db = null)
     {
-        return $this->queryScalar("COUNT($q)", $db);
+        return (int)$this->queryScalar("COUNT($q)", $db);
     }
 
     /**


### PR DESCRIPTION
Type hint is set to `integer` but in fact it returns a string.
When a controller is exposed as REST service, I have to force converting each result of `count()` to integer, because client-side javascript is very picky about types of parameters.
