### PR TITLE
Fixed query caching

### DIFF
--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -799,6 +799,7 @@ class Command extends Component
                 $cacheKey = [
                     __CLASS__,
                     $method,
+                    $fetchMode,
                     $this->db->dsn,
                     $this->db->username,
                     $rawSql,


### PR DESCRIPTION
It seems to me that query caching should take into account the `$fetchMode` also because without it those code will return same result while it should be different:

``` php
var_dump(Model::getDb()->cache(function () {
    return Model::find()->select('id')->column();
}, 0));

var_dump(Model::getDb()->cache(function () {
    return Model::find()->select('id')->asArray()->all();
}, 0));
```
