### PR TITLE
Fix documentation of client-side functions

### DIFF
--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -135,7 +135,7 @@
         name: undefined,
         // the jQuery selector of the container of the input field
         container: undefined,
-        // the jQuery selector of the input field under the context of the container
+        // the jQuery selector of the input field under the context of the form
         input: undefined,
         // the jQuery selector of the error tag under the context of the container
         error: '.help-block',

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -308,7 +308,7 @@ class Validator extends Component
      * - `$form`: a jQuery object containing the form element
      *
      * The `attribute` object contains the following properties:
-     * - `id`: the ID of the input element
+     * - `id`: a unique ID identifying an attribute (e.g. "loginform-username") in a form
      * - `name`: the name attribute of the input element
      * - `container`: the jQuery selector of the container of the input field
      * - `input`: the jQuery selector of the input field under the context of the container

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -156,7 +156,8 @@ class Validator extends Component
     /**
      * @var string a JavaScript function name whose return value determines whether this validator should be applied
      * on the client side. The signature of the function should be `function (attribute, value)`, where
-     * `attribute` is the name of the attribute being validated and `value` the current value of the attribute.
+     * `attribute` is an object describing the attribute being validated (see [[clientValidateAttribute()]])
+     * and `value` the current value of the attribute.
      *
      * This property is mainly provided to support conditional validation on the client side.
      * If this property is not set, this validator will be always applied on the client side.
@@ -300,11 +301,19 @@ class Validator extends Component
      *
      * The following JavaScript variables are predefined and can be used in the validation code:
      *
-     * - `attribute`: the name of the attribute being validated.
+     * - `attribute`: an object describing the the attribute being validated.
      * - `value`: the value being validated.
      * - `messages`: an array used to hold the validation error messages for the attribute.
      * - `deferred`: an array used to hold deferred objects for asynchronous validation
+     * - `$form`: a jQuery object containing the form element
      *
+     * The `attribute` object contains the following properties:
+     * - `id`: the ID of the input element
+     * - `name`: the name attribute of the input element
+     * - `container`: the jQuery selector of the container of the input field
+     * - `input`: the jQuery selector of the input field under the context of the container
+     * - `error`: the jQuery selector of the error tag under the context of the container
+     * 
      * @param \yii\base\Model $model the data model being validated
      * @param string $attribute the name of the attribute to be validated.
      * @param \yii\web\View $view the view object that is going to be used to render views or view files

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -313,6 +313,7 @@ class Validator extends Component
      * - `container`: the jQuery selector of the container of the input field
      * - `input`: the jQuery selector of the input field under the context of the form
      * - `error`: the jQuery selector of the error tag under the context of the container
+     * - `status`: status of the input field, 0: empty, not entered before, 1: validated, 2: pending validation, 3: validating
      *
      * @param \yii\base\Model $model the data model being validated
      * @param string $attribute the name of the attribute to be validated.

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -311,9 +311,9 @@ class Validator extends Component
      * - `id`: a unique ID identifying the attribute (e.g. "loginform-username") in the form
      * - `name`: attribute name or expression (e.g. "[0]content" for tabular input)
      * - `container`: the jQuery selector of the container of the input field
-     * - `input`: the jQuery selector of the input field under the context of the container
+     * - `input`: the jQuery selector of the input field under the context of the form
      * - `error`: the jQuery selector of the error tag under the context of the container
-     * 
+     *
      * @param \yii\base\Model $model the data model being validated
      * @param string $attribute the name of the attribute to be validated.
      * @param \yii\web\View $view the view object that is going to be used to render views or view files

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -308,8 +308,8 @@ class Validator extends Component
      * - `$form`: a jQuery object containing the form element
      *
      * The `attribute` object contains the following properties:
-     * - `id`: a unique ID identifying an attribute (e.g. "loginform-username") in a form
-     * - `name`: the name attribute of the input element
+     * - `id`: a unique ID identifying the attribute (e.g. "loginform-username") in the form
+     * - `name`: attribute name or expression (e.g. "[0]content" for tabular input)
      * - `container`: the jQuery selector of the container of the input field
      * - `input`: the jQuery selector of the input field under the context of the container
      * - `error`: the jQuery selector of the error tag under the context of the container


### PR DESCRIPTION
Fixed the documentation of the attribute variable, and added $form to clientValidateAttribute.

I only documented those properties of `attribute` that I felt were useful to these functions.

Fixes #8822, #9298
