### PR TITLE
Update tutorial-core-validators.md

### DIFF
--- a/docs/guide/tutorial-core-validators.md
+++ b/docs/guide/tutorial-core-validators.md
@@ -213,9 +213,7 @@ This validator checks if the input value is a valid email address.
     ['a1', 'exist', 'allowArray' => true],
 ]
 ```
-
-This validator checks if the input value can be found in a table column. It only works
-with [Active Record](db-active-record.md) model attributes. It supports validation against
+This validator checks if the input value can be found in the table column specified by the [ActiveRecord](db-active-record.md) class $targetClass and the attribute $targetAttribute. The target attributes can only be an [Active Record](db-active-record.md) model attribute. It supports validation against
 either a single column or multiple columns.
 
 - `targetClass`: the name of the [Active Record](db-active-record.md) class that should be used


### PR DESCRIPTION
Changing the basic description of the Exist core validator. The previous description lead me to think that an attribute from a Model extending class could not be validated with the Exist validator because it was not an ActiveRecord extending class. 
The truth is that only the exist validator target class has to be extending ActiveRecord. The validated input can be from a class only extending Model.
I hope my changes are sufficiently clear.
