### PR TITLE
Allow the key delimiter to be specified.

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -163,7 +163,7 @@ class BaseArrayHelper
      * ~~~
      *
      * @param array|object $array array or object to extract value from
-     * @param string|\Closure $key key name of the array element, or property name of the object,
+     * @param string|\Closure|array $key key name of the array element, or property name of the object,
      * or an anonymous function returning the value. The anonymous function signature should be:
      * `function($array, $defaultValue)`.
      * @param mixed $default the default value to be returned if the specified array key does not exist. Not used when
@@ -172,18 +172,26 @@ class BaseArrayHelper
      * @return mixed the value of the element if found, default value otherwise
      * @throws InvalidParamException if $array is neither an array nor an object.
      */
-    public static function getValue($array, $key, $default = null, $delimiter = '.')
+    public static function getValue($array, $key, $default = null)
     {
         if ($key instanceof \Closure) {
             return $key($array, $default);
+        }
+
+        if (is_array($key)) {
+            $final = array_pop($key);
+            foreach ($key as $_key) {
+                $array = static::getValue($array, $_key);
+            }
+            $key = $final;
         }
 
         if (is_array($array) && array_key_exists($key, $array)) {
             return $array[$key];
         }
 
-        if (($pos = strrpos($key, $delimiter)) !== false) {
-            $array = static::getValue($array, substr($key, 0, $pos), $default, $delimiter);
+        if (($pos = strrpos($key, '.')) !== false) {
+            $array = static::getValue($array, substr($key, 0, $pos), $default);
             $key = substr($key, $pos + 1);
         }
 

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -168,10 +168,11 @@ class BaseArrayHelper
      * `function($array, $defaultValue)`.
      * @param mixed $default the default value to be returned if the specified array key does not exist. Not used when
      * getting value from an object.
+     * @param string $delimiter the delimiter character for the key, defaults to a dot (.)
      * @return mixed the value of the element if found, default value otherwise
      * @throws InvalidParamException if $array is neither an array nor an object.
      */
-    public static function getValue($array, $key, $default = null)
+    public static function getValue($array, $key, $default = null, $delimiter = '.')
     {
         if ($key instanceof \Closure) {
             return $key($array, $default);
@@ -181,8 +182,8 @@ class BaseArrayHelper
             return $array[$key];
         }
 
-        if (($pos = strrpos($key, '.')) !== false) {
-            $array = static::getValue($array, substr($key, 0, $pos), $default);
+        if (($pos = strrpos($key, $delimiter)) !== false) {
+            $array = static::getValue($array, substr($key, 0, $pos), $default, $delimiter);
             $key = substr($key, $pos + 1);
         }
 

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -146,6 +146,10 @@ class BaseArrayHelper
      * or `$array->x` is neither an array nor an object, the default value will be returned.
      * Note that if the array already has an element `x.y.z`, then its value will be returned
      * instead of going through the sub-arrays.
+     * 
+     * If a sub-array has a key with a dot (.) `['values' => ['key.1' => 'value']]` it can be retrieved
+     * by specifying an array of key names. So if the key specified is `['values', 'key.1']` the returned value would
+     * be `$array['values']['key.1']`.
      *
      * Below are some usage examples,
      *
@@ -160,15 +164,22 @@ class BaseArrayHelper
      * });
      * // using dot format to retrieve the property of embedded object
      * $street = \yii\helpers\ArrayHelper::getValue($users, 'address.street');
+     * // using an array of keys to retrieve the value
+     * $array = [
+     *   'versions' => [
+     *     '1.0' => 'value1',
+     *     '2.0' => 'value2'
+     *   ]
+     * ];
+     * $value = \yii\helpers\ArrayHelper::getValue($array, ['versions', '1.0']);
      * ~~~
      *
      * @param array|object $array array or object to extract value from
-     * @param string|\Closure|array $key key name of the array element, or property name of the object,
+     * @param string|\Closure|array $key key name of the array element, an array of keys or property name of the object,
      * or an anonymous function returning the value. The anonymous function signature should be:
      * `function($array, $defaultValue)`.
      * @param mixed $default the default value to be returned if the specified array key does not exist. Not used when
      * getting value from an object.
-     * @param string $delimiter the delimiter character for the key, defaults to a dot (.)
      * @return mixed the value of the element if found, default value otherwise
      * @throws InvalidParamException if $array is neither an array nor an object.
      */

--- a/tests/unit/framework/helpers/ArrayHelperTest.php
+++ b/tests/unit/framework/helpers/ArrayHelperTest.php
@@ -344,6 +344,7 @@ class ArrayHelperTest extends TestCase
                 '31-12-2113test',
                 'test'
             ],
+            [['version', '1.0', 'option'], 'test'],
         ];
     }
 
@@ -372,6 +373,11 @@ class ArrayHelperTest extends TestCase
             'admin.lastname' => 'Xue',
             'admin' => [
                 'lastname' => 'cebe',
+            ],
+            'version' => [
+                '1.0' => [
+                    'option' => 'test'
+                ]
             ],
         ];
 


### PR DESCRIPTION
Expand `ArrayHelper::getValue` to allow the key delimiter to be specified.

``` php
$array = [
  'top' => [
    '1.0' => 'value1',
    '2.0' => 'value2'
  ]
];

ArrayHelper::getValue($array, 'top.1.0') // returns null
ArrayHelper::getValue($array, 'top|1.0', null, '|') // returns 'value1'
```
