### PR TITLE
getQueryParam() and getBodyParam() doc edits

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -416,6 +416,7 @@ class Request extends \yii\base\Request
 
     /**
      * Returns the named request body parameter value.
+     * If the parameter does not exist, the second parameter passed to this method will be returned.
      * @param string $name the parameter name
      * @param mixed $defaultValue the default parameter value if the parameter does not exist.
      * @return mixed the parameter value
@@ -492,8 +493,8 @@ class Request extends \yii\base\Request
 
     /**
      * Returns the named GET parameter value.
-     * If the GET parameter does not exist, the second parameter to this method will be returned.
-     * @param string $name the GET parameter name. If not specified, whole $_GET is returned.
+     * If the GET parameter does not exist, the second parameter passed to this method will be returned.
+     * @param string $name the GET parameter name.
      * @param mixed $defaultValue the default parameter value if the GET parameter does not exist.
      * @return mixed the GET parameter value
      * @see getBodyParam()


### PR DESCRIPTION
- Made yii\web\Request::getQueryParam() and getBodyParam()'s doc blocks more consistent with each other
- getQueryParam() was incorrectly stating that if $name was omitted, all of $_GET would be returned (but $name is required)
