### PR TITLE
Update Request.php

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -407,7 +407,7 @@ class Request extends \yii\base\Request
     {
         $params = $this->getBodyParams();
 
-        return isset($params[$name]) ? $params[$name] : $defaultValue;
+        return array_key_exists($name, $params) ? $params[$name] : $defaultValue;
     }
 
     /**


### PR DESCRIPTION
Using `isset()` in getBodyParams treats `null` as `$defaultValue` which is wrong since `$defaultValue` should be returned only when parameter is missing!
