### PR TITLE
Fix Html::addCssStyle helper bug for array format

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1705,7 +1705,7 @@ class BaseHtml
             }
             $style = static::cssStyleFromArray(array_merge($oldStyle, $newStyle));
         }
-        $options['style'] = $style;
+        $options['style'] = is_array($style) ? static::cssStyleFromArray($style) : $style;
     }
 
     /**


### PR DESCRIPTION
Correct the `Html::addCssStyle` helper function to rightly detect the style parameter passed as array format.
