### PR TITLE
Update Query.php

### DIFF
--- a/extensions/mongodb/Query.php
+++ b/extensions/mongodb/Query.php
@@ -377,8 +377,11 @@ class Query extends Component implements QueryInterface
     {
         $selectFields = [];
         if (!empty($this->select)) {
-            foreach ($this->select as $fieldName) {
-                $selectFields[$fieldName] = true;
+            foreach ($this->select as $key => $fieldName) {
+                if(!is_array($fieldName))
+                    $selectFields[$fieldName] = true;
+                else
+                    $selectFields[$key] = $fieldName;
             }
         }
         return $selectFields;


### PR DESCRIPTION
added opportunity to use fields as array with operation like $elemMatch
collection:
`{_id:{ type:1 } stats:{ { object:1 }, { object:2 } } }`
usage:
`$this->select(['stats' => ['$elemMatch' => ['object' => 2]]]);`
`$this->andWhere([  'stats' => ['$elemMatch' => ['object' => 2]] ]);`
response from bd:
`{_id:{ type:1 } stats:{ { object:2 } } }`
