### PR TITLE
Convert method validators to inline validators for application templates `User` model

### DIFF
--- a/apps/advanced/common/models/LoginForm.php
+++ b/apps/advanced/common/models/LoginForm.php
@@ -27,25 +27,15 @@ class LoginForm extends Model
             // rememberMe must be a boolean value
             ['rememberMe', 'boolean'],
             // password is validated by validatePassword()
-            ['password', 'validatePassword'],
+            ['password', function($attribute, $params) {
+                if (!$this->hasErrors()) {
+                    $user = $this->getUser();
+                    if (!$user || !$user->validatePassword($this->password)) {
+                        $this->addError($attribute, 'Incorrect username or password.');
+                    }
+                }
+            }],
         ];
-    }
-
-    /**
-     * Validates the password.
-     * This method serves as the inline validation for password.
-     *
-     * @param string $attribute the attribute currently being validated
-     * @param array $params the additional name-value pairs given in the rule
-     */
-    public function validatePassword($attribute, $params)
-    {
-        if (!$this->hasErrors()) {
-            $user = $this->getUser();
-            if (!$user || !$user->validatePassword($this->password)) {
-                $this->addError($attribute, 'Incorrect username or password.');
-            }
-        }
     }
 
     /**

--- a/apps/basic/models/LoginForm.php
+++ b/apps/basic/models/LoginForm.php
@@ -31,7 +31,6 @@ class LoginForm extends Model
             ['password', function($attribute, $params) {
                 if (!$this->hasErrors()) {
                     $user = $this->getUser();
-
                     if (!$user || !$user->validatePassword($this->password)) {
                         $this->addError($attribute, 'Incorrect username or password.');
                     }

--- a/apps/basic/models/LoginForm.php
+++ b/apps/basic/models/LoginForm.php
@@ -28,26 +28,16 @@ class LoginForm extends Model
             // rememberMe must be a boolean value
             ['rememberMe', 'boolean'],
             // password is validated by validatePassword()
-            ['password', 'validatePassword'],
+            ['password', function($attribute, $params) {
+                if (!$this->hasErrors()) {
+                    $user = $this->getUser();
+
+                    if (!$user || !$user->validatePassword($this->password)) {
+                        $this->addError($attribute, 'Incorrect username or password.');
+                    }
+                }
+            }],
         ];
-    }
-
-    /**
-     * Validates the password.
-     * This method serves as the inline validation for password.
-     *
-     * @param string $attribute the attribute currently being validated
-     * @param array $params the additional name-value pairs given in the rule
-     */
-    public function validatePassword($attribute, $params)
-    {
-        if (!$this->hasErrors()) {
-            $user = $this->getUser();
-
-            if (!$user || !$user->validatePassword($this->password)) {
-                $this->addError($attribute, 'Incorrect username or password.');
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Reason: inline validators is new feature which we need propagandize. Also this validation task looks like 100% inline validation task since there is no reason to have public `validatePassword()` inside form model. `User` model already contains that method.

Pros:
- less code needed

Cons:
- no
