### PR TITLE
Enh: allow user to send files which are not seekable (S3StreamWrapper, ...)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -61,6 +61,7 @@ Yii Framework 2 Change Log
 - Enh: `yii\widgets\LinkPager::$firstPageLabel` and `yii\widgets\LinkPager::$lastPageLabel` now could be set to true in order to use page number as label (samdark)
 - Chg #7924: Migrations in history are now ordered by time applied allowing to roll back in reverse order no matter how these were applied (samdark)
 - Chg: Updated dependency to `cebe/markdown` to version `1.1.x` (cebe)
+- Enh: Allow the user to enforce the fileSize to allow sending files which are not seekable. Needed when using S3 Stream Wrapper (pgaultier)
 
 
 2.0.3 March 01, 2015

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -61,7 +61,7 @@ Yii Framework 2 Change Log
 - Enh: `yii\widgets\LinkPager::$firstPageLabel` and `yii\widgets\LinkPager::$lastPageLabel` now could be set to true in order to use page number as label (samdark)
 - Chg #7924: Migrations in history are now ordered by time applied allowing to roll back in reverse order no matter how these were applied (samdark)
 - Chg: Updated dependency to `cebe/markdown` to version `1.1.x` (cebe)
-- Enh: Allow the user to enforce the fileSize to allow sending files which are not seekable. Needed when using S3 Stream Wrapper (pgaultier)
+- Enh #8171: Allow the user to enforce the fileSize to allow sending files which are not seekable. Needed when using S3 Stream Wrapper (pgaultier)
 
 
 2.0.3 March 01, 2015

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -504,6 +504,8 @@ class Response extends \yii\base\Response
      *  - `mimeType`: the MIME type of the content. Defaults to 'application/octet-stream'.
      *  - `inline`: boolean, whether the browser should open the file within the browser window. Defaults to false,
      *     meaning a download dialog will pop up.
+     *  - `fileSize`: the size of the content to stream this is usefull when size of the content is known
+     *     and the content is not seekable. Defaults to content size using `ftell()`
      *
      * @return static the response object itself
      * @throws HttpException if the requested range cannot be satisfied.
@@ -511,8 +513,12 @@ class Response extends \yii\base\Response
     public function sendStreamAsFile($handle, $attachmentName, $options = [])
     {
         $headers = $this->getHeaders();
-        fseek($handle, 0, SEEK_END);
-        $fileSize = ftell($handle);
+        if (isset($options['fileSize'])) {
+            $fileSize = $options['fileSize'];
+        } else {
+            fseek($handle, 0, SEEK_END);
+            $fileSize = ftell($handle);
+        }
 
         $range = $this->getHttpRange($fileSize);
         if ($range === false) {


### PR DESCRIPTION
When a stream is not seekable, the Response::sendFile() cannot be used.
Without this modification, it's not possible to send file (opened using S3StreamWrapper) which are located on Amazon S3.
