### PR TITLE
Comment methods for schema builder

### DIFF
--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -110,7 +110,7 @@ class ColumnSchemaBuilder extends Object
 
     /**
      * Specify the comment for the column.
-     * @param $comment the comment
+     * @param string $comment the comment
      * @return $this
      */
     public function comment($comment)

--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -49,7 +49,7 @@ class ColumnSchemaBuilder extends Object
     /**
      * @var mixed comment value of the column.
      */
-    protected $comment;
+    public $comment;
 
 
     /**

--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -46,6 +46,10 @@ class ColumnSchemaBuilder extends Object
      * @var mixed default value of the column.
      */
     protected $default;
+    /**
+     * @var mixed comment value of the column.
+     */
+    protected $comment;
 
 
     /**
@@ -105,6 +109,17 @@ class ColumnSchemaBuilder extends Object
     }
 
     /**
+     * Specify the comment for the column.
+     * @param $comment the comment
+     * @return $this
+     */
+    public function comment($comment)
+    {
+        $this->comment = $comment;
+        return $this;
+    }
+
+    /**
      * Build full string for create the column's schema
      * @return string
      */
@@ -116,7 +131,8 @@ class ColumnSchemaBuilder extends Object
             $this->buildNotNullString() .
             $this->buildUniqueString() .
             $this->buildDefaultString() .
