### PR TITLE
Correct SQLite version checking

### DIFF
--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -66,7 +66,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
     {
         // SQLite supports batch insert natively since 3.7.11
         // http://www.sqlite.org/releaselog/3_7_11.html
-        if (version_compare(\SQLite3::version()['versionString'], '3.7.11', '>=')) {
+        if (version_compare($this->db->pdo->getAttribute(\PDO::ATTR_SERVER_VERSION), '3.7.11', '>=')) {
             return parent::batchInsert($table, $columns, $rows);
         }
 


### PR DESCRIPTION
Current approach fail with exception `SQLite3` class not found and require excess `sqlite` extension to work even if you already have `pdo_sqlite`. This approach use correct `PDO way` version checking.
