### PR TITLE
added ActionColumn::$buttonOptions

### DIFF
--- a/extensions/bootstrap/CHANGELOG.md
+++ b/extensions/bootstrap/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 bootstrap extension Change Log
 -----------------------
 
 - Bug #5984: `yii\bootstrap\Activefield::checkbox()` caused browser to link label to the wrong input (cebe)
+- Enh: Added `ActionColumn::$buttonOptions` for defining HTML options to be added to the default buttons (cebe)
 
 
 2.0.3 March 01, 2015

--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -87,6 +87,11 @@ class ActionColumn extends Column
      * If this property is not set, button URLs will be created using [[createUrl()]].
      */
     public $urlCreator;
+    /**
+     * @var array html options to be applied to the [[initDefaultButtons()|default buttons]].
+     * @since 2.0.4
+     */
+    public $buttonOptions = [];
 
 
     /**
@@ -105,28 +110,28 @@ class ActionColumn extends Column
     {
         if (!isset($this->buttons['view'])) {
             $this->buttons['view'] = function ($url, $model, $key) {
-                return Html::a('<span class="glyphicon glyphicon-eye-open"></span>', $url, [
+                return Html::a('<span class="glyphicon glyphicon-eye-open"></span>', $url, array_merge([
                     'title' => Yii::t('yii', 'View'),
                     'data-pjax' => '0',
-                ]);
+                ], $this->buttonOptions));
             };
         }
         if (!isset($this->buttons['update'])) {
             $this->buttons['update'] = function ($url, $model, $key) {
-                return Html::a('<span class="glyphicon glyphicon-pencil"></span>', $url, [
+                return Html::a('<span class="glyphicon glyphicon-pencil"></span>', $url, array_merge([
                     'title' => Yii::t('yii', 'Update'),
                     'data-pjax' => '0',
-                ]);
+                ], $this->buttonOptions));
             };
         }
         if (!isset($this->buttons['delete'])) {
             $this->buttons['delete'] = function ($url, $model, $key) {
-                return Html::a('<span class="glyphicon glyphicon-trash"></span>', $url, [
+                return Html::a('<span class="glyphicon glyphicon-trash"></span>', $url, array_merge([
                     'title' => Yii::t('yii', 'Delete'),
                     'data-confirm' => Yii::t('yii', 'Are you sure you want to delete this item?'),
                     'data-method' => 'post',
                     'data-pjax' => '0',
-                ]);
+                ], $this->buttonOptions));
             };
         }
     }


### PR DESCRIPTION
allows for configuration of the default buttons like this:

``` php
[
    'class' => ActionColumn::className(),
    'template' => '<div class="btn-group text-center">{view} {update} {delete}</div>',
    'buttonOptions' => [
        'class' => 'btn btn-default btn-xs',
    ],
],
```

result:

![bildschirmfoto vom 2015-03-08 19 06 22](https://cloud.githubusercontent.com/assets/189796/6546904/3f658c52-c5c6-11e4-9733-498340e34cdb.png)
