### PR TITLE
Setting to ignore certain tables

### DIFF
--- a/extensions/gii/Module.php
+++ b/extensions/gii/Module.php
@@ -77,6 +77,10 @@ class Module extends \yii\base\Module implements BootstrapInterface
      * Defaults to 0777, meaning the directory can be read, written and executed by all users.
      */
     public $newDirMode = 0777;
+    /**
+     * @var array the list of table names to be ignored.
+     */
+    public $ignoreTables = [];
 
 
     /**

--- a/extensions/gii/generators/model/Generator.php
+++ b/extensions/gii/generators/model/Generator.php
@@ -525,6 +525,7 @@ class Generator extends \yii\gii\Generator
         }
         $tableNames = [];
         if (strpos($this->tableName, '*') !== false) {
+            $module = Yii::$app->controller->module;
             if (($pos = strrpos($this->tableName, '.')) !== false) {
                 $schema = substr($this->tableName, 0, $pos);
                 $pattern = '/^' . str_replace('*', '\w+', substr($this->tableName, $pos + 1)) . '$/';
@@ -534,6 +535,10 @@ class Generator extends \yii\gii\Generator
             }
 
             foreach ($db->schema->getTableNames($schema) as $table) {
+                if (in_array($table, $module->ignoreTables)) {
+                    continue;
+                }
+
                 if (preg_match($pattern, $table)) {
                     $tableNames[] = $schema === '' ? $table : ($schema . '.' . $table);
                 }


### PR DESCRIPTION
Every time we use the wildcard to select all the tables we see those who should never generate models. The migration table, for example.

I suggest creating an option to ignore certain tables.
