### PR TITLE
only truncate the original log file for rotation

### DIFF
--- a/framework/log/FileTarget.php
+++ b/framework/log/FileTarget.php
@@ -144,7 +144,7 @@ class FileTarget extends Target
                 } else {
                     if ($this->rotateByCopy) {
                         @copy($rotateFile, $file . '.' . ($i + 1));
-                        if ($fp = @fopen($rotateFile, 'a')) {
+                        if ($i === 0 && $fp = @fopen($rotateFile, 'a')) {
                             @ftruncate($fp, 0);
                             @fclose($fp);
                         }


### PR DESCRIPTION
other rotation log files will be overwrite, only the original log file need to truncate after copy.
