### PR TITLE
HttpCache: Testcases for RFC7232, sec 3.2

### DIFF
--- a/tests/unit/framework/filters/HttpCacheTest.php
+++ b/tests/unit/framework/filters/HttpCacheTest.php
@@ -52,6 +52,10 @@ class HttpCacheTest extends \yiiunit\TestCase
         $this->assertTrue($method->invoke($httpCache, 1, '"foo"'));
         $this->assertFalse($method->invoke($httpCache, 1, '"foos"'));
         $this->assertFalse($method->invoke($httpCache, null, null));
+
+        $_SERVER['HTTP_IF_NONE_MATCH'] = '*';
+        $this->assertFalse($method->invoke($httpCache, 0, '"foo"'));
+        $this->assertFalse($method->invoke($httpCache, 0, null));
     }
 
     /**


### PR DESCRIPTION
Not terribly important, but I remember a core dev saying test cases were always welcome: [RFC 7232, sec. 3.2](http://tools.ietf.org/html/rfc7232#section-3.2) demands all requests issued with `If-None-Match: *` to be served an uncached response unconditionally.
