### PR TITLE
Test find with params

### DIFF
--- a/tests/framework/ar/ActiveRecordTestTrait.php
+++ b/tests/framework/ar/ActiveRecordTestTrait.php
@@ -100,6 +100,11 @@ trait ActiveRecordTestTrait
         $this->assertTrue($customer instanceof $customerClass);
         $this->assertEquals(2, $customer->id);
 
+        // find with params
+        $customer = $customerClass::find()->where(['name' => ':user'])->params([':user' => 'user2'])->one();
+        $this->assertTrue($customer instanceof $customerClass);
+        $this->assertEquals(2, $customer->id);
+
         // scope
         $this->assertEquals(2, count($customerClass::find()->active()->all()));
         $this->assertEquals(2, $customerClass::find()->active()->count());


### PR DESCRIPTION
Find with params fails:

``` php
$customer = $customerClass::find()->where(['name' => ':user'])->params([':user' => 'user2'])->one();
```

`yii\db\Exception: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens`

Possible fix:

File: db\QueryBuilder.php

``` php
public function buildHashCondition($condition, &$params)
{
    $parts = [];
    foreach ($condition as $column => $value) {
        if (is_array($value) || $value instanceof Query) {
            // IN condition
            $parts[] = $this->buildInCondition('IN', [$column, $value], $params);
        } else {
            if (strpos($column, '(') === false) {
                $column = $this->db->quoteColumnName($column);
            }
            if ($value === null) {
                $parts[] = "$column IS NULL";
            } elseif ($value instanceof Expression) {
                $parts[] = "$column=" . $value->expression;
                foreach ($value->params as $n => $v) {
                    $params[$n] = $v;
                }
            } elseif (isset($params[$value])) {
                $parts[] = "$column=$value";
            } else {
                $phName = self::PARAM_PREFIX . count($params);
                $parts[] = "$column=$phName";
                $params[$phName] = $value;
            }
        }
    }
    return count($parts) === 1 ? $parts[0] : '(' . implode(') AND (', $parts) . ')';
}
```
