### PR TITLE
fix oci batchInsert

### DIFF
--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -159,4 +159,43 @@ EOD;
 
         return $sql;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function batchInsert($table, $columns, $rows)
+    {
+        $schema = $this->db->getSchema();
+        if (($tableSchema = $schema->getTableSchema($table)) !== null) {
+            $columnSchemas = $tableSchema->columns;
+        } else {
+            $columnSchemas = [];
+        }
+
+        $values = [];
+        foreach ($rows as $row) {
+            $vs = [];
+            foreach ($row as $i => $value) {
+                if (!is_array($value) && isset($columns[$i]) && isset($columnSchemas[$columns[$i]])) {
+                    $value = $columnSchemas[$columns[$i]]->dbTypecast($value);
+                }
+                if (is_string($value)) {
+                    $value = $schema->quoteValue($value);
+                } elseif ($value === false) {
+                    $value = 0;
+                } elseif ($value === null) {
+                    $value = 'NULL';
+                }
+                $vs[] = $value;
+            }
+            $values[] = 'SELECT ' . implode(', ', $vs) . ' FROM DUAL';
+        }
+
+        foreach ($columns as $i => $name) {
+            $columns[$i] = $schema->quoteColumnName($name);
+        }
+
+        return 'INSERT INTO ' . $schema->quoteTableName($table)
+        . ' (' . implode(', ', $columns) . ') ' . implode(' UNION ', $values);
+    }
 }


### PR DESCRIPTION
default batchInsert sql is

```
insert into  tableName(col1, col2, col3...) value(`col11`, `col12`,`col13`.... ),(`col21`, `col22`,`col23`.... );
```

which is illegal in oracle db. Change it to

```
insert into tableName(col1, col2, col3...)
  select 'col11', 'col12', 'col13' from dual union
  select 'col21', 'col22', 'col23' from dual union
  select 'col31', 'col32', 'col33' from dual;
```
