### PR TITLE
Normalized mb_* function calls to use Yii::$app->charset

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -38,6 +38,7 @@ Yii Framework 2 Change Log
 - Bug #10101: Fixed assignments saving on role removing in `\yii\rbac\PhpManager` (rezident1307)
 - Bug #10142: Fixed `yii\validators\EmailValidator` to check the length of email properly (silverfire)
 - Bug: Fixed generation of canonical URLs for `ViewAction` pages (samdark)
+- Bug: Fixed `mb_*` functions calls to use `UTF-8` or `Yii::$app->charset` (silverfire)
 - Enh #3506: Added `\yii\validators\IpValidator` to perform validation of IP addresses and subnets (SilverFire, samdark)
 - Enh #5146: Added `\yii\i18n\Formatter::asDuration()` method (nineinchnick, SilverFire)
 - Enh #7341: Client validation now skips disabled inputs (SamMousa)

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -189,7 +189,7 @@ class BaseFileHelper
     public static function getExtensionsByMimeType($mimeType, $magicFile = null)
     {
         $mimeTypes = static::loadMimeTypes($magicFile);
-        return array_keys($mimeTypes, mb_strtolower($mimeType, 'utf-8'), true);
+        return array_keys($mimeTypes, mb_strtolower($mimeType, 'UTF-8'), true);
     }
 
     private static $_mimeTypes = [];

--- a/framework/validators/FileValidator.php
+++ b/framework/validators/FileValidator.php
@@ -315,7 +315,7 @@ class FileValidator extends Validator
      */
     protected function validateExtension($file)
     {
-        $extension = mb_strtolower($file->extension, 'utf-8');
+        $extension = mb_strtolower($file->extension, 'UTF-8');
 
         if ($this->checkExtensionByMimeType) {
 

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -351,9 +351,9 @@ class AssetManager extends Component
             $asset = $bundle->sourcePath . '/' . $asset;
         }
 
-        $n = mb_strlen($asset);
+        $n = mb_strlen($asset, Yii::$app->charset);
         foreach ($this->assetMap as $from => $to) {
-            $n2 = mb_strlen($from);
+            $n2 = mb_strlen($from, Yii::$app->charset);
             if ($n2 <= $n && substr_compare($asset, $from, $n - $n2, $n2) === 0) {
                 return $to;
             }

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -391,8 +391,8 @@ class ErrorHandler extends \yii\base\ErrorHandler
                 $args[$key] = '<span class="keyword">' . ($value ? 'true' : 'false') . '</span>';
             } elseif (is_string($value)) {
                 $fullValue = $this->htmlEncode($value);
-                if (mb_strlen($value, 'utf8') > 32) {
-                    $displayValue = $this->htmlEncode(mb_substr($value, 0, 32, 'utf8')) . '...';
+                if (mb_strlen($value, Yii::$app->charset) > 32) {
+                    $displayValue = $this->htmlEncode(mb_substr($value, 0, 32, Yii::$app->charset)) . '...';
                     $args[$key] = "<span class=\"string\" title=\"$fullValue\">'$displayValue'</span>";
                 } else {
                     $args[$key] = "<span class=\"string\">'$fullValue'</span>";

--- a/tests/framework/i18n/FormatterDateTest.php
+++ b/tests/framework/i18n/FormatterDateTest.php
@@ -129,9 +129,9 @@ class FormatterDateTest extends TestCase
 
         // empty input
         $this->formatter->locale = 'de-DE';
-        $this->assertSame('01.01.1970 00:00:00', $this->formatter->asDatetime(''));
-        $this->assertSame('01.01.1970 00:00:00', $this->formatter->asDatetime(0));
-        $this->assertSame('01.01.1970 00:00:00', $this->formatter->asDatetime(false));
+        $this->assertRegExp('~01\.01\.1970,? 00:00:00~', $this->formatter->asDatetime(''));
+        $this->assertRegExp('~01\.01\.1970,? 00:00:00~', $this->formatter->asDatetime(0));
+        $this->assertRegExp('~01\.01\.1970,? 00:00:00~', $this->formatter->asDatetime(false));
     }
 
     public function testAsDatetime()


### PR DESCRIPTION
There are calls of mb_\* functions without specified charset or with wrong charset (`utf-8`, 'utf8').

This PR normalizes mb_\* functions calls to use `UTF-8` or `Yii::$app->charset`.
- [x] code
- [x] tests
- [x] changelog
- [x] code review
