### PR TITLE
fix generateActionParamComments() on only one pk

### DIFF
--- a/extensions/gii/generators/crud/Generator.php
+++ b/extensions/gii/generators/crud/Generator.php
@@ -504,7 +504,7 @@ class Generator extends \yii\gii\Generator
             return $params;
         }
         if (count($pks) === 1) {
-            return ['@param ' . $table->columns[$pks[0]]->phpType . ' $id'];
+            return ['@param ' . $table->columns[$pks[0]]->phpType . ' $' . $pks[0]];
         } else {
             $params = [];
             foreach ($pks as $pk) {


### PR DESCRIPTION
@cebe hmm yeah... probably here too...

``` php
   /**
     * Generates action parameters
     * @return string
     */
    public function generateActionParams()
    {
        /* @var $class ActiveRecord */
        $class = $this->modelClass;
        $pks = $class::primaryKey();
        if (count($pks) === 1) {
            return '$id';                               <-- return '$' . $pks[0];   // line 474
        } else {
            return '$' . implode(', $', $pks);
        }
    }
```

@samdark :) I have tested it but have done the changes on github... not pushed from local dev repo. Sorry my fault. Not the dot but the single quote at the end causes CI failing.
@qiangxue Will you give me right, that it is simply wrong if my primary key named i.e '$actor_id' and the generator output looks like

``` php
   /**
     * @param integer $id
     *
     * @return mixed
     */
    public function actionView($actor_id)
    {
```
