### PR TITLE
[WIP] New method `linkSync` to update junction tables

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1225,10 +1225,6 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
     
     public function linkSync($name, $keys)
     {
-        if (empty($keys)) {
-            return;
-        }
-
         $relation = $this->getRelation($name);
         if ($relation->via !== null) {
             if ($this->getIsNewRecord()) {
@@ -1268,15 +1264,17 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
                 ->createCommand(static::getDb())
                 ->queryAll();
                 
-            if (is_object($keys[0]) && $keys[0] instanceof self) { //Format an array of models
-                foreach ($keys as &$key) {
-                    $key = array_map(function($item) use (&$key) {
-                        return $key->$item;
-                    }, array_flip($relation->link));
-                }
-            } else if (!is_array($keys[0])) { //Format single keys
-                foreach ($keys as &$key) {
-                    $key = [reset($relation->link) => $key];
+            if (!empty($keys)) {
+                if (is_object($keys[0]) && $keys[0] instanceof self) { //Format an array of models
+                    foreach ($keys as &$key) {
+                        $key = array_map(function($item) use (&$key) {
+                            return $key->$item;
+                        }, array_flip($relation->link));
+                    }
+                } else if (!is_array($keys[0])) { //Format single keys
+                    foreach ($keys as &$key) {
+                        $key = [reset($relation->link) => $key];
+                    }
                 }
             }
             

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1225,6 +1225,10 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
     
     public function linkSync($name, $keys)
     {
+        if (empty($keys)) {
+            return;
+        }
+
         $relation = $this->getRelation($name);
         if ($relation->via !== null) {
             if ($this->getIsNewRecord()) {


### PR DESCRIPTION
Allow junction tables to be updated via the relation.

| $model-id | other-id |
| --- | --- |
| 1 | 1 |
| 1 | 2 |
| 1 | 3 |
| 1 | 4 |

`$model->linkSync('relation', [1, 2, 5, 6]);`
This would remove the relation to `3 & 4` and insert new relations to `5 & 6`.
Based this off `laravel->sync()` from an article I read.

This is more of a demo to get some thoughts as it would need updating to support relations more strongly.
