### PR TITLE
Changed usage of prop() to usage of attr()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -18,6 +18,7 @@ Yii Framework 2 Change Log
 - Bug #7868: Fixed creating raw sql (for logging) by skipping object and resource params (nineinchnick)
 - Bug #7868: Fixed Schema::getLastInsertID() by quoting sequence name (nineinchnick)
 - Bug #7957: Removed extra `parseFloat()` call for the `compare` js validator (CthulhuDen)
+- Bug #8014: Fixed setting incorrect form "action" property after submitting a form using a link with "data-method" and containing "action" among "data-params" (samdark) 
 - Enh #6895: Added `ignoreCategories` config option for message command to ignore categories specified (samdark)
 - Enh #6975: Pressing arrows while focused in inputs of Active Form with `validateOnType` enabled no longer triggers validation (slinstj)
 - Enh #7409: Allow `yii\filters\auth\CompositeAuth::authMethods` to take authentication objects (fernandezekiel, qiangxue)

--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -61,14 +61,14 @@ yii = (function ($) {
          * @return string|undefined the CSRF parameter name. Undefined is returned if CSRF validation is not enabled.
          */
         getCsrfParam: function () {
-            return $('meta[name=csrf-param]').prop('content');
+            return $('meta[name=csrf-param]').attr('content');
         },
 
         /**
          * @return string|undefined the CSRF token. Undefined is returned if CSRF validation is not enabled.
          */
         getCsrfToken: function () {
-            return $('meta[name=csrf-token]').prop('content');
+            return $('meta[name=csrf-token]').attr('content');
         },
 
         /**
@@ -78,8 +78,8 @@ yii = (function ($) {
          * @param value the CSRF token value
          */
         setCsrfToken: function (name, value) {
-            $('meta[name=csrf-param]').prop('content', name);
-            $('meta[name=csrf-token]').prop('content', value)
+            $('meta[name=csrf-param]').attr('content', name);
+            $('meta[name=csrf-token]').attr('content', value)
         },
 
         /**
@@ -164,8 +164,8 @@ yii = (function ($) {
                     action = window.location.href;
                 }
                 $form = $('<form method="' + method + '"></form>');
-                $form.prop('action', action);
-                var target = $e.prop('target');
+                $form.attr('action', action);
+                var target = $e.attr('target');
                 if (target) {
                     $form.attr('target', target);
                 }
@@ -195,20 +195,20 @@ yii = (function ($) {
                 });
             }
 
-            var oldMethod = $form.prop('method');
-            $form.prop('method', method);
+            var oldMethod = $form.attr('method');
+            $form.attr('method', method);
             var oldAction = null;
             if (action && action != '#') {
-                oldAction = $form.prop('action');
-                $form.prop('action', action);
+                oldAction = $form.attr('action');
+                $form.attr('action', action);
             }
 
             $form.trigger('submit');
 
             if (oldAction != null) {
-                $form.prop('action', oldAction);
+                $form.attr('action', oldAction);
             }
-            $form.prop('method', oldMethod);
+            $form.attr('method', oldMethod);
 
             // remove the temporarily added hidden inputs
             if (params && $.isPlainObject(params)) {


### PR DESCRIPTION
It ensures that $form.prop('action') doesn't return DOM element in case there's hidden "action" input. It happened when submitting a form using a link with data-method defined. The rest of prop() usages are changed to match.
