### PR TITLE
Fix contaner tag is set to false

### DIFF
--- a/framework/widgets/Menu.php
+++ b/framework/widgets/Menu.php
@@ -175,7 +175,12 @@ class Menu extends Widget
         if (!empty($items)) {
             $options = $this->options;
             $tag = ArrayHelper::remove($options, 'tag', 'ul');
-            echo Html::tag($tag, $this->renderItems($items), $options);
+            
+            if ($tag !== false) {
+                echo Html::tag($tag, $this->renderItems($items), $options);
+            } else {
+                echo $this->renderItems($items);
+            }
         }
     }
 


### PR DESCRIPTION
Do not add any empty tags when options['tag'] is set to false in Menu widget
Fixes #8064 
