### PR TITLE
enh: docs/guide/intro-yii add id to link

### DIFF
--- a/docs/guide/intro-yii.md
+++ b/docs/guide/intro-yii.md
@@ -31,13 +31,13 @@ If you're already familiar with another framework, you may appreciate knowing ho
   take advantage of Yii's solid extension architecture to use or develop redistributable extensions.
 - High performance is always a primary goal of Yii.
 
-Yii is not a one-man show, it is backed up by a [strong core developer team][], as well as a large community
+Yii is not a one-man show, it is backed up by a [strong core developer team][about_yii], as well as a large community
 of professionals constantly contributing to Yii's development. The Yii developer team
 keeps a close eye on the latest Web development trends and on the best practices and features
 found in other frameworks and projects. The most relevant best practices and features found elsewhere are regularly incorporated into the core framework and exposed
 via simple and elegant interfaces.
 
-[strong core developer team]: http://www.yiiframework.com/about/
+[about_yii]: http://www.yiiframework.com/about/
 
 Yii Versions
 ------------


### PR DESCRIPTION
Because translators must translate anchor text, it's better to use id for reference,
so they shouldn't translate it twice. Also not all translators puts same text in this case.
