### PR TITLE
ActiveForm scrolling to first error is optional.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -114,6 +114,7 @@ Yii Framework 2 Change Log
 - Enh #6442: Improved error message on `FileHelper::createDirectory()` to include the path name of the directory (cebe)
 - Enh #6895: Added `ignoreCategories` config option for message command to ignore categories specified (samdark)
 - Enh #6975: Pressing arrows while focused in inputs of Active Form with `validateOnType` enabled no longer triggers validation (slinstj)
+- Enh #7259: Added errorAttributes parameter to ActiveForm afterValidate event. Made scrolling to first error optional (nkovacs)
 - Enh #7409: Allow `yii\filters\auth\CompositeAuth::authMethods` to take authentication objects (fernandezekiel, qiangxue)
 - Enh #7443: Allow specification of the `$key` as an array at `yii\helpers\ArrayHelper::getValue()` (Alex-Code)
 - Enh #7488: Added `StringHelper::explode` to perform explode with trimming and skipping of empty elements (SilverFire, nineinchnick, creocoder, samdark)

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -152,6 +152,10 @@ class ActiveForm extends Widget
      */
     public $ajaxDataType = 'json';
     /**
+     * @var boolean whether to scroll to the first error after validation.
+     */
+    public $scrollToError = true;
+    /**
      * @var array the client validation options for individual attributes. Each element of the array
      * represents the validation options for a particular attribute.
      * @internal
@@ -214,6 +218,7 @@ class ActiveForm extends Widget
             'validatingCssClass' => $this->validatingCssClass,
             'ajaxParam' => $this->ajaxParam,
             'ajaxDataType' => $this->ajaxDataType,
+            'scrollToError' => $this->scrollToError,
         ];
         if ($this->validationUrl !== null) {
             $options['validationUrl'] = Url::to($this->validationUrl);
@@ -229,6 +234,7 @@ class ActiveForm extends Widget
             'validatingCssClass' => 'validating',
             'ajaxParam' => 'ajax',
             'ajaxDataType' => 'json',
+            'scrollToError' => true,
         ]);
     }
 


### PR DESCRIPTION
Added errorAttributes to afterValidate event, and moved default scrolling
behavior to afterValidate event handler.

Fixes #7259
