### PR TITLE
Fixed #9454: changed sqlsrv pdo class selection

### DIFF
--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -571,8 +571,12 @@ class Connection extends Component
             } elseif (($pos = strpos($this->dsn, ':')) !== false) {
                 $driver = strtolower(substr($this->dsn, 0, $pos));
             }
-            if (isset($driver) && ($driver === 'mssql' || $driver === 'dblib' || $driver === 'sqlsrv')) {
-                $pdoClass = 'yii\db\mssql\PDO';
+            if (isset($driver)) {
+                if ($driver === 'mssql' || $driver === 'dblib') {
+                    $pdoClass = 'yii\db\mssql\PDO';
+                } else if ($driver === 'sqlsrv'){
+                    $pdoClass = 'yii\db\mssql\SqlsrvPDO';
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/yiisoft/yii2/issues/9454
The sqlsrv driver now uses the correct PDO class.
