### PR TITLE
Fix rename column function for MSSQL

### DIFF
--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -137,7 +137,10 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     public function renameColumn($table, $name, $newName)
     {
-        return "sp_rename '$table.$name', '$newName', 'COLUMN'";
+        $table = $this->db->quoteTableName($table);
+        $name = $this->db->quoteColumnName($name);
+        $newName = $this->db->quoteColumnName($newName);
+        return "sp_rename '{$table}.{$name}', {$newName}, 'COLUMN'";
     }
 
     /**


### PR DESCRIPTION
Current function will generate sql that looks like this.
`
EXEC sp_rename '[table].[old_col]', '[new_col]', 'COLUMN';
`
This will result in having `[new_col]` instead of `new_col`.

So it needs to be fixed into
`
EXEC sp_rename '[table].[old_col]', [new_col], 'COLUMN';
`
Removing the single quote from `[new_col]` will result in having `new_col` as expected. The single quote for `[table].[old_col]` has to stay. Without it an error from server will occur.
