### PR TITLE
Update rest-quick-start.md

### DIFF
--- a/docs/guide/rest-quick-start.md
+++ b/docs/guide/rest-quick-start.md
@@ -160,7 +160,7 @@ Content-Type: application/xml
 The following command will create a new user by sending a POST request with the user data in JSON format:
 
 ```
-$ curl -i -H "Accept:application/json" -H "Content-Type:application/json" -XPOST "http://localhost/users" -d '{"username": "example", "email": "user@example.com"}'
+$ curl -i -H "Accept:application/json" -H "Content-Type:application/json" -XPOST "http://localhost/users/create" -d '{"username": "example", "email": "user@example.com"}'
 
 HTTP/1.1 201 Created
 ...


### PR DESCRIPTION
The -XPOST flag needs to go to users/create rather than just /users
Sending it to just /users sends an index action, rather than a create.
