### PR TITLE
Fix rbac db manager errors

### DIFF
--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -584,7 +584,7 @@ class DbManager extends BaseManager
         $query = (new Query)
             ->select(['name', 'type', 'description', 'rule_name', 'data', 'created_at', 'updated_at'])
             ->from([$this->itemTable, $this->itemChildTable])
-            ->where(['parent' => $name, 'name' => new Expression('child')]);
+            ->where(['parent' => $name, 'name' => new Expression('[[child]]')]);
 
         $children = [];
         foreach ($query->all($this->db) as $row) {


### PR DESCRIPTION
If not quoted `child` column, the error occurs in oracle db:

```
Exception 'yii\db\Exception' with message 'SQLSTATE[HY000]: General error: 904 OCIStmtExecute: ORA-00904: "CHILD": invalid identifier
 (/Users/wenbin/Desktop/pdo_oci/oci_statement.c:148)
The SQL being executed was: SELECT "name", "type", "description", "rule_name", "data", "created_at", "updated_at" FROM "auth_item", "auth_item_child" WHERE ("parent"='create_entry') AND ("name"=child)'

in /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/db/Schema.php:532

Error Info:
Array
(
    [0] => HY000
    [1] => 904
    [2] => OCIStmtExecute: ORA-00904: "CHILD": invalid identifier
 (/Users/wenbin/Desktop/pdo_oci/oci_statement.c:148)
)

Stack trace:
#0 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/db/Command.php(834): yii\db\Schema->convertException(Object(PDOException), 'SELECT "name", ...')
#1 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/db/Command.php(350): yii\db\Command->queryInternal('fetchAll', NULL)
#2 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/db/Query.php(206): yii\db\Command->queryAll()
#3 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/rbac/DbManager.php(590): yii\db\Query->all(Object(yii\db\Connection))
#4 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/rbac/DbManager.php(608): yii\rbac\DbManager->getChildren('create_entry')
#5 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/rbac/DbManager.php(537): yii\rbac\DbManager->detectLoop(Object(yii\rbac\Role), Object(yii\rbac\Permission))
#6 /Users/wenbin/Sites/genDBase/server/console/controllers/RbacController.php(199): yii\rbac\DbManager->addChild(Object(yii\rbac\Role), Object(yii\rbac\Permission))
#7 /Users/wenbin/Sites/genDBase/server/console/controllers/RbacController.php(63): console\controllers\RbacController->addDefaultRoles()
#8 [internal function]: console\controllers\RbacController->actionInit()
#9 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/base/InlineAction.php(55): call_user_func_array(Array, Array)
#10 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/base/Controller.php(151): yii\base\InlineAction->runWithParams(Array)
#11 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/console/Controller.php(91): yii\base\Controller->runAction('init', Array)
#12 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/base/Module.php(455): yii\console\Controller->runAction('init', Array)
#13 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/console/Application.php(161): yii\base\Module->runAction('rbac/init', Array)
#14 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/console/Application.php(137): yii\console\Application->runAction('rbac/init', Array)
#15 /Users/wenbin/Sites/genDBase/server/vendor/yiisoft/yii2/base/Application.php(375): yii\console\Application->handleRequest(Object(yii\console\Request))
#16 /Users/wenbin/Sites/genDBase/server/yii(30): yii\base\Application->run()
#17 {main}
```
