### PR TITLE
fixes #7757: in oci schema fix query results row keys case

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,7 +8,12 @@ Yii Framework 2 Change Log
 - Bug #6871: Fixed the bug that using defaults and hostnames in URL rules may cause an out-of-range index issue (qiangxue)
 - Bug #7529: Fixed `yii\web\Response::sendContentAsFile()` that was broken in 2.0.3 (samdark)
 - Bug #7603: Fixed escape characters in `FormatConverter` to work with unicode characters (maddoger, cebe)
+- Bug #7757: Fix fetching tables schema for oci and mysql when PDO::ATTR_CASE is set (nineinchnick)
 - Bug #7775: Added more strict check on controller IDs when they are being used to create controller instances on Windows (Bhoft, qiangxue)
+- Bug: Fixed fetching columns definition and composite foreign keys for oci (nineinchnick)
+- Bug: Removed column's autoIncrement detection from oci (nineinchnick)
+- Bug: Fixed creating raw sql (for logging) by skipping object and resource params (nineinchnick)
+- Bug: Fixed Schema::getLastInsertID() by quoting sequence name (nineinchnick)
 - Enh #6895: Added `ignoreCategories` config option for message command to ignore categories specified (samdark)
 - Enh #6975: Pressing arrows while focused in inputs of Active Form with `validateOnType` enabled no longer triggers validation (slinstj)
 - Enh #7488: Added `StringHelper::explode` to perform explode with trimming and skipping of empty elements (SilverFire, nineinchnick, creocoder, samdark)
@@ -18,6 +23,8 @@ Yii Framework 2 Change Log
 - Enh #7636: `yii\web\Session::getHasSessionId()` uses a more lenient way to check if session ID is provided in URL (robsch)
 - Enh #7850: Added `yii\filters\PageCache::cacheCookies` and `cacheHeaders` to allow selectively caching cookies and HTTP headers (qiangxue)
 - Enh: Added `yii\helper\Console::wrapText()` method to wrap indented text by console window width and used it in `yii help` command (cebe)
+- Enh: Implement batchInsert for oci (nineinchnick)
+- Enh: Detecting IntegrityException for oci (nineinchnick)
 - Chg: Updated dependency to `cebe/markdown` to version `1.1.x` (cebe)
 
 

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -157,28 +157,26 @@ class Command extends Component
     {
         if (empty($this->params)) {
             return $this->_sql;
-        } else {
-            $params = [];
-            foreach ($this->params as $name => $value) {
-                if (is_string($value)) {
-                    $params[$name] = $this->db->quoteValue($value);
-                } elseif ($value === null) {
-                    $params[$name] = 'NULL';
-                } else {
-                    $params[$name] = $value;
-                }
-            }
-            if (isset($params[1])) {
-                $sql = '';
-                foreach (explode('?', $this->_sql) as $i => $part) {
-                    $sql .= (isset($params[$i]) ? $params[$i] : '') . $part;
-                }
-
-                return $sql;
-            } else {
-                return strtr($this->_sql, $params);
+        }
+        $params = [];
+        foreach ($this->params as $name => $value) {
+            if (is_string($value)) {
+                $params[$name] = $this->db->quoteValue($value);
+            } elseif ($value === null) {
+                $params[$name] = 'NULL';
+            } elseif (!is_object($value) && !is_resource($value)) {
+                $params[$name] = $value;
             }
         }
+        if (!isset($params[1])) {
+            return strtr($this->_sql, $params);
+        }
+        $sql = '';
+        foreach (explode('?', $this->_sql) as $i => $part) {
+            $sql .= (isset($params[$i]) ? $params[$i] : '') . $part;
+        }
+
+        return $sql;
     }
 
     /**

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -313,7 +313,7 @@ abstract class Schema extends Object
     public function getLastInsertID($sequenceName = '')
     {
         if ($this->db->isActive) {
-            return $this->db->pdo->lastInsertId($sequenceName === '' ? null : $sequenceName);
+            return $this->db->pdo->lastInsertId($sequenceName === '' ? null : $this->quoteSimpleTableName($sequenceName));
         } else {
             throw new InvalidCallException('DB Connection is not active.');
         }

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -129,13 +129,13 @@ class Schema extends \yii\db\Schema
     {
         $column = $this->createColumnSchema();
 
-        $column->name = $info['Field'];
-        $column->allowNull = $info['Null'] === 'YES';
-        $column->isPrimaryKey = strpos($info['Key'], 'PRI') !== false;
-        $column->autoIncrement = stripos($info['Extra'], 'auto_increment') !== false;
-        $column->comment = $info['Comment'];
+        $column->name = $info['field'];
+        $column->allowNull = $info['null'] === 'YES';
+        $column->isPrimaryKey = strpos($info['key'], 'PRI') !== false;
+        $column->autoIncrement = stripos($info['extra'], 'auto_increment') !== false;
+        $column->comment = $info['comment'];
 
-        $column->dbType = $info['Type'];
+        $column->dbType = $info['type'];
         $column->unsigned = stripos($column->dbType, 'unsigned') !== false;
 
         $column->type = self::TYPE_STRING;
@@ -173,12 +173,12 @@ class Schema extends \yii\db\Schema
         $column->phpType = $this->getColumnPhpType($column);
 
         if (!$column->isPrimaryKey) {
-            if ($column->type === 'timestamp' && $info['Default'] === 'CURRENT_TIMESTAMP') {
+            if ($column->type === 'timestamp' && $info['default'] === 'CURRENT_TIMESTAMP') {
                 $column->defaultValue = new Expression('CURRENT_TIMESTAMP');
             } elseif (isset($type) && $type === 'bit') {
-                $column->defaultValue = bindec(trim($info['Default'],'b\''));
+                $column->defaultValue = bindec(trim($info['default'],'b\''));
             } else {
-                $column->defaultValue = $column->phpTypecast($info['Default']);
+                $column->defaultValue = $column->phpTypecast($info['default']);
             }
         }
 
@@ -206,6 +206,9 @@ class Schema extends \yii\db\Schema
             throw $e;
         }
         foreach ($columns as $info) {
+            if ($this->db->slavePdo->getAttribute(\PDO::ATTR_CASE) !== \PDO::CASE_LOWER) {
+                $info = array_change_key_case($info, CASE_LOWER);
+            }
             $column = $this->loadColumnSchema($info);
             $table->columns[$column->name] = $column;
             if ($column->isPrimaryKey) {

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -160,4 +160,61 @@ EOD;
 
         return $sql;
     }
+
+    /**
+     * Generates a batch INSERT SQL statement.
+     * For example,
+     *
+     * ~~~
+     * $sql = $queryBuilder->batchInsert('user', ['name', 'age'], [
+     *     ['Tom', 30],
+     *     ['Jane', 20],
+     *     ['Linda', 25],
+     * ]);
+     * ~~~
+     *
+     * Note that the values in each row must match the corresponding column names.
+     *
+     * @param string $table the table that new rows will be inserted into.
+     * @param array $columns the column names
+     * @param array $rows the rows to be batch inserted into the table
+     * @return string the batch INSERT SQL statement
+     */
+    public function batchInsert($table, $columns, $rows)
+    {
+        $schema = $this->db->getSchema();
+        if (($tableSchema = $schema->getTableSchema($table)) !== null) {
+            $columnSchemas = $tableSchema->columns;
+        } else {
+            $columnSchemas = [];
+        }
+
+        $values = [];
+        foreach ($rows as $row) {
+            $vs = [];
+            foreach ($row as $i => $value) {
+                if (isset($columns[$i], $columnSchemas[$columns[$i]]) && !is_array($value)) {
+                    $value = $columnSchemas[$columns[$i]]->dbTypecast($value);
+                }
+                if (is_string($value)) {
+                    $value = $schema->quoteValue($value);
+                } elseif ($value === false) {
+                    $value = 0;
+                } elseif ($value === null) {
+                    $value = 'NULL';
+                }
+                $vs[] = $value;
+            }
+            $values[] = '(' . implode(', ', $vs) . ')';
+        }
+
+        foreach ($columns as $i => $name) {
+            $columns[$i] = $schema->quoteColumnName($name);
+        }
+
+        $tableAndColumns = ' INTO ' . $schema->quoteTableName($table)
+        . ' (' . implode(', ', $columns) . ') VALUES ';
+
+        return 'INSERT ALL ' . $tableAndColumns . implode($tableAndColumns, $values) . ' SELECT 1 FROM SYS.DUAL';
+    }
 }

