### PR TITLE
Added validation of scopes in HttpBearerAuth

### DIFF
--- a/framework/filters/auth/HttpBearerAuth.php
+++ b/framework/filters/auth/HttpBearerAuth.php
@@ -33,6 +33,10 @@ class HttpBearerAuth extends AuthMethod
      */
     public $realm = 'api';
 
+    /**
+     * @var string|null available scopes
+     */
+    public $scopes = null;
 
     /**
      * @inheritdoc
@@ -41,7 +45,7 @@ class HttpBearerAuth extends AuthMethod
     {
         $authHeader = $request->getHeaders()->get('Authorization');
         if ($authHeader !== null && preg_match("/^Bearer\\s+(.*?)$/", $authHeader, $matches)) {
-            $identity = $user->loginByAccessToken($matches[1], get_class($this));
+            $identity = $user->loginByAccessToken($matches[1], get_class($this), $this->scopes);
             if ($identity === null) {
                 $this->handleFailure($response);
             }

--- a/framework/web/IdentityInterface.php
+++ b/framework/web/IdentityInterface.php
@@ -61,12 +61,13 @@ interface IdentityInterface
      * Finds an identity by the given token.
      * @param mixed $token the token to be looked for
      * @param mixed $type the type of the token. The value of this parameter depends on the implementation.
+     * @param mixed $scopes scopes of token
      * For example, [[\yii\filters\auth\HttpBearerAuth]] will set this parameter to be `yii\filters\auth\HttpBearerAuth`.
      * @return IdentityInterface the identity object that matches the given token.
      * Null should be returned if such an identity cannot be found
      * or the identity is not in an active state (disabled, deleted, etc.)
      */
-    public static function findIdentityByAccessToken($token, $type = null);
+    public static function findIdentityByAccessToken($token, $type = null, $scopes = null);
 
     /**
      * Returns an ID that can uniquely identify a user identity.

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -255,15 +255,16 @@ class User extends Component
      * If authentication fails or [[login()]] is unsuccessful, it will return null.
      * @param string $token the access token
      * @param mixed $type the type of the token. The value of this parameter depends on the implementation.
+     * @param string $scopes scopes of access token
      * For example, [[\yii\filters\auth\HttpBearerAuth]] will set this parameter to be `yii\filters\auth\HttpBearerAuth`.
      * @return IdentityInterface|null the identity associated with the given access token. Null is returned if
      * the access token is invalid or [[login()]] is unsuccessful.
      */
-    public function loginByAccessToken($token, $type = null)
+    public function loginByAccessToken($token, $type = null, $scopes = null)
     {
         /* @var $class IdentityInterface */
         $class = $this->identityClass;
-        $identity = $class::findIdentityByAccessToken($token, $type);
+        $identity = $class::findIdentityByAccessToken($token, $type, $scopes);
         if ($identity && $this->login($identity)) {
             return $identity;
         } else {

--- a/tests/framework/web/UserTest.php
+++ b/tests/framework/web/UserTest.php
@@ -115,7 +115,7 @@ class UserIdentity extends Component implements IdentityInterface
         }
     }
 
-    public static function findIdentityByAccessToken($token, $type = null)
+    public static function findIdentityByAccessToken($token, $type = null, $scopes = null)
     {
         throw new NotSupportedException();
     }


### PR DESCRIPTION
The use of Scope in an OAuth2 application is often key to proper permissioning. Scope is used to limit the authorization granted to the client by the resource owner.

For example:

``` php
$behaviors['authenticator'] = [
    'class' => CompositeAuth::className(),
    'authMethods' => [
        ['class' => HttpBearerAuth::className(), 'scopes' => 'wallet,music,video']
    ]
];
```

This code adds validation for scopes of accessToken

``` php
/**
 * Finds user by access token
 *
 * @param string $token
 * @param mixed $type
 * @param mixed $scopes
 *
 * @return static|null
 */
public static function findIdentityByAccessToken($token, $type = null, $scopes = null);
```

&#10071;**This code breaks backward compatibility, because changes the interface. Interface change yet can be canceled**&#10071;
