### PR TITLE
Added index to source_message table

### DIFF
--- a/framework/i18n/DbMessageSource.php
+++ b/framework/i18n/DbMessageSource.php
@@ -25,7 +25,8 @@ use yii\db\Query;
  * CREATE TABLE source_message (
  *     id INTEGER PRIMARY KEY AUTO_INCREMENT,
  *     category VARCHAR(32),
- *     message TEXT
+ *     message TEXT,
+ *     INDEX (category)
  * );
  *
  * CREATE TABLE message (


### PR DESCRIPTION
In the function loadMessagesFromDb the column sourceMessageTable.category is used in the where clause but is not indexed which might cause performance issues when the table gets big.
This patch adds the missing index.
