### PR TITLE
Disabled label render in hiddenInput() fixes #2990

### DIFF
--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -379,8 +379,12 @@ class ActiveField extends Component
     public function hiddenInput($options = [])
     {
         $options = array_merge($this->inputOptions, $options);
+        $renderAllParts = ArrayHelper::remove($options, 'renderAllParts', false);
         $this->adjustLabelFor($options);
         $this->parts['{input}'] = Html::activeHiddenInput($this->model, $this->attribute, $options);
+        if (!$renderAllParts) {
+            $this->parts['{label}'] = $this->parts['{error}'] = $this->parts['{hint}'] = '';
+        }
 
         return $this;
     }

--- a/tests/unit/framework/widgets/ActiveFieldTest.php
+++ b/tests/unit/framework/widgets/ActiveFieldTest.php
@@ -221,6 +221,31 @@ EOD;
         $this->activeField->hiddenInput();
         $this->assertEquals($expectedValue, $this->activeField->parts['{input}']);
     }
+    
+    public function testIssue2990() {
+        // https://github.com/yiisoft/yii2/issues/2990
+        $expectedValue = <<<EOD
+<div class="form-group field-dynamicmodel-attributename">
+<label class="control-label" for="dynamicmodel-attributename">Attribute Name</label>
+<input type="hidden" id="dynamicmodel-attributename" class="form-control" name="DynamicModel[attributeName]">
+
+<div class="help-block"></div>
+</div>
+EOD;
+        $this->activeField->hiddenInput(['renderAllParts' => true]);
+        $this->assertEquals($expectedValue, $this->activeField->render());
+        
+        $expectedValue = <<<EOD
+<div class="form-group field-dynamicmodel-attributename">
+
+<input type="hidden" id="dynamicmodel-attributename" class="form-control" name="DynamicModel[attributeName]">
+
+
+</div>
+EOD;
+        $this->activeField->hiddenInput();
+        $this->assertEquals($expectedValue, $this->activeField->render());
+    }
 
     public function testListBox()
     {


### PR DESCRIPTION
Disabled rendering of label, error and hint in `ActiveField::hiddenInput()` by default. Added `renderAllParts` option to allow rendering these extra parts if required.

Added unit test for both cases.

Issue is marked as discussion for 2.1, so will add changelog entry and docs changes when issue is agreed.
