### PR TITLE
Update QueryBuilder.php

### DIFF
--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -122,12 +122,16 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * Builds a SQL statement for enabling or disabling integrity check.
      * @param boolean $check whether to turn on or off the integrity check.
      * @param string $schema the schema of the tables. Defaults to empty string, meaning the current or default schema.
-     * @param string $table the table name. Defaults to empty string, meaning that no table will be changed.
+     * @param string $table the table name. Defaults to empty string, meaning that all tables will be changed.
      * @return string the SQL statement for checking integrity
      * @throws InvalidParamException if the table does not exist or there is no sequence associated with the table.
      */
     public function checkIntegrity($check = true, $schema = '', $table = '')
     {
+        $enable = $check ? 'CHECK' : 'NOCHECK';
+        if ($table === '') {
+    		return "EXEC sp_MSforeachtable 'ALTER TABLE ? {$enable} CONSTRAINT ALL'";
+    	}
         if ($schema !== '') {
             $table = "{$schema}.{$table}";
         }
@@ -135,8 +139,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         if ($this->db->getTableSchema($table) === null) {
             throw new InvalidParamException("Table not found: $table");
         }
-        $enable = $check ? 'CHECK' : 'NOCHECK';
-
+        
         return "ALTER TABLE {$table} {$enable} CONSTRAINT ALL";
     }
 


### PR DESCRIPTION
### Background Problem

In case of SQL Server. The function checkIntegrity function of [InitDbFixture](https://github.com/yiisoft/yii2/blob/master/framework/test/InitDbFixture.php) will always result in 

```
Table not found: []
```
### Cause

The function won't specify a table which needs to be checked.
### Solution

Update checkIntegrity function to enable or disable integrity checking to all tables in case of no table specify. This update makes aforementioned function can enable or disable integrity check on all tables when initializing fixtures. Moreover, it will have the same behavior with other database types. MySQL and SQLite will always perform on all tables. PgSQL will perform on all tables in case of no table specify. The rest of database types don't support.
### Note

The description checkIntegrity of [QueryBuilder](https://github.com/yiisoft/yii2/blob/master/framework/db/QueryBuilder.php) say:

```
@param string $table the table name. Defaults to empty string, meaning that no table will be changed.
```

Which is no longer relevant because all overrides functions of each database types likely to perform integrity check in case of no table specify.
