### PR TITLE
hotfix: Query->count() returns value of integer type

### DIFF
--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -277,7 +277,7 @@ class Query extends Component implements QueryInterface
      */
     public function count($q = '*', $db = null)
     {
-        return $this->queryScalar("COUNT($q)", $db);
+        return (integer)$this->queryScalar("COUNT($q)", $db);
     }
 
     /**


### PR DESCRIPTION
As declared in PHPDoc. Might be useful sometimes, if you want to "===" the result.
