### PR TITLE
Removed yii\db\Schema from use section

### DIFF
--- a/framework/views/migration.php
+++ b/framework/views/migration.php
@@ -8,11 +8,11 @@
 echo "<?php\n";
 ?>
 
-use yii\db\Schema;
 use yii\db\Migration;
 
 class <?= $className ?> extends Migration
 {
+
     public function up()
     {
 


### PR DESCRIPTION
Declaration of yii\db\Schema is not needed by default. Migration can be related with changing data or renaming column, so user should explicitly add it when it's needed.

And by the way use classes were not it alphabetical order.
