### PR TITLE
Fixed \yii\db\BaseActiveRecord::findOne return type

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -95,7 +95,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
 
     /**
      * @inheritdoc
-     * @return static|null ActiveRecord instance matching the condition, or `null` if nothing matches.
+     * @return static|false ActiveRecord instance matching the condition, or `false` if nothing matches.
      */
     public static function findOne($condition)
     {
@@ -115,7 +115,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * Finds ActiveRecord instance(s) by the given condition.
      * This method is internally called by [[findOne()]] and [[findAll()]].
      * @param mixed $condition please refer to [[findOne()]] for the explanation of this parameter
-     * @return ActiveQueryInterface the newly created [[ActiveQueryInterface|ActiveQuery]] instance. 
+     * @return ActiveQueryInterface the newly created [[ActiveQueryInterface|ActiveQuery]] instance.
      * @throws InvalidConfigException if there is no primary key defined
      * @internal
      */


### PR DESCRIPTION
Method `one()` used inside this method never return anything like `null`.
