### PR TITLE
Added missing russian translation for asRelativeTime() formatter

### DIFF
--- a/framework/messages/ru/yii.php
+++ b/framework/messages/ru/yii.php
@@ -85,6 +85,7 @@ return [
     'in {delta, plural, =1{a second} other{# seconds}}' => 'через {delta, plural, =1{секунду} one{# секунду} few{# секунды} many{# секунд} other{# секунды}}',
     'in {delta, plural, =1{a year} other{# years}}' => 'через {delta, plural, =1{год} one{# год} few{# года} many{# лет} other{# года}}',
     'in {delta, plural, =1{an hour} other{# hours}}' => 'через {delta, plural, =1{час} one{# час} few{# часа} many{# часов} other{# часа}}',
+    'just now' => 'прямо сейчас',
     'the input value' => 'введённое значение',
     '{attribute} "{value}" has already been taken.' => '{attribute} «{value}» уже занят.',
     '{attribute} cannot be blank.' => 'Необходимо заполнить «{attribute}».',


### PR DESCRIPTION
Функция:
https://github.com/yiisoft/yii2/blob/master/framework/i18n/Formatter.php#L644

Переводы:
https://github.com/yiisoft/yii2/blob/master/framework/messages/ru/yii.php

Всё переведено, а `just now` пропущено.

Эту фразу можно перевести как `сейчас` или `только что`, но вариант `прямо сейчас` одинаково хорошо смотрится как в прошедшем, так и в будущем времени:
- было опубликовано _прямо сейчас_;
- будет обновлено _прямо сейчас_.
