### PR TITLE
Fix #8349: Properties `fields` and `expand` added to `yii\rest\Serializer`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #8322: `yii\behaviors\TimestampBehavior::touch()` now throws an exception if owner is new record (klimov-paul)
 - Enh #8070: `yii\console\controllers\MessageController` now sorts created messages, even if there is no new one, while saving to PHP file (klimov-paul)
 - Enh #8286: `yii\console\controllers\MessageController` improved allowing extraction of nested translator calls (klimov-paul)
+- Enh #8349: Properties `fields` and `expand` added to `yii\rest\Serializer` (klimov-paul)
 
 
 2.0.4 May 10, 2015

--- a/tests/framework/rest/SerializerTest.php
+++ b/tests/framework/rest/SerializerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace yiiunit\framework\rest;
+
+use yii\rest\Serializer;
+use yiiunit\TestCase;
+use yii\web\Request;
+
+/**
+ * @group rest
+ */
+class SerializerTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mockApplication();
+    }
+
+    public function testSetupExpand()
+    {
+        $serializer = new Serializer();
+        $expand = [
+            'name1',
+            'name2',
+        ];
+        $serializer->setExpand($expand);
+        $this->assertEquals($expand, $serializer->getExpand());
+
+        $serializer = new Serializer();
+        $serializer->request = new Request();
+        $serializer->request->setQueryParams(['expand' => 'param1,param2']);
+        $this->assertEquals(['param1', 'param2'], $serializer->getExpand());
+    }
+
+    public function testSetupFields()
+    {
+        $serializer = new Serializer();
+        $fields = [
+            'name1',
+            'name2',
+        ];
+        $serializer->setFields($fields);
+        $this->assertEquals($fields, $serializer->getFields());
+
+        $serializer = new Serializer();
+        $serializer->request = new Request();
+        $serializer->request->setQueryParams(['fields' => 'param1,param2']);
+        $this->assertEquals(['param1', 'param2'], $serializer->getFields());
+    }
+} 


### PR DESCRIPTION
Fix #8349
Properties `fields` and `expand` added to `yii\rest\Serializer`
