### PR TITLE
fixes #9314, rbac\BaseManager::getPermissionsByUser also returns directly assigned permissions

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #8723: Fixed `yii\helpers\VarDumper::export()` unable to export circle referenced objects with `Closure` (klimov-paul)
 - Bug #9108: Negative number resulted in no formatting when using `Formatter::asSize()` or `Formatter::asShortSize` (nxnx, cebe)
+- Bug #9314: Fixed `yii\rbac\DbManager::getPermissionsByUser()` not returning permissions directly assigned to a user (hesna)
 - Bug #9415: Fixed regression in 2.0.6 where on Oracle DB `PDO::ATTR_CASE = PDO::CASE_LOWER` did not work anymore (cebe)
 - Bug #9442: Fixed `yii\db\Migration::renameTable()` caused fatal error when using SQLite driver (fetus-hina)
 - Chg #9369: `Yii::$app->user->can()` now returns `false` instead of erroring in case `authManager` component is not configured (creocoder)

--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -501,6 +501,39 @@ class DbManager extends BaseManager
             return [];
         }
 
+        $directPermission = $this->getDirectPermissionsByUser($userId);
+        $inheritedPermission = $this->getInheritedPermissionsByUser($userId);
+
+        return array_merge($directPermission, $inheritedPermission);
+    }
+
+    /**
+     * Returns all permissions that are directly assigned to user.
+     * @param string|integer $userId the user ID (see [[\yii\web\User::id]])
+     * @return Permission[] all direct permissions that the user has. The array is indexed by the permission names.
+     */
+    protected function getDirectPermissionsByUser($userId)
+    {
+        $query = (new Query)->select('b.*')
+            ->from(['a' => $this->assignmentTable, 'b' => $this->itemTable])
+            ->where('{{a}}.[[item_name]]={{b}}.[[name]]')
+            ->andWhere(['a.user_id' => (string) $userId])
+            ->andWhere(['b.type' => Item::TYPE_PERMISSION]);
+
+        $permissions = [];
+        foreach ($query->all($this->db) as $row) {
+            $permissions[$row['name']] = $this->populateItem($row);
+        }
+        return $permissions;
+    }
+
+    /**
+     * Returns all permissions that the user inherits from the roles assigned to him.
+     * @param string|integer $userId the user ID (see [[\yii\web\User::id]])
+     * @return Permission[] all inherited permissions that the user has. The array is indexed by the permission names.
+     */
+    protected function getInheritedPermissionsByUser($userId)
+    {
         $query = (new Query)->select('item_name')
             ->from($this->assignmentTable)
             ->where(['user_id' => (string) $userId]);

--- a/framework/rbac/PhpManager.php
+++ b/framework/rbac/PhpManager.php
@@ -426,6 +426,37 @@ class PhpManager extends BaseManager
      */
     public function getPermissionsByUser($userId)
     {
+        $directPermission = $this->getDirectPermissionsByUser($userId);
+        $inheritedPermission = $this->getInheritedPermissionsByUser($userId);
+
+        return array_merge($directPermission, $inheritedPermission);
+    }
+
+    /**
+     * Returns all permissions that are directly assigned to user.
+     * @param string|integer $userId the user ID (see [[\yii\web\User::id]])
+     * @return Permission[] all direct permissions that the user has. The array is indexed by the permission names.
+     */
+    protected function getDirectPermissionsByUser($userId)
+    {
+        $permissions = [];
+        foreach ($this->getAssignments($userId) as $name => $assignment) {
+            $permission = $this->items[$assignment->roleName];
+            if ($permission->type === Item::TYPE_PERMISSION) {
+                $permissions[$name] = $permission;
+            }
+        }
+
+        return $permissions;
+    }
+
+    /**
+     * Returns all permissions that the user inherits from the roles assigned to him.
+     * @param string|integer $userId the user ID (see [[\yii\web\User::id]])
+     * @return Permission[] all inherited permissions that the user has. The array is indexed by the permission names.
+     */
+    protected function getInheritedPermissionsByUser($userId)
+    {
         $assignments = $this->getAssignments($userId);
         $result = [];
         foreach (array_keys($assignments) as $roleName) {

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -158,6 +158,7 @@ abstract class ManagerTestCase extends TestCase
                 'createPost' => true,
                 'readPost' => true,
                 'updatePost' => true,
+                'deletePost' => true,
                 'updateAnyPost' => false,
             ],
             'admin C' => [
@@ -194,6 +195,10 @@ abstract class ManagerTestCase extends TestCase
         $readPost->description = 'read a post';
         $this->auth->add($readPost);
 
+        $deletePost = $this->auth->createPermission('deletePost');
+        $deletePost->description = 'delete a post';
+        $this->auth->add($deletePost);
+
         $updatePost = $this->auth->createPermission('updatePost');
         $updatePost->description = 'update a post';
         $updatePost->ruleName = $rule->name;
@@ -222,28 +227,29 @@ abstract class ManagerTestCase extends TestCase
 
         $this->auth->assign($reader, 'reader A');
         $this->auth->assign($author, 'author B');
+        $this->auth->assign($deletePost, 'author B');
         $this->auth->assign($admin, 'admin C');
     }
 
     public function testGetPermissionsByRole()
     {
         $this->prepareData();
-        $roles = $this->auth->getPermissionsByRole('admin');
+        $permissions = $this->auth->getPermissionsByRole('admin');
         $expectedPermissions = ['createPost', 'updatePost', 'readPost', 'updateAnyPost'];
-        $this->assertEquals(count($roles), count($expectedPermissions));
-        foreach ($expectedPermissions as $permission) {
-            $this->assertTrue($roles[$permission] instanceof Permission);
+        $this->assertEquals(count($expectedPermissions), count($permissions));
+        foreach ($expectedPermissions as $permissionName) {
+            $this->assertTrue($permissions[$permissionName] instanceof Permission);
         }
     }
 
     public function testGetPermissionsByUser()
     {
         $this->prepareData();
-        $roles = $this->auth->getPermissionsByUser('author B');
-        $expectedPermissions = ['createPost', 'updatePost', 'readPost'];
-        $this->assertEquals(count($roles), count($expectedPermissions));
-        foreach ($expectedPermissions as $permission) {
-            $this->assertTrue($roles[$permission] instanceof Permission);
+        $permissions = $this->auth->getPermissionsByUser('author B');
+        $expectedPermissions = ['deletePost', 'createPost', 'updatePost', 'readPost'];
+        $this->assertEquals(count($expectedPermissions), count($permissions));
+        foreach ($expectedPermissions as $permissionName) {
+            $this->assertTrue($permissions[$permissionName] instanceof Permission);
         }
     }
 


### PR DESCRIPTION
fixes #9314 
It's my first contribution, please let me know if there are any mistakes or missteps. tests has been adjusted to reflect the changes and are all green.