--- a/tests/unit/data/ar/Customer.php
+++ b/tests/unit/data/ar/Customer.php
@@ -39,12 +39,12 @@ class Customer extends ActiveRecord
 
     public function getExpensiveOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])->andWhere('total > 50')->orderBy('id');
+        return $this->hasMany(Order::className(), ['customer_id' => 'id'])->andWhere('[[total]] > 50')->orderBy('id');
     }
 
     public function getExpensiveOrdersWithNullFK()
     {
-        return $this->hasMany(OrderWithNullFK::className(), ['customer_id' => 'id'])->andWhere('total > 50')->orderBy('id');
+        return $this->hasMany(OrderWithNullFK::className(), ['customer_id' => 'id'])->andWhere('[[total]] > 50')->orderBy('id');
     }
 
     public function getOrdersWithNullFK()

--- a/tests/unit/data/ar/CustomerQuery.php
+++ b/tests/unit/data/ar/CustomerQuery.php
@@ -11,7 +11,7 @@ class CustomerQuery extends ActiveQuery
 {
     public function active()
     {
-        $this->andWhere('status=1');
+        $this->andWhere('[[status]]=1');
 
         return $this;
     }

--- a/tests/unit/data/oci.sql
+++ b/tests/unit/data/oci.sql
@@ -1,0 +1,277 @@
+/**
+ * This is the database schema for testing PostgreSQL support of yii Active Record.
+ * To test this feature, you need to create a database named 'yiitest' on 'localhost'
+ * and create an account 'postgres/postgres' which owns this test database.
+ */
+
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "composite_fk"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "order_item"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "item"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "order_item_with_null_fk"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "order"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "order_with_null_fk"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "category"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "customer"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "profile"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "type"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "null_values"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "constraints"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "bool_values"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "animal"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "validator_main"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP TABLE "validator_ref"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;--
+
+BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE "profile_SEQ"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -2289 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE "customer_SEQ"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -2289 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE "category_SEQ"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -2289 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE "item_SEQ"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -2289 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE "order_SEQ"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -2289 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE "order_with_null_fk_SEQ"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -2289 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE "bool_values_SEQ"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -2289 THEN RAISE; END IF; END;--
+BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE "animal_SEQ"'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -2289 THEN RAISE; END IF; END;--
+
+/* STATEMENTS */
+
+CREATE TABLE "constraints"
+(
+  "id" integer not null,
+  "field1" varchar2(255)
+);
+
+CREATE TABLE "profile" (
+  "id" integer not null,
+  "description" varchar2(128) NOT NULL,
+  CONSTRAINT "profile_PK" PRIMARY KEY ("id") ENABLE
+);
+
+CREATE SEQUENCE "profile_SEQ";
+
+CREATE TABLE "customer" (
+  "id" integer not null,
+  "email" varchar2(128) NOT NULL,
+  "name" varchar2(128),
+  "address" varchar(4000),
+  "status" integer DEFAULT 0,
+  "bool_status" char DEFAULT 0 check ("bool_status" in (0,1)),
+  "profile_id" integer,
+  CONSTRAINT "customer_PK" PRIMARY KEY ("id") ENABLE
+);
+CREATE SEQUENCE "customer_SEQ";
+
+comment on column "customer"."email" is 'someone@example.com';
+
+CREATE TABLE "category" (
+  "id" integer not null,
+  "name" varchar2(128) NOT NULL,
+  CONSTRAINT "category_PK" PRIMARY KEY ("id") ENABLE
+);
+CREATE SEQUENCE "category_SEQ";
+
+CREATE TABLE "item" (
+  "id" integer not null,
+  "name" varchar2(128) NOT NULL,
+  "category_id" integer NOT NULL references "category"("id") on DELETE CASCADE,
+  CONSTRAINT "item_PK" PRIMARY KEY ("id") ENABLE
+);
+CREATE SEQUENCE "item_SEQ";
+
+CREATE TABLE "order" (
+  "id" integer not null,
+  "customer_id" integer NOT NULL references "customer"("id") on DELETE CASCADE,
+  "created_at" integer NOT NULL,
+  "total" decimal(10,0) NOT NULL,
+  CONSTRAINT "order_PK" PRIMARY KEY ("id") ENABLE
+);
+CREATE SEQUENCE "order_SEQ";
+
+CREATE TABLE "order_with_null_fk" (
+  "id" integer not null,
+  "customer_id" integer,
+  "created_at" integer NOT NULL,
+  "total" decimal(10,0) NOT NULL,
+  CONSTRAINT "order_with_null_fk_PK" PRIMARY KEY ("id") ENABLE
+);
+CREATE SEQUENCE "order_with_null_fk_SEQ";
+
+CREATE TABLE "order_item" (
+  "order_id" integer NOT NULL references "order"("id") on DELETE CASCADE,
+  "item_id" integer NOT NULL references "item"("id") on DELETE CASCADE,
+  "quantity" integer NOT NULL,
+  "subtotal" decimal(10,0) NOT NULL,
+  CONSTRAINT "order_item_PK" PRIMARY KEY ("order_id", "item_id") ENABLE
+);
+
+CREATE TABLE "order_item_with_null_fk" (
+  "order_id" integer,
+  "item_id" integer,
+  "quantity" integer NOT NULL,
+  "subtotal" decimal(10,0) NOT NULL
+);
+
+CREATE TABLE "composite_fk" (
+  "id" integer NOT NULL,
+  "order_id" integer NOT NULL,
+  "item_id" integer NOT NULL,
+  CONSTRAINT "composite_fk_PK" PRIMARY KEY ("id") ENABLE,
+  CONSTRAINT FK_composite_fk_order_item FOREIGN KEY ("order_id", "item_id")
+    REFERENCES "order_item" ("order_id", "item_id") ON DELETE CASCADE
+);
+
+CREATE TABLE "null_values" (
+  "id" INT NOT NULL,
+  "var1" INT NULL,
+  "var2" INT NULL,
+  "var3" INT DEFAULT NULL,
+  "stringcol" varchar2(32) DEFAULT NULL,
+  CONSTRAINT "null_values_PK" PRIMARY KEY ("id") ENABLE
+);
+
+CREATE TABLE "type" (
+  "int_col" integer NOT NULL,
+  "int_col2" integer DEFAULT 1,
+  "smallint_col" smallint DEFAULT 1,
+  "char_col" char(100) NOT NULL,
+  "char_col2" varchar2(100) DEFAULT 'something',
+  "char_col3" varchar2(4000),
+  "float_col" double precision NOT NULL,
+  "float_col2" double precision DEFAULT 1.23,
+  "blob_col" blob,
+  "numeric_col" decimal(5,2) DEFAULT 33.22,
+  "time" timestamp DEFAULT to_timestamp('2002-01-01 00:00:00', 'yyyy-mm-dd hh24:mi:ss') NOT NULL,
+  "bool_col" char NOT NULL check ("bool_col" in (0,1)),
+  "bool_col2" char DEFAULT 1 check("bool_col2" in (0,1)),
+  "ts_default" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  "bit_col" char(3) DEFAULT 130 NOT NULL
+);
+
+CREATE TABLE "bool_values" (
+  "id" integer not null,
+  "bool_col" char check ("bool_col" in (0,1)),
+  "default_true" char default 1 not null check ("default_true" in (0,1)),
+  "default_false" char default 0 not null check ("default_false" in (0,1)),
+  CONSTRAINT "bool_values_PK" PRIMARY KEY ("id") ENABLE
+);
+CREATE SEQUENCE "bool_values_SEQ";
+
+
+CREATE TABLE "animal" (
+  "id" integer,
+  "type" varchar2(255) not null,
+  CONSTRAINT "animal_PK" PRIMARY KEY ("id") ENABLE
+);
+CREATE SEQUENCE "animal_SEQ";
+
+/**
+ * (Postgres-)Database Schema for validator tests
+ */
+
+CREATE TABLE "validator_main" (
+  "id" integer not null,
+  "field1" varchar2(255),
+  CONSTRAINT "validator_main_PK" PRIMARY KEY ("id") ENABLE
+);
+
+CREATE TABLE "validator_ref" (
+  "id" integer not null,
+  "a_field" varchar2(255),
+  "ref"     integer,
+  CONSTRAINT "validator_ref_PK" PRIMARY KEY ("id") ENABLE
+);
+
+/* TRIGGERS */
+
+CREATE TRIGGER "profile_TRG" BEFORE INSERT ON "profile" FOR EACH ROW BEGIN <<COLUMN_SEQUENCES>> BEGIN
+  IF INSERTING AND :NEW."id" IS NULL THEN SELECT "profile_SEQ".NEXTVAL INTO :NEW."id" FROM SYS.DUAL; END IF;
+END COLUMN_SEQUENCES;
+END;
+/
+CREATE TRIGGER "customer_TRG" BEFORE INSERT ON "customer" FOR EACH ROW BEGIN <<COLUMN_SEQUENCES>> BEGIN
+  IF INSERTING AND :NEW."id" IS NULL THEN SELECT "customer_SEQ".NEXTVAL INTO :NEW."id" FROM SYS.DUAL; END IF;
+END COLUMN_SEQUENCES;
+END;
+/
+CREATE TRIGGER "category_TRG" BEFORE INSERT ON "category" FOR EACH ROW BEGIN <<COLUMN_SEQUENCES>> BEGIN
+  IF INSERTING AND :NEW."id" IS NULL THEN SELECT "category_SEQ".NEXTVAL INTO :NEW."id" FROM SYS.DUAL; END IF;
+END COLUMN_SEQUENCES;
+END;
+/
+CREATE TRIGGER "item_TRG" BEFORE INSERT ON "item" FOR EACH ROW BEGIN <<COLUMN_SEQUENCES>> BEGIN
+  IF INSERTING AND :NEW."id" IS NULL THEN SELECT "item_SEQ".NEXTVAL INTO :NEW."id" FROM SYS.DUAL; END IF;
+END COLUMN_SEQUENCES;
+END;
+/
+CREATE TRIGGER "order_TRG" BEFORE INSERT ON "order" FOR EACH ROW BEGIN <<COLUMN_SEQUENCES>> BEGIN
+  IF INSERTING AND :NEW."id" IS NULL THEN SELECT "order_SEQ".NEXTVAL INTO :NEW."id" FROM SYS.DUAL; END IF;
+END COLUMN_SEQUENCES;
+END;
+/
+CREATE TRIGGER "order_with_null_fk_TRG" BEFORE INSERT ON "order_with_null_fk" FOR EACH ROW BEGIN <<COLUMN_SEQUENCES>> BEGIN
+  IF INSERTING AND :NEW."id" IS NULL THEN SELECT "order_with_null_fk_SEQ".NEXTVAL INTO :NEW."id" FROM SYS.DUAL; END IF;
+END COLUMN_SEQUENCES;
+END;
+/
+CREATE TRIGGER "bool_values_TRG" BEFORE INSERT ON "bool_values" FOR EACH ROW BEGIN <<COLUMN_SEQUENCES>> BEGIN
+  IF INSERTING AND :NEW."id" IS NULL THEN SELECT "bool_values_SEQ".NEXTVAL INTO :NEW."id" FROM SYS.DUAL; END IF;
+END COLUMN_SEQUENCES;
+END;
+/
+CREATE TRIGGER "animal_TRG" BEFORE INSERT ON "animal" FOR EACH ROW BEGIN <<COLUMN_SEQUENCES>> BEGIN
+  IF INSERTING AND :NEW."id" IS NULL THEN SELECT "animal_SEQ".NEXTVAL INTO :NEW."id" FROM SYS.DUAL; END IF;
+END COLUMN_SEQUENCES;
+END;
+/
+
+/* TRIGGERS */
+
+INSERT INTO "animal" ("type") VALUES ('yiiunit\data\ar\Cat');
+INSERT INTO "animal" ("type") VALUES ('yiiunit\data\ar\Dog');
+
+
+INSERT INTO "profile" ("description") VALUES ('profile customer 1');
+INSERT INTO "profile" ("description") VALUES ('profile customer 3');
+
+INSERT INTO "customer" ("email", "name", "address", "status", "bool_status", "profile_id") VALUES ('user1@example.com', 'user1', 'address1', 1, 1, 1);
+INSERT INTO "customer" ("email", "name", "address", "status", "bool_status") VALUES ('user2@example.com', 'user2', 'address2', 1, 1);
+INSERT INTO "customer" ("email", "name", "address", "status", "bool_status", "profile_id") VALUES ('user3@example.com', 'user3', 'address3', 2, 0, 2);
+
+INSERT INTO "category" ("name") VALUES ('Books');
+INSERT INTO "category" ("name") VALUES ('Movies');
+
+INSERT INTO "item" ("name", "category_id") VALUES ('Agile Web Application Development with Yii1.1 and PHP5', 1);
+INSERT INTO "item" ("name", "category_id") VALUES ('Yii 1.1 Application Development Cookbook', 1);
+INSERT INTO "item" ("name", "category_id") VALUES ('Ice Age', 2);
+INSERT INTO "item" ("name", "category_id") VALUES ('Toy Story', 2);
+INSERT INTO "item" ("name", "category_id") VALUES ('Cars', 2);
+
+INSERT INTO "order" ("customer_id", "created_at", "total") VALUES (1, 1325282384, 110.0);
+INSERT INTO "order" ("customer_id", "created_at", "total") VALUES (2, 1325334482, 33.0);
+INSERT INTO "order" ("customer_id", "created_at", "total") VALUES (2, 1325502201, 40.0);
+
+INSERT INTO "order_with_null_fk" ("customer_id", "created_at", "total") VALUES (1, 1325282384, 110.0);
+INSERT INTO "order_with_null_fk" ("customer_id", "created_at", "total") VALUES (2, 1325334482, 33.0);
+INSERT INTO "order_with_null_fk" ("customer_id", "created_at", "total") VALUES (2, 1325502201, 40.0);
+
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (1, 1, 1, 30.0);
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (1, 2, 2, 40.0);
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 4, 1, 10.0);
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 5, 1, 15.0);
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 3, 1, 8.0);
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (3, 2, 1, 40.0);
+
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (1, 1, 1, 30.0);
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (1, 2, 2, 40.0);
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 4, 1, 10.0);
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 5, 1, 15.0);
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 3, 1, 8.0);
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (3, 2, 1, 40.0);
+
+INSERT INTO "validator_main" ("id", "field1") VALUES (1, 'just a string1');
+INSERT INTO "validator_main" ("id", "field1") VALUES (2, 'just a string2');
+INSERT INTO "validator_main" ("id", "field1") VALUES (3, 'just a string3');
+INSERT INTO "validator_main" ("id", "field1") VALUES (4, 'just a string4');
+INSERT INTO "validator_ref" ("id", "a_field", "ref") VALUES (1, 'ref_to_2', 2);
+INSERT INTO "validator_ref" ("id", "a_field", "ref") VALUES (2, 'ref_to_2', 2);
+INSERT INTO "validator_ref" ("id", "a_field", "ref") VALUES (3, 'ref_to_3', 3);
+INSERT INTO "validator_ref" ("id", "a_field", "ref") VALUES (4, 'ref_to_4', 4);
+INSERT INTO "validator_ref" ("id", "a_field", "ref") VALUES (5, 'ref_to_4', 4);
+INSERT INTO "validator_ref" ("id", "a_field", "ref") VALUES (6, 'ref_to_5', 5);

