### PR TITLE
Fix #7896: Intelligent and more correct `Html::addCssClass`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Enh #7636: `yii\web\Session::getHasSessionId()` uses a more lenient way to check if session ID is provided in URL (robsch)
 - Enh #7850: Added `yii\filters\PageCache::cacheCookies` and `cacheHeaders` to allow selectively caching cookies and HTTP headers (qiangxue)
 - Enh: Added `yii\helper\Console::wrapText()` method to wrap indented text by console window width and used it in `yii help` command (cebe)
+- Enh #7896: Intelligent and more correct Html::addCssClass to allow more correct parsing of whitespaces (kartikv)
 - Chg: Updated dependency to `cebe/markdown` to version `1.1.x` (cebe)
 
 

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1715,7 +1715,7 @@ class BaseHtml
         if (isset($options['class'])) {
             $options['class'] = trim(preg_replace('/\s+/', ' ', $options['class']));
             $classes = ' ' . $options['class'] . ' ';
-            if (strpos( $classes, ' ' . $class . ' ') === false) {
+            if (strpos($classes, ' ' . $class . ' ') === false) {
                 $options['class'] .= ' ' . $class;
             }
         } else {

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1698,22 +1698,35 @@ class BaseHtml
      * Adds a CSS class (or a set of space / tab separated classes) to the specified options.
      * If the CSS class already exists in the options, it will not be added again.
      * @param array $options the options to be modified.
-     * @param string $class the CSS class(es) to be added. You can add multiple
-     * classes separated with a whitespace (space / tab).
+     * @param string|array $class the CSS class(es) to be added. You can add multiple
+     * classes either as an array OR separated with a whitespace (space / tab).
+     * @param bool whether to clean and sanitize whitespaces in the input. If set to true,
+     * the method will replace all whitespaces (tab, space, newlines) to single space and trim
+     * whitespaces from beginning and end of the generated options['class'].
      * @author Kartik Visweswaran <kartikv2@gmail.com>
      */
-    public static function addCssClass(&$options, $class)
+    public static function addCssClass(&$options, $class, $clean = false)
     {
-        if (preg_match('/\s/', $class)) {
-            $class = trim(preg_replace('/\s+/', ' ', $class));
+        if (is_array($class)) {
+            foreach ($class as $c) {
+                static::addCssClass($options, $c, $clean);
+            }
+            return;
+        }
+        elseif (preg_match('/\s/', $class)) {
+            if ($clean) {
+                $class = trim(preg_replace('/\s+/', ' ', $class));
+            }
             $classes = explode(' ', $class);
             foreach ($classes as $c) {
-                static::addCssClass($options, $c);
+                static::addCssClass($options, $c, $clean);
             }
             return;
         }
         if (isset($options['class'])) {
-            $options['class'] = trim(preg_replace('/\s+/', ' ', $options['class']));
+            if ($clean) {
+                $options['class'] = trim(preg_replace('/\s+/', ' ', $options['class']));
+            }
             $classes = ' ' . $options['class'] . ' ';
             if (strpos($classes, ' ' . $class . ' ') === false) {
                 $options['class'] .= ' ' . $class;

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1695,16 +1695,27 @@ class BaseHtml
     }
 
     /**
-     * Adds a CSS class to the specified options.
-     * If the CSS class is already in the options, it will not be added again.
+     * Adds a CSS class (or a set of space / tab separated classes) to the specified options.
+     * If the CSS class already exists in the options, it will not be added again.
      * @param array $options the options to be modified.
-     * @param string $class the CSS class to be added
+     * @param string $class the CSS class(es) to be added. You can add multiple
+     * classes separated with a whitespace (space / tab).
+     * @author Kartik Visweswaran <kartikv2@gmail.com>
      */
     public static function addCssClass(&$options, $class)
     {
+        if (preg_match('/\s/', $class)) {
+            $class = trim(preg_replace('/\s+/', ' ', $class));
+            $classes = explode(' ', $class);
+            foreach ($classes as $c) {
+                static::addCssClass($options, $c);
+            }
+            return;
+        }
         if (isset($options['class'])) {
+            $options['class'] = trim(preg_replace('/\s+/', ' ', $options['class']));
             $classes = ' ' . $options['class'] . ' ';
-            if (strpos($classes, ' ' . $class . ' ') === false) {
+            if (strpos( $classes, ' ' . $class . ' ') === false) {
                 $options['class'] .= ' ' . $class;
             }
         } else {

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1713,7 +1713,7 @@ class BaseHtml
             }
             return;
         }
-        elseif (preg_match('/\s/', $class)) {
+        if (preg_match('/\s/', $class)) {
             if ($clean) {
                 $class = trim(preg_replace('/\s+/', ' ', $class));
             }


### PR DESCRIPTION
Enhanced parsing of whitespaces in both `options['class']` and the `$class` param to  `Html::addCssClass` method.
