### PR TITLE
Passing parameters to can() via AccessRule

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -32,6 +32,7 @@ Yii Framework 2 Change Log
 - Enh #8574: Added `yii\console\controllers\MessageController` support .pot file creation (pgaultier)
 - Chg #6354: `ErrorHandler::logException()` will now log the whole exception object instead of only its string representation (cebe)
 - Chg #8556: Extracted `yii\web\User::getAuthManager()` method (samdark)
+- Enh #8426: `yii\filters\AccessRule` now allows passing GET parameters to the role checking function (fsateler)
 
 
 2.0.4 May 10, 2015


### PR DESCRIPTION
I am currently using this solution to make it easy to implement authorization based on query parameters.

For example, determining whether a post can be edited is determined by a Rule based on the post id. This implementation allows this type of use case to be easily done, without having to add a `matchCallback` to each action that needs a specific parameter to determine permission.

This is a first attempt at the problem, so I'm looking for feedback. If the feature is well received I can also modify the authorization section of the guide to explain usage.

Examples, given the following Rule:

``` php
    class EditOwnRule extends \yii\rbac\Rule {
        public $name = 'editOwnRule';

        public function execute($user, $item, $params) {
            if (Yii::$app->user->isGuest) {
                return false;
            }

            $item = ArrayHelper::getValue($params, 'item', null);
            if (!$item) {
                return false;
            }
            $q = Item::find()
                    ->where([
                        'owner_id' => $user,
                        'item.id' => $item
                    ]);
            return $q->exists();
        }
    }
```

Using this rule in an action would be as simple as doing the following:

``` php
    public function behaviors()
    {
        return [
            'access' => [
                'class' => AccessControl::className(),
                'rules' => [
                    [
                        'allow' => true,
                        'roles' => ['edit'],
                        'paramsMap' => [
                            // This will pass the 'id' query parameter as 'item' to can()
                            'id' => 'item',
                        ],
                        'actions' => [
                            'update',
                        ],
                    ],
                    [
                        'allow' => true,
                        'roles' => ['edit'],
                        'paramsMap' => [
                            // This will pass the 'item' query parameter as 'item' to can()
                            'item',
                        ],
                        'actions' => [
                            'updateComments',
                        ],
                    ],
                    [
                        'allow' => false,
                    ]
                ],
            ],
        ];
    }
```
