### PR TITLE
fix View::registerAssetBundle() to handle root namespaces properly

### DIFF
--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -279,6 +279,7 @@ class View extends \yii\base\View
      */
     public function registerAssetBundle($name, $position = null)
     {
+        $name = ltrim($name, '\\');
         if (!isset($this->assetBundles[$name])) {
             $am = $this->getAssetManager();
             $bundle = $am->getBundle($name);


### PR DESCRIPTION
It was possible to register the same asset bundle multiple times using fully qualified name (with root namespace) declaration.
Steps to reproduce:
- Create a view file with following contents:
  AppAsset::register($this);
  $this->registerJsFile('js/some.js', ['depends' => '\site\assets\AppAsset']);
- Check your View::assetBundles property in debugger. You will see asset be registered twice:
  [
    '\site\assets\AppAsset' => ...,
    'site\assets\AppAsset' => ...,
  ]
  If you don't compile yours assets it's a minor problem, but it cause a lot of problems if you overload assetmanager config with compressed asset configuration 
