### PR TITLE
Allow `$options['uncheck'] => false` in `activeRadio`,  `activeCheckbox`

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1308,6 +1308,8 @@ class BaseHtml
         }
         if (!array_key_exists('label', $options)) {
             $options['label'] = static::encode($model->getAttributeLabel(static::getAttributeName($attribute)));
+        } else if (false === $options['label']) {
+            unset($options['label']);
         }
 
         $checked = "$value" === "{$options['value']}";
@@ -1359,6 +1361,8 @@ class BaseHtml
         }
         if (!array_key_exists('label', $options)) {
             $options['label'] = static::encode($model->getAttributeLabel(static::getAttributeName($attribute)));
+        } else if (false === $options['label']) {
+            unset($options['label']);
         }
 
         $checked = "$value" === "{$options['value']}";

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1303,6 +1303,8 @@ class BaseHtml
         }
         if (!array_key_exists('uncheck', $options)) {
             $options['uncheck'] = '0';
+        } else if (false === $options['uncheck']) {
+            unset($options['uncheck']);
         }
         if (!array_key_exists('label', $options)) {
             $options['label'] = static::encode($model->getAttributeLabel(static::getAttributeName($attribute)));
@@ -1352,6 +1354,8 @@ class BaseHtml
         }
         if (!array_key_exists('uncheck', $options)) {
             $options['uncheck'] = '0';
+        } else if (false === $options['uncheck']) {
+            unset($options['uncheck']);
         }
         if (!array_key_exists('label', $options)) {
             $options['label'] = static::encode($model->getAttributeLabel(static::getAttributeName($attribute)));


### PR DESCRIPTION
There's no way to remove the hidden input when using `activeRadio` and `activeCheckbox`.
This PR allows you to specify `['uncheck' => false]` to not render the hidden input.
