### PR TITLE
Fix asset compression target to support asset bundle attributes other than basePath, baseUrl, js, and css.

### DIFF
--- a/framework/console/controllers/AssetController.php
+++ b/framework/console/controllers/AssetController.php
@@ -440,13 +440,11 @@ class AssetController extends Controller
         $array = [];
         foreach ($targets as $name => $target) {
             if (isset($this->targets[$name])) {
-                $array[$name] = [
+                $array[$name] = array_merge($this->targets[$name], [
                     'class' => get_class($target),
-                    'basePath' => $this->targets[$name]['basePath'],
-                    'baseUrl' => $this->targets[$name]['baseUrl'],
                     'js' => $target->js,
                     'css' => $target->css,
-                ];
+                ]);
             } else {
                 if ($this->isBundleExternal($target)) {
                     $array[$name] = $this->composeBundleConfig($target);


### PR DESCRIPTION
When I put a config in the asset compression target using 

```

    'targets' => [
        'all' => [
            'class' => 'yii\web\AssetBundle',
            'basePath' => '@webroot/assets',
            'baseUrl' => '@web/assets',
            'js' => 'js/all-{hash}.js',
            'css' => 'css/all-{hash}.css',
            'jsOptions' => ['some', 'options'],
        ],
    ],
```

or create a new custom `AssetBundle` with custom attribute for production.

```
class \my\custom\AssetBundle {
    public $foo;
}
```

all of the attributes except `baseUrl`, `basePath`, `js`, and `css` got disappear.

Wondering whether this is intended.
