### PR TITLE
force dot as decimal separator when casting float values of db columns to string

### DIFF
--- a/framework/db/ColumnSchema.php
+++ b/framework/db/ColumnSchema.php
@@ -122,7 +122,13 @@ class ColumnSchema extends Object
         switch ($this->phpType) {
             case 'resource':
             case 'string':
-                return is_resource($value) ? $value : (string) $value;
+                if (is_resource($value)) {
+                    return $value;
+                }
+                if (is_float($value)) {
+                    return str_replace(',', '.', (string)$value);
+                }
+                return (string)$value;
             case 'integer':
                 return (int) $value;
             case 'boolean':


### PR DESCRIPTION
Resolves #7847. The SQL standard requires all numeric to have dot as the decimal separator. All locales use only either a dot or a comma.
