### PR TITLE
hotfix: AccessControl->beforeAction() rules check is not interrupted by exception

### DIFF
--- a/framework/filters/AccessControl.php
+++ b/framework/filters/AccessControl.php
@@ -119,12 +119,7 @@ class AccessControl extends ActionFilter
             } elseif ($allow === false) {
                 if (isset($rule->denyCallback)) {
                     call_user_func($rule->denyCallback, $rule, $action);
-                } elseif (isset($this->denyCallback)) {
-                    call_user_func($this->denyCallback, $rule, $action);
-                } else {
-                    $this->denyAccess($user);
                 }
-                return false;
             }
         }
         if (isset($this->denyCallback)) {


### PR DESCRIPTION
It might be not a bug, but I don't see how should it work properly right now without this fix.
Maybe it also makes sense to change `} elseif ($allow === false) {` to just `} else {`
