### PR TITLE
remove unnecessary gettimeofday system call

### DIFF
--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -641,9 +641,7 @@ class Formatter extends Component
         }
         try {
             if (is_numeric($value)) { // process as unix timestamp, which is always in UTC
-                $timestamp = new DateTime();
-                $timestamp->setTimezone(new DateTimeZone('UTC'));
-                $timestamp->setTimestamp($value);
+                $timestamp = new DateTime('@' . $value, new DateTimeZone('UTC'));
                 return $checkTimeInfo ? [$timestamp, true] : $timestamp;
             } elseif (($timestamp = DateTime::createFromFormat('Y-m-d', $value, new DateTimeZone($this->defaultTimeZone))) !== false) { // try Y-m-d format (support invalid dates like 2012-13-01)
                 return $checkTimeInfo ? [$timestamp, false] : $timestamp;


### PR DESCRIPTION
`new DateTime()` initializes the datetime object with the current time, which uses the `gettimeofday` syscall. This can be pretty expensive on a system without vsyscall or vdso, and we had some serious performance problems partly because of this.
This is completely unnecessary, since the timestamp is then overwritten.
