### PR TITLE
Session's get&has optimisations

### DIFF
--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -555,6 +555,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      */
     public function get($key, $defaultValue = null)
     {
+        if(!$this->getHasSessionId() && !$this->getIsActive()) return $defaultValue;
         $this->open();
         return isset($_SESSION[$key]) ? $_SESSION[$key] : $defaultValue;
     }
@@ -606,6 +607,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      */
     public function has($key)
     {
+        if(!$this->getHasSessionId() && !$this->getIsActive()) return false;
         $this->open();
         return isset($_SESSION[$key]);
     }


### PR DESCRIPTION
In the case when user didn't sent Session ID and we don't yet opened the session, variable is 100% not exist so we can return $defaultValue. This fix also protects from auto-opening the session when not necessary.

I'm digging in this issue because of flooding my db with empty sessions. This happens because of  this line in my controller `$session=Yii::$app->session;` without actually performing the `->get()` (not reached within if condition) + Yii Debug panel that call  `get->($session->flashParam)` after content already sent to user. 
In Debug panel's **RequestPanel**:

```
$session = Yii::$app->has('session', true) ? Yii::$app->get('session') : null;
        if ($session === null) {
            return [];
        }
```

So this check passes, `session->get->('__flash')` called and empty **__flash** object stored in Session storage but because of content already sent to user this happens again and again on every request.

I don't think saving fresh session to storage without actually sending PHPSESSID to user is good way. How we can fix this? 
