### PR TITLE
One tip for render custom label

### DIFF
--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -174,7 +174,7 @@ class ActiveField extends Component
     {
         if ($content === null) {
             if (!isset($this->parts['{input}'])) {
-                $this->parts['{input}'] = Html::activeTextInput($this->model, $this->attribute, $this->inputOptions);
+                $this->parts['{input}'] = Html::activeInput($this->inputOptions['type'], $this->model, $this->attribute, $this->inputOptions);
             }
             if (!isset($this->parts['{label}'])) {
                 $this->parts['{label}'] = Html::activeLabel($this->model, $this->attribute, $this->labelOptions);


### PR DESCRIPTION
Change this 

``` php
$this->parts['{input}'] = Html::activeTextInput($this->model, $this->attribute, $this->inputOptions);
```

For this 

``` php
$this->parts['{input}'] = Html::activeInput($this->inputOptions['type'], $this->model, $this->attribute, $this->inputOptions);
```

And field exemple

``` php
$form->field($model, 'termsconditions', [
            'labelOptions' => [
                'label' => Yii->t('app','I agree to the ') . \yii\helpers\Html::a( Yii->t('app','Terms and Conditions'), ['#'])
            ],
            'inputOptions' => [
                'type' => 'checkbox',
                'uncheck'=>0,
            ]
        ]) 
```
