### PR TITLE
Initialize input tag value with ng-init when using AngularJS

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -496,6 +496,11 @@ class BaseHtml
         }
         $options['name'] = $name;
         $options['value'] = $value === null ? null : (string) $value;
+        if(isset($options['ng-model']) && $options['value'] !== null) {
+            if(isset($options['ng-init']) && $options['ng-init'] === true ) {
+                $options['ng-init'] = "{$options['ng-model']}='{$options['value']}'";
+            }
+        }
         return static::tag('input', '', $options);
     }
 


### PR DESCRIPTION
If AngularJS is used and input tag has mg-model then value will be ignored and input tag will not be initialized with the value.
In order to properly initialize input element we must provide ng-init attribute. 
I propose this enhancement and add ng-init="<model_name>='<value>'", but only if developer requested it 
by setting 'ng-init' option property to true to make it backward compatible.
