### PR TITLE
Allow the use of Yii aliases in a SQLite dsn

### DIFF
--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -521,6 +521,8 @@ class Connection extends Component
 
         if (empty($this->dsn)) {
             throw new InvalidConfigException('Connection::dsn cannot be empty.');
+        } else if (0 === strncmp('sqlite:@', $this->dsn, 8)) {
+            $this->dsn = 'sqlite:' . Yii::getAlias(substr($this->dsn, 7));
         }
         $token = 'Opening DB connection: ' . $this->dsn;
         try {


### PR DESCRIPTION
Making it possible to use a SQLite DSN like;

```
'db' => [
  'dsn' => 'sqlite:@app/db/database.sqlite3',
]
```

That way it'll always work out of the box and absolute paths aren't
needed.
