### PR TITLE
Added DB2 database driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
 
 
 script:
-  - vendor/bin/phpunit --verbose $PHPUNIT_FLAGS --exclude-group mssql,oci,wincache,xcache,zenddata,cubrid
+  - vendor/bin/phpunit --verbose $PHPUNIT_FLAGS --exclude-group mssql,oci,wincache,xcache,zenddata,cubrid,ibm
 
 after_script:
   - |

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -51,6 +51,7 @@ Yii Framework 2 Change Log
 - Chg #9369: `Yii::$app->user->can()` now returns `false` instead of erroring in case `authManager` component is not configured (creocoder)
 - Chg #9411: `DetailView` now automatically sets container tag ID in case it's not specified (samdark)
 - Chg #9953: `TimestampBehavior::getValue()` changed to make value processing consistent with `AttributeBehavior::getValue()` (silverfire)
+- New #5: Added DB2 database driver (vernik91)
 
 2.0.6 August 05, 2015
 ---------------------

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -278,6 +278,7 @@ class Connection extends Component
         'mssql' => 'yii\db\mssql\Schema', // older MSSQL driver on MS Windows hosts
         'dblib' => 'yii\db\mssql\Schema', // dblib drivers on GNU/Linux (and maybe other OSes) hosts
         'cubrid' => 'yii\db\cubrid\Schema', // CUBRID
