### PR TITLE
Add supporting correct output formating for SPL classes and Generators.

### DIFF
--- a/framework/web/XmlResponseFormatter.php
+++ b/framework/web/XmlResponseFormatter.php
@@ -44,6 +44,10 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
      * @var string the name of the elements that represent the array elements with numeric keys.
      */
     public $itemTag = 'item';
+    /**
+     * @var boolean whether to enable to interpret implemented \Traversable interface objects as array
+     */
+    public $useTraversableAsArray = true;
 
 
     /**
@@ -72,19 +76,7 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
      */
     protected function buildXml($element, $data)
     {
-        if (is_object($data)) {
-            $child = new DOMElement(StringHelper::basename(get_class($data)));
-            $element->appendChild($child);
-            if ($data instanceof Arrayable) {
-                $this->buildXml($child, $data->toArray());
-            } else {
-                $array = [];
-                foreach ($data as $name => $value) {
-                    $array[$name] = $value;
-                }
-                $this->buildXml($child, $array);
-            }
-        } elseif (is_array($data)) {
+        if (is_array($data) || $data instanceof \Traversable && $this->useTraversableAsArray) {
             foreach ($data as $name => $value) {
                 if (is_int($name) && is_object($value)) {
                     $this->buildXml($element, $value);
@@ -97,6 +89,18 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
                     $element->appendChild($child);
                     $child->appendChild(new DOMText((string) $value));
                 }
+            }
+        } elseif (is_object($data)) {
+            $child = new DOMElement(StringHelper::basename(get_class($data)));
+            $element->appendChild($child);
+            if ($data instanceof Arrayable) {
+                $this->buildXml($child, $data->toArray());
+            } else {
+                $array = [];
+                foreach ($data as $name => $value) {
+                    $array[$name] = $value;
+                }
+                $this->buildXml($child, $array);
             }
         } else {
             $element->appendChild(new DOMText((string) $data));

--- a/tests/framework/web/FormatterTest.php
+++ b/tests/framework/web/FormatterTest.php
@@ -66,6 +66,18 @@ abstract class FormatterTest extends \yiiunit\TestCase
     /**
      * @param mixed  $data the data to be formatted
      * @param string $json the expected JSON body
+     * @dataProvider formatTraversableObjectDataProvider
+     */
+    public function testFormatTraversableObjects($data, $json)
+    {
+        $this->response->data = $data;
+        $this->formatter->format($this->response);
+        $this->assertEquals($json, $this->response->content);
+    }
+
+    /**
+     * @param mixed  $data the data to be formatted
+     * @param string $json the expected JSON body
      * @dataProvider formatObjectDataProvider
      */
     public function testFormatObjects($data, $json)

--- a/tests/framework/web/XmlResponseFormatterTest.php
+++ b/tests/framework/web/XmlResponseFormatterTest.php
@@ -69,6 +69,27 @@ class XmlResponseFormatterTest extends FormatterTest
         ]);
     }
 
+    public function formatTraversableObjectDataProvider()
+    {
+        $expectedXmlForStack = '';
+        
+        $postsStack = new \SplStack();
+        
+        $postsStack->push(new Post(915, 'record1'));
+        $expectedXmlForStack = '<Post><id>915</id><title>record1</title></Post>' .
+          $expectedXmlForStack;
+        
+        $postsStack->push(new Post(456, 'record2'));
+        $expectedXmlForStack = '<Post><id>456</id><title>record2</title></Post>' .
+          $expectedXmlForStack;
+        
+        $data = [
+            [$postsStack, "<response>$expectedXmlForStack</response>\n"]
+        ];
+        
+        return $this->addXmlHead($data);
+    }
+
     public function formatObjectDataProvider()
     {
         return $this->addXmlHead([


### PR DESCRIPTION
Supporting correct output formatting for SPL classes and Generators.

Current implementation `\yii\web\XmlResponseFormatter` does not support SPL objects and Generators (PHP 5.5+).

E.g.:

``` php
public function actionTest()
{
  \Yii::$app->response->format = \yii\web\Response::FORMAT_XML;

  $generator = function ($start, $end) {
    for ($i = $start; $i <= $end; ++$i) {
      yield $i;
    }
  };

  return $generator(1, 3);
}
```

will output:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<response>
  <Generator>
    <item>1</item>
    <item>2</item>
    <item>3</item>
  </Generator>
</response>
```

but `<Generator`> is extra element and output must be:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<response>
  <item>1</item>
  <item>2</item>
  <item>3</item>
</response>
```

For SPL objects we have same situation, for example:

``` php
public function actionSitemap()
{
  \Yii::$app->response->format = \yii\web\Response::FORMAT_XML;
  \Yii::$app->response->formatters[\yii\web\Response::FORMAT_XML] = [
    'class'   => '\yii\web\XmlResponseFormatter',
    'rootTag' => 'urlset',
    'itemTag' => 'url'
  ];

  return \Yii::$app->contentTree->getItemsHeapForSitemap();
}
```

`getItemsHeapForSitemap` method return instance of `\SplQueue`.

will output:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset>
  <Heap>
    <url>
      <loc>https://domain/path.html</loc>
      <lastmod>2015-06-17</lastmod>
      <priority>0.99</priority>
    </url>
    <!-- next urls -->
  </Heap>
</urlset>
```

but preffered is:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset>
  <url>
    <loc>https://domain/path.html</loc>
    <lastmod>2015-06-17</lastmod>
    <priority>0.99</priority>
  </url>
  <!-- next urls -->
</urlset>
```

Because Generator and SPL classes implements `\Traversable` interface, I think it is possible to use it as arrays in `buildXml` method of `\yii\web\XmlResponseFormatter`.

I add `$useTraversableAsArray` (true by default) member to `\yii\web\XmlResponseFormatter`, if someone wants to use old style.

What do you think about this ?
