### PR TITLE
Remove unnecessary unsets

### DIFF
--- a/extensions/bootstrap/Dropdown.php
+++ b/extensions/bootstrap/Dropdown.php
@@ -90,7 +90,6 @@ class Dropdown extends Widget
         $lines = [];
         foreach ($items as $i => $item) {
             if (isset($item['visible']) && !$item['visible']) {
-                unset($items[$i]);
                 continue;
             }
             if (is_string($item)) {

--- a/extensions/bootstrap/Nav.php
+++ b/extensions/bootstrap/Nav.php
@@ -127,7 +127,6 @@ class Nav extends Widget
         $items = [];
         foreach ($this->items as $i => $item) {
             if (isset($item['visible']) && !$item['visible']) {
-                unset($items[$i]);
                 continue;
             }
             $items[] = $this->renderItem($item);


### PR DESCRIPTION
In Dropdown, there's no need to remove `$items[$i]`, since it won't be used afterwards. In Nav, it doesn't even exist.
