### PR TITLE
Fix #8627: invalidate table schema cache on DDL

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -18,6 +18,7 @@ Yii Framework 2 Change Log
 - Bug #8593: Fixed `yii\db\ActiveQuery` produces incorrect SQL for aggregations, when `sql` field is set (klimov-paul)
 - Bug #8595: Fixed `yii\rbac\DbManager::checkAccessFromCache()` to check against auth items loaded in cache recursively (achretien, qiangxue)
 - Bug #8606: Fixed `yii\web\Response::xSendFile()` does not reset format (vyants)
+- Bug #8627: Fixed `yii\db\Migration` produces incorrect results due to table schema caching (klimov-paul)
 - Bug: Fixed string comparison in `BaseActiveRecord::unlink()` which may result in wrong comparison result for hash valued primary keys starting with `0e` (cebe)
 - Bug: Pass correct action name to `yii\console\Controller::options()` when default action was requested (cebe)
 - Bug: Automatic garbage collection in `yii\caching\FileCache` was not triggered (kidol)

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -862,6 +862,7 @@ class Command extends Component
      * Marks specified table schema to be refreshed after command execution.
      * @param string $name name of the table, which schema should be refreshed.
      * @return $this this command instance
+     * @since 2.0.5
      */
     protected function requireTableSchemaRefresh($name)
     {
@@ -871,6 +872,7 @@ class Command extends Component
 
     /**
      * Refreshes table schema, which was marked by [[requireTableSchemaRefreshment()]]
+     * @since 2.0.5
      */
     protected function refreshTableSchema()
     {

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -93,6 +93,10 @@ class Command extends Component
      * @var string the SQL statement that this command represents
      */
     private $_sql;
+    /**
+     * @var string name of the table, which schema, should be refreshed after command execution.
+     */
+    private $_refreshTableName;
 
 
     /**
@@ -537,6 +541,7 @@ class Command extends Component
     public function renameTable($table, $newName)
     {
         $sql = $this->db->getQueryBuilder()->renameTable($table, $newName);
+        $this->requireTableSchemaRefreshment($table);
 
         return $this->setSql($sql);
     }
@@ -549,6 +554,7 @@ class Command extends Component
     public function dropTable($table)
     {
         $sql = $this->db->getQueryBuilder()->dropTable($table);
+        $this->requireTableSchemaRefreshment($table);
 
         return $this->setSql($sql);
     }
@@ -577,6 +583,7 @@ class Command extends Component
     public function addColumn($table, $column, $type)
     {
         $sql = $this->db->getQueryBuilder()->addColumn($table, $column, $type);
+        $this->requireTableSchemaRefreshment($table);
 
         return $this->setSql($sql);
     }
@@ -590,6 +597,7 @@ class Command extends Component
     public function dropColumn($table, $column)
     {
         $sql = $this->db->getQueryBuilder()->dropColumn($table, $column);
+        $this->requireTableSchemaRefreshment($table);
 
         return $this->setSql($sql);
     }
@@ -604,6 +612,7 @@ class Command extends Component
     public function renameColumn($table, $oldName, $newName)
     {
         $sql = $this->db->getQueryBuilder()->renameColumn($table, $oldName, $newName);
+        $this->requireTableSchemaRefreshment($table);
 
         return $this->setSql($sql);
     }
@@ -620,6 +629,7 @@ class Command extends Component
     public function alterColumn($table, $column, $type)
     {
         $sql = $this->db->getQueryBuilder()->alterColumn($table, $column, $type);
+        $this->requireTableSchemaRefreshment($table);
 
         return $this->setSql($sql);
     }
@@ -635,6 +645,7 @@ class Command extends Component
     public function addPrimaryKey($name, $table, $columns)
     {
         $sql = $this->db->getQueryBuilder()->addPrimaryKey($name, $table, $columns);
+        $this->requireTableSchemaRefreshment($table);
 
         return $this->setSql($sql);
     }
@@ -648,6 +659,7 @@ class Command extends Component
     public function dropPrimaryKey($name, $table)
     {
         $sql = $this->db->getQueryBuilder()->dropPrimaryKey($name, $table);
+        $this->requireTableSchemaRefreshment($table);
 
         return $this->setSql($sql);
     }
@@ -776,6 +788,8 @@ class Command extends Component
 
             Yii::endProfile($token, __METHOD__);
 
+            $this->refreshTableSchema();
+
             return $n;
         } catch (\Exception $e) {
             Yii::endProfile($token, __METHOD__);
@@ -849,5 +863,24 @@ class Command extends Component
         }
 
         return $result;
+    }
+
+    /**
+     * Marks specified table schema to be refreshed after command execution.
+     * @param string $name name of the table, which schema should be refreshed.
+     */
+    protected function requireTableSchemaRefreshment($name)
+    {
+        $this->_refreshTableName = $name;
+    }
+
+    /**
+     * Refreshes table schema, which was marked by [[requireTableSchemaRefreshment()]]
+     */
+    protected function refreshTableSchema()
+    {
+        if ($this->_refreshTableName !== null) {
+            $this->db->getSchema()->refreshTableSchema($this->_refreshTableName);
+        }
     }
 }

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -162,6 +162,7 @@ class Migration extends Component implements MigrationInterface
         $time = microtime(true);
         $this->db->createCommand($sql)->bindValues($params)->execute();
         echo " done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
+        $this->db->getSchema()->refresh(); // ensure possible schema changes applied
     }
 
     /**

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -66,6 +66,7 @@ class Migration extends Component implements MigrationInterface
     {
         parent::init();
         $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db->getSchema()->refresh();
     }
 
     /**
@@ -162,7 +163,6 @@ class Migration extends Component implements MigrationInterface
         $time = microtime(true);
         $this->db->createCommand($sql)->bindValues($params)->execute();
         echo " done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
-        $this->db->getSchema()->refresh(); // ensure possible schema changes applied
     }
 
     /**

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -281,6 +281,23 @@ abstract class Schema extends Object
     }
 
     /**
+     * Refreshes the particular table schema.
+     * This method cleans up cached table schema so that it can be re-created later
+     * to reflect the database schema change.
+     * @param string $name table name.
+     */
+    public function refreshTableSchema($name)
+    {
+        unset($this->_tables[$name]);
+        $this->_tableNames = [];
+        /* @var $cache Cache */
+        $cache = is_string($this->db->schemaCache) ? Yii::$app->get($this->db->schemaCache, false) : $this->db->schemaCache;
+        if ($this->db->enableSchemaCache && $cache instanceof Cache) {
+            $cache->delete($this->getCacheKey($name));
+        }
+    }
+
+    /**
      * Creates a query builder for the database.
      * This method may be overridden by child classes to create a DBMS-specific query builder.
      * @return QueryBuilder query builder instance

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -285,6 +285,7 @@ abstract class Schema extends Object
      * This method cleans up cached table schema so that it can be re-created later
      * to reflect the database schema change.
      * @param string $name table name.
+     * @since 2.0.5
      */
     public function refreshTableSchema($name)
     {

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -310,8 +310,6 @@ SQL;
         ], $record);
     }
 
