### PR TITLE
fix: mysql schema enumValues incorrect if enum def contains comma

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #4113: Error page stacktrace was generating links to private methods which are not part of the API docs (samdark)
 - Bug #9305: Fixed MSSQL `Schema::TYPE_TIMESTAMP` to be 'datetime' instead of 'timestamp', which is just an incremental number (nkovacs)
+- Bug #9616: Fixed mysql\Schema::loadColumnSchema to set enumValues attribute correctly if enum definition contains commas (fphammerle)
 - Bug #9796: Initialization of not existing `yii\grid\ActionColumn` default buttons (arogachev)
 - Bug #12681: Changed `data` column type from `text` to `blob` to handle null-byte (`\0`) in serialized RBAC rule properly (silverfire)
 - Bug #12714: Fixed `yii\validation\EmailValidator` to prevent false-positives checks when property `checkDns` is set to `true` (silverfire)

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -147,7 +147,7 @@ class Schema extends \yii\db\Schema
             }
             if (!empty($matches[2])) {
                 if ($type === 'enum') {
-                    preg_match_all('/\'[^\']*\'/', $matches[2], $values);
+                    preg_match_all("/'[^']*'/", $matches[2], $values);
                     foreach ($values[0] as $i => $value) {
                         $values[$i] = trim($value, "'");
                     }

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -147,8 +147,8 @@ class Schema extends \yii\db\Schema
             }
             if (!empty($matches[2])) {
                 if ($type === 'enum') {
-                    $values = explode(',', $matches[2]);
-                    foreach ($values as $i => $value) {
+                    preg_match_all('/\'[^\']*\'/', $matches[2], $values);
+                    foreach ($values[0] as $i => $value) {
                         $values[$i] = trim($value, "'");
                     }
                     $column->enumValues = $values;

--- a/tests/data/cubrid.sql
+++ b/tests/data/cubrid.sql
@@ -117,7 +117,7 @@ CREATE TABLE "type" (
   "char_col" char(100) NOT NULL,
   "char_col2" varchar(100) DEFAULT 'something',
   "char_col3" string,
-  "enum_col" enum('a','B'),
+  "enum_col" enum('a','B','c,D'),
   "float_col" double NOT NULL,
   "float_col2" double DEFAULT '1.23',
   "blob_col" blob,

--- a/tests/data/mysql.sql
+++ b/tests/data/mysql.sql
@@ -128,7 +128,7 @@ CREATE TABLE `type` (
   `char_col` char(100) NOT NULL,
   `char_col2` varchar(100) DEFAULT 'something',
   `char_col3` text,
-  `enum_col` enum('a', 'B'),
+  `enum_col` enum('a', 'B', 'c,D'),
   `float_col` double(4,3) NOT NULL,
   `float_col2` double DEFAULT '1.23',
   `blob_col` blob,

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -218,11 +218,11 @@ abstract class SchemaTest extends DatabaseTestCase
             ],
             'enum_col' => [
                 'type' => 'string',
-                'dbType' => "enum('a','B')",
+                'dbType' => "enum('a','B','c,D')",
                 'phpType' => 'string',
                 'allowNull' => true,
                 'autoIncrement' => false,
-                'enumValues' => ['a', 'B'],
+                'enumValues' => ['a', 'B','c,D'],
                 'size' => null,
                 'precision' => null,
                 'scale' => null,


### PR DESCRIPTION
fix: mysql\Schema::loadColumnSchema sets enumValues attribute incorrectly if enum definition contains comma

(i.e. "enum('a','B','c,D')" -> ['a','B','c','D'] instead of expected ['a','B','c,D'])
