### PR TITLE
Add HTML Imports to Yii2's AssetBundle system

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -47,6 +47,7 @@ Yii Framework 2 Change Log
 - Enh: Implement batchInsert for oci (nineinchnick)
 - Enh: Detecting IntegrityException for oci (nineinchnick)
 - Enh: `yii\widgets\LinkPager::$firstPageLabel` and `yii\widgets\LinkPager::$lastPageLabel` now could be set to true in order to use page number as label (samdark)
+- Enh: #8121: Added ability to include HTML imports in AssetBundles using `yii\web\AssetBundle::$imports`
 - Chg #7924: Migrations in history are now ordered by time applied allowing to roll back in reverse order no matter how these were applied (samdark)
 - Chg: Updated dependency to `cebe/markdown` to version `1.1.x` (cebe)
 

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -236,6 +236,27 @@ class BaseHtml
     }
 
     /**
+     * Generates a link tag that refers to an external HTML file to be imported.
+     * @param array|string $url the URL of the external HTML file. This parameter will be processed by [[Url::to()]].
+     * @param array $options the tag options in terms of name-value pairs.
+     *
+     * The options will be rendered as the attributes of the resulting link tag. The values will
+     * be HTML-encoded using [[encode()]]. If a value is null, the corresponding attribute will not be rendered.
+     * See [[renderTagAttributes()]] for details on how attributes are being rendered.
+     * @return string the generated link tag
+     * @see Url::to()
+     */
+    public static function importFile($url, $options = [])
+    {
+        if (!isset($options['rel'])) {
+            $options['rel'] = 'import';
+        }
+        $options['href'] = Url::to($url);
+
+        return static::tag('link', '', $options);
+    }
+
+    /**
      * Generates a script tag that refers to an external JavaScript file.
      * @param string $url the URL of the external JavaScript file. This parameter will be processed by [[Url::to()]].
      * @param array $options the tag options in terms of name-value pairs. The following option is specially handled:

--- a/framework/web/AssetBundle.php
+++ b/framework/web/AssetBundle.php
@@ -92,6 +92,10 @@ class AssetBundle extends Object
      */
     public $css = [];
     /**
+     * @var array list of HTML files (to be imported) that this bundle contains.
+     */
+    public $imports = [];
+    /**
      * @var array the options that will be passed to [[View::registerJsFile()]]
      * when registering the JS files in this bundle.
      */
@@ -101,6 +105,11 @@ class AssetBundle extends Object
      * when registering the CSS files in this bundle.
      */
     public $cssOptions = [];
+    /**
+     * @var array the options that will be passed to [[View::registerLinkTag()]]
+     * when registering the HTML imports in this bundle.
+     */
+    public $importOptions = [];
     /**
      * @var array the options to be passed to [[AssetManager::publish()]] when the asset bundle
      * is being published. This property is used only when [[sourcePath]] is set.
@@ -147,6 +156,9 @@ class AssetBundle extends Object
         }
         foreach ($this->css as $css) {
             $view->registerCssFile($manager->getAssetUrl($this, $css), $this->cssOptions);
+        }
+        foreach ($this->imports as $import) {
+            $view->registerImportFile($manager->getAssetUrl($this, $import), $this->importOptions);
         }
     }
 

--- a/tests/framework/web/AssetBundleTest.php
+++ b/tests/framework/web/AssetBundleTest.php
@@ -68,7 +68,8 @@ EOF;
         $this->assertTrue($view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3'] instanceof AssetBundle);
 
         $expected = <<<EOF
-1<link href="/files/cssFile.css" rel="stylesheet">23<script src="/js/jquery.js"></script>
+1<link href="/files/cssFile.css" rel="stylesheet">
+<link href="/files/import.html" rel="import">23<script src="/js/jquery.js"></script>
 <script src="/files/jsFile.js"></script>4
 EOF;
         $this->assertEqualsWithoutLE($expected, $view->renderFile('@yiiunit/data/views/rawlayout.php'));
@@ -125,19 +126,22 @@ EOF;
                 $expected = <<<EOF
 1<link href="/files/cssFile.css" rel="stylesheet">
 <script src="/js/jquery.js"></script>
-<script src="/files/jsFile.js"></script>234
+<script src="/files/jsFile.js"></script>
+<link href="/files/import.html" rel="import">234
 EOF;
             break;
             case View::POS_BEGIN:
                 $expected = <<<EOF
-1<link href="/files/cssFile.css" rel="stylesheet">2<script src="/js/jquery.js"></script>
+1<link href="/files/cssFile.css" rel="stylesheet">
+<link href="/files/import.html" rel="import">2<script src="/js/jquery.js"></script>
 <script src="/files/jsFile.js"></script>34
 EOF;
             break;
             default:
             case View::POS_END:
                 $expected = <<<EOF
-1<link href="/files/cssFile.css" rel="stylesheet">23<script src="/js/jquery.js"></script>
+1<link href="/files/cssFile.css" rel="stylesheet">
+<link href="/files/import.html" rel="import">23<script src="/js/jquery.js"></script>
 <script src="/files/jsFile.js"></script>4
 EOF;
             break;
@@ -224,6 +228,9 @@ class TestAssetBundle extends AssetBundle
     ];
     public $js = [
         'jsFile.js',
+    ];
+    public $imports = [
+        'import.html',
     ];
     public $depends = [
         'yiiunit\\framework\\web\\TestJqueryAsset'


### PR DESCRIPTION
This pull request is a Feature Request for supporting HTML imports.  This is a browser technology that is currently being implemented and has available polyfills.

This PR adds HTML Import specific knowledge to asset bundles so that they may declare HTML imports.  This is especially useful for any platform that wishes to make use of [Polymer](http://polymer-project.org/)

[Status of native browser implementation of the feature](https://www.chromestatus.com/feature/5144752345317376)

---

Imports are last on the list so that the required webcomponents.js can be included before the imports.
