### PR TITLE
totalCount in pagination ActiveDataProvider

### DIFF
--- a/framework/data/ActiveDataProvider.php
+++ b/framework/data/ActiveDataProvider.php
@@ -102,7 +102,7 @@ class ActiveDataProvider extends BaseDataProvider
         }
         $query = clone $this->query;
         if (($pagination = $this->getPagination()) !== false) {
-            $pagination->totalCount = $this->getTotalCount();
+            $pagination->totalCount = $pagination->totalCount?$pagination->totalCount:$this->getTotalCount();
             $query->limit($pagination->getLimit())->offset($pagination->getOffset());
         }
         if (($sort = $this->getSort()) !== false) {


### PR DESCRIPTION
Необходимо разрешать устанавливать значение totalCount, так как в некоторых случаях getTotalCount отрабатывает не корректно ( например при связи 1 ко многим ), так же это может понадобиться в других жизненных ситуациях.

--BEFORE--
new ActiveDataProvider([
            'query' => $query,
            'pagination' => [
                'pageSize' => 10
            ]
        ]);

--AFTER--
new ActiveDataProvider([
            'query' => $query,
            'pagination' => [
                'pageSize' => 10,
                'totalCount' => $query->count()+1 
            ]
        ]);
