### PR TITLE
Advanced table alias handling for Query and ActiveQuery

### DIFF
--- a/docs/guide/db-dao.md
+++ b/docs/guide/db-dao.md
@@ -278,7 +278,7 @@ $count = Yii::$app->db->createCommand("SELECT COUNT([[id]]) FROM {{employee}}")
 If most of your DB tables names share a common prefix, you may use the table prefix feature provided
 by Yii DAO.
 
-First, specify the table prefix via the [[yii\db\Connection::tablePrefix]] property:
+First, specify the table prefix via the [[yii\db\Connection::tablePrefix]] property in the application config:
 
 ```php
 return [

--- a/docs/guide/db-query-builder.md
+++ b/docs/guide/db-query-builder.md
@@ -624,7 +624,7 @@ value which will be used as the index value for the current row.
 
 Some use cases of query builder are to create an initial [[yii\db\Query]] object in one place and adjust
 it in other places of the application by adding further conditions or to change the sorting options.
-When more than one tables is used in the query, you may need to disambiguate column names to be explicit about
+When more than one table is used in the query, you may need to disambiguate column names to be explicit about
 which column a condition refers to, e.g. `user.id` vs. `post.id`.
 
 Since version 2.0.7 Yii provides methods that help you with disambiguating column names without the need
@@ -651,6 +651,21 @@ $query->leftJoin('post', $query->applyAlias('user', 'id') . ' = post.author_id')
 
 By using [[yii\db\Query::applyAlias()|applyAlias()]] here, this code will still work, even when the alias is changed or removed
 inside of the `getActiveUserQuery()` method implementation.
+
+In some situations the alias may not be known at the time the query is created because we allow to change the alias later in the code.
+Therefor a special syntax for referring to a table alias
+can be used which is simlar to the syntax used for [quoting table names](db-dao.md#quoting-table-and-column-names) and
+the [table prefix feature](db-dao.md#using-table-prefix).
+
+To refer to a table alias, the following syntax may be used:
+
+```php
+$query = User::getActiveUserQuery();
+$query->leftJoin('post', '{{@user}}.[[id]] = post.author_id') // LEFT JOIN post ON u.id = post.author_id
+```
+
+In the above code `{{@user}}` will be resolved to the alias used in the query. This works even if the alias will be changed afterwards
+as the evaluation of the expression is made after the SQL query has been created.
 
 
 ### Batch Query <span id="batch-query"></span>

--- a/docs/guide/db-query-builder.md
+++ b/docs/guide/db-query-builder.md
@@ -620,6 +620,38 @@ $query = (new \yii\db\Query())
 The anonymous function takes a parameter `$row` which contains the current row data and should return a scalar
 value which will be used as the index value for the current row.
 
+## Dealing with table aliases <span id="aliases"></span>
+
+Some use cases of query builder are to create an initial [[yii\db\Query]] object in one place and adjust
+it in other places of the application by adding further conditions or to change the sorting options.
+When more than one tables is used in the query, you may need to disambiguate column names to be explicit about
+which column a condition refers to, e.g. `user.id` vs. `post.id`.
+
+Since version 2.0.7 Yii provides methods that help you with disambiguating column names without the need
+to rely on a specific alias being defined in the original query. You may call the [[yii\db\Query::getAlias()]] method
+to get the alias name of a table in the query context, or [[yii\db\Query::applyAlias()]] to disambiguate a column.
+
+The following example shows how these methods are used:
+
+Consider this method to be defined in the `User` class:
+
+```php
+public static function getActiveUserQuery()
+{
+    return (new \yii\db\Query)->from(['u' => 'user'])->where(['active' => 1]);
+}
+```
+
+The following code, which is located elsewhere in the application, calls this methods and needs to adjust the query.
+
+```php
+$query = User::getActiveUserQuery();
+$query->leftJoin('post', $query->applyAlias('user', 'id') . ' = post.author_id') // LEFT JOIN post ON u.id = post.author_id
+```
+
+By using [[yii\db\Query::applyAlias()|applyAlias()]] here, this code will still work, even when the alias is changed or removed
+inside of the `getActiveUserQuery()` method implementation.
+
 
 ### Batch Query <span id="batch-query"></span>
 

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -403,9 +403,9 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 $callback = null;
             }
 
-            if (preg_match('/^(.*?)(\s+AS\s+|\s+)(\w+)$/i', $name, $matches)) {
+            if (preg_match('/^(.*?)(?:\s+AS\s+|\s+)(\w+)$/i', $name, $matches)) {
                 // relation is defined with an alias, adjust callback to apply alias
-                list(, $relation, , $alias) = $matches;
+                list(, $relation, $alias) = $matches;
                 $this->_relationAliases[$relation] = $alias;
                 $name = $relation;
                 $callback = function($query) use ($callback, $alias) {

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -148,7 +148,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             $this->joinWith = null;    // clean it up to avoid issue https://github.com/yiisoft/yii2/issues/2687
         }
 
-        if (empty($this->from)) { // TODO provide alias() method for convenience
+        if (empty($this->from)) {
             /* @var $modelClass ActiveRecord */
             $modelClass = $this->modelClass;
             $tableName = $modelClass::tableName();
@@ -768,6 +768,37 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             call_user_func($callable, $relation);
         }
 
+        return $this;
+    }
+
+    /**
+     * Define an alias for the table defined in [[modelClass]].
+     *
+     * This method will adjust [[from]] so that an already defined alias will be overwritten.
+     * If none was defined, [[from]] will be populated with the given alias.
+     *
+     * @param string $alias the table alias.
+     * @return $this the query object itself
+     * @since 2.0.7
+     */
+    public function alias($alias)
+    {
+        if (empty($this->from) || count($this->from) < 2) {
+            list($tableName, ) = $this->getQueryTableName($this);
+            $this->from = [$alias => $tableName];
+        } else {
+            /* @var $modelClass ActiveRecord */
+            $modelClass = $this->modelClass;
+            $tableName = $modelClass::tableName();
+
+            foreach($this->from as $key => $table) {
+                if ($table === $tableName) {
+                    unset($this->from[$key]);
+                    $this->from[$alias] = $tableName;
+                }
+            }
+        }
+        $this->populateAliases($this->from);
         return $this;
     }
 

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -352,7 +352,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      * which is equivalent to calling [[with()]] using the specified relations.
      *
      * Note that because a JOIN query will be performed, you are responsible to disambiguate column names.
-     * You may specify the table names manually or use the methods [[getRelationAlias()]] or [[applyRelationAlias()]] for this.
+     * You may specify the table names manually or use the methods described in the [Guide about alias handling](db-querybuilder#aliases)
+     * for this.
      *
      * This method differs from [[with()]] in that it will build up and execute a JOIN SQL statement
      * for the primary table. And when `$eagerLoading` is true, it will call [[with()]] in addition with the specified relations.
@@ -388,7 +389,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      *
      * @param boolean|array $eagerLoading whether to eager load the relations specified in `$with`.
      * When this is a boolean, it applies to all relations specified in `$with`. Use an array
-     * to explicitly list which relations in `$with` need to be eagerly loaded.
+     * to explicitly list which relations in `$with` need to be eagerly loaded. Defaults to `true`.
      * @param string|array $joinType the join type of the relations specified in `$with`.
      * When this is a string, it applies to all relations specified in `$with`. Use an array
      * in the format of `relationName => joinType` to specify different join types for different relations.
@@ -403,9 +404,9 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 $callback = null;
             }
 
-            if (preg_match('/^(.*?)(?:\s+AS\s+|\s+)(\w+)$/i', $name, $matches)) {
+            if (preg_match('/^.*?(?:\s+AS\s+|\s+)(\w+)$/i', $name, $matches)) {
                 // relation is defined with an alias, adjust callback to apply alias
-                list(, $relation, $alias) = $matches;
+                list($relation, $alias) = $matches;
                 $this->_relationAliases[$relation] = $alias;
                 $name = $relation;
                 $callback = function($query) use ($callback, $alias) {

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -122,6 +122,15 @@ class QueryBuilder extends \yii\base\Object
             $sql = "($sql){$this->separator}$union";
         }
 
+        // replace aliases with table names
+        $sql = preg_replace_callback(
+            '/\\{\\{@([\w\-\. ]+)\\}\\}/',
+            function ($matches) use ($query) {
+                return '{{' . $query->getAlias($matches[1]) . '}}';
+            },
+            $sql
+        );
+
         return [$sql, $params];
     }
 

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -406,6 +406,32 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertTrue($orders[1]->isRelationPopulated('customer'));
         $this->assertTrue($orders[2]->isRelationPopulated('customer'));
 
+        // join with table alias
+        $orders = Order::find()->joinWith('customer as c')->orderBy('c.id DESC, order.id')->all();
+        $this->assertEquals(3, count($orders));
+        $this->assertEquals(2, $orders[0]->id);
+        $this->assertEquals(3, $orders[1]->id);
+        $this->assertEquals(1, $orders[2]->id);
+        $this->assertTrue($orders[0]->isRelationPopulated('customer'));
+        $this->assertTrue($orders[1]->isRelationPopulated('customer'));
+        $this->assertTrue($orders[2]->isRelationPopulated('customer'));
+
+        // join with table alias sub-relation
+        $orders = Order::find()->innerJoinWith([
+            'items as t' => function ($q) {
+                $q->orderBy('t.id');
+            },
+            'items.category as c' => function ($q) {
+                $q->where('{{c}}.[[id]] = 2');
+            },
+        ])->orderBy('order.id')->all();
+        $this->assertEquals(1, count($orders));
+        $this->assertTrue($orders[0]->isRelationPopulated('items'));
+        $this->assertEquals(2, $orders[0]->id);
+        $this->assertEquals(3, count($orders[0]->items));
+        $this->assertTrue($orders[0]->items[0]->isRelationPopulated('category'));
+        $this->assertEquals(2, $orders[0]->items[0]->category->id);
+
         // join with ON condition
         $orders = Order::find()->joinWith('books2')->orderBy('order.id')->all();
         $this->assertEquals(3, count($orders));

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -687,6 +687,31 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals('cu.id', $query->applyRelationAlias('customer', 'id'));
     }
 
+    public function testAlias()
+    {
+        $query = Order::find();
+        $this->assertNull($query->from);
+        $this->assertEquals(Order::tableName(), $query->getAlias(Order::tableName()));
+
+        $query = Order::find()->alias('o');
+        $this->assertEquals(['o' => Order::tableName()], $query->from);
+        $this->assertEquals('o', $query->getAlias(Order::tableName()));
+
+        $query = Order::find()->alias('o')->alias('ord');
+        $this->assertEquals(['ord' => Order::tableName()], $query->from);
+        $this->assertEquals('ord', $query->getAlias(Order::tableName()));
+
+        $query = Order::find()->from([
+            'users',
+            'o' => Order::tableName(),
+        ])->alias('ord');
+        $this->assertEquals([
+            'users',
+            'ord' => Order::tableName(),
+        ], $query->from);
+        $this->assertEquals('ord', $query->getAlias(Order::tableName()));
+    }
+
     public function testInverseOf()
     {
         // eager loading: find one and all

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace yiiunit\framework\db;
 
+use yii\db\ActiveQuery;
 use yiiunit\data\ar\ActiveRecord;
 use yiiunit\data\ar\BitValues;
 use yiiunit\data\ar\Category;
@@ -419,6 +420,7 @@ class ActiveRecordTest extends DatabaseTestCase
         // join with table alias sub-relation
         $orders = Order::find()->innerJoinWith([
             'items as t' => function ($q) {
+//                $q->from(['t' => 'item']);
                 $q->orderBy('t.id');
             },
             'items.category as c' => function ($q) {
@@ -548,6 +550,141 @@ class ActiveRecordTest extends DatabaseTestCase
                 $q->orderBy('item.id');
             },
         ])->all();
+    }
+
+    /**
+     * Tests the alias syntax for joinWith: 'alias' => 'relation'
+     */
+    public function testJoinWithAlias()
+    {
+        // left join and eager loading
+        /** @var ActiveQuery $query */
+        $query = Order::find()->joinWith(['customer c']);
+        $orders = $query->orderBy($query->applyRelationAlias('customer', 'id') /* c.id */ . ' DESC, order.id')->all();
+        $this->assertEquals(3, count($orders));
+        $this->assertEquals(2, $orders[0]->id);
+        $this->assertEquals(3, $orders[1]->id);
+        $this->assertEquals(1, $orders[2]->id);
+        $this->assertTrue($orders[0]->isRelationPopulated('customer'));
+        $this->assertTrue($orders[1]->isRelationPopulated('customer'));
+        $this->assertTrue($orders[2]->isRelationPopulated('customer'));
+
+        // inner join filtering and eager loading
+        $orders = Order::find()->innerJoinWith(['customer c'])->where('{{c}}.[[id]]=2')->orderBy('order.id')->all();
+        $this->assertEquals(2, count($orders));
+        $this->assertEquals(2, $orders[0]->id);
+        $this->assertEquals(3, $orders[1]->id);
+        $this->assertTrue($orders[0]->isRelationPopulated('customer'));
+        $this->assertTrue($orders[1]->isRelationPopulated('customer'));
+
+        // inner join filtering without eager loading
+        $orders = Order::find()->innerJoinWith(['customer c'], false)->where('{{c}}.[[id]]=2')->orderBy('order.id')->all();
+        $this->assertEquals(2, count($orders));
+        $this->assertEquals(2, $orders[0]->id);
+        $this->assertEquals(3, $orders[1]->id);
+        $this->assertFalse($orders[0]->isRelationPopulated('customer'));
+        $this->assertFalse($orders[1]->isRelationPopulated('customer'));
+
+        // join with via-relation
+        $query = Order::find()->innerJoinWith(['books b']);
+        $orders = $query->where([$query->getRelationAlias('books') . '.name' => 'Yii 1.1 Application Development Cookbook'])->orderBy($query->applyAlias('order', 'id'))->all();
+        $this->assertEquals(2, count($orders));
+        $this->assertEquals(1, $orders[0]->id);
+        $this->assertEquals(3, $orders[1]->id);
+        $this->assertTrue($orders[0]->isRelationPopulated('books'));
+        $this->assertTrue($orders[1]->isRelationPopulated('books'));
+        $this->assertEquals(2, count($orders[0]->books));
+        $this->assertEquals(1, count($orders[1]->books));
+
+
+        $orders = Order::find()->innerJoinWith([
+            'items i' => function ($q) {
+                /** @var $q ActiveQuery */
+                $q->orderBy($q->applyAlias('item', 'id'));
+            },
+            'items.category c' => function ($q) {
+                    /** @var $q ActiveQuery */
+                    $q->where('{{c}}.[[id]] = 2');
+                },
+        ])->orderBy('i.id')->all();
+
+        $this->assertEquals(1, count($orders));
+        $this->assertTrue($orders[0]->isRelationPopulated('items'));
+        $this->assertEquals(2, $orders[0]->id);
+        $this->assertEquals(3, count($orders[0]->items));
+        $this->assertTrue($orders[0]->items[0]->isRelationPopulated('category'));
+        $this->assertEquals(2, $orders[0]->items[0]->category->id);
+
+        // join with ON condition
+        $orders = Order::find()->joinWith(['books2 b'])->orderBy('order.id')->all();
+        $this->assertEquals(3, count($orders));
+        $this->assertEquals(1, $orders[0]->id);
+        $this->assertEquals(2, $orders[1]->id);
+        $this->assertEquals(3, $orders[2]->id);
+        $this->assertTrue($orders[0]->isRelationPopulated('books2'));
+        $this->assertTrue($orders[1]->isRelationPopulated('books2'));
+        $this->assertTrue($orders[2]->isRelationPopulated('books2'));
+        $this->assertEquals(2, count($orders[0]->books2));
+        $this->assertEquals(0, count($orders[1]->books2));
+        $this->assertEquals(1, count($orders[2]->books2));
+
+        // join with count and query
+        /** @var $query ActiveQuery */
+        $query = Order::find()->joinWith(['customer c']);
+        $count = $query->count('c.id');
+        $this->assertEquals(3, $count);
+        $orders = $query->all();
+        $this->assertEquals(3, count($orders));
+
+        // relational query
+        $order = Order::findOne(1);
+        $customer = $order->getCustomer()->innerJoinWith(['orders o'], false)->where(['o.id' => 1])->one();
+        $this->assertNotNull($customer);
+        $this->assertEquals(1, $customer->id);
+
+        // join with sub-relation called inside Closure
+        $orders = Order::find()->joinWith([
+            'items' => function ($q) {
+                    /** @var $q ActiveQuery */
+                    $q->orderBy('item.id');
+                    $q->joinWith(['category c']);
+                    $q->where('{{c}}.[[id]] = 2');
+            },
+        ])->orderBy('order.id')->all();
+        $this->assertEquals(1, count($orders));
+        $this->assertTrue($orders[0]->isRelationPopulated('items'));
+        $this->assertEquals(2, $orders[0]->id);
+        $this->assertEquals(3, count($orders[0]->items));
+        $this->assertTrue($orders[0]->items[0]->isRelationPopulated('category'));
+        $this->assertEquals(2, $orders[0]->items[0]->category->id);
+
+    }
+
+
+
+    // TODO join a relation twice, once with
+
+
+    public function testRelationAlias()
+    {
+        /** @var $query ActiveQuery */
+        $query = Order::find()->joinWith(['items']);
+        $this->assertEquals('item', $query->getRelationAlias('items'));
+        $this->assertEquals('item.id', $query->applyRelationAlias('items', 'id'));
+
+        /** @var $query ActiveQuery */
+        $query = Order::find()->joinWith(['customer c']);
+        $this->assertEquals('c', $query->getRelationAlias('customer'));
+        $this->assertEquals('c.id', $query->applyRelationAlias('customer', 'id'));
+
+        /** @var $query ActiveQuery */
+        $query = Order::find()->joinWith([
+            'customer' => function ($q) {
+                $q->from('tbl_customer cu');
+            }
+		]);
+        $this->assertEquals('cu', $query->getRelationAlias('customer'));
+        $this->assertEquals('cu.id', $query->applyRelationAlias('customer', 'id'));
     }
 
     public function testInverseOf()

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -693,6 +693,20 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertEquals([':to' => 4], $params);
     }
 
+    public function testAlias()
+    {
+        /** @var $query Query */
+        $query = (new Query())
+            ->select('{{@user}}.[[name]]')
+            ->from(['u' => 'user'])
+            ->where(['{{@user}}.[[id]]' => 1]);
+
+        $command = $query->createCommand($this->getDb());
+        $expected = $this->replaceQuotes('SELECT [[u]].[[name]] FROM [[user]] [[u]] WHERE [[u]].[[id]]=:qp0');
+        $this->assertEquals($expected, $command->sql);
+        $this->assertEquals([':qp0' => 1], $command->params);
+    }
+
 //    public function testInsert()
 //    {
 //        // TODO implement


### PR DESCRIPTION
Allows to disambiguate colums without knowing the alias that has been
defined for a table elsewhere (e.g. in a relation definition).
- add methods: getAlias(), applyAlias() to Query for retrieving the
  alias for a table or disambiguate a column name.
- add methods: getRelationAlias() and applyRelationAlias() for
  retrieving the alias for a joined relation table and to disambiguate
  column names of these.
- Add alias syntax to joinWith(), e.g. joinWith('author a').
  No need to know the table name for defining an alias for the relation.

includes tests, docs are following.

Addresses the following issues:
- fixes #2377 (finally) :)
- fixes #9326
- fixes alias issues with default scope: #8743
- introduces new syntax for table alias resolution: `{{@user}}` similar to table prefix and table name escape syntax.
- picked test from https://github.com/yiisoft/yii2/pull/8788, thanks @nainoon

Open todos:
- [ ] add more tests
- [ ] complete documentation (cover #5137, adjust [gridview relation guide](https://github.com/yiisoft/yii2/blob/master/docs/guide/output-data-widgets.md#working-with-model-relations))
- [ ] make getAlias() work for tables from relations
- [x] add alias() method to ActiveQuery to fix #4972
- [ ] check how this relates to #7263
