### PR TITLE
Fixes #5610 - Allow `--generate` option for gii cli and overwrite existing files when --generate=1 and --interactive=0

### DIFF
--- a/extensions/gii/console/GenerateAction.php
+++ b/extensions/gii/console/GenerateAction.php
@@ -56,7 +56,7 @@ class GenerateAction extends \yii\base\Action
             return;
         }
         echo "The following files will be generated:\n";
-        $skipAll = $this->controller->interactive ? null : true;
+        $skipAll = $this->controller->interactive ? null : ($this->controller->generate ? false : true);
         $answers = [];
         foreach ($files as $file) {
             $path = $file->getRelativePath();

--- a/extensions/gii/console/GenerateController.php
+++ b/extensions/gii/console/GenerateController.php
@@ -119,16 +119,21 @@ class GenerateController extends Controller
      */
     public function options($id)
     {
+        $options = [];
         if (isset($this->generators[$id])) {
             $attributes = $this->generators[$id]->attributes;
             unset($attributes['templates']);
-            return array_merge(
+            $options = array_merge(
                 parent::options($id),
                 array_keys($attributes)
             );
         } else {
-            return parent::options($id);
+            $options = parent::options($id);
         }
+        return array_merge(
+            $options,
+            ['generate']
+        );
     }
 
     /**

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.1 under development
 -----------------------
 
+- Bug #5610: Allow `--generate` option for gii cli and overwrite existing files when --generate=1 and --interactive=0 (motin)
 - Enh #5600: Allow configuring debug panels in `yii\debug\Module::panels` as panel class name strings (qiangxue)
 - Bug #5584: `yii\rbac\DbRbacManager` should not delete items when deleting a rule on a database not supporting cascade update (mdmunir)
 


### PR DESCRIPTION
Fixes #5610 - Gii with --generate=1 is not available in cli and does not overwrite existing files as is claimed in the phpdoc

Testcase:
1. Set-up the basic app as instruction on https://github.com/yiisoft/yii2/blob/master/docs/internals/getting-started.md#getting-started-with-yii2-development
2. Add an empty database and adjust db credentials
3. Run the following commands:

```
$ ./yii migrate
Yii Migration Tool (based on Yii v2.0.1-dev)

Creating migration history table "migration"...done.
No new migration found. Your system is up-to-date.

$ ./yii gii/model --tableName=*
Running 'Model Generator'...

The following files will be generated:
        [new] models/Migration.php

Ready to generate the selected files? (yes|no) [yes]:

Files were generated successfully!
Generating code using template "/local/path/to/yii2-pr-base/extensions/gii/generators/model/default"...
 generated models/Migration.php
done!

$ ./yii gii/model --tableName=*
Running 'Model Generator'...

The following files will be generated:
  [unchanged] models/Migration.php

No files were chosen to be generated.

$ echo "a-change" >> models/Migration.php

$ ./yii gii/model --tableName=*
Running 'Model Generator'...

The following files will be generated:
    [changed] models/Migration.php
Do you want to overwrite this file? [y,n,ya,na,?]: ^C

$ ./yii gii/model --tableName=* --interactive=0
Running 'Model Generator'...

The following files will be generated:
    [changed] models/Migration.php

No files were chosen to be generated.

```

Without any of these commits, the following happens:

```
$ ./yii gii/model --tableName=* --interactive=0 --generate=1
Error: Unknown option: --generate
```

With [the first commit](https://github.com/motin/yii2/commit/80f4e46f5579df3aa94e67030f304d63fd31e10d) but without [the second commit](https://github.com/motin/yii2/commit/c7c855fc3321b2e9cdbd3d547b9bb1008748b756), the following happens:

```
$ ./yii gii/model --tableName=* --interactive=0 --generate=1
Running 'Model Generator'...

The following files will be generated:
    [changed] models/Migration.php

No files were chosen to be generated.
```

With the second commit, the desired behavior is achieved:

```

$ ./yii gii/model --tableName=* --interactive=0 --generate=1
Running 'Model Generator'...

The following files will be generated:
    [changed] models/Migration.php

Files were generated successfully!
Generating code using template "/local/path/to/yii2-pr-base/extensions/gii/generators/model/default"...
 overwrote models/Migration.php
done!
```

The same procedure for crud generation:

```
$ ./yii gii/crud --interactive=0 --generate=1 --modelClass=\\app\\models\\Migration --controllerClass=\\app\\controllers\\MigrationController
Running 'CRUD Generator'...

The following files will be generated:
        [new] controllers/MigrationController.php
        [new] views/migration/_form.php
        [new] views/migration/create.php
        [new] views/migration/index.php
        [new] views/migration/update.php
        [new] views/migration/view.php

Files were generated successfully!
Generating code using template "/local/path/to/yii2-pr-base/extensions/gii/generators/crud/default"...
 generated controllers/MigrationController.php
 generated views/migration/_form.php
 generated views/migration/create.php
 generated views/migration/index.php
 generated views/migration/update.php
 generated views/migration/view.php
done!

$ echo "a-change" >> controllers/MigrationController.php

$ ./yii gii/crud --interactive=0 --generate=1 --modelClass=\\app\\models\\Migration --controllerClass=\\app\\controllers\\MigrationController
Running 'CRUD Generator'...

The following files will be generated:
    [changed] controllers/MigrationController.php
  [unchanged] views/migration/_form.php
  [unchanged] views/migration/create.php
  [unchanged] views/migration/index.php
  [unchanged] views/migration/update.php
  [unchanged] views/migration/view.php

Files were generated successfully!
Generating code using template "/local/path/to/yii2-pr-base/extensions/gii/generators/crud/default"...
 overwrote controllers/MigrationController.php
   skipped views/migration/_form.php
   skipped views/migration/create.php
   skipped views/migration/index.php
   skipped views/migration/update.php
   skipped views/migration/view.php
done!

```
