### PR TITLE
All unchecked by default

### DIFF
--- a/extensions/gii/views/default/view/files.php
+++ b/extensions/gii/views/default/view/files.php
@@ -78,7 +78,7 @@ use yii\gii\CodeFile;
                     if ($file->operation === CodeFile::OP_SKIP) {
                         echo '&nbsp;';
                     } else {
-                        echo Html::checkBox("answers[{$file->id}]", isset($answers) ? isset($answers[$file->id]) : ($file->operation === CodeFile::OP_CREATE));
+                        echo Html::checkBox("answers[{$file->id}]", isset($answers[$file->id]));
                     }
                     ?>
                 </td>


### PR DESCRIPTION
It should only be generated the file code that the user explicitly desired.

It's safer that by default no file is checked.
When you have a very large list of files the user may not notice a marked file on the list.
