### PR TITLE
Update ActiveDataProvider.php

### DIFF
--- a/framework/data/ActiveDataProvider.php
+++ b/framework/data/ActiveDataProvider.php
@@ -101,7 +101,11 @@ class ActiveDataProvider extends BaseDataProvider
         }
         $query = clone $this->query;
         if (($pagination = $this->getPagination()) !== false) {
-            $pagination->totalCount = $this->getTotalCount();
+            if($pagination->totalCount){
+                $this->setTotalCount($pagination->totalCount);
+            }else{
+                $pagination->totalCount =$this->getTotalCount();
+            }
             $query->limit($pagination->getLimit())->offset($pagination->getOffset());
         }
         if (($sort = $this->getSort()) !== false) {


### PR DESCRIPTION
Change for ability to set totalCount by custom query;

practical usage 

``` php

public function search($params)
    {
        $query = self::find();
        $countquery=clone $query;
        $query->joinWith(
            [
                'dot.city',
                'dot.street',
                'dot.zone',
                'dot.docs0',
                'ordtovs.tov','ordservs.serv',
                'begunok'
            ]
        );
        $query->groupBy('{{%order}}.id');
        $countquery->joinWith(
            [
                'dot.docs0',
                'begunok'
            ]
        );

        $dataProvider = new ActiveDataProvider(
            [
                'query' => $query,
            ]
        );


        if (!($this->load($params) && $this->validate())) {
           $pager=new Pagination(['totalCount' => $countquery->count(), 'pageSize' => $this->pageSize]);
           $dataProvider->setPagination($pager);
            return $dataProvider;
        }

        $query->andFilterWhere(
            [
                                ...
            ]
        );
       $countquery->where = $query->where;
        $pager=new Pagination([
                'pageSize' => $this->pageSize,
                'totalCount'=>$countquery->count()
            ]);
        $dataProvider->setPagination($pager);
        return $dataProvider;
    }
```
