### PR TITLE
set a blank value by default for activePasswordInput

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -577,6 +577,7 @@ class BaseHtml
      */
     public static function passwordInput($name, $value = null, $options = [])
     {
+        $options['value'] = isset($options['value']) ? $options['value'] : '';
         return static::input('password', $name, $value, $options);
     }
 


### PR DESCRIPTION
Passwords are not readable so asking for its value to an ActiveRecord or a model is meaningless, since it will return blank (if its a model form), a hash or throw an exception (if its an ActiveRecord).

The only use it might have is when someone put the password wrong and then the page reloads asking for the password again with the previous password preloaded.

But since the user can't see the text previously provided then this is is useless since the first thing the user does is deleting all the '*' on the input then write the password all over again (or paste it).

The best way that the model won't get asked for the value of the password field is setting a default value

``` php
$form->field($user, 'password')->passwordInput(['value' => '']);
```

So my PR simply checks if there if `$options['value']` is provided, if not then set it using an empty string so that the model won't get asked for its value.
