### PR TITLE
Option to specify tag for pjax container

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -29,6 +29,7 @@ Yii Framework 2 Change Log
 - Enh #5735: Added `yii\bootstrap\Tabs::renderTabContent` to support manually rendering tab contents (RomeroMsk)
 - Enh #5770: Added more PHP error names for `ErrorException` (mongosoft)
 - Enh #5806: Allow `Html::encode()` to be used when the application is not started (qiangxue)
+- Enh #5902: Allow specifying of container tag for Pjax (Alex-Code)
 - Enh: `Console::confirm()` now uses `Console::stdout()` instead of `echo` to be consistent with all other functions (cebe)
 - Chg #3630: `yii\db\Command::queryInternal()` is now protected (samdark) 
 - Chg #5508: Dropped the support for the `--append` option for the `fixture` command (qiangxue)

--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -84,7 +84,10 @@ class Pjax extends Widget
      * [pjax project page](https://github.com/yiisoft/jquery-pjax) for available options.
      */
     public $clientOptions;
-
+    /**
+     * @var boolean whether to register the pjax events against the form and link selectors
+     */
+    public $registerEvents = true;
 
     /**
      * @inheritdoc
@@ -107,7 +110,9 @@ class Pjax extends Widget
                 echo Html::tag('title', Html::encode($view->title));
             }
         } else {
-            echo Html::beginTag('div', $this->options);
+            $options = $this->options;
+            $tag = ArrayHelper::remove($options, 'tag', 'div');
+            echo Html::beginTag($tag, $options);
         }
     }
 
@@ -117,7 +122,8 @@ class Pjax extends Widget
     public function run()
     {
         if (!$this->requiresPjax()) {
-            echo Html::endTag('div');
+            $tag = ArrayHelper::remove($this->options, 'tag', 'div');
+            echo Html::endTag($tag);
             $this->registerClientScript();
 
             return;
@@ -161,18 +167,21 @@ class Pjax extends Widget
      */
     public function registerClientScript()
     {
-        $id = $this->options['id'];
-        $this->clientOptions['push'] = $this->enablePushState;
-        $this->clientOptions['replace'] = $this->enableReplaceState;
-        $this->clientOptions['timeout'] = $this->timeout;
-        $this->clientOptions['scrollTo'] = $this->scrollTo;
-        $options = Json::encode($this->clientOptions);
-        $linkSelector = Json::encode($this->linkSelector !== null ? $this->linkSelector : '#' . $id . ' a');
-        $formSelector = Json::encode($this->formSelector !== null ? $this->formSelector : '#' . $id . ' form[data-pjax]');
         $view = $this->getView();
         PjaxAsset::register($view);
-        $js = "jQuery(document).pjax($linkSelector, \"#$id\", $options);";
-        $js .= "\njQuery(document).on('submit', $formSelector, function (event) {jQuery.pjax.submit(event, '#$id', $options);});";
-        $view->registerJs($js);
+        
+        if ($this->registerEvents) {
+            $id = $this->options['id'];
+            $this->clientOptions['push'] = $this->enablePushState;
+            $this->clientOptions['replace'] = $this->enableReplaceState;
+            $this->clientOptions['timeout'] = $this->timeout;
+            $this->clientOptions['scrollTo'] = $this->scrollTo;
+            $options = Json::encode($this->clientOptions);
+            $linkSelector = Json::encode($this->linkSelector !== null ? $this->linkSelector : '#' . $id . ' a');
+            $formSelector = Json::encode($this->formSelector !== null ? $this->formSelector : '#' . $id . ' form[data-pjax]');
+            $js = "jQuery(document).pjax($linkSelector, \"#$id\", $options);";
+            $js .= "\njQuery(document).on('submit', $formSelector, function (event) {jQuery.pjax.submit(event, '#$id', $options);});";
+            $view->registerJs($js);
+        }
     }
 }

--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -44,7 +44,10 @@ use yii\web\Response;
 class Pjax extends Widget
 {
     /**
-     * @var array the HTML attributes for the widget container tag.
+     * @var array the HTML attributes for the widget container tag. The following special options are recognized:
+     *
+     * - tag: string, defaults to "div", the tag name of the item container tags.
+     *
      * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
      */
     public $options = [];
@@ -84,11 +87,7 @@ class Pjax extends Widget
      * [pjax project page](https://github.com/yiisoft/jquery-pjax) for available options.
      */
     public $clientOptions;
-    /**
-     * @var boolean whether to register the pjax events against the form and link selectors
-     */
-    public $registerEvents = true;
-
+    
     /**
      * @inheritdoc
      */
@@ -167,21 +166,18 @@ class Pjax extends Widget
      */
     public function registerClientScript()
     {
+        $id = $this->options['id'];
+        $this->clientOptions['push'] = $this->enablePushState;
+        $this->clientOptions['replace'] = $this->enableReplaceState;
+        $this->clientOptions['timeout'] = $this->timeout;
+        $this->clientOptions['scrollTo'] = $this->scrollTo;
+        $options = Json::encode($this->clientOptions);
+        $linkSelector = Json::encode($this->linkSelector !== null ? $this->linkSelector : '#' . $id . ' a');
+        $formSelector = Json::encode($this->formSelector !== null ? $this->formSelector : '#' . $id . ' form[data-pjax]');
+        $js = "jQuery(document).pjax($linkSelector, \"#$id\", $options);";
+        $js .= "\njQuery(document).on('submit', $formSelector, function (event) {jQuery.pjax.submit(event, '#$id', $options);});";
         $view = $this->getView();
         PjaxAsset::register($view);
-        
-        if ($this->registerEvents) {
-            $id = $this->options['id'];
-            $this->clientOptions['push'] = $this->enablePushState;
-            $this->clientOptions['replace'] = $this->enableReplaceState;
-            $this->clientOptions['timeout'] = $this->timeout;
-            $this->clientOptions['scrollTo'] = $this->scrollTo;
-            $options = Json::encode($this->clientOptions);
-            $linkSelector = Json::encode($this->linkSelector !== null ? $this->linkSelector : '#' . $id . ' a');
-            $formSelector = Json::encode($this->formSelector !== null ? $this->formSelector : '#' . $id . ' form[data-pjax]');
-            $js = "jQuery(document).pjax($linkSelector, \"#$id\", $options);";
-            $js .= "\njQuery(document).on('submit', $formSelector, function (event) {jQuery.pjax.submit(event, '#$id', $options);});";
-            $view->registerJs($js);
-        }
+        $view->registerJs($js);
     }
 }


### PR DESCRIPTION
Allow the specifying of the container tag, defaults to `<div/>`.
Optional registering of Pjax events against the link and form selectors.

I needed to use Pjax in a table so the option to specify the container as a `<tbody/>` was needed.
I'm also using `$.pjax.reload(...)` so the JavaScript the widget registered wasn't needed.
