### PR TITLE
Replaced single quotes in comment

### DIFF
--- a/framework/widgets/Breadcrumbs.php
+++ b/framework/widgets/Breadcrumbs.php
@@ -29,7 +29,7 @@ use yii\helpers\Html;
  *         [
  *             'label' => 'Post Category',
  *             'url' => ['post-category/view', 'id' => 10],
- *             'template' => '<li><b>{link}</b></li>\n', // template for this link only
+ *             'template' => "<li><b>{link}</b></li>\n", // template for this link only
  *         ],
  *         ['label' => 'Sample Post', 'url' => ['post/edit', 'id' => 1]],
  *         'Edit',


### PR DESCRIPTION
The example given in the documentation shows a template with \n, while in single quotes. I replaced the single quotes with double quotes, such that the \n is actually replaced with a new line character. Without this fix '\n' is shown in the breadcrumbs when testing out the example.
