### PR TITLE
BaseListView render <tag>

### DIFF
--- a/framework/widgets/BaseListView.php
+++ b/framework/widgets/BaseListView.php
@@ -93,6 +93,10 @@ abstract class BaseListView extends Widget
      */
     public $layout = "{summary}\n{items}\n{pager}";
 
+    /**
+     * @var string html tag which is list view
+     */
+    private $_tag;
 
     /**
      * Renders the data models.
@@ -114,6 +118,8 @@ abstract class BaseListView extends Widget
         if (!isset($this->options['id'])) {
             $this->options['id'] = $this->getId();
         }
+        $this->_tag = ArrayHelper::remove($this->options, 'tag', 'div');
+        echo Html::beginTag($this->_tag, $this->options);
     }
 
     /**
@@ -130,8 +136,7 @@ abstract class BaseListView extends Widget
         } else {
             $content = $this->renderEmpty();
         }
-        $tag = ArrayHelper::remove($this->options, 'tag', 'div');
-        echo Html::tag($tag, $content, $this->options);
+        echo $content . Html::endTag($this->_tag);
     }
 
     /**


### PR DESCRIPTION
In the current implementation it is not possible to use correctly [panels-tables](http://getbootstrap.com/components/#panels-tables) because by default, the table is wrapped in a <div> which disrupts the structure of classes [.panel>.table](https://github.com/twbs/bootstrap/blob/master/less/panels.less#L104)

I added the ability to insert arbitrary html code in the block in which the table is positioned

``` php
<?php GridView::begin([
    'options' => [
        'class' => 'panel panel-default'
    ],
    'dataProvider' => $dataProvider,
    'columns' => [  ],
]); ?>

<!-- Default panel contents -->
<div class="panel-heading">Panel heading</div>
<div class="panel-body">
    <p>Some default panel content here.</p>
</div>

<?php GridView::end() ?>
```
