### PR TITLE
AttributeBehavior documentation cleanup [ci skip]

### DIFF
--- a/framework/behaviors/AttributeBehavior.php
+++ b/framework/behaviors/AttributeBehavior.php
@@ -13,12 +13,13 @@ use yii\base\Behavior;
 use yii\base\Event;
 
 /**
- * AttributeBehavior automatically assigns a specified value to one or multiple attributes of an ActiveRecord object when certain events happen.
+ * AttributeBehavior automatically assigns a specified value to one or multiple attributes of an ActiveRecord
+ * object when certain events happen.
  *
  * To use AttributeBehavior, configure the [[attributes]] property which should specify the list of attributes
- * that need to be updated and the corresponding events that should trigger the update. For example,
- * Then configure the [[value]] property with a PHP callable whose return value will be used to assign to the current
- * attribute(s). For example,
+ * that need to be updated and the corresponding events that should trigger the update. Then configure the
+ * [[value]] property with a PHP callable whose return value will be used to assign to the current attribute(s).
+ * For example,
  *
  * ~~~
  * use yii\behaviors\AttributeBehavior;


### PR DESCRIPTION
Removed a rogue 'For example' and split a long line
