### PR TITLE
Fixes bug where resetPassword do not save new password in database

### DIFF
--- a/apps/advanced/frontend/models/ResetPasswordForm.php
+++ b/apps/advanced/frontend/models/ResetPasswordForm.php
@@ -56,7 +56,7 @@ class ResetPasswordForm extends Model
     public function resetPassword()
     {
         $user = $this->_user;
-        $user->password = $this->password;
+        $user->setPassword($this->password);
         $user->removePasswordResetToken();
 
         return $user->save();


### PR DESCRIPTION
Advanced template - ResetPasswordForm.php

resetPassword() method will not save users new password in database. I have fixed that.
