### PR TITLE
Fix code style in gii form generator [skip ci]

### DIFF
--- a/extensions/gii/generators/form/default/form.php
+++ b/extensions/gii/generators/form/default/form.php
@@ -28,6 +28,7 @@ use yii\widgets\ActiveForm;
         <div class="form-group">
             <?= "<?= " ?>Html::submitButton(<?= $generator->generateString('Submit') ?>, ['class' => 'btn btn-primary']) ?>
         </div>
+
     <?= "<?php " ?>ActiveForm::end(); ?>
 
 </div><!-- <?= str_replace('/', '-', trim($generator->viewName, '-')) ?> -->


### PR DESCRIPTION
currenly, gii form generator generate the following : 

``` php
        <div class="form-group">
            <?= Html::submitButton('Submit', ['class' => 'btn btn-primary']) ?>
        </div>
    <?php ActiveForm::end(); ?>

</div><!-- site-index-->
```

with this change it generate the following : 

``` php
        <div class="form-group">
            <?= Html::submitButton('Submit', ['class' => 'btn btn-primary']) ?>
        </div>

    <?php ActiveForm::end(); ?>

</div><!-- site-index-->
```

Ending widget call should have individual PHP tag how the guide exaplain https://github.com/yiisoft/yii2/blob/master/docs/internals/view-code-style.md.