-
-
     /*
     public function testUpdate()
     {
@@ -508,5 +506,24 @@ SQL;
         $db = $this->getConnection(false);
         $command = $db->createCommand($sql, $params);
         $this->assertEquals($expectedRawSql, $command->getRawSql());
+    }
+
+    public function testAutoRefreshTableSchema()
+    {
+        $db = $this->getConnection(false);
+        $tableName = 'test';
+
+        $db->createCommand()->createTable($tableName, [
+            'id' => 'pk',
+            'name' => 'string',
+        ])->execute();
+        $initialSchema = $db->getSchema()->getTableSchema($tableName);
+
+        $db->createCommand()->addColumn($tableName, 'value', 'integer')->execute();
+        $newSchema = $db->getSchema()->getTableSchema($tableName);
+        $this->assertNotEquals($initialSchema, $newSchema);
+
+        $db->createCommand()->dropTable($tableName)->execute();
+        $this->assertNull($db->getSchema()->getTableSchema($tableName));
     }
 }

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -67,6 +67,23 @@ class SchemaTest extends DatabaseTestCase
         $this->assertEquals($noCacheTable, $cachedTable);
     }
 
+    /**
+     * @depends testSchemaCache
+     */
+    public function testRefreshTableSchema()
+    {
+        /* @var $schema Schema */
+        $schema = $this->getConnection()->schema;
+
+        $schema->db->enableSchemaCache = true;
+        $schema->db->schemaCache = new FileCache();
+        $noCacheTable = $schema->getTableSchema('type', true);
+
+        $schema->refreshTableSchema('type');
+        $refreshedTable = $schema->getTableSchema('type', false);
+        $this->assertFalse($noCacheTable === $refreshedTable);
+    }
+
     public function testCompositeFk()
     {
         /* @var $schema Schema */


### PR DESCRIPTION
Fix #8627: invalidate table schema cache on DDL

Any DDL statement composed using `yii\db\Command` methods automatically refreshing related table schema.
`Migration::execute()` refreshes entire database schema, because raw SQL may contain DDL, which changes several tables.
