### PR TITLE
fixed fixture controller config for applications

### DIFF
--- a/apps/advanced/tests/codeception/bin/yii
+++ b/apps/advanced/tests/codeception/bin/yii
@@ -22,6 +22,7 @@ $config = yii\helpers\ArrayHelper::merge(
                 'class' => 'yii\faker\FixtureController',
                 'fixtureDataPath' => '@tests/codeception/common/fixtures/data',
                 'templatePath' => '@tests/codeception/common/templates/fixtures',
+                'namespace' => 'tests\codeception\common\fixtures'
             ],
         ],
     ]

--- a/apps/basic/tests/codeception/bin/yii
+++ b/apps/basic/tests/codeception/bin/yii
@@ -18,7 +18,8 @@ $config = yii\helpers\ArrayHelper::merge(
             'fixture' => [
                 'class' => 'yii\faker\FixtureController',
                 'fixtureDataPath' => '@tests/codeception/fixtures',
-                'templatePath' => '@tests/codeception/templates'
+                'templatePath' => '@tests/codeception/templates',
+                'namespace' => 'tests\codeception\fixtures',
             ],
         ],
     ]


### PR DESCRIPTION
Fixed fixture controller config in `Yii2` application templates , so they now correctly points to default location of fixture class file so fixtures can be loaded 

@samdark review this one when you will have time 
