### PR TITLE
Unable to get target DOM element in pjax events upon deletion grid row

### DIFF
--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -178,7 +178,8 @@ yii = (function ($) {
                     replaceRedirect: pjaxReplaceRedirect,
                     pjaxSkipOuterContainers: pjaxSkipOuterContainers,
                     timeout: pjaxTimeout,
-                    originalEvent: event
+                    originalEvent: event,
+                    originalTarget: $e
                 }
             }
 


### PR DESCRIPTION
@SilverFire 
Hey, this issue is related to #10267.
As it was solved in #10267 it is possible now to get DOM element which triggers pjax plugin like:

```
$('#data-grid').on('pjax:success', function (event, data, status, xhr, options) {
    options.originalEvent.currentTarget; // clicked DOM element
});
```

It works perfect until grid row is deleted with Delete button.
In this case `options.originalEvent` is `undefined` and I am not able to reach button DOM element via `options.originalEvent.currentTarget`. But there is workaround for this case: I suggest to pass additional `$e`  jQuery object from `yii.js`. It contains DOM element even if grid row was deleted. You can reach DOM element with my pull request in this way:

```
$('#data-grid').on('pjax:success', function (event, data, status, xhr, options) {
    options.originalEvent.currentTarget; // clicked DOM element (undefined if row deleted)
    options.originalTarget; // clicked jQuery DOM element (always accessible)
});
```
