### PR TITLE
Remove `defined(...) or define(..., ...)` from applications entrance scripts

### DIFF
--- a/apps/advanced/environments/dev/backend/web/index-test.php
+++ b/apps/advanced/environments/dev/backend/web/index-test.php
@@ -5,8 +5,8 @@ if (!in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1'])) {
     die('You are not allowed to access this file.');
 }
 
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'test');
+define('YII_DEBUG', true);
+define('YII_ENV', 'test');
 
 require(__DIR__ . '/../../vendor/autoload.php');
 require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');

--- a/apps/advanced/environments/dev/backend/web/index.php
+++ b/apps/advanced/environments/dev/backend/web/index.php
@@ -1,6 +1,7 @@
 <?php
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'dev');
+
+define('YII_DEBUG', true);
+define('YII_ENV', 'dev');
 
 require(__DIR__ . '/../../vendor/autoload.php');
 require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');

--- a/apps/advanced/environments/dev/frontend/web/index-test.php
+++ b/apps/advanced/environments/dev/frontend/web/index-test.php
@@ -5,8 +5,8 @@ if (!in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1'])) {
     die('You are not allowed to access this file.');
 }
 
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'test');
+define('YII_DEBUG', true);
+define('YII_ENV', 'test');
 
 require(__DIR__ . '/../../vendor/autoload.php');
 require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');

--- a/apps/advanced/environments/dev/frontend/web/index.php
+++ b/apps/advanced/environments/dev/frontend/web/index.php
@@ -1,6 +1,7 @@
 <?php
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'dev');
+
+define('YII_DEBUG', true);
+define('YII_ENV', 'dev');
 
 require(__DIR__ . '/../../vendor/autoload.php');
 require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');

--- a/apps/advanced/environments/prod/backend/web/index.php
+++ b/apps/advanced/environments/prod/backend/web/index.php
@@ -1,6 +1,7 @@
 <?php
-defined('YII_DEBUG') or define('YII_DEBUG', false);
-defined('YII_ENV') or define('YII_ENV', 'prod');
+
+define('YII_DEBUG', false);
+define('YII_ENV', 'prod');
 
 require(__DIR__ . '/../../vendor/autoload.php');
 require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');

--- a/apps/advanced/environments/prod/frontend/web/index.php
+++ b/apps/advanced/environments/prod/frontend/web/index.php
@@ -1,6 +1,7 @@
 <?php
-defined('YII_DEBUG') or define('YII_DEBUG', false);
-defined('YII_ENV') or define('YII_ENV', 'prod');
+
+define('YII_DEBUG', false);
+define('YII_ENV', 'prod');
 
 require(__DIR__ . '/../../vendor/autoload.php');
 require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');

--- a/apps/basic/web/index-test.php
+++ b/apps/basic/web/index-test.php
@@ -5,8 +5,8 @@ if (!in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1'])) {
     die('You are not allowed to access this file.');
 }
 
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'test');
+define('YII_DEBUG', true);
+define('YII_ENV', 'test');
 
 require(__DIR__ . '/../vendor/autoload.php');
 require(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');

--- a/apps/basic/web/index.php
+++ b/apps/basic/web/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // comment out the following two lines when deployed to production
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'dev');
+define('YII_DEBUG', true);
+define('YII_ENV', 'dev');
 
 require(__DIR__ . '/../vendor/autoload.php');
 require(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');

--- a/apps/benchmark/index.php
+++ b/apps/benchmark/index.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('YII_DEBUG') or define('YII_DEBUG', false);
+define('YII_DEBUG', false);
 
 require(__DIR__ . '/protected/vendor/yiisoft/yii2/Yii.php');
 


### PR DESCRIPTION
Its absoluttely meaningless to have such construction inside entrance scripts. It looks like an old stereotype.
