### PR TITLE
Issue #8104 Fixed. Memcache set() expiration to seconds

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.4 under development
 -----------------------
 
+- Bug #8104: Fixed regression that had set Memcache expiration to time plus seconds instead of just seconds (wilwade)
 - Bug #6642: Fixed the bug that using confirmation dialog via `data-confirm` in an `ActiveForm` may cause the dialog to appear twice (pana1990, qiangxue)
 - Bug #6871: Fixed the bug that using defaults and hostnames in URL rules may cause an out-of-range index issue (qiangxue)
 - Bug #7473: Fixed `yii\console\controllers\AssetController` does not create missing folders for the target bundles (schmunk42, klimov-paul)

--- a/framework/caching/MemCache.php
+++ b/framework/caching/MemCache.php
@@ -282,7 +282,7 @@ class MemCache extends Cache
     {
         $expire = $duration > 0 ? $duration + time() : 0;
 
-        return $this->useMemcached ? $this->_cache->set($key, $value, $expire) : $this->_cache->set($key, $value, 0, $expire);
+        return $this->useMemcached ? $this->_cache->set($key, $value, $expire) : $this->_cache->set($key, $value, 0, $duration);
     }
 
     /**


### PR DESCRIPTION
Memcached uses timestamp expiration, while Memcache uses seconds (this is only for set() however. For add() it uses expiration which is correct in the code)

http://php.net/manual/en/memcache.set.php
http://php.net/manual/en/memcached.expiration.php
