### PR TITLE
fix for #9059 - processed case when $args is not provided in stacktrace

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.6 under development
 -----------------------
-
+- Bug #9059: Fixed PHP Notice: Undefined index: args for Error Handling
 - Bug #7305: Logging of Exception objects resulted in failure of the logger i.e. no logs being written (cebe)
 - Bug #7374: Use proper INSERT syntax with default values when no values are specified (nineinchnick)
 - Bug #7707: client-side `trim` validator now passes the trimmed value to subsequent validators (nkovacs)

--- a/framework/views/errorHandler/exception.php
+++ b/framework/views/errorHandler/exception.php
@@ -370,7 +370,7 @@ html,body{
             <?= $handler->renderCallStackItem($exception->getFile(), $exception->getLine(), null, null, [], 1) ?>
             <?php for ($i = 0, $trace = $exception->getTrace(), $length = count($trace); $i < $length; ++$i): ?>
                 <?= $handler->renderCallStackItem(@$trace[$i]['file'] ?: null, @$trace[$i]['line'] ?: null,
-                    @$trace[$i]['class'] ?: null, @$trace[$i]['function'] ?: null, $trace[$i]['args'], $i + 2) ?>
+                    @$trace[$i]['class'] ?: null, @$trace[$i]['function'] ?: null, @$trace[$i]['args']?:[], $i + 2) ?>
             <?php endfor; ?>
         </ul>
     </div>


### PR DESCRIPTION
fix for #9059 
Processed case when $args is not provided in stacktrace
Processing done in the same way it's done for other ones parameters of exception handling
