### PR TITLE
Update runtime-routing.md

### DIFF
--- a/docs/guide/runtime-routing.md
+++ b/docs/guide/runtime-routing.md
@@ -578,19 +578,11 @@ We can create the following URL rule class to solve this problem.
 ```php
 namespace app\components;
 
-use yii\web\UrlRule;
+use yii\web\UrlRuleInterface;
+use yii\base\Object;
 
-class CarUrlRule extends UrlRule
+class CarUrlRule extends Object implements UrlRuleInterface
 {
-    public $db = 'db';
-
-    public function init()
-    {
-        parent::init();
-        if ($this->name === null) {
-            $this->name = __CLASS__;
-        }
-    }
 
     public function createUrl($manager, $route, $params)
     {


### PR DESCRIPTION
If CarUrlRule extends UrlRule need define two parameters $pattern and $route which is not used.
But it would be more correct to implement the interface UrlRuleInterface.