-            $this->buildCheckString();
+            $this->buildCheckString() .
+            $this->buildCommentString();
     }
 
     /**
@@ -188,5 +204,14 @@ class ColumnSchemaBuilder extends Object
     protected function buildCheckString()
     {
         return $this->check !== null ? " CHECK ({$this->check})" : '';
+    }
+
+    /**
+     * Builds the comment specification for the column.
+     * @return string with comment.
+     */
+    protected function buildCommentString()
+    {
+        return $this->comment !== null ? " COMMENT '{$this->comment}'" : '';
     }
 }

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -754,6 +754,62 @@ class Command extends Component
     }
 
     /**
+     * Builds a SQL command for adding comment to column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function addCommentOnColumn($table, $column, $comment)
+    {
+        $sql = $this->db->getQueryBuilder()->addCommentOnColumn($table, $column, $comment);
+
+        return $this->setSql($sql);
+    }
+
+    /**
+     * Builds a SQL command for adding comment to table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function addCommentOnTable($table, $comment)
+    {
+        $sql = $this->db->getQueryBuilder()->addCommentOnTable($table, $comment);
+
+        return $this->setSql($sql);
+    }
+
+    /**
+     * Builds a SQL command for dropping comment from column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromColumn($table, $column)
+    {
+        $sql = $this->db->getQueryBuilder()->dropCommentFromColumn($table, $column);
+
+        return $this->setSql($sql);
+    }
+
+    /**
+     * Builds a SQL command for dropping comment from table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromTable($table)
+    {
+        $sql = $this->db->getQueryBuilder()->dropCommentFromTable($table);
+
+        return $this->setSql($sql);
+    }
+
+    /**
      * Executes the SQL statement.
      * This method should only be used for executing non-query SQL statement, such as `INSERT`, `DELETE`, `UPDATE` SQLs.
      * No result set will be returned.

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -8,6 +8,7 @@
 namespace yii\db;
 
 use yii\base\Component;
+use yii\db\ColumnSchemaBuilder;
 use yii\di\Instance;
 
 /**
@@ -258,6 +259,11 @@ class Migration extends Component implements MigrationInterface
         echo "    > create table $table ...";
         $time = microtime(true);
         $this->db->createCommand()->createTable($table, $columns, $options)->execute();
+        foreach ($columns as $column => $type) {
+            if ($type instanceof ColumnSchemaBuilder && $type->comment !== null) {
+                $this->db->createCommand()->addCommentOnColumn($table, $column, $type->comment)->execute();
+            }
+        }
         echo " done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
     }
 
@@ -311,6 +317,9 @@ class Migration extends Component implements MigrationInterface
         echo "    > add column $column $type to table $table ...";
         $time = microtime(true);
         $this->db->createCommand()->addColumn($table, $column, $type)->execute();
+        if ($type instanceof ColumnSchemaBuilder && $type->comment !== null) {
+            $this->db->createCommand()->addCommentOnColumn($table, $column, $type->comment)->execute();
+        }
         echo " done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
     }
 
@@ -354,6 +363,11 @@ class Migration extends Component implements MigrationInterface
         echo "    > alter column $column in table $table to $type ...";
         $time = microtime(true);
         $this->db->createCommand()->alterColumn($table, $column, $type)->execute();
+
+        if ($type instanceof ColumnSchemaBuilder && $type->comment !== null) {
+            $this->db->createCommand()->addCommentOnColumn($table, $column, $type->comment)->execute();
+        }
+
         echo " done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
     }
 

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -8,7 +8,6 @@
 namespace yii\db;
 
 use yii\base\Component;
-use yii\db\ColumnSchemaBuilder;
 use yii\di\Instance;
 
 /**

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -446,4 +446,64 @@ class Migration extends Component implements MigrationInterface
         $this->db->createCommand()->dropIndex($name, $table)->execute();
         echo " done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
     }
+
+    /**
+     * Builds and execute a SQL statement for adding comment to column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function addCommentOnColumn($table, $column, $comment)
+    {
+        echo "    > add comment on column $column ...";
+        $time = microtime(true);
+        $this->db->createCommand()->addCommentOnColumn($table, $column, $comment)->execute();
+        echo " done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
+    }
+
+    /**
+     * Builds a SQL statement for adding comment to table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function addCommentOnTable($table, $comment)
+    {
+        echo "    > add comment on table $table ...";
+        $time = microtime(true);
+        $this->db->createCommand()->addCommentOnTable($table, $comment)->execute();
+        echo " done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
+    }
+
+    /**
+     * Builds and execute a SQL statement for dropping comment from column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromColumn($table, $column)
+    {
+        echo "    > drop comment from column $column ...";
+        $time = microtime(true);
+        $this->db->createCommand()->dropCommentFromColumn($table, $column, $comment)->execute();
+        echo " done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
+    }
+
+    /**
+     * Builds a SQL statement for dropping comment from table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromTable($table)
+    {
+        echo "    > drop comment from table $table ...";
+        $time = microtime(true);
+        $this->db->createCommand()->dropCommentFromTable($table, $comment)->execute();
+        echo " done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
+    }
 }

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -553,6 +553,54 @@ class QueryBuilder extends \yii\base\Object
     }
 
     /**
+     * Builds a SQL command for adding comment to column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function addCommentOnColumn($table, $column, $comment)
+    {
+        return 'COMMENT ON COLUMN ' . $this->db->quoteTableName($table) . '.' . $this->db->quoteColumnName($column) . ' IS ' . $this->db->quoteValue($comment);
+    }
+
+    /**
+     * Builds a SQL command for adding comment to table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function addCommentOnTable($table, $comment)
+    {
+        return 'COMMENT ON TABLE ' . $this->db->quoteTableName($table) . ' IS ' . $this->db->quoteValue($comment);
+    }
+
+    /**
+     * Builds a SQL command for adding comment to column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromColumn($table, $column)
+    {
+        return 'COMMENT ON COLUMN ' . $this->db->quoteTableName($table) . '.' . $this->db->quoteColumnName($column) . ' IS NULL';
+    }
+
+    /**
+     * Builds a SQL command for adding comment to table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromTable($table)
+    {
+        return 'COMMENT ON TABLE ' . $this->db->quoteTableName($table) . ' IS NULL';
+    }
+
+    /**
      * Converts an abstract column type into a physical column type.
      * The conversion is done using the type map specified in [[typeMap]].
      * The following abstract column types are supported (using MySQL as an example to explain the corresponding

--- a/framework/db/cubrid/QueryBuilder.php
+++ b/framework/db/cubrid/QueryBuilder.php
@@ -191,7 +191,9 @@ class QueryBuilder extends \yii\db\QueryBuilder
             $row = array_values($row);
             $sql = $row[1];
         }
-        if (preg_match_all('/^\s*`(.*?)`\s+(.*?),?$/m', $sql, $matches)) {
+        $sql = preg_replace('/^[^(]+\((.*)\).*$/', '\1', $sql);
+        $sql = str_replace(', [', ",\n[", $sql);
+        if (preg_match_all('/^\s*\[(.*?)\]\s+(.*?),?$/m', $sql, $matches)) {
             foreach ($matches[1] as $i => $c) {
                 if ($c === $column) {
                     return $matches[2][$i];

--- a/framework/db/cubrid/QueryBuilder.php
+++ b/framework/db/cubrid/QueryBuilder.php
@@ -8,6 +8,7 @@
 namespace yii\db\cubrid;
 
 use yii\base\InvalidParamException;
+use yii\db\Exception;
 
 /**
  * QueryBuilder is the query builder for CUBRID databases (version 9.3.x and higher).
@@ -90,5 +91,113 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         return $sql;
+    }
+
+    /**
+     * Builds a SQL command for adding comment to column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function addCommentOnColumn($table, $column, $comment)
+    {
+        $quotedTable = $this->db->quoteTableName($table);
+        $definition = $this->getColumnDefinition($quotedTable, $column);
+        $definition = trim(preg_replace("/COMMENT '(.*?)'/i", '', $definition));
+        return sprintf(
+            'ALTER TABLE %s CHANGE %s %s%s COMMENT %s',
+            $quotedTable,
+            $this->db->quoteColumnName($column),
+            $this->db->quoteColumnName($column),
+            empty($definition) ? '' : ' ' . $definition,
+            $this->db->quoteValue($comment)
+        );
+    }
+
+    /**
+     * Builds a SQL command for adding comment to table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function addCommentOnTable($table, $comment)
+    {
+        $quotedTable = $this->db->quoteTableName($table);
+        return sprintf(
+            'ALTER TABLE %s COMMENT %s',
+            $quotedTable,
+            $this->db->quoteValue($comment)
+        );
+    }
+
+    /**
+     * Builds a SQL command for adding comment to column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromColumn($table, $column)
+    {
+        $quotedTable = $this->db->quoteTableName($table);
+        $definition = $this->getColumnDefinition($quotedTable, $column);
+        $definition = trim(preg_replace("/COMMENT '(.*?)'/i", '', $definition));
+        return sprintf(
+            'ALTER TABLE %s CHANGE %s %s%s COMMENT \'\'',
+            $quotedTable,
+            $this->db->quoteColumnName($column),
+            $this->db->quoteColumnName($column),
+            empty($definition) ? '' : ' ' . $definition
+        );
+    }
+
+    /**
+     * Builds a SQL command for adding comment to table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromTable($table)
+    {
+        $quotedTable = $this->db->quoteTableName($table);
+        return sprintf(
+            "ALTER TABLE %s COMMENT ''",
+            $quotedTable,
+            empty($definition) ? '' : ' ' . $definition
+        );
+    }
+
+
+    /**
+     * Gets column definition.
+     *
+     * @param string $table table name
+     * @param string $column column name
+     * @return null|string the column definition
+     * @throws Exception in case when table does not contain column
+     */
+    private function getColumnDefinition($table, $column)
+    {
+        $row = $this->db->createCommand('SHOW CREATE TABLE ' . $table)->queryOne();
+        if ($row === false) {
+            throw new Exception("Unable to find column '$column' in table '$table'.");
+        }
+        if (isset($row['Create Table'])) {
+            $sql = $row['Create Table'];
+        } else {
+            $row = array_values($row);
+            $sql = $row[1];
+        }
+        if (preg_match_all('/^\s*`(.*?)`\s+(.*?),?$/m', $sql, $matches)) {
+            foreach ($matches[1] as $i => $c) {
+                if ($c === $column) {
+                    return $matches[2][$i];
+                }
+            }
+        }
+        return null;
     }
 }

