### PR TITLE
Let yii\console\Application::handleRequest throw exception if $request i...

### DIFF
--- a/framework/console/Application.php
+++ b/framework/console/Application.php
@@ -8,6 +8,7 @@
 namespace yii\console;
 
 use Yii;
+use yii\base\InvalidConfigException;
 use yii\base\InvalidRouteException;
 
 /**
@@ -129,9 +130,14 @@ class Application extends \yii\base\Application
      * Handles the specified request.
      * @param Request $request the request to be handled
      * @return Response the resulting response
+     * @throws InvalidConfigException
      */
     public function handleRequest($request)
     {
+        if (!$request instanceof Request) {
+            throw new InvalidConfigException('Request component in console application config should be instance of \yii\console\Request');
+        }
+
         list ($route, $params) = $request->resolve();
         $this->requestedRoute = $route;
         $result = $this->runAction($route, $params);


### PR DESCRIPTION
...s not instance of yii\console\Request

For example, when in advanced app you override `yii\web\Request` with custom request component and put it into `common` config by mistake - console app cannot resolve the request and outputs `help`, which is not helpful in this case.
