### PR TITLE
Added defaultExpression() to ColumnSchemaBuilder

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #9415: Fixed regression in 2.0.6 where on Oracle DB `PDO::ATTR_CASE = PDO::CASE_LOWER` did not work anymore (cebe)
 - Chg #9369: `Yii::$app->user->can()` now returns `false` instead of erroring in case `authManager` component is not configured (creocoder)
 - Chg #9411: `DetailView` now automatically sets container tag ID in case it's not specified (samdark)
+- Enh #9337: Added defaultExpression() to `ColumnSchemaBuilder` to support DB Expression as default value (kotchuprik)
 
 
 2.0.6 August 05, 2015

--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -105,7 +105,7 @@ class ColumnSchemaBuilder extends Object
     }
 
     /**
-     * Specify the default DB Expression for the column.
+     * Specify the default value for the column in terms of a [[Expression|SQL expression]].
      * @param Expression $default the default value.
      * @return $this
      */

--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -105,6 +105,17 @@ class ColumnSchemaBuilder extends Object
     }
 
     /**
+     * Specify the default DB Expression for the column.
+     * @param Expression $default the default value.
+     * @return $this
+     */
+    public function defaultExpression(Expression $default)
+    {
+        $this->default = $default;
+        return $this;
+    }
+
+    /**
      * Build full string for create the column's schema
      * @return string
      */
@@ -173,6 +184,9 @@ class ColumnSchemaBuilder extends Object
                 break;
             case 'boolean':
                 $string .= $this->default ? 'TRUE' : 'FALSE';
+                break;
+            case 'object':
+                $string .= (string) $this->default;
                 break;
             default:
                 $string .= "'{$this->default}'";


### PR DESCRIPTION
Fix for https://github.com/yiisoft/yii2/issues/9337 and... I'm not sure that this is correct but can be used for fix #9445:

``` php
$this->defaultExpression(new Expression('NULL'))
```
