### PR TITLE
Fix undefined variable $scenario in test files.

### DIFF
--- a/apps/advanced/tests/codeception/backend/acceptance/LoginCept.php
+++ b/apps/advanced/tests/codeception/backend/acceptance/LoginCept.php
@@ -3,6 +3,8 @@
 use tests\codeception\backend\AcceptanceTester;
 use tests\codeception\common\_pages\LoginPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new AcceptanceTester($scenario);
 $I->wantTo('ensure login page works');
 

--- a/apps/advanced/tests/codeception/backend/functional/LoginCept.php
+++ b/apps/advanced/tests/codeception/backend/functional/LoginCept.php
@@ -3,6 +3,8 @@
 use tests\codeception\backend\FunctionalTester;
 use tests\codeception\common\_pages\LoginPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new FunctionalTester($scenario);
 $I->wantTo('ensure login page works');
 

--- a/apps/advanced/tests/codeception/frontend/acceptance/AboutCept.php
+++ b/apps/advanced/tests/codeception/frontend/acceptance/AboutCept.php
@@ -2,6 +2,8 @@
 use tests\codeception\frontend\AcceptanceTester;
 use tests\codeception\frontend\_pages\AboutPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new AcceptanceTester($scenario);
 $I->wantTo('ensure that about works');
 AboutPage::openBy($I);

--- a/apps/advanced/tests/codeception/frontend/acceptance/ContactCept.php
+++ b/apps/advanced/tests/codeception/frontend/acceptance/ContactCept.php
@@ -2,6 +2,8 @@
 use tests\codeception\frontend\AcceptanceTester;
 use tests\codeception\frontend\_pages\ContactPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new AcceptanceTester($scenario);
 $I->wantTo('ensure that contact works');
 

--- a/apps/advanced/tests/codeception/frontend/acceptance/HomeCept.php
+++ b/apps/advanced/tests/codeception/frontend/acceptance/HomeCept.php
@@ -1,6 +1,8 @@
 <?php
 use tests\codeception\frontend\AcceptanceTester;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new AcceptanceTester($scenario);
 $I->wantTo('ensure that home page works');
 $I->amOnPage(Yii::$app->homeUrl);

--- a/apps/advanced/tests/codeception/frontend/acceptance/LoginCept.php
+++ b/apps/advanced/tests/codeception/frontend/acceptance/LoginCept.php
@@ -2,6 +2,8 @@
 use tests\codeception\frontend\AcceptanceTester;
 use tests\codeception\common\_pages\LoginPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new AcceptanceTester($scenario);
 $I->wantTo('ensure login page works');
 

--- a/apps/advanced/tests/codeception/frontend/functional/AboutCept.php
+++ b/apps/advanced/tests/codeception/frontend/functional/AboutCept.php
@@ -2,6 +2,8 @@
 use tests\codeception\frontend\FunctionalTester;
 use tests\codeception\frontend\_pages\AboutPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new FunctionalTester($scenario);
 $I->wantTo('ensure that about works');
 AboutPage::openBy($I);

--- a/apps/advanced/tests/codeception/frontend/functional/ContactCept.php
+++ b/apps/advanced/tests/codeception/frontend/functional/ContactCept.php
@@ -2,6 +2,8 @@
 use tests\codeception\frontend\FunctionalTester;
 use tests\codeception\frontend\_pages\ContactPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new FunctionalTester($scenario);
 $I->wantTo('ensure that contact works');
 

--- a/apps/advanced/tests/codeception/frontend/functional/HomeCept.php
+++ b/apps/advanced/tests/codeception/frontend/functional/HomeCept.php
@@ -1,5 +1,8 @@
 <?php
 use tests\codeception\frontend\FunctionalTester;
+
+/* @var $scenario Codeception\Scenario */
+
 $I = new FunctionalTester($scenario);
 $I->wantTo('ensure that home page works');
 $I->amOnPage(Yii::$app->homeUrl);

--- a/apps/advanced/tests/codeception/frontend/functional/LoginCept.php
+++ b/apps/advanced/tests/codeception/frontend/functional/LoginCept.php
@@ -2,6 +2,8 @@
 use tests\codeception\frontend\FunctionalTester;
 use tests\codeception\common\_pages\LoginPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new FunctionalTester($scenario);
 $I->wantTo('ensure login page works');
 

--- a/apps/basic/tests/codeception/acceptance/AboutCept.php
+++ b/apps/basic/tests/codeception/acceptance/AboutCept.php
@@ -2,6 +2,8 @@
 
 use tests\codeception\_pages\AboutPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new AcceptanceTester($scenario);
 $I->wantTo('ensure that about works');
 AboutPage::openBy($I);

--- a/apps/basic/tests/codeception/acceptance/ContactCept.php
+++ b/apps/basic/tests/codeception/acceptance/ContactCept.php
@@ -2,6 +2,8 @@
 
 use tests\codeception\_pages\ContactPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new AcceptanceTester($scenario);
 $I->wantTo('ensure that contact works');
 

--- a/apps/basic/tests/codeception/acceptance/HomeCept.php
+++ b/apps/basic/tests/codeception/acceptance/HomeCept.php
@@ -1,5 +1,7 @@
 <?php
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new AcceptanceTester($scenario);
 $I->wantTo('ensure that home page works');
 $I->amOnPage(Yii::$app->homeUrl);

--- a/apps/basic/tests/codeception/acceptance/LoginCept.php
+++ b/apps/basic/tests/codeception/acceptance/LoginCept.php
@@ -2,6 +2,8 @@
 
 use tests\codeception\_pages\LoginPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new AcceptanceTester($scenario);
 $I->wantTo('ensure that login works');
 

--- a/apps/basic/tests/codeception/functional/AboutCept.php
+++ b/apps/basic/tests/codeception/functional/AboutCept.php
@@ -2,6 +2,8 @@
 
 use tests\codeception\_pages\AboutPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new FunctionalTester($scenario);
 $I->wantTo('ensure that about works');
 AboutPage::openBy($I);

--- a/apps/basic/tests/codeception/functional/ContactCept.php
+++ b/apps/basic/tests/codeception/functional/ContactCept.php
@@ -2,6 +2,8 @@
 
 use tests\codeception\_pages\ContactPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new FunctionalTester($scenario);
 $I->wantTo('ensure that contact works');
 

--- a/apps/basic/tests/codeception/functional/HomeCept.php
+++ b/apps/basic/tests/codeception/functional/HomeCept.php
@@ -1,5 +1,7 @@
 <?php
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new FunctionalTester($scenario);
 $I->wantTo('ensure that home page works');
 $I->amOnPage(Yii::$app->homeUrl);

--- a/apps/basic/tests/codeception/functional/LoginCept.php
+++ b/apps/basic/tests/codeception/functional/LoginCept.php
@@ -2,6 +2,8 @@
 
 use tests\codeception\_pages\LoginPage;
 
+/* @var $scenario Codeception\Scenario */
+
 $I = new FunctionalTester($scenario);
 $I->wantTo('ensure that login works');
 


### PR DESCRIPTION
IDE inspection indicate warrning `Undefined variable scenario` in test files.
To fix it was added var-type-hinting to `$scenario` variable in all `*Cept` files.
