### PR TITLE
yii\base\Model::load() typo fix

### DIFF
--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -761,7 +761,7 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
     public function load($data, $formName = null)
     {
         $scope = $formName === null ? $this->formName() : $formName;
-        if ($scope == '' && !empty($data)) {
+        if ($scope === '' && !empty($data)) {
             $this->setAttributes($data);
 
             return true;


### PR DESCRIPTION
`Model::formName()` return string by design so its safe to do strict comparsion here. Also `$formName` param of `Model::load()` method declared as string.
