### PR TITLE
fixed example with wrong namespace at MaskedInput.php

### DIFF
--- a/framework/widgets/MaskedInput.php
+++ b/framework/widgets/MaskedInput.php
@@ -33,7 +33,7 @@ use yii\web\View;
  * method, for example like this:
  *
  * ```php
- * <?= $form->field($model, 'from_date')->widget(\yii\jui\MaskedInput::classname(), [
+ * <?= $form->field($model, 'from_date')->widget(\yii\widgets\MaskedInput::classname(), [
  *     'mask' => '999-999-9999',
  * ]) ?>
  * ```


### PR DESCRIPTION
I think the correct namespace to reach `MaskedInput` should be `\yii\widgets`, not `\yii\jui`
