### PR TITLE
Fix #6043 Added support for array type styles and classes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #8322: `yii\behaviors\TimestampBehavior::touch()` now throws an exception if owner is new record (klimov-paul)
 - Bug #8451: `yii\i18n\Formatter` did not allow negative unix timestamps as input for date formatting (cebe)
 - Bug: Fixed string comparison in `BaseActiveRecord::unlink()` which may result in wrong comparison result for hash valued primary keys starting with `0e` (cebe)
+- Enh #6043: Specification for 'class' and 'style' in array format added to `yii\helpers\Html` (klimov-paul)
 - Enh #8070: `yii\console\controllers\MessageController` now sorts created messages, even if there is no new one, while saving to PHP file (klimov-paul)
 - Enh #8286: `yii\console\controllers\MessageController` improved allowing extraction of nested translator calls (klimov-paul)
 - Enh #8415: `yii\helpers\Html` allows correct rendering of conditional comments containing `!IE` (salaros, klimov-paul)

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -63,15 +63,15 @@ class HtmlTest extends TestCase
     public function testStyle()
     {
         $content = 'a <>';
-        $this->assertEquals("<style>$content</style>", Html::style($content));
-        $this->assertEquals("<style type=\"text/less\">$content</style>", Html::style($content, ['type' => 'text/less']));
+        $this->assertEquals("<style>{$content}</style>", Html::style($content));
+        $this->assertEquals("<style type=\"text/less\">{$content}</style>", Html::style($content, ['type' => 'text/less']));
     }
 
     public function testScript()
     {
         $content = 'a <>';
-        $this->assertEquals("<script>$content</script>", Html::script($content));
-        $this->assertEquals("<script type=\"text/js\">$content</script>", Html::script($content, ['type' => 'text/js']));
+        $this->assertEquals("<script>{$content}</script>", Html::script($content));
+        $this->assertEquals("<script type=\"text/js\">{$content}</script>", Html::script($content, ['type' => 'text/js']));
     }
 
     public function testCssFile()
@@ -537,6 +537,10 @@ EOD;
         $this->assertEquals('', Html::renderTagAttributes([]));
         $this->assertEquals(' name="test" value="1&lt;&gt;"', Html::renderTagAttributes(['name' => 'test', 'empty' => null, 'value' => '1<>']));
         $this->assertEquals(' checked disabled', Html::renderTagAttributes(['checked' => true, 'disabled' => true, 'hidden' => false]));
+        $this->assertEquals(' class="first second"', Html::renderTagAttributes(['class' => ['first', 'second']]));
+        $this->assertEquals('', Html::renderTagAttributes(['class' => []]));
+        $this->assertEquals(' style="width: 100px; height: 200px;"', Html::renderTagAttributes(['style' => ['width' => '100px', 'height' => '200px']]));
+        $this->assertEquals('', Html::renderTagAttributes(['style' => []]));
     }
 
     public function testAddCssClass()
@@ -556,6 +560,22 @@ EOD;
         $this->assertEquals(['class' => 'test test2 test3'], $options);
         Html::addCssClass($options, 'test2');
         $this->assertEquals(['class' => 'test test2 test3'], $options);
+
+        $options = [
+            'class' => ['test']
+        ];
+        Html::addCssClass($options, 'test2');
+        $this->assertEquals(['class' => ['test', 'test2']], $options);
+        Html::addCssClass($options, 'test2');
+        $this->assertEquals(['class' => ['test', 'test2']], $options);
+        Html::addCssClass($options, ['test3']);
+        $this->assertEquals(['class' => ['test', 'test2', 'test3']], $options);
+
+        $options = [
+            'class' => 'test'
+        ];
+        Html::addCssClass($options, ['test1', 'test2']);
+        $this->assertEquals(['class' => 'test test1 test2'], $options);
     }
 
     public function testRemoveCssClass()
@@ -569,6 +589,19 @@ EOD;
         $this->assertEquals(['class' => 'test3'], $options);
         Html::removeCssClass($options, 'test3');
         $this->assertEquals([], $options);
+
+        $options = ['class' => ['test', 'test2', 'test3']];
+        Html::removeCssClass($options, 'test2');
+        $this->assertEquals(['class' => ['test', 2 => 'test3']], $options);
+        Html::removeCssClass($options, 'test');
+        Html::removeCssClass($options, 'test3');
+        $this->assertEquals([], $options);
+
+        $options = [
+            'class' => 'test test1 test2'
+        ];
+        Html::removeCssClass($options, ['test1', 'test2']);
+        $this->assertEquals(['class' => 'test'], $options);
     }
 
     public function testCssStyleFromArray()
@@ -610,6 +643,14 @@ EOD;
         $options = [];
         Html::addCssStyle($options, 'width: 110px; color: red;', false);
         $this->assertEquals('width: 110px; color: red;', $options['style']);
+
+        $options = [
+            'style' => [
+                'width' => '100px'
+            ],
+        ];
+        Html::addCssStyle($options, ['color' => 'red'], false);
+        $this->assertEquals('width: 100px; color: red;', $options['style']);
     }
 
     public function testRemoveCssStyle()
@@ -625,6 +666,14 @@ EOD;
         $options = [];
         Html::removeCssStyle($options, ['color', 'background']);
         $this->assertTrue(!array_key_exists('style', $options));
+        $options = [
+            'style' => [
+                'color' => 'red',
+                'width' => '100px',
+            ],
+        ];
+        Html::removeCssStyle($options, ['color']);
+        $this->assertEquals('width: 100px;', $options['style']);
     }
 
     public function testBooleanAttributes()

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -578,6 +578,22 @@ EOD;
         $this->assertEquals(['class' => 'test test1 test2'], $options);
     }
 
+    /**
+     * @depends testAddCssClass
+     */
+    public function testMergeCssClass()
+    {
+        $options = [
+            'class' => [
+                'persistent' => 'test1'
+            ]
+        ];
+        Html::addCssClass($options, ['persistent' => 'test2']);
+        $this->assertEquals(['persistent' => 'test1'], $options['class']);
+        Html::addCssClass($options, ['additional' => 'test2']);
+        $this->assertEquals(['persistent' => 'test1', 'additional' => 'test2'], $options['class']);
+    }
+
     public function testRemoveCssClass()
     {
         $options = ['class' => 'test test2 test3'];


### PR DESCRIPTION
Fix #6043 Added support for array type styles and classes.
BC kept.

Pay attention for unit test `HtmlTest::testMergeCssClass()`: it demonstrates the solution for issues like:
#8229
#4916

https://github.com/yiisoft/yii2-bootstrap/pull/15
