### PR TITLE
PageCache&FragmentCache property $variations forced to be a array

### DIFF
--- a/framework/filters/PageCache.php
+++ b/framework/filters/PageCache.php
@@ -95,7 +95,7 @@ class PageCache extends ActionFilter
      * ]
      * ~~~
      */
-    public $variations;
+    public $variations = [];
     /**
      * @var boolean whether to enable the page cache. You may use this property to turn on and off
      * the page cache according to specific setting (e.g. enable page cache only for GET requests).
@@ -253,11 +253,7 @@ class PageCache extends ActionFilter
         if ($this->varyByRoute) {
             $key[] = Yii::$app->requestedRoute;
         }
-        if (is_array($this->variations)) {
-            foreach ($this->variations as $value) {
-                $key[] = $value;
-            }
-        }
-        return $key;
+
+        return array_merge($key, $this->variations);
     }
 }

--- a/framework/widgets/FragmentCache.php
+++ b/framework/widgets/FragmentCache.php
@@ -63,7 +63,7 @@ class FragmentCache extends Widget
      *     Yii::$app->language,
      * ]
      */
-    public $variations;
+    public $variations = [];
     /**
      * @var boolean whether to enable the fragment cache. You may use this property to turn on and off
      * the fragment cache according to specific setting (e.g. enable fragment cache only for GET requests).
@@ -176,13 +176,6 @@ class FragmentCache extends Widget
      */
     protected function calculateKey()
     {
-        $factors = [__CLASS__, $this->getId()];
-        if (is_array($this->variations)) {
-            foreach ($this->variations as $factor) {
-                $factors[] = $factor;
-            }
-        }
-
-        return $factors;
+        return array_merge([__CLASS__, $this->getId()], $this->variations);
     }
 }


### PR DESCRIPTION
Before, if somebody made a mistake, for example:

`'variations' => Yii::$app->language` instead of `'variations' => [Yii::$app->language]`

then variations wouldn't work without any warning.
