### PR TITLE
Added grid\DetailView

### DIFF
--- a/framework/grid/ColumnViewTrait.php
+++ b/framework/grid/ColumnViewTrait.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\grid;
+
+use Yii;
+use yii\i18n\Formatter;
+use yii\base\InvalidConfigException;
+
+/**
+ * ColumnViewTrait provides functionality common for GridView and DetailView and
+ * could be used for other classes containing [[DataColumn]]s
+ *
+ * @author Andrii Vasyliev <sol@hiqdev.com>
+ * @since 2.0
+ */
+trait ColumnViewTrait
+{
+    /**
+     * @var string the default data column class if the class name is not explicitly specified when configuring a data column.
+     * Defaults to 'yii\grid\DataColumn'.
+     */
+    public $dataColumnClass;
+    /**
+     * @var array grid column configuration. Each array element represents the configuration
+     * for one particular grid column. For example,
+     *
+     * ```php
+     * [
+     *     ['class' => SerialColumn::className()],
+     *     [
+     *         'class' => DataColumn::className(), // this line is optional
+     *         'attribute' => 'name',
+     *         'format' => 'text',
+     *         'label' => 'Name',
+     *     ],
+     *     ['class' => CheckboxColumn::className()],
+     * ]
+     * ```
+     *
+     * If a column is of class [[DataColumn]], the "class" element can be omitted.
+     *
+     * As a shortcut format, a string may be used to specify the configuration of a data column
+     * which only contains [[DataColumn::attribute|attribute]], [[DataColumn::format|format]],
+     * and/or [[DataColumn::label|label]] options: `"attribute:format:label"`.
+     * For example, the above "name" column can also be specified as: `"name:text:Name"`.
+     * Both "format" and "label" are optional. They will take default values if absent.
+     *
+     * Using the shortcut format the configuration for columns in simple cases would look like this:
+     *
+     * ```php
+     * [
+     *     'id',
+     *     'amount:currency:Total Amount',
+     *     'created_at:datetime',
+     * ]
+     * ```
+     *
+     * When using a [[dataProvider]] with active records, you can also display values from related records,
+     * e.g. the `name` attribute of the `author` relation:
+     *
+     * ```php
+     * // shortcut syntax
+     * 'author.name',
+     * // full syntax
+     * [
+     *     'attribute' => 'author.name',
+     *     // ...
+     * ]
+     * ```
+     */
+    public $columns = [];
+    /**
+     * @var array|Formatter the formatter used to format model attribute values into displayable texts.
+     * This can be either an instance of [[Formatter]] or an configuration array for creating the [[Formatter]]
+     * instance. If this property is not set, the "formatter" application component will be used.
+     */
+    public $formatter;
+
+    /**
+     * Initializes $formatter.
+     */
+    public function initFormatter()
+    {
+        if ($this->formatter === null) {
+            $this->formatter = Yii::$app->getFormatter();
+        } elseif (is_array($this->formatter)) {
+            $this->formatter = Yii::createObject($this->formatter);
+        }
+        if (!$this->formatter instanceof Formatter) {
+            throw new InvalidConfigException('The "formatter" property must be either a Format object or a configuration array.');
+        }
+    }
+
+    /**
+     * Creates column objects and initializes them.
+     */
+    protected function initColumns()
+    {
+        if (empty($this->columns)) {
+            $this->guessColumns();
+        }
+        foreach ($this->columns as $i => $column) {
+            if (is_string($column)) {
+                $column = $this->createDataColumn($column);
+            } else {
+                $column = $this->createColumnObject($column);
+            }
+            if (!$column->visible) {
+                unset($this->columns[$i]);
+                continue;
+            }
+            $this->columns[$i] = $column;
+        }
+    }
+
+    /**
+     * Creates a [[DataColumn]] object based on a string in the format of "attribute:format:label".
+     * @param string $text the column specification string
+     * @return DataColumn the column instance
+     * @throws InvalidConfigException if the column specification is invalid
+     */
+    protected function createDataColumn($text)
+    {
+        if (!preg_match('/^([^:]+)(:(\w*))?(:(.*))?$/', $text, $matches)) {
+            throw new InvalidConfigException('The column must be specified in the format of "attribute", "attribute:format" or "attribute:format:label"');
+        }
+
+        return $this->createColumnObject([
+            'attribute' => $matches[1],
+            'format' => isset($matches[3]) ? $matches[3] : 'text',
+            'label' => isset($matches[5]) ? $matches[5] : null,
+        ]);
+    }
+
+    /**
+     * Creates a [[DataColumn]] object with given additional config
+     * @param array $config additional config for [[DataColumn]]
+     * @return DataColumn the column instance
+     */
+    protected function createColumnObject(array $config = []) {
+        return Yii::createObject(array_merge([
+            'class' => $this->dataColumnClass ? : DataColumn::className(),
+            'grid' => $this,
+        ], $config));
+    }
+
+    /**
+     * This function tries to guess the columns to show from the given data
+     * if [[columns]] are not explicitly specified.
+     */
+    protected function guessColumns()
+    {
+        $models = $this->dataProvider->getModels();
+        $model = reset($models);
+        if (is_array($model) || is_object($model)) {
+            foreach ($model as $name => $value) {
+                $this->columns[] = $name;
+            }
+        }
+    }
+
+}

