### PR TITLE
ActiveForm forceValidate event on attributes

### DIFF
--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -395,7 +395,7 @@
     var watchAttribute = function ($form, attribute) {
         var $input = findInput($form, attribute);
         if (attribute.validateOnChange) {
-            $input.on('change.yiiActiveForm',function () {
+            $input.on('change.yiiActiveForm', function () {
                 validateAttribute($form, attribute, false);
             });
         }
@@ -413,6 +413,9 @@
                 }
             });
         }
+        $input.on('forceValidate.yiiActiveForm', function() {
+            validateAttribute($form, attribute, true);
+        });
     };
 
     var unwatchAttribute = function ($form, attribute) {


### PR DESCRIPTION
Allow attributes to have their validation triggered by a custom event `forceValidate.yiiActiveForm`.
`validateAttribute` is called with `forceValidate` set to true.

Use case;
I have a dropdown of parent pages with an input field where users can enter a url.
The url field has a rule to check for uniqueness (using ajax) against the currently selected parent.
If the user changes the parent page I need to check if the url is still unique but as it's value hasn't changed you can't use any of the existing events.
