### PR TITLE
fix SQLite renameTable() problem (#9442)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #8723: Fixed `yii\helpers\VarDumper::export()` unable to export circle referenced objects with `Closure` (klimov-paul)
 - Bug #9108: Negative number resulted in no formatting when using `Formatter::asSize()` or `Formatter::asShortSize` (nxnx, cebe)
 - Bug #9415: Fixed regression in 2.0.6 where on Oracle DB `PDO::ATTR_CASE = PDO::CASE_LOWER` did not work anymore (cebe)
+- Bug #9442: Fixed `yii\db\Migration::renameTable()` cause fatal error when using SQLite driver (fetus-hina)
 - Chg #9369: `Yii::$app->user->can()` now returns `false` instead of erroring in case `authManager` component is not configured (creocoder)
 - Chg #9411: `DetailView` now automatically sets container tag ID in case it's not specified (samdark)
 

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -235,6 +235,18 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
+     * Builds a SQL statement for renaming a DB table.
+     *
+     * @param string $table the table to be renamed. The name will be properly quoted by the method.
+     * @param string $newName the new table name. The name will be properly quoted by the method.
+     * @return string the SQL statement for renaming a DB table.
+     */
+    public function renameTable($table, $newName)
+    {
+        return 'ALTER TABLE ' . $this->db->quoteTableName($table) . ' RENAME TO ' . $this->db->quoteTableName($newName);
+    }
+
+    /**
      * Builds a SQL statement for changing the definition of a column.
      * @param string $table the table whose column is to be changed. The table name will be properly quoted by the method.
      * @param string $column the name of the column to be changed. The name will be properly quoted by the method.

--- a/tests/framework/db/sqlite/SqliteQueryBuilderTest.php
+++ b/tests/framework/db/sqlite/SqliteQueryBuilderTest.php
@@ -96,4 +96,10 @@ class SqliteQueryBuilderTest extends QueryBuilderTest
         $sql = $this->getQueryBuilder()->batchInsert('{{customer}} t', ['t.id', 't.name'], [[1, 'a'], [2, 'b']]);
         $this->assertEquals("INSERT INTO {{customer}} t (`t`.`id`, `t`.`name`) SELECT 1, 'a' UNION SELECT 2, 'b'", $sql);
     }
+
+    public function testRenameTable()
+    {
+        $sql = $this->getQueryBuilder()->renameTable('table_from', 'table_to');
+        $this->assertEquals("ALTER TABLE `table_from` RENAME TO `table_to`", $sql);
+    }
 }


### PR DESCRIPTION
`yii\db\sqlite\QueryBuilder::renameTable()` implemented, it copied from `oci`'s one.

As you know, my English is very poor.
Please fix my English on `CHANGELOG.md`, if my description is not to be comprehensible or inappropriate.