--- a/framework/grid/DetailView.php
+++ b/framework/grid/DetailView.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\grid;
+
+use Yii;
+use yii\base\Arrayable;
+use yii\i18n\Formatter;
+use yii\base\InvalidConfigException;
+use yii\base\Model;
+use yii\base\Widget;
+use yii\data\ArrayDataProvider;
+use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
+use yii\helpers\Inflector;
+
+/**
+ * DetailView displays the detail of a single data [[Model]].
+ *
+ * yii\grid\DetailView is similar to [[yii\widgets\DetailView]] but uses [[Column]]
+ * to show header and data part of given [[Model]].
+ *
+ * The contents of the detail table are configured in terms of [[Column]]
+ * classes, which are configured via $columns.
+ * Helps reuse your code by defining [[Column]]s once and reusing them for
+ * both GridView and DetailView. Filter and footer part of [[Column]] are
+ * not used.
+ *
+ * A typical usage of DetailView is as follows:
+ *
+ * ~~~
+ * echo DetailView::widget([
+ *     'model' => $model,
+ *     'columns' => [
+ *         'title',               // title attribute (in plain text)
+ *         'description:html',    // description attribute in HTML
+ *         [                      // the owner name of the model
+ *             'label' => 'Owner',
+ *             'value' => $model->owner->name,
+ *         ],
+ *         'created_at:datetime', // creation date formatted as datetime
+ *         [
+ *             'class' => ActionColumn::className(),
+ *         ],
+ *     ],
+ * ]);
+ * ~~~
+ *
+ * @author Andrii Vasyliev <sol@hiqdev.com>
+ * @since 2.0
+ */
+class DetailView extends Widget
+{
+    use ColumnViewTrait;
+
+    /**
+     * @var array|object the data model whose details are to be displayed. This can be a [[Model]] instance,
+     * an associative array, an object that implements [[Arrayable]] interface or simply an object with defined
+     * public accessible non-static properties.
+     */
+    public $model;
+    /**
+     * @var \yii\data\DataProviderInterface
+     * automatically created from $model
+     */
+    private $_dataProvider;
+    /**
+     * @var string|callable the template used to render a single attribute. If a string, the token `{label}`
+     * and `{value}` will be replaced with the label and the value of the corresponding attribute.
+     * If a callback (e.g. an anonymous function), the signature must be as follows:
+     *
+     * ~~~
+     * function ($attribute, $index, $widget)
+     * ~~~
+     *
+     * where `$attribute` refer to the specification of the attribute being rendered, `$index` is the zero-based
+     * index of the attribute in the [[attributes]] array, and `$widget` refers to this widget instance.
+     */
+    public $template = "<tr>{label}{value}</tr>";
+    /**
+     * @var array the HTML attributes for the container tag of this widget. The "tag" option specifies
+     * what container tag should be used. It defaults to "table" if not set.
+     * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
+     */
+    public $options = ['class' => 'table table-striped table-bordered detail-view'];
+
+    /**
+     * Initializes the detail view.
+     * This method will initialize required property values.
+     */
+    public function init()
+    {
+        if ($this->model === null) {
+            throw new InvalidConfigException('Please specify the "model" property.');
+        }
+        $this->_dataProvider = new ArrayDataProvider(['allModels' => [$this->model]]);
+        $this->initFormatter();
+        $this->initColumns();
+    }
+
+    /**
+     * Getter for _dataProvider
+     */
+    public function getDataProvider()
+    {
+        return $this->_dataProvider;
+    }
+
+    /**
+     * Renders the detail view.
+     * This is the main entry of the whole detail view rendering.
+     */
+    public function run()
+    {
+        $rows = [];
+        $i = 0;
+        foreach ($this->columns as $column) {
+            $rows[] = $this->renderColumn($column, $i++);
+        }
+
+        $tag = ArrayHelper::remove($this->options, 'tag', 'table');
+        echo Html::tag($tag, implode("\n", $rows), $this->options);
+    }
+
+    /**
+     * Renders a single column.
+     * @param array $column the specification of the column to be rendered.
+     * @param integer $index the zero-based index of the column in the [[columns]] array
+     * @return string the rendering result
+     */
+    protected function renderColumn($column, $index)
+    {
+        if (is_string($this->template)) {
+            return strtr($this->template, [
+                //'{label}' => $attribute['label'],
+                //'{value}' => $this->formatter->format($attribute['value'], $attribute['format']),
+                '{label}' => $column->renderHeaderCell(),
+                '{value}' => $column->renderDataCell($this->model, 0, 0),
+            ]);
+        } else {
+            return call_user_func($this->template, $column, $index, $this);
+        }
+    }
+
+}

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -9,8 +9,6 @@ namespace yii\grid;
 
 use Yii;
 use Closure;
