### PR TITLE
Add DateValidator::$timestampAttributeFormat

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Bug #6717: Fixed issue with UrlManager not matching a route on url creation when it was prefixed with `/` and pattern was empty (cebe)
 - Bug #6736: Removed `Content-Transfer-Encoding` from the list of default download headers (DaSourcerer)
 - Enh #4502: Added alias support to URL route when calling `Url::toRoute()` and `Url::to()` (qiangxue, lynicidn)
+- Enh #5053: Added possibility to specify a format for the `timestampAttribute` of date formatter (cebe)
 - Enh #5194: `yii\console\controllers\AssetController` now handles bundle files from external resources properly (klimov-paul)
 - Enh #6247: Logger and error handler are now using slightly less memory (stepanselyuk, samdark)
 - Enh #6398: Added support for specifying dependent component in terms of a configuration array for classes such as `DbCache` (qiangxue)

--- a/tests/unit/framework/i18n/FormatterDateTest.php
+++ b/tests/unit/framework/i18n/FormatterDateTest.php
@@ -399,6 +399,9 @@ class FormatterDateTest extends TestCase
             ['UTC'],
             ['Europe/Berlin'],
             ['America/Jamaica'],
+            // these two are near the International Date Line on different sides
+            ['Pacific/Kiritimati'],
+            ['Pacific/Honolulu'],
         ];
     }
 


### PR DESCRIPTION
**do not merge**, tests are currently failing due to a timezone problem in DateValidator
need to figure out if this is an existing bug or added by the new implementation.

fixes #5053
