### PR TITLE
Added interface and trait for enumerable relations.

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -40,8 +40,9 @@ use yii\helpers\ArrayHelper;
  * @author Carsten Brandt <mail@cebe.cc>
  * @since 2.0
  */
-abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
+abstract class BaseActiveRecord extends Model implements ActiveRecordInterface, EnumerableRelationInterface
 {
+    use EnumerableRelationTrait;
     /**
      * @event Event an event that is triggered when the record is initialized via [[init()]].
      */

--- a/framework/db/EnumerableRelationInterface.php
+++ b/framework/db/EnumerableRelationInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace yii\db;
+
+use yii\db\ActiveRecordInterface;
+
+/**
+ * Interface EnumerableRelationInterface
+ * The goal of this interface is to provide a consistent interface so that when a good implementation option becomes
+ * available (PHP7) we can easily adapt our code to use it.
+ *
+ * In the mean time this enables developers to use custom implementation for enumerating relations.
+ * Several non-ideal but working implementations come to mind:
+ * - Hard code / repeat names of relations in each model class.
+ * - Call all getters and check return values.
+ * - Scan PHPDoc comments.
+ *
+ *
+ * @package app\db
+ */
+interface EnumerableRelationInterface extends ActiveRecordInterface {
+
+    /**
+     * Returns the names of relations for this object.
+     * @return string[]
+     */
+    public function relations();
+}

--- a/framework/db/EnumerableRelationTrait.php
+++ b/framework/db/EnumerableRelationTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace yii\db;
+
+use yii\base\NotSupportedException;
+
+/**
+ * Class EnumerableRelationTrait
+ *
+ * Since there is no way to reliably determine return types until PHP7 hits, by default this trait just throws an exception.
+ * This way any developer needing to iterate over relation names can choose how to implement it.
+ * @see EnumerationRelationInterface
+ * @package app\db
+ */
+trait EnumerableRelationTrait {
+
+    public function relations() {
+        throw new NotSupportedException("Enumerating relations is not supported in PHP < 7");
+    }
+}


### PR DESCRIPTION
There have been a lot of discussions regarding enumeration of relations: #7710, #1282. #8402.

Summarized:
1. Enumerating relationships has its use cases, the number of tickets are a proof of that.
2. There is no clean implementation for getting all functions that return type X in PHP at this point in time.
3. There are several "ugly" / suboptimal solutions that could get us a list of relations:
- Enumerate getters, call them and check return type, slow probably don't want to do that.
- Parse PHPDOC, will work, but can be considered a hack.
- Explicitly define names of relationships. Not DRY, requiring me to define my relationships in several places.

This PR is an attempt to prepare Yii2 to support enumerable relationships. When PHP 7 hits, using the return type hint we can easily enumerate getters and check their return type.

Until then, developers that need relation enumeration are forced to create custom implementations which limit the reusability of their code and are very unlikely to be interoperable.

By adding this interface (or merging the interface with ActiveRecordInterface), the framework provides a uniform way for developers to implement enumeration if they need it.
1. This PR will not break BC for anyone, assuming they are not adding stuff to the yii\db namespace.
2. If instead the interface is merged with ActiveRecordInterface, it is a minor BC break (people implementing ActiveRecordInterface but not subclassing ActiveRecord will get errors).

--- My own use case for enumerating relations is to (for example) provide a REST API that supports dynamic discovery via HATEOAS.
