### PR TITLE
[Fixes #9519] Add dot format support for Model to access embedded object

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Enh #5469: Add mimetype validation by mask in FileValidator (kirsenn, samdark, silverfire)
 - Enh #8602: `yii\validators\DateValidator` skip validation for `timestampAttribute`, if it is already in correct format (klimov-paul)
 - Enh #8639: Improve ActiveRecord to not create new instances of classes when objects are available (cebe)
+- Enh #9519: `yii\base\Model` add support dot notation for access attributes (surgat)
 - Enh #9893: `yii.js` handleAction enhanced to support for data-form attribute, so links can trigger specific forms (SamMousa)
 - Enh #10451: Check of existence of `$_SERVER` in `\yii\web\Request` before using it (quantum13)
 - Enh #10487: `yii\helpers\BaseArrayHelper::index()` got a third parameter `$groupBy` to group the input array by the key in one or more dimensions (quantum13, silverfire, samdark)

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -14,6 +14,7 @@ use ArrayIterator;
 use ReflectionClass;
 use IteratorAggregate;
 use yii\helpers\Inflector;
+use yii\helpers\ArrayHelper;
 use yii\validators\RequiredValidator;
 use yii\validators\Validator;
 
@@ -83,6 +84,42 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      */
     private $_scenario = self::SCENARIO_DEFAULT;
 
+    /**
+     * PHP getter magic method.
+     * Add dot format support to retrieve the property of embedded object.
+     *
+     * @param string $name property name
+     * @throws \yii\base\InvalidParamException if relation name is wrong
+     * @return mixed property value
+     * @see ArrayHelper::getValue()
+     */
+    public function __get($name)
+    {
+        if (strpos($name, '.')) {
+            return ArrayHelper::getValue($this, $name);
+        }
+        return parent::__get($name);
+    }
+
+    /**
+     * PHP setter magic method.
+     * Add dot format support to set the property of embedded object.
+     *
+     * @param string $name property name
+     * @param mixed $value property value
+     */
+    public function __set($name, $value)
+    {
+        if (($pos = strrpos($name, '.')) !== false) {
+            $newName = substr($name, 0, $pos);
+            $model = ArrayHelper::getValue($this, $newName);
+            $attribute = substr($name, $pos + 1);
+            $model->$attribute = $value;
+            $name = $newName;
+            $value = $model;
+        }
+        parent::__set($name, $value);
+    }
 
     /**
      * Returns the validation rules for attributes.

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2109,10 +2109,16 @@ class BaseHtml
         $prefix = $matches[1];
         $attribute = $matches[2];
         $suffix = $matches[3];
+        $embeddedAttributes = '';
+        if (strpos($attribute, '.')) {
+            $list = explode('.', $attribute);
+            $attribute = array_shift($list);
+            $embeddedAttributes = '[' . implode('][', $list) . ']';
+        }
         if ($formName === '' && $prefix === '') {
-            return $attribute . $suffix;
+            return $attribute . $embeddedAttributes . $suffix;
         } elseif ($formName !== '') {
-            return $formName . $prefix . "[$attribute]" . $suffix;
+            return $formName . $prefix . "[$attribute]" . $embeddedAttributes . $suffix;
         } else {
             throw new InvalidParamException(get_class($model) . '::formName() cannot be empty for tabular inputs.');
         }

--- a/tests/data/base/Embed.php
+++ b/tests/data/base/Embed.php
@@ -1,0 +1,43 @@
+<?php
+namespace yiiunit\data\base;
+
+use Yii;
+use yii\base\Model;
+
+/**
+ * Model with point notations
+ */
+class Embed extends Model
+{
+    protected $_options;
+    public function getOptions()
+    {
+        return $this->_options ? unserialize($this->_options) : new Options;
+    }
+    public function setOptions($array)
+    {
+        $options = Yii::configure(new Options, $array);
+        $this->_options = serialize($options);
+    }
+    public function attributeLabels()
+    {
+        return [
+            'options.firstName' => 'Option First Name',
+        ];
+    }
+    public function rules()
+    {
+        return [
+            [['options.firstName', 'options.lastName'], 'required'],
+        ];
+    }
+    public function attributes()
+    {
+        return ['options'];
+    }
+}
+use \yii\base\Object;
+class Options extends Object {
+    public $firstName;
+    public $lastName = 'Lennon';
+}

--- a/tests/framework/base/ModelTest.php
+++ b/tests/framework/base/ModelTest.php
@@ -7,6 +7,7 @@ use yiiunit\data\base\RulesModel;
 use yiiunit\TestCase;
 use yiiunit\data\base\Speaker;
 use yiiunit\data\base\Singer;
+use yiiunit\data\base\Embed;
 use yiiunit\data\base\InvalidRulesModel;
 
 /**
@@ -348,6 +349,24 @@ class ModelTest extends TestCase
 
         $invalid = new InvalidRulesModel();
         $invalid->createValidators();
+    }
+
+    public function testSerializeLOBAttribute() {
+        $embed = new Embed;
+
+        $this->assertEquals('Option First Name', $embed->getAttributeLabel('options.firstName'));
+        $this->assertTrue($embed->isAttributeRequired('options.firstName'));
+
+        $attribute = 'options.firstName';
+        $embed->$attribute = 'abc';
+        $this->assertEquals('abc', $embed->options->firstName);
+
+        $attribute = 'options.lastName';
+        $this->assertEquals('Lennon', $embed->$attribute);
+
+        $embed->options = ['firstName' => 'abc', 'lastName' => 'cba'];
+        $this->assertEquals('abc', $embed->options->firstName);
+        $this->assertEquals('cba', $embed->options->lastName);
     }
 }
 


### PR DESCRIPTION
issue #9519 
Add support formats

``` php
public function attributeLabels()
{
    return [
        'feed.url' => 'Урл'
    ];
}

public function rules()
{
    return [
        ['feed.url', 'required']
    ];
}

echo $form->field($model, 'feed.url');
```

Profit
Can add serialize LOB (see yiiunit\data\base\Embed)
- with the addition of attribute in SLOB not need change DB scheme
- allows you to group attributes in a separate class
