### PR TITLE
Debug - Control access also by the hostname

### DIFF
--- a/extensions/debug/CHANGELOG.md
+++ b/extensions/debug/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.4 under development
 -----------------------
 
-- no changes in this release.
+- Enh #7655: Added ability to filter access by hostname (thiagotalma)
 
 
 2.0.3 March 01, 2015

--- a/extensions/debug/Module.php
+++ b/extensions/debug/Module.php
@@ -32,7 +32,8 @@ class Module extends \yii\base\Module implements BootstrapInterface
     public $allowedIPs = ['127.0.0.1', '::1'];
     /**
      * @var array the list of hosts that are allowed to access this module.
-     * Each array element represents a single hostname filter.
+     * Each array element is a hostname that will be resolved to an IP address that is compared 
+     * with the IP address of the user. A use case is to use a dynamic DNS (DDNS) to allow access.
      * The default value is `[]`.
      */
     public $allowedHosts = [];

--- a/extensions/debug/Module.php
+++ b/extensions/debug/Module.php
@@ -31,6 +31,12 @@ class Module extends \yii\base\Module implements BootstrapInterface
      */
     public $allowedIPs = ['127.0.0.1', '::1'];
     /**
+     * @var array the list of hosts that are allowed to access this module.
+     * Each array element represents a single hostname filter.
+     * The default value is `[]`.
+     */
+    public $allowedHosts = [];
+    /**
      * @inheritdoc
      */
     public $controllerNamespace = 'yii\debug\controllers';
@@ -194,6 +200,12 @@ class Module extends \yii\base\Module implements BootstrapInterface
         $ip = Yii::$app->getRequest()->getUserIP();
         foreach ($this->allowedIPs as $filter) {
             if ($filter === '*' || $filter === $ip || (($pos = strpos($filter, '*')) !== false && !strncmp($ip, $filter, $pos))) {
+                return true;
+            }
+        }
+        foreach ($this->allowedHosts as $hostname) {
+            $filter = gethostbyname($hostname);
+            if ($filter === $ip) {
                 return true;
             }
         }


### PR DESCRIPTION
That way we can use dynamic DNS, as `noip.com` or `freedns.affraid.org`.

I understand that there will be a name resolution that is not instantaneous, but that will only be performed when the developer indeed want it to be done.

Solves the problem of having to change the configuration file every time the developer's IP address changes.
