### PR TITLE
do not extra convert to floats in CompareValidator client code

### DIFF
--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -292,16 +292,16 @@ yii.validation = (function ($) {
                     valid = value !== compareValue;
                     break;
                 case '>':
-                    valid = parseFloat(value) > parseFloat(compareValue);
+                    valid = value > compareValue;
                     break;
                 case '>=':
-                    valid = parseFloat(value) >= parseFloat(compareValue);
+                    valid = value >= compareValue;
                     break;
                 case '<':
-                    valid = parseFloat(value) < parseFloat(compareValue);
+                    valid = value < compareValue;
                     break;
                 case '<=':
-                    valid = parseFloat(value) <= parseFloat(compareValue);
+                    valid = value <= compareValue;
                     break;
                 default:
                     valid = false;


### PR DESCRIPTION
See https://github.com/yiisoft/yii2/blob/1d32f4d269765d75a413ea026b22922f81990f71/framework/assets/yii.validation.js#L277, conversion is already done if needed. For me this bug stops from validating a date (comparing two dates in php:Y-m-d format).
