### PR TITLE
docs/guide/security-authorization.md - fix [ci skip]

### DIFF
--- a/docs/guide/security-authorization.md
+++ b/docs/guide/security-authorization.md
@@ -90,11 +90,13 @@ matches. This should be an array of controller IDs. The comparison is case-sensi
 empty or not set, it means the rule applies to all controllers.
 
  * [[yii\filters\AccessRule::roles|roles]]: specifies which user roles that this rule matches.
-Two special roles are recognized, and they are checked via [[yii\web\User::isGuest]]:
+   Two special roles are recognized, and they are checked via [[yii\web\User::isGuest]]:
+
      - `?`: matches a guest user (not authenticated yet)
      - `@`: matches an authenticated user
-Using other role names requires RBAC (to be described in the next section), and [[yii\web\User::can()]] will be called.
-If this option is empty or not set, it means this rule applies to all roles.
+
+   Using other role names requires RBAC (to be described in the next section), and [[yii\web\User::can()]] will be called.
+   If this option is empty or not set, it means this rule applies to all roles.
 
  * [[yii\filters\AccessRule::ips|ips]]: specifies which [[yii\web\Request::userIP|client IP addresses]] this rule matches.
 An IP address can contain the wildcard `*` at the end so that it matches IP addresses with the same prefix.
@@ -202,7 +204,7 @@ return [
 
 The `authManager` can now be accessed via `\Yii::$app->authManager`.
 
-> Tip: By default, [[yii\rbac\PhpManager]] stores RBAC data in files under `@app/rbac/` directory. Make sure directory
+> Tip: By default, [[yii\rbac\PhpManager]] stores RBAC data in files under `@app/rbac/` directory. Make sure the directory
   and all the files in it are writable by the Web server process if permissions hierarchy needs to be changed online.
 
 
@@ -219,7 +221,7 @@ Building authorization data is all about the following tasks:
 Depending on authorization flexibility requirements the tasks above could be done in different ways.
 
 If your permissions hierarchy doesn't change at all and you have a fixed number of users you can create a
-[console command](tutorial-console.md#create-command) command that will initialize authorization data once via APIs offered by `authManager`:
+[console command](tutorial-console.md#create-command) that will initialize authorization data once via APIs offered by `authManager`:
 
 ```php
 <?php
@@ -271,7 +273,7 @@ After executing the command with `yii rbac/init` we'll get the following hierarc
 Author can create post, admin can update post and do everything author can.
 
 If your application allows user signup you need to assign roles to these new users once. For example, in order for all
-signed up users to become authors you in advanced application template you need to modify `frontend\models\SignupForm::signup()`
+signed up users to become authors in your advanced application template you need to modify `frontend\models\SignupForm::signup()`
 as follows:
 
 ```php
@@ -410,7 +412,7 @@ assign each user to a RBAC role. Let's use an example to show how this can be do
 
 Assume in the user table, you have a `group` column which uses 1 to represent the administrator group and 2 the author group.
 You plan to have two RBAC roles `admin` and `author` to represent the permissions for these two groups, respectively.
-You can create set up the RBAC data as follows,
+You can set up the RBAC data as follows,
 
 
 ```php


### PR DESCRIPTION
In lines 93 - 99, the empty lines and the leading spaces are added to get the expected markdown rendering of the nested lists.
