### PR TITLE
Fixing the application config widget registration after the #6991 fix

### DIFF
--- a/extensions/smarty/ViewRenderer.php
+++ b/extensions/smarty/ViewRenderer.php
@@ -99,7 +99,7 @@ class ViewRenderer extends BaseViewRenderer
         // Register function widgets specified in configuration array
         if (isset($this->widgets['functions'])) {
             foreach(($this->widgets['functions']) as $tag => $class) {
-                $this->smarty->registerPlugin('function', $tag, [$this, '_widget_func__' . $tag]);
+                $this->smarty->registerPlugin('function', $tag, [$this, '_widget_function__' . $tag]);
                 $this->smarty->registerClass($tag, $class);
             }
         }


### PR DESCRIPTION
#6991 changed a string that made the global registration in application config not work anymore. This makes it so widgets declared in the config work again.
