### PR TITLE
Fixed issue #11076: TimestampBehavior trying to insert invalid default values

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -32,6 +32,7 @@ Yii Framework 2 Change Log
 - Bug #9984: Fixed wrong captcha color in case Imagick is used (DrDeath72)
 - Bug #9999: Fixed `yii\web\UrlRule` to allow route parameter names with `-`, `_`, `.`characters (silverfire)
 - Bug #10029: Fixed MaskedInput not working with PJAX (martrix78, samdark)
+- Bug #10076: TimestampBehavior trying to insert invalid values in database (c_schmitz) 
 - Bug: Fixed generation of canonical URLs for `ViewAction` pages (samdark)
 - Enh #3506: Added `\yii\validators\IpValidator` to perform validation of IP addresses and subnets (SilverFire, samdark)
 - Enh #5146: Added `\yii\i18n\Formatter::asDuration()` method (nineinchnick, SilverFire)

--- a/framework/behaviors/TimestampBehavior.php
+++ b/framework/behaviors/TimestampBehavior.php
@@ -108,7 +108,7 @@ class TimestampBehavior extends AttributeBehavior
     protected function getValue($event)
     {
         if ($this->value === null) {
-            return time();
+            return new Expression('CURRENT_TIMESTAMP'); // ANSI compliant
         }
         return parent::getValue($event);
     }


### PR DESCRIPTION
Uses now as default the DB ANSI compliant method for current datetime stamp which is compatible across DB types.
