### PR TITLE
Added support for the array to the method hasErrors() of the \yii\base\Model

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Enh #5600: Allow configuring debug panels in `yii\debug\Module::panels` as panel class name strings (qiangxue)
 - Enh #5613: Added `--overwrite` option to Gii console command to support overwriting all files (motin, qiangxue)
 - Enh #5646: Call `yii\base\ErrorHandler::unregister()` instead of `restore_*_handlers` directly (aivus)
+- Enh: Added support for the array to the method hasErrors() of the \yii\base\Model class
 
 2.0.0 October 12, 2014
 ----------------------

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -489,12 +489,22 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
 
     /**
      * Returns a value indicating whether there is any validation error.
-     * @param string|null $attribute attribute name. Use null to check all attributes.
+     * @param string|array|null $attributes attribute name. Use null to check all attributes.
      * @return boolean whether there is any error.
      */
-    public function hasErrors($attribute = null)
+    public function hasErrors($attributes = null)
     {
-        return $attribute === null ? !empty($this->_errors) : isset($this->_errors[$attribute]);
+        if ($attributes === null) {
+            return !empty($this->_errors);
+        } else if(is_array($attributes)) {
+            foreach ($attributes as $attribute) {
+                if (isset($this->_errors[$attribute])) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return isset($this->_errors[$attributes]);
     }
 
     /**

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -489,7 +489,10 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
 
     /**
      * Returns a value indicating whether there is any validation error.
-     * @param string|array|null $attributes attribute name. Use null to check all attributes.
+     * @param string|array|null $attributes attribute name.
+     * Use null to check all attributes.
+     * Use string to check one attribute.
+     * Use array (eg ['first', 'second']) to check each attribute. Returns true if at least one attribute has an error.
      * @return boolean whether there is any error.
      */
     public function hasErrors($attributes = null)

--- a/tests/unit/framework/base/ModelTest.php
+++ b/tests/unit/framework/base/ModelTest.php
@@ -134,6 +134,7 @@ class ModelTest extends TestCase
 
         $this->assertFalse($speaker->hasErrors());
         $this->assertFalse($speaker->hasErrors('firstName'));
+        $this->assertFalse($speaker->hasErrors(['firstName', 'lastName']));
 
         $speaker->addError('firstName', 'Something is wrong!');
         $this->assertEquals(['firstName' => ['Something is wrong!']], $speaker->getErrors());
@@ -146,6 +147,7 @@ class ModelTest extends TestCase
         $this->assertTrue($speaker->hasErrors());
         $this->assertTrue($speaker->hasErrors('firstName'));
         $this->assertFalse($speaker->hasErrors('lastName'));
+        $this->assertTrue($speaker->hasErrors(['firstName', 'lastName']));
 
         $this->assertEquals(['firstName' => 'Something is wrong!'], $speaker->getFirstErrors());
         $this->assertEquals('Something is wrong!', $speaker->getFirstError('firstName'));


### PR DESCRIPTION
Made these changes, because is not the first time need them.
A simple example:
In the view, form is divided into blocks. If all the fields in the block are valid then the block is constricted.

``` php
//view
<div class="<?= $model->hasErrors(['first', 'second', 'third']) ? "open" : "close"; ?>">
</div>
```
