### PR TITLE
Added yii\web\Request::getPath()

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -60,6 +60,8 @@ use yii\helpers\StringHelper;
  * turned into upper case. This property is read-only.
  * @property string $pathInfo Part of the request URL that is after the entry script and before the question
  * mark. Note, the returned path info is already URL-decoded.
+ * @property string $path The requested route path. By default this will return the [[pathInfo path info]].
+ * This property is read-only.
  * @property integer $port Port number for insecure requests.
  * @property array $queryParams The request GET parameter values.
  * @property string $queryString Part of the request URL that is after the question mark. This property is
@@ -721,6 +723,18 @@ class Request extends \yii\base\Request
         }
 
         return (string) $pathInfo;
+    }
+
+    /**
+     * The requested route path.
+     * By default this will return the [[getPathInfo() path info]].
+     * The starting and ending slashes are both removed.
+     *
+     * @return string the requested path.
+     */
+    public function getPath()
+    {
+        return $this->getPathInfo();
     }
 
     /**

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -227,7 +227,7 @@ class UrlManager extends Component
     public function parseRequest($request)
     {
         if ($this->enablePrettyUrl) {
-            $pathInfo = $request->getPathInfo();
+            $path = $request->getPath();
             /* @var $rule UrlRule */
             foreach ($this->rules as $rule) {
                 if (($result = $rule->parseRequest($this, $request)) !== false) {
@@ -242,11 +242,11 @@ class UrlManager extends Component
             Yii::trace('No matching URL rules. Using default URL parsing logic.', __METHOD__);
 
             $suffix = (string) $this->suffix;
-            if ($suffix !== '' && $pathInfo !== '') {
+            if ($suffix !== '' && $path !== '') {
                 $n = strlen($this->suffix);
-                if (substr_compare($pathInfo, $this->suffix, -$n, $n) === 0) {
-                    $pathInfo = substr($pathInfo, 0, -$n);
-                    if ($pathInfo === '') {
+                if (substr_compare($path, $this->suffix, -$n, $n) === 0) {
+                    $path = substr($path, 0, -$n);
+                    if ($path === '') {
                         // suffix alone is not allowed
                         return false;
                     }
@@ -256,7 +256,7 @@ class UrlManager extends Component
                 }
             }
 
-            return [$pathInfo, []];
+            return [$path, []];
         } else {
             Yii::trace('Pretty URL not enabled. Using default URL parsing logic.', __METHOD__);
             $route = $request->getQueryParam($this->routeParam, '');

--- a/framework/web/UrlRule.php
+++ b/framework/web/UrlRule.php
@@ -215,13 +215,13 @@ class UrlRule extends Object implements UrlRuleInterface
             return false;
         }
 
-        $pathInfo = $request->getPathInfo();
+        $path = $request->getPath();
         $suffix = (string) ($this->suffix === null ? $manager->suffix : $this->suffix);
-        if ($suffix !== '' && $pathInfo !== '') {
+        if ($suffix !== '' && $path !== '') {
             $n = strlen($suffix);
-            if (substr_compare($pathInfo, $suffix, -$n, $n) === 0) {
-                $pathInfo = substr($pathInfo, 0, -$n);
-                if ($pathInfo === '') {
+            if (substr_compare($path, $suffix, -$n, $n) === 0) {
+                $path = substr($path, 0, -$n);
+                if ($path === '') {
                     // suffix alone is not allowed
                     return false;
                 }
@@ -231,10 +231,10 @@ class UrlRule extends Object implements UrlRuleInterface
         }
 
         if ($this->host !== null) {
-            $pathInfo = strtolower($request->getHostInfo()) . ($pathInfo === '' ? '' : '/' . $pathInfo);
+            $path = strtolower($request->getHostInfo()) . ($path === '' ? '' : '/' . $path);
         }
 
-        if (!preg_match($this->pattern, $pathInfo, $matches)) {
+        if (!preg_match($this->pattern, $path, $matches)) {
             return false;
         }
         foreach ($this->defaults as $name => $value) {


### PR DESCRIPTION
Gives applications a way to define the requested path without having to override (and change the meaning of) getPathInfo().

We have a need for this in [Craft](http://buildwithcraft.com/) for a couple reasons:
1. The path may be defined by either a `?p=` query param _or_ the PATH_INFO (configurable), but this technicality generally does not affect how URLs should be generated (a .htaccess redirect is responsible for passing the path to index.php, however that is supposed to happen).
2. The path may actually need to be altered a bit before routing kicks in (for example, if it began with "admin/", Craft will set itself to Control Panel mode, and remove "admin/" from the path before letting routing take place.)

Implementing this change will give us a clean way to communicate to UrlManager/UrlRule what the "path" is, without us overriding a bunch of code.
