### PR TITLE
i18n MessageController now supports config parameter 'markUnused' that turns adding @@s either on or off

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -29,6 +29,7 @@ Yii Framework 2 Change Log
 - Enh #8486: Added support to automatically set the `maxlength` attribute for `Html::activeTextArea()` and `Html::activePassword()` (klimov-paul)
 - Enh #8566: Added support for 'only' and 'except' options for `yii\web\AssetManager::publish()` (klimov-paul)
 - Enh #8574: Added `yii\console\controllers\MessageController` support .pot file creation (pgaultier)
+- Enh #8625: MessageController adds "@@" to messages, that aren't directly used via Yii::t() (marius7383)
 - Chg #6354: `ErrorHandler::logException()` will now log the whole exception object instead of only its string representation (cebe)
 - Chg #8556: Extracted `yii\web\User::getAuthManager()` method (samdark)
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -29,7 +29,7 @@ Yii Framework 2 Change Log
 - Enh #8486: Added support to automatically set the `maxlength` attribute for `Html::activeTextArea()` and `Html::activePassword()` (klimov-paul)
 - Enh #8566: Added support for 'only' and 'except' options for `yii\web\AssetManager::publish()` (klimov-paul)
 - Enh #8574: Added `yii\console\controllers\MessageController` support .pot file creation (pgaultier)
-- Enh #8625: MessageController adds "@@" to messages, that aren't directly used via Yii::t() (marius7383)
+- Enh #8625: Added 'markUnused' option to `yii\console\controllers\MessageController` (marius7383)
 - Chg #6354: `ErrorHandler::logException()` will now log the whole exception object instead of only its string representation (cebe)
 - Chg #8556: Extracted `yii\web\User::getAuthManager()` method (samdark)
 

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -8,6 +8,16 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to following the instructions
 for both A and B.
 
+
+Upgrade from Yii 2.0.4
+----------------------
+  
+* The signature of several `saveMessagesTo...` methods in `yii\console\controllers\MessageController` is changed. They now have an additional parameter named `markUnused`:
+  - `saveMessagesToDb($messages, $db, $sourceMessageTable, $messageTable, $removeUnused, $markUnused, $languages)`
+  - `saveMessagesToPHP($messages, $dirName, $overwrite, $removeUnused, $markUnused, $sort)`
+  - `saveMessagesCategoryToPHP($messages, $fileName, $overwrite, $removeUnused, $markUnused, $sort, $category)`
+  - `saveMessagesToPO($messages, $dirName, $overwrite, $removeUnused, $markUnused, $sort, $catalog)`
+
 Upgrade from Yii 2.0.3
 ----------------------
 

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -12,7 +12,7 @@ for both A and B.
 Upgrade from Yii 2.0.4
 ----------------------
   
-* The signature of several `saveMessagesTo...` methods in `yii\console\controllers\MessageController` is changed. They now have an additional parameter named `markUnused`:
+* The signature of the following methods in `yii\console\controllers\MessageController` has changed. They have an extra parameter `$markUnused`.
   - `saveMessagesToDb($messages, $db, $sourceMessageTable, $messageTable, $removeUnused, $markUnused, $languages)`
   - `saveMessagesToPHP($messages, $dirName, $overwrite, $removeUnused, $markUnused, $sort)`
   - `saveMessagesCategoryToPHP($messages, $fileName, $overwrite, $removeUnused, $markUnused, $sort, $category)`


### PR DESCRIPTION
This is a rework of pull request #8632 since it was not setup properly and addresses issue #8625 as well. 

@klimov-paul  About the newly added content in the upgrade-log I am not fully sure, because I had to add the `Upgrade from Yii 2.0.4` section and the `MessageController` doesn't seem to be a class that is supposed to be used in application development. Hope it's still correct.
