### PR TITLE
extensions\apidoc\helper\ApiIndexer.php - add Unicode support FileInfo(jsSearch) for bootstrap-guide mode.

### DIFF
--- a/extensions/apidoc/helpers/ApiIndexer.php
+++ b/extensions/apidoc/helpers/ApiIndexer.php
@@ -25,18 +25,18 @@ class ApiIndexer extends Indexer
      */
     protected function generateFileInfo($file, $contents, $basePath, $baseUrl)
     {
-        // create file entry
-        if (preg_match('~<h1>(.*?)</h1>~s', $contents, $matches)) {
+		// create file entry
+        if (preg_match('~<h1>(.*|\r*|\n*?)</h1>~u', $contents, $matches)) {
             $title = str_replace('&para;', '', strip_tags($matches[1]));
-        } elseif (preg_match('~<title>(.*?)</title>~s', $contents, $matches)) {
+        } elseif (preg_match('~<title>(.*|\r*|\n*?)</title>~u', $contents, $matches)) {
             $title = strip_tags($matches[1]);
         } else {
             $title = '<i>No title</i>';
         }
 
-        if (preg_match('~<div id="classDescription">\s*<strong>(.*?)</strong>~s', $contents, $matches)) {
+        if (preg_match('~<div id="classDescription">\s*<strong>(.*|\r*|\n*?)</strong>~u', $contents, $matches)) {
             $description = strip_tags($matches[1]);
-        } elseif (preg_match('~<p>(.*?)</p>~s', $contents, $matches)) {
+        } elseif (preg_match('~<p>(.*|\r*|\n*?)</p>~u', $contents, $matches)) {
             $description = strip_tags($matches[1]);
             if (mb_strlen($description) > 1000) { // TODO truncate by words
                 $description = mb_substr($description, 0, 1000) . '...';


### PR DESCRIPTION
extensions\apidoc\helper\ApiIndexer.php - add Unicode support FileInfo(jsSearch) for bootstrap-guide mode.

```
preg_match(/(.*)/s)
```

replaced 
    preg_match(/(._|\r_|\n*)/u)