-use yii\i18n\Formatter;
-use yii\base\InvalidConfigException;
 use yii\helpers\Url;
 use yii\helpers\Html;
 use yii\helpers\Json;
@@ -46,15 +44,12 @@ use yii\base\Model;
  */
 class GridView extends BaseListView
 {
+    use ColumnViewTrait;
+
     const FILTER_POS_HEADER = 'header';
     const FILTER_POS_FOOTER = 'footer';
     const FILTER_POS_BODY = 'body';
 
-    /**
-     * @var string the default data column class if the class name is not explicitly specified when configuring a data column.
-     * Defaults to 'yii\grid\DataColumn'.
-     */
-    public $dataColumnClass;
     /**
      * @var string the caption of the grid table
      * @see captionOptions
@@ -130,61 +125,6 @@ class GridView extends BaseListView
      */
     public $showOnEmpty = true;
     /**
-     * @var array|Formatter the formatter used to format model attribute values into displayable texts.
-     * This can be either an instance of [[Formatter]] or an configuration array for creating the [[Formatter]]
-     * instance. If this property is not set, the "formatter" application component will be used.
-     */
-    public $formatter;
-    /**
-     * @var array grid column configuration. Each array element represents the configuration
-     * for one particular grid column. For example,
-     *
-     * ```php
-     * [
-     *     ['class' => SerialColumn::className()],
-     *     [
-     *         'class' => DataColumn::className(), // this line is optional
-     *         'attribute' => 'name',
-     *         'format' => 'text',
-     *         'label' => 'Name',
-     *     ],
-     *     ['class' => CheckboxColumn::className()],
-     * ]
-     * ```
-     *
-     * If a column is of class [[DataColumn]], the "class" element can be omitted.
-     *
-     * As a shortcut format, a string may be used to specify the configuration of a data column
-     * which only contains [[DataColumn::attribute|attribute]], [[DataColumn::format|format]],
-     * and/or [[DataColumn::label|label]] options: `"attribute:format:label"`.
-     * For example, the above "name" column can also be specified as: `"name:text:Name"`.
-     * Both "format" and "label" are optional. They will take default values if absent.
-     *
-     * Using the shortcut format the configuration for columns in simple cases would look like this:
-     *
-     * ```php
-     * [
-     *     'id',
-     *     'amount:currency:Total Amount',
-     *     'created_at:datetime',
-     * ]
-     * ```
-     *
-     * When using a [[dataProvider]] with active records, you can also display values from related records,
-     * e.g. the `name` attribute of the `author` relation:
-     *
-     * ```php
-     * // shortcut syntax
-     * 'author.name',
-     * // full syntax
-     * [
-     *     'attribute' => 'author.name',
-     *     // ...
-     * ]
-     * ```
-     */
-    public $columns = [];
-    /**
      * @var string the HTML display when the content of a cell is empty
      */
     public $emptyCell = '&nbsp;';
@@ -254,18 +194,10 @@ class GridView extends BaseListView
     public function init()
     {
         parent::init();
-        if ($this->formatter == null) {
-            $this->formatter = Yii::$app->getFormatter();
-        } elseif (is_array($this->formatter)) {
-            $this->formatter = Yii::createObject($this->formatter);
-        }
-        if (!$this->formatter instanceof Formatter) {
-            throw new InvalidConfigException('The "formatter" property must be either a Format object or a configuration array.');
-        }
         if (!isset($this->filterRowOptions['id'])) {
             $this->filterRowOptions['id'] = $this->options['id'] . '-filters';
         }
-
+        $this->initFormatter();
         $this->initColumns();
     }
 
@@ -507,64 +439,4 @@ class GridView extends BaseListView
         return Html::tag('tr', implode('', $cells), $options);
     }
 
