### PR TITLE
error with yii\db\sqlite\QueryBuilder:batchInsert()

### DIFF
--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -66,8 +66,10 @@ class QueryBuilder extends \yii\db\QueryBuilder
     {
         // SQLite supports batch insert natively since 3.7.11
         // http://www.sqlite.org/releaselog/3_7_11.html
-        if (version_compare(\SQLite3::version()['versionString'], '3.7.11', '>=')) {
-            return parent::batchInsert($table, $columns, $rows);
+        if (extension_loaded('sqlite3')) {
+            if (version_compare(\SQLite3::version()['versionString'], '3.7.11', '>=')) {
+                return parent::batchInsert($table, $columns, $rows);
+            }
         }
 
         $schema = $this->db->getSchema();


### PR DESCRIPTION
error with yii\db\sqlite\QueryBuilder:batchInsert() if php_sqlite3 extension is disabled, as class SQLite3 does not exist

line 69 
if (version_compare(\SQLite3::version()['versionString'], '3.7.11', '>=')) {
return parent::batchInsert($table, $columns, $rows);
}

must be wrapped in like

```
if (extension_loaded('sqlite3')) {
    if (version_compare(\SQLite3::version()['versionString'], '3.7.11', '>=')) {
        return parent::batchInsert($table, $columns, $rows);
    }
}
```
