### PR TITLE
fix for #9067 - EmailValidator error on valid email

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.6 under development
 -----------------------
-
+- Bug #9067: Email validator error on valid email (andrewnester)
 - Bug #7305: Logging of Exception objects resulted in failure of the logger i.e. no logs being written (cebe)
 - Bug #7374: Use proper INSERT syntax with default values when no values are specified (nineinchnick)
 - Bug #7707: client-side `trim` validator now passes the trimmed value to subsequent validators (nkovacs)

--- a/framework/validators/EmailValidator.php
+++ b/framework/validators/EmailValidator.php
@@ -24,13 +24,13 @@ class EmailValidator extends Validator
      * @var string the regular expression used to validate the attribute value.
      * @see http://www.regular-expressions.info/email.html
      */
-    public $pattern = '/^[a-zA-Z0-9!#$%&\'*+\\/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&\'*+\\/=?^_`{|}~-]+)*@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/';
+    public $pattern = '/(*UTF8)^[\pL0-9!#$%&\'*+\\/=?^_`{|}~-]+(?:\.[\pL0-9!#$%&\'*+\\/=?^_`{|}~-]+)*@(?:[\pL0-9](?:[\pL0-9-]*[\pL0-9])?\.)+[\pL0-9](?:[\pL0-9-]*[\pL0-9])?$/';
     /**
      * @var string the regular expression used to validate email addresses with the name part.
      * This property is used only when [[allowName]] is true.
      * @see allowName
      */
