### PR TITLE
Fixed wrong YII_ENV in tests of Advanced app template

### DIFF
--- a/apps/advanced/tests/codeception/bin/_bootstrap.php
+++ b/apps/advanced/tests/codeception/bin/_bootstrap.php
@@ -7,6 +7,9 @@
  * @license http://www.yiiframework.com/license/
  */
 
+defined('YII_DEBUG') or define('YII_DEBUG', true);
+defined('YII_ENV') or define('YII_ENV', 'test');
+
 // fcgi doesn't have STDIN and STDOUT defined by default
 defined('STDIN') or define('STDIN', fopen('php://stdin', 'r'));
 defined('STDOUT') or define('STDOUT', fopen('php://stdout', 'w'));
@@ -16,8 +19,5 @@ defined('YII_APP_BASE_PATH') or define('YII_APP_BASE_PATH', dirname(dirname(dirn
 require_once(YII_APP_BASE_PATH . '/vendor/autoload.php');
 require_once(YII_APP_BASE_PATH . '/vendor/yiisoft/yii2/Yii.php');
 require_once(YII_APP_BASE_PATH . '/common/config/bootstrap.php');
-
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'test');
 
 Yii::setAlias('@tests', dirname(dirname(__DIR__)));


### PR DESCRIPTION
`YII_ENV` was wrongly set to `prod` instead of `test` when runned by `tests/codeception/bin/yii` in Advanced app template
