### PR TITLE
Fixes #7519

### DIFF
--- a/extensions/bootstrap/ActiveField.php
+++ b/extensions/bootstrap/ActiveField.php
@@ -285,6 +285,69 @@ class ActiveField extends \yii\widgets\ActiveField
     }
 
     /**
+     * Renders a button group with checkbox toggle buttons.
+     * @see http://getbootstrap.com/javascript/#buttons-checkbox-radio
+     *
+     * @param array $items the data item used to generate the checkboxes.
+     * The array values are the labels, while the array keys are the corresponding checkbox values.
+     * Note that the labels will NOT be HTML-encoded, while the values will.
+     * @param array $options options (name => config) for the button group. The following options are specially handled:
+     *
+     * - unselect: string, the value that should be submitted when none of the checkboxes is selected.
+     *   By setting this option, a hidden input will be generated. If you do not want any hidden input,
+     *   you should explicitly set this option as null.
+     * - separator: string, the HTML code that separates items.
+     * - item: callable, a callback that can be used to customize the generation of the HTML code
+     *   corresponding to a single item in $items. The signature of this callback must be:
+     *
+     * ~~~
+     * function ($index, $label, $name, $checked, $value)
+     * ~~~
+     *
+     * where $index is the zero-based index of the checkbox in the whole list; $label
+     * is the label for the checkbox; and $name, $value and $checked represent the name,
+     * value and the checked status of the checkbox input.
+     * @return static the field object itself
+     */
+    public function checkboxButtonGroup($items, $options = [])
+    {
+        $this->renderButtonGroup('checkbox', $items, $options);
+        return $this;
+    }
+
+    /**
+     * Renders a button group with radio toggle buttons.
+     * @see http://getbootstrap.com/javascript/#buttons-checkbox-radio
+     *
+     * The selection of the radio buttons is taken from the value of the model attribute.
+     * @param array $items the data item used to generate the radio buttons.
+     * The array values are the labels, while the array keys are the corresponding radio values.
+     * Note that the labels will NOT be HTML-encoded, while the values will.
+     * @param array $options options (name => config) for the button group. The following options are specially handled:
+     *
+     * - unselect: string, the value that should be submitted when none of the radio buttons is selected.
+     *   By setting this option, a hidden input will be generated. If you do not want any hidden input,
+     *   you should explicitly set this option as null.
+     * - separator: string, the HTML code that separates items.
+     * - item: callable, a callback that can be used to customize the generation of the HTML code
+     *   corresponding to a single item in $items. The signature of this callback must be:
+     *
+     * ~~~
+     * function ($index, $label, $name, $checked, $value)
+     * ~~~
+     *
+     * where $index is the zero-based index of the radio button in the whole list; $label
+     * is the label for the radio button; and $name, $value and $checked represent the name,
+     * value and the checked status of the radio button input.
+     * @return static the field object itself
+     */
+    public function radioButtonGroup($items, $options = [])
+    {
+        $this->renderButtonGroup('radio', $items, $options);
+        return $this;
+    }
+
+    /**
      * @inheritdoc
      */
     public function label($label = null, $options = [])
@@ -379,5 +442,45 @@ class ActiveField extends \yii\widgets\ActiveField
         $this->parts['{beginLabel}'] = Html::beginTag('label', $options);
         $this->parts['{endLabel}'] = Html::endTag('label');
         $this->parts['{labelTitle}'] = $label;
+    }
+
+    /**
+     * Renders a button group with checkbox or radio toggle buttons.
+     * This method is mainly called by [[checkboxButtonGroup()]] and [[radioButtonGroup()]].
+     * @param string $type the input type. This can be 'checkbox' or 'radio'.
+     * @param array $items the data item used to generate the checkboxes or radio buttons.
+     * @param array $options options (name => config) for the button group.
+     */
+    protected function renderButtonGroup($type, $items, $options = [])
+    {
+        if (!isset($options['template'])) {
+            $this->template = $type === 'checkbox' ? $this->inlineCheckboxListTemplate : $this->inlineRadioListTemplate;
+        } else {
+            $this->template = $options['template'];
+            unset($options['template']);
+        }
+        if (!isset($options['class'])) {
+            $options['class'] = 'btn-group';
+        }
+        $options['data-toggle'] = 'buttons';
+        if (!isset($options['itemOptions'])) {
+            $options['itemOptions'] = [
+                'labelOptions' => ['class' => 'btn btn-default'],
+            ];
+        }
+        if (!isset($options['item'])) {
+            $options['item'] = function ($index, $label, $name, $checked, $value) use ($options, $type){
+                $labelOptions = ArrayHelper::getValue($options, 'itemOptions.labelOptions');
+                if ($checked) {
+                    Html::addCssClass($labelOptions, 'active');
+                }
+                return Html::$type($name, $checked, ['label' => $label, 'labelOptions' => $labelOptions, 'value' => $value]);
+            };
+        }
+        if ($type === 'checkbox') {
+            parent::checkboxList($items, $options);
+        } else {
+            parent::radioList($items, $options);
+        }
     }
 }


### PR DESCRIPTION
Added new `yii\bootstrap\ActiveField` methods for generating button groups with checkbox or radio list (see http://getbootstrap.com/javascript/#buttons-checkbox-radio): `checkboxButtonGroup()` and `radioButtonGroup()`.
