### PR TITLE
Update start-installation.md nginx config

### DIFF
--- a/docs/guide/start-installation.md
+++ b/docs/guide/start-installation.md
@@ -185,7 +185,7 @@ server {
     root        /path/to/basic/web;
     index       index.php;
 
-    access_log  /path/to/basic/log/access.log main;
+    access_log  /path/to/basic/log/access.log;
     error_log   /path/to/basic/log/error.log;
 
     location / {


### PR DESCRIPTION
Fixes the nginx configuration file which led to nginx: [emerg] unknown log format "main" in /etc/nginx/sites-enabled/domain.com:xx on nginx 1.6.2

The file access.log and error.log must still exist so that nginx configuration file test is successful.
