### PR TITLE
Allow link buttons inside another form when method/action set

### DIFF
--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -148,7 +148,9 @@ yii = (function ($) {
                 $form = $e.closest('form'),
                 action = $e.attr('href'),
                 params = $e.data('params');
-
+                
+            var newForm = !$form.length;
+            
             if (method === undefined) {
                 if (action && action != '#') {
                     window.location = action;
@@ -156,9 +158,10 @@ yii = (function ($) {
                     $form.trigger('submit');
                 }
                 return;
+            } else if (method.match(/(post)/i) && action && action != '#') {
+                newForm = true;
             }
 
-            var newForm = !$form.length;
             if (newForm) {
                 if (!action || !action.match(/(^\/|:\/\/)/)) {
                     action = window.location.href;


### PR DESCRIPTION
Adding the below link inside a form doesn't work as expected even though both url and method are set.

``` php
Html::a(
   'Delete',
    ['item/delete', 'id' => $item->id],
    [
        'data' => [
            'method' => 'post',
            'confirm' => Yii::t('app', 'Are you sure you want to delete this?'),
        ]
    ]
)
```
