### PR TITLE
Fix rename table function for MSSQL

### DIFF
--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -125,7 +125,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     public function renameTable($table, $newName)
     {
-        return "sp_rename '$table', '$newName'";
+        return 'sp_rename ' . $this->db->quoteTableName($table) . ', ' . $this->db->quoteTableName($newName);
     }
 
     /**


### PR DESCRIPTION
Current sql will generate SQL that looks like this
`
EXEC sp_rename '[old_table]', '[new_table]'
`
This makes the new table has a new `[new_table]` instead of `new_table`. It could be a flaw within `sp_rename` stored procedure.

However, by removing a single quote to make SQL becomes this
`
EXEC sp_rename [old_table], [new_table]
`
The new table has a name `new_table` as expected.
