### PR TITLE
Fixed bug #7270

### DIFF
--- a/extensions/elasticsearch/ActiveQuery.php
+++ b/extensions/elasticsearch/ActiveQuery.php
@@ -215,7 +215,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             /* @var $class ActiveRecord */
             $class = $this->modelClass;
             $model = $class::instantiate($result);
-            $class::populateRecord($model, $result);
+            $_class = get_class($model);
+            $_class::populateRecord($model, $result);
             if (!empty($this->with)) {
                 $models = [$model];
                 $this->findWith($this->with, $models);

--- a/extensions/mongodb/file/ActiveQuery.php
+++ b/extensions/mongodb/file/ActiveQuery.php
@@ -146,7 +146,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 /* @var $class ActiveRecord */
                 $class = $this->modelClass;
                 $model = $class::instantiate($row);
-                $class::populateRecord($model, $row);
+                $_class = get_class($model);
+                $_class::populateRecord($model, $row);
             }
             if (!empty($this->with)) {
                 $models = [$model];

--- a/extensions/redis/ActiveQuery.php
+++ b/extensions/redis/ActiveQuery.php
@@ -169,7 +169,8 @@ class ActiveQuery extends Component implements ActiveQueryInterface
             /* @var $class ActiveRecord */
             $class = $this->modelClass;
             $model = $class::instantiate($row);
-            $class::populateRecord($model, $row);
+            $_class = get_class($model);
+            $_class::populateRecord($model, $row);
         }
         if (!empty($this->with)) {
             $models = [$model];

--- a/extensions/sphinx/ActiveQuery.php
+++ b/extensions/sphinx/ActiveQuery.php
@@ -195,7 +195,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 /* @var $class ActiveRecord */
                 $class = $this->modelClass;
                 $model = $class::instantiate($row);
-                $class::populateRecord($model, $row);
+                $_class = get_class($model);
+                $_class::populateRecord($model, $row);
             }
             if (!empty($this->with)) {
                 $models = [$model];

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.3 under development
 -----------------------
 
+- Bug #7271: Classes that call `*::populateRecord()` after retrieving data from ddbb call now the method on the class of the model returned by `*::instantiate()`. (jlorente)
 - Bug #5457: `yii\web\Cors` should handle `Access-Control-Request-Headers` in a case-insensitive manner (qiangxue)
 - Bug #6919: Fixed wrong namespaces under advanced application's TestCase classes (ivokund)
 - Bug #6940: `yii\web\Response::sendContentAsFile()` may not send correct `content-length` header (sadgnome)

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -129,13 +129,15 @@ trait ActiveQueryTrait
             if ($this->indexBy === null) {
                 foreach ($rows as $row) {
                     $model = $class::instantiate($row);
-                    $class::populateRecord($model, $row);
+                    $_class = get_class($model);
+                    $_class::populateRecord($model, $row);
                     $models[] = $model;
                 }
             } else {
                 foreach ($rows as $row) {
                     $model = $class::instantiate($row);
-                    $class::populateRecord($model, $row);
+                    $_class = get_class($model);
+                    $_class::populateRecord($model, $row);
                     if (is_string($this->indexBy)) {
                         $key = $model->{$this->indexBy};
                     } else {

--- a/tests/unit/data/ar/Animal.php
+++ b/tests/unit/data/ar/Animal.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar;
+
+/**
+ * Class Animal
+ *
+ * @author Jose Lorente <jose.lorente.martin@gmail.com>
+ * @property integer $id
+ * @property string $type
+ */
+class Animal extends ActiveRecord {
+
+    public $does;
+
+    public static function tableName() {
+        return 'animal';
+    }
+
+    public function init() {
+        parent::init();
+        $this->type = get_called_class();
+    }
+
+    public function getDoes() {
+        return $this->does;
+    }
+
+    /**
+     * 
+     * @param type $row
+     * @return \yiiunit\data\ar\Animal
+     */
+    public static function instantiate($row) {
+        $class = $row['type'];
+        return new $class;
+    }
+
+}

--- a/tests/unit/data/ar/Cat.php
+++ b/tests/unit/data/ar/Cat.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar;
+
+/**
+ * Class Cat
+ *
+ * @author Jose Lorente <jose.lorente.martin@gmail.com>
+ * @since 2.0
+ */
+class Cat extends Animal {
+
+    /**
+     * 
+     * @param self $record
+     * @param array $row
+     */
+    public static function populateRecord($record, $row) {
+        parent::populateRecord($record, $row);
+
+        $record->does = 'meow';
+    }
+
+}

--- a/tests/unit/data/ar/Dog.php
+++ b/tests/unit/data/ar/Dog.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar;
+
+/**
+ * Class Dog
+ *
+ * @author Jose Lorente <jose.lorente.martin@gmail.com>
+ * @since 2.0
+ */
+class Dog extends Animal {
+
+    /**
+     * 
+     * @param self $record
+     * @param array $row
+     */
+    public static function populateRecord($record, $row) {
+        parent::populateRecord($record, $row);
+
+        $record->does = 'bark';
+    }
+
+}

--- a/tests/unit/data/ar/elasticsearch/Animal.php
+++ b/tests/unit/data/ar/elasticsearch/Animal.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar\elasticsearch;
+
+/**
+ * Class Animal
+ *
+ * @author Jose Lorente <jose.lorente.martin@gmail.com>
+ * @since 2.0
+ */
+class Animal extends ActiveRecord {
+
+    public $does;
+
+    public static function primaryKey() {
+        return ['id'];
+    }
+
+    public static function type() {
+        return 'test_animals';
+    }
+
+    public function attributes() {
+        return ['id', 'type'];
+    }
+
+    /**
+     * sets up the index for this record
+     * @param Command $command
+     */
+    public static function setUpMapping($command) {
+        $command->deleteMapping(static::index(), static::type());
+        $command->setMapping(static::index(), static::type(), [
+            static::type() => [
+                "_id" => ["path" => "id", "index" => "not_analyzed", "store" => "yes"],
+                "properties" => [
+                    "type" => ["type" => "string", "index" => "not_analyzed"]
+                ]
+            ]
+        ]);
+    }
+
+    public function init() {
+        parent::init();
+        $this->type = get_called_class();
+    }
+
+    public function getDoes() {
+        return $this->does;
+    }
+
+    /**
+     * 
+     * @param type $row
+     * @return \yiiunit\data\ar\elasticsearch\Animal
+     */
+    public static function instantiate($row) {
+        $class = $row['_source']['type'];
+        return new $class;
+    }
+
+}

--- a/tests/unit/data/ar/elasticsearch/Cat.php
+++ b/tests/unit/data/ar/elasticsearch/Cat.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar\elasticsearch;
+
+/**
+ * Class Cat
+ *
+ * @author Jose Lorente <jose.lorente.martin@gmail.com>
+ * @since 2.0
+ */
+class Cat extends Animal {
+
+    /**
+     * 
+     * @param self $record
+     * @param array $row
+     */
+    public static function populateRecord($record, $row) {
+        parent::populateRecord($record, $row);
+
+        $record->does = 'meow';
+    }
+
+}

--- a/tests/unit/data/ar/elasticsearch/Dog.php
+++ b/tests/unit/data/ar/elasticsearch/Dog.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar\elasticsearch;
+
+/**
+ * Class Dog
+ *
+ * @author Jose Lorente <jose.lorente.martin@gmail.com>
+ * @since 2.0
+ */
+class Dog extends Animal {
+
+    /**
+     * 
+     * @param self $record
+     * @param array $row
+     */
+    public static function populateRecord($record, $row) {
+        parent::populateRecord($record, $row);
+
+        $record->does = 'bark';
+    }
+
+}

--- a/tests/unit/data/ar/mongodb/Animal.php
+++ b/tests/unit/data/ar/mongodb/Animal.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar\mongodb;
+
+/**
+ * Class Animal
+ *
+ * @author Jose Lorente <jose.lorente.martin@gmail.com>
+ * @since 2.0
+ */
+class Animal extends ActiveRecord {
+
+    public $does;
+
+    public static function collectionName() {
+        return 'test_animals';
+    }
+
+    public function attributes() {
+        return ['_id', 'type'];
+    }
+
+    public function init() {
+        parent::init();
+        $this->type = get_called_class();
+    }
+
+    public function getDoes() {
+        return $this->does;
+    }
+
+    /**
+     * 
+     * @param type $row
+     * @return \yiiunit\data\ar\elasticsearch\Animal
+     */
+    public static function instantiate($row) {
+        $class = $row['type'];
+        return new $class;
+    }
+
+}

--- a/tests/unit/data/ar/mongodb/Cat.php
+++ b/tests/unit/data/ar/mongodb/Cat.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar\mongodb;
+
+/**
+ * Class Cat
+ *
+ * @author Jose Lorente <jose.lorente.martin@gmail.com>
+ * @since 2.0
+ */
+class Cat extends Animal {
+
+    /**
+     * 
+     * @param self $record
+     * @param array $row
+     */
+    public static function populateRecord($record, $row) {
+        parent::populateRecord($record, $row);
+
+        $record->does = 'meow';
+    }
+
+}

--- a/tests/unit/data/ar/mongodb/Dog.php
+++ b/tests/unit/data/ar/mongodb/Dog.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar\mongodb;
+
+/**
+ * Class Dog
+ *
+ * @author Jose Lorente <jose.lorente.martin@gmail.com>
+ * @since 2.0
+ */
+class Dog extends Animal {
+
+    /**
+     * 
+     * @param self $record
+     * @param array $row
+     */
+    public static function populateRecord($record, $row) {
+        parent::populateRecord($record, $row);
+
+        $record->does = 'bark';
+    }
+
+}

--- a/tests/unit/data/mysql.sql
+++ b/tests/unit/data/mysql.sql
@@ -15,6 +15,7 @@ DROP TABLE IF EXISTS `profile` CASCADE;
 DROP TABLE IF EXISTS `null_values` CASCADE;
 DROP TABLE IF EXISTS `type` CASCADE;
 DROP TABLE IF EXISTS `constraints` CASCADE;
+DROP TABLE IF EXISTS `animal` CASCADE;
 
 CREATE TABLE `constraints`
 (
@@ -125,6 +126,15 @@ CREATE TABLE `type` (
   `ts_default` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `bit_col` BIT(8) NOT NULL DEFAULT b'10000010'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `animal` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `type` VARCHAR(255) NOT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `animal` (`type`) VALUES ('yiiunit\data\ar\Cat');
+INSERT INTO `animal` (`type`) VALUES ('yiiunit\data\ar\Dog');
 
 INSERT INTO `profile` (description) VALUES ('profile customer 1');
 INSERT INTO `profile` (description) VALUES ('profile customer 3');

--- a/tests/unit/framework/db/ActiveRecordTest.php
+++ b/tests/unit/framework/db/ActiveRecordTest.php
@@ -14,6 +14,9 @@ use yiiunit\data\ar\Profile;
 use yiiunit\data\ar\Type;
 use yiiunit\framework\ar\ActiveRecordTestTrait;
 use yiiunit\framework\db\cubrid\CubridActiveRecordTest;
+use yiiunit\data\ar\Animal;
+use yiiunit\data\ar\Dog;
+use yiiunit\data\ar\Cat;
 
 /**
  * @group db
@@ -670,5 +673,16 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals(2, count($orders[0]->orderItems));
         $this->assertEquals(3, count($orders[1]->orderItems));
         $this->assertEquals(1, count($orders[2]->orderItems));
+    }
+    
+    public function testPopulateRecordCallWhenQueryingOnParentClass() {
+        (new Cat())->save(false);
+        (new Dog())->save(false);
+
+        $animal = Animal::find()->where(['type' => Dog::className()])->one();
+        $this->assertEquals('bark', $animal->getDoes());
+
+        $animal = Animal::find()->where(['type' => Cat::className()])->one();
+        $this->assertEquals('meow', $animal->getDoes());
     }
 }


### PR DESCRIPTION
Fixed bug #7271. Classes that call '_::populateRecord()' after retrieving data from ddbb call now the method on the class of the model returned by '_::instantiate()'. Tests for mysql, elasticsearch and mongodb attached.
