### PR TITLE
Added cookie validation whitelist

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.7 under development
 -----------------------
 
-
+- Enh #9158: Added `yii\web\Request::$cookieValidationWhitelist` to allow specific unsecure cookies in case cookie validation is enabled (kidol)
 
 2.0.6 August 05, 2015
 ---------------------

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -364,16 +364,10 @@ class Response extends \yii\base\Response
             return;
         }
         $request = Yii::$app->getRequest();
-        if ($request->enableCookieValidation) {
-            if ($request->cookieValidationKey == '') {
-                throw new InvalidConfigException(get_class($request) . '::cookieValidationKey must be configured with a secret key.');
-            }
-            $validationKey = $request->cookieValidationKey;
-        }
         foreach ($this->getCookies() as $cookie) {
             $value = $cookie->value;
-            if ($cookie->expire != 1  && isset($validationKey)) {
-                $value = Yii::$app->getSecurity()->hashData(serialize([$cookie->name, $value]), $validationKey);
+            if ($cookie->expire != 1 && $request->enableCookieValidation && !in_array((string)$cookie->name, $request->cookieValidationWhitelist, true)) {
+                $value = Yii::$app->getSecurity()->hashData(serialize([$cookie->name, $value]), $request->cookieValidationKey);
             }
             setcookie($cookie->name, $value, $cookie->expire, $cookie->path, $cookie->domain, $cookie->secure, $cookie->httpOnly);
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -67,6 +67,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         ], $config));
     }
 
