### PR TITLE
Added external link functionality in bootstrap/tabs

### DIFF
--- a/extensions/bootstrap/Tabs.php
+++ b/extensions/bootstrap/Tabs.php
@@ -43,6 +43,10 @@ use yii\helpers\Html;
  *                  ],
  *             ],
  *         ],
+ *         [
+ *              'label' => 'External link',
+ *              'url => ['//other/route']
+ *         ]
  *     ],
  * ]);
  * ```
@@ -171,8 +175,15 @@ class Tabs extends Widget
                     Html::addCssClass($options, 'active');
                     Html::addCssClass($headerOptions, 'active');
                 }
-                $linkOptions['data-toggle'] = 'tab';
-                $header = Html::a($label, '#' . $options['id'], $linkOptions);
+
+                // allow tabs with external links (if content should not be called by inline ajax)
+                if(isset($item['url'])){ 
+                    $header = Html::a($label, $item['url'], $linkOptions);
+                }else{
+                    $linkOptions['data-toggle'] = 'tab';
+                    $header = Html::a($label, '#' . $options['id'], $linkOptions);                    
+                }                  
+                
                 if ($this->renderTabContent) {
                     $panes[] = Html::tag('div', isset($item['content']) ? $item['content'] : '', $options);
                 }

--- a/tests/unit/extensions/bootstrap/TabsTest.php
+++ b/tests/unit/extensions/bootstrap/TabsTest.php
@@ -2,7 +2,7 @@
 namespace yiiunit\extensions\bootstrap;
 
 use yii\bootstrap\Tabs;
-
+use yii\helpers\Html;
 /**
  * Tests for Tabs widget
  *
@@ -36,7 +36,10 @@ class TabsTest extends BootstrapTestCase
                         ['label' => 'Page4', 'content' => 'Page4'],
                         ['label' => 'Page5', 'content' => 'Page5'],
                     ]
-                ]
+                ],
+                [
+                    'label' => $extAnchor='External link', 'url' => $extUrl=['//other/route'],
+                ],                
             ]
         ]);
 
@@ -65,6 +68,7 @@ class TabsTest extends BootstrapTestCase
             "id=\"$page3\"",
             "id=\"$page4\"",
             "id=\"$page5\"",
+            Html::a($extAnchor,$extUrl),
         ];
 
         foreach ($shouldContain as $string) {


### PR DESCRIPTION
Usecase is if content should not be loaded inline by Ajax because of:
- content is on different route
- content cannot (correctly) be loaded by inline ajax
