### PR TITLE
Implemented basic connection interface.

### DIFF
--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -130,7 +130,7 @@ use yii\caching\Cache;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-class Connection extends Component
+class Connection extends Component implements ConnectionInterface
 {
     /**
      * @event Event an event that is triggered after a DB connection is established

--- a/framework/db/ConnectionInterface.php
+++ b/framework/db/ConnectionInterface.php
@@ -1,0 +1,245 @@
+<?php
+
+
+namespace yii\db;
+
+
+interface ConnectionInterface
+{
+    /**
+     * Creates a command for execution.
+     * @param string $sql the SQL statement to be executed
+     * @param array $params the parameters to be bound to the SQL statement
+     * @return Command the DB command
+     */
+    public function createCommand($sql = null, $params = []);
+
+    /**
+     * Uses query cache for the queries performed with the callable.
+     * When query caching is enabled ([[enableQueryCache]] is true and [[queryCache]] refers to a valid cache),
+     * queries performed within the callable will be cached and their results will be fetched from cache if available.
+     * For example,
+     *
+     * ```php
+     * // The customer will be fetched from cache if available.
+     * // If not, the query will be made against DB and cached for use next time.
+     * $customer = $db->cache(function (Connection $db) {
+     *     return $db->createCommand('SELECT * FROM customer WHERE id=1')->queryOne();
+     * });
+     * ```
+     *
+     * Note that query cache is only meaningful for queries that return results. For queries performed with
+     * [[Command::execute()]], query cache will not be used.
+     *
+     * @param callable $callable a PHP callable that contains DB queries which will make use of query cache.
+     * The signature of the callable is `function (Connection $db)`.
+     * @param integer $duration the number of seconds that query results can remain valid in the cache. If this is
+     * not set, the value of [[queryCacheDuration]] will be used instead.
+     * Use 0 to indicate that the cached data will never expire.
+     * @param \yii\caching\Dependency $dependency the cache dependency associated with the cached query results.
+     * @return mixed the return result of the callable
+     * @throws \Exception if there is any exception during query
+     * @see enableQueryCache
+     * @see queryCache
+     * @see noCache()
+     */
+    public function cache(callable $callable, $duration = null, $dependency = null);
+
+
+    /**
+     * Starts a transaction.
+     * @param string|null $isolationLevel The isolation level to use for this transaction.
+     * See [[Transaction::begin()]] for details.
+     * @return Transaction the transaction initiated
+     */
+    public function beginTransaction($isolationLevel = null);
+
+
+    /**
+     * Returns the schema information for the database opened by this connection.
+     * @return Schema the schema information for the database opened by this connection.
+     * @throws NotSupportedException if there is no support for the current driver type
+     */
+    public function getSchema();
+
+    /**
+     * Closes the currently active DB connection.
+     * It does nothing if the connection is already closed.
+     */
+    public function close();
+
+
+    /**
+     * Returns the query builder for the current DB connection.
+     * @return QueryBuilder the query builder for the current DB connection.
+     */
+    public function getQueryBuilder();
+
+    /**
+     * Quotes a string value for use in a query.
+     * Note that if the parameter is not a string, it will be returned without change.
+     * @param string $value string to be quoted
+     * @return string the properly quoted string
+     * @see http://www.php.net/manual/en/function.PDO-quote.php
+     */
+    public function quoteValue($value);
+
+
+    /**
+     * Processes a SQL statement by quoting table and column names that are enclosed within double brackets.
+     * Tokens enclosed within double curly brackets are treated as table names, while
+     * tokens enclosed within double square brackets are column names. They will be quoted accordingly.
+     * Also, the percentage character "%" at the beginning or ending of a table name will be replaced
+     * with [[tablePrefix]].
+     * @param string $sql the SQL to be quoted
+     * @return string the quoted SQL
+     */
+    public function quoteSql($sql);
+
+    /**
+     * Quotes a table name for use in a query.
+     * If the table name contains schema prefix, the prefix will also be properly quoted.
+     * If the table name is already quoted or contains special characters including '(', '[[' and '{{',
+     * then this method will do nothing.
+     * @param string $name table name
+     * @return string the properly quoted table name
+     */
+    public function quoteTableName($name);
+
+
+    /**
+     * Quotes a column name for use in a query.
+     * If the column name contains prefix, the prefix will also be properly quoted.
+     * If the column name is already quoted or contains special characters including '(', '[[' and '{{',
+     * then this method will do nothing.
+     * @param string $name column name
+     * @return string the properly quoted column name
+     */
+    public function quoteColumnName($name);
+
+    /**
+     * Returns the name of the DB driver. Based on the the current [[dsn]], in case it was not set explicitly
+     * by an end user.
+     * @return string name of the DB driver
+     */
+    public function getDriverName();
+
+    /**
+     * Returns a value indicating whether the DB connection is established.
+     * @return boolean whether the DB connection is established
+     */
+    public function getIsActive();
+
+    /**
+     * Establishes a DB connection.
+     * It does nothing if a DB connection has already been established.
+     * @throws Exception if connection fails
+     */
+    public function open();
+
+    /**
+     * Returns the PDO instance for the currently active slave connection.
+     * When [[enableSlaves]] is true, one of the slaves will be used for read queries, and its PDO instance
+     * will be returned by this method.
+     * @param boolean $fallbackToMaster whether to return a master PDO in case none of the slave connections is available.
+     * @return PDO the PDO instance for the currently active slave connection. Null is returned if no slave connection
+     * is available and `$fallbackToMaster` is false.
+     */
+    public function getSlavePdo($fallbackToMaster = true);
+
+    /**
+     * Returns the PDO instance for the currently active master connection.
+     * This method will open the master DB connection and then return [[pdo]].
+     * @return PDO the PDO instance for the currently active master connection.
+     */
+    public function getMasterPdo();
+
+    /**
+     * Returns the currently active slave connection.
+     * If this method is called the first time, it will try to open a slave connection when [[enableSlaves]] is true.
+     * @param boolean $fallbackToMaster whether to return a master connection in case there is no slave connection available.
+     * @return Connection the currently active slave connection. Null is returned if there is slave available and
+     * `$fallbackToMaster` is false.
+     */
+    public function getSlave($fallbackToMaster = true);
+
+    /**
+     * Executes the provided callback by using the master connection.
+     *
+     * This method is provided so that you can temporarily force using the master connection to perform
+     * DB operations even if they are read queries. For example,
+     *
+     * ```php
+     * $result = $db->useMaster(function ($db) {
+     *     return $db->createCommand('SELECT * FROM user LIMIT 1')->queryOne();
+     * });
+     * ```
+     *
+     * @param callable $callback a PHP callable to be executed by this method. Its signature is
+     * `function (Connection $db)`. Its return value will be returned by this method.
+     * @return mixed the return value of the callback
+     */
+    public function useMaster(callable $callback);
+
+
+    /**
+     * Disables query cache temporarily.
+     * Queries performed within the callable will not use query cache at all. For example,
+     *
+     * ```php
+     * $db->cache(function (Connection $db) {
+     *
+     *     // ... queries that use query cache ...
+     *
+     *     return $db->noCache(function (Connection $db) {
+     *         // this query will not use query cache
+     *         return $db->createCommand('SELECT * FROM customer WHERE id=1')->queryOne();
+     *     });
+     * });
+     * ```
+     *
+     * @param callable $callable a PHP callable that contains DB queries which should not use query cache.
+     * The signature of the callable is `function (Connection $db)`.
+     * @return mixed the return result of the callable
+     * @throws \Exception if there is any exception during query
+     * @see enableQueryCache
+     * @see queryCache
+     * @see cache()
+     */
+    public function noCache(callable $callable);
+
+
+    /**
+     * Returns the current query cache information.
+     * This method is used internally by [[Command]].
+     * @param integer $duration the preferred caching duration. If null, it will be ignored.
+     * @param \yii\caching\Dependency $dependency the preferred caching dependency. If null, it will be ignored.
+     * @return array the current query cache information, or null if query cache is not enabled.
+     * @internal
+     */
+    public function getQueryCacheInfo($duration, $dependency);
+
+
+    /**
+     * Returns the currently active transaction.
+     * @return Transaction the currently active transaction. Null if no active transaction.
+     */
+    public function getTransaction();
+
+    /**
+     * Changes the current driver name.
+     * @param string $driverName name of the DB driver
+     */
+    public function setDriverName($driverName);
+
+    /**
+     * Executes callback provided in a transaction.
+     *
+     * @param callable $callback a valid PHP callback that performs the job. Accepts connection instance as parameter.
+     * @param string|null $isolationLevel The isolation level to use for this transaction.
+     * See [[Transaction::begin()]] for details.
+     * @throws \Exception
+     * @return mixed result of callback function
+     */
+    public function transaction(callable $callback, $isolationLevel = null);
+}


### PR DESCRIPTION
This is a first implementation of the ConnectionInterface from #9743.

Note that all public function of the Connection class are in the interface, with the exception of getLastInsertID which is used no where in the code as far as I can tell.

There are currently a number of public properties that are directly used by other classes, these should be changed to getters / setters and added to the interface.

Also this interface should at some point be split up into a more basic interface and several more advanced interfaces.
Some interfaces that come to mind:
- ConnectionInterface --> basic connection 
- TransactionConnectionInterface --> implemented by connections that (maybe) support transactions, note the maybe here is because a Connection class might support different drivers that may support transactions.
- CacheableInterface --> This could be even broader than just connection. Basically any class could have a cache function that is defined as:
  
  ```
  public function cache(Closure $closure, $timeout) {
      // Do pre-caching stuff..
      $closure($this);
      // Do post-caching stuff.
  }
  ```
- PooledConnectionInterface --> implemented by connections that support pooling.

All these interfaces do not break BC but do add some cleanliness to the code. In general type hinting should be aimed more at interfaces and less at classes.
