### PR TITLE
Change private member variables to protected in class UrlRule

### DIFF
--- a/framework/web/UrlRule.php
+++ b/framework/web/UrlRule.php
@@ -91,19 +91,19 @@ class UrlRule extends Object implements UrlRuleInterface
     /**
      * @var string the template for generating a new URL. This is derived from [[pattern]] and is used in generating URL.
      */
-    protected $_template;
+    private $_template;
     /**
      * @var string the regex for matching the route part. This is used in generating URL.
      */
-    protected $_routeRule;
+    private $_routeRule;
     /**
      * @var array list of regex for matching parameters. This is used in generating URL.
      */
-    protected $_paramRules = [];
+    private $_paramRules = [];
     /**
      * @var array list of parameters used in the route.
      */
-    protected $_routeParams = [];
+    private $_routeParams = [];
 
 
     /**
@@ -340,5 +340,14 @@ class UrlRule extends Object implements UrlRuleInterface
         }
 
         return $url;
+    }
+
+    /**
+     * Allows read access to this rule's parameter keys and regexp rules.
+     * @return array parameter keys and regexp rules.
+     */
+    public function getParamRules() 
+    {
+        return $this->_paramRules;
     }
 }

--- a/framework/web/UrlRule.php
+++ b/framework/web/UrlRule.php
@@ -91,19 +91,19 @@ class UrlRule extends Object implements UrlRuleInterface
     /**
      * @var string the template for generating a new URL. This is derived from [[pattern]] and is used in generating URL.
      */
-    private $_template;
+    protected $_template;
     /**
      * @var string the regex for matching the route part. This is used in generating URL.
      */
-    private $_routeRule;
+    protected $_routeRule;
     /**
      * @var array list of regex for matching parameters. This is used in generating URL.
      */
-    private $_paramRules = [];
+    protected $_paramRules = [];
     /**
      * @var array list of parameters used in the route.
      */
-    private $_routeParams = [];
+    protected $_routeParams = [];
 
 
     /**


### PR DESCRIPTION
By changing the private member variables of class UrlRule to protected, they may be accessed by sub-classes of UrlRule (which in turn are specified by 'ruleConfig' => ['class' => 'app\src\components\UrlRule'], in UrlManager config).

$_paramRules is especially important to be able to determine expected parameters to a route.
