### PR TITLE
Use native hash_equals in Security::compareString

### DIFF
--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -648,6 +648,9 @@ class Security extends Component
      */
     public function compareString($expected, $actual)
     {
+        if (function_exists('hash_equals')) {
+            return hash_equals($expected, $actual);
+        }
         $expected .= "\0";
         $actual .= "\0";
         $expectedLength = StringHelper::byteLength($expected);


### PR DESCRIPTION
Using native timing attack safe function http://php.net/manual/ru/function.hash-equals.php
