### PR TITLE
Updated autoloading

### DIFF
--- a/apps/basic/web/index-test.php
+++ b/apps/basic/web/index-test.php
@@ -9,7 +9,6 @@ defined('YII_DEBUG') or define('YII_DEBUG', true);
 defined('YII_ENV') or define('YII_ENV', 'test');
 
 require(__DIR__ . '/../vendor/autoload.php');
-require(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 
 $config = require(__DIR__ . '/../tests/codeception/config/acceptance.php');
 

--- a/apps/basic/web/index.php
+++ b/apps/basic/web/index.php
@@ -5,7 +5,6 @@ defined('YII_DEBUG') or define('YII_DEBUG', true);
 defined('YII_ENV') or define('YII_ENV', 'dev');
 
 require(__DIR__ . '/../vendor/autoload.php');
-require(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 
 $config = require(__DIR__ . '/../config/web.php');
 

--- a/apps/basic/yii
+++ b/apps/basic/yii
@@ -15,7 +15,6 @@ defined('STDIN') or define('STDIN', fopen('php://stdin', 'r'));
 defined('STDOUT') or define('STDOUT', fopen('php://stdout', 'w'));
 
 require(__DIR__ . '/vendor/autoload.php');
-require(__DIR__ . '/vendor/yiisoft/yii2/Yii.php');
 
 $config = require(__DIR__ . '/config/console.php');
 

--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,8 @@
             "yii\\swiftmailer\\": "extensions/swiftmailer/",
             "yii\\sphinx\\": "extensions/sphinx/",
             "yii\\twig\\": "extensions/twig/"
-        }
+        },
+        "classmap": ["framework/Yii.php"]
     },
     "bin": [
         "framework/yii"

--- a/framework/composer.json
+++ b/framework/composer.json
@@ -65,7 +65,8 @@
         "bower-asset/yii2-pjax": ">=2.0.1"
     },
     "autoload": {
-        "psr-4": {"yii\\": ""}
+        "psr-4": {"yii\\": ""},
+        "classmap": ["Yii.php"]
     },
     "bin": [
         "yii"


### PR DESCRIPTION
Hi.
I've noticed that you're both loading `Yii.php` manually and using composer autoloading mechanism, so i've kinda merged it.
The only thing that is wrong is that i can't perform complete testing of this thing without publishing a package on packagist, and i couldn't find delete button up there. So i didn't test through the packagist using regular mechanisms (i will never publish such a package), i just [created fake repository](https://gist.github.com/etki/99da56773cacaadb7eac) with same autoloading section in basic application's composer.json, and everything worked okay.
If you want to be 100% sure, you can create separate dev branch and test it using branch reference.
