### PR TITLE
resolve #3335 - add SchemaType

### DIFF
--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -589,6 +589,7 @@ class QueryBuilder extends \yii\base\Object
      */
     public function getColumnType($type)
     {
+        $type = (string)$type;
         if (isset($this->typeMap[$type])) {
             return $this->typeMap[$type];
         } elseif (preg_match('/^(\w+)\((.+?)\)(.*)$/', $type, $matches)) {

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -56,6 +56,166 @@ abstract class Schema extends Object
     const TYPE_MONEY = 'money';
 
     /**
+     * Specify type of field as pk
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function primaryKey($size = null)
+    {
+        return new SchemaType(self::TYPE_PK, $size);
+    }
+
+    /**
+     * Specify type of field as big primary key
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function bigPrimaryKey($size = null)
+    {
+        return new SchemaType(self::TYPE_BIGPK, $size);
+    }
+
+    /**
+     * Specify type of field as string
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function string($size = null)
+    {
+        return new SchemaType(self::TYPE_STRING, $size);
+    }
+
+    /**
+     * Specify type of field as text
+     * @param integer $size size of primary key
+     * @return SchemaType field params
+     */
+    public static function text($size = null)
+    {
+        return new SchemaType(self::TYPE_TEXT, $size);
+    }
+
+    /**
+     * Specify type of field as smallint
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function smallint($size = null)
+    {
+        return new SchemaType(self::TYPE_SMALLINT, $size);
+    }
+
+    /**
+     * Specify type of field as integer
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function integer($size = null)
+    {
+        return new SchemaType(self::TYPE_INTEGER, $size);
+    }
+
+    /**
+     * Specify type of field as bigint
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function bigint($size = null)
+    {
+        return new SchemaType(self::TYPE_BIGINT, $size);
+    }
+
+    /**
+     * Specify type of field as float
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function float($size = null)
+    {
+        return new SchemaType(self::TYPE_FLOAT, $size);
+    }
+
+    /**
+     * Specify type of field as decimal
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function decimal($size = null)
+    {
+        return new SchemaType(self::TYPE_DECIMAL, $size);
+    }
+
+    /**
+     * Specify type of field as datetime
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function datetime($size = null)
+    {
+        return new SchemaType(self::TYPE_DATETIME, $size);
+    }
+
+    /**
+     * Specify type of field as timestamp
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function timestamp($size = null)
+    {
+        return new SchemaType(self::TYPE_TIMESTAMP, $size);
+    }
+
+    /**
+     * Specify type of field as time
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function time($size = null)
+    {
+        return new SchemaType(self::TYPE_TIME, $size);
+    }
+
+    /**
+     * Specify type of field as date
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function date($size = null)
+    {
+        return new SchemaType(self::TYPE_DATE, $size);
+    }
+
+    /**
+     * Specify type of field as binary
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function binary($size = null)
+    {
+        return new SchemaType(self::TYPE_BINARY, $size);
+    }
+
+    /**
+     * Specify type of field as boolean
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function boolean($size = null)
+    {
+        return new SchemaType(self::TYPE_BOOLEAN, $size);
+    }
+
+    /**
+     * Specify type of field as money
+     * @param integer $size size of field
+     * @return SchemaType field params
+     */
+    public static function money($size = null)
+    {
+        return new SchemaType(self::TYPE_MONEY, $size);
+    }
+
+    /**
      * @var Connection the database connection
      */
     public $db;

--- a/framework/db/SchemaType.php
+++ b/framework/db/SchemaType.php
@@ -84,6 +84,16 @@ class SchemaType extends Object
     }
 
     /**
+     * Trick for use keyword as class method
+     */
+    public function __call($name, $args)
+    {
+        if ($name == "default") {
+            return call_user_func_array(array($this, "defaultValue"), $args);
+        }
+    }
+
+    /**
      * Set size of column
      * @param  integer $size size of column
      * @return SchemaType

--- a/framework/db/SchemaType.php
+++ b/framework/db/SchemaType.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db;
+
+use yii\base\Object;
+
+/**
+ * SchemaType is the class for easy define DB's shema types.
+ */
+class SchemaType extends Object
+{
+    const ATTR_BINARY = 'BINARY';
+    const ATTR_UNSIGNED = 'UNSIGNED';
+    const ATTR_UNSIGNED_ZEROFILL = 'UNSIGNED ZEROFILL';
+    const ATTR_TIMESTAMP = 'ON UPDATE CURRENT_TIMESTAMP';
+
+    /**
+     * Type of column
+     * @var string
+     */
+    private $_type;
+
+    /**
+     * Size of column
+     * @var integer
+     */
+    private $_size;
+
+    /**
+     * Specify may column value be Null or not
+     * @var boolean
+     */
+    private $_notNull;
+
+    /**
+     * Default value of column
+     * @var string
+     */
+    private $_default;
+
+    /**
+     * Comment of column
+     * @var string
+     */
+    private $_comment;
+
+    /**
+     * Attributes of column
+     * @var string
+     */
+    private $_attributes;
+
+    /**
+     * Charset of column
+     * @var string
+     */
+    private $_charset;
+
+    /**
+     * Specify column will auto incement value
+     * @var boolean
+     */
+    private $_auto_increment;
+
+    /**
+     * Collate of column
+     * @var string
+     */
+    private $_collate;
+
+    /**
+     * @param string  $type type of column
+     * @param integer $size size of column
+     */
+    public function __construct($type, $size = null)
+    {
+        $this->_type = $type;
+        $this->size($size);
+    }
+
+    /**
+     * Set size of column
+     * @param  integer $size size of column
+     * @return SchemaType
+     */
+    public function size($size)
+    {
+        $this->_size = $size;
+        return $this;
+    }
+
+    /**
+     * Specify column as not null
+     * @return SchemaType
+     */
+    public function notNull()
+    {
+        $this->_notNull = true;
+        return $this;
+    }
+
+    /**
+     * Set default value for column
+     * @param  mixed $value default value
+     * @return SchemaType
+     */
+    public function defaultValue($value)
+    {
+        $valueType = gettype($value);
+        if ($valueType == 'string') {
+            $this->_default = "'" . $value . "'";
+        } else {
+            $this->_default = $value;
+        }
+        return $this;
+    }
+
+    /**
+     * Set comment for column
+     * @param  string $comment comment for column
+     * @return SchemaType
+     */
+    public function comment($comment)
+    {
+        $this->_comment = $comment;
+        return $this;
+    }
+
+
+    /**
+     * Set attribute for column
+     * @param  string $attribute attribute for column
+     * @return SchemaType
+     */
+    public function attribute($attribute)
+    {
+        $this->_attributes = $attribute;
+        return $this;
+    }
+
+    /**
+     * Set charset and collate for column
+     * @param  string $charset charset for column
+     * @param  string $collate collate for column
+     * @return SchemaType
+     */
+    public function charset($charset, $collate = null)
+    {
+        $this->_charset = $charset;
+        $this->_collate = $collate;
+        return $this;
+    }
+
+    /**
+     * Specify column as not null
+     * @return SchemaType
+     */
+    public function autoIncrement()
+    {
+        $this->_auto_increment = true;
+        return $this;
+    }
+
+    /**
+     * Return string interpritation of type
+     * @return string
+     */
+    public function __toString()
+    {
+        $type = "";
+        if ($this->_type == null) {
+            return $type;
+        }
+        $type .= $this->_type;
+
+        if ($this->_size != null) {
+            $type .= "(" . $this->_size . ")";
+        }
+
+        if ($this->_attributes) {
+            $type .= " " . $this->_attributes;
+        }
+
+        if ($this->_charset) {
+            $type .= " CHARACTER SET " . $this->_charset;
+        }
+
+        if ($this->_collate) {
+            $type .= " COLLATE " . $this->_collate;
+        }
+
+        if ($this->_notNull) {
+            $type .= " NOT NULL";
+        }
+
+        if ($this->_default !== null) {
+            $type .= " DEFAULT " . $this->_default;
+        }
+
+        if ($this->_auto_increment) {
+            $type .= " AUTO_INCREMENT";
+        }
+
+        if ($this->_comment) {
+            $type .= " COMMENT '" . $this->_comment . "'";
+        }
+
+        return $type;
+    }
+}


### PR DESCRIPTION
Write migrations like 

``` php
$this->createTable('{{table}}', [
    'name' => Schema::string(64)->notNull(),
    'type' => Schema::integer()->notNull()->defaultValue(10),
    'description' => Schema::text(),
    'rule_name' => Schema::string(64),
    'data' => Schema::text(),
    'created_at' => Schema::integer(),
    'updated_at' => Schema::integer(),
]);
```