-    public $fullPattern = '/^[^@]*<[a-zA-Z0-9!#$%&\'*+\\/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&\'*+\\/=?^_`{|}~-]+)*@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?>$/';
+    public $fullPattern = '/(*UTF8)^[^@]*<[\pL0-9!#$%&\'*+\\/=?^_`{|}~-]+(?:\.[\pL0-9!#$%&\'*+\\/=?^_`{|}~-]+)*@(?:[\pL0-9](?:[\pL0-9-]*[\pL0-9])?\.)+[\pL0-9](?:[\pL0-9-]*[\pL0-9])?>$/';
     /**
      * @var boolean whether to allow name in the email address (e.g. "John Smith <john.smith@example.com>"). Defaults to false.
      * @see fullPattern

--- a/tests/framework/validators/EmailValidatorTest.php
+++ b/tests/framework/validators/EmailValidatorTest.php
@@ -22,40 +22,37 @@ class EmailValidatorTest extends TestCase
 
         $this->assertTrue($validator->validate('sam@rmcreative.ru'));
         $this->assertTrue($validator->validate('5011@gmail.com'));
+
         $this->assertFalse($validator->validate('rmcreative.ru'));
         $this->assertFalse($validator->validate('Carsten Brandt <mail@cebe.cc>'));
         $this->assertFalse($validator->validate('"Carsten Brandt" <mail@cebe.cc>'));
         $this->assertFalse($validator->validate('<mail@cebe.cc>'));
-        $this->assertTrue($validator->validate('info@örtliches.de'));
-        $this->assertTrue($validator->validate('sam@рмкреатиф.ru'));
-        $this->assertTrue($validator->validate('üñîçøðé@example.com'));
-        $this->assertTrue($validator->validate('üñîçøðé@üñîçøðé.com'));
+        $this->assertFalse($validator->validate('info@örtliches.de'));
+        $this->assertFalse($validator->validate('sam@рмкреатиф.ru'));
+        $this->assertFalse($validator->validate('üñîçøðé@example.com'));
+        $this->assertFalse($validator->validate('üñîçøðé@üñîçøðé.com'));
 
         $validator->allowName = true;
 
         $this->assertTrue($validator->validate('sam@rmcreative.ru'));
         $this->assertTrue($validator->validate('5011@gmail.com'));
-        $this->assertFalse($validator->validate('rmcreative.ru'));
         $this->assertTrue($validator->validate('Carsten Brandt <mail@cebe.cc>'));
         $this->assertTrue($validator->validate('"Carsten Brandt" <mail@cebe.cc>'));
         $this->assertTrue($validator->validate('<mail@cebe.cc>'));
-        $this->assertTrue($validator->validate('info@örtliches.de'));
-        $this->assertTrue($validator->validate('sam@рмкреатиф.ru'));
-        $this->assertFalse($validator->validate('Informtation info@oertliches.de'));
         $this->assertTrue($validator->validate('test@example.com'));
         $this->assertTrue($validator->validate('John Smith <john.smith@example.com>'));
+
+        $this->assertFalse($validator->validate('sam@рмкреатиф.ru'));
+        $this->assertFalse($validator->validate('rmcreative.ru'));
+        $this->assertFalse($validator->validate('info@örtliches.de'));
         $this->assertFalse($validator->validate('John Smith <example.com>'));
-        $this->assertTrue($validator->validate('üñîçøðé@example.com'));
-        $this->assertTrue($validator->validate('üñîçøðé@üñîçøðé.com'));
+        $this->assertFalse($validator->validate('Informtation info@oertliches.de'));
+        $this->assertFalse($validator->validate('üñîçøðé@example.com'));
+        $this->assertFalse($validator->validate('üñîçøðé@üñîçøðé.com'));
     }
 
     public function testValidateValueIdn()
     {
-        if (!function_exists('idn_to_ascii')) {
-            $this->markTestSkipped('Intl extension required');
-
-            return;
-        }
         $validator = new EmailValidator();
         $validator->enableIDN = true;
 
@@ -66,31 +63,35 @@ class EmailValidatorTest extends TestCase
         $this->assertTrue($validator->validate('sam@рмкреатиф.ru'));
         $this->assertTrue($validator->validate('sam@rmcreative.ru'));
         $this->assertTrue($validator->validate('5011@gmail.com'));
+        $this->assertTrue($validator->validate('üñîçøðé@example.com'));
+        $this->assertTrue($validator->validate('üñîçøðé@üñîçøðé.com'));
+
         $this->assertFalse($validator->validate('rmcreative.ru'));
         $this->assertFalse($validator->validate('Carsten Brandt <mail@cebe.cc>'));
         $this->assertFalse($validator->validate('"Carsten Brandt" <mail@cebe.cc>'));
         $this->assertFalse($validator->validate('<mail@cebe.cc>'));
-        $this->assertTrue($validator->validate('üñîçøðé@example.com'));
-        $this->assertTrue($validator->validate('üñîçøðé@üñîçøðé.com'));
 
 
         $validator->allowName = true;
 
         $this->assertTrue($validator->validate('info@örtliches.de'));
         $this->assertTrue($validator->validate('Informtation <info@örtliches.de>'));
-        $this->assertFalse($validator->validate('Informtation info@örtliches.de'));
         $this->assertTrue($validator->validate('sam@рмкреатиф.ru'));
         $this->assertTrue($validator->validate('sam@rmcreative.ru'));
         $this->assertTrue($validator->validate('5011@gmail.com'));
-        $this->assertFalse($validator->validate('rmcreative.ru'));
         $this->assertTrue($validator->validate('Carsten Brandt <mail@cebe.cc>'));
         $this->assertTrue($validator->validate('"Carsten Brandt" <mail@cebe.cc>'));
         $this->assertTrue($validator->validate('<mail@cebe.cc>'));
         $this->assertTrue($validator->validate('test@example.com'));
         $this->assertTrue($validator->validate('John Smith <john.smith@example.com>'));
-        $this->assertFalse($validator->validate('John Smith <example.com>'));
         $this->assertTrue($validator->validate('üñîçøðé@example.com'));
         $this->assertTrue($validator->validate('üñîçøðé@üñîçøðé.com'));
+
+
+        $this->assertFalse($validator->validate('rmcreative.ru'));
+        $this->assertFalse($validator->validate('John Smith <example.com>'));
+        $this->assertFalse($validator->validate('Informtation info@örtliches.de'));
+
     }
 
     public function testValidateValueMx()

--- a/tests/framework/validators/EmailValidatorTest.php
+++ b/tests/framework/validators/EmailValidatorTest.php
@@ -26,8 +26,10 @@ class EmailValidatorTest extends TestCase
         $this->assertFalse($validator->validate('Carsten Brandt <mail@cebe.cc>'));
         $this->assertFalse($validator->validate('"Carsten Brandt" <mail@cebe.cc>'));
         $this->assertFalse($validator->validate('<mail@cebe.cc>'));
-        $this->assertFalse($validator->validate('info@örtliches.de'));
-        $this->assertFalse($validator->validate('sam@рмкреатиф.ru'));
+        $this->assertTrue($validator->validate('info@örtliches.de'));
+        $this->assertTrue($validator->validate('sam@рмкреатиф.ru'));
+        $this->assertTrue($validator->validate('üñîçøðé@example.com'));
+        $this->assertTrue($validator->validate('üñîçøðé@üñîçøðé.com'));
 
         $validator->allowName = true;
 
@@ -37,12 +39,14 @@ class EmailValidatorTest extends TestCase
         $this->assertTrue($validator->validate('Carsten Brandt <mail@cebe.cc>'));
         $this->assertTrue($validator->validate('"Carsten Brandt" <mail@cebe.cc>'));
         $this->assertTrue($validator->validate('<mail@cebe.cc>'));
-        $this->assertFalse($validator->validate('info@örtliches.de'));
-        $this->assertFalse($validator->validate('sam@рмкреатиф.ru'));
+        $this->assertTrue($validator->validate('info@örtliches.de'));
+        $this->assertTrue($validator->validate('sam@рмкреатиф.ru'));
         $this->assertFalse($validator->validate('Informtation info@oertliches.de'));
         $this->assertTrue($validator->validate('test@example.com'));
         $this->assertTrue($validator->validate('John Smith <john.smith@example.com>'));
         $this->assertFalse($validator->validate('John Smith <example.com>'));
+        $this->assertTrue($validator->validate('üñîçøðé@example.com'));
+        $this->assertTrue($validator->validate('üñîçøðé@üñîçøðé.com'));
     }
 
     public function testValidateValueIdn()
@@ -66,6 +70,9 @@ class EmailValidatorTest extends TestCase
         $this->assertFalse($validator->validate('Carsten Brandt <mail@cebe.cc>'));
         $this->assertFalse($validator->validate('"Carsten Brandt" <mail@cebe.cc>'));
         $this->assertFalse($validator->validate('<mail@cebe.cc>'));
+        $this->assertTrue($validator->validate('üñîçøðé@example.com'));
+        $this->assertTrue($validator->validate('üñîçøðé@üñîçøðé.com'));
+
 
         $validator->allowName = true;
 
@@ -82,6 +89,8 @@ class EmailValidatorTest extends TestCase
         $this->assertTrue($validator->validate('test@example.com'));
         $this->assertTrue($validator->validate('John Smith <john.smith@example.com>'));
         $this->assertFalse($validator->validate('John Smith <example.com>'));
+        $this->assertTrue($validator->validate('üñîçøðé@example.com'));
+        $this->assertTrue($validator->validate('üñîçøðé@üñîçøðé.com'));
     }
 
     public function testValidateValueMx()


### PR DESCRIPTION
#9067: Email validator error on valid email

Regex in EmailValidator changed to accept unicode letter
