### PR TITLE
Correcting beforeCopy example

### DIFF
--- a/docs/guide/structure-assets.md
+++ b/docs/guide/structure-assets.md
@@ -195,7 +195,7 @@ class FontAwesomeAsset extends AssetBundle
     {
         parent::init();
         $this->publishOptions['beforeCopy'] = function ($from, $to) {
-            $dirname = basename(dirname($from));
+            $dirname = basename($from);
             return $dirname === 'fonts' || $dirname === 'css';
         };
     }


### PR DESCRIPTION
The `$from` parameter takes values like `/folder1/folder2/folder3/css`. `dirname($from)` returns `/folder1/folder2/folder3` and therefore `basename(dirname($from))` returns `folder3` instead of the intended `css` in the given example to make it work right.
