### PR TITLE
Make logging available for unit tests

### DIFF
--- a/apps/advanced/backend/config/main.php
+++ b/apps/advanced/backend/config/main.php
@@ -10,21 +10,11 @@ return [
     'id' => 'app-backend',
     'basePath' => dirname(__DIR__),
     'controllerNamespace' => 'backend\controllers',
-    'bootstrap' => ['log'],
     'modules' => [],
     'components' => [
         'user' => [
             'identityClass' => 'common\models\User',
             'enableAutoLogin' => true,
-        ],
-        'log' => [
-            'traceLevel' => YII_DEBUG ? 3 : 0,
-            'targets' => [
-                [
-                    'class' => 'yii\log\FileTarget',
-                    'levels' => ['error', 'warning'],
-                ],
-            ],
         ],
         'errorHandler' => [
             'errorAction' => 'site/error',

--- a/apps/advanced/common/config/main.php
+++ b/apps/advanced/common/config/main.php
@@ -1,7 +1,17 @@
 <?php
 return [
     'vendorPath' => dirname(dirname(__DIR__)) . '/vendor',
+    'bootstrap' => ['log'],
     'components' => [
+        'log' => [
+            'traceLevel' => YII_DEBUG ? 3 : 0,
+            'targets' => [
+                [
+                    'class' => 'yii\log\FileTarget',
+                    'levels' => ['error', 'warning'],
+                ],
+            ],
+        ],
         'cache' => [
             'class' => 'yii\caching\FileCache',
         ],

--- a/apps/advanced/common/runtime/.gitignore
+++ b/apps/advanced/common/runtime/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/apps/advanced/console/config/main.php
+++ b/apps/advanced/console/config/main.php
@@ -9,20 +9,10 @@ $params = array_merge(
 return [
     'id' => 'app-console',
     'basePath' => dirname(__DIR__),
-    'bootstrap' => ['log', 'gii'],
+    'bootstrap' => ['gii'],
     'controllerNamespace' => 'console\controllers',
     'modules' => [
         'gii' => 'yii\gii\Module',
-    ],
-    'components' => [
-        'log' => [
-            'targets' => [
-                [
-                    'class' => 'yii\log\FileTarget',
-                    'levels' => ['error', 'warning'],
-                ],
-            ],
-        ],
     ],
     'params' => $params,
 ];

--- a/apps/advanced/frontend/config/main.php
+++ b/apps/advanced/frontend/config/main.php
@@ -9,21 +9,11 @@ $params = array_merge(
 return [
     'id' => 'app-frontend',
     'basePath' => dirname(__DIR__),
-    'bootstrap' => ['log'],
     'controllerNamespace' => 'frontend\controllers',
     'components' => [
         'user' => [
             'identityClass' => 'common\models\User',
             'enableAutoLogin' => true,
-        ],
-        'log' => [
-            'traceLevel' => YII_DEBUG ? 3 : 0,
-            'targets' => [
-                [
-                    'class' => 'yii\log\FileTarget',
-                    'levels' => ['error', 'warning'],
-                ],
-            ],
         ],
         'errorHandler' => [
             'errorAction' => 'site/error',

--- a/apps/advanced/tests/codeception/config/common/unit.php
+++ b/apps/advanced/tests/codeception/config/common/unit.php
@@ -9,6 +9,6 @@ return yii\helpers\ArrayHelper::merge(
     require(dirname(__DIR__) . '/unit.php'),
     [
         'id' => 'app-common',
-        'basePath' => dirname(__DIR__),
+        'basePath' => YII_APP_BASE_PATH. '/common',
     ]
 );

--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -266,6 +266,10 @@ abstract class Target extends Component
             return call_user_func($this->prefix, $message);
         }
 
+        if (!Yii::$app) {
+            return '';
+        }
+        
         $request = Yii::$app->getRequest();
         $ip = $request instanceof Request ? $request->getUserIP() : '-';
 


### PR DESCRIPTION
This fix allows to write logs from unit tests.

Logger config moved to upper level in case of being available to unit tests for common classes.
