### PR TITLE
Allow yii\boostrap\ActiveField to customize the DIV and the LABEL tag around the checkboxList's inputs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,10 @@
         "yii2",
         "framework"
     ],
+    "config": {
+        "process-timeout": 3600
+    },
+
     "homepage": "http://www.yiiframework.com/",
     "type": "yii2-extension",
     "license": "BSD-3-Clause",
@@ -81,7 +85,7 @@
         "bower-asset/jquery": "2.1.*@stable | 1.11.*@stable",
         "bower-asset/jquery.inputmask": "3.1.*",
         "bower-asset/punycode": "1.3.*",
-        "bower-asset/yii2-pjax": "2.0.*",
+        "bower-asset/yii2-pjax": "v2.0.1",
         "bower-asset/bootstrap": "3.2.* | 3.1.*",
         "bower-asset/jquery-ui": "1.11.*@stable",
         "bower-asset/typeahead.js": "0.10.*"
@@ -89,7 +93,7 @@
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
         "twig/twig": "*",
-        "smarty/smarty": "*",
+        "smarty/smarty": "3.1.20",
         "imagine/imagine": "v0.5.0",
         "swiftmailer/swiftmailer": "*",
         "fzaninotto/faker": "*",

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,6 @@
         "yii2",
         "framework"
     ],
-    "config": {
-        "process-timeout": 3600
-    },
-
     "homepage": "http://www.yiiframework.com/",
     "type": "yii2-extension",
     "license": "BSD-3-Clause",
@@ -85,7 +81,7 @@
         "bower-asset/jquery": "2.1.*@stable | 1.11.*@stable",
         "bower-asset/jquery.inputmask": "3.1.*",
         "bower-asset/punycode": "1.3.*",
-        "bower-asset/yii2-pjax": "v2.0.1",
+        "bower-asset/yii2-pjax": "2.0.*",
         "bower-asset/bootstrap": "3.2.* | 3.1.*",
         "bower-asset/jquery-ui": "1.11.*@stable",
         "bower-asset/typeahead.js": "0.10.*"
@@ -93,7 +89,7 @@
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
         "twig/twig": "*",
-        "smarty/smarty": "3.1.20",
+        "smarty/smarty": "*",
         "imagine/imagine": "v0.5.0",
         "swiftmailer/swiftmailer": "*",
         "fzaninotto/faker": "*",

--- a/extensions/bootstrap/ActiveField.php
+++ b/extensions/bootstrap/ActiveField.php
@@ -286,9 +286,19 @@ class ActiveField extends \yii\widgets\ActiveField
                 ];
             }
         }  elseif (!isset($options['item'])) {
-            $options['item'] = function ($index, $label, $name, $checked, $value) {
-                return '<div class="radio">' . Html::radio($name, $checked, ['label' => $label, 'value' => $value]) . '</div>';
-            };
+            if(isset($options['itemOptions'])){
+                $options['item'] = function ($index, $label, $name, $checked, $value) use($options) {
+                    $containerOptions = isset($options['itemOptions']['containerOptions'])?$options['itemOptions']['containerOptions']:[];
+                    unset($options['itemOptions']['containerOptions']);
+                    return html::tag(
+                        'div', Html::radio($name, $checked, ['label' => $label, 'value' => $value]+$options['itemOptions']),
+                        $containerOptions);
+                };
+            } else{
+                $options['item'] = function ($index, $label, $name, $checked, $value) {
+                    return '<div class="radio">'    . Html::radio($name, $checked, ['label' => $label, 'value' => $value]) . '</div>';
+                };
+            }
         }
         parent::radioList($items, $options);
         return $this;