+    protected function getRequest(array $config = [])
+    {
+        return new \yii\web\Request(array_merge(['cookieValidationKey' => 'dummy'], $config));
+    }
+    
     protected function getVendorPath()
     {
         $vendor = dirname(dirname(__DIR__)) . '/vendor';

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -21,6 +21,7 @@ class HtmlTest extends TestCase
                     'class' => 'yii\web\Request',
                     'url' => '/test',
                     'enableCsrfValidation' => false,
+                    'cookieValidationKey' => 'dummy',
                 ],
                 'response' => [
                     'class' => 'yii\web\Response',

--- a/tests/framework/helpers/UrlTest.php
+++ b/tests/framework/helpers/UrlTest.php
@@ -20,6 +20,7 @@ class UrlTest extends TestCase
             'components' => [
                 'request' => [
                     'class' => 'yii\web\Request',
+                    'cookieValidationKey' => 'dummy',
                     'scriptUrl' => '/base/index.php',
                     'hostInfo' => 'http://example.com/',
                     'url' => '/base/index.php&r=site%2Fcurrent&id=42'

--- a/tests/framework/rest/UrlRuleTest.php
+++ b/tests/framework/rest/UrlRuleTest.php
@@ -34,7 +34,7 @@ class UrlRuleTest extends TestCase
     public function testParseRequest()
     {
         $manager = new UrlManager(['cache' => null]);
-        $request = new Request(['hostInfo' => 'http://en.example.com', 'methodParam' => '_METHOD',]);
+        $request = new Request(['hostInfo' => 'http://en.example.com', 'methodParam' => '_METHOD', 'cookieValidationKey' => 'dummy']);
         $suites = $this->getTestsForParseRequest();
         foreach ($suites as $i => $suite) {
             list ($name, $config, $tests) = $suite;

--- a/tests/framework/web/GroupUrlRuleTest.php
+++ b/tests/framework/web/GroupUrlRuleTest.php
@@ -36,7 +36,7 @@ class GroupUrlRuleTest extends TestCase
     public function testParseRequest()
     {
         $manager = new UrlManager(['cache' => null]);
-        $request = new Request(['hostInfo' => 'http://en.example.com']);
+        $request = $this->getRequest(['hostInfo' => 'http://en.example.com']);
         $suites = $this->getTestsForParseRequest();
         foreach ($suites as $i => $suite) {
             list ($name, $config, $tests) = $suite;

--- a/tests/framework/web/RequestTest.php
+++ b/tests/framework/web/RequestTest.php
@@ -17,7 +17,7 @@ class RequestTest extends TestCase
 {
     public function testParseAcceptHeader()
     {
-        $request = new Request;
+        $request = $this->getRequest();
 
         $this->assertEquals([], $request->parseAcceptHeader(' '));
 
@@ -44,37 +44,37 @@ class RequestTest extends TestCase
             'language' => 'en',
         ]);
 
-        $request = new Request();
+        $request = $this->getRequest();
         $request->acceptableLanguages = [];
         $this->assertEquals('en', $request->getPreferredLanguage());
 
-        $request = new Request();
+        $request = $this->getRequest();
         $request->acceptableLanguages = ['de'];
         $this->assertEquals('en', $request->getPreferredLanguage());
 
-        $request = new Request();
+        $request = $this->getRequest();
         $request->acceptableLanguages = ['en-us', 'de', 'ru-RU'];
         $this->assertEquals('en', $request->getPreferredLanguage(['en']));
 
-        $request = new Request();
+        $request = $this->getRequest();
         $request->acceptableLanguages = ['en-us', 'de', 'ru-RU'];
         $this->assertEquals('de', $request->getPreferredLanguage(['ru', 'de']));
         $this->assertEquals('de-DE', $request->getPreferredLanguage(['ru', 'de-DE']));
 
-        $request = new Request();
+        $request = $this->getRequest();
         $request->acceptableLanguages = ['en-us', 'de', 'ru-RU'];
         $this->assertEquals('de', $request->getPreferredLanguage(['de', 'ru']));
 
-        $request = new Request();
+        $request = $this->getRequest();
         $request->acceptableLanguages = ['en-us', 'de', 'ru-RU'];
         $this->assertEquals('ru-ru', $request->getPreferredLanguage(['ru-ru']));
 
-        $request = new Request();
+        $request = $this->getRequest();
         $request->acceptableLanguages = ['en-us', 'de'];
         $this->assertEquals('ru-ru', $request->getPreferredLanguage(['ru-ru', 'pl']));
         $this->assertEquals('ru-RU', $request->getPreferredLanguage(['ru-RU', 'pl']));
 
-        $request = new Request();
+        $request = $this->getRequest();
         $request->acceptableLanguages = ['en-us', 'de'];
         $this->assertEquals('pl', $request->getPreferredLanguage(['pl', 'ru-ru']));
     }
@@ -83,7 +83,7 @@ class RequestTest extends TestCase
     {
         $this->mockWebApplication();
 
-        $request = new Request();
+        $request = $this->getRequest();
         $request->enableCsrfCookie = false;
 
         $token = $request->getCsrfToken();
@@ -107,7 +107,7 @@ class RequestTest extends TestCase
             ]
         ]);
 
-        $request = new Request();
+        $request = $this->getRequest();
         $request->pathInfo = 'posts';
 
         $_GET['page'] = 1;
@@ -127,7 +127,7 @@ class RequestTest extends TestCase
 
         unset($_GET['page']);
 
-        $request = new Request();
+        $request = $this->getRequest();
         $request->pathInfo = 'post/21';
 
         $this->assertEquals($_GET, []);

--- a/tests/framework/web/UrlManagerTest.php
+++ b/tests/framework/web/UrlManagerTest.php
@@ -211,7 +211,7 @@ class UrlManagerTest extends TestCase
     public function testParseRequest()
     {
         $manager = new UrlManager(['cache' => null]);
-        $request = new Request;
+        $request = $this->getRequest();
 
         // default setting without 'r' param
         unset($_GET['r']);
@@ -340,7 +340,7 @@ class UrlManagerTest extends TestCase
 
     public function testParseRESTRequest()
     {
-        $request = new Request;
+        $request = $this->getRequest();
 
         // pretty URL rules
         $manager = new UrlManager([
@@ -380,7 +380,8 @@ class UrlManagerTest extends TestCase
             'components' => [
                 'request' => [
                     'hostInfo' => 'http://localhost/',
-                    'baseUrl' => '/app'
+                    'baseUrl' => '/app',
+                    'cookieValidationKey' => 'dummy',
                 ]
             ]
         ], \yii\web\Application::className());

--- a/tests/framework/web/UrlRuleTest.php
+++ b/tests/framework/web/UrlRuleTest.php
@@ -36,7 +36,7 @@ class UrlRuleTest extends TestCase
     public function testParseRequest()
     {
         $manager = new UrlManager(['cache' => null]);
-        $request = new Request(['hostInfo' => 'http://en.example.com']);
+        $request = $this->getRequest(['hostInfo' => 'http://en.example.com']);
         $suites = $this->getTestsForParseRequest();
         foreach ($suites as $i => $suite) {
             list ($name, $config, $tests) = $suite;


### PR DESCRIPTION
Fixes #9158

I don't understand the reasoning for doing the `cookieValidationKey`-check in 2 different methods. So I added this check to `Request::init()` instead.
