### PR TITLE
Allow indirect modifications of overloaded properties when using MongoDB

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -233,7 +233,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * @return mixed property value
      * @see getAttribute()
      */
-    public function __get($name)
+    public function &__get($name)
     {
         if (isset($this->_attributes[$name]) || array_key_exists($name, $this->_attributes)) {
             return $this->_attributes[$name];


### PR DESCRIPTION
Take for example this data structure saved in a MongoDB database:

```
_id: '3456345b6serbts34sdfbtsdf',
type: [
    "admin",
    "client"
],
personal_info: {
    name: 'Bob',
    surnames: ['', '', '', ''....],
    bday: ISODate(....),
},
credentials: {
    email: 'qqq@www.com',
    pass: '123123',
    salt: '2345c2345v345wq'
}
```

Getting the entire document is easy, `$person = Person::find(["_id" => "....."]);`

But modifying any subdocument values is not possible:

```
var_dump($person->credentials);  // <--- works
var_dump($person->credentials['password']); // <--- works
$person->credentials["password"] == "new password"; // fails with "Indirect modification of overloaded property"
```

This patch fixes this and, as far as I'm aware of, it doesn't introduce any bugs or any API breaks.
