### PR TITLE
Re-initialize the generators in beforeAction

### DIFF
--- a/extensions/gii/Module.php
+++ b/extensions/gii/Module.php
@@ -112,8 +112,10 @@ class Module extends \yii\base\Module implements BootstrapInterface
             throw new ForbiddenHttpException('You are not allowed to access this page.');
         }
 
-        foreach (array_merge($this->coreGenerators(), $this->generators) as $id => $config) {
-            $this->generators[$id] = Yii::createObject($config);
+        if (is_array(current($this->generators))) {
+            foreach (array_merge($this->coreGenerators(), $this->generators) as $id => $config) {
+                $this->generators[$id] = Yii::createObject($config);
+            }
         }
 
         $this->resetGlobalSettings();

--- a/extensions/gii/Module.php
+++ b/extensions/gii/Module.php
@@ -112,7 +112,7 @@ class Module extends \yii\base\Module implements BootstrapInterface
             throw new ForbiddenHttpException('You are not allowed to access this page.');
         }
 
-        if (is_array(current($this->generators))) {
+        if (is_array(current($this->generators)) || $this->generators == []) {
             foreach (array_merge($this->coreGenerators(), $this->generators) as $id => $config) {
                 $this->generators[$id] = Yii::createObject($config);
             }


### PR DESCRIPTION
when we call gii module twice, there is an attempt to re-initialize the generators in beforeAction
bug example:

``` php
namespace console\controllers;

use yii\console\Controller;
class GenerateModelsController extends Controller {
    public function actionIndex() {
        $modelsList = [
            'common\modules\catalog\models\CarsMarks',
        ];
        foreach ($modelsList as $modelClass => $modelConfig) {
            if (is_string($modelConfig)) {
                $modelClass = $modelConfig;
                $modelConfig = [];
            }

            $classParts = explode('\\', $modelClass);
            $messageCategory = implode('.', $classParts);
            $defaultConfig = [
                'baseClass' => 'execut\yii\db\ActiveRecord',
                'enableI18N' => 1,
                'messageCategory' => $messageCategory,
                'modelClass' => $classParts[count($classParts) - 1],
                'ns' => implode('\\', array_splice($classParts, 0, count($classParts) - 1)) . '\base',
                'overwrite' => 1,
                'tableName' => \yii\helpers\Inflector::camel2id($classParts[0], '_'),
                'interactive' => 0,
            ];

            $config = array_merge($defaultConfig, $modelConfig);

            $this->run('gii/model', $config);
        }
    }
} 
```
