### PR TITLE
Added "submenu" property for "items" config in Menu widget

### DIFF
--- a/framework/widgets/Menu.php
+++ b/framework/widgets/Menu.php
@@ -68,6 +68,9 @@ class Menu extends Widget
      *   The token `{url}` will be replaced by the URL associated with this menu item,
      *   and the token `{label}` will be replaced by the label of the menu item.
      *   If this option is not set, [[linkTemplate]] or [[labelTemplate]] will be used instead.
+     * - submenu: string, optional, the template used to render the list of sub-menus.
+     *   The token `{items}` will be replaced with the renderer sub-menu items.
+     *   If this option is not set, [[submenuTemplate]] will be used instead.
      * - options: array, optional, the HTML attributes for the menu container tag.
      */
     public $items = [];
@@ -207,7 +210,8 @@ class Menu extends Widget
 
             $menu = $this->renderItem($item);
             if (!empty($item['items'])) {
-                $menu .= strtr($this->submenuTemplate, [
+                $submenuTemplate = ArrayHelper::getValue($item, 'submenu', $this->submenuTemplate);
+                $menu .= strtr($submenuTemplate, [
                     '{items}' => $this->renderItems($item['items']),
                 ]);
             }


### PR DESCRIPTION
Implementation of https://github.com/yiisoft/yii2/issues/5681.

Allowing to set a specific submenu template will be very helpful for generating menu with 3-4 sub-levels.
