### PR TITLE
Fix for #5619: log message is duplicated for 'flushInterval' = 1 and 'exportInterval' = 1

### DIFF
--- a/framework/log/Logger.php
+++ b/framework/log/Logger.php
@@ -162,10 +162,11 @@ class Logger extends Component
      */
     public function flush($final = false)
     {
+        $messages = $this->messages;
+        $this->messages = []; // prevent processing same message twice in case flush is invoked during dispatching
         if ($this->dispatcher instanceof Dispatcher) {
-            $this->dispatcher->dispatch($this->messages, $final);
+            $this->dispatcher->dispatch($messages, $final);
         }
-        $this->messages = [];
     }
 
     /**


### PR DESCRIPTION
Fix for #5619: log message is duplicated for 'flushInterval' = 1 and 'exportInterval' = 1

`yii\log\Logger::flush()` updated to reset messages before passing them to the dispatcher. This prevents same message to be processed twice.
Due to PHP internal optimization extra copy of `$this->messages` does not incease the memory usage, so it should be all fine.
