### PR TITLE
Fixed content-length in sendContentAsFile()

### DIFF
--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -475,9 +475,6 @@ class Response extends \yii\base\Response
             throw new HttpException(416, 'Requested range not satisfiable');
         }
 
-        $mimeType = isset($options['mimeType']) ? $options['mimeType'] : 'application/octet-stream';
-        $this->setDownloadHeaders($attachmentName, $mimeType, !empty($options['inline']), $contentLength);
-
         list($begin, $end) = $range;
         if ($begin != 0 || $end != $contentLength - 1) {
             $this->setStatusCode(206);
@@ -487,6 +484,9 @@ class Response extends \yii\base\Response
             $this->setStatusCode(200);
             $this->content = $content;
         }
+
+        $mimeType = isset($options['mimeType']) ? $options['mimeType'] : 'application/octet-stream';
+        $this->setDownloadHeaders($attachmentName, $mimeType, !empty($options['inline']), $end - $begin + 1);
 
         $this->format = self::FORMAT_RAW;
 


### PR DESCRIPTION
Fixed wrong Content-Length header when sending partial content using Response::sendContentAsFile. sendStreamAsFile sends correct headers.
