### PR TITLE
style guide examples should follow its own rules

### DIFF
--- a/docs/internals/core-code-style.md
+++ b/docs/internals/core-code-style.md
@@ -251,11 +251,12 @@ $config = [
 ```php
 if ($event === null) {
     return new Event();
-} elseif ($event instanceof CoolEvent) {
-    return $event->instance();
-} else {
-    return null;
 }
+if ($event instanceof CoolEvent) {
+    return $event->instance();
+}
+return null;
+
 
 // the following is NOT allowed:
 if (!$model && null === $event)


### PR DESCRIPTION
example code suffering from a double case of else-after-return simplified according to the subsequent rule
