### PR TITLE
Fix logger for case Yii::$app lost on process exiting

### DIFF
--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -266,6 +266,10 @@ abstract class Target extends Component
             return call_user_func($this->prefix, $message);
         }
 
+        if (!isset(Yii::$app)) {
+            return "";
+        }
+
         $request = Yii::$app->getRequest();
         $ip = $request instanceof Request ? $request->getUserIP() : '-';
 


### PR DESCRIPTION
`Logger::flush()` might be called by `register_shutdown_function()` when application instance has gone.

In fact, Codeception extension clears `Yii::$app` on every test cases.

https://github.com/yiisoft/yii2/blob/c9d51ee0fddec74a5c5da61c1eb933c7b3c8a49e/extensions/codeception/TestCase.php#L129
