### PR TITLE
Clarify escaping column name quoting in createIndex()

### DIFF
--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -411,7 +411,8 @@ class Migration extends Component implements MigrationInterface
      * @param string $name the name of the index. The name will be properly quoted by the method.
      * @param string $table the table that the new index will be created for. The table name will be properly quoted by the method.
      * @param string|array $columns the column(s) that should be included in the index. If there are multiple columns, please separate them
-     * by commas or use an array. The column names will be properly quoted by the method.
+     * by commas or use an array. Each column name will be properly quoted by the method. Quoting will be escaped for column names that
+     * include a left parenthesis "(".
      * @param boolean $unique whether to add UNIQUE constraint on the created index.
      */
     public function createIndex($name, $table, $columns, $unique = false)


### PR DESCRIPTION
Added information about when column names are not quoted when using createIndex() as discussed in #9017. "left parenthesis" was used rather than just "parenthesis" to reflect the exact code working.
