### PR TITLE
Bug Model Translate in Module

### DIFF
--- a/docs/guide/tutorial-i18n.md
+++ b/docs/guide/tutorial-i18n.md
@@ -326,10 +326,10 @@ class Module extends \yii\base\Module
     public function init()
     {
         parent::init();
-        $this->registerTranslations();
+        self::registerTranslations();
     }
 
-    public function registerTranslations()
+    public static function registerTranslations()
     {
         Yii::$app->i18n->translations['modules/users/*'] = [
             'class' => 'yii\i18n\PhpMessageSource',
@@ -345,6 +345,10 @@ class Module extends \yii\base\Module
 
     public static function t($category, $message, $params = [], $language = null)
     {
+        if (!isset(Yii::$app->i18n->translations['modules/users/*'])) {
+            self::registerTranslations();
+        }
+        
         return Yii::t('modules/users/' . $category, $message, $params, $language);
     }
 


### PR DESCRIPTION
if we try get some value ( that need to translate like attributeLabels() ) from model that placed in module, we got bug "Unable to locate message source for category" because we translate in model like Module::t(), it static and when we get model not from module actions:
action public function init()
    {
        parent::init();
        $this->registerTranslations();
    }
this function is not called and our translation sourse never gotten in application
