### PR TITLE
added check for undefined application

### DIFF
--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -266,6 +266,10 @@ abstract class Target extends Component
             return call_user_func($this->prefix, $message);
         }
 
+        if (Yii::$app === null) {
+            return "[n/a]";
+        }
+
         $request = Yii::$app->getRequest();
         $ip = $request instanceof Request ? $request->getUserIP() : '-';
 


### PR DESCRIPTION
During unit testing with codeception, I experienced the problem, that Yii is unable to find the running application, when writing to the log target.
