### PR TITLE
Fix #9133: optimitic lock doesn't work when using load()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.7 under development
 -----------------------
 
+- Bug #9133: Fixed optimitic lock doesn't work if the lock field is missing in the input data passed to load() (EvgenyOrekhov)
 - Bug #6351: Find MySQL FK constraints from `information_schema` tables instead of `SHOW CREATE TABLE` to improve reliability (nineinchnick)
 - Bug #6363, #8301, #8582, #9566: Fixed data methods and PJAX issues when used together (derekisbusy)
 - Bug #6876: Fixed RBAC migration MSSQL cascade problem (thejahweh)

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1571,4 +1571,20 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
             unset($this->$offset);
         }
     }
+
+    /**
+     * @inheritdoc
+     *
+     * This method sets the optimistic lock value to null before calling
+     * the parent implementation.
+     */
+    public function load($data, $formName = null)
+    {
+        $lock = $this->optimisticLock();
+        if ($lock !== null) {
+            $this->$lock = null;
+        }
+
+        return parent::load($data, $formName);
+    }
 }

--- a/tests/data/ar/Document.php
+++ b/tests/data/ar/Document.php
@@ -14,4 +14,11 @@ class Document extends ActiveRecord
     {
         return 'version';
     }
+
+    public function scenarios()
+    {
+        return [
+            'test' => ['title', 'content', 'version'],
+        ];
+    }
 }

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -703,7 +703,7 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals(1, $model->status);
     }
 
-    public function testPopulateRecordCallWhenQueryingOnParentClass() 
+    public function testPopulateRecordCallWhenQueryingOnParentClass()
     {
         (new Cat())->save(false);
         (new Dog())->save(false);
@@ -734,6 +734,26 @@ class ActiveRecordTest extends DatabaseTestCase
         $record = Document::findOne(1);
         $record->content = 'Rewrite attempt content';
         $record->version = 0;
+        $this->setExpectedException('yii\db\StaleObjectException');
+        $record->save(false);
+    }
+
+    public function testOptimisticLockAfterLoad()
+    {
+        /* @var $record Document */
+
+        $record = Document::findOne(1);
+        $record->scenario = 'test';
+        $record->load([
+            'content' => 'New Content',
+            'version' => $record->version,
+        ], '');
+        $record->save(false);
+        $this->assertEquals(1, $record->version);
+
+        $record = Document::findOne(1);
+        $record->scenario = 'test';
+        $record->load(['content' => 'Rewrite attempt content'], '');
         $this->setExpectedException('yii\db\StaleObjectException');
         $record->save(false);
     }


### PR DESCRIPTION
Optimitic lock didn't work when the lock field was missing
in the input data passed to load()
