### PR TITLE
Revert "Use latest ES version for fix tests" when travis has updated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ matrix:
 services:
   - redis-server
   - memcached
+  - elasticsearch
   - mongodb
 
 # faster builds on new travis setup not using sudo
-# Disabled for install and use latest elasticsearch version
-# sudo: false
+sudo: false
 
 # cache vendor dirs
 cache:
@@ -35,10 +35,6 @@ cache:
 # try running against postgres 9.3
 addons:
   postgresql: "9.3"
-
-before_install:
-  - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.3.4.deb && sudo dpkg -i --force-confnew elasticsearch-1.3.4.deb
-  - sudo service elasticsearch start
 
 install:
   - composer self-update && composer --version


### PR DESCRIPTION
Reverts yiisoft/yii2#5660

**Merge only after https://github.com/travis-ci/travis-ci/issues/2884 has been merged and shipped**
