### PR TITLE
Fixed `yii\console\Application::runAction` to not to corrupt response

### DIFF
--- a/framework/console/Application.php
+++ b/framework/console/Application.php
@@ -158,13 +158,14 @@ class Application extends \yii\base\Application
      * If the route is empty, the method will use [[defaultRoute]].
      * @param string $route the route that specifies the action.
      * @param array $params the parameters to be passed to the action
-     * @return integer the status code returned by the action execution. 0 means normal, and other values mean abnormal.
+     * @return integer|Response the result of the action: exit code or Response object.
      * @throws Exception if the route is invalid
      */
     public function runAction($route, $params = [])
     {
         try {
-            return (int)parent::runAction($route, $params);
+            $res = parent::runAction($route, $params);
+            return is_object($res) ? $res : (int)$res;
         } catch (InvalidRouteException $e) {
             throw new Exception("Unknown command \"$route\".", 0, $e);
         }

--- a/tests/framework/console/ControllerTest.php
+++ b/tests/framework/console/ControllerTest.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\console;
 
 use Yii;
+use yii\console\Request;
 use yiiunit\TestCase;
 use yiiunit\framework\di\stubs\Qux;
 use yiiunit\framework\web\stubs\Bar;
@@ -92,4 +93,39 @@ class ControllerTest extends TestCase
         $result = $controller->runAction('aksi7', $params);
 
     }
+
+    public function assertResponseStatus($status, $response)
+    {
+        $this->assertInstanceOf('yii\console\Response', $response);
+        $this->assertSame($status, $response->exitStatus);
+    }
+
+    public function runRequest($route, $args = 0)
+    {
+        $request = new Request();
+        $request->setParams(func_get_args());
+        return Yii::$app->handleRequest($request);
+    }
+
+    public function testResponse()
+    {
+        $this->mockApplication();
+        Yii::$app->controllerMap = [
+            'fake' => 'yiiunit\framework\console\FakeController',
+        ];
+        $status = 123;
+
+        $response = $this->runRequest('fake/status');
+        $this->assertResponseStatus(0, $response);
+
+        $response = $this->runRequest('fake/status', (string)$status);
+        $this->assertResponseStatus($status, $response);
+
+        $response = $this->runRequest('fake/response');
+        $this->assertResponseStatus(0, $response);
+
+        $response = $this->runRequest('fake/response', (string)$status);
+        $this->assertResponseStatus($status, $response);
+    }
+
 }

--- a/tests/framework/console/FakeController.php
+++ b/tests/framework/console/FakeController.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\console;
 
 use yii\console\Controller;
+use yii\console\Response;
 use yiiunit\framework\di\stubs\QuxInterface;
 use yiiunit\framework\web\stubs\Bar;
 use yii\validators\EmailValidator;
@@ -62,5 +63,17 @@ class FakeController extends Controller
     public function actionAksi9($arg1, $arg2, QuxInterface $quxApp)
     {
         return func_get_args();
+    }
+
+    public function actionStatus($status = 0)
+    {
+        return $status;
+    }
+
+    public function actionResponse($status = 0)
+    {
+        $response = new Response();
+        $response->exitStatus = (int)$status;
+        return $response;
     }
 }


### PR DESCRIPTION
… exit code when action returns Response object

Original code forced casting to integer which resulted in changing Response object with exitStatus = 0 to integer 1.
