### PR TITLE
#8573 fix

### DIFF
--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -395,12 +395,14 @@ SQL;
 
         if (strpos($dbType, 'FLOAT') !== false || strpos($dbType, 'DOUBLE') !== false) {
             $column->type = 'double';
-        } elseif ($dbType == 'NUMBER' || strpos($dbType, 'INTEGER') !== false) {
-            if ($scale !== null && $scale > 0) {
+        }  elseif (strpos($dbType, 'NUMBER') !== false) {
+            if ($scale === null || $scale > 0) {
                 $column->type = 'decimal';
             } else {
                 $column->type = 'integer';
             }
+        } elseif (strpos($dbType, 'INTEGER') !== false) {
+            $column->type = 'integer';
         } elseif (strpos($dbType, 'BLOB') !== false) {
             $column->type = 'binary';
         } elseif (strpos($dbType, 'CLOB') !== false) {


### PR DESCRIPTION
fixing [#8573](https://github.com/yiisoft/yii2/issues/8573)
**NUMBER, NUMBER(x,y)** - (data_scale is null or > 0) should be mapped to **decimal**,
**NUMBER(x,0), NUMBER(x)** - (data_scale = 0) should be mapped to **integer**,
**INTEGER** always should be mapped to **integer**