--- a/tests/unit/framework/db/ActiveRecordTest.php
+++ b/tests/unit/framework/db/ActiveRecordTest.php
@@ -64,8 +64,13 @@ class ActiveRecordTest extends DatabaseTestCase
     public function testCustomColumns()
     {
         // find custom column
-        $customer = Customer::find()->select(['*', '(status*2) AS status2'])
-            ->where(['name' => 'user3'])->one();
+        if ($this->driverName === 'oci') {
+            $customer = Customer::find()->select(['{{customer}}.*', '([[status]]*2) AS [[status2]]'])
+                ->where(['name' => 'user3'])->one();
+        } else {
+            $customer = Customer::find()->select(['*', '([[status]]*2) AS [[status2]]'])
+                ->where(['name' => 'user3'])->one();
+        }
         $this->assertEquals(3, $customer->id);
         $this->assertEquals(4, $customer->status2);
     }
@@ -74,41 +79,41 @@ class ActiveRecordTest extends DatabaseTestCase
     {
         // find count, sum, average, min, max, scalar
         $this->assertEquals(3, Customer::find()->count());
-        $this->assertEquals(2, Customer::find()->where('id=1 OR id=2')->count());
-        $this->assertEquals(6, Customer::find()->sum('id'));
-        $this->assertEquals(2, Customer::find()->average('id'));
-        $this->assertEquals(1, Customer::find()->min('id'));
-        $this->assertEquals(3, Customer::find()->max('id'));
+        $this->assertEquals(2, Customer::find()->where('[[id]]=1 OR [[id]]=2')->count());
+        $this->assertEquals(6, Customer::find()->sum('[[id]]'));
+        $this->assertEquals(2, Customer::find()->average('[[id]]'));
+        $this->assertEquals(1, Customer::find()->min('[[id]]'));
+        $this->assertEquals(3, Customer::find()->max('[[id]]'));
         $this->assertEquals(3, Customer::find()->select('COUNT(*)')->scalar());
     }
 
     public function testFindScalar()
     {
         // query scalar
-        $customerName = Customer::find()->where(['id' => 2])->select('name')->scalar();
+        $customerName = Customer::find()->where(['[[id]]' => 2])->select('[[name]]')->scalar();
         $this->assertEquals('user2', $customerName);
     }
 
     public function testFindColumn()
     {
         /* @var $this TestCase|ActiveRecordTestTrait */
-        $this->assertEquals(['user1', 'user2', 'user3'], Customer::find()->select('name')->column());
-        $this->assertEquals(['user3', 'user2', 'user1'], Customer::find()->orderBy(['name' => SORT_DESC])->select('name')->column());
+        $this->assertEquals(['user1', 'user2', 'user3'], Customer::find()->select('[[name]]')->column());
+        $this->assertEquals(['user3', 'user2', 'user1'], Customer::find()->orderBy(['[[name]]' => SORT_DESC])->select('[[name]]')->column());
     }
 
     public function testFindBySql()
     {
         // find one
-        $customer = Customer::findBySql('SELECT * FROM customer ORDER BY id DESC')->one();
+        $customer = Customer::findBySql('SELECT * FROM {{customer}} ORDER BY [[id]] DESC')->one();
         $this->assertTrue($customer instanceof Customer);
         $this->assertEquals('user3', $customer->name);
 
         // find all
-        $customers = Customer::findBySql('SELECT * FROM customer')->all();
+        $customers = Customer::findBySql('SELECT * FROM {{customer}}')->all();
         $this->assertEquals(3, count($customers));
 
         // find with parameter binding
-        $customer = Customer::findBySql('SELECT * FROM customer WHERE id=:id', [':id' => 2])->one();
+        $customer = Customer::findBySql('SELECT * FROM {{customer}} WHERE [[id]]=:id', [':id' => 2])->one();
         $this->assertTrue($customer instanceof Customer);
         $this->assertEquals('user2', $customer->name);
     }
