### PR TITLE
Add char type to db schema.

### DIFF
--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -42,6 +42,7 @@ abstract class Schema extends Object
      */
     const TYPE_PK = 'pk';
     const TYPE_BIGPK = 'bigpk';
+    const TYPE_CHAR = 'char';
     const TYPE_STRING = 'string';
     const TYPE_TEXT = 'text';
     const TYPE_SMALLINT = 'smallint';


### PR DESCRIPTION
https://github.com/yiisoft/yii2/blob/master/framework/db/SchemaBuilderTrait.php is also missing a char() method.
