### PR TITLE
Update SiteController Documentation

### DIFF
--- a/docs/guide/security-auth-clients.md
+++ b/docs/guide/security-auth-clients.md
@@ -134,7 +134,7 @@ class SiteController extends Controller
                 $user = $auth->user;
                 Yii::$app->user->login($user);
             } else { // signup
-                if (User::find()->where(['email' => $attributes['email']])->exists()) {
+                if (isset($attributes['email']) && isset($attributes['username']) && User::find()->where(['email' => $attributes['email']])->exists()) {
                     Yii::$app->getSession()->setFlash('error', [
                         Yii::t('app', "User with the same email as in {client} account already exists but isn't linked to it. Login using email first to link it.", ['client' => $client->getTitle()]),
                     ]);


### PR DESCRIPTION
This sitecontroller documentation can be improved. There are instances where you won't return in an email for Facebook (when someone registers via phone). In addition, you may not return a login as well therefore you get an error. I added a check to make sure that they returned. In my personal instance, I returned a message where they had to use another login/register method if it didn't have an email. I also used email as the login.