-    /**
-     * Creates column objects and initializes them.
-     */
-    protected function initColumns()
-    {
-        if (empty($this->columns)) {
-            $this->guessColumns();
-        }
-        foreach ($this->columns as $i => $column) {
-            if (is_string($column)) {
-                $column = $this->createDataColumn($column);
-            } else {
-                $column = Yii::createObject(array_merge([
-                    'class' => $this->dataColumnClass ? : DataColumn::className(),
-                    'grid' => $this,
-                ], $column));
-            }
-            if (!$column->visible) {
-                unset($this->columns[$i]);
-                continue;
-            }
-            $this->columns[$i] = $column;
-        }
-    }
-
-    /**
-     * Creates a [[DataColumn]] object based on a string in the format of "attribute:format:label".
-     * @param string $text the column specification string
-     * @return DataColumn the column instance
-     * @throws InvalidConfigException if the column specification is invalid
-     */
-    protected function createDataColumn($text)
-    {
-        if (!preg_match('/^([^:]+)(:(\w*))?(:(.*))?$/', $text, $matches)) {
-            throw new InvalidConfigException('The column must be specified in the format of "attribute", "attribute:format" or "attribute:format:label"');
-        }
-
-        return Yii::createObject([
-            'class' => $this->dataColumnClass ? : DataColumn::className(),
-            'grid' => $this,
-            'attribute' => $matches[1],
-            'format' => isset($matches[3]) ? $matches[3] : 'text',
-            'label' => isset($matches[5]) ? $matches[5] : null,
-        ]);
-    }
-
-    /**
-     * This function tries to guess the columns to show from the given data
-     * if [[columns]] are not explicitly specified.
-     */
-    protected function guessColumns()
-    {
-        $models = $this->dataProvider->getModels();
-        $model = reset($models);
-        if (is_array($model) || is_object($model)) {
-            foreach ($model as $name => $value) {
-                $this->columns[] = $name;
-            }
-        }
-    }
 }


### PR DESCRIPTION
[[yii\grid\DetailView]] is similar to [[yii\widgets\DetailView]] but uses [[Column]]
to show header and data part of given [[Model]].

Helps reuse your code by defining [[Column]]s once and reusing them for
both GridView and DetailView, like this:

``` php
$columns = [
    [
        'class' => SomeMyColumn::actionClass(),
    ],
    [
        'class' => ActionColumn::actionClass(),
    ],
];

GridView::widget([
    'dataProvider' => $dataProvider,
    'filterModel'  => $searchModel,
    'columns'      => $columns,
]);

DetailView::widget([
    'model'        => $model,
    'columns'      => $columns,
]);
```
