### PR TITLE
added a constant to template js validation function

### DIFF
--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -24,6 +24,12 @@ use yii\web\JsExpression;
 class ActiveField extends Component
 {
     /**
+     * A template for functions like sprintf() etc. that is
+     * used for generating js field validation code
+     */
+    const FIELD_JS_VALIDATION_TEMPLATE = 'function (attribute, value, messages, deferred, $form) { %s }';
+
+    /**
      * @var ActiveForm the form that this field is associated with.
      */
     public $form;
@@ -799,7 +805,7 @@ class ActiveField extends Component
         }
 
         if (!empty($validators)) {
-            $options['validate'] = new JsExpression("function (attribute, value, messages, deferred, \$form) {" . implode('', $validators) . '}');
+            $options['validate'] = new JsExpression( sprintf(self::FIELD_JS_VALIDATION_TEMPLATE,implode('',$validators)) );
         }
 
         // only get the options that are different from the default ones (set in yii.activeForm.js)


### PR DESCRIPTION
While developing ActiveForm fields that are added dynamically via JavaScript and trying to enable new client-side validators I stumbled upon a piece of hard-code. Because I needed to wrap js validators with the same code I decided to make this small fix. I used sprintf and an according "template", but i would appreciate suggestions as to how to make it more elegant.
