### PR TITLE
Обрезается вывод при вызове в консоли "yii.bat"

### DIFF
--- a/framework/helpers/BaseConsole.php
+++ b/framework/helpers/BaseConsole.php
@@ -659,11 +659,11 @@ class BaseConsole
     public static function wrapText($text, $indent = 0, $refresh = false)
     {
         $size = static::getScreenSize($refresh);
-        if ($size === false || $size[0] <= $indent) {
+        if ($size === false || $size[1] <= $indent) {
             return $text;
         }
         $pad = str_repeat(' ', $indent);
-        $lines = explode("\n", wordwrap($text, $size[0] - $indent, "\n", true));
+        $lines = explode("\n", wordwrap($text, $size[1] - $indent, "\n", true));
         $first = true;
         foreach ($lines as $i => $line) {
             if ($first) {


### PR DESCRIPTION
Результатом вызова команды в Windows "mode con" у меня является следующее (Windows7 x64):
## Состояние устройства CON:

```
Строки:                42
Столбцы:               160
Скорость клавиатуры:   31
Задержка клавиатуры:   1
Кодовая страница:      866
```

Так как нас интересуют столбцы, то это $size[1]
