### PR TITLE
Fixed header Content-Type when response is empty

### DIFF
--- a/framework/web/HtmlResponseFormatter.php
+++ b/framework/web/HtmlResponseFormatter.php
@@ -35,6 +35,8 @@ class HtmlResponseFormatter extends Component implements ResponseFormatterInterf
             $this->contentType .= '; charset=' . $response->charset;
         }
         $response->getHeaders()->set('Content-Type', $this->contentType);
-        $response->content = $response->data;
+        if ($response->data !== null) {
+            $response->content = $response->data;
+        }
     }
 }

--- a/framework/web/JsonResponseFormatter.php
+++ b/framework/web/JsonResponseFormatter.php
@@ -49,7 +49,9 @@ class JsonResponseFormatter extends Component implements ResponseFormatterInterf
     protected function formatJson($response)
     {
         $response->getHeaders()->set('Content-Type', 'application/json; charset=UTF-8');
-        $response->content = Json::encode($response->data);
+        if ($response->data !== null) {
+            $response->content = Json::encode($response->data);
+        }
     }
 
     /**
@@ -61,7 +63,7 @@ class JsonResponseFormatter extends Component implements ResponseFormatterInterf
         $response->getHeaders()->set('Content-Type', 'application/javascript; charset=UTF-8');
         if (is_array($response->data) && isset($response->data['data'], $response->data['callback'])) {
             $response->content = sprintf('%s(%s);', $response->data['callback'], Json::encode($response->data['data']));
-        } else {
+        } elseif ($response->data !== null) {
             $response->content = '';
             Yii::warning("The 'jsonp' response requires that the data be an array consisting of both 'data' and 'callback' elements.", __METHOD__);
         }

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -920,7 +920,7 @@ class Response extends \yii\base\Response
      */
     protected function prepare()
     {
-        if ($this->stream !== null || $this->data === null) {
+        if ($this->stream !== null) {
             return;
         }
 

--- a/framework/web/XmlResponseFormatter.php
+++ b/framework/web/XmlResponseFormatter.php
@@ -57,13 +57,11 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
             $this->contentType .= '; charset=' . $charset;
         }
         $response->getHeaders()->set('Content-Type', $this->contentType);
-        if ($response->data !== null) {
-            $dom = new DOMDocument($this->version, $charset);
-            $root = new DOMElement($this->rootTag);
-            $dom->appendChild($root);
-            $this->buildXml($root, $response->data);
-            $response->content = $dom->saveXML();
-        }
+        $dom = new DOMDocument($this->version, $charset);
+        $root = new DOMElement($this->rootTag);
+        $dom->appendChild($root);
+        $this->buildXml($root, $response->data);
+        $response->content = $dom->saveXML();
     }
 
     /**

--- a/framework/web/XmlResponseFormatter.php
+++ b/framework/web/XmlResponseFormatter.php
@@ -57,11 +57,13 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
             $this->contentType .= '; charset=' . $charset;
         }
         $response->getHeaders()->set('Content-Type', $this->contentType);
-        $dom = new DOMDocument($this->version, $charset);
-        $root = new DOMElement($this->rootTag);
-        $dom->appendChild($root);
-        $this->buildXml($root, $response->data);
-        $response->content = $dom->saveXML();
+        if ($response->data !== null) {
+            $dom = new DOMDocument($this->version, $charset);
+            $root = new DOMElement($this->rootTag);
+            $dom->appendChild($root);
+            $this->buildXml($root, $response->data);
+            $response->content = $dom->saveXML();
+        }
     }
 
     /**


### PR DESCRIPTION
Now, the empty response sent with invalid "Content-Type", because formatters skipped and not set header.