@@ -308,7 +313,7 @@ class ActiveRecordTest extends DatabaseTestCase
         // inner join filtering and eager loading
         $orders = Order::find()->innerJoinWith([
             'customer' => function ($query) {
-                $query->where('customer.id=2');
+                $query->where('{{customer}}.[[id]]=2');
             },
         ])->orderBy('order.id')->all();
         $this->assertEquals(2, count($orders));
@@ -330,7 +335,7 @@ class ActiveRecordTest extends DatabaseTestCase
         // inner join filtering without eager loading
         $orders = Order::find()->innerJoinWith([
             'customer' => function ($query) {
-                $query->where('customer.id=2');
+                $query->where('{{customer}}.[[id]]=2');
             },
         ], false)->orderBy('order.id')->all();
         $this->assertEquals(2, count($orders));
@@ -365,7 +370,7 @@ class ActiveRecordTest extends DatabaseTestCase
                 $q->orderBy('item.id');
             },
             'items.category' => function ($q) {
-                $q->where('category.id = 2');
+                $q->where('{{category}}.[[id]] = 2');
             },
         ])->orderBy('order.id')->all();
         $this->assertEquals(1, count($orders));
@@ -449,7 +454,7 @@ class ActiveRecordTest extends DatabaseTestCase
                     $q->orderBy('item.id');
                     $q->joinWith([
                             'category'=> function ($q) {
-                                $q->where('category.id = 2');
+                                $q->where('{{category}}.[[id]] = 2');
                             }
                         ]);
                 },

