### PR TITLE
simplify findByCondition

### DIFF
--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -165,12 +165,11 @@ class ActiveRecord extends BaseActiveRecord
      * Finds ActiveRecord instance(s) by the given condition.
      * This method is internally called by [[findOne()]] and [[findAll()]].
      * @param mixed $condition please refer to [[findOne()]] for the explanation of this parameter
-     * @param boolean $one whether this method is called by [[findOne()]] or [[findAll()]]
-     * @return static|static[]
+     * @return ActiveQueryInterface the newly created [[ActiveQueryInterface|ActiveQuery]] instance. 
      * @throws InvalidConfigException if there is no primary key defined
      * @internal
      */
-    protected static function findByCondition($condition, $one)
+    protected static function findByCondition($condition)
     {
         $query = static::find();
 
@@ -188,7 +187,7 @@ class ActiveRecord extends BaseActiveRecord
             }
         }
 
-        return $one ? $query->andWhere($condition)->one() : $query->andWhere($condition)->all();
+        return $query->andWhere($condition);
     }
 
     /**

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -98,7 +98,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public static function findOne($condition)
     {
-        return static::findByCondition($condition, true);
+        return static::findByCondition($condition)->one();
     }
 
     /**
@@ -107,19 +107,18 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public static function findAll($condition)
     {
-        return static::findByCondition($condition, false);
+        return static::findByCondition($condition)->all();
     }
 
     /**
      * Finds ActiveRecord instance(s) by the given condition.
      * This method is internally called by [[findOne()]] and [[findAll()]].
      * @param mixed $condition please refer to [[findOne()]] for the explanation of this parameter
-     * @param boolean $one whether this method is called by [[findOne()]] or [[findAll()]]
-     * @return static|static[]
+     * @return ActiveQueryInterface the newly created [[ActiveQueryInterface|ActiveQuery]] instance. 
      * @throws InvalidConfigException if there is no primary key defined
      * @internal
      */
-    protected static function findByCondition($condition, $one)
+    protected static function findByCondition($condition)
     {
         $query = static::find();
 
@@ -133,7 +132,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
             }
         }
 
-        return $one ? $query->andWhere($condition)->one() : $query->andWhere($condition)->all();
+        return $query->andWhere($condition);
     }
 
     /**


### PR DESCRIPTION
`findByCondition` now returns an `ActiveQuery` instead of the final result, this way the code is easier to understand and it allows to extend the functionalities more easily.

For example

``` php
class Product extends ActiveRecord
{
     public static function findMostExpensive($condition)
     {
         return static::findByCondition($condition)->max('price');
     }
}
```

``` php
class Author extends ActiveRecord
{
     public static function countBooks($condition)
     {
         return static::findByCondition($condition)
             // loads the relation with books.
             ->innerJoinWith('books')
             ->count();
     }
}
```

Usage

``` php
// count all the books whos authors were born in México
Author::countBooks(['country' => 'México']);
```

Basically this makes `findByCondition` more versatile and allows other methods to use it, no longer being just able to return the same results as findOne and findAll

This is a backwards compatible merge since previously findByCondition could only be used by findOne and findAll, fixing those methods to invoke ->one() and ->all() direclty fix any possible incompatibility.
