### PR TITLE
Update TimestampBehavior.php

### DIFF
--- a/framework/behaviors/TimestampBehavior.php
+++ b/framework/behaviors/TimestampBehavior.php
@@ -90,7 +90,7 @@ class TimestampBehavior extends AttributeBehavior
 
         if (empty($this->attributes)) {
             $this->attributes = [
-                BaseActiveRecord::EVENT_BEFORE_INSERT => [$this->createdAtAttribute, $this->updatedAtAttribute],
+                BaseActiveRecord::EVENT_BEFORE_INSERT => [$this->createdAtAttribute],
                 BaseActiveRecord::EVENT_BEFORE_UPDATE => $this->updatedAtAttribute,
             ];
         }


### PR DESCRIPTION
hi all..
if we want create new record, we only need to insert auto datetime to "created_at" only, and not to "updated_at" to. because we do not want to touch "updated_at", and let "updated_at" set to "0000-00-00 00:00:00". we do not want suddenly "updated_at" touched because indeed because it is new record and no one do update. so let update time alone. it is important to us. if in future we want create statistic what articles in latest update. we do not want in latest update list contains new record that actually never be update. sorry for my poor english. i just want to say that user do not want update time is filled when new record created. thank you :)
