### PR TITLE
Adds cases for newer JSON error codes.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -68,6 +68,7 @@ Yii Framework 2 Change Log
 - Enh #9249: Added `hashCallback` in `yii\web\AssetManager` to allow custom hash generation for asset directory (petrabarus)
 - Enh #9263: Avoid extra DB query in RBAC DbManager in case auth item name is empty (samdark)
 - Enh #9268: Improved display of boolean parameters in logged SQL queries (arkhamvm, samdark)
+- Enh #9282: Adding PHP 5.5 JSON error codes to JSON error handler (mcgrogan91)
 - Chg #6354: `ErrorHandler::logException()` will now log the whole exception object instead of only its string representation (cebe)
 - Chg #8556: Extracted `yii\web\User::getAuthManager()` method (samdark)
 - Chg #9181: `yii\helpers\BaseStringHelper::truncateHtml()` is now using `runtime` directory for `HTMLPurifier` cache (webdevsega)

--- a/framework/helpers/BaseJson.php
+++ b/framework/helpers/BaseJson.php
@@ -98,6 +98,12 @@ class BaseJson
                 throw new InvalidParamException('Invalid or malformed JSON.');
             case JSON_ERROR_UTF8:
                 throw new InvalidParamException('Malformed UTF-8 characters, possibly incorrectly encoded.');
+            case JSON_ERROR_RECURSION:
+                throw new InvalidParamException('One or more recursive references in the value to be encoded.');
+            case JSON_ERROR_INF_OR_NAN:
+                throw new InvalidParamException('One or more NAN or INF values in the value to be encoded.');
+            case JSON_ERROR_UNSUPPORTED_TYPE:
+                throw new InvalidParamException('A value of a type that cannot be encoded was given.');
             default:
                 throw new InvalidParamException('Unknown JSON decoding error.');
         }

--- a/framework/helpers/BaseJson.php
+++ b/framework/helpers/BaseJson.php
@@ -98,11 +98,11 @@ class BaseJson
                 throw new InvalidParamException('Invalid or malformed JSON.');
             case JSON_ERROR_UTF8:
                 throw new InvalidParamException('Malformed UTF-8 characters, possibly incorrectly encoded.');
-            case JSON_ERROR_RECURSION:
+            case 6: //JSON_ERROR_RECURSION
                 throw new InvalidParamException('One or more recursive references in the value to be encoded.');
-            case JSON_ERROR_INF_OR_NAN:
+            case 7: //JSON_ERROR_INF_OR_NAN
                 throw new InvalidParamException('One or more NAN or INF values in the value to be encoded.');
-            case JSON_ERROR_UNSUPPORTED_TYPE:
+            case 8: //JSON_ERROR_UNSUPPORTED_TYPE
                 throw new InvalidParamException('A value of a type that cannot be encoded was given.');
             default:
                 throw new InvalidParamException('Unknown JSON decoding error.');


### PR DESCRIPTION
Adds handling for PHP 5.5 JSON error codes JSON_ERROR_RECURSION, JSON_ERROR_INF_OR_NAN, and JSON_ERROR_UNSUPPORTED_TYPE in BaseJson::handleJsonError() related to #9282 
