### PR TITLE
Work around #6506: About yii2-mongodb find()->one

### DIFF
--- a/extensions/mongodb/Query.php
+++ b/extensions/mongodb/Query.php
@@ -147,8 +147,9 @@ class Query extends Component implements QueryInterface
     protected function fetchRowsInternal($cursor, $all, $indexBy)
     {
         $result = [];
-        if ($all) {
-            foreach ($cursor as $row) {
+
+        foreach ($cursor as $row) {
+            if ($all) {
                 if ($indexBy !== null) {
                     if (is_string($indexBy)) {
                         $key = $row[$indexBy];
@@ -159,12 +160,10 @@ class Query extends Component implements QueryInterface
                 } else {
                     $result[] = $row;
                 }
-            }
-        } else {
-            if ($cursor->hasNext()) {
-                $result = $cursor->getNext();
             } else {
-                $result = false;
+                $result = $row;
+
+                break;
             }
         }
 

--- a/extensions/mongodb/Query.php
+++ b/extensions/mongodb/Query.php
@@ -146,7 +146,7 @@ class Query extends Component implements QueryInterface
      */
     protected function fetchRowsInternal($cursor, $all, $indexBy)
     {
-        $result = [];
+        $result = $all ? [] : false;
 
         foreach ($cursor as $row) {
             if ($all) {


### PR DESCRIPTION
Dotdeb now has php5-mongo_1%3a1.6.0-1~dotdeb.2_amd64.deb for Debian 7

Stack trace:

``` php
PHP Warning 'yii\base\ErrorException' with message 'Invalid argument supplied for foreach()'

in /project/vendor/composer/yiisoft/yii2/db/BaseActiveRecord.php:1047

Stack trace:
#0 /project/vendor/composer/yiisoft/yii2/db/BaseActiveRecord.php(1047): yii\base\ErrorHandler->handleError(2, 'Invalid argumen...', '/project...', 1047, Array)
#1 /project/vendor/composer/yiisoft/yii2/db/ActiveQueryTrait.php(132): yii\db\BaseActiveRecord::populateRecord(Object(app\models\Setting), NULL)
#2 /project/vendor/composer/yiisoft/yii2-mongodb/ActiveQuery.php(215): yii\mongodb\ActiveQuery->createModels(Array)
#3 /project/vendor/composer/yiisoft/yii2-mongodb/ActiveQuery.php(154): yii\mongodb\ActiveQuery->populate(Array)
#4 /project/app/components/Settings.php(31): yii\mongodb\ActiveQuery->one()
#5 /project/vendor/composer/yiisoft/yii2/base/Object.php(107): app\components\Settings->init()
#6 [internal function]: yii\base\Object->__construct(Array)
#7 /project/vendor/composer/yiisoft/yii2/di/Container.php(362): ReflectionClass->newInstanceArgs(Array)
#8 /project/vendor/composer/yiisoft/yii2/di/Container.php(147): yii\di\Container->build('app\\components\\...', Array, Array)
#9 /project/vendor/composer/yiisoft/yii2/BaseYii.php(344): yii\di\Container->get('app\\components\\...', Array, Array)
#10 /project/vendor/composer/yiisoft/yii2/di/ServiceLocator.php(133): yii\BaseYii::createObject(Array)
#11 /project/vendor/composer/yiisoft/yii2/base/Application.php(302): yii\di\ServiceLocator->get('settings')
#12 /project/vendor/composer/yiisoft/yii2/web/Application.php(63): yii\base\Application->bootstrap()
#13 /project/vendor/composer/yiisoft/yii2/base/Application.php(267): yii\web\Application->bootstrap()
#14 /project/vendor/composer/yiisoft/yii2/base/Object.php(107): yii\base\Application->init()
#15 /project/vendor/composer/yiisoft/yii2/base/Application.php(206): yii\base\Object->__construct(Array)
#16 /project/web/index.php(40): yii\base\Application->__construct(Array)
#17 {main}
```

I found the following code in `mongo-php-driver` (maybe it will help):

`v1.5.8` - https://github.com/mongodb/mongo-php-driver/blob/1.5.8/cursor.c#L234:

``` c
    if (!cursor->started_iterating) {
        MONGO_METHOD(MongoCursor, doQuery, return_value, getThis());
        cursor->started_iterating = 1;
    }
```

`v1.6.0` - https://github.com/mongodb/mongo-php-driver/blob/1.6.0/cursor.c#L240:

``` c
    if (!cursor->started_iterating) {
        php_mongo_runquery(cursor TSRMLS_CC);
        if (EG(exception)) {
            RETURN_NULL();
        }
        cursor->started_iterating = 1;
    }
```

Now, in Yii (don't pretend to be correct, but in that case - it works ;) ):

https://github.com/yiisoft/yii2/blob/master/extensions/mongodb/Query.php#L147-L172

``` php
    protected function fetchRowsInternal($cursor, $all, $indexBy)
    {
        $result = [];
        if ($all) {
            foreach ($cursor as $row) {
                if ($indexBy !== null) {
                    if (is_string($indexBy)) {
                        $key = $row[$indexBy];
                    } else {
                        $key = call_user_func($indexBy, $row);
                    }
                    $result[$key] = $row;
                } else {
                    $result[] = $row;
                }
            }
        } else {
            if ($cursor->hasNext()) {
                $result = $cursor->getNext();
            } else {
                $result = false;
            }
        }
        return $result;
    }
```

I replace with:

``` php
    protected function fetchRowsInternal($cursor, $all, $indexBy)
    {
        $result = $all ? [] : false;

        foreach ($cursor as $row) {
            // if we need all - no changes:
            if ($all) {
                if ($indexBy !== null) {
                    if (is_string($indexBy)) {
                        $key = $row[$indexBy];
                    } else {
                        $key = call_user_func($indexBy, $row);
                    }
                    $result[$key] = $row;
                } else {
                    $result[] = $row;
                }
            // otherwise get one and break:
            } else {
                $result = $row;

                break;
            }
        }

        return $result;
    }
```
