### PR TITLE
ErrorHandler not clearing preallocated memory reserve

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -22,6 +22,7 @@ Yii Framework 2 Change Log
 - Bug #9754: Fixed `yii\web\Request` error when path info is empty (dynasource)
 - Bug #9791: Fixed endless loop on file creation for non-existing device letters on windows (lukos, cebe)
 - Bug: Fixed generation of canonical URLs for `ViewAction` pages (samdark)
+- Bug: Fixed `yii\base\ErrorHandler` not clearing the preallocated memory reserve (kidol)
 - Enh #7581: Added ability to specify range using anonymous function in `RangeValidator` (RomeroMsk)
 - Enh #8613: `yii\widgets\FragmentCache` will not store empty content anymore which fixes some problems related to `yii\filters\PageCache` (kidol)
 - Enh #9476: Added DI injection via controller action method signature (mdmunir)

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -218,7 +218,7 @@ abstract class ErrorHandler extends Component
      */
     public function handleFatalError()
     {
-        unset($this->_memoryReserve);
+        $this->_memoryReserve = null;
 
         // load ErrorException manually here because autoloading them will not work
         // when error occurs while autoloading a class


### PR DESCRIPTION
> Fatal error: Uncaught exception 'yii\base\InvalidCallException' with message 'Unsetting an unknown or read-only property: yii\web\ErrorHandler::_memoryReserve' in Y:\wamp\apps\yii2\framework\base\Component.php:261

Reproduce:
1. Enable YII_DEBUG
2. `trigger_error("error", E_USER_ERROR);`
