### PR TITLE
Do not render client validation when `Validator::with` is set and `withClient` is not

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -43,6 +43,7 @@ Yii Framework 2 Change Log
 - Chg #9369: `Yii::$app->user->can()` now returns `false` instead of erroring in case `authManager` component is not configured (creocoder)
 - Chg #9411: `DetailView` now automatically sets container tag ID in case it's not specified (samdark)
 - Chg #9953: `TimestampBehavior::getValue()` changed to make value processing consistent with `AttributeBehavior::getValue()` (silverfire)
+- Chg #9983: `ActiveFieleld::getClientOptions()` does not render JS validation, when `Validator::when` is defined, and `Validatior::withClient` is not (silverfire)
 
 2.0.6 August 05, 2015
 ---------------------

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -150,6 +150,8 @@ class Validator extends Component
      * }
      * ```
      *
+     * When this property is set while [[whenClient]] is not - the [[clientValidateAttribute()]] will not be called.
+     *
      * @see whenClient
      */
     public $when;
@@ -169,6 +171,8 @@ class Validator extends Component
      *     return $('#country').val() === 'USA';
      * }
      * ```
+     *
+     * When this property is _NOT_ set while [[when]] is set - the [[clientValidateAttribute()]] will not be called.
      *
      * @see when
      */

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -697,7 +697,7 @@ class ActiveField extends Component
             foreach ($this->model->getActiveValidators($attribute) as $validator) {
                 /* @var $validator \yii\validators\Validator */
                 $js = $validator->clientValidateAttribute($this->model, $attribute, $this->form->getView());
-                if ($validator->enableClientValidation && $js != '') {
+                if ($validator->enableClientValidation && $js != '' && ($validator->whenClient !== null || $validator->when === null)) {
                     if ($validator->whenClient !== null) {
                         $js = "if (({$validator->whenClient})(attribute, value)) { $js }";
                     }


### PR DESCRIPTION
There is a common problem with model attribute validation: when developer defines `when` condition in the model rule, but forgots about `whenClient`.
This leads to inconsistend client-side validation.

This PR fixes behaviour of `ActiveFieleld::getClientOptions()` so JS will not be rendered, when `when` is defined, and `withClient` is not.
