### PR TITLE
Add configurable properties for links and meta envelope

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -45,6 +45,7 @@ Yii Framework 2 Change Log
 - Enh: Detecting IntegrityException for oci (nineinchnick)
 - Chg #7924: Migrations in history are now ordered by time applied allowing to roll back in reverse order no matter how these were applied (samdark)
 - Chg: Updated dependency to `cebe/markdown` to version `1.1.x` (cebe)
+- Enh: Add new properties to `yii\rest\Serializer` (arturf)
 
 
 2.0.3 March 01, 2015

--- a/framework/rest/Serializer.php
+++ b/framework/rest/Serializer.php
@@ -89,6 +89,21 @@ class Serializer extends Component
      * The pagination information as shown in `_links` and `_meta` can be accessed from the response HTTP headers.
      */
     public $collectionEnvelope;
+
+    /**
+     * @var string the name of the envelope (e.g. `_links`) for returning the links objects.
+     * Works only if `collectionEnvelope` is set.
+     * @since 2.0.4
+     */
+    public $linksEnvelope = '_links';
+
+    /**
+     * @var string the name of the envelope (e.g. `_meta`) for returning the pagination object.
+     * Works only if `collectionEnvelope` is set.
+     * @since 2.0.4
+     */
+    public $metaEnvelope = '_meta';
+
     /**
      * @var Request the current request. If not set, the `request` application component will be used.
      */
@@ -190,8 +205,8 @@ class Serializer extends Component
     protected function serializePagination($pagination)
     {
         return [
-            '_links' => Link::serialize($pagination->getLinks(true)),
-            '_meta' => [
+            $this->linksEnvelope => Link::serialize($pagination->getLinks(true)),
+            $this->metaEnvelope => [
                 'totalCount' => $pagination->totalCount,
                 'pageCount' => $pagination->getPageCount(),
                 'currentPage' => $pagination->getPage() + 1,


### PR DESCRIPTION
Headers and data envelope are configurable at the moment but links and meta not. This will be usefull in some cases and more easy then overriding `yii\rest\Serializer`
