### PR TITLE
HHVM nightly is no longer supported  on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
 
 env:
   - CUBRID_VERSION=9.3.0/CUBRID-9.3.0.0206 CUBRID_PDO_VERSION=9.3.0.0001
@@ -16,7 +15,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: hhvm-nightly
     - php: 7.0
 
 services:


### PR DESCRIPTION
HHVM nightly is no longer supported on Ubuntu Precise. See https://github.com/travis-ci/travis-ci/issues/3788 and https://github.com/facebook/hhvm/issues/5220

https://travis-ci.org/yiisoft/yii2/jobs/78771655
