### PR TITLE
StringHelper::pregExplode implemented

### DIFF
--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -268,4 +268,37 @@ class BaseStringHelper
         }
         return $result;
     }
+
+    /**
+     * Explodes string into array using regular expression, optionally trims values and skips empty ones
+     *
+     * @param string $string String to be exploded.
+     * @param string $pattern Delimiter regular expression. Default is `/[\s,;]+/`.
+     * @param mixed $trim Whether to trim each element. Can be:
+     *   - boolean - to trim normally;
+     *   - string - custom characters to trim. Will be passed as a second argument to `trim()` function.
+     *   - callable - will be called for each value instead of trim. Takes the only argument - value.
+     * @param boolean $skipEmpty Whether to skip empty strings between delimiters. Default is false.
+     * @return array
+     * @since 2.0.7
+     */
+    public static function pregExplode($string, $pattern = '/[\s,;]+/', $trim = true, $skipEmpty = false)
+    {
+        $result = preg_split($pattern, $string);
+        if ($trim) {
+            if ($trim === true) {
+                $trim = 'trim';
+            } elseif (!is_callable($trim)) {
+                $trim = function ($v) use ($trim) {
+                    return trim($v, $trim);
+                };
+            }
+            $result = array_map($trim, $result);
+        }
+        if ($skipEmpty) {
+            // Wrapped with array_values to make array keys sequential after empty values removing
+            $result = array_values(array_filter($result));
+        }
+        return $result;
+    }
 }

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -236,4 +236,13 @@ class StringHelperTest extends TestCase
         $this->assertEquals(['Здесь', 'multibyte', 'строка'], StringHelper::explode("Здесь我 multibyte我 строка", '我'));
         $this->assertEquals(['Disable', '  trim  ', 'here but ignore empty'], StringHelper::explode("Disable,  trim  ,,,here but ignore empty", ',', false, true));
     }
+
+    public function testPregExplode()
+    {
+        $this->assertEquals(['It', 'is', 'a', 'first', 'test'], StringHelper::pregExplode("It, is a first, test"));
+        $this->assertEquals(['It', 'is', 'a second', 'test'], StringHelper::pregExplode("It) is) a second] test", '/[)}\]]+/'));
+        $this->assertEquals(['All_that_chars_are_treated', 'as_singe_separator'], StringHelper::pregExplode("All_that_chars_are_treated; ;,; as_singe_separator"));
+        $this->assertEquals(['Здесь', 'multibyte', 'строка'], StringHelper::pregExplode("ЗдесьΨ multibyte我 строка", '/(我|Ψ|,)/'));
+        $this->assertEquals(['Disable', '  trim  ', 'here but ignore empty'], StringHelper::pregExplode("Disable1  trim  123here but ignore empty", '/\d/', false, true));
+    }
 }


### PR DESCRIPTION
Propose to add pregExplode method to the `StringHelper`.
The difference with `StringHelper::explode` is that this one is for splitting using regular expression.
