### PR TITLE
Fixes #6667 : Gii form generator rendering mistake view

### DIFF
--- a/extensions/gii/CHANGELOG.md
+++ b/extensions/gii/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.4 under development
 -----------------------
 
-- no changes in this release.
+- Bug #6667: Gii form generator rendering mistake view (pana1990)
 
 
 2.0.3 March 01, 2015

--- a/extensions/gii/generators/form/default/action.php
+++ b/extensions/gii/generators/form/default/action.php
@@ -22,7 +22,7 @@ public function action<?= Inflector::id2camel(trim(basename($generator->viewName
         }
     }
 
-    return $this->render('<?= $generator->viewName ?>', [
+    return $this->render('<?= basename($generator->viewName) ?>', [
         'model' => $model,
     ]);
 }


### PR DESCRIPTION
Currently gii form generator rendering mistake view in controller's action.

For example, if View name is "site/index", gii generate : 

``` php
return $this->render('site/index', [
      'model' => $model,
]);
```

and it should be : 

``` php
return $this->render('index', [
      'model' => $model,
]);
```
