### PR TITLE
Fix for #1468: Added ability to specify hints for model attributes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -23,6 +23,7 @@ Yii Framework 2 Change Log
 - Bug #8032: `yii\rbac\PhpManager::updateItem()` was unable to rename item updated (ChristopheBrun, samdark) 
 - Bug #8068: Fixed `yii\db\Query::count()` fails for query containing 'having' without 'group by' (klimov-paul)
 - Bug #8073: Fixed `yii\data\ArrayDataProvider::getKeys()` return wrong when `yii\data\ArrayDataProvider::$allModels` contain integer key (mdmunir, klimov-paul)
+- Enh #1468: Added ability to specify hints for model attributes via `attributeHints()` method (klimov-paul)
 - Enh #3376: Added `yii\validators\EachValidator`, which allows validation of the array attributes (klimov-paul)
 - Enh #6895: Added `ignoreCategories` config option for message command to ignore categories specified (samdark)
 - Enh #6975: Pressing arrows while focused in inputs of Active Form with `validateOnType` enabled no longer triggers validation (slinstj)

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -287,6 +287,26 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
     }
 
     /**
+     * Returns the attribute hints.
+     *
+     * Attribute hints are mainly used for display purpose. For example, given an attribute
+     * `isPublic`, we can declare a hint `Whether the post should be visible for not logged in users`,
+     * which provides user-friendly description of the attribute meaning and can be displayed to end users.
+     *
+     * Unlike label hint will not be generated, if its explicit declaration is omitted.
+     *
+     * Note, in order to inherit hints defined in the parent class, a child class needs to
+     * merge the parent hints with child hints using functions such as `array_merge()`.
+     *
+     * @return array attribute hints (name => hint)
+     * @since 2.0.4
+     */
+    public function attributeHints()
+    {
+        return [];
+    }
+
+    /**
      * Performs the data validation.
      *
      * This method executes the validation rules applicable to the current [[scenario]].
@@ -485,6 +505,19 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
     {
         $labels = $this->attributeLabels();
         return isset($labels[$attribute]) ? $labels[$attribute] : $this->generateAttributeLabel($attribute);
+    }
+
+    /**
+     * Returns the text hint for the specified attribute.
+     * @param string $attribute the attribute name
+     * @return string the attribute hint
+     * @see attributeHints()
+     * @since 2.0.4
+     */
+    public function getAttributeHint($attribute)
+    {
+        $hints = $this->attributeHints();
+        return isset($hints[$attribute]) ? $hints[$attribute] : '';
     }
 
     /**

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1068,6 +1068,38 @@ class BaseHtml
     }
 
     /**
+     * Generates a hint tag for the given model attribute.
+     * The hint text is the hint associated with the attribute, obtained via [[Model::getAttributeHint()]].
+     * If no hint content can be obtained, method will return an empty string.
+     * @param Model $model the model object
+     * @param string $attribute the attribute name or expression. See [[getAttributeName()]] for the format
+     * about attribute expression.
+     * @param array $options the tag options in terms of name-value pairs. These will be rendered as
+     * the attributes of the resulting tag. The values will be HTML-encoded using [[encode()]].
+     * If a value is null, the corresponding attribute will not be rendered.
+     * The following options are specially handled:
+     *
+     * - hint: this specifies the hint to be displayed. Note that this will NOT be [[encode()|encoded]].
+     *   If this is not set, [[Model::getAttributeHint()]] will be called to get the hint for display
+     *   (after encoding).
+     *
+     * See [[renderTagAttributes()]] for details on how attributes are being rendered.
+     *
+     * @return string the generated label tag
+     */
+    public static function activeHint($model, $attribute, $options = [])
+    {
+        $attribute = static::getAttributeName($attribute);
+        $hint = isset($options['hint']) ? $options['hint'] : static::encode($model->getAttributeHint($attribute));
+        if (empty($hint)) {
+            return '';
+        }
+        $tag = ArrayHelper::remove($options, 'tag', 'div');
+        unset($options['hint']);
+        return static::tag($tag, $hint, $options);
+    }
+
+    /**
      * Generates a summary of the validation errors.
      * If there is no validation error, an empty error summary markup will still be generated, but it will be hidden.
      * @param Model|Model[] $models the model(s) whose validation errors are to be displayed

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1081,7 +1081,7 @@ class BaseHtml
      *
      * - hint: this specifies the hint to be displayed. Note that this will NOT be [[encode()|encoded]].
      *   If this is not set, [[Model::getAttributeHint()]] will be called to get the hint for display
-     *   (after encoding).
+     *   (without encoding).
      *
      * See [[renderTagAttributes()]] for details on how attributes are being rendered.
      *
@@ -1090,7 +1090,7 @@ class BaseHtml
     public static function activeHint($model, $attribute, $options = [])
     {
         $attribute = static::getAttributeName($attribute);
-        $hint = isset($options['hint']) ? $options['hint'] : static::encode($model->getAttributeHint($attribute));
+        $hint = isset($options['hint']) ? $options['hint'] : $model->getAttributeHint($attribute);
         if (empty($hint)) {
             return '';
         }

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -190,7 +190,7 @@ class ActiveField extends Component
                 $this->parts['{error}'] = Html::error($this->model, $this->attribute, $this->errorOptions);
             }
             if (!isset($this->parts['{hint}'])) {
-                $this->parts['{hint}'] = '';
+                $this->parts['{hint}'] = Html::activeHint($this->model, $this->attribute, $this->hintOptions);
             }
             $content = strtr($this->template, $this->parts);
         } elseif (!is_string($content)) {

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -86,7 +86,7 @@ EOD;
         $this->assertEqualsWithoutLE($expectedValue, $actualValue);
     }
 
-    public function testBeginHasErros()
+    public function testBeginHasErrors()
     {
         $this->helperModel->addError($this->attributeName, "Error Message");
 
@@ -96,7 +96,7 @@ EOD;
         $this->assertEquals($expectedValue, $actualValue);
     }
 
-    public function testBeginAttributeIsRequered()
+    public function testBeginAttributeIsRequired()
     {
         $this->helperModel->addRule($this->attributeName, 'required');
 


### PR DESCRIPTION
Fix for #1468: Added ability to specify hints for model attributes
