### PR TITLE
fix order in pgsql schema findTableNames, findConstraints and for indexes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 Change Log
 - Bug #7603: Fixed escape characters in `FormatConverter` to work with unicode characters (maddoger, cebe)
 - Bug #7757: Fix fetching tables schema for oci and mysql when PDO::ATTR_CASE is set (nineinchnick)
 - Bug #7775: Added more strict check on controller IDs when they are being used to create controller instances on Windows (Bhoft, qiangxue)
+- Bug #7831: Add order when fetching database table names and constraints (nineinchnick)
 - Bug #7867: Fixed findUniqueIndexes not to perform any processing on unique index on function for pgsql (nineinchnick)
 - Bug #7868: Fixed fetching columns definition and composite foreign keys for oci (nineinchnick)
 - Bug #7868: Removed column's autoIncrement detection from oci (nineinchnick)

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -392,6 +392,7 @@ SQL;
 SELECT [t].[table_name]
 FROM [INFORMATION_SCHEMA].[TABLES] AS [t]
 WHERE [t].[table_schema] = :schema AND [t].[table_type] IN ('BASE TABLE', 'VIEW')
+ORDER BY [t].[table_name]
 SQL;
 
         return $this->db->createCommand($sql, [':schema' => $schema])->queryColumn();

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -294,11 +294,12 @@ SQL;
     {
         if ($schema === '') {
             $sql = <<<SQL
-SELECT table_name as table_schema FROM user_tables
+SELECT table_name FROM user_tables
 UNION ALL
-SELECT view_name AS table_name as table_schema FROM user_views
+SELECT view_name AS table_name FROM user_views
 UNION ALL
-SELECT mview_name AS table_name as table_schema FROM user_mviews
+SELECT mview_name AS table_name FROM user_mviews
+ORDER BY table_name
 SQL;
             $command = $this->db->createCommand($sql);
         } else {
@@ -306,6 +307,7 @@ SQL;
 SELECT object_name AS table_name
 FROM all_objects
 WHERE object_type IN ('TABLE', 'VIEW', 'MATERIALIZED VIEW') AND owner=:schema
+ORDER BY object_name
 SQL;
             $command = $this->db->createCommand($sql, [':schema' => $schema]);
         }

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -176,14 +176,14 @@ class Schema extends \yii\db\Schema
         if ($schema === '') {
             $schema = $this->defaultSchema;
         }
-        $sql = <<<EOD
+        $sql = <<<SQL
 SELECT c.relname AS table_name
 FROM pg_class c
 INNER JOIN pg_namespace ns ON ns.oid = c.relnamespace
 WHERE ns.nspname = :schema AND c.relkind IN ('r','v','m','f')
-EOD;
-        $command = $this->db->createCommand($sql);
-        $command->bindParam(':schema', $schema);
+ORDER BY c.relname
+SQL;
+        $command = $this->db->createCommand($sql, [':schemaName' => $schema]);
         $rows = $command->queryAll();
         $names = [];
         foreach ($rows as $row) {
@@ -208,35 +208,40 @@ EOD;
 
         $sql = <<<SQL
 select
-    (select string_agg(attname,',') attname from pg_attribute where attrelid=ct.conrelid and attnum = any(ct.conkey)) as columns,
+    a.attname as column_name,
     fc.relname as foreign_table_name,
     fns.nspname as foreign_table_schema,
-    (select string_agg(attname,',') attname from pg_attribute where attrelid=ct.confrelid and attnum = any(ct.confkey)) as foreign_columns
+    fa.attname as foreign_column_name
 from
     pg_constraint ct
+    inner join generate_subscripts(ct.conkey, 1) as s on 1=1
     inner join pg_class c on c.oid=ct.conrelid
     inner join pg_namespace ns on c.relnamespace=ns.oid
+    inner join pg_attribute a on a.attrelid=ct.conrelid and a.attnum = ct.conkey[s]
     left join pg_class fc on fc.oid=ct.confrelid
     left join pg_namespace fns on fc.relnamespace=fns.oid
-
+    left join pg_attribute fa on fa.attrelid=ct.confrelid and fa.attnum = ct.confkey[s]
 where
     ct.contype='f'
     and c.relname={$tableName}
     and ns.nspname={$tableSchema}
+order by
+    fns.nspname, fc.relname, a.attnum
 SQL;
 
-        $constraints = $this->db->createCommand($sql)->queryAll();
-        foreach ($constraints as $constraint) {
-            $columns = explode(',', $constraint['columns']);
-            $fcolumns = explode(',', $constraint['foreign_columns']);
+        $constraints = [];
+        foreach ($this->db->createCommand($sql)->queryAll() as $constraint) {
             if ($constraint['foreign_table_schema'] !== $this->defaultSchema) {
                 $foreignTable = $constraint['foreign_table_schema'] . '.' . $constraint['foreign_table_name'];
             } else {
                 $foreignTable = $constraint['foreign_table_name'];
             }
+            $constraints[$foreignTable][$constraint['column_name']] = $constraint['foreign_column_name'];
+        }
+        foreach ($constraints as $foreignTable => $columns) {
             $citem = [$foreignTable];
-            foreach ($columns as $idx => $column) {
-                $citem[$column] = $fcolumns[$idx];
+            foreach ($columns as $column => $foreignColumn) {
+                $citem[$column] = $foreignColumn;
             }
             $table->foreignKeys[] = $citem;
         }
@@ -249,9 +254,6 @@ SQL;
      */
     protected function getUniqueIndexInformation($table)
     {
-        $tableName = $this->quoteValue($table->name);
-        $tableSchema = $this->quoteValue($table->schemaName);
-
         $sql = <<<SQL
 SELECT
     i.relname as indexname,
@@ -262,11 +264,14 @@ INNER JOIN pg_class i ON i.oid = idx.indexrelid
 INNER JOIN pg_class c ON c.oid = idx.indrelid
 INNER JOIN pg_namespace ns ON c.relnamespace = ns.oid
 WHERE idx.indisprimary = FALSE AND idx.indisunique = TRUE
-AND c.relname = {$tableName} AND ns.nspname = {$tableSchema}
+AND c.relname = :tableName AND ns.nspname = :schemaName
 ORDER BY i.relname, k
 SQL;
 
-        return $this->db->createCommand($sql)->queryAll();
+        return $this->db->createCommand($sql, [
+            ':schemaName' => $table->schemaName,
+            ':tableName' => $table->name,
+        ])->queryAll();
     }
 
     /**

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -98,7 +98,7 @@ class Schema extends \yii\db\Schema
      */
     protected function findTableNames($schema = '')
     {
-        $sql = "SELECT DISTINCT tbl_name FROM sqlite_master WHERE tbl_name<>'sqlite_sequence'";
+        $sql = "SELECT DISTINCT tbl_name FROM sqlite_master WHERE tbl_name<>'sqlite_sequence' ORDER BY tbl_name";
 
         return $this->db->createCommand($sql)->queryColumn();
     }


### PR DESCRIPTION
References #7831. The fix for fetching constraints actually fixes a bug for composite fkeys, where they would be randomly assigned to table columns.
