### PR TITLE
UnauthorizedHttpException insted of ForbiddenHttpException

### DIFF
--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -428,7 +428,7 @@ class User extends Component
                 return Yii::$app->getResponse()->redirect($this->loginUrl);
             }
         }
-        throw new UnauthorizedHttpException(Yii::t('yii', 'Login Required'));
+        throw new UnauthorizedHttpException;
     }
 
     /**

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -428,7 +428,7 @@ class User extends Component
                 return Yii::$app->getResponse()->redirect($this->loginUrl);
             }
         }
-        throw new ForbiddenHttpException(Yii::t('yii', 'Login Required'));
+        throw new UnauthorizedHttpException(Yii::t('yii', 'Login Required'));
     }
 
     /**


### PR DESCRIPTION
Hi, why `yii/web/User::loginRequired()` throws `ForbiddenHttpException`? According to [wiki](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes):

> #### 401 Unauthorized
> 
> Similar to 403 Forbidden, but specifically for use when authentication is required and has failed or has not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource. See Basic access authentication and Digest access authentication.
> #### 403 Forbidden
> 
> The request was a valid request, but the server is refusing to respond to it. Unlike a 401 Unauthorized response, authenticating will make no difference.

I think, `UnauthorizedHttpException` (401 http code) describes error more accurately,  in contrast to `ForbiddenHttpException` (403 http code).
