### PR TITLE
fix oci schema type errors

### DIFF
--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -213,6 +213,8 @@ EOD;
         $this->extractColumnType($c, $column['DATA_TYPE']);
         $this->extractColumnSize($c, $column['DATA_TYPE']);
 
+        $c->phpType = $this->getColumnPhpType($c);
+
         if (!$c->isPrimaryKey) {
             if (stripos($column['DATA_DEFAULT'], 'timestamp') !== false) {
                 $c->defaultValue = null;
@@ -302,6 +304,10 @@ EOD;
             } else {
                 $column->type = 'double';
             }
+        } elseif (strpos($dbType, 'BLOB') !== false) {
+            $column->type = 'binary';
+        } elseif (strpos($dbType, 'CLOB') !== false) {
+            $column->type = 'text';
         } else {
             $column->type = 'string';
         }


### PR DESCRIPTION
when oci creates ColumnSchema, it forgot to get column php type, and the implement of `extractColumnType` is incomplete, must add common used CLOB and BLOB type
