### PR TITLE
fix left over closing backticks

### DIFF
--- a/extensions/bootstrap/Collapse.php
+++ b/extensions/bootstrap/Collapse.php
@@ -53,8 +53,6 @@ class Collapse extends Widget
      * - content: string, required, the content (HTML) of the group
      * - options: array, optional, the HTML attributes of the group
      * - contentOptions: optional, the HTML attributes of the group's content
-     *
-     * ```
      */
     public $items = [];
 


### PR DESCRIPTION
creates an empty code block:
http://www.yiiframework.com/doc-2.0/yii-bootstrap-collapse.html#$items-detail
