### PR TITLE
DataGrid selectedRows fix for $showHeader=false #9074

### DIFF
--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -119,7 +119,7 @@
             var $grid = $(this);
             var id = $(this).attr('id');
             gridData[id].selectionColumn = options.name;
-            if (!options.multiple) {
+            if (!options.multiple || !options.checkAll) {
                 return;
             }
             var checkAll = "#" + id + " input[name='" + options.checkAll + "']";

--- a/framework/grid/CheckboxColumn.php
+++ b/framework/grid/CheckboxColumn.php
@@ -81,6 +81,15 @@ class CheckboxColumn extends Column
         if (substr_compare($this->name, '[]', -2, 2)) {
             $this->name .= '[]';
         }
+
+        $name = $this->grid->showHeader ? $this->getHeaderCheckBoxName() : NULL;
+        $id = $this->grid->options['id'];
+        $options = json_encode([
+            'name' => $this->name,
+            'multiple' => $this->multiple,
+            'checkAll' => $name,
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->grid->getView()->registerJs("jQuery('#$id').yiiGridView('setSelectionColumn', $options);");
     }
 
     /**
@@ -91,18 +100,10 @@ class CheckboxColumn extends Column
      */
     protected function renderHeaderCellContent()
     {
-        $name = rtrim($this->name, '[]') . '_all';
-        $id = $this->grid->options['id'];
-        $options = json_encode([
-            'name' => $this->name,
-            'multiple' => $this->multiple,
-            'checkAll' => $name,
-        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        $this->grid->getView()->registerJs("jQuery('#$id').yiiGridView('setSelectionColumn', $options);");
-
         if ($this->header !== null || !$this->multiple) {
             return parent::renderHeaderCellContent();
         } else {
+            $name = $this->getHeaderCheckBoxName();
             return Html::checkBox($name, false, ['class' => 'select-on-check-all']);
         }
     }
@@ -122,5 +123,14 @@ class CheckboxColumn extends Column
         }
 
         return Html::checkbox($this->name, !empty($options['checked']), $options);
+    }
+
+    /**
+     * Returns header checkbox name
+     * @return string header checkbox name
+     */
+    private function getHeaderCheckBoxName()
+    {
+        return rtrim($this->name, '[]') . '_all';
     }
 }

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -272,6 +272,11 @@ class GridView extends BaseListView
             $this->filterRowOptions['id'] = $this->options['id'] . '-filters';
         }
 
+        $id = $this->options['id'];
+        $options = Json::htmlEncode($this->getClientOptions());
+        $view = $this->getView();
+        $view->registerJs("jQuery('#$id').yiiGridView($options);");
+
         $this->initColumns();
     }
 
@@ -280,11 +285,9 @@ class GridView extends BaseListView
      */
     public function run()
     {
-        $id = $this->options['id'];
-        $options = Json::htmlEncode($this->getClientOptions());
         $view = $this->getView();
         GridViewAsset::register($view);
-        $view->registerJs("jQuery('#$id').yiiGridView($options);");
+
         parent::run();
     }
 


### PR DESCRIPTION
I just fixed issue #9074. 
Problem was due to column not initialized if `$showHeader=false`, cause column initialization code was placed in `renderHeaderCellContent`. And i moved `GridView`  JS initializer to `init();` instead of `run()` because `GridView` should be initialized  before its columns.
