### PR TITLE
Change fields and extraFields

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -90,7 +90,37 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * @var array related models indexed by the relation names
      */
     private $_related = [];
+    
+    protected $fields = [];
+    
+    protected $extraFields = [];
+    
 
+    public function getExtraFields(){
+        
+        return $this->extraFields;
+    }
+    
+    public function setExtraFields(array $fields){
+        
+        $this->extraFields = $fields;
+        
+        return $this;
+    }
+    
+    
+    public function getFields(){
+        
+        return $this->fields;
+    }
+    
+    
+    public function setFields(array $fields){
+        
+        $this->fields = $fields;
+        
+        return $this;
+    }
 
     /**
      * @inheritdoc
@@ -1480,9 +1510,14 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function fields()
     {
+        if($fields = $this->getFields())
+            return $fields;
+        
         $fields = array_keys($this->_attributes);
+        
+        $this->setFields(array_combine($fields, $fields));
 
-        return array_combine($fields, $fields);
+        return $this->getFields();
     }
 
     /**
@@ -1492,9 +1527,14 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function extraFields()
     {
+        if($fields = $this->getExtraFields())
+            return $fields;
+            
         $fields = array_keys($this->getRelatedRecords());
+            
+        $this->setExtraFields(array_combine($fields, $fields));
 
-        return array_combine($fields, $fields);
+        return $this->getExtraFields();
     }
 
     /**


### PR DESCRIPTION
Adding getter and setter for fields and extraFields.

Бывает необходимо устанавливать на лету fields и extraFields. С подходом, который был ранее 

```
public function fields()
    {
        return ['field1', 'field2', 'field3'];
    }
```

это не возможно, поля определялись один раз. Хочется, чтобы можно было делать это на лету.

С данным изменением можно использовать как прежний подход, так и ряд новых, с условием, что метот fields() не будет переопределен. Например, можно делать так:

```
public function init(){

    $this->setFields(['field1', 'field2', 'field3']);

}

public function setUserFields(){
    $this->setFields(['field1', 'field2']);
}


public function setAdminFields(){
    $this->setFields(['field1', 'field2', 'field3', 'field4']);
}

public function getCurrentFields(){
    return $this->getFields();   // or $this->fields();
}
```

или поля можно определять так: 

```
    protected fields = [
        'field1',
        'field2'
    ];
```

Прошу рассмотреть данные изменения, они могут быть весьма полезны
