### PR TITLE
Added missing function to ActiveRecordInterface interface.

### DIFF
--- a/framework/db/ActiveRecordInterface.php
+++ b/framework/db/ActiveRecordInterface.php
@@ -402,4 +402,12 @@ interface ActiveRecordInterface
      * @return mixed the database connection used by this AR class.
      */
     public static function getDb();
+
+    /**
+     * Populates the named relation with the related records.
+     * Note that this method does not check if the relation exists or not.
+     * @param string $name the relation name (case-sensitive)
+     * @param ActiveRecordInterface|array|null $records the related records to be populated into the relation.
+     */
+    public function populateRelation($name, $records);
 }


### PR DESCRIPTION
This adds the missing populateRelation function to the ActiveRecordInterface (#9745).

For now I've only added the function that undisputed should be part of the interface.