--- a/extensions/bootstrap/ActiveField.php
+++ b/extensions/bootstrap/ActiveField.php
@@ -250,9 +250,19 @@ class ActiveField extends \yii\widgets\ActiveField
                 ];
             }
         }  elseif (!isset($options['item'])) {
-            $options['item'] = function ($index, $label, $name, $checked, $value) {
-                return '<div class="checkbox">' . Html::checkbox($name, $checked, ['label' => $label, 'value' => $value]) . '</div>';
-            };
+            if(isset($options['itemOptions'])){
+                $options['item'] = function ($index, $label, $name, $checked, $value) use($options) {
+                    $containerOptions = isset($options['itemOptions']['containerOptions'])?$options['itemOptions']['containerOptions']:[];
+                    unset($options['itemOptions']['containerOptions']);
+                    return html::tag(
+                        'div', Html::checkbox($name, $checked, ['label' => $label, 'value' => $value]+$options['itemOptions']),
+                        $containerOptions);
+                };
+            } else{
+                $options['item'] = function ($index, $label, $name, $checked, $value) {
+                    return '<div class="checkbox">' . Html::checkbox($name, $checked, ['label' => $label, 'value' => $value]) . '</div>';
+                };
+            }
         }
         parent::checkboxList($items, $options);
         return $this;

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -110,6 +110,30 @@ class QueryBuilder extends \yii\base\Object
     }
 
     /**
+     * Generates a sub-join SQL statement from a [[SubJoin]] object.
+     * @param SubJoin $subJoin the [[SubJoin]] object from which the SQL statement will be generated.
+     * @param array $params the parameters to be bound to the generated SQL statement. These parameters will
+     * be included in the result with the additional parameters generated during the query building process.
+     * @return array the generated SQL statement (the first array element) and the corresponding
+     * parameters to be bound to the SQL statement (the second array element). The parameters returned
+     * include those provided in `$params`.
+     */
+    public function buildSubJoin($subJoin, $params = [])
+    {
+        $subJoin = $subJoin->prepare($this);
+
+        $params = empty($params) ? $subJoin->params : array_merge($params, $subJoin->params);
+
+        $clauses = [
+            $this->buildJoin($subJoin->join, $params),
+        ];
+
+        $sql = implode($this->separator, array_filter($clauses));
+
+        return [$sql, $params];
+    }
+
+    /**
      * Creates an INSERT SQL statement.
      * For example,
      *
@@ -701,7 +725,10 @@ class QueryBuilder extends \yii\base\Object
     private function quoteTableNames($tables, &$params)
     {
         foreach ($tables as $i => $table) {
-            if ($table instanceof Query) {
+            if ($table instanceof SubJoin) {
+                list($sql, $params) = $this->buildSubJoin($table, $params);
+                $tables[$i] = "($sql)";
+            } elseif ($table instanceof Query) {
                 list($sql, $params) = $this->build($table, $params);
                 $tables[$i] = "($sql) " . $this->db->quoteTableName($i);
             } elseif (is_string($i)) {

--- a/framework/db/SubJoin.php
+++ b/framework/db/SubJoin.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ivan
+ * Date: 2/6/15
+ * Time: 10:00 PM
+ */
+
+namespace yii\db;
+
+
+use Yii;
+use yii\base\Component;
+
+class SubJoin extends Query{
+
+    /**
+     * Creates a DB command that can be used to execute this query.
+     * @param Connection $db the database connection used to generate the SQL statement.
+     * If this parameter is not given, the `db` application component will be used.
+     * @return Command the created DB command instance.
+     */
+    public function createCommand($db = null)
+    {
+        if ($db === null) {
+            $db = Yii::$app->getDb();
+        }
+        list ($sql, $params) = $db->getQueryBuilder()->buildSubJoin($this);
+
+        return $db->createCommand($sql, $params);
+    }
+
+
+    public function subJoin($table, $params = [])
+    {
+        if(is_array($this->join) && count($this->join)>0){
+            throw new Exception('SubJoin could be only in first position');
+        }
+        $this->join[] = ['', $table];
+        return $this->addParams($params);
+    }
+
+}


### PR DESCRIPTION
If inline attribute is _false_ ( https://github.com/yiisoft/yii2/blob/master/extensions/bootstrap/ActiveField.php#97 ) there's no possibility to customize tags around input for the activeField checkboxList.
This patch allows to set the attributes even to DIV and to LABEL.

**How to use**

Inside _itemOptions_
add _containerOptions_ to set the DIV attributes 
and/or
add _labelOptions_ to set the LABEL attributes

```
\yii\bootstrap\ActiveForm::checkboxList(
    $check_box_array, [
        'class' => "outside-class",
        'itemOptions' => [
            'containerOptions' => [
                'class' => "div-wrapper-class",
            ],
            'labelOptions'     => [
                'class' => 'label-wrapper-class'
            ],
            'class' => 'input-tag-class',
        ]
    ]);
```

**The effects**
From this HTML

```
<div id="queryform-answermultiple" class="outside-class">
    <div class="checkbox">  // <-----------------------
        <label>   // <-----------------------
            <input type="checkbox" class="input-tag-class" name="QueryForm[answerMultiple][]" value="123">
        </label>
    </div>
    <div class="checkbox">
        <label>
            <input type="checkbox" class="input-tag-class" name="QueryForm[answerMultiple][]" value="456">
        </label>
    </div>
</div>
```

To this HTML

```
<div id="queryform-answermultiple" class="outside-class">
    <div class="div-wrapper-class">   // <-----------------------
        <label class="label-wrapper-class" >   // <-----------------------
            <input type="checkbox" class="input-tag-class" name="QueryForm[answerMultiple][]" value="414">
        </label>
    </div>
    <div class="div-wrapper-class">
        <label class="label-wrapper-class">
            <input type="checkbox" class="input-tag-class" name="QueryForm[answerMultiple][]" value="415">
        </label>
    </div>
</div>
```
