### PR TITLE
Cache which rule belongs to a given route+params

### DIFF
--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -129,6 +129,7 @@ class UrlManager extends Component
     private $_baseUrl;
     private $_scriptUrl;
     private $_hostInfo;
+    private $_ruleMatchCache;
 
 
     /**
@@ -309,9 +310,19 @@ class UrlManager extends Component
         $baseUrl = $this->showScriptName || !$this->enablePrettyUrl ? $this->getScriptUrl() : $this->getBaseUrl();
 
         if ($this->enablePrettyUrl) {
+            $key = $route . ',' . implode(',', array_keys($params));
+
+            if (isset($this->_ruleMatchCache[$key])) {
+                $rules = $this->_ruleMatchCache[$key];
+            } else {
+                $rules = $this->rules;
+            }
+
             /* @var $rule UrlRule */
-            foreach ($this->rules as $rule) {
+            foreach ($rules as $rule) {
                 if (($url = $rule->createUrl($this, $route, $params)) !== false) {
+                    $this->_ruleMatchCache[$key] = [$rule];
+
                     if (strpos($url, '://') !== false) {
                         if ($baseUrl !== '' && ($pos = strpos($url, '/', 8)) !== false) {
                             return substr($url, 0, $pos) . $baseUrl . substr($url, $pos);
@@ -323,6 +334,8 @@ class UrlManager extends Component
                     }
                 }
             }
+
+            $this->_ruleMatchCache[$key] = [];
 
             if ($this->suffix !== null) {
                 $route .= $this->suffix;


### PR DESCRIPTION
Something else that stood out while profiling a Yii2 application was the huge amount of calls to `UrlRule::createUrl`.

Currently, every time a url is generated from a route (for example, by `Html::a()`), UrlManager iterates over all existing url rules until a matching rule is found. Imagine your application has 50 url rules, and you have 100 links on a page: in the worst case this would result in 5000 different calls to `createUrl`.

This doesn't seem neccessary at all. Once we have determined that a certain url rule matches with the route `['car/view', 'id' => $id]`, all subsequent calls to `UrlManager::createUrl` with that same signature (route name + parameter names) can instantly use the rule we matched earlier.

This patch does just that, by using `$route . ',' . implode(',', array_keys($params));` as cache key and storing the matched rule (or the fact that none of the url rules match) with that key.

Profiling results for a page containing around 1000 different links: a few extra kilobytes of memory to store the matches, but a **16%** performance increase.

```
Before:
yii\web\UrlRule::createUrl  43,309  calls
Total Incl. Wall Time (microsec):   1,671,670 microsecs
Total Incl. CPU (microsecs):    1,662,765 microsecs
Total Incl. MemUse (bytes): 20,533,208 bytes
Total Incl. PeakMemUse (bytes): 21,317,528 bytes
Number of Function Calls:   237,350

After:
yii\web\UrlRule::createUrl  1,202   calls
Total Incl. Wall Time (microsec):   1,399,313 microsecs
Total Incl. CPU (microsecs):    1,374,664 microsecs
Total Incl. MemUse (bytes): 20,541,008 bytes
Total Incl. PeakMemUse (bytes): 21,324,616 bytes
Number of Function Calls:   183,039
```
