### PR TITLE
Compare it equals

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -519,7 +519,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
     public function isAttributeChanged($name)
     {
         if (isset($this->_attributes[$name], $this->_oldAttributes[$name])) {
-            return $this->_attributes[$name] !== $this->_oldAttributes[$name];
+            return $this->_attributes[$name] != $this->_oldAttributes[$name];
         } else {
             return isset($this->_attributes[$name]) || isset($this->_oldAttributes[$name]);
         }


### PR DESCRIPTION
If the comparison was made as identical, all integers from forms submitted by the user will be marked as changed.

Even though this PR is not the best solution, this inconsistency needs to be solved.
