### PR TITLE
Fix #6824 gii button form creation missing value attribute

### DIFF
--- a/extensions/gii/CHANGELOG.md
+++ b/extensions/gii/CHANGELOG.md
@@ -1,6 +1,10 @@
 Yii Framework 2 gii extension Change Log
 ========================================
 
+2.0.? January 11, 2015 
+----------------------
+Bug #6824 Gii view.php creates HTML for Buttons incorrectly (apyii)
+
 2.0.3 under development
 -----------------------
 

--- a/extensions/gii/views/default/view.php
+++ b/extensions/gii/views/default/view.php
@@ -42,10 +42,10 @@ foreach ($generator->templates as $name => $path) {
                         Please select which set of the templates should be used to generated the code.
                 ') ?>
                 <div class="form-group">
-                    <?= Html::submitButton('Preview', ['name' => 'preview', 'class' => 'btn btn-primary']) ?>
+                    <?= Html::submitButton('Preview', ['value' => 'Preview', 'name' => 'preview', 'class' => 'btn btn-primary']) ?>
 
                     <?php if (isset($files)): ?>
-                        <?= Html::submitButton('Generate', ['name' => 'generate', 'class' => 'btn btn-success']) ?>
+                        <?= Html::submitButton('Generate', ['value' => 'Generate', 'name' => 'generate', 'class' => 'btn btn-success']) ?>
                     <?php endif; ?>
                 </div>
             </div>


### PR DESCRIPTION
This bug cannot have existed for long as the Gii generation would not work at all. I was not able to find the cause of this in the history of the changed file (view.php). Perhaps the cause is that html::submitButton has changed. If that is the case then perhaps the change should be made there and this request ignored.
