### PR TITLE
Added fallback for datepicker language files

### DIFF
--- a/extensions/jui/CHANGELOG.md
+++ b/extensions/jui/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 jui extension Change Log
 2.0.2 under development
 -----------------------
 
-- Enh: Datepicker now uses fallback to find language files, e.g. application language is `de-DE` and the translation files does not exists, it will use `de` instead (cebe)
+- Enh #6570: Datepicker now uses fallback to find language files, e.g. application language is `de-DE` and the translation files does not exists, it will use `de` instead (cebe)
 
 
 2.0.1 December 07, 2014

--- a/extensions/jui/CHANGELOG.md
+++ b/extensions/jui/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 jui extension Change Log
 2.0.2 under development
 -----------------------
 
-- no changes in this release.
+- Enh: Datepicker now uses fallback to find language files, e.g. application language is `de-DE` and the translation files does not exists, it will use `de` instead (cebe)
 
 
 2.0.1 December 07, 2014

--- a/extensions/jui/DatePicker.php
+++ b/extensions/jui/DatePicker.php
@@ -54,8 +54,11 @@ use yii\helpers\Json;
 class DatePicker extends InputWidget
 {
     /**
-     * @var string the locale ID (eg 'fr', 'de') for the language to be used by the date picker.
+     * @var string the locale ID (e.g. 'fr', 'de', 'en-GB') for the language to be used by the date picker.
      * If this property is empty, then the current application language will be used.
+     *
+     * Since version 2.0.2 a fallback is used if the application language includes a locale part (e.g. `de-DE`) and the language
+     * file does not exist, it will fall back to using `de`.
      */
     public $language;
     /**
@@ -134,6 +137,10 @@ class DatePicker extends InputWidget
             $view = $this->getView();
             $bundle = DatePickerLanguageAsset::register($view);
             if ($bundle->autoGenerate) {
+                $fallbackLanguage = substr($language, 0, 2);
+                if ($fallbackLanguage !== $language && !file_exists(Yii::getAlias($bundle->sourcePath . "/ui/i18n/datepicker-$language.js"))) {
+                    $language = $fallbackLanguage;
+                }
                 $view->registerJsFile($bundle->baseUrl . "/ui/i18n/datepicker-$language.js", [
                     'depends' => [JuiAsset::className()],
                 ]);


### PR DESCRIPTION
Datepicker now uses fallback to find language files, e.g. application language is `de-DE` and the translation files does not exists, it will use `de` instead.
