### PR TITLE
Fix #2146: Active Record scopes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -18,6 +18,7 @@ Yii Framework 2 Change Log
 - Bug #7868: Fixed creating raw sql (for logging) by skipping object and resource params (nineinchnick)
 - Bug #7868: Fixed Schema::getLastInsertID() by quoting sequence name (nineinchnick)
 - Bug #7957: Removed extra `parseFloat()` call for the `compare` js validator (CthulhuDen)
+- Enh #2146: Added ability to declare scopes for `yii\db\ActiveQuery` as static methods of `yii\db\ActiveRecord` (SamMousa, klimov-paul)
 - Enh #6895: Added `ignoreCategories` config option for message command to ignore categories specified (samdark)
 - Enh #6975: Pressing arrows while focused in inputs of Active Form with `validateOnType` enabled no longer triggers validation (slinstj)
 - Enh #7409: Allow `yii\filters\auth\CompositeAuth::authMethods` to take authentication objects (fernandezekiel, qiangxue)

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -32,6 +32,31 @@ trait ActiveQueryTrait
 
 
     /**
+     * Calls the named method which is not a class method.
+     *
+     * This method will check if [[modelClass]] declares static named method
+     * and will execute it if available passing self instance as a first argument.
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when an unknown method is being invoked.
+     * @param string $name the method name
+     * @param array $params method parameters
+     * @return mixed the method return value
+     */
+    public function __call($name, $params)
+    {
+        $reflection = new \ReflectionClass($this->modelClass);
+        if ($reflection->hasMethod($name)) {
+            $method = $reflection->getMethod($name);
+            if ($method->isStatic() && $method->isPublic() && $method->getNumberOfParameters() > 0) {
+                array_unshift($params, $this);
+                return forward_static_call_array([$this->modelClass, $name], $params);
+            }
+        }
+        return parent::__call($name, $params);
+    }
+
+    /**
      * Sets the [[asArray]] property.
      * @param boolean $value whether to return the query results in terms of arrays instead of Active Records.
      * @return static the query object itself

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -50,7 +50,8 @@ trait ActiveQueryTrait
             $method = $reflection->getMethod($name);
             if ($method->isStatic() && $method->isPublic() && $method->getNumberOfParameters() > 0) {
                 array_unshift($params, $this);
-                return forward_static_call_array([$this->modelClass, $name], $params);
+                forward_static_call_array([$this->modelClass, $name], $params);
+                return $this;
             }
         }
         return parent::__call($name, $params);

--- a/tests/unit/data/ar/Customer.php
+++ b/tests/unit/data/ar/Customer.php
@@ -84,4 +84,14 @@ class Customer extends ActiveRecord
     {
         return new CustomerQuery(get_called_class());
     }
+
+    /**
+     * @param ActiveQuery $query
+     * @return ActiveQuery
+     */
+    public static function whereActive($query)
+    {
+        $query->andWhere('[[status]]=1');
+        return $query;
+    }
 }

--- a/tests/unit/data/ar/Customer.php
+++ b/tests/unit/data/ar/Customer.php
@@ -87,11 +87,9 @@ class Customer extends ActiveRecord
 
     /**
      * @param ActiveQuery $query
-     * @return ActiveQuery
      */
     public static function whereActive($query)
     {
         $query->andWhere('[[status]]=1');
-        return $query;
     }
 }

--- a/tests/unit/framework/ar/ActiveRecordTestTrait.php
+++ b/tests/unit/framework/ar/ActiveRecordTestTrait.php
@@ -103,6 +103,9 @@ trait ActiveRecordTestTrait
         // scope
         $this->assertEquals(2, count($customerClass::find()->active()->all()));
         $this->assertEquals(2, $customerClass::find()->active()->count());
+        // inline scope
+        $this->assertEquals(2, count($customerClass::find()->whereActive()->all()));
+        $this->assertEquals(2, $customerClass::find()->whereActive()->count());
     }
 
     public function testFindAsArray()


### PR DESCRIPTION
Fix #2146: Added ability to declare scopes for `yii\db\ActiveQuery` as static methods of `yii\db\ActiveRecord`
