### PR TITLE
Remove Content-Transfer-Encoding from the list of default download headers

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Bug #6648: Added explicit type casting to avoid dblib issues on SQL Server 2014 (o-rey)
 - Bug #6691: Fixed console help description parsing with UTF8 characters (cebe)
 - Bug #6717: Fixed issue with UrlManager not matching a route on url creation when it was prefixed with `/` and pattern was empty (cebe)
+- Bug #6736: Removed `Content-Transfer-Encoding` from the list of default download headers (DaSourcerer)
 - Enh #4502: Added alias support to URL route when calling `Url::toRoute()` and `Url::to()` (qiangxue, lynicidn)
 - Enh #6247: Logger and error handler are now using slightly less memory (stepanselyuk, samdark)
 - Enh #6434: Added `yii\behaviors\SluggableBehavior::immutable` to support keeping the generated slug unchanged (trntv)

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -557,7 +557,6 @@ class Response extends \yii\base\Response
             ->setDefault('Accept-Ranges', 'bytes')
             ->setDefault('Expires', '0')
             ->setDefault('Cache-Control', 'must-revalidate, post-check=0, pre-check=0')
-            ->setDefault('Content-Transfer-Encoding', 'binary')
             ->setDefault('Content-Disposition', "$disposition; filename=\"$attachmentName\"");
 
         if ($mimeType !== null) {


### PR DESCRIPTION
`Content-Transfer-Encoding` is not a valid HTTP header (cf [RFC 7230, section 3.3.1](http://tools.ietf.org/html/rfc7230#section-3.3.1), [RFC 7231, section 8.3](http://tools.ietf.org/html/rfc7231#section-8.3) → [IANA Message Header Registry](http://www.iana.org/assignments/message-headers/message-headers.xhtml)). The correct HTTP pendant to `Content-Transfer-Encoding: binary` would have been `Transfer-Encoding: identity` until RFC 7230ff.
