### PR TITLE
Fix "These extra patterns will take precedence over $patterns."

### DIFF
--- a/framework/rest/UrlRule.php
+++ b/framework/rest/UrlRule.php
@@ -166,7 +166,7 @@ class UrlRule extends CompositeUrlRule
     {
         $only = array_flip($this->only);
         $except = array_flip($this->except);
-        $patterns = array_merge($this->patterns, $this->extraPatterns);
+        $patterns = array_merge($this->extraPatterns, $this->patterns);
         $rules = [];
         foreach ($this->controller as $urlName => $controller) {
             $prefix = trim($this->prefix . '/' . $urlName, '/');


### PR DESCRIPTION
Hi, [array_merge](http://php.net/manual/en/function.array-merge.php) saves order of array's (hash's) elements, if keys are integers or not identical strings. So rules [creation](https://github.com/yiisoft/yii2/blob/master/framework/rest/UrlRule.php#L173-L176) and [parsing](https://github.com/yiisoft/yii2/blob/master/framework/rest/UrlRule.php#L220-L226) will be done within same order as `array_merge()` will return, which contradicts the docs. 
### as said in [docs](http://www.yiiframework.com/doc-2.0/yii-rest-urlrule.html#$extraPatterns-detail)

> These extra patterns will take precedence over $patterns.

If docs doesn't lie, `array_merge` arguments must be in reverse order [here](https://github.com/yiisoft/yii2/blob/master/framework/rest/UrlRule.php#L169).
