### PR TITLE
Fixed link in REST doc to point to correct page

### DIFF
--- a/docs/guide/rest-controllers.md
+++ b/docs/guide/rest-controllers.md
@@ -22,7 +22,7 @@ will be described in detail in the next few sections:
 [[yii\rest\ActiveController]] in addition provides the following features:
 
 * A set of commonly needed actions: `index`, `view`, `create`, `update`, `delete`, `options`;
-* User authorization in regarding to the requested action and resource.
+* User authorization in regard to the requested action and resource.
 
 
 ## Creating Controller Classes <span id="creating-controller"></span>

--- a/docs/guide/rest-quick-start.md
+++ b/docs/guide/rest-quick-start.md
@@ -185,7 +185,7 @@ For example, the URL `http://localhost/users?fields=id,email` will only return t
 
 > Info: You may have noticed that the result of `http://localhost/users` includes some sensitive fields,
 > such as `password_hash`, `auth_key`. You certainly do not want these to appear in your API result.
-> You can and should filter out these fields as described in the [Response Formatting](rest-response-formatting.md) section.
+> You can and should filter out these fields as described in the [Resources](rest-resources.md) section.
 
 
 ## Summary <span id="summary"></span>


### PR DESCRIPTION
Filtering out fields is not described in the Response Formatting section but in the Resources section.
