### PR TITLE
Update composer-asset-plugin version

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -15,7 +15,7 @@ The preferred way to install the Yii framework is through [composer](http://getc
 Either run
 
 ```
-composer global require "fxp/composer-asset-plugin:~1.0.3"
+composer global require "fxp/composer-asset-plugin:~1.1.0"
 composer require yiisoft/yii2
 ```
 


### PR DESCRIPTION
The composer-asset-plugin is now on version 1.1.0 and unless there's a reason why Yii requires ~1.0.3 I propose this update to the documentation.
