### PR TITLE
docs/guide/runtime-bootstrapping.md - OPCache instead of APC [ci skip]

### DIFF
--- a/docs/guide/runtime-bootstrapping.md
+++ b/docs/guide/runtime-bootstrapping.md
@@ -34,7 +34,7 @@ needs to register additional URL parsing rules, it should be listed in the
 [bootstrap property](structure-applications.md#bootstrap) so that the new URL rules can take effect
 before they are used to resolve requests.
 
-In production mode, enable bytecode cache, such as APC, to minimize the time needed for including
+In production mode, enable bytecode cache, such as OPCache, to minimize the time needed for including
 and parsing PHP files.
 
 Some large applications have very complex application [configurations](concept-configurations.md)


### PR DESCRIPTION
OPCache instead of APC might be the standard choice for byte code cache now.
