### PR TITLE
Fixed #7150 - support ICU single quote syntaxes

### DIFF
--- a/framework/helpers/BaseFormatConverter.php
+++ b/framework/helpers/BaseFormatConverter.php
@@ -120,7 +120,15 @@ class BaseFormatConverter
             }
         }
         // http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
-        return strtr($pattern, [
+        // escaped text
+        $escaped = [];
+        if (preg_match_all('/(?<!\')\'(.+?)\'/', $pattern, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $escaped[$match[0]] = '\\'.implode('\\', str_split($match[1]));
+            }
+        }
+        return strtr($pattern, array_merge($escaped, [
+            '\'\'' => '\'', // two single quotes produce one
             'G' => '', // era designator like (Anno Domini)
             'Y' => 'o',     // 4digit year of "Week of Year"
             'y' => 'Y',     // 4digit year e.g. 2014
@@ -220,7 +228,7 @@ class BaseFormatConverter
             'xxx' => 'P',    // Time Zone: ISO8601 extended hm, without Z, e.g. -08:00
             'xxxx' => '',   // Time Zone: ISO8601 basic hms?, without Z, e.g. -0800, -075258
             'xxxxx' => '',  // Time Zone: ISO8601 extended hms?, without Z, e.g. -08:00, -07:52:58
-        ]);
+        ]));
     }
 
     /**
@@ -323,7 +331,14 @@ class BaseFormatConverter
             }
         }
         // http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
-        return strtr($pattern, [
+        // escaped text
+        $escaped = [];
+        if (preg_match_all('/(?<!\')\'.+?\'/', $pattern, $matches)) {
+            foreach ($matches[0] as $match) {
+                $escaped[$match] = $match;
+            }
+        }
+        return strtr($pattern, array_merge($escaped, [
             'G' => '',      // era designator like (Anno Domini)
             'Y' => '',      // 4digit year of "Week of Year"
             'y' => 'yy',    // 4digit year e.g. 2014
@@ -423,7 +438,7 @@ class BaseFormatConverter
             'xxx' => '',    // Time Zone: ISO8601 extended hm, without Z, e.g. -08:00
             'xxxx' => '',   // Time Zone: ISO8601 basic hms?, without Z, e.g. -0800, -075258
             'xxxxx' => '',  // Time Zone: ISO8601 extended hms?, without Z, e.g. -08:00, -07:52:58
-        ]);
+        ]));
     }
 
     /**

--- a/framework/helpers/BaseFormatConverter.php
+++ b/framework/helpers/BaseFormatConverter.php
@@ -122,13 +122,14 @@ class BaseFormatConverter
         // http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
         // escaped text
         $escaped = [];
-        if (preg_match_all('/(?<!\')\'(.+?)\'/', $pattern, $matches, PREG_SET_ORDER)) {
+        if (preg_match_all('/(?<!\')\'(.*?[^\'])\'(?!\')/', $pattern, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
+                $match[1] = str_replace('\'\'', '\'', $match[1]);
                 $escaped[$match[0]] = '\\'.implode('\\', str_split($match[1]));
             }
         }
         return strtr($pattern, array_merge($escaped, [
-            '\'\'' => '\'', // two single quotes produce one
+            '\'\'' => '\\\'', // two single quotes produce one
             'G' => '', // era designator like (Anno Domini)
             'Y' => 'o',     // 4digit year of "Week of Year"
             'y' => 'Y',     // 4digit year e.g. 2014
@@ -333,7 +334,7 @@ class BaseFormatConverter
         // http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
         // escaped text
         $escaped = [];
-        if (preg_match_all('/(?<!\')\'.+?\'/', $pattern, $matches)) {
+        if (preg_match_all('/(?<!\')\'.*?[^\']\'(?!\')/', $pattern, $matches)) {
             foreach ($matches[0] as $match) {
                 $escaped[$match] = $match;
             }

--- a/tests/unit/framework/helpers/FormatConverterTest.php
+++ b/tests/unit/framework/helpers/FormatConverterTest.php
@@ -37,6 +37,16 @@ class FormatConverterTest extends TestCase
         $this->assertEquals('d.m.y', FormatConverter::convertDateIcuToPhp('short', 'date', 'de-DE'));
     }
 
+    public function testEscapedIcuToPhp()
+    {
+        $this->assertEquals('\\o\\\'\\c\\l\\o\\c\\k', FormatConverter::convertDateIcuToPhp('\'o\'\'clock\''));
+    }
+
+    public function testEscapedIcuToJui()
+    {
+        $this->assertEquals('\'o\'\'clock\'', FormatConverter::convertDateIcuToJui('\'o\'\'clock\''));
+    }
+
     public function testIntlOneDigitIcu()
     {
         $formatter = new Formatter(['locale' => 'en-US']);


### PR DESCRIPTION
- When converting an ICU date/time format to PHP, text within single quotes will be replaced with backslashes in front of each character (the PHP date() method for escaping text), and double-single quotes will be replaced with single quotes.
- When converting an ICU date/time format to jQuery UI, text  within single quotes, and double-single quotes, will each be preserved (rather than parsed for date/time format symbols), as jQuery UI uses the same text escaping and single quote syntax as ICU.
