### PR TITLE
Update Menu.php

### DIFF
--- a/framework/widgets/Menu.php
+++ b/framework/widgets/Menu.php
@@ -212,7 +212,11 @@ class Menu extends Widget
                     '{items}' => $this->renderItems($item['items']),
                 ]);
             }
-            $lines[] = Html::tag($tag, $menu, $options);
+            if($tag){
+                $lines[] = Html::tag($tag, $menu, $options);    
+            }else{
+                $lines[] = $menu;
+            }
         }
 
         return implode("\n", $lines);


### PR DESCRIPTION
The feature:
http://getbootstrap.com/components/#list-group-linked

Currently, Menu isnt capable of creating a bootstraps list-group-linked because:
- Menu forces a item container around the link

However, Menu does allow:
- defining the tag of the menu container
- defining the tag of the item container
- defining the template of the link

This means, that its a small step to enable a menu like the list-group-linked in which:
- menu container is a DIV
- there are no item containers
- there are only links which should get the correct status by the (link)template
- bootstraps list-group-linked can easily be created by a patch

I provided this patch in which you can set the item-tag on false. When this is done,
the item tag is ignored and no LI is created, which is necessary for the list-group-linked.
