### PR TITLE
docs/guide corrections

### DIFF
--- a/docs/guide/start-looking-ahead.md
+++ b/docs/guide/start-looking-ahead.md
@@ -1,7 +1,7 @@
 Looking Ahead
 =============
 
-If you've read through the entire "Getting Started" section, you have now created a complete Yii application. In the process, you have learned how to implement some commonly
+If you've read through the entire "Getting Started" chapter, you have now created a complete Yii application. In the process, you have learned how to implement some commonly
 needed features, such as getting data from users via an HTML form, fetching data from a database, and
 displaying data in a paginated fashion. You have also learned how to use [Gii](tool-gii.md) to generate
 code automatically. Using Gii for code generation turns the bulk of your Web development process into a task as simple as just filling out some forms. 

--- a/docs/guide/structure-entry-scripts.md
+++ b/docs/guide/structure-entry-scripts.md
@@ -90,7 +90,7 @@ Entry scripts are the best place for defining global constants. Yii supports the
 * `YII_DEBUG`: specifies whether the application is running in debug mode. When in debug mode, an application
   will keep more log information, and will reveal detailed error call stacks if exceptions are thrown. For this
   reason, debug mode should be used mainly during development. The default value of `YII_DEBUG` is false.
-* `YII_ENV`: specifies which environment the application is running in. This has been described in
+* `YII_ENV`: specifies which environment the application is running in. This will be described in
   more detail in the [Configurations](concept-configurations.md#environment-constants) section.
   The default value of `YII_ENV` is `'prod'`, meaning the application is running in production environment.
 * `YII_ENABLE_ERROR_HANDLER`: specifies whether to enable the error handler provided by Yii. The default


### PR DESCRIPTION
1) "Getting started" is a "chapter" instead of a "section" in docs/guide/looking-ahead.md
2) In docs/guide/structure-entry-scripts, "concept" charter comes _after_ "structure" chapter, now.