+        'ibm' => 'yii\db\ibm\Schema', // DB2
     ];
     /**
      * @var string Custom PDO wrapper class. If not set, it will use "PDO" or "yii\db\mssql\PDO" when MSSQL is used.
@@ -606,6 +607,9 @@ class Connection extends Component
         }
         if ($this->charset !== null && in_array($this->getDriverName(), ['pgsql', 'mysql', 'mysqli', 'cubrid'])) {
             $this->pdo->exec('SET NAMES ' . $this->pdo->quote($this->charset));
+        }
+        if ($this->getDriverName() === 'ibm') {
+            $this->pdo->setAttribute(PDO::ATTR_CASE, PDO::CASE_NATURAL);
         }
         $this->trigger(self::EVENT_AFTER_OPEN);
     }

--- a/framework/db/ibm/QueryBuilder.php
+++ b/framework/db/ibm/QueryBuilder.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db\ibm;
+
+use yii\base\InvalidParamException;
+use yii\db\Expression;
+
+/**
+ * QueryBuilder is the query builder for DB2 databases.
+ *
+ * @author Nikita Verkhovin <vernik91@gmail.com>
+ */
+class QueryBuilder extends \yii\db\QueryBuilder
+{
+    public $typeMap = [
+        Schema::TYPE_PK => 'integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1)',
+        Schema::TYPE_BIGPK => 'bigint NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1)',
+        Schema::TYPE_STRING => 'varchar(255)',
+        Schema::TYPE_TEXT => 'clob',
+        Schema::TYPE_SMALLINT => 'smallint',
+        Schema::TYPE_INTEGER => 'integer',
+        Schema::TYPE_BIGINT => 'bigint',
+        Schema::TYPE_FLOAT => 'float',
+        Schema::TYPE_DOUBLE => 'double',
+        Schema::TYPE_DECIMAL => 'decimal(10,0)',
+        Schema::TYPE_DATETIME => 'timestamp',
+        Schema::TYPE_TIMESTAMP => 'timestamp',
+        Schema::TYPE_TIME => 'time',
+        Schema::TYPE_DATE => 'date',
+        Schema::TYPE_BINARY => 'blob',
+        Schema::TYPE_BOOLEAN => 'smallint',
+        Schema::TYPE_MONEY => 'decimal(19,4)',
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    public function resetSequence($tableName, $value = null)
+    {
+        $table = $this->db->getTableSchema($tableName);
+
+        if ($table !== null && isset($table->columns[$table->sequenceName])) {
+            if ($value === null) {
+                $sql = 'SELECT MAX("'. $table->sequenceName .'") FROM "'. $tableName . '"';
+                $value = $this->db->createCommand($sql)->queryScalar() + 1;
+            } else {
+                $value = (int) $value;
+            }
+            return 'ALTER TABLE "' . $tableName . '" ALTER COLUMN "'.$table->sequenceName.'" RESTART WITH ' . $value;
+        } elseif ($table === null) {
+            throw new InvalidParamException("Table not found: $tableName");
+        } else {
+            throw new InvalidParamException("There is no sequence associated with table '$tableName'.");
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function buildOrderByAndLimit($sql, $orderBy, $limit, $offset)
+    {
+        $orderByStatment = $this->buildOrderBy($orderBy);
+        if ($orderByStatment !== '') {
+            $sql .= $this->separator . $orderByStatment;
+        }
+
+        $limitOffsetStatment = $this->buildLimit($limit, $offset);
+        if ($limitOffsetStatment != '') {
+            $sql = str_replace(':query', $sql, $limitOffsetStatment);
+        }
+        return $sql;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function buildLimit($limit, $offset)
+    {
+        if (!$this->hasLimit($limit) && !$this->hasOffset($offset)) {
+            return '';
+        }
+
+        $limitOffsetStatment = 'SELECT * FROM (SELECT SUBQUERY_.*, ROW_NUMBER() OVER() AS RN_ FROM ( :query ) AS SUBQUERY_) WHERE :offset :limit';
+
+        $replacement = $this->hasOffset($offset) ? 'RN_ > ' . $offset : 'RN_ > 0';
+        $limitOffsetStatment = str_replace(':offset', $replacement, $limitOffsetStatment);
+
+        $replacement = $this->hasLimit($limit) ? 'AND RN_ <= ' . ($limit + $offset) : '';
+        $limitOffsetStatment = str_replace(':limit', $replacement, $limitOffsetStatment);
+
+        return $limitOffsetStatment;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function alterColumn($table, $column, $type)
+    {
+        return 'ALTER TABLE ' . $this->db->quoteTableName($table) . ' ALTER COLUMN '
+        . $this->db->quoteColumnName($column) . ' SET DATA TYPE '
+        . $this->getColumnType($type);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function buildCompositeInCondition($operator, $columns, $values, &$params)
+    {
+        $vss = [];
+        foreach ($values as $value) {
+            $vs = [];
+            foreach ($columns as $column) {
+                if (isset($value[$column])) {
+                    $phName = self::PARAM_PREFIX . count($params);
+                    $params[$phName] = $value[$column];
+                    $vs[] = $phName;
+                } else {
+                    $vs[] = 'NULL';
+                }
+            }
+            $vss[] = 'select ' . implode(', ', $vs) . ' from SYSIBM.SYSDUMMY1';
+        }
+        foreach ($columns as $i => $column) {
+            if (strpos($column, '(') === false) {
+                $columns[$i] = $this->db->quoteColumnName($column);
+            }
+        }
+
+        return '(' . implode(', ', $columns) . ") $operator (" . implode(' UNION ', $vss) . ')';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function insert($table, $columns, &$params)
+    {
+        $schema = $this->db->getSchema();
+        if (($tableSchema = $schema->getTableSchema($table)) !== null) {
+            $columnSchemas = $tableSchema->columns;
+        } else {
+            $columnSchemas = [];
+        }
+        $names = [];
+        $placeholders = [];
+        foreach ($columns as $name => $value) {
+            $names[] = $schema->quoteColumnName($name);
+            if ($value instanceof Expression) {
+                $placeholders[] = $value->expression;
+                foreach ($value->params as $n => $v) {
+                    $params[$n] = $v;
+                }
+            } else {
+                $phName = self::PARAM_PREFIX . count($params);
+                $placeholders[] = $phName;
+                $params[$phName] = !is_array($value) && isset($columnSchemas[$name]) ? $columnSchemas[$name]->dbTypecast($value) : $value;
+            }
+        }
+
+        if (empty($placeholders)) {
+            $placeholders = array_fill(0, count($columnSchemas), 'DEFAULT');
+        }
+
+        return 'INSERT INTO ' . $schema->quoteTableName($table)
+        . (!empty($names) ? ' (' . implode(', ', $names) . ')' : '')
+        . ' VALUES (' . implode(', ', $placeholders) . ')';
+    }
+}

--- a/framework/db/ibm/Schema.php
+++ b/framework/db/ibm/Schema.php
@@ -1,0 +1,390 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db\ibm;
+
+use PDO;
+use yii\db\Expression;
+use yii\db\TableSchema;
+use yii\db\Transaction;
+
+/**
+ * Schema is the class for retrieving metadata from a DB2 database.
+ *
+ * @author Nikita Verkhovin <vernik91@gmail.com>
+ */
+class Schema extends \yii\db\Schema
+{
+    public $typeMap = [
+        'character' => self::TYPE_STRING,
+        'varchar' => self::TYPE_STRING,
+        'clob' => self::TYPE_TEXT,
+        'graphic' => self::TYPE_STRING,
+        'vargraphic' => self::TYPE_STRING,
+        'dbclob' => self::TYPE_TEXT,
+        'nchar' => self::TYPE_STRING,
+        'nvarchar' => self::TYPE_STRING,
+        'nclob' => self::TYPE_TEXT,
+        'binary' => self::TYPE_BINARY,
+        'varbinary' => self::TYPE_BINARY,
+        'blob' => self::TYPE_BINARY,
+        'smallint' => self::TYPE_SMALLINT,
+        'int' => self::TYPE_INTEGER,
+        'integer' => self::TYPE_INTEGER,
+        'bigint' => self::TYPE_BIGINT,
+        'decimal' => self::TYPE_DECIMAL,
+        'numeric' => self::TYPE_DECIMAL,
+        'real' => self::TYPE_FLOAT,
+        'float' => self::TYPE_FLOAT,
+        'double' => self::TYPE_DOUBLE,
+        'decfloat' => self::TYPE_FLOAT,
+        'date' => self::TYPE_DATE,
+        'time' => self::TYPE_TIME,
+        'timestamp' => self::TYPE_TIMESTAMP
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+
+        if (isset($this->defaultSchema)) {
+            $this->db->createCommand('SET SCHEMA ' . $this->quoteSimpleTableName($this->defaultSchema))->execute();
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function quoteSimpleTableName($name)
+    {
+        return strpos($name, '"') !== false ? $name : '"' . $name . '"';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function quoteSimpleColumnName($name)
+    {
+        return strpos($name, '"') !== false || $name === '*' ? $name : '"' . $name . '"';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createQueryBuilder()
+    {
+        return new QueryBuilder($this->db);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function loadTableSchema($name)
+    {
+        $table = new TableSchema();
+        $this->resolveTableNames($table, $name);
+
+        if ($this->findColumns($table)) {
+            $this->findConstraints($table);
+            return $table;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function resolveTableNames($table, $name)
+    {
+        $parts = explode('.', str_replace('"', '', $name));
+        if (isset($parts[1])) {
+            $table->schemaName = $parts[0];
+            $table->name = $parts[1];
+            $table->fullName = $table->schemaName . '.' . $table->name;
+        } else {
+            $table->fullName = $table->name = $parts[0];
+        }
+    }
+
+    /**
+     * Determines the PDO type for the given PHP data value.
+     * @param mixed $data the data whose PDO type is to be determined
+     * @return integer the PDO type
+     * @see http://www.php.net/manual/en/pdo.constants.php
+     */
+    public function getPdoType($data)
+    {
+        static $typeMap = [
+            // php type => PDO type
+            'boolean' => \PDO::PARAM_INT, // PARAM_BOOL is not supported by DB2 PDO
+            'integer' => \PDO::PARAM_INT,
+            'string' => \PDO::PARAM_STR,
+            'resource' => \PDO::PARAM_LOB,
+            'NULL' => \PDO::PARAM_INT, // PDO IBM doesn't support PARAM_NULL
+        ];
+        $type = gettype($data);
+
+        return isset($typeMap[$type]) ? $typeMap[$type] : \PDO::PARAM_STR;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function loadColumnSchema($info)
+    {
+        $column = $this->createColumnSchema();
+
+        $column->name = $info['name'];
+        $column->dbType = $info['dbtype'];
+        $column->defaultValue = isset($info['defaultvalue']) ? trim($info['defaultvalue'], "''") : null;
+        $column->scale = (int) $info['scale'];
+        $column->size = (int) $info['size'];
+        $column->precision = (int) $info['size'];
+        $column->allowNull = $info['allownull'] === '1';
+        $column->isPrimaryKey = $info['isprimarykey'] === '1';
+        $column->autoIncrement = $info['autoincrement'] === '1';
+        $column->unsigned = false;
+        $column->type = $this->typeMap[strtolower($info['dbtype'])];
+        $column->enumValues = null;
+        $column->comment = isset($info['comment']) ? $info['comment'] : null;
+
+        if (preg_match('/(varchar|character|clob|graphic|binary|blob)/i', $info['dbtype'])) {
+            $column->dbType .= '(' . $info['size'] . ')';
+        } elseif (preg_match('/(decimal|double|real)/i', $info['dbtype'])) {
+            $column->dbType .= '(' . $info['size'] . ',' . $info['scale'] . ')';
+        }
+
+        if ($column->defaultValue) {
+            if ($column->type === 'timestamp' && $column->defaultValue === 'CURRENT TIMESTAMP') {
+                $column->defaultValue = new Expression($column->defaultValue);
+            }
+        }
+
+        $column->phpType = $this->getColumnPhpType($column);
+
+        return $column;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function findColumns($table)
+    {
+        $sql = <<<SQL
+            SELECT
+                c.colname AS name,
+                c.typename AS dbtype,
+                cast(c.default as varchar(254)) AS defaultvalue,
+                c.scale AS scale,
+                c.length AS size,
+                CASE WHEN c.nulls = 'Y'         THEN 1 ELSE 0 END AS allownull,
+                CASE WHEN c.keyseq IS NOT NULL  THEN 1 ELSE 0 END AS isprimarykey,
+                CASE WHEN c.identity = 'Y'      THEN 1 ELSE 0 END AS autoincrement,
+                c.remarks AS comment
+            FROM
+                syscat.columns AS c
+            WHERE
+                c.tabname = :table
+SQL;
+
+        if (isset($table->schemaName)) {
+            $sql .= ' AND c.tabschema = :schema';
+        }
+
+        $sql .= ' ORDER BY c.colno';
+
+        $command = $this->db->createCommand($sql);
+        $command->bindValue(':table', $table->name);
+
+        if (isset($table->schemaName)) {
+            $command->bindValue(':schema', $table->schemaName);
+        }
+        $columns = $command->queryAll();
+        if (empty($columns)) {
+            return false;
+        }
+
+        foreach ($columns as $info) {
+            if ($this->db->slavePdo->getAttribute(PDO::ATTR_CASE) !== PDO::CASE_LOWER) {
+                $info = array_change_key_case($info, CASE_LOWER);
+            }
+            $column = $this->loadColumnSchema($info);
+            $table->columns[$column->name] = $column;
+            if ($column->isPrimaryKey) {
+                $table->primaryKey[] = $column->name;
+                if ($column->autoIncrement) {
+                    $table->sequenceName = $column->name;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function findConstraints($table)
+    {
+        $sql = <<<SQL
+            SELECT
+                pk.tabname AS tablename,
+                fk.colname AS fk,
+                pk.colname AS pk
+            FROM
+                syscat.references AS ref
+            INNER JOIN
+                syscat.keycoluse AS fk ON ref.constname = fk.constname
+            INNER JOIN
+                syscat.keycoluse AS pk ON ref.refkeyname = pk.constname AND pk.colseq = fk.colseq
+            WHERE
+                fk.tabname = :table
+SQL;
+
+        if (isset($table->schemaName)) {
+            $sql .= ' AND fk.tabschema = :schema';
+        }
+
+        $command = $this->db->createCommand($sql);
+        $command->bindValue(':table', $table->name);
+
+        if (isset($table->schemaName)) {
+            $command->bindValue(':schema', $table->schemaName);
+        }
+
+        $results = $command->queryAll();
+        $foreignKeys = [];
+        foreach ($results as $result) {
+            if ($this->db->slavePdo->getAttribute(PDO::ATTR_CASE) !== PDO::CASE_LOWER) {
+                $result = array_change_key_case($result, CASE_LOWER);
+            }
+            $tablename = $result['tablename'];
+            $fk = $result['fk'];
+            $pk = $result['pk'];
+            $foreignKeys[$tablename][$fk] = $pk;
+        }
+        foreach ($foreignKeys as $tablename => $keymap) {
+            $constraint = [$tablename];
+            foreach ($keymap as $fk => $pk) {
+                $constraint[$fk] = $pk;
+            }
+            $table->foreignKeys[] = $constraint;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function findUniqueIndexes($table)
+    {
+        $sql = <<<SQL
+            SELECT
+                i.indname AS indexname,
+                ic.colname AS column
+            FROM
+                syscat.indexes AS i
+            INNER JOIN
+                syscat.indexcoluse AS ic ON i.indname = ic.indname
+            WHERE
+                i.tabname = :table
+SQL;
+
+        if (isset($table->schemaName)) {
+            $sql .= ' AND tabschema = :schema';
+        }
+
+        $sql .= ' ORDER BY ic.colseq';
+
+        $command = $this->db->createCommand($sql);
+        $command->bindValue(':table', $table->name);
+
+        if (isset($table->schemaName)) {
+            $command->bindValue(':schema', $table->schemaName);
+        }
+
+        $results = $command->queryAll();
+        $indexes = [];
+        foreach ($results as $result) {
+            if ($this->db->slavePdo->getAttribute(PDO::ATTR_CASE) !== PDO::CASE_LOWER) {
+                $result = array_change_key_case($result, CASE_LOWER);
+            }
+            $indexes[$result['indexname']][] = $result['column'];
+        }
+        return $indexes;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function findTableNames($schema = '')
+    {
+        $sql = <<<SQL
+            SELECT
+                t.tabname
+            FROM
+                syscat.tables AS t
+            WHERE
+                t.type in ('T', 'V') AND
+                t.ownertype != 'S'
+SQL;
+
+        if ($schema !== '') {
+            $sql .= ' AND t.tabschema = :schema';
+        }
+
+        $command = $this->db->createCommand($sql);
+
+        if ($schema !== '') {
+            $command->bindValue(':schema', $schema);
+        }
+
+        return $command->queryColumn();
+    }
+
+    /**
+     * Sets the isolation level of the current transaction.
+     * @param string $level The transaction isolation level to use for this transaction.
+     */
+    public function setTransactionIsolationLevel($level)
+    {
+        switch ($level) {
+            case Transaction::READ_UNCOMMITTED:
+                $this->db->createCommand('SET CURRENT ISOLATION UR')->execute();
+                break;
+            case Transaction::READ_COMMITTED:
+                $this->db->createCommand('SET CURRENT ISOLATION CS')->execute();
+                break;
+            case Transaction::REPEATABLE_READ:
+                $this->db->createCommand('SET CURRENT ISOLATION RS')->execute();
+                break;
+            case Transaction::SERIALIZABLE:
+                $this->db->createCommand('SET CURRENT ISOLATION RR')->execute();
+                break;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function refreshTableSchema($name)
+    {
+        try {
+            $sql = "CALL ADMIN_CMD ('REORG TABLE " . $this->db->quoteTableName($name) . "')";
+            $this->db->createCommand($sql)->execute();
+        } catch (\Exception $ex) {
+            // Do not throw error on table which doesn't exist
+            if (!(isset($ex->errorInfo[1]) && $ex->errorInfo[1] === -2211)) {
+                throw new \Exception($ex->getMessage(), $ex->getCode(), $ex->getPrevious());
+            }
+        }
+
+        parent::refreshTableSchema($name);
+    }
+}

--- a/tests/data/config.php
+++ b/tests/data/config.php
@@ -43,6 +43,12 @@ $config = [
             'password' => 'postgres',
             'fixture' => __DIR__ . '/postgres.sql',
         ],
+        'ibm' => [
+            'dsn' => 'ibm:DRIVER={IBM DB2 ODBC DRIVER};DATABASE=yiitest;HOSTNAME=localhost;PORT=50000;PROTOCOL=TCPIP',
+            'username' => 'travis',
+            'password' => '',
+            'fixture' => __DIR__ . '/ibm.sql',
+        ]
     ],
 ];
 

--- a/tests/data/ibm.sql
+++ b/tests/data/ibm.sql
@@ -1,0 +1,232 @@
+/**
+ * This is the database schema for testing DB2 support of Yii DAO and Active Record.
+ * The database setup in config.php is required to perform then relevant tests:
+ */
+
+BEGIN
+  DECLARE CONTINUE HANDLER FOR SQLSTATE '42704' BEGIN END;
+  EXECUTE IMMEDIATE 'DROP TABLE "composite_fk"';
+  EXECUTE IMMEDIATE 'DROP TABLE "order_item"';
+  EXECUTE IMMEDIATE 'DROP TABLE "order_item_with_null_fk"';
+  EXECUTE IMMEDIATE 'DROP TABLE "item"';
+  EXECUTE IMMEDIATE 'DROP TABLE "order"';
+  EXECUTE IMMEDIATE 'DROP TABLE "order_with_null_fk"';
+  EXECUTE IMMEDIATE 'DROP TABLE "category"';
+  EXECUTE IMMEDIATE 'DROP TABLE "customer"';
+  EXECUTE IMMEDIATE 'DROP TABLE "profile"';
+  EXECUTE IMMEDIATE 'DROP TABLE "null_values"';
+  EXECUTE IMMEDIATE 'DROP TABLE "type"';
+  EXECUTE IMMEDIATE 'DROP TABLE "constraints"';
+  EXECUTE IMMEDIATE 'DROP TABLE "animal"';
+  EXECUTE IMMEDIATE 'DROP TABLE "default_pk"';
+  EXECUTE IMMEDIATE 'DROP TABLE "document"';
+  EXECUTE IMMEDIATE 'DROP TABLE "validator_main"';
+  EXECUTE IMMEDIATE 'DROP TABLE "validator_ref"';
+  EXECUTE IMMEDIATE 'DROP TABLE "bit_values"';
+  EXECUTE IMMEDIATE 'DROP VIEW "animal_view"';
+END;--
+
+/* STATEMENTS */
+
+CREATE TABLE "constraints" (
+  "id" integer not null,
+  "field1" varchar(255)
+);
+
+CREATE TABLE "profile" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "description" varchar(128) NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+CREATE TABLE "customer" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "email" varchar(128) NOT NULL,
+  "name" varchar(128),
+  "address" clob,
+  "status" integer DEFAULT 0,
+  "profile_id" integer,
+  PRIMARY KEY ("id")
+);
+
+CREATE TABLE "category" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "name" varchar(128) NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+CREATE TABLE "item" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "name" varchar(128) NOT NULL,
+  "category_id" integer NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "FK_item_category_id" FOREIGN KEY ("category_id") REFERENCES "category" ("id") ON DELETE CASCADE
+);
+CREATE INDEX "FK_item_category_id" ON "item" ("category_id");
+
+CREATE TABLE "order" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "customer_id" integer NOT NULL,
+  "created_at" integer NOT NULL,
+  "total" decimal(10,0) NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "FK_order_customer_id" FOREIGN KEY ("customer_id") REFERENCES "customer" ("id") ON DELETE CASCADE
+);
+
+CREATE TABLE "order_with_null_fk" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "customer_id" integer,
+  "created_at" integer NOT NULL,
+  "total" decimal(10,0) NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+CREATE TABLE "order_item" (
+  "order_id" integer NOT NULL,
+  "item_id" integer NOT NULL,
+  "quantity" integer NOT NULL,
+  "subtotal" decimal(10,0) NOT NULL,
+  PRIMARY KEY ("order_id", "item_id"),
+  CONSTRAINT "FK_order_item_order_id" FOREIGN KEY ("order_id") REFERENCES "order" ("id") ON DELETE CASCADE,
+  CONSTRAINT "FK_order_item_item_id" FOREIGN KEY ("item_id") REFERENCES "item" ("id") ON DELETE CASCADE
+);
+CREATE INDEX "FK_order_item_item_id" ON "order_item" ("item_id");
+
+CREATE TABLE "order_item_with_null_fk" (
+  "order_id" integer,
+  "item_id" integer,
+  "quantity" integer NOT NULL,
+  "subtotal" decimal(10,0) NOT NULL
+);
+
+CREATE TABLE "composite_fk" (
+  "id" integer NOT NULL,
+  "order_id" integer NOT NULL,
+  "item_id" integer NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "FK_composite_fk_order_item" FOREIGN KEY ("order_id", "item_id") REFERENCES "order_item" ("order_id", "item_id") ON DELETE CASCADE
+);
+
+CREATE TABLE "null_values" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "var1" integer,
+  "var2" integer,
+  "var3" integer DEFAULT NULL,
+  "stringcol" varchar(32) DEFAULT NULL,
+  PRIMARY KEY ("id")
+);
+
+CREATE TABLE "type" (
+  "int_col" integer NOT NULL,
+  "int_col2" integer DEFAULT 1,
+  "smallint_col" smallint DEFAULT 1,
+  "char_col" char(100) NOT NULL,
+  "char_col2" varchar(100) DEFAULT 'something',
+  "char_col3" clob,
+  "float_col" double NOT NULL,
+  "float_col2" double DEFAULT 1.23,
+  "blob_col" blob,
+  "numeric_col" decimal(5,2) DEFAULT 33.22,
+  "time" timestamp NOT NULL DEFAULT '2002-01-01 00:00:00',
+  "bool_col" smallint NOT NULL,
+  "bool_col2" smallint DEFAULT 1,
+  "ts_default" timestamp NOT NULL DEFAULT CURRENT TIMESTAMP,
+  "bit_col" smallint NOT NULL DEFAULT 130
+);
+
+CREATE TABLE "animal" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "type" varchar(255) NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+CREATE TABLE "default_pk" (
+  "id" integer NOT NULL DEFAULT 5,
+  "type" varchar(255) NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+CREATE TABLE "document" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "title" varchar(255) NOT NULL,
+  "content" clob,
+  "version" integer NOT NULL DEFAULT 0,
+  PRIMARY KEY ("id")
+);
+
+CREATE TABLE "validator_main" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "field1" varchar(255),
+  PRIMARY KEY ("id")
+);
+
+CREATE TABLE "validator_ref" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "a_field" varchar(255),
+  "ref" integer,
+  PRIMARY KEY ("id")
+);
+
+CREATE TABLE "bit_values" (
+  "id" integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+  "val" smallint NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+CREATE VIEW "animal_view" AS SELECT * FROM "animal";
+
+INSERT INTO "animal" ("type") VALUES ('yiiunit\data\ar\Cat');
+INSERT INTO "animal" ("type") VALUES ('yiiunit\data\ar\Dog');
+
+INSERT INTO "profile" ("description") VALUES ('profile customer 1');
+INSERT INTO "profile" ("description") VALUES ('profile customer 3');
+
+INSERT INTO "customer" ("email", "name", "address", "status", "profile_id") VALUES ('user1@example.com', 'user1', 'address1', 1, 1);
+INSERT INTO "customer" ("email", "name", "address", "status") VALUES ('user2@example.com', 'user2', 'address2', 1);
+INSERT INTO "customer" ("email", "name", "address", "status", "profile_id") VALUES ('user3@example.com', 'user3', 'address3', 2, 2);
+
+INSERT INTO "category" ("name") VALUES ('Books');
+INSERT INTO "category" ("name") VALUES ('Movies');
+
+INSERT INTO "item" ("name", "category_id") VALUES ('Agile Web Application Development with Yii1.1 and PHP5', 1);
+INSERT INTO "item" ("name", "category_id") VALUES ('Yii 1.1 Application Development Cookbook', 1);
+INSERT INTO "item" ("name", "category_id") VALUES ('Ice Age', 2);
+INSERT INTO "item" ("name", "category_id") VALUES ('Toy Story', 2);
+INSERT INTO "item" ("name", "category_id") VALUES ('Cars', 2);
+
+INSERT INTO "order" ("customer_id", "created_at", "total") VALUES (1, 1325282384, 110.0);
+INSERT INTO "order" ("customer_id", "created_at", "total") VALUES (2, 1325334482, 33.0);
+INSERT INTO "order" ("customer_id", "created_at", "total") VALUES (2, 1325502201, 40.0);
+
+INSERT INTO "order_with_null_fk" ("customer_id", "created_at", "total") VALUES (1, 1325282384, 110.0);
+INSERT INTO "order_with_null_fk" ("customer_id", "created_at", "total") VALUES (2, 1325334482, 33.0);
+INSERT INTO "order_with_null_fk" ("customer_id", "created_at", "total") VALUES (2, 1325502201, 40.0);
+
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (1, 1, 1, 30.0);
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (1, 2, 2, 40.0);
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 4, 1, 10.0);
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 5, 1, 15.0);
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 3, 1, 8.0);
+INSERT INTO "order_item" ("order_id", "item_id", "quantity", "subtotal") VALUES (3, 2, 1, 40.0);
+
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (1, 1, 1, 30.0);
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (1, 2, 2, 40.0);
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 4, 1, 10.0);
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 5, 1, 15.0);
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 3, 1, 8.0);
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (3, 2, 1, 40.0);
+
+INSERT INTO "document" ("title", "content", "version") VALUES ('Yii 2.0 guide', 'This is Yii 2.0 guide', 0);
+
+INSERT INTO "validator_main" ("field1") VALUES ('just a string1');
+INSERT INTO "validator_main" ("field1") VALUES ('just a string2');
+INSERT INTO "validator_main" ("field1") VALUES ('just a string3');
+INSERT INTO "validator_main" ("field1") VALUES ('just a string4');
+INSERT INTO "validator_ref" ("a_field", "ref") VALUES ('ref_to_2', 2);
+INSERT INTO "validator_ref" ("a_field", "ref") VALUES ('ref_to_2', 2);
+INSERT INTO "validator_ref" ("a_field", "ref") VALUES ('ref_to_3', 3);
+INSERT INTO "validator_ref" ("a_field", "ref") VALUES ('ref_to_4', 4);
+INSERT INTO "validator_ref" ("a_field", "ref") VALUES ('ref_to_4', 4);
+INSERT INTO "validator_ref" ("a_field", "ref") VALUES ('ref_to_5', 5);
+
+INSERT INTO "bit_values" ("val") VALUES (0), (1);

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -19,6 +19,7 @@ use yiiunit\framework\db\cubrid\CubridActiveRecordTest;
 use yiiunit\data\ar\Animal;
 use yiiunit\data\ar\Cat;
 use yiiunit\data\ar\Dog;
+use yiiunit\framework\db\ibm\IbmActiveRecordTest;
 
 /**
  * @group db
@@ -66,7 +67,7 @@ class ActiveRecordTest extends DatabaseTestCase
     public function testCustomColumns()
     {
         // find custom column
-        if ($this->driverName === 'oci') {
+        if ($this->driverName === 'oci' || $this->driverName === 'ibm') {
             $customer = Customer::find()->select(['{{customer}}.*', '([[status]]*2) AS [[status2]]'])
                 ->where(['name' => 'user3'])->one();
         } else {
@@ -593,6 +594,8 @@ class ActiveRecordTest extends DatabaseTestCase
         if ($this instanceof CubridActiveRecordTest) {
             // cubrid has non-standard timestamp representation
             $this->assertEquals('12:00:00 AM 01/01/2002', $model->time);
+        } else if ($this instanceof IbmActiveRecordTest) {
+            $this->assertEquals('2002-01-01-00.00.00.000000', $model->time);
         } else {
             $this->assertEquals('2002-01-01 00:00:00', $model->time);
         }

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -292,6 +292,7 @@ SQL;
             case 'pgsql': $expression = "EXTRACT(YEAR FROM TIMESTAMP 'now')"; break;
             case 'cubrid':
             case 'mysql': $expression = "YEAR(NOW())"; break;
+            case 'ibm': $expression = "YEAR(CURRENT TIMESTAMP)"; break;
             default:
             case 'sqlite': $expression = "strftime('%Y')"; break;
         }

--- a/tests/framework/db/DatabaseTestCase.php
+++ b/tests/framework/db/DatabaseTestCase.php
@@ -78,6 +78,9 @@ abstract class DatabaseTestCase extends TestCase
                 list($drops, $creates) = explode('/* STATEMENTS */', file_get_contents($fixture), 2);
                 list($statements, $triggers, $data) = explode('/* TRIGGERS */', $creates, 3);
                 $lines = array_merge(explode('--', $drops), explode(';', $statements), explode('/', $triggers), explode(';', $data));
+            } else if ($this->driverName === 'ibm') {
+                list($drops, $creates) = explode('/* STATEMENTS */', file_get_contents($fixture), 2);
+                $lines = array_merge(explode('--', $drops), explode(';', $creates));
             } else {
                 $lines = explode(';', file_get_contents($fixture));
             }

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -13,6 +13,7 @@ use yii\db\mssql\QueryBuilder as MssqlQueryBuilder;
 use yii\db\pgsql\QueryBuilder as PgsqlQueryBuilder;
 use yii\db\cubrid\QueryBuilder as CubridQueryBuilder;
 use yii\db\oci\QueryBuilder as OracleQueryBuilder;
+use yii\db\ibm\QueryBuilder as IbmQueryBuilder;
 
 /**
  * @group db
@@ -50,6 +51,8 @@ class QueryBuilderTest extends DatabaseTestCase
                 return new CubridQueryBuilder($connection);
             case 'oci':
                 return new OracleQueryBuilder($connection);
+            case 'ibm':
+                return new IbmQueryBuilder($connection);
         }
         throw new \Exception('Test is not implemented for ' . $this->driverName);
     }
@@ -256,6 +259,12 @@ class QueryBuilderTest extends DatabaseTestCase
                     [ ['not in', ['id', 'name'], [['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']]], '((`id` != :qp0 OR `name` != :qp1) AND (`id` != :qp2 OR `name` != :qp3))', [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'] ],
                     //[ ['in', ['id', 'name'], (new Query())->select(['id', 'name'])->from('users')->where(['active' => 1])], 'EXISTS (SELECT 1 FROM (SELECT `id`, `name` FROM `users` WHERE `active`=:qp0) AS a WHERE a.`id` = `id AND a.`name` = `name`)', [':qp0' => 1] ],
                     //[ ['not in', ['id', 'name'], (new Query())->select(['id', 'name'])->from('users')->where(['active' => 1])], 'NOT EXISTS (SELECT 1 FROM (SELECT `id`, `name` FROM `users` WHERE `active`=:qp0) AS a WHERE a.`id` = `id` AND a.`name = `name`)', [':qp0' => 1] ],
+                ]);
+                break;
+            case 'ibm':
+                $conditions = array_merge($conditions, [
+                    [ ['in', ['id', 'name'], [['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']]], '("id", "name") IN (select :qp0, :qp1 from SYSIBM.SYSDUMMY1 UNION select :qp2, :qp3 from SYSIBM.SYSDUMMY1)', [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'] ],
+                    [ ['not in', ['id', 'name'], [['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']]], '("id", "name") NOT IN (select :qp0, :qp1 from SYSIBM.SYSDUMMY1 UNION select :qp2, :qp3 from SYSIBM.SYSDUMMY1)', [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'] ],
                 ]);
                 break;
             default:

--- a/tests/framework/db/ibm/IbmActiveDataProviderTest.php
+++ b/tests/framework/db/ibm/IbmActiveDataProviderTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace yiiunit\framework\db\ibm;
+
+use yiiunit\framework\data\ActiveDataProviderTest;
+
+/**
+ * @group db
+ * @group ibm
+ * @group data
+ */
+class IbmActiveDataProviderTest extends ActiveDataProviderTest
+{
+    public $driverName = 'ibm';
+}

--- a/tests/framework/db/ibm/IbmActiveRecordTest.php
+++ b/tests/framework/db/ibm/IbmActiveRecordTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace yiiunit\framework\db\ibm;
+
+use yiiunit\data\ar\NullValues;
+use yiiunit\data\ar\Type;
+use yiiunit\framework\db\ActiveRecordTest;
+
+/**
+ * @group db
+ * @group ibm
+ */
+class IbmActiveRecordTest extends ActiveRecordTest
+{
+    public $driverName = 'ibm';
+
+    public function testFindAsArray()
+    {
+        /* @var $customerClass \yii\db\ActiveRecordInterface */
+        $customerClass = $this->getCustomerClass();
+
+        // asArray
+        $customer = $customerClass::find()->where(['id' => 2])->asArray()->one();
+        // clob: segmentation fault error
+        unset($customer['address']);
+        $this->assertEquals([
+            'id' => '2',
+            'email' => 'user2@example.com',
+            'name' => 'user2',
+            'status' => '1',
+            'profile_id' => null,
+        ], $customer);
+
+        // find all asArray
+        $customers = $customerClass::find()->asArray()->all();
+        $this->assertEquals(3, count($customers));
+        $this->assertArrayHasKey('id', $customers[0]);
+        $this->assertArrayHasKey('name', $customers[0]);
+        $this->assertArrayHasKey('email', $customers[0]);
+        $this->assertArrayHasKey('address', $customers[0]);
+        $this->assertArrayHasKey('status', $customers[0]);
+        $this->assertArrayHasKey('id', $customers[1]);
+        $this->assertArrayHasKey('name', $customers[1]);
+        $this->assertArrayHasKey('email', $customers[1]);
+        $this->assertArrayHasKey('address', $customers[1]);
+        $this->assertArrayHasKey('status', $customers[1]);
+        $this->assertArrayHasKey('id', $customers[2]);
+        $this->assertArrayHasKey('name', $customers[2]);
+        $this->assertArrayHasKey('email', $customers[2]);
+        $this->assertArrayHasKey('address', $customers[2]);
+        $this->assertArrayHasKey('status', $customers[2]);
+    }
+
+    public function testStoreNull()
+    {
+        $record = new NullValues();
+        $this->assertNull($record->var1);
+        $this->assertNull($record->var2);
+        $this->assertNull($record->var3);
+        $this->assertNull($record->stringcol);
+
+        $record->var1 = 123;
+        $record->var2 = 456;
+        $record->var3 = 789;
+        $record->stringcol = 'hello!';
+
+        $record->save(false);
+        $this->assertTrue($record->refresh());
+
+        $this->assertEquals(123, $record->var1);
+        $this->assertEquals(456, $record->var2);
+        $this->assertEquals(789, $record->var3);
+        $this->assertEquals('hello!', $record->stringcol);
+
+        $record->var1 = null;
+        $record->var2 = null;
+        $record->var3 = null;
+        $record->stringcol = null;
+
+        $record->save(false);
+        $this->assertTrue($record->refresh());
+
+        $this->assertNull($record->var1);
+        $this->assertNull($record->var2);
+        $this->assertNull($record->var3);
+        $this->assertNull($record->stringcol);
+
+        $record->var1 = 0;
+        $record->var2 = 0;
+        $record->var3 = 0;
+        $record->stringcol = '';
+
+        $record->save(false);
+        $this->assertTrue($record->refresh());
+
+        $this->assertEquals(0, $record->var1);
+        $this->assertEquals(0, $record->var2);
+        $this->assertEquals(0, $record->var3);
+        $this->assertEquals('', $record->stringcol);
+    }
+
+    public function testStoreEmpty()
+    {
+        $record = new NullValues();
+
+        // this is to simulate empty html form submission
+        $record->var1 = '';
+        $record->var2 = '';
+        $record->var3 = '';
+        $record->stringcol = '';
+
+        $record->save(false);
+        $this->assertTrue($record->refresh());
+
+        // https://github.com/yiisoft/yii2/commit/34945b0b69011bc7cab684c7f7095d837892a0d4#commitcomment-4458225
+        $this->assertTrue($record->var1 === $record->var2);
+        $this->assertTrue($record->var2 === $record->var3);
+    }
+
+    public function testCastValues()
+    {
+        $model = new Type();
+        $model->int_col = 123;
+        $model->int_col2 = 456;
+        $model->smallint_col = 42;
+        $model->char_col = '1337';
+        $model->char_col2 = 'test';
+        $model->char_col3 = 'test123';
+        $model->float_col = 3.742;
+        $model->float_col2 = 42.1337;
+        $model->bool_col = true;
+        $model->bool_col2 = false;
+        $model->save(false);
+
+        /* @var $model Type */
+        $model = Type::find()->one();
+        $this->assertSame(123, $model->int_col);
+        $this->assertSame(456, $model->int_col2);
+        $this->assertSame(42, $model->smallint_col);
+        $this->assertSame('1337', trim($model->char_col));
+        $this->assertSame('test', $model->char_col2);
+        // clob: segmentation fault error
+        // $this->assertSame('test123', $model->char_col3);
+    }
+}

--- a/tests/framework/db/ibm/IbmCommandTest.php
+++ b/tests/framework/db/ibm/IbmCommandTest.php
@@ -1,0 +1,211 @@
+<?php
+namespace yiiunit\framework\db\ibm;
+
+use yii\db\Expression;
+use yiiunit\framework\db\CommandTest;
+use yii\db\Schema;
+
+/**
+ * @group db
+ * @group ibm
+ */
+class IbmCommandTest extends CommandTest
+{
+    public $driverName = 'ibm';
+
+    public function testClobBlobValues()
+    {
+        $db = $this->getConnection();
+
+        $sql = <<<SQL
+INSERT INTO {{type}} ([[int_col]], [[char_col]], [[float_col]], [[blob_col]], [[char_col3]], [[bool_col]])
+  VALUES (:int_col, :char_col, :float_col, :blob_col, :char_col3, :bool_col)
+SQL;
+        $command = $db->createCommand($sql);
+        $intCol = 123;
+        $charCol = 'text';
+        $floatCol = 1.23;
+        $bool = true;
+        $blob = "\x10\x11\x12";
+        $clob = "clob";
+        $command->bindParam(':int_col', $intCol, \PDO::PARAM_INT);
+        $command->bindParam(':char_col', $charCol);
+        $command->bindParam(':float_col', $floatCol);
+        $command->bindParam(':blob_col', $blob);
+        $command->bindParam(':char_col3', $clob);
+        $command->bindParam(':bool_col', $bool, \PDO::PARAM_INT);
+        $this->assertEquals(1, $command->execute());
+
+        $command = $db->createCommand('SELECT [[int_col]], [[char_col]], [[float_col]], [[blob_col]], [[char_col3]] FROM {{type}}');
+
+        $row = $command->queryOne();
+
+        $row['blob_col'] = stream_get_contents($row['blob_col']);
+        $row['char_col3'] = stream_get_contents($row['char_col3']);
+
+        $this->assertEquals($blob, $row['blob_col']);
+        $this->assertEquals($clob, $row['char_col3']);
+    }
+
+    public function testAutoQuoting()
+    {
+        $db = $this->getConnection(false);
+
+        $sql = 'SELECT [[id]], [[t.name]] FROM {{customer}} t';
+        $command = $db->createCommand($sql);
+        $this->assertEquals('SELECT "id", "t"."name" FROM "customer" t', $command->sql);
+    }
+
+    public function testBindParamValue()
+    {
+        $db = $this->getConnection();
+
+        // bindParam
+        $sql = 'INSERT INTO {{customer}}([[email]], [[name]], [[address]]) VALUES (:email, :name, :address)';
+        $command = $db->createCommand($sql);
+        $email = 'user4@example.com';
+        $name = 'user4';
+        $address = 'address4';
+        $command->bindParam(':email', $email);
+        $command->bindParam(':name', $name);
+        $command->bindParam(':address', $address);
+        $command->execute();
+
+        $sql = 'SELECT [[name]] FROM {{customer}} WHERE [[email]] = :email';
+        $command = $db->createCommand($sql);
+        $command->bindParam(':email', $email);
+        $this->assertEquals($name, $command->queryScalar());
+
+        $sql = <<<SQL
+INSERT INTO {{type}} ([[int_col]], [[char_col]], [[float_col]], [[blob_col]], [[numeric_col]], [[bool_col]])
+  VALUES (:int_col, :char_col, :float_col, :blob_col, :numeric_col, :bool_col)
+SQL;
+        $command = $db->createCommand($sql);
+        $intCol = 123;
+        $charCol = str_repeat('abc', 33) . 'x'; // a 100 char string
+        $boolCol = false;
+        $command->bindParam(':int_col', $intCol, \PDO::PARAM_INT);
+        $command->bindParam(':char_col', $charCol);
+        $command->bindParam(':bool_col', $boolCol, \PDO::PARAM_INT);
+        $floatCol = 1.23;
+        $numericCol = '1.23';
+        $blobCol = "\x10\x11\x12";
+        $command->bindParam(':float_col', $floatCol);
+        $command->bindParam(':numeric_col', $numericCol);
+        $command->bindParam(':blob_col', $blobCol);
+        $this->assertEquals(1, $command->execute());
+
+        $command = $db->createCommand('SELECT [[int_col]], [[char_col]], [[float_col]], [[blob_col]], [[numeric_col]], [[bool_col]] FROM {{type}}');
+
+        $row = $command->queryOne();
+        $this->assertEquals($intCol, $row['int_col']);
+        $this->assertEquals($charCol, $row['char_col']);
+        $this->assertEquals($floatCol, $row['float_col']);
+        // For some reason it returns empty string (commented for now)
+        // $this->assertEquals($blobCol, stream_get_contents($row['blob_col']));
+        $this->assertEquals($boolCol, $row['bool_col']);
+
+        // bindValue
+        $sql = 'INSERT INTO {{customer}}([[email]], [[name]], [[address]]) VALUES (:email, \'user5\', \'address5\')';
+        $command = $db->createCommand($sql);
+        $command->bindValue(':email', 'user5@example.com');
+        $command->execute();
+
+        $sql = 'SELECT [[email]] FROM {{customer}} WHERE [[name]] = :name';
+        $command = $db->createCommand($sql);
+        $command->bindValue(':name', 'user5');
+        $this->assertEquals('user5@example.com', $command->queryScalar());
+    }
+
+    public function testInsert()
+    {
+        $db = $this->getConnection();
+        $db->createCommand('DELETE FROM {{customer}};')->execute();
+
+        $command = $db->createCommand();
+        $command->insert(
+            '{{customer}}',
+            [
+                'email' => 't1@example.com',
+                'name' => 'test',
+                'address' => 'test address',
+            ]
+        )->execute();
+        $this->assertEquals(1, $db->createCommand('SELECT COUNT(*) FROM {{customer}};')->queryScalar());
+        $record = $db->createCommand('SELECT "email", "name", "address" FROM {{customer}};')->queryOne();
+        // clob: segmentation fault error
+        unset($record['address']);
+        $this->assertEquals([
+            'email' => 't1@example.com',
+            'name' => 'test'
+        ], $record);
+    }
+
+    public function testInsertExpression()
+    {
+        $db = $this->getConnection();
+        $db->createCommand('DELETE FROM {{order_with_null_fk}};')->execute();
+
+        $expression = "YEAR(CURRENT TIMESTAMP)";
+
+        $command = $db->createCommand();
+        $command->insert(
+            '{{order_with_null_fk}}',
+            [
+                'created_at' => new Expression($expression),
+                'total' => 1,
+            ]
+        )->execute();
+        $this->assertEquals(1, $db->createCommand('SELECT COUNT(*) FROM {{order_with_null_fk}};')->queryScalar());
+        $record = $db->createCommand('SELECT "created_at" FROM {{order_with_null_fk}};')->queryOne();
+        $this->assertEquals([
+            'created_at' => date('Y'),
+        ], $record);
+    }
+
+    public function testCreateTable()
+    {
+        $db = $this->getConnection();
+        // on the first run the 'testCreateTable' table does not exist
+        try {
+            $db->createCommand()->dropTable('testCreateTable')->execute();
+        } catch (\Exception $ex) {
+            // 'testCreateTable' table does not exist
+        }
+
+        $db->createCommand()->createTable('testCreateTable', ['id' => Schema::TYPE_PK, 'bar' => Schema::TYPE_INTEGER])->execute();
+        $db->createCommand()->insert('testCreateTable', ['bar' => 1])->execute();
+        $records = $db->createCommand('SELECT [[id]], [[bar]] FROM {{testCreateTable}};')->queryAll();
+        $this->assertEquals([
+            ['id' => 1, 'bar' => 1],
+        ], $records);
+    }
+
+    public function testAlterTable()
+    {
+        $db = $this->getConnection();
+        // on the first run the 'testAlterTable' table does not exist
+        try {
+            $db->createCommand()->dropTable('testAlterTable')->execute();
+        } catch (\Exception $ex) {
+            // 'testAlterTable' table does not exist
+        }
+
+        $db->createCommand()->createTable('testAlterTable', ['id' => Schema::TYPE_PK, 'bar' => Schema::TYPE_INTEGER])->execute();
+        $db->createCommand()->insert('testAlterTable', ['bar' => 1])->execute();
+
+        $db->createCommand()->alterColumn('testAlterTable', 'bar', Schema::TYPE_STRING)->execute();
+
+        $db->createCommand()->insert('testAlterTable', ['bar' => 'hello'])->execute();
+        $records = $db->createCommand('SELECT [[id]], [[bar]] FROM {{testAlterTable}};')->queryAll();
+        $this->assertEquals([
+            ['id' => 1, 'bar' => 1],
+            ['id' => 2, 'bar' => 'hello'],
+        ], $records);
+    }
+
+    public function testIntegrityViolation()
+    {
+        $this->markTestSkipped('DB2 can\'t insert row with explicitly specified PK');
+    }
+}

--- a/tests/framework/db/ibm/IbmConnectionTest.php
+++ b/tests/framework/db/ibm/IbmConnectionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace yiiunit\framework\db\ibm;
+
+use yii\db\Connection;
+use yii\db\Transaction;
+use yiiunit\framework\db\ConnectionTest;
+
+/**
+ * @group db
+ * @group ibm
+ */
+class IbmConnectionTest extends ConnectionTest
+{
+    public $driverName = 'ibm';
+
+    public function testQuoteValue()
+    {
+        $connection = $this->getConnection(false);
+        $this->assertEquals(123, $connection->quoteValue(123));
+        $this->assertEquals("'string'", $connection->quoteValue('string'));
+        $this->assertEquals("'It''s interesting'", $connection->quoteValue("It's interesting"));
+    }
+
+    public function testQuoteTableName()
+    {
+        $connection = $this->getConnection(false);
+        $this->assertEquals('"table"', $connection->quoteTableName('table'));
+        $this->assertEquals('"table"', $connection->quoteTableName('"table"'));
+        $this->assertEquals('"schema"."table"', $connection->quoteTableName('schema.table'));
+        $this->assertEquals('"schema"."table"', $connection->quoteTableName('schema."table"'));
+        $this->assertEquals('{{table}}', $connection->quoteTableName('{{table}}'));
+        $this->assertEquals('(table)', $connection->quoteTableName('(table)'));
+    }
+
+    public function testQuoteColumnName()
+    {
+        $connection = $this->getConnection(false);
+        $this->assertEquals('"column"', $connection->quoteColumnName('column'));
+        $this->assertEquals('"column"', $connection->quoteColumnName('"column"'));
+        $this->assertEquals('"table"."column"', $connection->quoteColumnName('table.column'));
+        $this->assertEquals('"table"."column"', $connection->quoteColumnName('table."column"'));
+        $this->assertEquals('[[column]]', $connection->quoteColumnName('[[column]]'));
+        $this->assertEquals('{{column}}', $connection->quoteColumnName('{{column}}'));
+        $this->assertEquals('(column)', $connection->quoteColumnName('(column)'));
+    }
+
+    public function testTransaction()
+    {
+        $connection = $this->getConnection(false);
+        $this->assertNull($connection->transaction);
+        $transaction = $connection->beginTransaction();
+        $this->assertNotNull($connection->transaction);
+        $this->assertTrue($transaction->isActive);
+
+        $connection->createCommand()->insert('profile', ['description' => 'test transaction'])->execute();
+
+        $transaction->rollBack();
+        $this->assertFalse($transaction->isActive);
+        $this->assertNull($connection->transaction);
+
+        $this->assertEquals(0, $connection->createCommand('SELECT COUNT(*) FROM "profile" WHERE "description" = \'test transaction\';')->queryScalar());
+
+        $transaction = $connection->beginTransaction();
+        $connection->createCommand()->insert('profile', ['description' => 'test transaction'])->execute();
+        $transaction->commit();
+        $this->assertFalse($transaction->isActive);
+        $this->assertNull($connection->transaction);
+
+        $this->assertEquals(1, $connection->createCommand('SELECT COUNT(*) FROM "profile" WHERE "description" = \'test transaction\';')->queryScalar());
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testTransactionShortcutException()
+    {
+        $connection = $this->getConnection(true);
+        $connection->transaction(function () use ($connection) {
+            $connection->createCommand()->insert('profile', ['description' => 'test transaction shortcut'])->execute();
+            throw new \Exception('Exception in transaction shortcut');
+        });
+
+        $profilesCount = $connection->createCommand('SELECT COUNT(*) FROM "profile" WHERE "description" = \'test transaction shortcut\';')->queryScalar();
+        $this->assertEquals(0, $profilesCount, 'profile should not be inserted in transaction shortcut');
+    }
+
+    public function testTransactionShortcutCorrect()
+    {
+        $connection = $this->getConnection(true);
+
+        $result = $connection->transaction(function () use ($connection) {
+            $connection->createCommand()->insert('profile', ['description' => 'test transaction shortcut'])->execute();
+            return true;
+        });
+
+        $this->assertTrue($result, 'transaction shortcut valid value should be returned from callback');
+
+        $profilesCount = $connection->createCommand('SELECT COUNT(*) FROM "profile" WHERE "description" = \'test transaction shortcut\';')->queryScalar();
+        $this->assertEquals(1, $profilesCount, 'profile should be inserted in transaction shortcut');
+    }
+
+    public function testTransactionShortcutCustom()
+    {
+        $connection = $this->getConnection(true);
+
+        $result = $connection->transaction(function (Connection $db) {
+            $db->createCommand()->insert('profile', ['description' => 'test transaction shortcut'])->execute();
+            return true;
+        }, Transaction::READ_UNCOMMITTED);
+
+        $this->assertTrue($result, 'transaction shortcut valid value should be returned from callback');
+
+        $profilesCount = $connection->createCommand('SELECT COUNT(*) FROM "profile" WHERE "description" = \'test transaction shortcut\';')->queryScalar();
+        $this->assertEquals(1, $profilesCount, 'profile should be inserted in transaction shortcut');
+    }
+}

--- a/tests/framework/db/ibm/IbmQueryBuilderTest.php
+++ b/tests/framework/db/ibm/IbmQueryBuilderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace yiiunit\framework\db\ibm;
+
+use yii\db\Schema;
+use yiiunit\framework\db\QueryBuilderTest;
+
+/**
+ * @group db
+ * @group ibm
+ */
+class IbmQueryBuilderTest extends QueryBuilderTest
+{
+    public $driverName = 'ibm';
+
+    /**
+     * this is not used as a dataprovider for testGetColumnType to speed up the test
+     * when used as dataprovider every single line will cause a reconnect with the database which is not needed here
+     */
+    public function columnTypes()
+    {
+        return [
+            [Schema::TYPE_PK, $this->primaryKey(), 'integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1)'],
+            [Schema::TYPE_PK . ' CHECK (value > 5)', $this->primaryKey()->check('value > 5'), 'integer NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1) CHECK (value > 5)'],
+            [Schema::TYPE_STRING, $this->string(), 'varchar(255)'],
+            [Schema::TYPE_STRING . '(32)', $this->string(32), 'varchar(32)'],
+            [Schema::TYPE_STRING . " CHECK (value LIKE 'test%')", $this->string()->check("value LIKE 'test%'"), "varchar(255) CHECK (value LIKE 'test%')"],
+            [Schema::TYPE_STRING . "(32) CHECK (value LIKE 'test%')", $this->string(32)->check("value LIKE 'test%'"), "varchar(32) CHECK (value LIKE 'test%')"],
+            [Schema::TYPE_STRING . ' NOT NULL', $this->string()->notNull(), 'varchar(255) NOT NULL'],
+            [Schema::TYPE_TEXT, $this->text(), 'clob'],
+            [Schema::TYPE_TEXT . '(255)', $this->text(), 'clob', Schema::TYPE_TEXT],
+            [Schema::TYPE_TEXT . " CHECK (value LIKE 'test%')", $this->text()->check("value LIKE 'test%'"), "clob CHECK (value LIKE 'test%')"],
+            [Schema::TYPE_TEXT . "(255) CHECK (value LIKE 'test%')", $this->text()->check("value LIKE 'test%'"), "clob CHECK (value LIKE 'test%')", Schema::TYPE_TEXT . " CHECK (value LIKE 'test%')"],
+            [Schema::TYPE_TEXT . ' NOT NULL', $this->text()->notNull(), 'clob NOT NULL'],
+            [Schema::TYPE_TEXT . '(255) NOT NULL', $this->text()->notNull(), 'clob NOT NULL', Schema::TYPE_TEXT . ' NOT NULL'],
+            [Schema::TYPE_SMALLINT, $this->smallInteger(), 'smallint'],
+            [Schema::TYPE_INTEGER, $this->integer(), 'integer'],
+            [Schema::TYPE_INTEGER . ' CHECK (value > 5)', $this->integer()->check('value > 5'), 'integer CHECK (value > 5)'],
+            [Schema::TYPE_INTEGER . ' NOT NULL', $this->integer()->notNull(), 'integer NOT NULL'],
+            [Schema::TYPE_BIGINT, $this->bigInteger(), 'bigint'],
+            [Schema::TYPE_BIGINT . ' CHECK (value > 5)', $this->bigInteger()->check('value > 5'), 'bigint CHECK (value > 5)'],
+            [Schema::TYPE_BIGINT . ' NOT NULL', $this->bigInteger()->notNull(), 'bigint NOT NULL'],
+            [Schema::TYPE_FLOAT, $this->float(), 'float'],
+            [Schema::TYPE_FLOAT . '(16)', $this->float(16), 'float'],
+            [Schema::TYPE_FLOAT . ' CHECK (value > 5.6)', $this->float()->check('value > 5.6'), 'float CHECK (value > 5.6)'],
+            [Schema::TYPE_FLOAT . '(16) CHECK (value > 5.6)', $this->float(16)->check('value > 5.6'), 'float CHECK (value > 5.6)'],
+            [Schema::TYPE_FLOAT . ' NOT NULL', $this->float()->notNull(), 'float NOT NULL'],
+            [Schema::TYPE_DOUBLE, $this->double(), 'double'],
+            [Schema::TYPE_DOUBLE . '(16)', $this->double(16), 'double'],
+            [Schema::TYPE_DOUBLE . ' CHECK (value > 5.6)', $this->double()->check('value > 5.6'), 'double CHECK (value > 5.6)'],
+            [Schema::TYPE_DOUBLE . '(16) CHECK (value > 5.6)', $this->double(16)->check('value > 5.6'), 'double CHECK (value > 5.6)'],
+            [Schema::TYPE_DOUBLE . ' NOT NULL', $this->double()->notNull(), 'double NOT NULL'],
+            [Schema::TYPE_DECIMAL, $this->decimal(), 'decimal(10,0)'],
+            [Schema::TYPE_DECIMAL . '(12,4)', $this->decimal(12, 4), 'decimal(12,4)'],
+            [Schema::TYPE_DECIMAL . ' CHECK (value > 5.6)', $this->decimal()->check('value > 5.6'), 'decimal(10,0) CHECK (value > 5.6)'],
+            [Schema::TYPE_DECIMAL . '(12,4) CHECK (value > 5.6)', $this->decimal(12, 4)->check('value > 5.6'), 'decimal(12,4) CHECK (value > 5.6)'],
+            [Schema::TYPE_DECIMAL . ' NOT NULL', $this->decimal()->notNull(), 'decimal(10,0) NOT NULL'],
+            [Schema::TYPE_DATETIME, $this->dateTime(), 'timestamp'],
+            [Schema::TYPE_DATETIME . " CHECK (value BETWEEN '2011-01-01' AND '2013-01-01')", $this->dateTime()->check("value BETWEEN '2011-01-01' AND '2013-01-01'"), "timestamp CHECK (value BETWEEN '2011-01-01' AND '2013-01-01')"],
+            [Schema::TYPE_DATETIME . ' NOT NULL', $this->dateTime()->notNull(), 'timestamp NOT NULL'],
+            [Schema::TYPE_TIMESTAMP, $this->timestamp(), 'timestamp'],
+            [Schema::TYPE_TIMESTAMP . " CHECK (value BETWEEN '2011-01-01' AND '2013-01-01')", $this->timestamp()->check("value BETWEEN '2011-01-01' AND '2013-01-01'"), "timestamp CHECK (value BETWEEN '2011-01-01' AND '2013-01-01')"],
+            [Schema::TYPE_TIMESTAMP . ' NOT NULL', $this->timestamp()->notNull(), 'timestamp NOT NULL'],
+            [Schema::TYPE_TIME, $this->time(), 'time'],
+            [Schema::TYPE_TIME . " CHECK (value BETWEEN '12:00:00' AND '13:01:01')", $this->time()->check("value BETWEEN '12:00:00' AND '13:01:01'"), "time CHECK (value BETWEEN '12:00:00' AND '13:01:01')"],
+            [Schema::TYPE_TIME . ' NOT NULL', $this->time()->notNull(), 'time NOT NULL'],
+            [Schema::TYPE_DATE, $this->date(), 'date'],
+            [Schema::TYPE_DATE . " CHECK (value BETWEEN '2011-01-01' AND '2013-01-01')", $this->date()->check("value BETWEEN '2011-01-01' AND '2013-01-01'"), "date CHECK (value BETWEEN '2011-01-01' AND '2013-01-01')"],
+            [Schema::TYPE_DATE . ' NOT NULL', $this->date()->notNull(), 'date NOT NULL'],
+            [Schema::TYPE_BINARY, $this->binary(), 'blob'],
+            [Schema::TYPE_BOOLEAN, $this->boolean(), 'smallint'],
+            [Schema::TYPE_BOOLEAN . ' NOT NULL DEFAULT 1', $this->boolean()->notNull()->defaultValue(1), 'smallint NOT NULL DEFAULT 1'],
+            [Schema::TYPE_MONEY, $this->money(), 'decimal(19,4)'],
+            [Schema::TYPE_MONEY . '(16,2)', $this->money(16, 2), 'decimal(16,2)'],
+            [Schema::TYPE_MONEY . ' CHECK (value > 0.0)', $this->money()->check('value > 0.0'), 'decimal(19,4) CHECK (value > 0.0)'],
+            [Schema::TYPE_MONEY . '(16,2) CHECK (value > 0.0)', $this->money(16, 2)->check('value > 0.0'), 'decimal(16,2) CHECK (value > 0.0)'],
+            [Schema::TYPE_MONEY . ' NOT NULL', $this->money()->notNull(), 'decimal(19,4) NOT NULL'],
+        ];
+    }
+}

--- a/tests/framework/db/ibm/IbmQueryTest.php
+++ b/tests/framework/db/ibm/IbmQueryTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace yiiunit\framework\db\ibm;
+
+use yiiunit\framework\db\QueryTest;
+
+/**
+ * @group db
+ * @group ibm
+ */
+class IbmQueryTest extends QueryTest
+{
+    public $driverName = 'ibm';
+}

--- a/tests/framework/db/ibm/IbmSchemaTest.php
+++ b/tests/framework/db/ibm/IbmSchemaTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace yiiunit\framework\db\ibm;
+
+use yii\db\Expression;
+use yii\db\ibm\Schema;
+use yiiunit\framework\db\SchemaTest;
+
+/**
+ * @group db
+ * @group ibm
+ */
+class IbmSchemaTest extends SchemaTest
+{
+    public $driverName = 'ibm';
+
+    public function testGetPDOType()
+    {
+        $values = [
+            [null, \PDO::PARAM_INT],
+            ['', \PDO::PARAM_STR],
+            ['hello', \PDO::PARAM_STR],
+            [0, \PDO::PARAM_INT],
+            [1, \PDO::PARAM_INT],
+            [1337, \PDO::PARAM_INT],
+            [true, \PDO::PARAM_INT],
+            [false, \PDO::PARAM_INT],
+            [$fp = fopen(__FILE__, 'rb'), \PDO::PARAM_LOB],
+        ];
+
+        /* @var $schema Schema */
+        $schema = $this->getConnection()->schema;
+
+        foreach ($values as $value) {
+            $this->assertEquals($value[1], $schema->getPdoType($value[0]), 'type for value ' . print_r($value[0], true) . ' does not match.');
+        }
+        fclose($fp);
+    }
+
+    public function getExpectedColumns()
+    {
+        $columns = parent::getExpectedColumns();
+        unset($columns['enum_col']);
+        $columns['int_col']['dbType'] = 'INTEGER';
+        $columns['int_col']['size'] = 4;
+        $columns['int_col']['precision'] = 4;
+        $columns['int_col']['scale'] = 0;
+        $columns['int_col2']['dbType'] = 'INTEGER';
+        $columns['int_col2']['size'] = 4;
+        $columns['int_col2']['precision'] = 4;
+        $columns['int_col2']['scale'] = 0;
+        $columns['int_col2']['defaultValue'] = '1';
+        $columns['smallint_col']['dbType'] = 'SMALLINT';
+        $columns['smallint_col']['size'] = 2;
+        $columns['smallint_col']['precision'] = 2;
+        $columns['smallint_col']['scale'] = 0;
+        $columns['smallint_col']['defaultValue'] = '1';
+        $columns['char_col']['dbType'] = 'CHARACTER(100)';
+        $columns['char_col']['scale'] = 0;
+        $columns['char_col2']['dbType'] = 'VARCHAR(100)';
+        $columns['char_col2']['scale'] = 0;
+        $columns['char_col3']['dbType'] = 'CLOB(1048576)';
+        $columns['char_col3']['size'] = 1048576;
+        $columns['char_col3']['precision'] = 1048576;
+        $columns['char_col3']['scale'] = 0;
+        $columns['float_col']['dbType'] = 'DOUBLE(8,0)';
+        $columns['float_col']['size'] = 8;
+        $columns['float_col']['precision'] = 8;
+        $columns['float_col']['scale'] = 0;
+        $columns['float_col2']['dbType'] = 'DOUBLE(8,0)';
+        $columns['float_col2']['size'] = 8;
+        $columns['float_col2']['precision'] = 8;
+        $columns['float_col2']['scale'] = 0;
+        $columns['float_col2']['defaultValue'] = '1.23';
+        $columns['blob_col']['dbType'] = 'BLOB(1048576)';
+        $columns['blob_col']['size'] = 1048576;
+        $columns['blob_col']['precision'] = 1048576;
+        $columns['blob_col']['scale'] = 0;
+        $columns['numeric_col']['dbType'] = 'DECIMAL(5,2)';
+        $columns['numeric_col']['size'] = 5;
+        $columns['numeric_col']['precision'] = 5;
+        $columns['numeric_col']['scale'] = 2;
+        $columns['time']['dbType'] = 'TIMESTAMP';
+        $columns['time']['size'] = 10;
+        $columns['time']['precision'] = 10;
+        $columns['time']['scale'] = 6;
+        $columns['time']['defaultValue'] = '2002-01-01-00.00.00.000000';
+        $columns['bool_col']['dbType'] = 'SMALLINT';
+        $columns['bool_col']['size'] = 2;
+        $columns['bool_col']['precision'] = 2;
+        $columns['bool_col']['scale'] = 0;
+        $columns['bool_col2']['dbType'] = 'SMALLINT';
+        $columns['bool_col2']['size'] = 2;
+        $columns['bool_col2']['precision'] = 2;
+        $columns['bool_col2']['scale'] = 0;
+        $columns['bool_col2']['defaultValue'] = '1';
+        $columns['ts_default']['dbType'] = 'TIMESTAMP';
+        $columns['ts_default']['size'] = 10;
+        $columns['ts_default']['precision'] = 10;
+        $columns['ts_default']['scale'] = 6;
+        $columns['ts_default']['defaultValue'] = new Expression('CURRENT TIMESTAMP');
+        $columns['bit_col']['type'] = 'smallint';
+        $columns['bit_col']['dbType'] = 'SMALLINT';
+        $columns['bit_col']['size'] = 2;
+        $columns['bit_col']['precision'] = 2;
+        $columns['bit_col']['scale'] = 0;
+        $columns['bit_col']['defaultValue'] = '130';
+        return $columns;
+    }
+}


### PR DESCRIPTION
This Pull Request solves #5.
Tested on Ubuntu 14.04 x64 "DB2 v10.5.0.5", "s141128", "IP23633", and Fix Pack "5"
PHP 5.5.9, PDO_IBM-1.3.3
Tests: 212, Assertions: 1366, Errors: 1, Failures: 1, Skipped: 2.

pdo_ibm is buggy, e.g. using PDO::PARAM_NULL throws error.
It would be nice, if someone update pdo_ibm.

test config

```
$config['databases']['ibm'] = [
    'dsn' => 'ibm:yiitest',
    'username' => 'vagrant',
    'password' => 'vagrant',
    'fixture' => __DIR__ . '/ibm.sql',
];
```

Remaning issues:
- testExplicitPkOnAutoIncrement failed. In db2 it seems to be a problem.
- problems with blob (empty result string) and clob (segmentation fault error). I wrote test for that testClobBlobValues
- Need to implement checkIntegrity. Solution from https://github.com/vbsessa/yii2-db2 doesn't work in my DB2 version.

I can send DB2 and pdo_ibm installation guide below, because it's tricky.
Now we have some beginning :)
