### PR TITLE
Wrong order of comments in default messages config file

### DIFF
--- a/framework/views/messageConfig.php
+++ b/framework/views/messageConfig.php
@@ -69,11 +69,7 @@ return [
     /*
     // 'po' output format is for saving messages to gettext po files.
     'format' => 'po',
-    // Root directory containing message translations.
-    'messagePath' => __DIR__ . DIRECTORY_SEPARATOR . 'messages',
     // Name of the file that will be used for translations.
     'catalog' => 'messages',
-    // boolean, whether the message file should be overwritten with the merged messages
-    'overwrite' => true,
     */
 ];

--- a/framework/views/messageConfig.php
+++ b/framework/views/messageConfig.php
@@ -26,11 +26,6 @@ return [
     // and the '.svn' will match all files and directories named exactly '.svn'.
     // Note, the '/' characters in a pattern matches both '/' and '\'.
     // See helpers/FileHelper::findFiles() description for more details on pattern matching rules.
-    'only' => ['*.php'],
-    // array, list of patterns that specify which files (not directories) should be processed.
-    // If empty or not set, all files will be processed.
-    // Please refer to "except" for details about the patterns.
-    // If a file/directory matches both a pattern in "only" and "except", it will NOT be processed.
     'except' => [
         '.svn',
         '.git',
@@ -40,6 +35,11 @@ return [
         '.hgkeep',
         '/messages',
     ],
+    // array, list of patterns that specify which files (not directories) should be processed.
+    // If empty or not set, all files will be processed.
+    // Please refer to "except" for details about the patterns.
+    // If a file/directory matches both a pattern in "only" and "except", it will NOT be processed.
+    'only' => ['*.php'],
 
     // 'php' output format is for saving messages to php files.
     'format' => 'php',


### PR DESCRIPTION
The generated file with the command `./yii message/config path/to/config.php` contains comments in the wrong order.
