### PR TITLE
New method `asEmpty`

### DIFF
--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -286,7 +286,20 @@ class Formatter extends Component
         }
         return $value;
     }
-
+    
+    /**
+     * Formats the value based on the given format type.
+     * @param mixed $value
+     * @param string|array $format
+     * @return string the formatted result or an empty string.
+     * @see Formatter::format()
+     */
+    public function asEmpty($value, $format)
+    {
+        $result = $this->format($value, $format);
+        return $result === $this->nullDisplay ? '' : $result;
+    }
+    
     /**
      * Formats the value as an HTML-encoded plain text.
      * @param string $value the value to be formatted.


### PR DESCRIPTION
This follows the same pattern as `format` but will return an empty string instead of the `nullDisplay` value if the formatted result is null.

I needed this as I'm displaying a date from the database in an input field.
If the date from the db was null the `<input />` would get a value of `<span class="not-set">(not set)</span>`.
