### PR TITLE
Update BlameableBehavior.php

### DIFF
--- a/framework/behaviors/BlameableBehavior.php
+++ b/framework/behaviors/BlameableBehavior.php
@@ -87,7 +87,7 @@ class BlameableBehavior extends AttributeBehavior
 
         if (empty($this->attributes)) {
             $this->attributes = [
-                BaseActiveRecord::EVENT_BEFORE_INSERT => [$this->createdByAttribute, $this->updatedByAttribute],
+                BaseActiveRecord::EVENT_BEFORE_INSERT => [$this->createdByAttribute],
                 BaseActiveRecord::EVENT_BEFORE_UPDATE => $this->updatedByAttribute,
             ];
         }


### PR DESCRIPTION
if we create new record, we don want "update by" field filled by present user too. so, let update by alone. in reality, if we want create "latest updater list" then this new record creator should not appear in list. do you want listed as updater when you never do update thing? thank you :)
