### PR TITLE
log the whole exception object to allow log targets to work with it

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 Change Log
 - Enh #8070: `yii\console\controllers\MessageController` now sorts created messages, even if there is no new one, while saving to PHP file (klimov-paul)
 - Enh #8286: `yii\console\controllers\MessageController` improved allowing extraction of nested translator calls (klimov-paul)
 - Enh #8415: `yii\helpers\Html` allows correct rendering of conditional comments containing `!IE` (salaros, klimov-paul)
+- Chg #6354: `ErrorHandler::logException()` will now log the whole exception object instead of only its string representation (cebe)
 
 
 2.0.4 May 10, 2015

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -215,7 +215,7 @@ abstract class ErrorHandler extends Component
         } elseif ($exception instanceof \ErrorException) {
             $category .= ':' . $exception->getSeverity();
         }
-        Yii::error((string) $exception, $category);
+        Yii::error($exception, $category);
     }
 
     /**


### PR DESCRIPTION
fixes #6354
made possible by #7305 (dd19955 and https://github.com/yiisoft/yii2-debug/commit/9a945c208f20c129da4fcfe5e8110e0c113c7871)

not 100% sure about BC yet. Custom log targets may not expect and exception object but when threating the message as string, php should automatically cast it...