--- a/tests/unit/framework/db/CommandTest.php
+++ b/tests/unit/framework/db/CommandTest.php
@@ -52,7 +52,7 @@ class CommandTest extends DatabaseTestCase
     {
         $db = $this->getConnection(false);
 
-        $command = $db->createCommand('SELECT * FROM customer');
+        $command = $db->createCommand('SELECT * FROM {{customer}}');
         $this->assertEquals(null, $command->pdoStatement);
         $command->prepare();
         $this->assertNotEquals(null, $command->pdoStatement);
@@ -64,11 +64,11 @@ class CommandTest extends DatabaseTestCase
     {
         $db = $this->getConnection();
 
-        $sql = 'INSERT INTO customer(email, name , address) VALUES (\'user4@example.com\', \'user4\', \'address4\')';
+        $sql = 'INSERT INTO {{customer}}([[email]], [[name]], [[address]]) VALUES (\'user4@example.com\', \'user4\', \'address4\')';
         $command = $db->createCommand($sql);
         $this->assertEquals(1, $command->execute());
 
-        $sql = 'SELECT COUNT(*) FROM customer WHERE name =\'user4\'';
+        $sql = 'SELECT COUNT(*) FROM {{customer}} WHERE [[name]] = \'user4\'';
         $command = $db->createCommand($sql);
         $this->assertEquals(1, $command->queryScalar());
 
@@ -82,55 +82,55 @@ class CommandTest extends DatabaseTestCase
         $db = $this->getConnection();
 
         // query
-        $sql = 'SELECT * FROM customer';
+        $sql = 'SELECT * FROM {{customer}}';
         $reader = $db->createCommand($sql)->query();
         $this->assertTrue($reader instanceof DataReader);
 
         // queryAll
-        $rows = $db->createCommand('SELECT * FROM customer')->queryAll();
+        $rows = $db->createCommand('SELECT * FROM {{customer}}')->queryAll();
         $this->assertEquals(3, count($rows));
         $row = $rows[2];
         $this->assertEquals(3, $row['id']);
         $this->assertEquals('user3', $row['name']);
 
-        $rows = $db->createCommand('SELECT * FROM customer WHERE id=10')->queryAll();
+        $rows = $db->createCommand('SELECT * FROM {{customer}} WHERE [[id]] = 10')->queryAll();
         $this->assertEquals([], $rows);
 
         // queryOne
-        $sql = 'SELECT * FROM customer ORDER BY id';
+        $sql = 'SELECT * FROM {{customer}} ORDER BY [[id]]';
         $row = $db->createCommand($sql)->queryOne();
         $this->assertEquals(1, $row['id']);
         $this->assertEquals('user1', $row['name']);
 
-        $sql = 'SELECT * FROM customer ORDER BY id';
+        $sql = 'SELECT * FROM {{customer}} ORDER BY [[id]]';
         $command = $db->createCommand($sql);
         $command->prepare();
         $row = $command->queryOne();
         $this->assertEquals(1, $row['id']);
         $this->assertEquals('user1', $row['name']);
 
-        $sql = 'SELECT * FROM customer WHERE id=10';
+        $sql = 'SELECT * FROM {{customer}} WHERE [[id]] = 10';
         $command = $db->createCommand($sql);
         $this->assertFalse($command->queryOne());
 
         // queryColumn
-        $sql = 'SELECT * FROM customer';
+        $sql = 'SELECT * FROM {{customer}}';
         $column = $db->createCommand($sql)->queryColumn();
         $this->assertEquals(range(1, 3), $column);
 
-        $command = $db->createCommand('SELECT id FROM customer WHERE id=10');
+        $command = $db->createCommand('SELECT [[id]] FROM {{customer}} WHERE [[id]] = 10');
         $this->assertEquals([], $command->queryColumn());
 
         // queryScalar
-        $sql = 'SELECT * FROM customer ORDER BY id';
+        $sql = 'SELECT * FROM {{customer}} ORDER BY [[id]]';
         $this->assertEquals($db->createCommand($sql)->queryScalar(), 1);
 
-        $sql = 'SELECT id FROM customer ORDER BY id';
+        $sql = 'SELECT [[id]] FROM {{customer}} ORDER BY [[id]]';
         $command = $db->createCommand($sql);
         $command->prepare();
         $this->assertEquals(1, $command->queryScalar());
 
-        $command = $db->createCommand('SELECT id FROM customer WHERE id=10');
+        $command = $db->createCommand('SELECT [[id]] FROM {{customer}} WHERE [[id]] = 10');
         $this->assertFalse($command->queryScalar());
 
         $command = $db->createCommand('bad SQL');
@@ -143,7 +143,7 @@ class CommandTest extends DatabaseTestCase
         $db = $this->getConnection();
 
         // bindParam
-        $sql = 'INSERT INTO customer(email, name, address) VALUES (:email, :name, :address)';
+        $sql = 'INSERT INTO {{customer}}([[email]], [[name]], [[address]]) VALUES (:email, :name, :address)';
         $command = $db->createCommand($sql);
         $email = 'user4@example.com';
         $name = 'user4';
@@ -153,54 +153,68 @@ class CommandTest extends DatabaseTestCase
         $command->bindParam(':address', $address);
         $command->execute();
 
-        $sql = 'SELECT name FROM customer WHERE email=:email';
+        $sql = 'SELECT [[name]] FROM {{customer}} WHERE [[email]] = :email';
         $command = $db->createCommand($sql);
         $command->bindParam(':email', $email);
         $this->assertEquals($name, $command->queryScalar());
 
-        $sql = 'INSERT INTO type (int_col, char_col, float_col, blob_col, numeric_col, bool_col) VALUES (:int_col, :char_col, :float_col, :blob_col, :numeric_col, :bool_col)';
+        $sql = <<<SQL
+INSERT INTO {{type}} ([[int_col]], [[char_col]], [[float_col]], [[blob_col]], [[numeric_col]], [[bool_col]])
+  VALUES (:int_col, :char_col, :float_col, :blob_col, :numeric_col, :bool_col)
+SQL;
         $command = $db->createCommand($sql);
         $intCol = 123;
         $charCol = str_repeat('abc', 33) . 'x'; // a 100 char string
-        $floatCol = 1.23;
-        $blobCol = "\x10\x11\x12";
-        $numericCol = '1.23';
         $boolCol = false;
-        $command->bindParam(':int_col', $intCol);
+        $command->bindParam(':int_col', $intCol, \PDO::PARAM_INT);
         $command->bindParam(':char_col', $charCol);
-        $command->bindParam(':float_col', $floatCol);
-        $command->bindParam(':blob_col', $blobCol);
-        $command->bindParam(':numeric_col', $numericCol);
-        $command->bindParam(':bool_col', $boolCol);
+        $command->bindParam(':bool_col', $boolCol, \PDO::PARAM_BOOL);
+        if ($this->driverName === 'oci') {
+            // can't bind floats without support from a custom PDO driver
+            $floatCol = 2;
+            $numericCol = 3;
+            // can't use blobs without support from a custom PDO driver
+            $blobCol = null;
+            $command->bindParam(':float_col', $floatCol, \PDO::PARAM_INT);
+            $command->bindParam(':numeric_col', $numericCol, \PDO::PARAM_INT);
+            $command->bindParam(':blob_col', $blobCol);
+        } else {
+            $floatCol = 1.23;
+            $numericCol = '1.23';
+            $blobCol = "\x10\x11\x12";
+            $command->bindParam(':float_col', $floatCol);
+            $command->bindParam(':numeric_col', $numericCol);
+            $command->bindParam(':blob_col', $blobCol);
+        }
         $this->assertEquals(1, $command->execute());
 
-        $command = $db->createCommand('SELECT int_col, char_col, float_col, blob_col, numeric_col, bool_col FROM type');
+        $command = $db->createCommand('SELECT [[int_col]], [[char_col]], [[float_col]], [[blob_col]], [[numeric_col]], [[bool_col]] FROM {{type}}');
 //        $command->prepare();
 //        $command->pdoStatement->bindColumn('blob_col', $bc, \PDO::PARAM_LOB);
         $row = $command->queryOne();
         $this->assertEquals($intCol, $row['int_col']);
         $this->assertEquals($charCol, $row['char_col']);
         $this->assertEquals($floatCol, $row['float_col']);
-        if ($this->driverName === 'mysql' || $this->driverName === 'sqlite') {
+        if ($this->driverName === 'mysql' || $this->driverName === 'sqlite' || $this->driverName === 'oci') {
             $this->assertEquals($blobCol, $row['blob_col']);
         } else {
             $this->assertTrue(is_resource($row['blob_col']));
             $this->assertEquals($blobCol, stream_get_contents($row['blob_col']));
         }
         $this->assertEquals($numericCol, $row['numeric_col']);
-        if ($this->driverName === 'mysql' || defined('HHVM_VERSION') && $this->driverName === 'sqlite') {
+        if ($this->driverName === 'mysql' || (defined('HHVM_VERSION') && $this->driverName === 'sqlite') || $this->driverName === 'oci') {
             $this->assertEquals($boolCol, (int) $row['bool_col']);
         } else {
             $this->assertEquals($boolCol, $row['bool_col']);
         }
 
         // bindValue
-        $sql = 'INSERT INTO customer(email, name, address) VALUES (:email, \'user5\', \'address5\')';
+        $sql = 'INSERT INTO {{customer}}([[email]], [[name]], [[address]]) VALUES (:email, \'user5\', \'address5\')';
         $command = $db->createCommand($sql);
         $command->bindValue(':email', 'user5@example.com');
         $command->execute();
 
-        $sql = 'SELECT email FROM customer WHERE name=:name';
+        $sql = 'SELECT [[email]] FROM {{customer}} WHERE [[name]] = :name';
         $command = $db->createCommand($sql);
         $command->bindValue(':name', 'user5');
         $this->assertEquals('user5@example.com', $command->queryScalar());
@@ -211,20 +225,20 @@ class CommandTest extends DatabaseTestCase
         $db = $this->getConnection();
 
         // default: FETCH_ASSOC
-        $sql = 'SELECT * FROM customer';
+        $sql = 'SELECT * FROM {{customer}}';
         $command = $db->createCommand($sql);
         $result = $command->queryOne();
         $this->assertTrue(is_array($result) && isset($result['id']));
 
         // FETCH_OBJ, customized via fetchMode property
-        $sql = 'SELECT * FROM customer';
+        $sql = 'SELECT * FROM {{customer}}';
         $command = $db->createCommand($sql);
         $command->fetchMode = \PDO::FETCH_OBJ;
         $result = $command->queryOne();
         $this->assertTrue(is_object($result));
 
         // FETCH_NUM, customized in query method
-        $sql = 'SELECT * FROM customer';
+        $sql = 'SELECT * FROM {{customer}}';
         $command = $db->createCommand($sql);
         $result = $command->queryOne([], \PDO::FETCH_NUM);
         $this->assertTrue(is_array($result) && isset($result[0]));
@@ -233,8 +247,10 @@ class CommandTest extends DatabaseTestCase
     public function testBatchInsert()
     {
         $command = $this->getConnection()->createCommand();
-        $command->batchInsert('customer',
-            ['email', 'name', 'address'], [
+        $command->batchInsert(
+            '{{customer}}',
+            ['email', 'name', 'address'],
+            [
                 ['t1@example.com', 't1', 't1 address'],
                 ['t2@example.com', null, false],
             ]
@@ -310,7 +326,7 @@ class CommandTest extends DatabaseTestCase
 
         $db = $this->getConnection();
 
-        $sql = 'INSERT INTO profile(id, description) VALUES (123, \'duplicate\')';
+        $sql = 'INSERT INTO {{profile}}([[id]], [[description]]) VALUES (123, \'duplicate\')';
         $command = $db->createCommand($sql);
         $command->execute();
         $command->execute();
@@ -321,10 +337,10 @@ class CommandTest extends DatabaseTestCase
         $db = $this->getConnection();
         $db->enableQueryCache = true;
         $db->queryCache = new FileCache(['cachePath' => '@yiiunit/runtime/cache']);
-        $command = $db->createCommand('SELECT name FROM customer WHERE id=:id');
+        $command = $db->createCommand('SELECT [[name]] FROM {{customer}} WHERE [[id]] = :id');
 
         $this->assertEquals('user1', $command->bindValue(':id', 1)->queryScalar());
-        $update = $db->createCommand('UPDATE customer SET name=:name WHERE id=:id');
+        $update = $db->createCommand('UPDATE {{customer}} SET [[name]] = :name WHERE [[id]] = :id');
         $update->bindValues([':id' => 1, ':name' => 'user11'])->execute();
         $this->assertEquals('user11', $command->bindValue(':id', 1)->queryScalar());
 
@@ -348,16 +364,40 @@ class CommandTest extends DatabaseTestCase
         }, 10);
 
         $db->enableQueryCache = true;
-        $command = $db->createCommand('SELECT name FROM customer WHERE id=:id')->cache();
+        $command = $db->createCommand('SELECT [[name]] FROM {{customer}} WHERE [[id]] = :id')->cache();
         $this->assertEquals('user11', $command->bindValue(':id', 1)->queryScalar());
         $update->bindValues([':id' => 1, ':name' => 'user1'])->execute();
         $this->assertEquals('user11', $command->bindValue(':id', 1)->queryScalar());
         $this->assertEquals('user1', $command->noCache()->bindValue(':id', 1)->queryScalar());
 
-        $command = $db->createCommand('SELECT name FROM customer WHERE id=:id');
+        $command = $db->createCommand('SELECT [[name]] FROM {{customer}} WHERE [[id]] = :id');
         $db->cache(function (Connection $db) use ($command, $update) {
             $this->assertEquals('user11', $command->bindValue(':id', 1)->queryScalar());
             $this->assertEquals('user1', $command->noCache()->bindValue(':id', 1)->queryScalar());
         }, 10);
+    }
+
+    public function testColumnCase()
+    {
+        $db = $this->getConnection(false);
+        $this->assertEquals(\PDO::CASE_NATURAL, $db->slavePdo->getAttribute(\PDO::ATTR_CASE));
+
+        $sql = 'SELECT [[customer_id]], [[total]] FROM {{order}}';
+        $rows = $db->createCommand($sql)->queryAll();
+        $this->assertTrue(isset($rows[0]));
+        $this->assertTrue(isset($rows[0]['customer_id']));
+        $this->assertTrue(isset($rows[0]['total']));
+
+        $db->slavePdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_LOWER);
+        $rows = $db->createCommand($sql)->queryAll();
+        $this->assertTrue(isset($rows[0]));
+        $this->assertTrue(isset($rows[0]['customer_id']));
+        $this->assertTrue(isset($rows[0]['total']));
+
+        $db->slavePdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_UPPER);
+        $rows = $db->createCommand($sql)->queryAll();
+        $this->assertTrue(isset($rows[0]));
+        $this->assertTrue(isset($rows[0]['CUSTOMER_ID']));
+        $this->assertTrue(isset($rows[0]['TOTAL']));
     }
 }

--- a/tests/unit/framework/db/DatabaseTestCase.php
+++ b/tests/unit/framework/db/DatabaseTestCase.php
@@ -19,6 +19,9 @@ abstract class DatabaseTestCase extends TestCase
         $databases = self::getParam('databases');
         $this->database = $databases[$this->driverName];
         $pdo_database = 'pdo_'.$this->driverName;
+        if ($this->driverName === 'oci') {
+            $pdo_database = 'oci8';
+        }
 
         if (!extension_loaded('pdo') || !extension_loaded($pdo_database)) {
             $this->markTestSkipped('pdo and '.$pdo_database.' extension are required.');
@@ -71,7 +74,13 @@ abstract class DatabaseTestCase extends TestCase
         }
         $db->open();
         if ($fixture !== null) {
-            $lines = explode(';', file_get_contents($fixture));
+            if ($this->driverName === 'oci') {
+                list($drops, $creates) = explode('/* STATEMENTS */', file_get_contents($fixture), 2);
+                list($statements, $triggers, $data) = explode('/* TRIGGERS */', $creates, 3);
+                $lines = array_merge(explode('--', $drops), explode(';', $statements), explode('/', $triggers), explode(';', $data));
+            } else {
+                $lines = explode(';', file_get_contents($fixture));
+            }
             foreach ($lines as $line) {
                 if (trim($line) !== '') {
                     $db->pdo->exec($line);

--- a/tests/unit/framework/db/SchemaTest.php
+++ b/tests/unit/framework/db/SchemaTest.php
@@ -38,6 +38,16 @@ class SchemaTest extends DatabaseTestCase
         }
     }
 
+    public function testGetTableSchemasWithAttrCase()
+    {
+        $db = $this->getConnection(false);
+        $db->slavePdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_LOWER);
+        $this->assertEquals(count($db->schema->getTableNames()), count($db->schema->getTableSchemas()));
+
+        $db->slavePdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_UPPER);
+        $this->assertEquals(count($db->schema->getTableNames()), count($db->schema->getTableSchemas()));
+    }
+
     public function testGetNonExistingTableSchema()
     {
         $this->assertNull($this->getConnection()->schema->getTableSchema('nonexisting_table'));

--- a/tests/unit/framework/db/oci/OracleActiveDataProviderTest.php
+++ b/tests/unit/framework/db/oci/OracleActiveDataProviderTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace yiiunit\framework\db\oci;
+
+use yiiunit\framework\data\ActiveDataProviderTest;
+use yii\data\ActiveDataProvider;
+use yiiunit\data\ar\Order;
+
+/**
+ * @group db
+ * @group oci
+ * @group data
+ */
+class OracleActiveDataProviderTest extends ActiveDataProviderTest
+{
+    public $driverName = 'oci';
+}

--- a/tests/unit/framework/db/oci/OracleActiveRecordTest.php
+++ b/tests/unit/framework/db/oci/OracleActiveRecordTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace yiiunit\framework\db\oci;
+
+use yiiunit\framework\db\ActiveRecordTest;
+use yiiunit\data\ar\Type;
+
+/**
+ * @group db
+ * @group oci
+ */
+class OracleActiveRecordTest extends ActiveRecordTest
+{
+    protected $driverName = 'oci';
+
+    public function testCastValues()
+    {
+        // pass, because boolean casting is not available
+        return;
+        $model = new Type();
+        $model->int_col = 123;
+        $model->int_col2 = 456;
+        $model->smallint_col = 42;
+        $model->char_col = '1337';
+        $model->char_col2 = 'test';
+        $model->char_col3 = 'test123';
+        $model->float_col = 3.742;
+        $model->float_col2 = 42.1337;
+        $model->bool_col = 1;
+        $model->bool_col2 = 0;
+        $model->save(false);
+
+        /* @var $model Type */
+        $model = Type::find()->one();
+        $this->assertSame(123, $model->int_col);
+        $this->assertSame(456, $model->int_col2);
+        $this->assertSame(42, $model->smallint_col);
+        $this->assertSame('1337', trim($model->char_col));
+        $this->assertSame('test', $model->char_col2);
+        $this->assertSame('test123', $model->char_col3);
+//        $this->assertSame(1337.42, $model->float_col);
+//        $this->assertSame(42.1337, $model->float_col2);
+//        $this->assertSame(true, $model->bool_col);
+//        $this->assertSame(false, $model->bool_col2);
+    }
+
+    public function testDefaultValues()
+    {
+        $model = new Type();
+        $model->loadDefaultValues();
+        $this->assertEquals(1, $model->int_col2);
+        $this->assertEquals('something', $model->char_col2);
+        $this->assertEquals(1.23, $model->float_col2);
+        $this->assertEquals(33.22, $model->numeric_col);
+        $this->assertEquals(true, $model->bool_col2);
+
+        // not testing $model->time, because oci\Schema can't read default value
+
+        $model = new Type();
+        $model->char_col2 = 'not something';
+
+        $model->loadDefaultValues();
+        $this->assertEquals('not something', $model->char_col2);
+
+        $model = new Type();
+        $model->char_col2 = 'not something';
+
+        $model->loadDefaultValues(false);
+        $this->assertEquals('something', $model->char_col2);
+    }
+
+    public function testFindAsArray()
+    {
+        /* @var $customerClass \yii\db\ActiveRecordInterface */
+        $customerClass = $this->getCustomerClass();
+
+        // asArray
+        $customer = $customerClass::find()->where(['id' => 2])->asArray()->one();
+        $this->assertEquals([
+            'id' => 2,
+            'email' => 'user2@example.com',
+            'name' => 'user2',
+            'address' => 'address2',
+            'status' => 1,
+            'profile_id' => null,
+            'bool_status' => true,
+        ], $customer);
+
+        // find all asArray
+        $customers = $customerClass::find()->asArray()->all();
+        $this->assertEquals(3, count($customers));
+        $this->assertArrayHasKey('id', $customers[0]);
+        $this->assertArrayHasKey('name', $customers[0]);
+        $this->assertArrayHasKey('email', $customers[0]);
+        $this->assertArrayHasKey('address', $customers[0]);
+        $this->assertArrayHasKey('status', $customers[0]);
+        $this->assertArrayHasKey('bool_status', $customers[0]);
+        $this->assertArrayHasKey('id', $customers[1]);
+        $this->assertArrayHasKey('name', $customers[1]);
+        $this->assertArrayHasKey('email', $customers[1]);
+        $this->assertArrayHasKey('address', $customers[1]);
+        $this->assertArrayHasKey('status', $customers[1]);
+        $this->assertArrayHasKey('bool_status', $customers[1]);
+        $this->assertArrayHasKey('id', $customers[2]);
+        $this->assertArrayHasKey('name', $customers[2]);
+        $this->assertArrayHasKey('email', $customers[2]);
+        $this->assertArrayHasKey('address', $customers[2]);
+        $this->assertArrayHasKey('status', $customers[2]);
+        $this->assertArrayHasKey('bool_status', $customers[2]);
+    }
+}

--- a/tests/unit/framework/db/oci/OracleCommandTest.php
+++ b/tests/unit/framework/db/oci/OracleCommandTest.php
@@ -1,0 +1,22 @@
+<?php
+namespace yiiunit\framework\db\oci;
+
+use yiiunit\framework\db\CommandTest;
+
+/**
+ * @group db
+ * @group oci
+ */
+class OracleCommandTest extends CommandTest
+{
+    protected $driverName = 'oci';
+
+    public function testAutoQuoting()
+    {
+        $db = $this->getConnection(false);
+
+        $sql = 'SELECT [[id]], [[t.name]] FROM {{customer}} t';
+        $command = $db->createCommand($sql);
+        $this->assertEquals('SELECT "id", "t"."name" FROM "customer" t', $command->sql);
+    }
+}

--- a/tests/unit/framework/db/oci/OracleQueryTest.php
+++ b/tests/unit/framework/db/oci/OracleQueryTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace yiiunit\framework\db\oci;
+
+use yiiunit\framework\db\QueryTest;
+use yii\db\Query;
+
+/**
+ * @group db
+ * @group oci
+ */
+class OracleQueryTest extends QueryTest
+{
+    protected $driverName = 'oci';
+
+    public function testOne()
+    {
+        $db = $this->getConnection();
+
+        $result = (new Query)->from('customer')->where(['[[status]]' => 2])->one($db);
+        $this->assertEquals('user3', $result['name']);
+
+        $result = (new Query)->from('customer')->where(['[[status]]' => 3])->one($db);
+        $this->assertFalse($result);
+    }
+}

--- a/tests/unit/framework/db/oci/OracleSchemaTest.php
+++ b/tests/unit/framework/db/oci/OracleSchemaTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace yiiunit\framework\db\oci;
+
+use yii\db\Expression;
+use yii\db\oci\Schema;
+use yiiunit\framework\db\SchemaTest;
+
+/**
+ * @group db
+ * @group oci
+ */
+class OracleSchemaTest extends SchemaTest
+{
+    public $driverName = 'oci';
+
+    public function getExpectedColumns()
+    {
+        $columns = parent::getExpectedColumns();
+        unset($columns['enum_col']);
+        $columns['int_col']['dbType'] = 'NUMBER';
+        $columns['int_col']['size'] = 22;
+        $columns['int_col']['precision'] = null;
+        $columns['int_col']['scale'] = 0;
+        $columns['int_col2']['dbType'] = 'NUMBER';
+        $columns['int_col2']['size'] = 22;
+        $columns['int_col2']['precision'] = null;
+        $columns['int_col2']['scale'] = 0;
+        $columns['smallint_col']['dbType'] = 'NUMBER';
+        $columns['smallint_col']['type'] = 'integer';
+        $columns['smallint_col']['size'] = 22;
+        $columns['smallint_col']['precision'] = null;
+        $columns['smallint_col']['scale'] = 0;
+        $columns['char_col']['dbType'] = 'CHAR';
+        $columns['char_col']['precision'] = null;
+        $columns['char_col']['size'] = 100;
+        $columns['char_col2']['dbType'] = 'VARCHAR2';
+        $columns['char_col2']['precision'] = null;
+        $columns['char_col2']['size'] = 100;
+        $columns['char_col3']['type'] = 'string';
+        $columns['char_col3']['dbType'] = 'VARCHAR2';
+        $columns['char_col3']['precision'] = null;
+        $columns['char_col3']['size'] = 4000;
+        $columns['float_col']['dbType'] = 'FLOAT';
+        $columns['float_col']['precision'] = 126;
+        $columns['float_col']['scale'] = null;
+        $columns['float_col']['size'] = 22;
+        $columns['float_col2']['dbType'] = 'FLOAT';
+        $columns['float_col2']['precision'] = 126;
+        $columns['float_col2']['scale'] = null;
+        $columns['float_col2']['size'] = 22;
+        $columns['blob_col']['dbType'] = 'BLOB';
+        $columns['blob_col']['phpType'] = 'resource';
+        $columns['blob_col']['type'] = 'binary';
+        $columns['blob_col']['size'] = 4000;
+        $columns['numeric_col']['dbType'] = 'NUMBER';
+        $columns['numeric_col']['size'] = 22;
+        $columns['time']['dbType'] = 'TIMESTAMP(6)';
+        $columns['time']['size'] = 11;
+        $columns['time']['scale'] = 6;
+        $columns['time']['defaultValue'] = null;
+        $columns['bool_col']['type'] = 'string';
+        $columns['bool_col']['phpType'] = 'string';
+        $columns['bool_col']['dbType'] = 'CHAR';
+        $columns['bool_col']['size'] = 1;
+        $columns['bool_col']['precision'] = null;
+        $columns['bool_col2']['type'] = 'string';
+        $columns['bool_col2']['phpType'] = 'string';
+        $columns['bool_col2']['dbType'] = 'CHAR';
+        $columns['bool_col2']['size'] = 1;
+        $columns['bool_col2']['precision'] = null;
+        $columns['bool_col2']['defaultValue'] = '1';
+        $columns['ts_default']['type'] = 'timestamp';
+        $columns['ts_default']['phpType'] = 'string';
+        $columns['ts_default']['dbType'] = 'TIMESTAMP(6)';
+        $columns['ts_default']['scale'] = 6;
+        $columns['ts_default']['size'] = 11;
+        $columns['ts_default']['defaultValue'] = null;
+        $columns['bit_col']['type'] = 'string';
+        $columns['bit_col']['phpType'] = 'string';
+        $columns['bit_col']['dbType'] = 'CHAR';
+        $columns['bit_col']['size'] = 3;
+        $columns['bit_col']['precision'] = null;
+        $columns['bit_col']['defaultValue'] = '130';
+        return $columns;
+    }
+
+    /**
+     * Autoincrement columns detection should be disabled for Oracle
+     * because there is no way of associating a column with a sequence.
+     */
+    public function testAutoincrementDisabled()
+    {
+        $table = $this->getConnection(false)->schema->getTableSchema('order', true);
+        $this->assertSame(false, $table->columns['id']->autoIncrement);
+    }
+}


### PR DESCRIPTION
fixes #7757: in oci schema fix query results row keys case when PDO::ATTR_CASE is set to PDO::CASE_LOWER