--- a/framework/db/mssql/ColumnSchemaBuilder.php
+++ b/framework/db/mssql/ColumnSchemaBuilder.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db\mssql;
+
+use yii\db\ColumnSchemaBuilder as AbstractColumnSchemaBuilder;
+
+/**
+ * ColumnSchemaBuilder is the schema builder for Oracle databases.
+ *
+ * @author Vasenin Matvey <vaseninm@gmail.com>
+ * @since 2.0.6
+ */
+class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
+{
+    /**
+     * @inheritdoc
+     */
+
+    protected function buildCommentString()
+    {
+        return '';
+    }
+}

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -185,6 +185,53 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
+     * Builds a SQL command for adding comment to column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function addCommentOnColumn($table, $column, $comment)
+    {
+        return "sp_updateextendedproperty @name = N'MS_Description', @value = {$this->db->quoteValue($comment)}, @level1type = N'Table',  @level1name = {$this->db->quoteTableName($table)}, @level2type = N'Column', @level2name = {$this->db->quoteColumnName($column)}";
+    }
+
+    /**
+     * Builds a SQL command for adding comment to table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function addCommentOnTable($table, $comment)
+    {
+        return "sp_updateextendedproperty @name = N'MS_Description', @value = {$this->db->quoteValue($comment)}, @level1type = N'Table',  @level1name = {$this->db->quoteTableName($table)}";
+    }
+    /**
+     * Builds a SQL command for adding comment to column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromColumn($table, $column)
+    {
+        return "sp_dropextendedproperty @name = N'MS_Description', @level1type = N'Table',  @level1name = {$this->db->quoteTableName($table)}, @level2type = N'Column', @level2name = {$this->db->quoteColumnName($column)}";
+    }
+
+    /**
+     * Builds a SQL command for adding comment to table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromTable($table)
+    {
+        return "sp_dropextendedproperty @name = N'MS_Description', @level1type = N'Table',  @level1name = {$this->db->quoteTableName($table)}";
+    }
+
+    /**
      * Returns an array of column names given model name
      *
      * @param string $modelClass name of the model class

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -125,6 +125,14 @@ class Schema extends \yii\db\Schema
     }
 
     /**
+     * @inheritdoc
+     */
+    public function createColumnSchemaBuilder($type, $length = null)
+    {
+        return new ColumnSchemaBuilder($type, $length);
+    }
+
+    /**
      * Loads the metadata for the specified table.
      * @param string $name table name
      * @return TableSchema|null driver dependent table metadata. Null if the table does not exist.

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -257,4 +257,27 @@ EOD;
 
         return 'INSERT ALL ' . $tableAndColumns . implode($tableAndColumns, $values) . ' SELECT 1 FROM SYS.DUAL';
     }
+
+    /**
+     * Builds a SQL command for adding comment to column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromColumn($table, $column)
+    {
+        return 'COMMENT ON COLUMN ' . $this->db->quoteTableName($table) . '.' . $this->db->quoteColumnName($column) . " IS ' '";
+    }
+
+    /**
+     * Builds a SQL command for adding comment to table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @return $this the command object itself
+     */
+    public function dropCommentFromTable($table)
+    {
+        return 'COMMENT ON TABLE ' . $this->db->quoteTableName($table) . " IS ' '";
+    }
 }

