### PR TITLE
Fix phpdoc typo

### DIFF
--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -215,7 +215,7 @@ class Formatter extends Component
      */
     public $currencyCode;
     /**
-     * @var array the base at which a kilobyte is calculated (1000 or 1024 bytes per kilobyte), used by [[asSize]] and [[asShortSize]].
+     * @var integer the base at which a kilobyte is calculated (1000 or 1024 bytes per kilobyte), used by [[asSize]] and [[asShortSize]].
      * Defaults to 1024.
      */
     public $sizeFormatBase = 1024;


### PR DESCRIPTION
Change property type from array to integer for $sizeFormatBase in i18n/Formatter
