### PR TITLE
BaseArrayHelper treats objects properties as array keys

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -202,12 +202,12 @@ class BaseArrayHelper
                 return $array->$key;
             }
             $propertyIsPublic = function($object, $propertyName) {
-                $reflect = new ReflectionObject($object);
-                foreach ($reflect->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+                $reflect = new \ReflectionObject($object);
+                foreach ($reflect->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
                     if($property->getName()===$propertyName) 
                         return true;
                 }
-            }
+            };
             if(property_exists($array, $key) && $propertyIsPublic($array, $key)) {
                 return $array->$key;
             }

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -170,8 +170,7 @@ class BaseArrayHelper
      * or an anonymous function returning the value. The anonymous function signature should be:
      * `function($array, $defaultValue)`.
      * The possibility to pass an array of keys is available since version 2.0.4.
-     * @param mixed $default the default value to be returned if the specified array key does not exist. Not used when
-     * getting value from an object.
+     * @param mixed $default the default value to be returned if the specified array key does not exist. 
      * @return mixed the value of the element if found, default value otherwise
      * @throws InvalidParamException if $array is neither an array nor an object.
      */
@@ -199,7 +198,20 @@ class BaseArrayHelper
         }
 
         if (is_object($array)) {
-            return $array->$key;
+            if(isset($array->$key)) {
+                return $array->$key;
+            }
+            $propertyIsPublic = function($object, $propertyName) {
+                $reflect = new ReflectionObject($object);
+                foreach ($reflect->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+                    if($property->getName()===$propertyName) 
+                        return true;
+                }
+            }
+            if(property_exists($array, $key) && $propertyIsPublic($array, $key)) {
+                return $array->$key;
+            }
+            return $default;
         } elseif (is_array($array)) {
             return array_key_exists($key, $array) ? $array[$key] : $default;
         } else {

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -351,6 +351,7 @@ class ArrayHelperTest extends TestCase
             ['postObject.empty',null, 'defaultValue'],
             ['postObject.secret','defaultValue', 'defaultValue'],
             ['postObject.title','tt', 'defaultValue'],
+            ['postObject.nonexistent','defaultValue', 'defaultValue'],
         ];
     }
 

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -11,6 +11,8 @@ class Post1
 {
     public $id = 23;
     public $title = 'tt';
+    private $secret;
+    public $empty;
 }
 
 class Post2 extends Object
@@ -346,6 +348,9 @@ class ArrayHelperTest extends TestCase
             ],
             [['version', '1.0', 'status'], 'released'],
             [['version', '1.0', 'date'], 'defaultValue', 'defaultValue'],
+            ['postObject.empty',null, 'defaultValue'],
+            ['postObject.secret','defaultValue', 'defaultValue'],
+            ['postObject.title','tt', 'defaultValue'],
         ];
     }
 
@@ -380,10 +385,12 @@ class ArrayHelperTest extends TestCase
                     'status' => 'released'
                 ]
             ],
+            'postObject'=> new Post1()
         ];
 
         $this->assertEquals($expected, ArrayHelper::getValue($array, $key, $default));
     }
+    
 
     public function testIsAssociative()
     {


### PR DESCRIPTION
If object property is private or not exists, it returns default value.