--- a/framework/db/pgsql/ColumnSchemaBuilder.php
+++ b/framework/db/pgsql/ColumnSchemaBuilder.php
@@ -5,29 +5,24 @@
  * @license http://www.yiiframework.com/license/
  */
 
-namespace yii\db\oci;
+namespace yii\db\pgsql;
 
 use yii\db\ColumnSchemaBuilder as AbstractColumnSchemaBuilder;
 
 /**
- * ColumnSchemaBuilder is the schema builder for Oracle databases.
+ * ColumnSchemaBuilder is the schema builder for Postgres databases.
  *
  * @author Vasenin Matvey <vaseninm@gmail.com>
  * @since 2.0.6
  */
 class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
 {
+
     /**
      * @inheritdoc
      */
-    public function __toString()
+    protected function buildCommentString()
     {
-        return
-            $this->type .
-            $this->buildLengthString() .
-            $this->buildDefaultString() .
-            $this->buildNotNullString() .
-            $this->buildCheckString() .
-            $this->buildCommentString();
+        return '';
     }
 }

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -118,6 +118,14 @@ class Schema extends \yii\db\Schema
     }
 
     /**
+     * @inheritdoc
+     */
+    public function createColumnSchemaBuilder($type, $length = null)
+    {
+        return new ColumnSchemaBuilder($type, $length);
+    }
+
+    /**
      * Resolves the table name and schema name (if any).
      * @param TableSchema $table the table metadata object
      * @param string $name the table name

--- a/framework/db/sqlite/ColumnSchemaBuilder.php
+++ b/framework/db/sqlite/ColumnSchemaBuilder.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db\sqlite;
+
+use yii\base\NotSupportedException;
+use yii\db\ColumnSchemaBuilder as AbstractColumnSchemaBuilder;
+
+/**
+ * ColumnSchemaBuilder is the schema builder for Postgres databases.
+ *
+ * @author Vasenin Matvey <vaseninm@gmail.com>
+ * @since 2.0.6
+ */
+class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
+{
+    /**
+     * Specify the comment for the column.
+     * @param string $comment the comment
+     * @return $this
+     * @throws NotSupportedException this is not supported by SQLite
+     */
+    public function comment($comment)
+    {
+        throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    protected function buildCommentString()
+    {
+        return '';
+    }
+}

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -276,6 +276,58 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
+     * Builds a SQL command for adding comment to column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     * @throws NotSupportedException this is not supported by SQLite
+     */
+    public function addCommentOnColumn($table, $column, $comment)
+    {
+        throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');
+    }
+
+    /**
+     * Builds a SQL command for adding comment to table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     * @return $this the command object itself
+     * @throws NotSupportedException this is not supported by SQLite
+     */
+    public function addCommentOnTable($table, $comment)
+    {
+        throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');
+    }
+
+    /**
+     * Builds a SQL command for adding comment to column
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @return $this the command object itself
+     * @throws NotSupportedException this is not supported by SQLite
+     */
+    public function dropCommentFromColumn($table, $column)
+    {
+        throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');
+    }
+
+    /**
+     * Builds a SQL command for adding comment to table
+     *
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @return $this the command object itself
+     * @throws NotSupportedException this is not supported by SQLite
+     */
+    public function dropCommentFromTable($table)
+    {
+        throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');
+    }
+
+    /**
      * @inheritdoc
      */
     public function buildLimit($limit, $offset)

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -92,6 +92,14 @@ class Schema extends \yii\db\Schema
     }
 
     /**
+     * @inheritdoc
+     */
+    public function createColumnSchemaBuilder($type, $length = null)
+    {
+        return new ColumnSchemaBuilder($type, $length);
+    }
+
+    /**
      * Returns all table names in the database.
      * @param string $schema the schema of the tables. Defaults to empty string, meaning the current or default schema.
      * @return array all table names in the database. The names have NO schema name prefix.

--- a/tests/data/mysql.sql
+++ b/tests/data/mysql.sql
@@ -18,6 +18,7 @@ DROP TABLE IF EXISTS `constraints` CASCADE;
 DROP TABLE IF EXISTS `animal` CASCADE;
 DROP TABLE IF EXISTS `default_pk` CASCADE;
 DROP TABLE IF EXISTS `document` CASCADE;
+DROP TABLE IF EXISTS `comment` CASCADE;
 DROP VIEW IF EXISTS `animal_view`;
 
 CREATE TABLE `constraints`
@@ -147,6 +148,14 @@ CREATE TABLE `document` (
   `title` VARCHAR(255) NOT NULL,
   `content` TEXT,
   `version` INT(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `comment` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `add_comment` VARCHAR(255) NOT NULL,
+  `replace_comment` VARCHAR(255) COMMENT 'comment',
+  `delete_comment` VARCHAR(128) NOT NULL COMMENT 'comment',
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/tests/data/postgres.sql
+++ b/tests/data/postgres.sql
@@ -20,6 +20,7 @@ DROP TABLE IF EXISTS "bool_values" CASCADE;
 DROP TABLE IF EXISTS "animal" CASCADE;
 DROP TABLE IF EXISTS "default_pk" CASCADE;
 DROP TABLE IF EXISTS "document" CASCADE;
+DROP TABLE IF EXISTS "comment" CASCADE;
 DROP VIEW IF EXISTS "animal_view";
 DROP SCHEMA IF EXISTS "schema1" CASCADE;
 DROP SCHEMA IF EXISTS "schema2" CASCADE;
@@ -152,6 +153,12 @@ CREATE TABLE "document" (
   title varchar(255) not null,
   content text not null,
   version integer not null default 0
+);
+
+CREATE TABLE "comment" (
+  id serial primary key,
+  name varchar(255) not null,
+  message text not null
 );
 
 CREATE VIEW "animal_view" AS SELECT * FROM "animal";

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -136,6 +136,7 @@ class QueryBuilderTest extends DatabaseTestCase
             [Schema::TYPE_MONEY . ' CHECK (value > 0.0)', $this->money()->check('value > 0.0'), 'decimal(19,4) CHECK (value > 0.0)'],
             [Schema::TYPE_MONEY . '(16,2) CHECK (value > 0.0)', $this->money(16, 2)->check('value > 0.0'), 'decimal(16,2) CHECK (value > 0.0)'],
             [Schema::TYPE_MONEY . ' NOT NULL', $this->money()->notNull(), 'decimal(19,4) NOT NULL'],
+            [Schema::TYPE_MONEY . ' NOT NULL COMMENT \'this is money column\'', $this->money()->notNull()->comment('this is money column'), 'decimal(19,4) NOT NULL COMMENT \'this is money column\''],
         ];
     }
 

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -517,4 +517,34 @@ class QueryBuilderTest extends DatabaseTestCase
         ];
         (new Query())->from('customer')->where($condition)->all($this->getConnection());
     }
+
+    public function testCommentColumn()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = "ALTER TABLE `comment` CHANGE `add_comment` `add_comment` varchar(255) NOT NULL COMMENT 'This is my column.'";
+        $sql = $qb->addCommentOnColumn('comment', 'add_comment', 'This is my column.');
+        $this->assertEquals($expected, $sql);
+
+        $expected = "ALTER TABLE `comment` CHANGE `replace_comment` `replace_comment` varchar(255) DEFAULT NULL COMMENT 'This is my column.'";
+        $sql = $qb->addCommentOnColumn('comment', 'replace_comment', 'This is my column.');
+        $this->assertEquals($expected, $sql);
+
+        $expected = "ALTER TABLE `comment` CHANGE `delete_comment` `delete_comment` varchar(128) NOT NULL COMMENT ''";
+        $sql = $qb->dropCommentFromColumn('comment', 'delete_comment');
+        $this->assertEquals($expected, $sql);
+    }
+
+    public function testCommentTable()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = "ALTER TABLE `comment` COMMENT 'This is my table.'";
+        $sql = $qb->addCommentOnTable('comment', 'This is my table.');
+        $this->assertEquals($expected, $sql);
+
+        $expected = "ALTER TABLE `comment` COMMENT ''";
+        $sql = $qb->dropCommentFromTable('comment');
+        $this->assertEquals($expected, $sql);
+    }
 }

--- a/tests/framework/db/cubrid/CubridQueryBuilderTest.php
+++ b/tests/framework/db/cubrid/CubridQueryBuilderTest.php
@@ -82,6 +82,7 @@ class CubridQueryBuilderTest extends QueryBuilderTest
             [Schema::TYPE_MONEY . ' CHECK (value > 0.0)', $this->money()->check('value > 0.0'), 'decimal(19,4) CHECK (value > 0.0)'],
             [Schema::TYPE_MONEY . '(16,2) CHECK (value > 0.0)', $this->money(16, 2)->check('value > 0.0'), 'decimal(16,2) CHECK (value > 0.0)'],
             [Schema::TYPE_MONEY . ' NOT NULL', $this->money()->notNull(), 'decimal(19,4) NOT NULL'],
+            [Schema::TYPE_MONEY . ' NOT NULL COMMENT \'this is money column\'', $this->money()->notNull()->comment('this is money column'), 'decimal(19,4) NOT NULL COMMENT \'this is money column\''],
         ];
     }
 }

--- a/tests/framework/db/mssql/MssqlQueryBuilderTest.php
+++ b/tests/framework/db/mssql/MssqlQueryBuilderTest.php
@@ -54,4 +54,30 @@ class MssqlQueryBuilderTest extends QueryBuilderTest
         $this->assertEquals($expectedQuerySql, $actualQuerySql);
         $this->assertEquals($expectedQueryParams, $actualQueryParams);
     }
+
+    public function testCommentColumn()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = "sp_updateextendedproperty @name = N'MS_Description', @value = 'This is my column.', @level1type = N'Table',  @level1name = comment, @level2type = N'Column', @level2name = text";
+        $sql = $qb->addCommentOnColumn('comment', 'text', 'This is my column.');
+        $this->assertEquals($expected, $sql);
+
+        $expected = "sp_dropextendedproperty @name = N'MS_Description', @level1type = N'Table',  @level1name = comment, @level2type = N'Column', @level2name = text";
+        $sql = $qb->dropCommentFromColumn('comment', 'text');
+        $this->assertEquals($expected, $sql);
+    }
+
+    public function testCommentTable()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = "sp_updateextendedproperty @name = N'MS_Description', @value = 'This is my table.', @level1type = N'Table',  @level1name = comment";
+        $sql = $qb->addCommentOnTable('comment', 'This is my table.');
+        $this->assertEquals($expected, $sql);
+
+        $expected = "sp_dropextendedproperty @name = N'MS_Description', @level1type = N'Table',  @level1name = comment";
+        $sql = $qb->dropCommentFromTable('comment');
+        $this->assertEquals($expected, $sql);
+    }
 }

--- a/tests/framework/db/oci/OracleQueryBuilderTest.php
+++ b/tests/framework/db/oci/OracleQueryBuilderTest.php
@@ -82,6 +82,33 @@ class OracleQueryBuilderTest extends QueryBuilderTest
             [Schema::TYPE_MONEY . ' CHECK (value > 0.0)', $this->money()->check('value > 0.0'), 'NUMBER(19,4) CHECK (value > 0.0)'],
             [Schema::TYPE_MONEY . '(16,2) CHECK (value > 0.0)', $this->money(16, 2)->check('value > 0.0'), 'NUMBER(16,2) CHECK (value > 0.0)'],
             [Schema::TYPE_MONEY . ' NOT NULL', $this->money()->notNull(), 'NUMBER(19,4) NOT NULL'],
+            [Schema::TYPE_MONEY . ' NOT NULL', $this->money()->notNull()->comment('this is money column'), 'NUMBER(19,4) NOT NULL'],
         ];
+    }
+
+    public function testCommentColumn()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = "COMMENT ON COLUMN \"comment\".\"text\" IS 'This is my column.'";
+        $sql = $qb->addCommentOnColumn('comment', 'text', 'This is my column.');
+        $this->assertEquals($expected, $sql);
+
+        $expected = "COMMENT ON COLUMN \"comment\".\"text\" IS ' '";
+        $sql = $qb->dropCommentFromColumn('comment', 'text');
+        $this->assertEquals($expected, $sql);
+    }
+
+    public function testCommentTable()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = "COMMENT ON TABLE \"comment\" IS 'This is my table.'";
+        $sql = $qb->addCommentOnTable('comment', 'This is my table.');
+        $this->assertEquals($expected, $sql);
+
+        $expected = "COMMENT ON TABLE \"comment\" IS ' '";
+        $sql = $qb->dropCommentFromTable('comment');
+        $this->assertEquals($expected, $sql);
     }
 }

--- a/tests/framework/db/pgsql/PostgreSQLQueryBuilderTest.php
+++ b/tests/framework/db/pgsql/PostgreSQLQueryBuilderTest.php
@@ -77,6 +77,7 @@ class PostgreSQLQueryBuilderTest extends QueryBuilderTest
             [Schema::TYPE_MONEY . ' CHECK (value > 0.0)', $this->money()->check('value > 0.0'), 'numeric(19,4) CHECK (value > 0.0)'],
             [Schema::TYPE_MONEY . '(16,2) CHECK (value > 0.0)', $this->money(16, 2)->check('value > 0.0'), 'numeric(16,2) CHECK (value > 0.0)'],
             [Schema::TYPE_MONEY . ' NOT NULL', $this->money()->notNull(), 'numeric(19,4) NOT NULL'],
+            [Schema::TYPE_MONEY . ' NOT NULL', $this->money()->notNull()->comment('this is money column'), 'numeric(19,4) NOT NULL'],
         ];
     }
 

--- a/tests/framework/db/pgsql/PostgreSQLQueryBuilderTest.php
+++ b/tests/framework/db/pgsql/PostgreSQLQueryBuilderTest.php
@@ -126,4 +126,30 @@ class PostgreSQLQueryBuilderTest extends QueryBuilderTest
         $sql = $qb->alterColumn('foo1', 'bar', 'reset xyz');
         $this->assertEquals($expected, $sql);
     }
+
+    public function testCommentColumn()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = "COMMENT ON COLUMN \"comment\".\"text\" IS 'This is my column.'";
+        $sql = $qb->addCommentOnColumn('comment', 'text', 'This is my column.');
+        $this->assertEquals($expected, $sql);
+
+        $expected = "COMMENT ON COLUMN \"comment\".\"text\" IS NULL";
+        $sql = $qb->dropCommentFromColumn('comment', 'text');
+        $this->assertEquals($expected, $sql);
+    }
+
+    public function testCommentTable()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = "COMMENT ON TABLE \"comment\" IS 'This is my table.'";
+        $sql = $qb->addCommentOnTable('comment', 'This is my table.');
+        $this->assertEquals($expected, $sql);
+
+        $expected = "COMMENT ON TABLE \"comment\" IS NULL";
+        $sql = $qb->dropCommentFromTable('comment');
+        $this->assertEquals($expected, $sql);
+    }
 }

--- a/tests/framework/db/sqlite/SqliteQueryBuilderTest.php
+++ b/tests/framework/db/sqlite/SqliteQueryBuilderTest.php
@@ -87,6 +87,30 @@ class SqliteQueryBuilderTest extends QueryBuilderTest
         parent::testAddDropPrimaryKey();
     }
 
+    public function testCommentOnColumnSchemaBuilder()
+    {
+        $this->setExpectedException('yii\base\NotSupportedException');
+        $this->string()->comment('comment');
+    }
+
+    public function testCommentColumn()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $this->setExpectedException('yii\base\NotSupportedException');
+        $qb->addCommentOnColumn('comment', 'text', 'This is my column.');
+        $qb->dropCommentFromColumn('comment', 'text');
+    }
+
+    public function testCommentTable()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $this->setExpectedException('yii\base\NotSupportedException');
+        $qb->addCommentOnTable('comment', 'This is my table.');
+        $qb->dropCommentFromTable('comment');
+    }
+
     public function testBatchInsert()
     {
         $db = $this->getConnection();


### PR DESCRIPTION
Hi. I start work with issue #8148. 
I add 4 methods for Migration:
- addCommentOnColumn($table, $column, $comment)
- dropCommentFromColumn($table, $column)
- addCommentOnTable($table, $comment)
- dropCommentFromTable($table)

and one method to ColumnSchemaBuilder:
- comment($comment)

Now i add support for 
- mysql (all methods)
- postgresql (Migration methods and empty for column string, but if we create method in migrate controller - we add comments on each column)
- sqllite (NotSupportedException for all)

I hope for your code review... 

Tested with DBMS:
- [x] MySQL
- [x] MSSQL
- [x] PostgreSQL
- [x] SQLite
- [x] CUBRID
- [x] Oracle
