### PR TITLE
fix phpTypecast bugs

### DIFF
--- a/framework/db/ColumnSchema.php
+++ b/framework/db/ColumnSchema.php
@@ -95,8 +95,9 @@ class ColumnSchema extends Object
         }
         switch ($this->phpType) {
             case 'resource':
-            case 'string':
                 return is_resource($value) ? $value : (string) $value;
+            case 'string':
+                return is_resource($value) ? stream_get_contents($value) : (string) $value;
             case 'integer':
                 return (int) $value;
             case 'boolean':


### PR DESCRIPTION
if phpType is string and value type is resource, we must use `stream_get_contents` to cast value to string, instead of return the resource handle.
