### PR TITLE
Added submenuOptions property to Dropdown

### DIFF
--- a/extensions/bootstrap/CHANGELOG.md
+++ b/extensions/bootstrap/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 bootstrap extension Change Log
 2.0.3 under development
 -----------------------
 
-- no changes in this release.
+- Enh #7427: Added `yii\bootstrap\Dropdown::$submenuOptions` (spikyjt)
 
 
 2.0.2 January 11, 2015

--- a/extensions/bootstrap/Dropdown.php
+++ b/extensions/bootstrap/Dropdown.php
@@ -56,6 +56,11 @@ class Dropdown extends Widget
      * @var boolean whether the labels for header items should be HTML-encoded.
      */
     public $encodeLabels = true;
+    /**
+     * @var array the HTML attributes for submenu container tags.
+     * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
+     */
+    public $submenuOptions;
 
 
     /**
@@ -64,6 +69,10 @@ class Dropdown extends Widget
      */
     public function init()
     {
+        if ($this->submenuOptions === null) {
+            $this->submenuOptions = $this->options;
+        }
+        
         parent::init();
         Html::addCssClass($this->options, 'dropdown-menu');
     }
@@ -113,10 +122,8 @@ class Dropdown extends Widget
                     $content = Html::a($label, $url, $linkOptions);
                 }
             } else {
-                $submenuOptions = $options;
-                unset($submenuOptions['id']);
                 $content = Html::a($label, $url === null ? '#' : $url, $linkOptions)
-                    . $this->renderItems($item['items'], $submenuOptions);
+                    . $this->renderItems($item['items'], $this->submenuOptions);
                 Html::addCssClass($itemOptions, 'dropdown-submenu');
             }
 

--- a/tests/unit/extensions/bootstrap/DropdownTest.php
+++ b/tests/unit/extensions/bootstrap/DropdownTest.php
@@ -41,7 +41,7 @@ class DropdownTest extends BootstrapTestCase
 
         $expected = <<<EXPECTED
 <ul id="w0" class="dropdown-menu"><li class="dropdown-header">Page1</li>
-<li class="dropdown-submenu"><a href="#" tabindex="-1">Dropdown1</a><ul class="dropdown-menu"><li class="dropdown-header">Page2</li>
+<li class="dropdown-submenu"><a href="#" tabindex="-1">Dropdown1</a><ul><li class="dropdown-header">Page2</li>
 <li class="dropdown-header">Page3</li></ul></li></ul>
 EXPECTED;
 

--- a/tests/unit/extensions/bootstrap/DropdownTest.php
+++ b/tests/unit/extensions/bootstrap/DropdownTest.php
@@ -37,12 +37,37 @@ class DropdownTest extends BootstrapTestCase
                     ]
                 ]
             ]
+        ) . "\n" . Dropdown::widget(
+            [
+                'options' => [
+                    'role' => 'menu',
+                ],
+                'submenuOptions' => [
+                    'class' => 'dropdown-submenu',
+                ],
+                'items' => [
+                    [
+                        'label' => 'Page6',
+                        'content' => 'Page6',
+                    ],
+                    [
+                        'label' => 'Dropdown3',
+                        'items' => [
+                            ['label' => 'Page7', 'content' => 'Page7'],
+                            ['label' => 'Page8', 'content' => 'Page8'],
+                        ]
+                    ],
+                ]
+            ]
         );
 
         $expected = <<<EXPECTED
 <ul id="w0" class="dropdown-menu"><li class="dropdown-header">Page1</li>
 <li class="dropdown-submenu"><a href="#" tabindex="-1">Dropdown1</a><ul><li class="dropdown-header">Page2</li>
 <li class="dropdown-header">Page3</li></ul></li></ul>
+<ul id="w1" class="dropdown-menu" role="menu"><li class="dropdown-header">Page6</li>
+<li class="dropdown-submenu"><a href="#" tabindex="-1">Dropdown3</a><ul class="dropdown-submenu"><li class="dropdown-header">Page7</li>
+<li class="dropdown-header">Page8</li></ul></li></ul>
 EXPECTED;
 
         $this->assertEqualsWithoutLE($expected, $out);


### PR DESCRIPTION
A submenu options array adds flexibility to the dropdown, allowing custom attributes to be added to submenus. This patch doesn't break BC, as it sets submenuOptions to options, if it has not been explicitly set. However it does get the rid of the dropdown-menu class that is currently set on submenus, causing them to be hidden by default.
