### PR TITLE
Fix migrate/down order

### DIFF
--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -124,7 +124,7 @@ class MigrateController extends BaseMigrateController
         $query = new Query;
         $rows = $query->select(['version', 'apply_time'])
             ->from($this->migrationTable)
-            ->orderBy('apply_time DESC')
+            ->orderBy('apply_time DESC, version DESC')
             ->limit($limit)
             ->createCommand($this->db)
             ->queryAll();


### PR DESCRIPTION
Migrations were applied at the same time. This cause invalid sort order while downgrade.

Command `yii migrate`

Output:

```
Yii Migration Tool (based on Yii v2.0.4-dev)

Total 2 new migrations to be applied:
        m150402_075534_initial
        m150402_075544_feedback
```

Command `yii migrate/down 2`

```
Yii Migration Tool (based on Yii v2.0.4-dev)

Total 2 migrations to be reverted:
        m150402_075534_initial
        m150402_075544_feedback
```

In databasse

```
"m000000_000000_base";1428382302
"m150402_075534_initial";1428388855           <----
"m150402_075544_feedback";1428388855     <----
```
