### PR TITLE
Fix Logger memory performance

### DIFF
--- a/framework/log/Logger.php
+++ b/framework/log/Logger.php
@@ -124,6 +124,8 @@ class Logger extends Component
         });
     }
 
+    private $_messagesCount = 0;
+
     /**
      * Logs a message with the given type and category.
      * If [[traceLevel]] is greater than 0, additional call stack information about
@@ -153,8 +155,11 @@ class Logger extends Component
                 }
             }
         }
+
         $this->messages[] = [$message, $level, $category, $time, $traces];
-        if ($this->flushInterval > 0 && count($this->messages) >= $this->flushInterval) {
+        $this->_messagesCount++;
+
+        if ($this->flushInterval > 0 && $this->_messagesCount >= $this->flushInterval) {
             $this->flush();
         }
     }


### PR DESCRIPTION
Hi everyone. I was trying to write a php daemon on yiiiiiiiiii and came across one unpleasant thing.
This is my example on pseudocode:

``` php

// Worker.php

class Worker
{
    public function work()
    {
        while (true) {
            try {
                $this->run();
            } catch (\Exception $e) {
                // do nothing
            }
        }
    }

    protected function run()
    {
        // some code

        throw new \yii\base\InvalidConfigException();
    }
}


// test.php

$worker = new Worker();
$worker->work();

```

I run the code in an infinite loop and measure the memory that has been allocated to this PHP script (logging is enabled). 

This is my simple memory test (php::memory_get_usage).

```
      yii2                        after patch
```

|-------------------------|------------------------|
| 3.0283966064453  |2.9009246826172|
| 3.041259765625    |2.9009246826172|
| 3.0538177490234  |2.9009246826172|
| .............................. |2.9009246826172|
| .............................. |2.9009246826172|
| .............................. |2.9009246826172|
| 3.977897644043    |2.9009246826172|
| 3.9904556274414  |2.9009246826172|
| 4.0030136108398  |2.9009246826172|
| 3.977897644011    |2.9009246826172|
| 3.8009246826172  |2.9009246826172|
