### PR TITLE
Separate IdentityInterface in two interfaces basic and common that exten...

### DIFF
--- a/docs/guide-ru/intro-upgrade-from-v1.md
+++ b/docs/guide-ru/intro-upgrade-from-v1.md
@@ -495,12 +495,12 @@ class MyBehavior extends Behavior
 ```
 
 
-User и IdentityInterface
+User и BasicIdentityInterface|IdentityInterface
 ---------------------------
 
 Класс `CWebUser` из версии 1.1 теперь заменён классом [[yii\web\User]]. Также больше не существует класса `CUserIdentity`.
-Вы должны реализовать интерфейс [[yii\web\IdentityInterface]], что гораздо проще. Пример реализации представлен в шаблоне
-приложения advanced.
+Вы должны реализовать интерфейс [[yii\web\BasicIdentityInterface]] либо [[yii\web\IdentityInterface]], что
+гораздо проще. Пример реализации представлен в шаблоне приложения advanced.
 
 Более подробная информация представлена в разделах «[Аутентификация](security-authentication.md)»,
 «[Авторизация](security-authorization.md)» и «[Шаблон приложения advanced](tutorial-advanced-app.md)».

--- a/docs/guide/intro-upgrade-from-v1.md
+++ b/docs/guide/intro-upgrade-from-v1.md
@@ -498,12 +498,13 @@ class MyBehavior extends Behavior
 ```
 
 
-User and IdentityInterface
+User and BasicIdentityInterface|IdentityInterface
 --------------------------
 
 The `CWebUser` class in 1.1 is now replaced by [[yii\web\User]], and there is no more
