### PR TITLE
Performance of `yii\base\Model` methods `attributes()` and `formName()`

### DIFF
--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -239,9 +239,15 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      */
     public function formName()
     {
-        $reflector = new ReflectionClass($this);
+        static $formNames = [];
 
-        return $reflector->getShortName();
+        $className = get_class($this);
+        if (!isset($formNames[$className])) {
+            $reflector = new ReflectionClass($this);
+            $formNames[$className] = $reflector->getShortName();
+        }
+
+        return $formNames[$className];
     }
 
     /**
@@ -252,15 +258,21 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      */
     public function attributes()
     {
-        $class = new ReflectionClass($this);
-        $names = [];
-        foreach ($class->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
-            if (!$property->isStatic()) {
-                $names[] = $property->getName();
+        static $attributes = [];
+
+        $className = get_class($this);
+        if (!isset($attributes[$className])) {
+            $class = new ReflectionClass($className);
+            $names = [];
+            foreach ($class->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+                if (!$property->isStatic()) {
+                    $names[] = $property->getName();
+                }
             }
+            $attributes[$className] = $names;
         }
 
-        return $names;
+        return $attributes[$className];
     }
 
     /**

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -4,6 +4,7 @@ namespace yiiunit\framework\helpers;
 
 use Yii;
 use yii\helpers\Html;
+use yiiunit\data\base\Singer;
 use yiiunit\TestCase;
 
 /**
@@ -638,6 +639,15 @@ EOD;
         $this->assertEquals('<link src="xyz" ng-a="1" ng-b="c">', Html::tag('link', '', ['src' => 'xyz', 'ng' => ['a' => 1, 'b' => 'c']]));
         $this->assertEquals('<link src="xyz" data-ng-a="1" data-ng-b="c">', Html::tag('link', '', ['src' => 'xyz', 'data-ng' => ['a' => 1, 'b' => 'c']]));
         $this->assertEquals('<link src=\'{"a":1,"b":"It\\u0027s"}\'>', Html::tag('link', '', ['src' => ['a' => 1, 'b' => "It's"]]));
+    }
+
+    public function testGetInputName()
+    {
+        $model = new Singer();
+
+        $this->assertEquals('Singer[firstName]', Html::getInputName($model, 'firstName'));
+        $this->assertEquals('Singer[firstName][]', Html::getInputName($model, 'firstName[]'));
+        $this->assertEquals('Singer[firstName][1]', Html::getInputName($model, 'firstName[1]'));
     }
 
     protected function getDataItems()


### PR DESCRIPTION
Extracted from #8247

> The proposed optimization approach is problematic. See this gist: https://gist.github.com/qiangxue/9c6635ffeacef3eff8a9
> You will get "BB" rather than "BA".

Fixed
