### PR TITLE
Update tip 'style required fields with asterisks'

### DIFF
--- a/docs/guide/input-forms.md
+++ b/docs/guide/input-forms.md
@@ -109,7 +109,7 @@ class like it is done in the above example with [[yii\helpers\Html::submitButton
 > Tip: In order to style required fields with asterisks, you can use the following CSS:
 >
 > ```css
-> div.required label:after {
+> div.required label.control-label:after {
 >     content: " *";
 >     color: red;
 > }


### PR DESCRIPTION
Update tip 'style required fields with asterisks' with solution to remove the red start after each radiolist item
