### PR TITLE
#8723 BaseVarDumper var_export() fix

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.5 under development
 -----------------------
 
+- Bug #8723: Fixed yii\helpers\BaseVarDumper error when handling missing variables in debugger page. (XzAeRo)
 - Bug #7305: Logging of Exception objects resulted in failure of the logger i.e. no logs being written (cebe)
 - Bug #7374: Use proper INSERT syntax with default values when no values are specified (nineinchnick)
 - Bug #7707: client-side `trim` validator now passes the trimmed value to subsequent validators (nkovacs)

--- a/framework/helpers/BaseVarDumper.php
+++ b/framework/helpers/BaseVarDumper.php
@@ -184,7 +184,7 @@ class BaseVarDumper
                 } catch (\Exception $e) {
                     // serialize may fail, for example: if object contains a `\Closure` instance
                     // so we use regular `var_export()` as fallback
-                    $output = var_export($var, true);
+                    $output = \yii\helpers\VarDumper::dumpAsString($var);
                 }
                 self::$_output .= $output;
                 break;


### PR DESCRIPTION
Changed var_export to VarDumper::dumpAsString()
