### PR TITLE
Properly register plugin

### DIFF
--- a/extensions/bootstrap/Dropdown.php
+++ b/extensions/bootstrap/Dropdown.php
@@ -59,7 +59,8 @@ class Dropdown extends Widget
     public function run()
     {
         echo $this->renderItems($this->items, $this->options);
-        BootstrapPluginAsset::register($this->getView());
+        $this->registerPlugin('dropdown');
+
     }
 
     /**


### PR DESCRIPTION
In the run() method of all the bootstrap components, the parent's registerPlugin() is called. However, the Dropdown component is an exception; it just registers the Bootstrap plugin.

Consequently, nothing is done with the clientEvents property (nor with the clientOptions).
