### PR TITLE
Object key check error fix

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -199,7 +199,7 @@ class BaseArrayHelper
         }
 
         if (is_object($array)) {
-            return property_exists($array,$key) ? $array->$key : $default;
+            return isset($array->$key) ? $array->$key : $default;
         } elseif (is_array($array)) {
             return array_key_exists($key, $array) ? $array[$key] : $default;
         } else {

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -199,7 +199,7 @@ class BaseArrayHelper
         }
 
         if (is_object($array)) {
-            return $array->$key;
+            return property_exists($array,$key) ? $array->$key : $default;
         } elseif (is_array($array)) {
             return array_key_exists($key, $array) ? $array[$key] : $default;
         } else {


### PR DESCRIPTION
it's returning error to getting key if the array haven't that key. 
i think this is corret
return property_exists($array,$key) ? $array->$key : $default;
but it doesn't work with ActiveRecord. 
What can i do for this?
