### PR TITLE
Add Bootstrap dropdown-header functionality.

### DIFF
--- a/extensions/bootstrap/Dropdown.php
+++ b/extensions/bootstrap/Dropdown.php
@@ -85,8 +85,17 @@ class Dropdown extends Widget
             $options = ArrayHelper::getValue($item, 'options', []);
             $linkOptions = ArrayHelper::getValue($item, 'linkOptions', []);
             $linkOptions['tabindex'] = '-1';
-            $content = Html::a($label, ArrayHelper::getValue($item, 'url', '#'), $linkOptions);
-            if (!empty($item['items'])) {
+            $url = ArrayHelper::getValue($item, 'url', '#');
+            if (empty($item['items'])) {
+                if ($url == '#') {
+                    $content = $label;
+                    Html::addCssClass($options, 'dropdown-header');
+                } else {
+                    $content = Html::a($label, $url, $linkOptions);
+                }
+            } else {
+                unset($this->_containerOptions['id']);
+                $content = Html::a($label, $url, $linkOptions);
                 $content .= $this->renderItems($item['items']);
                 Html::addCssClass($options, 'dropdown-submenu');
             }


### PR DESCRIPTION
(This is a partial repeat of old PR #3366; leaving out the magic syntax portion for separators, including only the headers which is a _useful feature_ that adds no complexity.)

This change adds syntax support for Bootstrap Dropdown menu headers, and brings it in line with existing syntax.

The syntax is simply a menu item with no URL specified:

``` php
['label' => 'This is a header']
```

Menu headers can be used as a nicer alternative to simple separators, especially with some extra styling. Although headers can be created trivially with plain HTML (`<li class="dropdown-header">Header</li>`), it becomes non-trivial when you want to use them for dynamic menus. This code enhancement is necessary to enable the use of features like 'visible', which allows the creation of dynamic sectioned menus. Example: http://i.imgur.com/CPnFE3H.png (full disclosure: Image contains minor extra styling on the headers, primary difference is a bottom border).

Short example menu:

``` php
['label' => 'Forums', 'url' => ['/forum'], 'items' => [
    ['label' => 'Forums'], // header item; note lack of URL.
    ['label' => 'General Chat', 'url' => ['/forum/1']
    [...more menu items...]
    ['label' => 'Administrators Only', 'visible' => Yii::$app->user->checkAccess('manageForums')], // header item with 'visible' property
    ['label' => 'Check Reported Posts', 'url' => ['/forumadmin/reported'], 'visible' => Yii::$app->user->checkAccess('manageForums')],
    ['label' => 'Pending Moderated Posts', 'url' => ['/forumadmin/pending'], 'visible' => Yii::$app->user->checkAccess('manageForums')],
]]
```

I actually use this feature on my site in much more advanced manners than shown above. This is also similar to the syntax used by the Yiistrap, YiiBooster, and other Bootstrap extensions for Yii1.1, so it will be familiar to many. It is also very simple and easy to learn.
