### PR TITLE
Clear 'static' from method signature

### DIFF
--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -194,7 +194,7 @@ abstract class Target extends Component
      * @param array $except the message categories to exclude. If empty, it means all categories are allowed.
      * @return array the filtered messages.
      */
-    public static function filterMessages($messages, $levels = 0, $categories = [], $except = [])
+    public function filterMessages($messages, $levels = 0, $categories = [], $except = [])
     {
         foreach ($messages as $i => $message) {
             if ($levels && !($levels & $message[1])) {


### PR DESCRIPTION
This method [is called as not static method](https://github.com/yiisoft/yii2/blob/ff71eb2251cac033522e7c54d1bc6cbb027b39da/framework/log/Target.php#L102)
