### PR TITLE
Changed signature of yii\web\UrlRuleInterface::createUrl() - pass `$params` by reference

### DIFF
--- a/framework/rest/UrlRule.php
+++ b/framework/rest/UrlRule.php
@@ -234,7 +234,7 @@ class UrlRule extends CompositeUrlRule
     /**
      * @inheritdoc
      */
-    public function createUrl($manager, $route, $params)
+    public function createUrl($manager, $route, &$params)
     {
         foreach ($this->controller as $urlName => $controller) {
             if (strpos($route, $controller) !== false) {

--- a/framework/web/CompositeUrlRule.php
+++ b/framework/web/CompositeUrlRule.php
@@ -60,7 +60,7 @@ abstract class CompositeUrlRule extends Object implements UrlRuleInterface
     /**
      * @inheritdoc
      */
-    public function createUrl($manager, $route, $params)
+    public function createUrl($manager, $route, &$params)
     {
         foreach ($this->rules as $rule) {
             /* @var $rule \yii\web\UrlRule */

--- a/framework/web/GroupUrlRule.php
+++ b/framework/web/GroupUrlRule.php
@@ -127,7 +127,7 @@ class GroupUrlRule extends CompositeUrlRule
     /**
      * @inheritdoc
      */
-    public function createUrl($manager, $route, $params)
+    public function createUrl($manager, $route, &$params)
     {
         if ($this->routePrefix === '' || strpos($route, $this->routePrefix . '/') === 0) {
             return parent::createUrl($manager, $route, $params);

--- a/framework/web/UrlRule.php
+++ b/framework/web/UrlRule.php
@@ -270,7 +270,7 @@ class UrlRule extends Object implements UrlRuleInterface
      * @param array $params the parameters
      * @return string|boolean the created URL, or false if this rule cannot be used for creating this URL.
      */
-    public function createUrl($manager, $route, $params)
+    public function createUrl($manager, $route, &$params)
     {
         if ($this->mode === self::PARSING_ONLY) {
             return false;

--- a/framework/web/UrlRuleInterface.php
+++ b/framework/web/UrlRuleInterface.php
@@ -30,5 +30,5 @@ interface UrlRuleInterface
      * @param array $params the parameters
      * @return string|boolean the created URL, or false if this rule cannot be used for creating this URL.
      */
-    public function createUrl($manager, $route, $params);
+    public function createUrl($manager, $route, &$params);
 }


### PR DESCRIPTION
Now it is not possible to change signature of custom `urlRule::createUrl()` to pass `$params` by reference because:

```
Declaration of common\components\CatalogUrlRule::createUrl() must be compatible with yii\web\UrlRuleInterface::createUrl($manager, $route, $params)
```

With your custom `urlRule` you may pass special `$params` to build pretty url, some of which you may need to unset before you return result to `UrlManager` - because if custom rule was not satisfied for some reason you don't want this params to be passed by `UrlManager` to `http_build_query()`  ( https://github.com/yiisoft/yii2/blob/master/framework/web/UrlManager.php#L329 ).

Use case: to build seo-links you want pass `Products` and `Category` objects to you custom `urlRule::createUrl()` (to avoid in `urlRule` duplicate database trips to retrieve data you already have).
After creating url you need to unset this objects.

Example:

```
catalog/product/view?category[path]=tele-video-audio%2F010-televizory-ot-15-do-28
```

Here `category[path]=tele-video-audio%2F010-televizory-ot-15-do-28` was part of `Category` object and `UrlManager` passed it to `http_build_query()` after custom rule was not satisfied.

Note: BC-breaking changes
