### PR TITLE
[Feature request] Fixture data classes

### DIFF
--- a/framework/test/BaseActiveFixture.php
+++ b/framework/test/BaseActiveFixture.php
@@ -104,7 +104,7 @@ abstract class BaseActiveFixture extends DbFixture implements \IteratorAggregate
 	    if ($this->dataClass !== null) {
 		    $activeFixtureData = Yii::createObject($this->dataClass);
 		    if (!is_subclass_of($activeFixtureData, BaseActiveFixtureData::className())) {
-			    throw new InvalidConfigException("{$this->dataClass} is not instance of ActiveFixtureData");
+			    throw new InvalidConfigException("{$this->dataClass} is not instance of BaseActiveFixtureData");
 		    }
 
 		    return $activeFixtureData->getData();

--- a/framework/test/BaseActiveFixture.php
+++ b/framework/test/BaseActiveFixture.php
@@ -34,6 +34,12 @@ abstract class BaseActiveFixture extends DbFixture implements \IteratorAggregate
      * to be returned by [[getData()]]. You can set this property to be false to prevent loading any data.
      */
     public $dataFile;
+	/**
+	 * @var string the instance of BaseActiveFixtureData model class that contains the fixture data. If
+	 * this not set [[getData()]] function will use fixture data contains in [[dataFile]] property.
+	 * @see BaseActiveFixtureData
+	 */
+	public $dataClass;
 
     /**
      * @var \yii\db\ActiveRecord[] the loaded AR models
@@ -95,7 +101,16 @@ abstract class BaseActiveFixture extends DbFixture implements \IteratorAggregate
      */
     protected function getData()
     {
-        if ($this->dataFile === false || $this->dataFile === null) {
+	    if ($this->dataClass !== null) {
+		    $activeFixtureData = Yii::createObject($this->dataClass);
+		    if (!is_subclass_of($activeFixtureData, BaseActiveFixtureData::className())) {
+			    throw new InvalidConfigException("{$this->dataClass} is not instance of ActiveFixtureData");
+		    }
+
+		    return $activeFixtureData->getData();
+	    }
+
+	    if ($this->dataFile === false || $this->dataFile === null) {
             return [];
         }
         $dataFile = Yii::getAlias($this->dataFile);

--- a/framework/test/BaseActiveFixtureData.php
+++ b/framework/test/BaseActiveFixtureData.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace yii\test;
+
+use Yii;
+use yii\base\Object;
+
+/**
+ * ActiveFixtureData represents a fixture data file.
+ *
+ * @author Andrey Kolomenskiy <link@onedev.ru>
+ * @since 2.0
+ */
+abstract class BaseActiveFixtureData extends Object
+{
+    /**
+     * Returns fixture data array
+     * @return array
+     */
+    abstract public function getData();
+}


### PR DESCRIPTION
The problem:

transaction.php fixture file

``` php
<?php

return [
    [
        'id' => 1,
        'currency_id' => 1,
        'type_id' => 2,
        'state_enum' => 'success',
    ],
]
```

What is id 1 in currency field? id2? In project that contains many relations and many tests that hardcored ids make trouble work with fixtures. And heavy troubles when need refactor tests. In refactoring I will replace all _sucess_ strings and remember what means 1 and 2.

Look at this TransactionFixtureData.php

``` php
<?php

class TransactionFixtureData extends BaseActiveFixtureData
{
    public function getData()
    {
        $rubCurrency = Currency::findByName(Currency::RUB);
        $refundType = TransactionType::findByName(TransactionType::REFUND);
        $successState = TransactionState::findByName(TransactionState::IS_SUCCESS);

        return [
            [
                'id' => 1,
                'currency_id' => $rubCurrency->id,
                'type_id' => $refundType->id,
                'state_enum' => $successState->name,
            ]
        ];
    }
}
```

Problems:
- It's class, not static file
- Class makes requests to database (need right depends)
- Impossible use templates

Benefit: it's readable.
Yii communities need it?
