### PR TITLE
Fix client-side trim validator.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.5 under development
 -----------------------
 
+- Bug #7707: client-side `trim` validator now passes the trimmed value to subsequent validators (nkovacs)
 - Bug #8322: `yii\behaviors\TimestampBehavior::touch()` now throws an exception if owner is new record (klimov-paul)
 
 

--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -237,8 +237,10 @@ yii.validation = (function ($) {
             var $input = $form.find(attribute.input);
             var value = $input.val();
             if (!options.skipOnEmpty || !pub.isEmpty(value)) {
-                $input.val($.trim(value));
+                value = $.trim(value);
+                $input.val(value);
             }
+            return value;
         },
 
         captcha: function (value, messages, options) {

--- a/framework/validators/FilterValidator.php
+++ b/framework/validators/FilterValidator.php
@@ -89,6 +89,6 @@ class FilterValidator extends Validator
 
         ValidationAsset::register($view);
 
-        return 'yii.validation.trim($form, attribute, ' . json_encode($options, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . ');';
+        return 'value = yii.validation.trim($form, attribute, ' . json_encode($options, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . ');';
     }
 }


### PR DESCRIPTION
Subsequent validators now use the trimmed value instead of the original value.

fixes #7707
