### PR TITLE
Revoke should be type $item instead of $role

### DIFF
--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -760,7 +760,7 @@ class DbManager extends BaseManager
     /**
      * @inheritdoc
      */
-    public function revoke($role, $userId)
+    public function revoke($item, $userId)
     {
         if (empty($userId)) {
             return false;


### PR DESCRIPTION
Item is the parent of role and permission.  Revoke can be used for both.
