### PR TITLE
Added `yii\grid\DataColumn::items`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -54,6 +54,7 @@ Yii Framework 2 Change Log
 - Enh: `Console::confirm()` now uses `Console::stdout()` instead of `echo` to be consistent with all other functions (cebe)
 - Enh: `yii\rbac\DbManager` migration now uses database component specified in component settings instead of always using default `db` (samdark)
 - Enh: Added `yii\base\Controller::renderContent()` (qiangxue)
+- Enh: Added `yii\grid\DataColumn::items` to support rendering label of values (leandrogehlen)
 - Chg #3630: `yii\db\Command::queryInternal()` is now protected (samdark) 
 - Chg #5508: Dropped the support for the `--append` option for the `fixture` command (qiangxue)
 - Chg #5874: Upgraded Twitter Bootstrap to 3.3.x (samdark)

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -66,6 +66,11 @@ class DataColumn extends Column
      */
     public $value;
     /**
+     * @var array the option data items.
+     * The array keys are option values, and the array values are the corresponding option labels.
+     */
+    public $items = [];
+    /**
      * @var string|array in which format should the value of each data model be displayed as (e.g. `"raw"`, `"text"`, `"html"`,
      * `['date', 'php:Y-m-d']`). Supported formats are determined by the [[GridView::formatter|formatter]] used by
      * the [[GridView]]. Default format is "text" which will format the value as an HTML-encoded plain text when
@@ -185,7 +190,12 @@ class DataColumn extends Column
                 return call_user_func($this->value, $model, $key, $index, $this);
             }
         } elseif ($this->attribute !== null) {
-            return ArrayHelper::getValue($model, $this->attribute);
+            $value = ArrayHelper::getValue($model, $this->attribute);
+            if (ArrayHelper::keyExists($value, $this->items)) {
+                return $this->items[$value];
+            } else {
+                return $value;
+            }
         }
         return null;
     }


### PR DESCRIPTION
Allow  rendering label of values.

Example:

``` php
/**
* @property integer $id
* @property string $username
* @property string $password
* @property integer $status
*/
class User extends ActiveRecord {

     const STATUS_INACTIVE = 0;
     const STATUS_ACTIVE = 1;  

}

// in view/user/index.php

<?= GridView::widget([
       'dataProvider' => $userProvider,
        'columns' => [
            'username',
            [
                'attribute' => 'status',
                'items' => [
                    User::STATUS_ACTIVE => 'Active', 
                    User::STATUS_INACTIVE => 'Inactive'
                ]                
            ],
        ]
]); ?>
```
