### PR TITLE
Twig url()/path() more functional to resolve #6924

### DIFF
--- a/extensions/twig/Extension.php
+++ b/extensions/twig/Extension.php
@@ -180,14 +180,17 @@ class Extension extends \Twig_Extension
     /**
      * Generates relative URL
      *
-     * @param string $path the parameter to be used to generate a valid URL
+     * @param string|array $path the parameter to be used to generate a valid URL
      * @param array $args arguments
      * @return string the generated relative URL
      */
-    public function path($path, $args = [])
+    public function path($path, $args = null)
     {
-        if ($args !== []) {
-            $path = array_merge([$path], $args);
+        if ($args !== null) {
+            if (!is_array($path)) {
+                $path = [$path];
+            }
+            $path = array_merge($path, $args);
         }
         return Url::to($path);
     }
@@ -195,14 +198,17 @@ class Extension extends \Twig_Extension
     /**
      * Generates absolute URL
      *
-     * @param string $path the parameter to be used to generate a valid URL
+     * @param string|array $path the parameter to be used to generate a valid URL
      * @param array $args arguments
      * @return string the generated absolute URL
      */
-    public function url($path, $args = [])
+    public function url($path, $args = null)
     {
-        if ($args !== []) {
-            $path = array_merge([$path], $args);
+        if ($args !== null) {
+            if (!is_array($path)) {
+                $path = [$path];
+            }
+            $path = array_merge($path, $args);
         }
         return Url::to($path, true);
     }

--- a/tests/unit/extensions/twig/ViewRendererTest.php
+++ b/tests/unit/extensions/twig/ViewRendererTest.php
@@ -112,6 +112,53 @@ class ViewRendererTest extends DatabaseTestCase
         $view->renderFile('@yiiunit/extensions/twig/views/nulls.twig', ['order' => $order]);
     }
 
+    public function testUrls()
+    {
+        $this->mockWebApplication([
+            'components' => [
+                'request' => [
+                    'hostInfo' => 'http://localhost',
+                    'baseUrl' => '/test',
+                ],
+                'urlManager' => [
+                    'enablePrettyUrl' => true,
+                    'showScriptName' => false,
+                    'rules' => [
+                        '/' => 'site/index',
+                    ],
+                ],
+            ],
+        ]);
+        $view = $this->mockView();
+        $results = json_decode($view->renderFile('@yiiunit/extensions/twig/views/urls.twig'), true);
+
+        // path('/site/index', {})
+        $this->assertEquals('/test/', $results['path_no_params']);
+        // path('/site/index', { page: 2 })
+        $this->assertEquals('/test/?page=2', $results['path_with_params']);
+        // path(['/site/index'])
+        $this->assertEquals('/test/', $results['path_no_params_array']);
+        // path(['/site/index'], { page: 2 })
+        $this->assertEquals('/test/?page=2', $results['path_with_params_array']);
+        // path('@web/css/style.css')
+        $this->assertEquals('/test/css/style.css', $results['path_use_alias']);
+        // path('/site/index')
+        $this->assertEquals('/site/index', $results['path_as_is']);
+
+        // url('/site/index', {})
+        $this->assertEquals('http://localhost/test/', $results['url_no_params']);
+        // url('/site/index', { page: 2 })
+        $this->assertEquals('http://localhost/test/?page=2', $results['url_with_params']);
+        // url(['/site/index'])
+        $this->assertEquals('http://localhost/test/', $results['url_no_params_array']);
+        // url(['/site/index'], { page: 2 })
+        $this->assertEquals('http://localhost/test/?page=2', $results['url_with_params_array']);
+        // url('@web/css/style.css')
+        $this->assertEquals('http://localhost/test/css/style.css', $results['url_use_alias']);
+        // url('/site/index')
+        $this->assertEquals('http://localhost/site/index', $results['url_as_is']);
+    }
+
     /**
      * Mocks view instance
      * @return View

--- a/tests/unit/extensions/twig/views/urls.twig
+++ b/tests/unit/extensions/twig/views/urls.twig
@@ -1,0 +1,14 @@
+{
+    "path_no_params": "{{ path('/site/index', {}) }}",
+    "path_with_params": "{{ path('/site/index', { page: 2 }) }}",
+    "path_no_params_array": "{{ path(['/site/index']) }}",
+    "path_with_params_array": "{{ path(['/site/index'], { page: 2 }) }}",
+    "path_use_alias": "{{ path('@web/css/style.css') }}",
+    "path_as_is": "{{ path('/site/index') }}",
+    "url_no_params": "{{ url('/site/index', {}) }}",
+    "url_with_params": "{{ url('/site/index', { page: 2 }) }}",
+    "url_no_params_array": "{{ url(['/site/index']) }}",
+    "url_with_params_array": "{{ url(['/site/index'], { page: 2 }) }}",
+    "url_use_alias": "{{ url('@web/css/style.css') }}",
+    "url_as_is": "{{ url('/site/index') }}"
+}


### PR DESCRIPTION
My idea for Twig renderers' `url()` / `path()` to resolve #6924 is below:
## 1

They should work same even when empty array passed as 2nd argument explicitly, because there are actions with no params.

```
url('/site/index', {page:2})
url('/site/index', {})
```
## 2

They also should accept array as 1st argument in order to distinguish action-routes from plain pathes or aliases.

```
url(['/site/index'])
url('/other-app/some/path.html')
url('@web/css/style.css')
```
