### PR TITLE
get Pagination data before Models

### DIFF
--- a/framework/data/BaseDataProvider.php
+++ b/framework/data/BaseDataProvider.php
@@ -195,6 +195,7 @@ abstract class BaseDataProvider extends Component implements DataProviderInterfa
                 $config['pageSizeParam'] = $this->id . '-per-page';
             }
             $this->_pagination = Yii::createObject(array_merge($config, $value));
+            $this->_pagination->totalCount = $this->getTotalCount();
         } elseif ($value instanceof Pagination || $value === false) {
             $this->_pagination = $value;
         } else {


### PR DESCRIPTION
``` php
    public function actionIndex()
    {
        $_GET['page'] = 3;

        $dataProvider = new ArrayDataProvider([
            'allModels' => [
                ['id' => 1],
                ['id' => 2],
                ['id' => 3],
                ['id' => 4],
                ['id' => 5],
                ['id' => 6],
                ['id' => 7],
            ],
            'pagination' => [
                'pageSize' => 2,
            ],
        ]);

        var_dump($dataProvider->getPagination()->getPage());
        // return => int 0

        var_dump($dataProvider->getModels());
        // return => array (size=2)
        //  0 => 
        //    array (size=1)
        //      'id' => int 1
        //  1 => 
        //    array (size=1)
        //      'id' => int 2

        return 'OK';
    }
```

``` php
    public function actionIndex()
    {
        $_GET['page'] = 3;

        $dataProvider = new ArrayDataProvider([
            'allModels' => [
                ['id' => 1],
                ['id' => 2],
                ['id' => 3],
                ['id' => 4],
                ['id' => 5],
                ['id' => 6],
                ['id' => 7],
            ],
            'pagination' => [
                'pageSize' => 2,
            ],
        ]);

        var_dump($dataProvider->getModels());
        // return => array (size=2)
        //  4 => 
        //    array (size=1)
        //      'id' => int 5
        //  5 => 
        //    array (size=1)
        //      'id' => int 6

        var_dump($dataProvider->getPagination()->getPage());
        // return => int 2

        return 'OK';
    }
```
