### PR TITLE
Fixes #8036 : `yii\log\Logger` unable to export session id

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -26,6 +26,7 @@ Yii Framework 2 Change Log
 - Bug #8012: Fixed fetching multiple relations between two tables for pgsql (nineinchnick)
 - Bug #8014: Fixed setting incorrect form "action" property after submitting a form using a link with "data-method" and containing "action" among "data-params" (samdark)
 - Bug #8032: `yii\rbac\PhpManager::updateItem()` was unable to rename item updated (ChristopheBrun, samdark)
+- Bug #8036: Fixed `yii\log\Logger` unable to export session id (klimov-paul)
 - Bug #8068: Fixed `yii\db\Query::count()` fails for query containing 'having' without 'group by' (klimov-paul)
 - Bug #8073: Fixed `yii\data\ArrayDataProvider::getKeys()` return wrong when `yii\data\ArrayDataProvider::$allModels` contain integer key (mdmunir, klimov-paul)
 - Bug #8082: Fixed `yii\db\BaseActiveRecord::getAttributeLabel()` return wrong label for related attribute, if several relations in chain share same name (klimov-paul)

--- a/framework/log/Logger.php
+++ b/framework/log/Logger.php
@@ -116,7 +116,10 @@ class Logger extends Component
     {
         parent::init();
         register_shutdown_function(function () {
-            // make sure "flush()" is called last when there are multiple shutdown functions
+            // make regular flush before other shutdown functions, which allows session data collection and so on
+            $this->flush();
+            // make sure log entries written by shutdown functions are also flushed
+            // ensure "flush()" is called last when there are multiple shutdown functions
             register_shutdown_function([$this, 'flush'], true);
         });
     }


### PR DESCRIPTION
Fixes #8036 : `yii\log\Logger` unable to export session id
