### PR TITLE
Catalogue support for models

### DIFF
--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -1076,11 +1076,12 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      */
     public static function ensureCatalogues()
     {
-        if (self::$_catalogues === null) {
-            self::$_catalogues= self::catalogues();
+        $class = static::className();
+        if (!isset(self::$_catalogues[$class])) {
+            self::$_catalogues[$class] = self::catalogues();
         }
 
-        return self::$_catalogues;
+        return self::$_catalogues[$class];
     }
 
     /**

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -1090,9 +1090,9 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      * @param string $name catalogue to find
      * @return array|null the indexed terms or null if there is no catalogue
      */
-    public static function getCatalogue($name)
+    public static function getCatalogue($catalogue)
     {
-        return ArrayHelper::getValue(self::ensureCatalogues(), $name);
+        return ArrayHelper::getValue(self::ensureCatalogues(), $catalogue);
     }
 
     /**
@@ -1103,7 +1103,7 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      */
     public static function getTerminology($catalogue, $index)
     {
-        return ArrayHelper::getValue(self::getCatalogue($name), $index);
+        return ArrayHelper::getValue(self::getCatalogue($catalogue), $index);
     }
 
     /**

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -1078,7 +1078,7 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
     {
         $class = static::className();
         if (!isset(self::$_catalogues[$class])) {
-            self::$_catalogues[$class] = self::catalogues();
+            self::$_catalogues[$class] = static::catalogues();
         }
 
         return self::$_catalogues[$class];

--- a/tests/data/base/PersonModel.php
+++ b/tests/data/base/PersonModel.php
@@ -8,8 +8,8 @@ use yii\base\Model;
  */
 class PersonModel extends Model
 {
-    const GENDER_FEMENINE = F;
-    const GENDER_MASCULINE = M;
+    const GENDER_FEMENINE = 'F';
+    const GENDER_MASCULINE = 'M';
   
     const EYECOLOR_BLACK = 'black';
     const EYECOLOR_BLUE = 'blue';

--- a/tests/data/base/PersonModel.php
+++ b/tests/data/base/PersonModel.php
@@ -1,0 +1,90 @@
+<?php
+namespace yiiunit\data\base;
+use yii\base\Model;
+/**
+ * Speaker
+ */
+class Speaker extends Model
+{
+    const GENDER_FEMENINE = F;
+    const GENDER_MASCULINE = M;
+  
+    const EYECOLOR_BLACK = 'black';
+    const EYECOLOR_BLUE = 'blue';
+    const EYECOLOR_GREEN = 'green';
+
+    const BODYTYPE_PETITE = 'petite';
+    const BODYTYPE_AVERAGE = 'average';
+    const BODYTYPE_TALL = 'tall';
+
+    public $firstName;
+    public $lastName;
+  
+    public $gender_index;
+    public $eyecolor_index;
+  
+    // in centimeters
+    public $height;
+  
+    public function catalogues()
+    {
+        return [
+            'gender_index' => [
+                self::GENDER_FEMENINE => Yii::t('yii', 'Femenine'),
+                self::GENDER_MASCULINE => Yii::t('yii', 'Masculine'),
+            ],
+            'eyecolor_index' => [
+                self::EYECOLOR_BLACK => '#000000',
+                self::EYECOLOR_BLUE => '#0000FF',
+                self::EYECOLOR_GREEN => '#00FF00',
+            ],
+            'bodyTypeIndex' => [
+                self::BODYTYPE_PETITE => Yii::t('yii', 'Petite'),
+                self::BODYTYPE_AVERAGE => Yii::t('yii', 'Average'),
+                self::BODYTYPE_TALL => Yii::t('yii', 'Tall'),
+            ],
+        ];
+    }
+    
+    public function getBodyTypeIndex()
+    {
+        if ($this->height < 155) {
+            return self::BODYTYPE_PETITE;
+        } elseif($this->height < 175) {
+            return self::BODTYPE_AVERAGE;
+        } else {
+            return self::BODYTYPE_TAL;
+        }
+    }
+    
+    public function getGender()
+    {
+        return $this->getAttributeTerminology('gender_index');
+    }
+    
+    public function getEyeColor()
+    {
+        return $this->getAttributeTerminology('eyecolor_index');
+    }
+    
+    public function getBodyType()
+    {
+        return $this->getAttributeTerminology('bodyTypeIndex');
+    }
+    
+    public function rules()
+    {
+        return [
+            [
+                ['gender_index'],
+                'in',
+                'range' => array_keys(self::getCatalogue('gender_index'))
+            ],
+            [
+                ['eyecolor_index'],
+                'in',
+                'range' => array_keys(self::getCatalogue('eyecolor_index'))
+            ],
+        ];
+    }
+}

--- a/tests/data/base/PersonModel.php
+++ b/tests/data/base/PersonModel.php
@@ -1,5 +1,7 @@
 <?php
 namespace yiiunit\data\base;
+
+use Yii;
 use yii\base\Model;
 /**
  * Person

--- a/tests/data/base/PersonModel.php
+++ b/tests/data/base/PersonModel.php
@@ -28,7 +28,7 @@ class PersonModel extends Model
     // in centimeters
     public $height;
   
-    public function catalogues()
+    public static function catalogues()
     {
         return [
             'gender_index' => [

--- a/tests/data/base/PersonModel.php
+++ b/tests/data/base/PersonModel.php
@@ -2,9 +2,9 @@
 namespace yiiunit\data\base;
 use yii\base\Model;
 /**
- * Speaker
+ * Person
  */
-class Speaker extends Model
+class Person extends Model
 {
     const GENDER_FEMENINE = F;
     const GENDER_MASCULINE = M;

--- a/tests/data/base/PersonModel.php
+++ b/tests/data/base/PersonModel.php
@@ -4,7 +4,7 @@ use yii\base\Model;
 /**
  * Person
  */
-class Person extends Model
+class PersonModel extends Model
 {
     const GENDER_FEMENINE = F;
     const GENDER_MASCULINE = M;

--- a/tests/framework/base/ModelTest.php
+++ b/tests/framework/base/ModelTest.php
@@ -383,7 +383,7 @@ class ModelTest extends TestCase
         $person->height = 145;
         
         $this->assertTrue($person->validate());
-        $this->assertEquals(Yii::t('yii', 'Femenino'), $person->gender);
+        $this->assertEquals(Yii::t('yii', 'Femenine'), $person->gender);
         $this->assertEquals('#000000', $person->eyecolor);
         $this->assertEquals(Yii::t('yii', 'Petite'), $person->bodyType);
         

--- a/tests/framework/base/ModelTest.php
+++ b/tests/framework/base/ModelTest.php
@@ -2,6 +2,7 @@
 
 namespace yiiunit\framework\base;
 
+use Yii;
 use yii\base\Model;
 use yiiunit\data\base\RulesModel;
 use yiiunit\TestCase;

--- a/tests/framework/base/ModelTest.php
+++ b/tests/framework/base/ModelTest.php
@@ -372,7 +372,7 @@ class ModelTest extends TestCase
         
         $this->assertNull(PersonModel::getCatalogue('unexistant'));
         
-        $this->assertEquals('#000000',PersonModel::getTerminology('eyecolor_index', 'black');
+        $this->assertEquals('#000000', PersonModel::getTerminology('eyecolor_index', 'black'));
         $this->assertNull(PersonModel::getTerminology('eyecolor_index', 'orange'));
 
         $person = new PersonModel();

--- a/tests/framework/base/ModelTest.php
+++ b/tests/framework/base/ModelTest.php
@@ -5,6 +5,7 @@ namespace yiiunit\framework\base;
 use yii\base\Model;
 use yiiunit\data\base\RulesModel;
 use yiiunit\TestCase;
+use yiiunit\data\base\PersonModel;
 use yiiunit\data\base\Speaker;
 use yiiunit\data\base\Singer;
 use yiiunit\data\base\InvalidRulesModel;
@@ -348,6 +349,49 @@ class ModelTest extends TestCase
 
         $invalid = new InvalidRulesModel();
         $invalid->createValidators();
+    }
+    
+    public function testCatalogues()
+    {
+        $this->assertEquals(
+            [
+                'F' => Yii::t('yii', 'Femenine'),
+                'M' => Yii::t('yii', 'Masculine'),
+            ],
+            PersonModel::getCatalogue('gender_index')
+        );
+        
+        $this->assertEquals(
+            [
+                'black' =>  '#000000',
+                'blue' =>  '#0000FF',
+                'green' => '#00FF00',
+            ],
+            PersonModel::getCatalogue('eyecolor_index')
+        );
+        
+        $this->assertNull(PersonModel::getCatalogue('unexistant'));
+        
+        $this->assertEquals('#000000',PersonModel::getTerminology('eyecolor_index', 'black');
+        $this->assertNull(PersonModel::getTerminology('eyecolor_index', 'orange'));
+
+        $person = new PersonModel();
+        
+        $person->gender_index = 'F';
+        $person->eyecolor_index = 'black';
+        $person->height = 145;
+        
+        $this->assertTrue($person->validate());
+        $this->assertEquals(Yii::t('yii', 'Femenino'), $person->gender);
+        $this->assertEquals('#000000', $person->eyecolor);
+        $this->assertEquals(Yii::t('yii', 'Petite'), $person->bodyType);
+        
+        $person->gender_index = 'X';
+        $person->eyecolor_index = 'orange';
+        
+        $this->assertFalse($person->validate());
+        $this->assertNull($person->gender);
+        $this->assertNull($person->eyecolor);
     }
 }
 


### PR DESCRIPTION
I don't know if this is done in other frameworks with other names.

The case usage is that on the database sometimes the columns contain an index or abbreviaton of the value to be shown to the user. Other times the data needs to be translated to be shown and it can be time consuming to type `Yii::t('app', $model->attribute)` everytime its used or create internal methods to do it.

With this there is an introduction to a new functionality named `Model::catalogues()` which handles static data to be used inside the class. The data can be accesed using the `Model::getTerminology()` static method or `Model::getAttributeTerminology` instanced method.

The method `Model::catalogues contain documentation with usage examples.`
- [x] functional methods.
- [x] phpDoc
- [x] Unit tests
- [ ] include it on the model guide.
- [ ] squash commits on another branch
