### PR TITLE
Fix conversion of ICU 'L' symbol.

### DIFF
--- a/framework/helpers/BaseFormatConverter.php
+++ b/framework/helpers/BaseFormatConverter.php
@@ -153,7 +153,7 @@ class BaseFormatConverter
             'MMM' => 'M',   // A short textual representation of a month, three letters
             'MMMM' => 'F',  // A full textual representation of a month, such as January or March
             'MMMMM' => '',  //
-            'L' => 'm',     // Stand alone month in year
+            'L' => 'n',     // Stand alone month in year
             'LL' => 'm',    // Stand alone month in year
             'LLL' => 'M',   // Stand alone month in year
             'LLLL' => 'F',  // Stand alone month in year
@@ -363,7 +363,7 @@ class BaseFormatConverter
             'MMM' => 'M',   // A short textual representation of a month, three letters
             'MMMM' => 'MM', // A full textual representation of a month, such as January or March
             'MMMMM' => '',  //
-            'L' => 'mm',     // Stand alone month in year
+            'L' => 'm',     // Stand alone month in year
             'LL' => 'mm',   // Stand alone month in year
             'LLL' => 'M',   // Stand alone month in year
             'LLLL' => 'MM', // Stand alone month in year

--- a/tests/unit/framework/helpers/FormatConverterTest.php
+++ b/tests/unit/framework/helpers/FormatConverterTest.php
@@ -71,4 +71,16 @@ class FormatConverterTest extends TestCase
         $formatter = new Formatter(['locale' => 'ru-RU']);
         $this->assertEquals('24 авг 2014 г.', $formatter->asDate('2014-8-24', 'dd MMM y \'г\'.'));
     }
+
+    public function testIntlL()
+    {
+        $formatter = new Formatter(['locale' => 'en-US']);
+
+        $format = "L";
+        // NOTE: assertEquals would pass, because '08' == '8'
+        $this->assertSame(
+            $formatter->asDate('2014-8-24', $format),
+            date(FormatConverter::convertDateIcuToPhp($format), strtotime('2014-8-24'))
+        );
+    }
 }


### PR DESCRIPTION
L should not contain a leading zero.
Added a test for this too.
