### PR TITLE
Fix links in documentation

### DIFF
--- a/framework/widgets/InputWidget.php
+++ b/framework/widgets/InputWidget.php
@@ -20,8 +20,8 @@ use yii\helpers\Html;
  * or a name and a value. If the former, the name and the value will
  * be generated automatically.
  *
- * Classes extending from this widget can be used in an [[yii\widgets\ActiveForm|ActiveForm]]
- * using the [[yii\widgets\ActiveField::widget()|widget()]] method, for example like this:
+ * Classes extending from this widget can be used in an [[\yii\widgets\ActiveForm|ActiveForm]]
+ * using the [[\yii\widgets\ActiveField::widget()|widget()]] method, for example like this:
  *
  * ```php
  * <?= $form->field($model, 'from_date')->widget('WidgetClassName', [


### PR DESCRIPTION
The links on http://www.yiiframework.com/doc-2.0/yii-widgets-inputwidget.html are broken, the generator prefixes them with `\yii\widgets\`, so I think this will fix them. (so would removing `yii\widgets`, but I think it's better to be explicit)
