### PR TITLE
fix for #9027 - UploadedFile early instantiation problem

### DIFF
--- a/framework/web/UploadedFile.php
+++ b/framework/web/UploadedFile.php
@@ -108,7 +108,7 @@ class UploadedFile extends Object
     public static function getInstanceByName($name)
     {
         $files = self::loadFiles();
-        return isset($files[$name]) ? $files[$name] : null;
+        return isset($files[$name]) ? new static($files[$name]) : null;
     }
 
     /**
@@ -124,12 +124,12 @@ class UploadedFile extends Object
     {
         $files = self::loadFiles();
         if (isset($files[$name])) {
-            return [$files[$name]];
+            return [new static($files[$name])];
         }
         $results = [];
         foreach ($files as $key => $file) {
             if (strpos($key, "{$name}[") === 0) {
-                $results[] = $file;
+                $results[] = new static($file);
             }
         }
         return $results;
@@ -224,13 +224,13 @@ class UploadedFile extends Object
                 self::loadFilesRecursive($key . '[' . $i . ']', $name, $tempNames[$i], $types[$i], $sizes[$i], $errors[$i]);
             }
         } elseif ($errors !== UPLOAD_ERR_NO_FILE) {
-            self::$_files[$key] = new static([
+            self::$_files[$key] = [
                 'name' => $names,
                 'tempName' => $tempNames,
                 'type' => $types,
                 'size' => $sizes,
                 'error' => $errors,
-            ]);
+            ];
         }
     }
 }

--- a/tests/framework/web/UploadedFileTest.php
+++ b/tests/framework/web/UploadedFileTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace yiiunit\framework\web;
+
+use yii\base\Model;
+use yiiunit\TestCase;
+use yii\web\UploadedFile;
+use yiiunit\framework\web\stubs\ProductImage;
+use yiiunit\framework\web\stubs\VendorImage;
+use yiiunit\framework\web\stubs\ImageModel;
+
+/**
+ * @group web
+ */
+class UploadedFileTest extends TestCase
+{
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mockApplication();
+        $this->generateFakeFiles();
+    }
+
+    public function testGetInstance()
+    {
+        $productImage = ProductImage::getInstance(new ImageModel(), 'prod_image');
+        $vendorImage = VendorImage::getInstance(new ImageModel(), 'vendor_image');
+
+        $this->assertInstanceOf('\yiiunit\framework\web\stubs\ProductImage', $productImage);
+        $this->assertInstanceOf('\yiiunit\framework\web\stubs\VendorImage', $vendorImage);
+    }
+
+    public function testGetInstances()
+    {
+        $productImages = ProductImage::getInstances(new ImageModel(), 'prod_images');
+        $vendorImages = VendorImage::getInstances(new ImageModel(), 'vendor_images');
+
+        foreach ($productImages as $productImage) {
+            $this->assertInstanceOf('\yiiunit\framework\web\stubs\ProductImage', $productImage);
+        }
+
+        foreach ($vendorImages as $vendorImage) {
+            $this->assertInstanceOf('\yiiunit\framework\web\stubs\VendorImage', $vendorImage);
+        }
+    }
+
+    private function generateFakeFileData()
+    {
+        return [
+            'name' => md5(mt_rand()),
+            'tmp_name' => md5(mt_rand()),
+            'type' => 'image/jpeg',
+            'size' => mt_rand(1000, 10000),
+            'error' => 0
+        ];
+    }
+
+    private function generateFakeFiles()
+    {
+        $_FILES['ImageModel[prod_image]'] = $this->generateFakeFileData();
+        $_FILES['ImageModel[prod_images][]'] = $this->generateFakeFileData();
+        $_FILES['ImageModel[prod_images][]'] = $this->generateFakeFileData();
+        $_FILES['ImageModel[prod_images][]'] = $this->generateFakeFileData();
+
+        $_FILES['ImageModel[vendor_image]'] = $this->generateFakeFileData();
+        $_FILES['ImageModel[vendor_images][]'] = $this->generateFakeFileData();
+        $_FILES['ImageModel[vendor_images][]'] = $this->generateFakeFileData();
+        $_FILES['ImageModel[vendor_images][]'] = $this->generateFakeFileData();
+    }
+}

--- a/tests/framework/web/stubs/ImageModel.php
+++ b/tests/framework/web/stubs/ImageModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace yiiunit\framework\web\stubs;
+
+use yii\base\Model;
+
+class ImageModel extends Model
+{
+
+}

--- a/tests/framework/web/stubs/ProductImage.php
+++ b/tests/framework/web/stubs/ProductImage.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace yiiunit\framework\web\stubs;
+
+use yii\web\UploadedFile;
+
+class ProductImage extends UploadedFile
+{
+
+}

--- a/tests/framework/web/stubs/VendorImage.php
+++ b/tests/framework/web/stubs/VendorImage.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace yiiunit\framework\web\stubs;
+
+use yii\web\UploadedFile;
+
+class VendorImage extends UploadedFile
+{
+
+}


### PR DESCRIPTION
fix for #9027 - UploadedFile early instantiation problem
To solve issue now class instance is created on demand when getInstance or getInstances called, not when loadFiles called
