### PR TITLE
Allow extension of HtmlPurifier to set default config

### DIFF
--- a/framework/helpers/BaseHtmlPurifier.php
+++ b/framework/helpers/BaseHtmlPurifier.php
@@ -52,7 +52,17 @@ class BaseHtmlPurifier
         if ($config instanceof \Closure) {
             call_user_func($config, $configInstance);
         }
+        static::config($configInstance);
 
         return $purifier->purify($content);
+    }
+
+    /**
+     * Allow the extended HtmlPurifier class to set some default config options.
+     * @param \HTMLPurifier_Config $config
+     */
+    protected static function config($config)
+    {
+        
     }
 }


### PR DESCRIPTION
New static method `config` which will be called before purification.

Currently the only way to configure `HtmlPurifier` is with each call of `process`.
The new method allows `BaseHtmlPurifier` to be extended to set default config options.

``` php
class HtmlPurifier extends \yii\helpers\BaseHtmlPurifier
{
    protected static function config($config)
    {
        $config->set('Filter.Custom', [new Filter()]); 
    }
}
```
