### PR TITLE
improved error message on createDirectory

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #7868: Removed column's autoIncrement detection from oci (nineinchnick)
 - Bug #7868: Fixed creating raw sql (for logging) by skipping object and resource params (nineinchnick)
 - Bug #7868: Fixed Schema::getLastInsertID() by quoting sequence name (nineinchnick)
+- Enh #6442: Improved error message on `FileHelper::createDirectory()` to include the path name of the directory (cebe)
 - Enh #6895: Added `ignoreCategories` config option for message command to ignore categories specified (samdark)
 - Enh #6975: Pressing arrows while focused in inputs of Active Form with `validateOnType` enabled no longer triggers validation (slinstj)
 - Enh #7488: Added `StringHelper::explode` to perform explode with trimming and skipping of empty elements (SilverFire, nineinchnick, creocoder, samdark)

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -447,6 +447,7 @@ class BaseFileHelper
      * @param integer $mode the permission to be set for the created directory.
      * @param boolean $recursive whether to create parent directories if they do not exist.
      * @return boolean whether the directory is created successfully
+     * @throws \yii\base\Exception if the directory could not be created.
      */
     public static function createDirectory($path, $mode = 0775, $recursive = true)
     {
@@ -457,8 +458,12 @@ class BaseFileHelper
         if ($recursive && !is_dir($parentDir)) {
             static::createDirectory($parentDir, $mode, true);
         }
-        $result = mkdir($path, $mode);
-        chmod($path, $mode);
+        try {
+            $result = mkdir($path, $mode);
+            chmod($path, $mode);
+        } catch(\Exception $e) {
+            throw new \yii\base\Exception("Failed to create directory '$path': " . $e->getMessage(), $e->getCode(), $e);
+        }
 
         return $result;
     }


### PR DESCRIPTION
ensure the directory name is included in the error message.

fixes #6442

![bildschirmfoto vom 2015-04-01 00 55 07](https://cloud.githubusercontent.com/assets/189796/6931103/b34e65c6-d809-11e4-83a0-f8dd80f51efc.png)
