### PR TITLE
Added `visible` option to \yii\bootstrap\Tab widget items. Instead of `a...

### DIFF
--- a/extensions/bootstrap/Tabs.php
+++ b/extensions/bootstrap/Tabs.php
@@ -22,7 +22,8 @@ use yii\helpers\Html;
  *         [
  *             'label' => 'One',
  *             'content' => 'Anim pariatur cliche...',
- *             'active' => true
+ *             'active' => true,
+ *             'visible' => true
  *         ],
  *         [
  *             'label' => 'Two',
@@ -65,6 +66,7 @@ class Tabs extends Widget
      * - content: string, optional, the content (HTML) of the tab pane.
      * - options: array, optional, the HTML attributes of the tab pane container.
      * - active: boolean, optional, whether the item tab header and pane should be visible or not.
+     * - visible: boolean, optional, whether the item tab header and pane should be rendered or not.
      * - items: array, optional, can be used instead of `content` to specify a dropdown items
      *   configuration array. Each item can hold three extra keys, besides the above ones:
      *     * active: boolean, optional, whether the item tab header and pane should be visible or not.
@@ -139,6 +141,9 @@ class Tabs extends Widget
             if (!isset($item['label'])) {
                 throw new InvalidConfigException("The 'label' option is required.");
             }
+            if (isset($item['visible']) && !$item['visible']) {
+                continue;
+            }
             $encodeLabel = isset($item['encode']) ? $item['encode'] : $this->encodeLabels;
             $label = $encodeLabel ? Html::encode($item['label']) : $item['label'];
             $headerOptions = array_merge($this->headerOptions, ArrayHelper::getValue($item, 'headerOptions', []));
@@ -204,7 +209,7 @@ class Tabs extends Widget
         $itemActive = false;
 
         foreach ($items as $n => &$item) {
-            if (is_string($item)) {
+            if (is_string($item) || (isset($item['visible']) && !$item['visible'])) {
                 continue;
             }
             if (!isset($item['content'])) {


### PR DESCRIPTION
Added `visible` option to \yii\bootstrap\Tab widget items. Instead of `active` attribute it determines whether the item tab header and pane should be rendered or not.