-`CUserIdentity` class. Instead, you should implement the [[yii\web\IdentityInterface]] which
-is much more straightforward to use. The advanced project template provides such an example.
+`CUserIdentity` class. Instead, you should implement the [[yii\web\BasicIdentityInterface]] or
+[[yii\web\IdentityInterface]] which is much more straightforward to use. The advanced project template provides
+such an example.
 
 Please refer to the [Authentication](security-authentication.md), [Authorization](security-authorization.md), and [Advanced Project Template](https://github.com/yiisoft/yii2-app-advanced/blob/master/docs/guide/README.md) sections for more details.
 

--- a/docs/guide/security-authentication.md
+++ b/docs/guide/security-authentication.md
@@ -19,7 +19,7 @@ class User extends ActiveRecord implements IdentityInterface
      * Finds an identity by the given ID.
      *
      * @param string|integer $id the ID to be looked for
-     * @return IdentityInterface|null the identity object that matches the given ID.
+     * @return BasicIdentityInterface|null the identity object that matches the given ID.
      */
     public static function findIdentity($id)
     {
@@ -60,6 +60,35 @@ class User extends ActiveRecord implements IdentityInterface
     public function validateAuthKey($authKey)
     {
         return $this->getAuthKey() === $authKey;
+    }
+}
+```
+
+If You don't need to used authorization key, You can implement Your User class from BasicIdentityInterface and realize
+only two methods.
+Below, only the interface methods are listed:
+```php
+class User extends ActiveRecord implements IdentityInterface
+{
+    // ...
+
+    /**
+     * Finds an identity by the given ID.
+     *
+     * @param string|integer $id the ID to be looked for
+     * @return BasicIdentityInterface|null the identity object that matches the given ID.
+     */
+    public static function findIdentity($id)
+    {
+        return static::findOne($id);
+    }
+
+    /**
+     * @return int|string current user ID
+     */
+    public function getId()
+    {
+        return $this->id;
     }
 }
 ```

--- a/docs/guide/security-authorization.md
+++ b/docs/guide/security-authorization.md
@@ -288,7 +288,7 @@ class RbacController extends Controller
         $auth->addChild($admin, $updatePost);
         $auth->addChild($admin, $author);
 
-        // Assign roles to users. 1 and 2 are IDs returned by IdentityInterface::getId()
+        // Assign roles to users. 1 and 2 are IDs returned by BasicIdentityInterface::getId()
         // usually implemented in your User model.
         $auth->assign($author, 2);
         $auth->assign($admin, 1);

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -271,6 +271,7 @@ return [
   'yii\web\HeaderCollection' => YII2_PATH . '/web/HeaderCollection.php',
   'yii\web\HtmlResponseFormatter' => YII2_PATH . '/web/HtmlResponseFormatter.php',
   'yii\web\HttpException' => YII2_PATH . '/web/HttpException.php',
+  'yii\web\BasicIdentityInterface' => YII2_PATH . '/web/BasicIdentityInterface.php',
   'yii\web\IdentityInterface' => YII2_PATH . '/web/IdentityInterface.php',
   'yii\web\JqueryAsset' => YII2_PATH . '/web/JqueryAsset.php',
   'yii\web\JsExpression' => YII2_PATH . '/web/JsExpression.php',

--- a/framework/filters/auth/AuthInterface.php
+++ b/framework/filters/auth/AuthInterface.php
@@ -10,7 +10,7 @@ namespace yii\filters\auth;
 use yii\web\User;
 use yii\web\Request;
 use yii\web\Response;
-use yii\web\IdentityInterface;
+use yii\web\BasicIdentityInterface;
 use yii\web\UnauthorizedHttpException;
 
 /**
@@ -26,7 +26,7 @@ interface AuthInterface
      * @param User $user
      * @param Request $request
      * @param Response $response
-     * @return IdentityInterface the authenticated user identity. If authentication information is not provided, null will be returned.
+     * @return BasicIdentityInterface the authenticated user identity. If authentication information is not provided, null will be returned.
      * @throws UnauthorizedHttpException if authentication information is provided but is invalid.
      */
     public function authenticate($user, $request, $response);

--- a/framework/web/BasicIdentityInterface.php
+++ b/framework/web/BasicIdentityInterface.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\web;
+
+/**
+ * BasicIdentityInterface is the basic interface that should be implemented by a class providing identity information.
+ * You need implement this interface instead IdentityInterface if You don`t need authorization key.
+ *
+ * This interface can typically be implemented by a user model class. For example, the following
+ * code shows how to implement this interface by a User ActiveRecord class:
+ *
+ * ~~~
+ * class User extends ActiveRecord implements BasicIdentityInterface
+ * {
+ *     public static function findIdentity($id)
+ *     {
+ *         return static::findOne($id);
+ *     }
+ *
+ *     public function getId()
+ *     {
+ *         return $this->id;
+ *     }
+ * }
+ * ~~~
+ *
+ * @author Qiang Xue <qiang.xue@gmail.com>
+ * @author Shkarbatov Dmitriy <shkarbatov@gmail.com>
+ * @since 2.0.4
+ */
+interface BasicIdentityInterface
+{
+    /**
+     * Finds an identity by the given ID.
+     * @param string|integer $id the ID to be looked for
+     * @return BasicIdentityInterface the identity object that matches the given ID.
+     * Null should be returned if such an identity cannot be found
+     * or the identity is not in an active state (disabled, deleted, etc.)
+     */
+    public static function findIdentity($id);
+    /**
+     * Returns an ID that can uniquely identify a user identity.
+     * @return string|integer an ID that uniquely identifies a user identity.
+     */
+    public function getId();
+}

--- a/framework/web/IdentityInterface.php
+++ b/framework/web/IdentityInterface.php
@@ -9,6 +9,7 @@ namespace yii\web;
 
 /**
  * IdentityInterface is the interface that should be implemented by a class providing identity information.
+ * IdentityInterface extends [[BasicIdentityInterface]] by using basic identity interface.
  *
  * This interface can typically be implemented by a user model class. For example, the following
  * code shows how to implement this interface by a User ActiveRecord class:
@@ -46,16 +47,8 @@ namespace yii\web;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-interface IdentityInterface
+interface IdentityInterface extends BasicIdentityInterface
 {
-    /**
-     * Finds an identity by the given ID.
-     * @param string|integer $id the ID to be looked for
-     * @return IdentityInterface the identity object that matches the given ID.
-     * Null should be returned if such an identity cannot be found
-     * or the identity is not in an active state (disabled, deleted, etc.)
-     */
-    public static function findIdentity($id);
     /**
      * Finds an identity by the given token.
      * @param mixed $token the token to be looked for
@@ -66,11 +59,6 @@ interface IdentityInterface
      * or the identity is not in an active state (disabled, deleted, etc.)
      */
     public static function findIdentityByAccessToken($token, $type = null);
-    /**
-     * Returns an ID that can uniquely identify a user identity.
-     * @return string|integer an ID that uniquely identifies a user identity.
-     */
-    public function getId();
     /**
      * Returns a key that can be used to check the validity of a given identity ID.
      *

--- a/framework/web/UserEvent.php
+++ b/framework/web/UserEvent.php
@@ -18,7 +18,7 @@ use yii\base\Event;
 class UserEvent extends Event
 {
     /**
-     * @var IdentityInterface the identity object associated with this event
+     * @var BasicIdentityInterface the identity object associated with this event
      */
     public $identity;
     /**


### PR DESCRIPTION
Separate IdentityInterface in two interfaces BasicIdentityInterface and IdentityInterface that extends BasicIdentityInterface.

If we need to create simple authorization, without token, we don't need all methods from IdentityInterface like: findIdentityByAccessToken(), getAuthKey() and validateAuthKey().

Example Yii2 basic:
https://github.com/yiisoft/yii2-app-basic

Wee need to implement all methods from IdentityInterface, but we dont use them all.
https://github.com/yiisoft/yii2-app-basic/blob/master/models/User.php

So it turns redundancy.

In my pull request we will need implement only BasicIdentityInterface, so we don't need to implement redundancy methods.
