### PR TITLE
Fix methods references

### DIFF
--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -120,8 +120,8 @@ class Security extends Component
      * @param string $inputKey the input to use for encryption and authentication
      * @param string $info optional context and application specific information, see [[hkdf()]]
      * @return string the encrypted data
-     * @see decryptByPassword()
-     * @see encryptByKey()
+     * @see decryptByKey()
+     * @see encryptByPassword()
      */
     public function encryptByKey($data, $inputKey, $info = null)
     {


### PR DESCRIPTION
And one small question.  
`encryptByKey` returns value that not ready to store in db. I use base64 encode/decode, but maybe exist some other way? Thanks.
