### PR TITLE
Formatter::asDatetime() => asDateTime()

### DIFF
--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -498,7 +498,7 @@ class Formatter extends Component
      * @throws InvalidConfigException if the date format is invalid.
      * @see datetimeFormat
      */
-    public function asDatetime($value, $format = null)
+    public function asDateTime($value, $format = null)
     {
         if ($format === null) {
             $format = $this->datetimeFormat;


### PR DESCRIPTION
Fixed the 'T' capitalization. (The function is being referenced to as "asDateTime" elsewhere in the codebase.)
