### PR TITLE
Define a SubJoin class to do subjoins into querybuilder

### DIFF
--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -110,6 +110,30 @@ class QueryBuilder extends \yii\base\Object
     }
 
     /**
+     * Generates a SELECT SQL statement from a [[SubJoin]] object.
+     * @param SubJoin $subJoin the [[SubJoin]] object from which the SQL statement will be generated.
+     * @param array $params the parameters to be bound to the generated SQL statement. These parameters will
+     * be included in the result with the additional parameters generated during the query building process.
+     * @return array the generated SQL statement (the first array element) and the corresponding
+     * parameters to be bound to the SQL statement (the second array element). The parameters returned
+     * include those provided in `$params`.
+     */
+    public function buildSubJoin($subJoin, $params = [])
+    {
+        $subJoin = $subJoin->prepare($this);
+
+        $params = empty($params) ? $subJoin->params : array_merge($params, $subJoin->params);
+
+        $clauses = [
+            $this->buildJoin($subJoin->join, $params),
+        ];
+
+        $sql = implode($this->separator, array_filter($clauses));
+
+        return [$sql, $params];
+    }
+
+    /**
      * Creates an INSERT SQL statement.
      * For example,
      *
@@ -704,7 +728,10 @@ class QueryBuilder extends \yii\base\Object
     private function quoteTableNames($tables, &$params)
     {
         foreach ($tables as $i => $table) {
-            if ($table instanceof Query) {
+            if ($table instanceof SubJoin) {
+                list($sql, $params) = $this->buildSubJoin($table, $params);
+                $tables[$i] = "($sql)";
+            } elseif ($table instanceof Query) {
                 list($sql, $params) = $this->build($table, $params);
                 $tables[$i] = "($sql) " . $this->db->quoteTableName($i);
             } elseif (is_string($i)) {

--- a/framework/db/SubJoin.php
+++ b/framework/db/SubJoin.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ivan
+ * Date: 2/6/15
+ * Time: 10:00 PM
+ */
+
+namespace yii\db;
+
+
+use Yii;
+use yii\base\Component;
+
+class SubJoin extends Query{
+
+    /**
+     * Creates a DB command that can be used to execute this query.
+     * @param Connection $db the database connection used to generate the SQL statement.
+     * If this parameter is not given, the `db` application component will be used.
+     * @return Command the created DB command instance.
+     */
+    public function createCommand($db = null)
+    {
+        if ($db === null) {
+            $db = Yii::$app->getDb();
+        }
+        list ($sql, $params) = $db->getQueryBuilder()->buildSubJoin($this);
+
+        return $db->createCommand($sql, $params);
+    }
+
+
+    public function subJoin($table, $params = [])
+    {
+        if(is_array($this->join) && count($this->join)>0){
+            throw new Exception('SubJoin could be only in first position');
+        }
+        $this->join[] = ['', $table];
+        return $this->addParams($params);
+    }
+
+}

--- a/framework/db/SubJoin.php
+++ b/framework/db/SubJoin.php
@@ -39,5 +39,4 @@ class SubJoin extends Query{
         $this->join[] = ['', $table];
         return $this->addParams($params);
     }
-
 }


### PR DESCRIPTION
At the moment YII allows only to do sub-query, but SQL allows also to do sub-joins.
I usually use with an INNER JOIN chain LEFT JOINed with the FROM table.

The goal is this kind of sub-JOIN:

```
FROM user us
LEFT JOIN ( `lessonactivity` `st` INNER JOIN  `lesson` `ls` ON st.lessonId=ls.id INNER JOIN `chapter` `ch` ON ls.chapterId=ch.id INNER JOIN `topic` `tp` ON ch.topicId=tp.id) ON st.userId=us.id                 
```

The code

```
$_subJoin = (new \yii\db\SubJoin())
                    ->subJoin(['st'=>'lessonactivity'])
                    ->innerJoin([ 'ls'=>'lesson' ],'st.lessonId=ls.id')
                    ->innerJoin([ 'ch'=>'chapter' ],'ls.chapterId=ch.id')
                    ->innerJoin([ 'tp'=>'topic' ],'ch.topicId=tp.id');

$_query = (new \yii\db\Query())
->from(['us'=>'user'])
->leftJoin(["sj"=>$_subJoin], 'st.userId=us.id' );

```

I tried to reduce at the minimum the impact, and may be there's a better way to do, so I'm open to any improvement.
