### PR TITLE
Fixed inappropriate error response on invalid JSON request

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Bug #9108: Negative number resulted in no formatting when using `Formatter::asSize()` or `Formatter::asShortSize` (nxnx, cebe)
 - Bug #9415: Fixed regression in 2.0.6 where on Oracle DB `PDO::ATTR_CASE = PDO::CASE_LOWER` did not work anymore (cebe)
 - Bug #9442: Fixed `yii\db\Migration::renameTable()` caused fatal error when using SQLite driver (fetus-hina)
+- Bug: Server response on invalid JSON request included a wrong message about "Internal Server Error" with status 500 (cebe)
 - Chg #9369: `Yii::$app->user->can()` now returns `false` instead of erroring in case `authManager` component is not configured (creocoder)
 - Chg #9411: `DetailView` now automatically sets container tag ID in case it's not specified (samdark)
 

--- a/framework/web/JsonParser.php
+++ b/framework/web/JsonParser.php
@@ -51,9 +51,8 @@ class JsonParser implements RequestParserInterface
             return Json::decode($rawBody, $this->asArray);
         } catch (InvalidParamException $e) {
             if ($this->throwException) {
-                throw new BadRequestHttpException('Invalid JSON data in request body: ' . $e->getMessage(), 0, $e);
+                throw new BadRequestHttpException('Invalid JSON data in request body: ' . $e->getMessage());
             }
-
             return null;
         }
     }


### PR DESCRIPTION
Current API responds to invalid JSON with:

``` json
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=UTF-8
...

{"name":"Bad Request","message":"Invalid JSON data in request body: Syntax error.","code":0,"status":400,"previous":{"name":"Internal Server Error","message":"There was an error at the server.","code":0,"status":500}}
```

While it should be

``` json
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=UTF-8
...

{"name":"Bad Request","message":"Invalid JSON data in request body: Syntax error.","code":0,"status":400}
```
