### PR TITLE
Update tutorial-core-validators.md

### DIFF
--- a/docs/guide/tutorial-core-validators.md
+++ b/docs/guide/tutorial-core-validators.md
@@ -240,7 +240,7 @@ either a single column or multiple columns.
 [
     // checks if "primaryImage" is an uploaded image file in PNG, JPG or GIF format.
     // the file size must be less than 1MB
-    ['primaryImage', 'file', 'extensions' => ['png', 'jpg', 'gif'], 'maxSize' => 1024*1024*1024],
+    ['primaryImage', 'file', 'extensions' => ['png', 'jpg', 'gif'], 'maxSize' => 1024*1024],
 ]
 ```
 


### PR DESCRIPTION
The maxSize validator validates in bytes, so the example was incorrect (it was 1GB instead of 1MB).
