### PR TITLE
Allow set params from actions

### DIFF
--- a/framework/rest/Serializer.php
+++ b/framework/rest/Serializer.php
@@ -155,8 +155,11 @@ class Serializer extends Component
      */
     protected function getRequestedFields()
     {
-        $fields = $this->request->get($this->fieldsParam);
-        $expand = $this->request->get($this->expandParam);
+        $actionParamsFields = isset(\Yii::$app->controller->actionParams[$this->fieldsParam]) ? \Yii::$app->controller->actionParams[$this->fieldsParam] : null;
+        $actionParamsExpand = isset(\Yii::$app->controller->actionParams[$this->expandParam]) ? \Yii::$app->controller->actionParams[$this->expandParam] : null;
+
+        $fields = $this->request->get($this->fieldsParam, $actionParamsFields);
+        $expand = $this->request->get($this->expandParam, $actionParamsExpand);
 
         return [
             preg_split('/\s*,\s*/', $fields, -1, PREG_SPLIT_NO_EMPTY),


### PR DESCRIPTION
use case

``` php
class UsersViewAction extends \yii\rest\ViewAction
{
    /**
     * @inheritdoc
     */
    public function run($id = null, $expand = 'profile')
    {
        if (is_null($id)) {
            $id = \Yii::$app->user->id;
        }

        return parent::run($id);
    }
}
```

and we have clean url like this `/api/v1/user/`
