### PR TITLE
BaseInflector::transliterate() is now public. Introduced different levels of transliteration strictness

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -49,6 +49,7 @@ Yii Framework 2 Change Log
 - Enh #9869: Allow path alias for SQLite database files in DSN config (ASlatius)
 - Enh #9901: Default `Cache.SerializerPermissions` configuration option for `HTMLPurifier` is set to `0775` (klimov-paul)
 - Enh #10056: Allowed any callable to be passed to `ActionColumn::$urlCreator` (freezy-sk)
+- Enh #10061: `yii\helpers\BaseInflector::transliterate()` is now public. Introduced different levels of transliteration strictness (silverfire)
 - Enh: Added last resort measure for `FileHelper::removeDirectory()` fail to unlink symlinks under Windows (samdark)
 - Chg #9369: `Yii::$app->user->can()` now returns `false` instead of erroring in case `authManager` component is not configured (creocoder)
 - Chg #9411: `DetailView` now automatically sets container tag ID in case it's not specified (samdark)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -14,6 +14,10 @@ Make sure you have global install of latest version of composer asset plugin:
 php composer.phar global require "fxp/composer-asset-plugin"
 ```
 
+Upgrade from Yii 2.0.6
+----------------------
+  
+* The signature of `yii\helpers\BaseInflector::transliterate()` was changed. The method is now public and has an extra optional parameter `$transliterator`.
 
 Upgrade from Yii 2.0.5
 ----------------------

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -217,7 +217,7 @@ class BaseInflector
         'Yengeese' => 'Yengeese',
     ];
     /**
-     * @var array fallback map for transliteration used by [[slug()]] when intl isn't available.
+     * @var array fallback map for transliteration used by [[transliterate()]] when intl isn't available.
      */
     public static $transliteration = [
         'À' => 'A', 'Á' => 'A', 'Â' => 'A', 'Ã' => 'A', 'Ä' => 'A', 'Å' => 'A', 'Æ' => 'AE', 'Ç' => 'C',
@@ -231,13 +231,53 @@ class BaseInflector
         'ø' => 'o', 'ù' => 'u', 'ú' => 'u', 'û' => 'u', 'ü' => 'u', 'ű' => 'u', 'ý' => 'y', 'þ' => 'th',
         'ÿ' => 'y',
     ];
+
     /**
-     * @var mixed Either a [[Transliterator]] or a string from which a [[Transliterator]]
-     * can be built for transliteration used by [[slug()]] when intl is available.
+     * Shortcut for `Any-Latin; NFKD` transliteration rule. The rule is strict, letters will be transliterated with
+     * the closest sound-representation chars. The result my contain any UTF-8 chars. For example:
+     * `获取到 どちら Українська: ґ,є, Српска: ђ, њ, џ! ¿Español?` will be transliterated to
+     * `huò qǔ dào dochira Ukraí̈nsʹka: g̀,ê, Srpska: đ, n̂, d̂! ¿Español?`
+     *
+     * Used in [[transliterate()]].
+     * For detailed information see [unicode normalization forms](http://unicode.org/reports/tr15/#Normalization_Forms_Table)
+     * @see http://unicode.org/reports/tr15/#Normalization_Forms_Table
+     * @see transliterate()
+     */
+    const TRANSLITERATE_STRICT = 'Any-Latin; NFKD';
+
+    /**
+     * Shortcut for `Any-Latin; Latin-ASCII` transliteration rule. The rule is loose, letters will be
+     * transliterated to characters of Latin-1 ASCII table. For example:
+     * `获取到 どちら Українська: ґ,є, Српска: ђ, њ, џ! ¿Español?` will be transliterated to
+     * `huo qu dao dochira Ukrainsʹka: g,e, Srpska: d, n, d! ¿Espanol?`
+     *
+     * Used in [[transliterate()]].
+     * For detailed information see [unicode normalization forms](http://unicode.org/reports/tr15/#Normalization_Forms_Table)
+     * @see http://unicode.org/reports/tr15/#Normalization_Forms_Table
+     * @see transliterate()
+     */
+    const TRANSLITERATE_MEDIUM = 'Any-Latin; Latin-ASCII';
+
+    /**
+     * Shortcut for `Any-Latin; Latin-ASCII; [\u0080-\uffff] remove` transliteration rule. The rule is strict, letters will be transliterated with
+     * the closest sound-representation chars. The result my contain any UTF-8 chars. For example:
+     * `获取到 どちら Українська: ґ,є, Српска: ђ, њ, џ! ¿Español?` will be transliterated to
+     * `huo qu dao dochira Ukrainska: g,e, Srpska: d, n, d! Espanol?`
+     *
+     * Used in [[transliterate()]].
+     * For detailed information see [unicode normalization forms](http://unicode.org/reports/tr15/#Normalization_Forms_Table)
+     * @see http://unicode.org/reports/tr15/#Normalization_Forms_Table
+     * @see transliterate()
+     */
+    const TRANSLITERATE_LOOSE = 'Any-Latin; Latin-ASCII; [\u0080-\uffff] remove';
+
+
+    /**
+     * @var mixed Either a [[\Transliterator]], or a string from which a [[\Transliterator]] can be built
+     * for transliteration. Used by [[transliterate()]] when intl is available. Defaults to [[TRANSLITERATE_LOOSE]]
      * @see http://php.net/manual/en/transliterator.transliterate.php
      */
-    public static $transliterator = 'Any-Latin; NFKD';
-
+    public static $transliterator = self::TRANSLITERATE_LOOSE;
 
     /**
      * Converts a word to its plural form.
@@ -438,12 +478,18 @@ class BaseInflector
      * of the helper.
      *
      * @param string $string input string
+     * @param string|\Transliterator $transliterator either a [[Transliterator]] or a string
+     * from which a [[Transliterator]] can be built.
      * @return string
      */
-    protected static function transliterate($string)
+    public static function transliterate($string, $transliterator = null)
     {
         if (static::hasIntl()) {
-            return transliterator_transliterate(static::$transliterator, $string);
+            if ($transliterator === null) {
+                $transliterator = static::$transliterator;
+            }
+
+            return transliterator_transliterate($transliterator, $string);
         } else {
             return str_replace(array_keys(static::$transliteration), static::$transliteration, $string);
         }

--- a/tests/framework/helpers/InflectorTest.php
+++ b/tests/framework/helpers/InflectorTest.php
@@ -162,23 +162,17 @@ class InflectorTest extends TestCase
         $data = [
             // Korean
             '해동검도' => 'haedong-geomdo',
-
             // Hiragana
             'ひらがな' => 'hiragana',
-
             // Georgian
             'საქართველო' => 'sakartvelo',
-
             // Arabic
             'العربي' => 'alrby',
             'عرب' => 'rb',
-
             // Hebrew
             'עִבְרִית' => 'iberiyt',
-
             // Turkish
-            'Sanırım hepimiz aynı şeyi düşünüyoruz.' => 'sanrm-hepimiz-ayn-seyi-dusunuyoruz',
-
+            'Sanırım hepimiz aynı şeyi düşünüyoruz.' => 'sanirim-hepimiz-ayni-seyi-dusunuyoruz',
             // Russian
             'недвижимость' => 'nedvizimost',
             'Контакты' => 'kontakty',
@@ -186,6 +180,129 @@ class InflectorTest extends TestCase
 
         foreach ($data as $source => $expected) {
             $this->assertEquals($expected, Inflector::slug($source));
+        }
+    }
+
+    public function testTransliterateStrict()
+    {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('intl extension is required.');
+        }
+
+        // Some test strings are from https://github.com/bergie/midgardmvc_helper_urlize. Thank you, Henri Bergius!
+        $data = [
+            // Korean
+            '해동검도' => 'haedong-geomdo',
+            // Hiragana
+            'ひらがな' => 'hiragana',
+            // Georgian
+            'საქართველო' => 'sakartvelo',
+            // Arabic
+            'العربي' => 'ạlʿrby',
+            'عرب' => 'ʿrb',
+            // Hebrew
+            'עִבְרִית' => 'ʻibĕriyţ',
+            // Turkish
+            'Sanırım hepimiz aynı şeyi düşünüyoruz.' => 'Sanırım hepimiz aynı şeyi düşünüyoruz.',
+
+            // Russian
+            'недвижимость' => 'nedvižimostʹ',
+            'Контакты' => 'Kontakty',
+
+            // Ukrainian
+            'Українська: ґанок, європа' => 'Ukraí̈nsʹka: g̀anok, êvropa',
+
+            // Serbian
+            'Српска: ђ, њ, џ!' => 'Srpska: đ, n̂, d̂!',
+
+            // Spanish
+            '¿Español?' => '¿Español?',
+        ];
+
+        foreach ($data as $source => $expected) {
+            $this->assertEquals($expected, Inflector::transliterate($source, Inflector::TRANSLITERATE_STRICT));
+        }
+    }
+
+    public function testTransliterateMedium()
+    {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('intl extension is required.');
+        }
+
+        // Some test strings are from https://github.com/bergie/midgardmvc_helper_urlize. Thank you, Henri Bergius!
+        $data = [
+            // Korean
+            '해동검도' => 'haedong-geomdo',
+            // Hiragana
+            'ひらがな' => 'hiragana',
+            // Georgian
+            'საქართველო' => 'sakartvelo',
+            // Arabic
+            'العربي' => 'alʿrby',
+            'عرب' => 'ʿrb',
+            // Hebrew
+            'עִבְרִית' => 'ʻiberiyt',
+            // Turkish
+            'Sanırım hepimiz aynı şeyi düşünüyoruz.' => 'Sanirim hepimiz ayni seyi dusunuyoruz.',
+
+            // Russian
+            'недвижимость' => 'nedvizimostʹ',
+            'Контакты' => 'Kontakty',
+
+            // Ukrainian
+            'Українська: ґанок, європа' => 'Ukrainsʹka: ganok, evropa',
+
+            // Serbian
+            'Српска: ђ, њ, џ!' => 'Srpska: d, n, d!',
+
+            // Spanish
+            '¿Español?' => '¿Espanol?'
+        ];
+
+        foreach ($data as $source => $expected) {
+            $this->assertEquals($expected, Inflector::transliterate($source, Inflector::TRANSLITERATE_MEDIUM));
+        }
+    }
+
+    public function testTransliterateLoose()
+    {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('intl extension is required.');
+        }
+
+        // Some test strings are from https://github.com/bergie/midgardmvc_helper_urlize. Thank you, Henri Bergius!
+        $data = [
+            // Korean
+            '해동검도' => 'haedong-geomdo',
+            // Hiragana
+            'ひらがな' => 'hiragana',
+            // Georgian
+            'საქართველო' => 'sakartvelo',
+            // Arabic
+            'العربي' => 'alrby',
+            'عرب' => 'rb',
+            // Hebrew
+            'עִבְרִית' => 'iberiyt',
+            // Turkish
+            'Sanırım hepimiz aynı şeyi düşünüyoruz.' => 'Sanirim hepimiz ayni seyi dusunuyoruz.',
+
+            // Russian
+            'недвижимость' => 'nedvizimost',
+            'Контакты' => 'Kontakty',
+
+            // Ukrainian
+            'Українська: ґанок, європа' => 'Ukrainska: ganok, evropa',
+
+            // Serbian
+            'Српска: ђ, њ, џ!' => 'Srpska: d, n, d!',
+
+            // Spanish
+            '¿Español?' => 'Espanol?'
+        ];
+
+        foreach ($data as $source => $expected) {
+            $this->assertEquals($expected, Inflector::transliterate($source, Inflector::TRANSLITERATE_LOOSE));
         }
     }
 


### PR DESCRIPTION
Closes #10061 
- [x] Code
- [x] Tests
- [x] Changelog
- [x] Docs
- [x] Code review

:exclamation: Changes:
- Default `$transliterator` changed from `Any-Latin; NFKD` to `Any-Latin; Latin-ASCII; [\u0080-\uffff] remove`, so the slug will be generated more correctly. Leaded to changing a test-case on old line 180
