### PR TITLE
Do not unset main controller

### DIFF
--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -453,7 +453,9 @@ class Module extends ServiceLocator
             $oldController = Yii::$app->controller;
             Yii::$app->controller = $controller;
             $result = $controller->runAction($actionID, $params);
-            Yii::$app->controller = $oldController;
+            if ($oldController !== null) {
+                Yii::$app->controller = $oldController;
+            }
 
             return $result;
         } else {


### PR DESCRIPTION
Because Url helper need an active controller to create url, do not unset main controller in order to be able to work with URL on the later stages, i.e. `Response::beforeSend`
