### PR TITLE
Enh #7222: Added RTL support for debug toolbar

### DIFF
--- a/extensions/debug/CHANGELOG.md
+++ b/extensions/debug/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 debug extension Change Log
 
 - Bug #6903: Fixed display issue with phpinfo() table (kalayda, cebe)
 - Enh #6890: Added ability to filter by query type (pana1990)
+- Enh #7222: Added RTL support for debug toolbar `<html dir="rtl">` (johonunu)
 
 
 2.0.2 January 11, 2015

--- a/extensions/debug/assets/toolbar.css
+++ b/extensions/debug/assets/toolbar.css
@@ -185,3 +185,32 @@
     right: 31px;
     bottom: 4px;
 }
+
+html[dir=rtl] #yii-debug-toolbar .yii-debug-toolbar-block {
+    float: right;
+}
+
+html[dir=rtl] #yii-debug-toolbar .yii-debug-toolbar-block a, 
+html[dir=rtl] #yii-debug-toolbar .yii-debug-toolbar-block span.label{
+    unicode-bidi: bidi-override;
+}
+
+html[dir=rtl] #yii-debug-toolbar .yii-debug-toolbar-toggler,
+html[dir=rtl] #yii-debug-toolbar-min .yii-debug-toolbar-toggler{
+    left: 10px;
+    right: initial;
+}
+
+html[dir=rtl] #yii-debug-toolbar-min{
+    border-right: 1px solid #ccc;
+    border-left: initial;
+    border-top-right-radius:6px;
+    border-top-left-radius:initial;
+    left: 0px;
+    right: 0px;
+}
+
+html[dir=rtl] #yii-debug-toolbar-min #yii-debug-toolbar-logo{
+    left: 31px;
+    right: initial;
+}


### PR DESCRIPTION
Hi I hope this fixes the problem with RTL support for yii2-debug toolbar. 
I must admit I am not RTL user, so it would be nice to check if everything is ok.

To test RTL support add html tag to layout like this:

```
<html dir="rtl">
```
