### PR TITLE
Fixed #6978: DI Container is not reset when destroying application in functional tests

### DIFF
--- a/extensions/codeception/CHANGELOG.md
+++ b/extensions/codeception/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Codeception extension Change Log
 2.0.3 under development
 -----------------------
 
-- no changes in this release.
+- Bug #6978: DI Container is not reset when destroying application in functional tests (ivokund)
 
 
 2.0.2 January 11, 2015

--- a/extensions/codeception/TestCase.php
+++ b/extensions/codeception/TestCase.php
@@ -12,6 +12,7 @@ use yii\base\InvalidConfigException;
 use Codeception\TestCase\Test;
 use yii\base\UnknownMethodException;
 use yii\base\UnknownPropertyException;
+use yii\di\Container;
 use yii\test\ActiveFixture;
 use yii\test\BaseActiveFixture;
 use yii\test\FixtureTrait;
@@ -128,5 +129,6 @@ class TestCase extends Test
     protected function destroyApplication()
     {
         Yii::$app = null;
+        Yii::$container = new Container();
     }
 }

--- a/extensions/codeception/TestCase.php
+++ b/extensions/codeception/TestCase.php
@@ -117,6 +117,7 @@ class TestCase extends Test
                 $config['class'] = 'yii\web\Application';
             }
 
+            Yii::$container = new Container();
             return Yii::createObject($config);
         } else {
             throw new InvalidConfigException('Please provide a configuration array to mock up an application.');

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #6919: Fixed wrong namespaces under advanced application's TestCase classes (ivokund)
 - Bug #6969: `yii\helpers\ArrayHelper::htmlEncode()` and `htmlDecode()` should not remove non-string data (qiangxue)
+- Bug #6978: DI Container is not reset when destroying application in functional tests (ivokund)
 - Enh #5663: Added support for using `data-params` to specify additional form data to be submitted via the `data-method` approach (usualdesigner, qiangxue)
 - Enh #6106: Added ability to specify `encode` for each item of `yii\widgets\Breadcrumbs` (samdark, aleksanderd)
 - Enh #6493: Added support for the `Access-Control-Expose-Headers` header by `yii\filters\Cors` (usualdesigner)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,7 +6,6 @@ Yii Framework 2 Change Log
 
 - Bug #6919: Fixed wrong namespaces under advanced application's TestCase classes (ivokund)
 - Bug #6969: `yii\helpers\ArrayHelper::htmlEncode()` and `htmlDecode()` should not remove non-string data (qiangxue)
-- Bug #6978: DI Container is not reset when destroying application in functional tests (ivokund)
 - Enh #5663: Added support for using `data-params` to specify additional form data to be submitted via the `data-method` approach (usualdesigner, qiangxue)
 - Enh #6106: Added ability to specify `encode` for each item of `yii\widgets\Breadcrumbs` (samdark, aleksanderd)
 - Enh #6493: Added support for the `Access-Control-Expose-Headers` header by `yii\filters\Cors` (usualdesigner)


### PR DESCRIPTION
Added code to reset the DI container when destroying the application
