### PR TITLE
added m4a to the list of extensions => mimeTypes available.

### DIFF
--- a/framework/helpers/mimeTypes.php
+++ b/framework/helpers/mimeTypes.php
@@ -414,6 +414,7 @@ return [
     'm3a' => 'audio/mpeg',
     'm3u' => 'audio/x-mpegurl',
     'm3u8' => 'application/vnd.apple.mpegurl',
+    'm4a' => 'audio/mp4',
     'm4u' => 'video/vnd.mpegurl',
     'm4v' => 'video/x-m4v',
     'ma' => 'application/mathematica',


### PR DESCRIPTION
The title says it all. I added `audio/mp4` for the `.m4a` extensions. This is quite crucial when streaming the files to players.
