### PR TITLE
unicode in parameter names

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -96,7 +96,7 @@ class BaseHtml
      * @param unknown $utfString
      * @return unknown|string
      */
-    protected static function convertToEncoding($utfString)
+    public static function convertToEncoding($utfString)
     {
     	$charset = strtoupper(Yii::$app->charset);
     	if ($charset === 'UTF-8') { //nothing to do
@@ -111,7 +111,7 @@ class BaseHtml
      * @param unknown $encString
      * @return unknown|string
      */
-    protected static function convertToUTF($encString)
+    public static function convertToUTF($encString)
     {
         $charset = strtoupper(Yii::$app->charset);
         if ($charset === 'UTF-8') { //nothing to do

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1940,7 +1940,7 @@ class BaseHtml
      */
     public static function getAttributeName($attribute)
     {
-        if (preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/', $attribute, $matches)) {
+        if (preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/u', $attribute, $matches)) {
             return $matches[2];
         } else {
             throw new InvalidParamException('Attribute name must contain word characters only.');
@@ -1963,7 +1963,7 @@ class BaseHtml
      */
     public static function getAttributeValue($model, $attribute)
     {
-        if (!preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/', $attribute, $matches)) {
+        if (!preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/u', $attribute, $matches)) {
             throw new InvalidParamException('Attribute name must contain word characters only.');
         }
         $attribute = $matches[2];
@@ -2013,7 +2013,7 @@ class BaseHtml
     public static function getInputName($model, $attribute)
     {
         $formName = $model->formName();
-        if (!preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/', $attribute, $matches)) {
+        if (!preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/u', $attribute, $matches)) {
             throw new InvalidParamException('Attribute name must contain word characters only.');
         }
         $prefix = $matches[1];

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2040,7 +2040,7 @@ class BaseHtml
      */
     public static function getInputId($model, $attribute)
     {
-        $name = strtolower(static::getInputName($model, $attribute));
+        $name = mb_strtolower(static::getInputName($model, $attribute));
         return str_replace(['[]', '][', '[', ']', ' ', '.'], ['', '-', '-', '', '-', '-'], $name);
     }
 }

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -98,11 +98,10 @@ class BaseHtml
      */
     public static function convertToEncoding($utfString)
     {
-    	$charset = strtoupper(Yii::$app->charset);
-    	if ($charset === 'UTF-8') { //nothing to do
+    	if (strcasecmp(Yii::$app->charset, 'UTF-8') === 0) { //nothing to do
     		return $utfString;
     	}
-    	return mb_convert_encoding($utfString, $charset, 'UTF-8');
+    	return mb_convert_encoding($utfString, Yii::$app->charset, 'UTF-8');
     }
     
     /**
@@ -113,11 +112,10 @@ class BaseHtml
      */
     public static function convertToUTF($encString)
     {
-        $charset = strtoupper(Yii::$app->charset);
-        if ($charset === 'UTF-8') { //nothing to do
+        if (strcasecmp(Yii::$app->charset, 'UTF-8') === 0) { //nothing to do
             return $encString;
         }
-        return mb_convert_encoding($encString, 'UTF-8', $charset);
+        return mb_convert_encoding($encString, 'UTF-8', Yii::$app->charset);
     }
     
 

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2040,7 +2040,7 @@ class BaseHtml
      */
     public static function getInputId($model, $attribute)
     {
-        $name = mb_strtolower(static::getInputName($model, $attribute));
+        $name = mb_strtolower(static::getInputName($model, $attribute), Yii::$app->charset);
         return str_replace(['[]', '][', '[', ']', ' ', '.'], ['', '-', '-', '', '-', '-'], $name);
     }
 }

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -317,7 +317,7 @@ class BaseInflector
      */
     public static function camel2words($name, $ucwords = true)
     {
-        $label = trim(strtolower(str_replace([
+        $label = trim(mb_strtolower(str_replace([
             '-',
             '_',
             '.'

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -321,7 +321,7 @@ class BaseInflector
             '-',
             '_',
             '.'
-        ], ' ', preg_replace('/(?<![A-Z])[A-Z]/', ' \0', $name)), Yii::$app->charset));
+        ], ' ', preg_replace('/(?<![A-Z])[A-Z]/', ' \0', $name), Yii::$app->charset)));
 
         return $ucwords ? ucwords($label) : $label;
     }

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -317,13 +317,12 @@ class BaseInflector
      */
     public static function camel2words($name, $ucwords = true)
     {
-        $label = trim(mb_strtolower(str_replace([
-            '-',
-            '_',
-            '.'
-        ], ' ', preg_replace('/(?<![A-Z])[A-Z]/', ' \0', $name), Yii::$app->charset)));
-
-        return $ucwords ? ucwords($label) : $label;
+        $label = preg_replace('/(?<![A-Z])[A-Z]/', ' \0', $name); // add spaces TODO: unicode?
+        $label = str_replace(['-', '_', '.'], ' ', $label);
+        $label = mb_strtolower($label, Yii::$app->charset);
+        $label = trim($label);
+        
+        return $ucwords ? mb_convert_case($label, MB_CASE_TITLE, Yii::$app->charset) : $label;
     }
 
     /**

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -317,13 +317,7 @@ class BaseInflector
      */
     public static function camel2words($name, $ucwords = true)
     {
-    	$charset = strtoupper(Yii::$app->charset);
-    	$is_utf8 = ($charset === 'UTF-8' ? true : false);
-    	
-    	// UTF-8 zone start -->
-    	if (!$is_utf8) {// conv to utf-8 for preg_match to work. other way?
-    		$name = mb_convert_encoding($name, 'UTF-8', $charset);
-    	}
+    	$name = Html::convertToUTF($name);
     	
 		$label = preg_replace('/(?<![\p{Lu}])[\p{Lu}]/u', ' \0', $name); // add spaces
 		$label = str_replace(['-', '_', '.'], ' ', $label);
@@ -334,12 +328,7 @@ class BaseInflector
 			$label = mb_convert_case($label, MB_CASE_TITLE, 'UTF-8');
 		}
 		
-		if (!$is_utf8) { // conv back to initial encoding 
-			$label = mb_convert_encoding($label, $charset, 'UTF-8');
-		}
-		// UTF-8 zone end <--
-		
-		return $label;
+		return Html::convertToEncoding($label);
     }
 
     /**

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -317,12 +317,29 @@ class BaseInflector
      */
     public static function camel2words($name, $ucwords = true)
     {
-        $label = preg_replace('/(?<![A-Z])[A-Z]/', ' \0', $name); // add spaces TODO: unicode?
-        $label = str_replace(['-', '_', '.'], ' ', $label);
-        $label = mb_strtolower($label, Yii::$app->charset);
-        $label = trim($label);
-        
-        return $ucwords ? mb_convert_case($label, MB_CASE_TITLE, Yii::$app->charset) : $label;
+    	$charset = strtoupper(Yii::$app->charset);
+    	$is_utf8 = ($charset === 'UTF-8' ? true : false);
+    	
+    	// UTF-8 zone start -->
+    	if (!$is_utf8) {// conv to utf-8 for preg_match to work. other way?
+    		$name = mb_convert_encoding($name, 'UTF-8', $charset);
+    	}
+    	
+		$label = preg_replace('/(?<![\p{Lu}])[\p{Lu}]/u', ' \0', $name); // add spaces
+		$label = str_replace(['-', '_', '.'], ' ', $label);
+		$label = mb_strtolower($label, 'UTF-8');
+		$label = trim($label);
+
+		if ($ucwords) {
+			$label = mb_convert_case($label, MB_CASE_TITLE, 'UTF-8');
+		}
+		
+		if (!$is_utf8) { // conv back to initial encoding 
+			$label = mb_convert_encoding($label, $charset, 'UTF-8');
+		}
+		// UTF-8 zone end <--
+		
+		return $label;
     }
 
     /**

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -321,7 +321,7 @@ class BaseInflector
             '-',
             '_',
             '.'
-        ], ' ', preg_replace('/(?<![A-Z])[A-Z]/', ' \0', $name))));
+        ], ' ', preg_replace('/(?<![A-Z])[A-Z]/', ' \0', $name)), Yii::$app->charset));
 
         return $ucwords ? ucwords($label) : $label;
     }

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -501,9 +501,21 @@ class Request extends \yii\base\Request
      */
     public function getQueryParam($name, $defaultValue = null)
     {
+    	$is_utf8 = strtoupper(\Yii::$app->charset) === 'UTF-8' ? true : false;
+    	if (!$is_utf8) {
+    		$name = mb_convert_encoding($name, 'UTF-8', \Yii::$app->charset);
+    	}
+    	
         $params = $this->getQueryParams();
-
-        return isset($params[$name]) ? $params[$name] : $defaultValue;
+        
+        if (isset($params[$name])) {
+        	if (!$is_utf8) {
+        		return mb_convert_encoding($params[$name], \Yii::$app->charset, 'UTF-8');
+        	}
+        	return $params[$name];
+        }
+        
+        return $defaultValue;
     }
 
     private $_hostInfo;

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -10,6 +10,7 @@ namespace yii\web;
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\helpers\StringHelper;
+use yii\helpers\Html;
 
 /**
  * The web Request class represents an HTTP request
@@ -501,18 +502,11 @@ class Request extends \yii\base\Request
      */
     public function getQueryParam($name, $defaultValue = null)
     {
-    	$is_utf8 = strtoupper(\Yii::$app->charset) === 'UTF-8' ? true : false;
-    	if (!$is_utf8) {
-    		$name = mb_convert_encoding($name, 'UTF-8', \Yii::$app->charset);
-    	}
-    	
+    	$name = Html::convertToUTF($name);
         $params = $this->getQueryParams();
         
         if (isset($params[$name])) {
-        	if (!$is_utf8) {
-        		return mb_convert_encoding($params[$name], \Yii::$app->charset, 'UTF-8');
-        	}
-        	return $params[$name];
+        	return Html::convertToEncoding($params[$name]);
         }
         
         return $defaultValue;

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -459,10 +459,19 @@ class Request extends \yii\base\Request
     public function getQueryParams()
     {
         if ($this->_queryParams === null) {
-            return $_GET;
+        	if (strcasecmp(\Yii::$app->charset, 'UTF-8') === 0) {
+        		return $_GET;
+        	}
+        	$get = [];
+        	foreach ($_GET as $k=>$v) { //NOT GOOD
+        		$k = mb_convert_encoding($k, Yii::$app->charset, 'UTF-8');
+        		$v = mb_convert_encoding($v, Yii::$app->charset, 'UTF-8');
+        		$get[$k] = $v;
+        	}
+        	return $get;
         }
 
-        return $this->_queryParams;
+        return $this->_queryParams; //never reached
     }
 
     /**
@@ -502,11 +511,10 @@ class Request extends \yii\base\Request
      */
     public function getQueryParam($name, $defaultValue = null)
     {
-    	$name = Html::convertToUTF($name);
-        $params = $this->getQueryParams();
+        $params = $this->getQueryParams(); //REALLY? no setQueryParams() is called!
         
         if (isset($params[$name])) {
-        	return Html::convertToEncoding($params[$name]);
+        	return $params[$name];
         }
         
         return $defaultValue;

--- a/tests/framework/helpers/InflectorTest.php
+++ b/tests/framework/helpers/InflectorTest.php
@@ -115,7 +115,7 @@ class InflectorTest extends TestCase
         $this->destroyApplication();
         
         //TODO: test if $ucwords is false
-        $this->mockApplication(['charset' => $enc]);
+        $this->mockApplication();
         $this->assertEquals('lower case', Inflector::camel2words('lowerCase', false)); //ucwords false
     }
 

--- a/tests/framework/helpers/InflectorTest.php
+++ b/tests/framework/helpers/InflectorTest.php
@@ -83,9 +83,40 @@ class InflectorTest extends TestCase
 
     public function testCamel2words()
     {
+    	// default encoding is 'UTF-8'
+    	$this->mockApplication();
+    	// latin, english
         $this->assertEquals('Camel Case', Inflector::camel2words('camelCase'));
         $this->assertEquals('Lower Case', Inflector::camel2words('lower_case'));
         $this->assertEquals('Tricky Stuff It Is Testing', Inflector::camel2words(' tricky_stuff.it-is testing... '));
+        //latin, español
+        $this->assertEquals('Año Año', Inflector::camel2words('añoAño'));
+        $this->assertEquals('Año Año', Inflector::camel2words('año_año'));
+        $this->assertEquals('Añoooo Añooo Añ Añ Añooooo', Inflector::camel2words(' añoooo_añooo.añ-añ añooooo... '));
+        //cyrillic, українська
+        $this->assertEquals('Рік Рік', Inflector::camel2words('рікРік'));
+        $this->assertEquals('Рік Рік', Inflector::camel2words('рік_рік'));
+        $this->assertEquals('Рікккк Ріккк Рі Рі Ріккккк', Inflector::camel2words(' рікккк_ріккк.рі-рі ріккккк... '));
+        $this->destroyApplication();
+
+        // try custom encoding
+        $enc = 'KOI8-U'; // ukrainian
+        $this->mockApplication(['charset' => $enc]);
+        $name_enc = mb_convert_encoding('рікРік', $enc, 'UTF-8');
+        $name_enc_result = mb_convert_encoding('Рік Рік', $enc, 'UTF-8');
+        $this->assertEquals($name_enc_result, Inflector::camel2words($name_enc));
+        $this->destroyApplication();
+
+        $enc = 'ISO-8859-1'; // spanish
+        $this->mockApplication(['charset' => $enc]);
+        $name_enc = mb_convert_encoding('añoAño', $enc, 'UTF-8');
+        $name_enc_result = mb_convert_encoding('Año Año', $enc, 'UTF-8');
+        $this->assertEquals($name_enc_result, Inflector::camel2words($name_enc));
+        $this->destroyApplication();
+        
+        //TODO: test if $ucwords is false
+        $this->mockApplication(['charset' => $enc]);
+        $this->assertEquals('lower case', Inflector::camel2words('lowerCase', false)); //ucwords false
     }
 
     public function testCamel2id()


### PR DESCRIPTION
for https://github.com/yiisoft/yii2/issues/8508
just to show what i mean

---

<b>similar</b>
#4446 (will fail if source is not in utf8)

---

<b>notes</b>
- htmlspecialchars hit a limit of available charsets for code files
- code becomes very heavy on check if other charset than utf-8  is supported
- gives ability to use url with non ascii chars like  index.php?єжыъэ=эъхж , in fact, it's a must in some cases when non ascii attribute is translated into query string via GET

---

<b>current</b>

```
// Yii::$app->charset = 'cp1251', project files are encoded in cp1251 accordingly     
$f = ActiveForm::begin();
echo $f->field($ar, 'рік');
ActiveForm::end();
```

output looks like

```
<form id="w0" action=".." method="post"><div class="form-group field-test-рік">
<label class="control-label" for="test-рік">Рік</label>
<input type="text" id="test-рік" class="form-control" name="Test[рік]" value="2010">

<div class="help-block"></div>
</div></form>
```
