### PR TITLE
Removed useless type check in yii\i18n\Formatter.

### DIFF
--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -9,6 +9,7 @@ namespace yii\i18n;
 
 use DateInterval;
 use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use IntlDateFormatter;
@@ -539,6 +540,10 @@ class Formatter extends Component
             }
             if ($formatter === null) {
                 throw new InvalidConfigException(intl_get_error_message());
+            }
+            // make IntlDateFormatter work with DateTimeImmutable
+            if ($timestamp instanceof DateTimeImmutable) {
+                $timestamp = new DateTime($timestamp->format(DateTime::ISO8601), $timestamp->getTimezone());
             }
             return $formatter->format($timestamp);
         } else {

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -557,7 +557,7 @@ class Formatter extends Component
     /**
      * Normalizes the given datetime value as a DateTime object that can be taken by various date/time formatting methods.
      *
-     * @param integer|string|DateTime $value the datetime value to be normalized. The following
+     * @param integer|string|DateTimeInterface $value the datetime value to be normalized. The following
      * types of value are supported:
      *
      * - an integer representing a UNIX timestamp
@@ -570,7 +570,7 @@ class Formatter extends Component
      */
     protected function normalizeDatetimeValue($value)
     {
-        if ($value === null || $value instanceof DateTime || $value instanceof DateTimeInterface) {
+        if ($value === null || $value instanceof DateTimeInterface) {
             // skip any processing
             return $value;
         }

--- a/tests/unit/framework/i18n/FormatterTest.php
+++ b/tests/unit/framework/i18n/FormatterTest.php
@@ -8,6 +8,7 @@ use Yii;
 use yiiunit\TestCase;
 use DateTime;
 use DateInterval;
+use DateTimeImmutable;
 
 /**
  * @group i18n
@@ -216,6 +217,10 @@ class FormatterTest extends TestCase
 
         // null display
         $this->assertSame($this->formatter->nullDisplay, $this->formatter->asDate(null));
+
+        // DateTimeImmutable input
+        $date = new DateTimeImmutable('now');
+        $this->assertSame($date->format('Y/m/d'), $this->formatter->asDatetime($date, 'php:Y/m/d'));
     }
 
     public function testIntlAsTime()
@@ -241,6 +246,9 @@ class FormatterTest extends TestCase
         $this->assertSame('12:00:00 AM', $this->formatter->asTime(false));
         // null display
         $this->assertSame($this->formatter->nullDisplay, $this->formatter->asTime(null));
+        // DateTimeImmutable input
+        $date = new DateTimeImmutable('now');
+        $this->assertSame($date->format('h:i:s A'), $this->formatter->asDatetime($date, 'php:h:i:s A'));
     }
 
     public function testIntlAsDatetime()
@@ -266,6 +274,9 @@ class FormatterTest extends TestCase
         $this->assertSame('Jan 1, 1970 12:00:00 AM', $this->formatter->asDatetime(false));
         // null display
         $this->assertSame($this->formatter->nullDisplay, $this->formatter->asDatetime(null));
+        // DateTimeImmutable input
+        $date = new DateTimeImmutable('now');
+        $this->assertSame($date->format('Y/m/d h:i:s A'), $this->formatter->asDatetime($date, 'php:Y/m/d h:i:s A'));
     }
 
     public function testIntlAsTimestamp()


### PR DESCRIPTION
DateTime class implements DateTimeInterface, so we don't need to check if variable is an instance of DateTime and check only for DateTimeInterface.
