### PR TITLE
add setParams to init

### DIFF
--- a/apps/advanced/environments/dev/common/config/main-local.php
+++ b/apps/advanced/environments/dev/common/config/main-local.php
@@ -3,9 +3,9 @@ return [
     'components' => [
         'db' => [
             'class' => 'yii\db\Connection',
-            'dsn' => 'mysql:host=localhost;dbname=yii2advanced',
-            'username' => 'root',
-            'password' => '',
+            'dsn' => 'mysql:host={{db.host|127.0.0.1}};dbname={{db.name}}',
+            'username' => '{{db.username|root}}',
+            'password' => '{{db.password}}',
             'charset' => 'utf8',
         ],
         'mailer' => [

--- a/apps/advanced/environments/index.php
+++ b/apps/advanced/environments/index.php
@@ -32,15 +32,18 @@ return [
             'backend/runtime',
             'backend/web/assets',
             'frontend/runtime',
-            'frontend/web/assets',
+            'frontend/web/assets'
         ],
         'setExecutable' => [
-            'yii',
+            'yii'
         ],
         'setCookieValidationKey' => [
             'backend/config/main-local.php',
-            'frontend/config/main-local.php',
+            'frontend/config/main-local.php'
         ],
+        'setParams' => [
+            'common/config/main-local.php'
+        ]
     ],
     'Production' => [
         'path' => 'prod',
@@ -48,14 +51,17 @@ return [
             'backend/runtime',
             'backend/web/assets',
             'frontend/runtime',
-            'frontend/web/assets',
+            'frontend/web/assets'
         ],
         'setExecutable' => [
-            'yii',
+            'yii'
         ],
         'setCookieValidationKey' => [
             'backend/config/main-local.php',
-            'frontend/config/main-local.php',
+            'frontend/config/main-local.php'
         ],
+        'setParams' => [
+            'common/config/main-local.php'
+        ]
     ],
 ];

--- a/apps/advanced/environments/prod/common/config/main-local.php
+++ b/apps/advanced/environments/prod/common/config/main-local.php
@@ -3,9 +3,9 @@ return [
     'components' => [
         'db' => [
             'class' => 'yii\db\Connection',
-            'dsn' => 'mysql:host=localhost;dbname=yii2advanced',
-            'username' => 'root',
-            'password' => '',
+            'dsn' => 'mysql:host={{db.host|127.0.0.1}};dbname={{db.name}}',
+            'username' => '{{db.username|root}}',
+            'password' => '{{db.password}}',
             'charset' => 'utf8',
         ],
         'mailer' => [

--- a/apps/advanced/init
+++ b/apps/advanced/init
@@ -72,7 +72,7 @@ foreach ($files as $file) {
     }
 }
 
-$callbacks = ['setCookieValidationKey', 'setWritable', 'setExecutable'];
+$callbacks = ['setCookieValidationKey', 'setWritable', 'setExecutable', 'setParams'];
 foreach ($callbacks as $callback) {
     if (!empty($env[$callback])) {
         $callback($root, $env[$callback]);
@@ -117,7 +117,6 @@ function copyFile($root, $source, $target, &$all, $params)
         } else {
             echo "      exist $target\n";
             echo "            ...overwrite? [Yes|No|All|Quit] ";
-
 
             $answer = !empty($params['overwrite']) ? $params['overwrite'] : trim(fgets(STDIN));
             if (!strncasecmp($answer, 'q', 1)) {
@@ -201,5 +200,37 @@ function createSymlink($links)
         if (!is_link($link)) {
             symlink($target, $link);
         }
+    }
+}
+
+function setParams($root, $paths)
+{
+    foreach ($paths as $file) {
+        echo '   set params in ' . $file . PHP_EOL;
+        $filePath = $root . DIRECTORY_SEPARATOR . $file;
+        $fileContent = file_get_contents($filePath);
+
+        preg_match_all('/{{(.*?)}}/', $fileContent, $params);
+
+        if (isset($params[1])) {
+            $params[0] = array_unique($params[0]);
+            $params[1] = array_unique($params[1]);
+
+            foreach ($params[1] as $key => $param) {
+                if (strpos($param, '|') !== false) {
+                    $param = explode('|', $param);
+                    echo '      value of ' . $param[0] . ' (' . $param[1] . '): ';
+                    $answer = trim(fgets(\STDIN));
+                    if (!$answer) {
+                        $answer = $param[1];
+                    }
+                } else {
+                    echo '      value of ' . $param . ': ';
+                    $answer = trim(fgets(\STDIN));
+                }
+                $fileContent = str_replace($params[0][$key], $answer, $fileContent);
+            }
+        }
+        file_put_contents($filePath, $fileContent);
     }
 }


### PR DESCRIPTION
Adds an interactive setting of params during init
Placeholder formats:
`{{nameOfValue}}` or `{{nameOfValue|defaultValue}}`

``` php
<?php
return [
    'components' => [
        'db' => [
            'class' => 'yii\db\Connection',
            'dsn' => 'mysql:host={{db.host|127.0.0.1}};dbname={{db.name}}',
            'username' => '{{db.username|root}}',
            'password' => '{{db.password}}',
            'charset' => 'utf8',
        ]
    ],
];
```

init output:

```
   set params in common/config/db-local.php
      value of db.tablePrefix ():
      value of db.host (127.0.0.1):
      value of db.name: yii2-app
      value of db.username: root
      value of db.password:
   set params in common/config/bootstrap-local.php
      value of domain (dev.example.com):
```
