### PR TITLE
fix generateActionParamComments() on only one pk

### DIFF
--- a/extensions/gii/generators/crud/Generator.php
+++ b/extensions/gii/generators/crud/Generator.php
@@ -495,7 +495,7 @@ class Generator extends \yii\gii\Generator
             return $params;
         }
         if (count($pks) === 1) {
-            return ['@param ' . $table->columns[$pks[0]]->phpType . ' $id'];
+            return ['@param ' . $table->columns[$pks[0]]->phpType . ' $' . $pks[0]'];
         } else {
             $params = [];
             foreach ($pks as $pk) {


### PR DESCRIPTION
line 498, if only one primary key, set the right model pk name instead of ever '$id'
