### PR TITLE
Faster buildInCondition from array of integers

### DIFF
--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -1094,7 +1094,7 @@ class QueryBuilder extends \yii\base\Object
                 foreach ($value->params as $n => $v) {
                     $params[$n] = $v;
                 }
-            } elseif (gettype($value) !== 'integer' && gettype($value) !== 'double') {
+            } elseif (is_int($value) === false && is_float($value) === false) {
                 $phName = self::PARAM_PREFIX . count($params);
                 $params[$phName] = $value;
                 $values[$i] = $phName;

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -1094,7 +1094,7 @@ class QueryBuilder extends \yii\base\Object
                 foreach ($value->params as $n => $v) {
                     $params[$n] = $v;
                 }
-            } else {
+            } elseif (gettype($value) !== 'integer' && gettype($value) !== 'double') {
                 $phName = self::PARAM_PREFIX . count($params);
                 $params[$phName] = $value;
                 $values[$i] = $phName;


### PR DESCRIPTION
`buildInCondition` checks each value from an array for it's type(`NULL` or `Expression`). Otherwise it converts value to PDO binding param, which is not effective for numbers.
My fix just skips variables of integer or double type so they are not binded, leaved as-is and are just imploded on line 1108. That's much faster.
