### PR TITLE
Unusable JsonParser 'asArray' parameter

### DIFF
--- a/framework/web/JsonParser.php
+++ b/framework/web/JsonParser.php
@@ -48,7 +48,7 @@ class JsonParser implements RequestParserInterface
     public function parse($rawBody, $contentType)
     {
         try {
-            return Json::decode($rawBody, $this->asArray);
+            return (array)Json::decode($rawBody, $this->asArray);
         } catch (InvalidParamException $e) {
             if ($this->throwException) {
                 throw new BadRequestHttpException('Invalid JSON data in request body: ' . $e->getMessage(), 0, $e);


### PR DESCRIPTION
Use case: Use `ActiveController` to handle application/json objects in POST data, validate it through ActiveRecord JsonSchema validator and put in storage.

If you configure request like this:

``` php
            'request' => [
                'parsers' => [
                    'application/json' => [
                        'class' => 'yii\web\JsonParser',
                        'asArray' => false,
                    ]
                ]
            ],
```

You'll get object in `Request::_bodyParams`, but `Request::getBodyParam()` operates with array, so parsed data became unusable and you'll get nothing in your AR model attributes.

So, we need to always return Array at the top level.
