### PR TITLE
IDE type hinting fix

### DIFF
--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -139,7 +139,7 @@ class Container extends Component
      * they appear in the constructor declaration. If you want to skip some parameters, you should index the remaining
      * ones with the integers that represent their positions in the constructor parameter list.
      * @param array $config a list of name-value pairs that will be used to initialize the object properties.
-     * @return object an instance of the requested class.
+     * @return mixed an instance of the requested class.
      * @throws InvalidConfigException if the class cannot be recognized or correspond to an invalid definition
      */
     public function get($class, $params = [], $config = [])


### PR DESCRIPTION
IDE does not understand `object` type, and highlights an error.

![Error](https://ziedlejas.lv/screenshots/img.2015.07.03.pNbsVk.png)

With mixed type it works.
