### PR TITLE
`TimestampBehavior::getValue()` value processing is consistent with `AttributeBehavior`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -41,6 +41,7 @@ Yii Framework 2 Change Log
 - Enh: Added last resort measure for `FileHelper::removeDirectory()` fail to unlink symlinks under Windows (samdark)
 - Chg #9369: `Yii::$app->user->can()` now returns `false` instead of erroring in case `authManager` component is not configured (creocoder)
 - Chg #9411: `DetailView` now automatically sets container tag ID in case it's not specified (samdark)
+- Chg #9953: `TimestampBehavior::getValue()` changed to make value processing consistent with `AttributeBehavior::getValue()` (silverfire)
 
 2.0.6 August 05, 2015
 ---------------------

--- a/framework/behaviors/AttributeBehavior.php
+++ b/framework/behaviors/AttributeBehavior.php
@@ -62,7 +62,8 @@ class AttributeBehavior extends Behavior
      */
     public $attributes = [];
     /**
-     * @var mixed the value that will be assigned to the current attributes. This can be an anonymous function
+     * @var mixed the value that will be assigned to the current attributes. This can be an anonymous function,
+     * an [[Expression]] object representing a DB expression (e.g. `new Expression('NOW()')`), scalar, string
      * or an arbitrary value. If the former, the return value of the function will be assigned to the attributes.
      * The signature of the function should be as follows,
      *
@@ -103,7 +104,7 @@ class AttributeBehavior extends Behavior
     }
 
     /**
-     * Returns the value of the current attributes.
+     * Returns the value for the current attributes.
      * This method is called by [[evaluateAttributes()]]. Its return value will be assigned
      * to the attributes corresponding to the triggering event.
      * @param Event $event the event that triggers the current attribute updating.

--- a/framework/behaviors/TimestampBehavior.php
+++ b/framework/behaviors/TimestampBehavior.php
@@ -7,6 +7,8 @@
 
 namespace yii\behaviors;
 
+use Closure;
+use yii\base\Event;
 use yii\base\InvalidCallException;
 use yii\db\BaseActiveRecord;
 use yii\db\Expression;
@@ -78,10 +80,8 @@ class TimestampBehavior extends AttributeBehavior
      */
     public $updatedAtAttribute = 'updated_at';
     /**
-     * @var callable|Expression The expression that will be used for generating the timestamp.
-     * This can be either an anonymous function that returns the timestamp value,
-     * or an [[Expression]] object representing a DB expression (e.g. `new Expression('NOW()')`).
-     * If not set, it will use the value of `time()` to set the attributes.
+     * {@inheritdoc}
+     * In case, when the value is null - the [[time()]] function value will be used.
      */
     public $value;
 
@@ -102,15 +102,15 @@ class TimestampBehavior extends AttributeBehavior
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
+     * [[time()]] function return value will be used, when [[value]] is null.
      */
     protected function getValue($event)
     {
-        if ($this->value instanceof Expression) {
-            return $this->value;
-        } else {
-            return $this->value !== null ? call_user_func($this->value, $event) : time();
+        if ($this->value === null) {
+            return time();
         }
+        return parent::getValue($event);
     }
 
     /**

--- a/tests/framework/behaviors/TimestampBehaviorTest.php
+++ b/tests/framework/behaviors/TimestampBehaviorTest.php
@@ -105,6 +105,8 @@ class TimestampBehaviorTest extends TestCase
         return [
             [function() { return '2015-01-01'; }, '2015-01-01'],
             [new Expression("strftime('%Y')"), date('Y')],
+            ['2015-10-20', '2015-10-20'],
+            [time(), time()],
         ];
     }
 


### PR DESCRIPTION
Closes #9953 
