### PR TITLE
If the 2nd parameter of \MongoCollection::distinct() is an empty array, ...

### DIFF
--- a/extensions/mongodb/Collection.php
+++ b/extensions/mongodb/Collection.php
@@ -520,7 +520,13 @@ class Collection extends Object
         Yii::info($token, __METHOD__);
         try {
             Yii::beginProfile($token, __METHOD__);
-            $result = $this->mongoCollection->distinct($column, $condition);
+
+            if (empty($condition)) {
+                $result = $this->mongoCollection->distinct($column);
+            } else {
+                $result = $this->mongoCollection->distinct($column, $condition);
+            }
+
             Yii::endProfile($token, __METHOD__);
 
             return $result;


### PR DESCRIPTION
...the result will be false when working with MongoDB 2.8.

Please refer to [the PHP bug #68858](https://bugs.php.net/bug.php?id=68858) for more detail.
