### PR TITLE
require PHP mcrypt extension

### DIFF
--- a/framework/composer.json
+++ b/framework/composer.json
@@ -54,6 +54,7 @@
     "require": {
         "php": ">=5.4.0",
         "ext-mbstring": "*",
+        "ext-mcrypt": "*",
         "lib-pcre": "*",
         "yiisoft/yii2-composer": "*",
         "ezyang/htmlpurifier": "4.6.*",


### PR DESCRIPTION
eg. used in /var/www/app/vendor/yiisoft/yii2/base/Security.php at line 465
