### PR TITLE
Fixed 0-id RBAC not finding roles

### DIFF
--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -447,7 +447,7 @@ class DbManager extends BaseManager
      */
     public function getRolesByUser($userId)
     {
-        if (empty($userId)) {
+        if (!isset($userId) || $userId===null || $userId === false) {
             return [];
         }
 
@@ -490,7 +490,7 @@ class DbManager extends BaseManager
      */
     public function getPermissionsByUser($userId)
     {
-        if (empty($userId)) {
+        if (!isset($userId) || $userId===null || $userId === false) {
             return [];
         }
 
@@ -590,7 +590,7 @@ class DbManager extends BaseManager
      */
     public function getAssignment($roleName, $userId)
     {
-        if (empty($userId)) {
+        if (!isset($userId) || $userId===null || $userId === false) {
             return null;
         }
 
@@ -614,7 +614,7 @@ class DbManager extends BaseManager
      */
     public function getAssignments($userId)
     {
-        if (empty($userId)) {
+        if (!isset($userId) || $userId===null || $userId === false) {
             return [];
         }
 
@@ -762,7 +762,7 @@ class DbManager extends BaseManager
      */
     public function revoke($role, $userId)
     {
-        if (empty($userId)) {
+        if (!isset($userId) || $userId===null || $userId === false) {
             return false;
         }
 
@@ -776,7 +776,7 @@ class DbManager extends BaseManager
      */
     public function revokeAll($userId)
     {
-        if (empty($userId)) {
+        if (!isset($userId) || $userId===null || $userId === false) {
             return false;
         }
 

--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -447,7 +447,7 @@ class DbManager extends BaseManager
      */
     public function getRolesByUser($userId)
     {
-        if (!isset($userId) || $userId===null || $userId === false) {
+        if (!isset($userId) || $userId === false) {
             return [];
         }
 
@@ -490,7 +490,7 @@ class DbManager extends BaseManager
      */
     public function getPermissionsByUser($userId)
     {
-        if (!isset($userId) || $userId===null || $userId === false) {
+        if (!isset($userId) || $userId === false) {
             return [];
         }
 
@@ -590,7 +590,7 @@ class DbManager extends BaseManager
      */
     public function getAssignment($roleName, $userId)
     {
-        if (!isset($userId) || $userId===null || $userId === false) {
+        if (!isset($userId) || $userId === false) {
             return null;
         }
 
@@ -614,7 +614,7 @@ class DbManager extends BaseManager
      */
     public function getAssignments($userId)
     {
-        if (!isset($userId) || $userId===null || $userId === false) {
+        if (!isset($userId) || $userId === false) {
             return [];
         }
 
@@ -762,7 +762,7 @@ class DbManager extends BaseManager
      */
     public function revoke($role, $userId)
     {
-        if (!isset($userId) || $userId===null || $userId === false) {
+        if (!isset($userId) || $userId === false) {
             return false;
         }
 
@@ -776,7 +776,7 @@ class DbManager extends BaseManager
      */
     public function revokeAll($userId)
     {
-        if (!isset($userId) || $userId===null || $userId === false) {
+        if (!isset($userId) || $userId === false) {
             return false;
         }
 


### PR DESCRIPTION
DbManager couldn't get roles of users with id = 0 because empty($userId) was true.

Changed empty with combination of isset, === false.
