### PR TITLE
Improve performance by using static variables for class-level data

### DIFF
--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -239,9 +239,15 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      */
     public function formName()
     {
-        $reflector = new ReflectionClass($this);
+        static $formName = null;
 
-        return $reflector->getShortName();
+        if ($formName === null) {
+            $reflector = new ReflectionClass($this);
+
+            $formName = $reflector->getShortName();
+        }
+
+        return $formName;
     }
 
     /**
@@ -252,15 +258,21 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      */
     public function attributes()
     {
-        $class = new ReflectionClass($this);
-        $names = [];
-        foreach ($class->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
-            if (!$property->isStatic()) {
-                $names[] = $property->getName();
+        static $attributes = null;
+
+        if ($attributes === null) {
+            $class = new ReflectionClass($this);
+            $names = [];
+            foreach ($class->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+                if (!$property->isStatic()) {
+                    $names[] = $property->getName();
+                }
             }
+
+            $attributes = $names;
         }
 
-        return $names;
+        return $attributes;
     }
 
     /**
@@ -917,9 +929,15 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      */
     public function fields()
     {
-        $fields = $this->attributes();
+        static $fields = null;
 
-        return array_combine($fields, $fields);
+        if ($fields === null) {
+            $attributes = $this->attributes();
+
+            $fields = array_combine($attributes, $attributes);
+        }
+
+        return $fields;
     }
 
     /**

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -114,7 +114,13 @@ class ActiveRecord extends BaseActiveRecord
      */
     public function loadDefaultValues($skipIfSet = true)
     {
-        foreach ($this->getTableSchema()->columns as $column) {
+        static $columns = null;
+
+        if ($columns === null) {
+            $columns = $this->getTableSchema()->columns;
+        }
+        
+        foreach ($columns as $column) {
             if ($column->defaultValue !== null && (!$skipIfSet || $this->{$column->name} === null)) {
                 $this->{$column->name} = $column->defaultValue;
             }
@@ -281,7 +287,13 @@ class ActiveRecord extends BaseActiveRecord
      */
     public static function tableName()
     {
-        return '{{%' . Inflector::camel2id(StringHelper::basename(get_called_class()), '_') . '}}';
+        static $tableName = null;
+
+        if ($tableName === null) {
+            $tableName = '{{%' . Inflector::camel2id(StringHelper::basename(get_called_class()), '_') . '}}';
+        }
+
+        return $tableName;
     }
 
     /**
@@ -291,12 +303,18 @@ class ActiveRecord extends BaseActiveRecord
      */
     public static function getTableSchema()
     {
-        $schema = static::getDb()->getSchema()->getTableSchema(static::tableName());
-        if ($schema !== null) {
-            return $schema;
-        } else {
-            throw new InvalidConfigException("The table does not exist: " . static::tableName());
+        static $tableSchema = null;
+
+        if ($tableSchema === null) {
+            $schema = static::getDb()->getSchema()->getTableSchema(static::tableName());
+            if ($schema !== null) {
+                $tableSchema = $schema;
+            } else {
+                throw new InvalidConfigException("The table does not exist: " . static::tableName());
+            }
         }
+
+        return $tableSchema;
     }
 
     /**
@@ -314,7 +332,13 @@ class ActiveRecord extends BaseActiveRecord
      */
     public static function primaryKey()
     {
-        return static::getTableSchema()->primaryKey;
+        static $primaryKey = null;
+
+        if ($primaryKey === null) {
+            $primaryKey = static::getTableSchema()->primaryKey;
+        }
+
+        return $primaryKey;
     }
 
     /**
@@ -324,7 +348,13 @@ class ActiveRecord extends BaseActiveRecord
      */
     public function attributes()
     {
-        return array_keys(static::getTableSchema()->columns);
+        static $attributes = null;
+
+        if ($attributes === null) {
+            $attributes = array_keys(static::getTableSchema()->columns);
+        }
+
+        return $attributes;
     }
 
     /**
@@ -364,7 +394,12 @@ class ActiveRecord extends BaseActiveRecord
      */
     public static function populateRecord($record, $row)
     {
-        $columns = static::getTableSchema()->columns;
+        static $columns = null;
+
+        if ($columns === null) {
+            $columns = static::getTableSchema()->columns;
+        }
+        
         foreach ($row as $name => $value) {
             if (isset($columns[$name])) {
                 $row[$name] = $columns[$name]->phpTypecast($value);

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -418,7 +418,13 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function hasAttribute($name)
     {
-        return isset($this->_attributes[$name]) || in_array($name, $this->attributes());
+        static $attributes = [];
+
+        if (!array_key_exists($name, $attributes)) {
+            $attributes[$name] = isset($this->_attributes[$name]) || in_array($name, $this->attributes());
+        }
+
+        return $attributes[$name];
     }
 
     /**

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -310,12 +310,14 @@ class Command extends Component
             return $this;
         }
 
+        $schema = $this->db->getSchema();
+
         foreach ($values as $name => $value) {
             if (is_array($value)) {
                 $this->_pendingParams[$name] = $value;
                 $this->params[$name] = $value[0];
             } else {
-                $type = $this->db->getSchema()->getPdoType($value);
+                $type = $schema->getPdoType($value);
                 $this->_pendingParams[$name] = [$value, $type];
                 $this->params[$name] = $value;
             }

--- a/tests/framework/db/pgsql/PostgreSQLActiveRecordTest.php
+++ b/tests/framework/db/pgsql/PostgreSQLActiveRecordTest.php
@@ -168,6 +168,11 @@ class PostgreSQLActiveRecordTest extends ActiveRecordTest
         $record->save(false);
         $this->assertEquals(5, $record->primaryKey);
     }
+    
+    public function getCustomerClass()
+    {
+        return Customer::className();
+    }
 }
 
 class BoolAR extends ActiveRecord
@@ -195,4 +200,8 @@ class UserAR extends ActiveRecord
             TimestampBehavior::className(),
         ];
     }
+}
+
+class Customer extends \yiiunit\data\ar\Customer
+{
 }


### PR DESCRIPTION
While profiling a Yii2 application, I discovered some interesting results: a few (yii-internal) functions that were called a very large amount of times, while they were essentially calculating static data.

A good example is BaseActiveRecord's __get() function: almost every invocation results in a call to BaseActiveRecord.hasAttribute(), which leads to Model.attributes(), which uses reflection on the object's class to determine its set of properties.

Right now, the entire process of reflection is re-calculated (almost) every time __get() is called on an object, while the return value of all these intermediary functions (hasAttribute(), attributes()) could be cached not only within an object instance, but within an object's class: while not all of the affected functions are static*, for all of them it's impossible that invocations on two different instances of the same class would ever return different results.

PHP's "static variables" (http://php.net/manual/en/language.variables.scope.php) are perfect for this situation: it remembers the contents of a variable in a function's scope across all invocations to that function within the same class.

With this commit, this strategy is added to all applicable functions that are likely to be called many times within the same request. The performance gains can be huge, especially in situations where many instances of the same ActiveRecord are instanciated in a single request. These are the profiling statistics for a real-world application where around 1350 ActiveRecord instances - spread over mostly 4 different classes - are used on a single page:

Before:

```
yii\db\Connection::getSchema    10,229 calls

Total Incl. Wall Time (microsec):   1,704,351 microsecs
Total Incl. CPU (microsecs):    1,688,537 microsecs
Total Incl. MemUse (bytes): 22,212,712 bytes
Total Incl. PeakMemUse (bytes): 23,626,296 bytes
Number of Function Calls:       245,465
```

After:

```
yii\db\Connection::getSchema    28 calls

Total Incl. Wall Time (microsec):   1,205,574 microsecs
Total Incl. CPU (microsecs):    1,198,505 microsecs
Total Incl. MemUse (bytes): 22,247,936 bytes
Total Incl. PeakMemUse (bytes): 23,598,200 bytes
Number of Function Calls:   168,656
```

.. an improvement in execution time of **30%**.

*We could later refactor these functions to become static, by using `new ReflectionClass(get_called_class())` instead of `new ReflectionClass($this)`.
