### PR TITLE
Yii2 basic code coverage added

### DIFF
--- a/apps/basic/tests/README.md
+++ b/apps/basic/tests/README.md
@@ -59,5 +59,53 @@ codecept run functional
 codecept run unit
 ```
 
+Code coverage support
+---------------------
+
+By default, code coverage is disabled in `codeception.yaml` configuration file, you should uncomment needed rows to be able
+to collect code coverage. You can run your tests and collect coverage with the following command:
+
+```
+#collect coverage for all tests
+codecept run --coverage-html --coverage-xml
+
+#collect coverage only for unit tests
+codecept run unit --coverage-html --coverage-xml
+
+#collect coverage for unit and functional tests
+codecept run functional,unit --coverage-html --coverage-xml
+```
+
+You can see code coverage output under the `tests/_output` directory.
+
+###Remote code coverage
+
+When you run your tests not in the same process where code coverage is collected, then you should uncomment `remote` option and its
+related options, to be able to collect code coverage correctly. To setup remote code coverage you should follow [instructions](http://codeception.com/docs/11-Codecoverage)
+from codeception site.
+
+1. install Codeception c3 remote support `composer require "codeception/c3:*"`;
+
+2. copy c3.php file under your `web` directory and include;
+
+3. include `c3.php` file in your `index-test.php` file before application run, so it can catch needed requests.
+
+Configuration options that are used by remote code coverage:
+
+- c3_url: url pointing to entry script that includes `c3.php` file, so `Codeception` will be able to produce code coverage;
+- remote: whether to enable remote code coverage or not;
+- remote_config: path to the `codeception.yaml` configuration file, from the directory where `c3.php` file is located. This is needed
+  so that `Codeception` can create itself instance and collect code coverage correctly.
+
+By default `c3_url` and `remote_config` setup correctly, you only need to copy and include `c3.php` file in your `index-test.php`
+
+After that you should be able to collect code coverage from tests that run through `PhpBrowser` or `WebDriver` with same command
+as for other tests:
+
+```
+#collect coverage from remote
+codecept run acceptance --coverage-html --coverage-xml
+```
+
 Please refer to [Codeception tutorial](http://codeception.com/docs/01-Introduction) for
 more details about writing and running acceptance, functional and unit tests.

--- a/apps/basic/tests/README.md
+++ b/apps/basic/tests/README.md
@@ -84,9 +84,9 @@ When you run your tests not in the same process where code coverage is collected
 related options, to be able to collect code coverage correctly. To setup remote code coverage you should follow [instructions](http://codeception.com/docs/11-Codecoverage)
 from codeception site.
 
-1. install Codeception c3 remote support `composer require "codeception/c3:*"`;
+1. install `Codeception c3` remote support `composer require "codeception/c3:*"`;
 
-2. copy c3.php file under your `web` directory and include;
+2. copy `c3.php` file under your `web` directory;
 
 3. include `c3.php` file in your `index-test.php` file before application run, so it can catch needed requests.
 

--- a/apps/basic/tests/README.md
+++ b/apps/basic/tests/README.md
@@ -62,7 +62,7 @@ codecept run unit
 Code coverage support
 ---------------------
 
-By default, code coverage is disabled in `codeception.yaml` configuration file, you should uncomment needed rows to be able
+By default, code coverage is disabled in `codeception.yml` configuration file, you should uncomment needed rows to be able
 to collect code coverage. You can run your tests and collect coverage with the following command:
 
 ```
@@ -94,7 +94,7 @@ Configuration options that are used by remote code coverage:
 
 - c3_url: url pointing to entry script that includes `c3.php` file, so `Codeception` will be able to produce code coverage;
 - remote: whether to enable remote code coverage or not;
-- remote_config: path to the `codeception.yaml` configuration file, from the directory where `c3.php` file is located. This is needed
+- remote_config: path to the `codeception.yml` configuration file, from the directory where `c3.php` file is located. This is needed
   so that `Codeception` can create itself instance and collect code coverage correctly.
 
 By default `c3_url` and `remote_config` setup correctly, you only need to copy and include `c3.php` file in your `index-test.php`

--- a/apps/basic/tests/codeception.yml
+++ b/apps/basic/tests/codeception.yml
@@ -1,4 +1,24 @@
 actor: Tester
+#coverage:
+#    #c3_url: http://localhost:8080/index-test.php/
+#    enabled: true
+#    #remote: true
+#    #remote_config: '../tests/codeception.yml'
+#    white_list:
+#        include:
+#            - ../models/*
+#            - ../controllers/*
+#            - ../commands/*
+#            - ../mail/*
+#    blacklist:
+#        include:
+#            - ../assets/*
+#            - ../config/*
+#            - ../runtime/*
+#            - ../vendor/*
+#            - ../views/*
+#            - ../web/*
+#            - ../tests/*
 paths:
     tests: codeception
     log: codeception/_output


### PR DESCRIPTION
Added notes about code coverage for `yii2_basic`, since it was fixed in `Codeception` with `Yii2` related issues. 
Will submit for `yii2_advanced` same notes later 

Related with this [one](https://github.com/yiisoft/yii2/issues/4180) and [this](https://github.com/yiisoft/yii2/issues/4692) 
