### PR TITLE
yii\base\Object::className() now has a flag to return a short class name

### DIFF
--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -241,9 +241,7 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      */
     public function formName()
     {
-        $reflector = new ReflectionClass($this);
-
-        return $reflector->getShortName();
+        return self::className(false);
     }
 
     /**

--- a/framework/base/Object.php
+++ b/framework/base/Object.php
@@ -7,6 +7,7 @@
 
 namespace yii\base;
 
+use ReflectionClass;
 use Yii;
 
 /**
@@ -78,11 +79,12 @@ class Object
 {
     /**
      * Returns the fully qualified name of this class.
+     * @param $fullyQualified bool whether to return a FQCN, defaults to true
      * @return string the fully qualified name of this class.
      */
-    public static function className()
+    public static function className($fullyQualified = true)
     {
-        return get_called_class();
+        return $fullyQualified ? get_called_class() : (new ReflectionClass(self::className()))->getShortName();
     }
 
     /**


### PR DESCRIPTION
I think that we may cache ReflectionClass instance into a private field so we son't create it every time if the ::className() method was called on one class at least twice. just let me know.
