### PR TITLE
Allow all callables instead of only Closures in ActionColumn

### DIFF
--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -157,7 +157,7 @@ class ActionColumn extends Column
      */
     public function createUrl($action, $model, $key, $index)
     {
-        if ($this->urlCreator instanceof Closure) {
+        if (is_callable($this->urlCreator)) {
             return call_user_func($this->urlCreator, $action, $model, $key, $index);
         } else {
             $params = is_array($key) ? $key : ['id' => (string) $key];


### PR DESCRIPTION
Allow all callables instead of only Closures when defining custom urlCreator in ActionColumn
