### PR TITLE
remove redefined parent property

### DIFF
--- a/framework/console/Application.php
+++ b/framework/console/Application.php
@@ -64,11 +64,6 @@ class Application extends \yii\base\Application
      * Defaults to true.
      */
     public $enableCoreCommands = true;
-    /**
-     * @var Controller the currently active controller instance
-     */
-    public $controller;
-
 
     /**
      * @inheritdoc

--- a/framework/web/Application.php
+++ b/framework/web/Application.php
@@ -45,11 +45,6 @@ class Application extends \yii\base\Application
      * Defaults to null, meaning catch-all is not used.
      */
     public $catchAll;
-    /**
-     * @var Controller the currently active controller instance
-     */
-    public $controller;
-
 
     /**
      * @inheritdoc


### PR DESCRIPTION
Property $controller already defined in parent class \yii\base\Application, both console\Application and web\Application already inherit it.

No need to redefine it in both classes.
