### PR TITLE
add setVar function for the View object.

### DIFF
--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -52,6 +52,10 @@ class View extends Component
      */
     public $params = [];
     /**
+     * @var array variables that can be put into the views context dynamically
+     */
+    private $_vars = [];
+    /**
      * @var array a list of available renderers indexed by their corresponding supported file extensions.
      * Each renderer may be a view renderer object or the configuration for creating the renderer object.
      * For example, the following configuration enables both Smarty and Twig view renderers:
@@ -117,6 +121,17 @@ class View extends Component
         } elseif (is_string($this->theme)) {
             $this->theme = Yii::createObject($this->theme);
         }
+    }
+
+    /**
+     * add context variable to the view context
+     *
+     * @param string $key
+     * @param mixed $value
+     */
+    public function setVar($key, $value)
+    {
+        $this->_vars[$key] = $value;
     }
 
     /**
@@ -234,6 +249,7 @@ class View extends Component
         $this->_viewFiles[] = $viewFile;
 
         if ($this->beforeRender($viewFile, $params)) {
+            $params = array_merge($this->_vars, $params);
             Yii::trace("Rendering view file: $viewFile", __METHOD__);
             $ext = pathinfo($viewFile, PATHINFO_EXTENSION);
             if (isset($this->renderers[$ext])) {


### PR DESCRIPTION
User can call `$this->setVar($key, $value)` within the view context or
`$view->setVar($key, $value)` anywhere with the view object, and the `$key` and `$value` can be accessed in the view file by `$key`.
This feature is very useful in the view::beforeRender function, such as
pass the site url to all views:

```
public function beforeRender($viewFile, $params)
{
    if (parent::beforeRender($viewFile, $params)) {
        $this->setVar('host', Yii::$app->params['host']);
        // other codes
        return true;
    }
    return false;
}
```

With the setVar function, you don't need to pass the url in the action
using `$this->render('view files', ['host'=>'xxx.com'])` any more.
