### PR TITLE
Update LinkPager.php

### DIFF
--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -104,6 +104,11 @@ class LinkPager extends Widget
      * @var boolean Hide widget when only one page exist.
      */
     public $hideOnSinglePage = true;
+    /**
+     * @var boolean turns on|off the <a> tag for the active pager item. It is recommended to set it to false
+     * for the sake of Search Engines Optimisation. Defaults to false.
+     */
+    public $activeLinkable = false;
 
 
     /**
@@ -215,6 +220,11 @@ class LinkPager extends Widget
         }
         $linkOptions = $this->linkOptions;
         $linkOptions['data-page'] = $page;
+
+        // turn off link for active item
+        if ($active && !$this->activeLinkable) {
+            return Html::tag('li', Html::tag('span', $label, $linkOptions), $options);
+        }
 
         return Html::tag('li', Html::a($label, $this->pagination->createUrl($page), $linkOptions), $options);
     }


### PR DESCRIPTION
Added "activeLinkable" property. 
It serves for turning off the anchor tag from the LinkPager active item. I set the default value to false and this changed the previous functionality.
The main idea of this revision is to follow google recommendation that the page must avoid links to itself.
