### PR TITLE
Allow to use attrs like 'tagName' in ButtonGroup->buttons configs

### DIFF
--- a/extensions/bootstrap/ButtonGroup.php
+++ b/extensions/bootstrap/ButtonGroup.php
@@ -7,7 +7,6 @@
 
 namespace yii\bootstrap;
 
-use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
 
 /**
@@ -81,14 +80,10 @@ class ButtonGroup extends Widget
         $buttons = [];
         foreach ($this->buttons as $button) {
             if (is_array($button)) {
-                $label = ArrayHelper::getValue($button, 'label');
-                $options = ArrayHelper::getValue($button, 'options');
-                $buttons[] = Button::widget([
-                    'label' => $label,
-                    'options' => $options,
-                    'encodeLabel' => $this->encodeLabels,
-                    'view' => $this->getView()
-                ]);
+                $button['view'] = $this->getView();
+                if (!isset($button['encodeLabel']))
+                    $button['encodeLabel'] = $this->encodeLabels;
+                $buttons[] = Button::widget($button);
             } else {
                 $buttons[] = $button;
             }


### PR DESCRIPTION
Pass all the button's config array to Button::widget() instead of creating new one item by item. Now allowed to pass in ButtonGroup button's configs any possible attributes(like tagName, encodeLabel, etc).
