### PR TITLE
Allow VerbFilter to respond to OPTIONS requests

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -29,6 +29,7 @@ Yii Framework 2 Change Log
 - Enh #5770: Added more PHP error names for `ErrorException` (mongosoft)
 - Enh #5806: Allow `Html::encode()` to be used when the application is not started (qiangxue)
 - Enh: `Console::confirm()` now uses `Console::stdout()` instead of `echo` to be consistent with all other functions (cebe)
+- Enh: `yii\filters\VerbFilter` is now able to respond to OPTIONS requests (cebe)
 - Chg #3630: `yii\db\Command::queryInternal()` is now protected (samdark) 
 - Chg #5508: Dropped the support for the `--append` option for the `fixture` command (qiangxue) 
 

--- a/framework/filters/VerbFilter.php
+++ b/framework/filters/VerbFilter.php
@@ -69,6 +69,12 @@ class VerbFilter extends Behavior
      * ~~~
      */
     public $actions = [];
+    /**
+     * @var boolean whether VerbFilter should respond to an HTTP OPTIONS request.
+     * If set to `true`, and the request is an OPTIONS request, it will be answered directly without invoking the action.
+     * Defaults to `false`.
+     */
+    public $respondToOptionsRequest = false;
 
 
     /**
@@ -98,6 +104,13 @@ class VerbFilter extends Behavior
 
         $verb = Yii::$app->getRequest()->getMethod();
         $allowed = array_map('strtoupper', $verbs);
+
+        // if the current request is an OPTIONS request, answer it with the available information
+        if ($this->respondToOptionsRequest && $verb === 'OPTIONS') {
+            Yii::$app->getResponse()->getHeaders()->set('Allow', implode(', ', $allowed));
+            return $event->isValid = false;
+        }
+
         if (!in_array($verb, $allowed)) {
             $event->isValid = false;
             // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.7


### PR DESCRIPTION
this allows using the information configured in VerbFilter without the need to
duplicate it in an action.
