### PR TITLE
use the ActiveField public methods for the default rendering

### DIFF
--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -181,13 +181,13 @@ class ActiveField extends Component
     {
         if ($content === null) {
             if (!isset($this->parts['{input}'])) {
-                $this->parts['{input}'] = Html::activeTextInput($this->model, $this->attribute, $this->inputOptions);
+                $this->textInput();
             }
             if (!isset($this->parts['{label}'])) {
-                $this->parts['{label}'] = Html::activeLabel($this->model, $this->attribute, $this->labelOptions);
+                $this->label();
             }
             if (!isset($this->parts['{error}'])) {
-                $this->parts['{error}'] = Html::error($this->model, $this->attribute, $this->errorOptions);
+                $this->error();
             }
             if (!isset($this->parts['{hint}'])) {
                 $this->parts['{hint}'] = '';


### PR DESCRIPTION
This is useful in case someone extends the `yii\widgets\ActiveField` class to modify the behavior of the methods `label()`, `error()` or `textInput()` one need to also edit the `render()`

For example the current code produce this behavior

``` php
$form = ActiveForm::begin(['fieldClass' => MyActiveField::className()]);

echo $form->field($model, 'attribute');
// renders the inputs, labels and error the same as ActiveField

echo $form->field($model, 'attribute')->textInput()->label()->error();
// renders the extended methods defined in MyActiveField
```
