### PR TITLE
Fix test failures

### DIFF
--- a/tests/unit/framework/db/QueryBuilderTest.php
+++ b/tests/unit/framework/db/QueryBuilderTest.php
@@ -434,7 +434,7 @@ class QueryBuilderTest extends DatabaseTestCase
             ->from('accounts')
             ->addSelect(['operations_count' => $subquery]);
         list ($sql, $params) = $this->getQueryBuilder()->build($query);
-        $expected = 'SELECT *, (SELECT COUNT(*) FROM `operations` WHERE account_id = accounts.id) AS `operations_count` FROM `accounts`';
+        $expected = 'SELECT *, (SELECT COUNT(*) FROM "operations" WHERE account_id = accounts.id) AS "operations_count" FROM "accounts"';
         $this->assertEquals($expected, $sql);
         $this->assertEmpty($params);
     }

--- a/tests/unit/framework/db/QueryBuilderTest.php
+++ b/tests/unit/framework/db/QueryBuilderTest.php
@@ -434,7 +434,10 @@ class QueryBuilderTest extends DatabaseTestCase
             ->from('accounts')
             ->addSelect(['operations_count' => $subquery]);
         list ($sql, $params) = $this->getQueryBuilder()->build($query);
-        $expected = 'SELECT *, (SELECT COUNT(*) FROM "operations" WHERE account_id = accounts.id) AS "operations_count" FROM "accounts"';
+        $expected = 'SELECT *, (SELECT COUNT(*) FROM `operations` WHERE account_id = accounts.id) AS `operations_count` FROM `accounts`';
+        if (!in_array($this->driverName, ['mssql', 'mysql', 'sqlite'])) {
+            $expected = str_replace('`', '"', $expected);
+        }
         $this->assertEquals($expected, $sql);
         $this->assertEmpty($params);
     }


### PR DESCRIPTION
https://travis-ci.org/yiisoft/yii2/jobs/38423752#L869

```
There were 2 failures:

1) yiiunit\framework\db\cubrid\CubridQueryBuilderTest::testSelectSubquery
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'SELECT *, (SELECT COUNT(*) FROM `operations` WHERE account_id = accounts.id) AS `operations_count` FROM `accounts`'
+'SELECT *, (SELECT COUNT(*) FROM "operations" WHERE account_id = accounts.id) AS "operations_count" FROM "accounts"'

/home/travis/build/yiisoft/yii2/tests/unit/framework/db/QueryBuilderTest.php:438
/home/travis/build/yiisoft/yii2/vendor/phpunit/phpunit/composer/bin/phpunit:63

2) yiiunit\framework\db\pgsql\PostgreSQLQueryBuilderTest::testSelectSubquery
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'SELECT *, (SELECT COUNT(*) FROM `operations` WHERE account_id = accounts.id) AS `operations_count` FROM `accounts`'
+'SELECT *, (SELECT COUNT(*) FROM "operations" WHERE account_id = accounts.id) AS "operations_count" FROM "accounts"'

/home/travis/build/yiisoft/yii2/tests/unit/framework/db/QueryBuilderTest.php:438
/home/travis/build/yiisoft/yii2/vendor/phpunit/phpunit/composer/bin/phpunit:63
```
