### PR TITLE
Fix trimming PHPDoc prefix with TAB indent

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -34,6 +34,7 @@ Yii Framework 2 Change Log
 - Chg #6661: Hyperlinks that are enclosed within an exist form will use the same form for submission if they specify both of the `href` and `data-method` attributes (qiangxue)
 - Chg #7094: Console confirmation must be answered correctly. To return `true`: `y` or `yes`. To return `false`: `n` or `no`. Any other input the question will be asked again (thiagotalma)
 - Chg #7130: Changed the signature of `ActiveRecord::findByCondition()` to simplify the implementation and usage (Faryshta)
+- Bug #7358: Fix trimming PHPDoc prefix with TAB indent in `yii\console\Controller::parseDocCommentSummary()` (gugglegum)
 
 2.0.2 January 11, 2015
 ----------------------

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -488,7 +488,7 @@ class Controller extends \yii\base\Controller
     {
         $docLines = preg_split('~\R~u', $reflection->getDocComment());
         if (isset($docLines[1])) {
-            return trim($docLines[1], ' *');
+            return trim($docLines[1], "\x09 *");
         }
         return '';
     }

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -488,7 +488,7 @@ class Controller extends \yii\base\Controller
     {
         $docLines = preg_split('~\R~u', $reflection->getDocComment());
         if (isset($docLines[1])) {
-            return trim($docLines[1], "\x09 *");
+            return trim($docLines[1], "\t *");
         }
         return '';
     }


### PR DESCRIPTION
When PHP code contains TAB characters for code indentation there was a bug with trimming PHPDoc signature. As a result `./yii help command` displays a list of sub-commands with " \* " prefix in every sub-command description. This commit fixes this.
