### PR TITLE
close output buffer for widget on exception

### DIFF
--- a/framework/base/Widget.php
+++ b/framework/base/Widget.php
@@ -90,10 +90,15 @@ class Widget extends Component implements ViewContextInterface
     {
         ob_start();
         ob_implicit_flush(false);
-        /* @var $widget Widget */
-        $config['class'] = get_called_class();
-        $widget = Yii::createObject($config);
-        $out = $widget->run();
+        try {
+            /* @var $widget Widget */
+            $config['class'] = get_called_class();
+            $widget = Yii::createObject($config);
+            $out = $widget->run();
+        } catch(\Exception $e) {
+            ob_end_clean();
+            throw $e;
+        }
 
         return ob_get_clean() . $out;
     }


### PR DESCRIPTION
while running bootstrap extension unit tests which were failing first
I found phpunit complaining about risky tests because output buffers
were not closed correctly. This change fixes this problem.
