### PR TITLE
Fixed empty($class->method()) style for 5.4

### DIFF
--- a/docs/guide/rest-error-handling.md
+++ b/docs/guide/rest-error-handling.md
@@ -77,7 +77,7 @@ return [
             'class' => 'yii\web\Response',
             'on beforeSend' => function ($event) {
                 $response = $event->sender;
-                if ($response->data !== null && !empty(Yii::$app->request->get('suppress_response_code'))) {
+                if ($response->data !== null && Yii::$app->request->get('suppress_response_code')) {
                     $response->data = [
                         'success' => $response->isSuccessful,
                         'data' => $response->data,


### PR DESCRIPTION
Fixed empty($class->method()) style for 5.4, because this feature allowed for php5.5 or high.
