### PR TITLE
Add basePath and baseUrl to compressed assets bundle

### DIFF
--- a/framework/console/controllers/AssetController.php
+++ b/framework/console/controllers/AssetController.php
@@ -438,6 +438,7 @@ class AssetController extends Controller
     protected function saveTargets($targets, $bundleFile)
     {
         $array = [];
+        $bundles = $this->loadBundles($this->bundles);
         foreach ($targets as $name => $target) {
             if (isset($this->targets[$name])) {
                 $array[$name] = [
@@ -451,8 +452,11 @@ class AssetController extends Controller
                 if ($this->isBundleExternal($target)) {
                     $array[$name] = $this->composeBundleConfig($target);
                 } else {
+                    $bundle = $bundles[$name];
                     $array[$name] = [
                         'sourcePath' => null,
+                        'baseUrl' => $bundle->baseUrl,
+                        'basePath' => $bundle->basePath,
                         'js' => [],
                         'css' => [],
                         'depends' => $target->depends,


### PR DESCRIPTION
If you use construction like this:

```
$bundle = AppAsset::register($this);
<img src="<?= $bundle->baseUrl ?>/images/some-image.gif">" title="My cool image">
```

After compression it will be broken, because baseUrl will be empty.
This pull request fix it.
