### PR TITLE
This is because method names in PHP are not case-insensitive

### DIFF
--- a/docs/guide/concept-properties.md
+++ b/docs/guide/concept-properties.md
@@ -65,8 +65,8 @@ properties.
 
 There are several special rules for, and limitations on, the properties defined via getters and setters:
 
-* The names of such properties are *case-insensitive*. For example, `$object->label` and `$object->Label` are the same.
-  This is because method names in PHP are case-insensitive.
+* The names of such properties are not *case-insensitive*. For example, `$object->label` and `$object->Label` are the same.
+  This is because method names in PHP are not case-insensitive.
 * If the name of such a property is the same as a class member variable, the latter will take precedence.
   For example, if the above `Foo` class has a member variable `label`, then the assignment `$object->label = 'abc'`
   will affect the *member variable* 'label'; that line would not call the  `setLabel()` setter method.


### PR DESCRIPTION
This is because method names in PHP are not case-insensitive
