### PR TITLE
connection schema check per action

### DIFF
--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -182,6 +182,7 @@ class Connection extends Component
      * @var boolean whether to enable schema caching.
      * Note that in order to enable truly schema caching, a valid cache component as specified
      * by [[schemaCache]] must be enabled and [[enableSchemaCache]] must be set true.
+     * If only [[enableSchemaCache]] is valid $schema will be cached per [[\yii\db\Connection]] object (simply said, it will be acquired only once during [[\yii\db\Connection]] life cycle)
      * @see schemaCacheDuration
      * @see schemaCacheExclude
      * @see schemaCache
@@ -674,7 +675,7 @@ class Connection extends Component
      */
     public function getSchema()
     {
-        if ($this->_schema !== null) {
+        if ($this->enableSchemaCache && $this->_schema !== null) {
             return $this->_schema;
         } else {
             $driver = $this->getDriverName();


### PR DESCRIPTION
sample answer to issue topic #8627 

```
function actionTest()
{
    ob_start();

    $m = new \yii\db\Migration();
    //clean
    $m->dropTable('test');
    $m->createTable('test', ['a' => 'int', 'b' => 'int']);
    // 1
    $m->insert('test', ['b' => 'b']); // 0 -- expected (but strange why no error)
    // 2
    $m->alterColumn('test', 'b', 'text');
    $m->insert('test', ['b' => 'b']); // 0 -- silent fail, per request "cache" as schema object is never updated
    // 3
    $m->db->enableSchemaCache = false; // after added check
    $m->insert('test', ['b' => 'b']); // 'b' - OK

    echo str_replace("\n", '<br/>', ob_get_clean());
}
```
