### PR TITLE
canonical url needs to ignore specified params

### DIFF
--- a/framework/helpers/BaseUrl.php
+++ b/framework/helpers/BaseUrl.php
@@ -296,13 +296,20 @@ class BaseUrl
      * ```php
      * $this->registerLinkTag(['rel' => 'canonical', 'href' => Url::canonical()]);
      * ```
-     *
+     * If you do not want to track some URL parameters in the canonical url, specify them in an array and pass for the
+     * first parameter.
+     * 
+     * @param array $unsetKeys specify the parameters that should not track in the url
      * @return string the canonical URL of the currently requested page
      */
-    public static function canonical()
+    public static function canonical($unsetKeys = [])
     {
         $params = Yii::$app->controller->actionParams;
         $params[0] = Yii::$app->controller->getRoute();
+
+        foreach ($unsetKeys as $key) {
+            unset($params[$key]);
+        }
 
         return Yii::$app->getUrlManager()->createAbsoluteUrl($params);
     }


### PR DESCRIPTION
Canonical URL should not capture all the parameters provided in the URL. So we need to specify what parameters to ignore when generating the canonical URL. For example, on a product listing page I would need to ignore a "sort"parameter and point all the sorting links to the one specific product page. 
Ex: 
1. www.mysite.com/mens/dresses?sort=by_price
2. www.mysite.com/mens/dresses?sort=by_date

Canonical URL for above two samples should be.
www.mysite.com/mens/dresses

So I need to tell to ignore 'sort' param when generating the canonical url. That is why this change is proposed.
