### PR TITLE
Controller->viewPath can be set, fixes #10086

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -59,7 +59,7 @@ Yii Framework 2 Change Log
 - Enh #10056: Allowed any callable to be passed to `ActionColumn::$urlCreator` (freezy-sk)
 - Enh #10061: `yii\helpers\BaseInflector::transliterate()` is now public. Introduced different levels of transliteration strictness (silverfire)
 - Enh #10078: Added `csrf` option to `Html::beginForm()` to allow disabling the hidden csrf field generation (machour)
-- Enh #10086: yii\base\Controller->viewPath is now configurable (Sibilino)
+- Enh #10086: `yii\base\Controller->viewPath` is now configurable (Sibilino)
 - Enh #10098: Changed `yii.confirm` context to the event's target DOM element which is triggered by clickable or changeable elements (lichunqiang)
 - Enh #10118: Allow easy extension of slug generation in `yii\behaviors\SluggableBehavior` (cebe, hesna)
 - Enh #10149: Made `yii\db\Connection` serializable (Sam Mousa)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -59,6 +59,7 @@ Yii Framework 2 Change Log
 - Enh #10056: Allowed any callable to be passed to `ActionColumn::$urlCreator` (freezy-sk)
 - Enh #10061: `yii\helpers\BaseInflector::transliterate()` is now public. Introduced different levels of transliteration strictness (silverfire)
 - Enh #10078: Added `csrf` option to `Html::beginForm()` to allow disabling the hidden csrf field generation (machour)
+- Enh #10086: yii\base\Controller->viewPath is now configurable (Sibilino)
 - Enh #10098: Changed `yii.confirm` context to the event's target DOM element which is triggered by clickable or changeable elements (lichunqiang)
 - Enh #10118: Allow easy extension of slug generation in `yii\behaviors\SluggableBehavior` (cebe, hesna)
 - Enh #10149: Made `yii\db\Connection` serializable (Sam Mousa)

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -19,8 +19,7 @@ use Yii;
  * @property string $uniqueId The controller ID that is prefixed with the module ID (if any). This property is
  * read-only.
  * @property View|\yii\web\View $view The view object that can be used to render views or view files.
- * @property string $viewPath The directory containing the view files for this controller. This property is
- * read-only.
+ * @property string $viewPath The directory containing the view files for this controller.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -67,6 +66,10 @@ class Controller extends Component implements ViewContextInterface
      * @var View the view object that can be used to render views or view files.
      */
     private $_view;
+    /**
+     * @var string the root directory that contains view files for this controller.
+     */
+    private $_viewPath;
 
 
     /**
@@ -449,7 +452,21 @@ class Controller extends Component implements ViewContextInterface
      */
     public function getViewPath()
     {
-        return $this->module->getViewPath() . DIRECTORY_SEPARATOR . $this->id;
+        if ($this->_viewPath !== null) {
+            return $this->_viewPath;
+        } else {
+            return $this->_viewPath = $this->module->getViewPath() . DIRECTORY_SEPARATOR . $this->id;
+        }
+    }
+
+    /**
+     * Sets the directory that contains the view files.
+     * @param string $path the root directory of view files.
+     * @throws InvalidParamException if the directory is invalid
+     */
+    public function setViewPath($path)
+    {
+        $this->_viewPath = Yii::getAlias($path);
     }
 
     /**

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -463,6 +463,7 @@ class Controller extends Component implements ViewContextInterface
      * Sets the directory that contains the view files.
      * @param string $path the root directory of view files.
      * @throws InvalidParamException if the directory is invalid
+     * @since 2.0.7
      */
     public function setViewPath($path)
     {

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -452,11 +452,10 @@ class Controller extends Component implements ViewContextInterface
      */
     public function getViewPath()
     {
-        if ($this->_viewPath !== null) {
-            return $this->_viewPath;
-        } else {
-            return $this->_viewPath = $this->module->getViewPath() . DIRECTORY_SEPARATOR . $this->id;
+        if ($this->_viewPath === null) {
+            $this->_viewPath = $this->module->getViewPath() . DIRECTORY_SEPARATOR . $this->id;
         }
+        return $this->_viewPath;
     }
 
     /**

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -243,11 +243,10 @@ class Module extends ServiceLocator
      */
     public function getViewPath()
     {
-        if ($this->_viewPath !== null) {
-            return $this->_viewPath;
-        } else {
-            return $this->_viewPath = $this->getBasePath() . DIRECTORY_SEPARATOR . 'views';
+        if ($this->_viewPath === null) {
+            $this->_viewPath = $this->getBasePath() . DIRECTORY_SEPARATOR . 'views';
         }
+        return $this->_viewPath;
     }
 
     /**


### PR DESCRIPTION
Added setViewPath() that allows setting the base path for the
controller's views. Changed getViewPath() to return the value that was
explicitly set, before defaulting to the usual module-based path.

Thus, #10086 can be fixed using:

``` php
public $controllerMap = [
    'account' => [
        'class' => 'app\controllers\UserController',
        'viewPath' => '/home/[user]/public_html/yii_example/views/user'
    ],
    // ...
]
```
