### PR TITLE
Unable to get data passed via "data-params" in pjax events

### DIFF
--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -172,7 +172,7 @@ yii = (function ($) {
                     replace: pjaxReplaceState,
                     scrollTo: pjaxScrollTo,
                     timeout: pjaxTimeout,
-                    params: params
+                    originalEvent: event
                 }
             }
 

--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -171,7 +171,8 @@ yii = (function ($) {
                     push: pjaxPushState,
                     replace: pjaxReplaceState,
                     scrollTo: pjaxScrollTo,
-                    timeout: pjaxTimeout
+                    timeout: pjaxTimeout,
+                    params: params
                 }
             }
 


### PR DESCRIPTION
Hey, I have found another issue related to #9952.
I am not able to reach extra params passed to pjax via "data-params" attribute.

My button link options are:

``` php
[
    'data-method' => 'post',
    'data-pjax' => 1,
    'data-pjax-container' => '#data-grid',
    'data-pjax-push-state' => 0,
    'data-pjax-timeout' => 0,
    'data-params' => ['foo' => 'bar'],
];
```

But I was not able to get ['foo' => 'bar'] object in pjax events ('pjax:success' e.g.)

I have discovered that "data-params" is not passed to pjax options in yii.js
To solve this issue "pjaxOptions" var in yii.js should be extended with "params" option, and shall look like:

``` js
pjaxOptions = {
    container: pjaxContainer,
    push:pjaxPushState,
    replace:pjaxReplaceState,
    scrollTo:pjaxScrollTo,
    timeout:pjaxTimeout,
    params:params
}
```

After the change I made I have managed to reach passed params as:

``` js
$('#data-grid').on('pjax:success', function (event, data, status, xhr, options) {
    options.params // contains {foo: "bar"} object
});
```

CHANGELOG: 

Option `params` replaced with `originalEvent` which is more flexible as you can reach triggered DOM object. For example, you are able to reach passed params in PJAX event as:

``` js
$('#data-grid').on('pjax:success', function (event, data, status, xhr, options) {
    $(options.originalEvent.currentTarget).data('params'); // contains {foo: "bar"} object
});
```
