### PR TITLE
Fix test for migration

### DIFF
--- a/tests/framework/console/controllers/MigrateControllerTestTrait.php
+++ b/tests/framework/console/controllers/MigrateControllerTestTrait.php
@@ -117,7 +117,9 @@ CODE;
     protected function parseNameClassMigration($class)
     {
         $files = FileHelper::findFiles($this->migrationPath);
-        return preg_replace('/class (m\d+_\d+) extents Migration {/', "class $class extends Migration {", file_get_contents($files[0]));
+        $file = preg_replace('/class (m\d+_\d+_.*) extends Migration/', "class $class extends Migration", file_get_contents($files[0]));
+        $this->tearDownMigrationPath();
+        return $file;
     }
 
     /**


### PR DESCRIPTION
@SilverFire it pass all tests now, the error was in regular expression and olds migrations (now i call tearDownMigrationPath in parseName method to avoid this one).
