### PR TITLE
Fix #10217 for the case when there is hidden input combined with list view

### DIFF
--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -95,7 +95,7 @@
             var namesInFilter = Object.keys(data);
 
             $.each(yii.getQueryParams(settings.filterUrl), function (name, value) {
-                if (namesInFilter.indexOf(name) === -1) {
+                if (namesInFilter.indexOf(name) === -1 && namesInFilter.indexOf(name.replace(/\[\]$/, '')) === -1) {
                     if (!(name in data)) {
                         data[name] = [];
                     }


### PR DESCRIPTION
I've found small, but important bug.

I the case when you have standard `Html::activeListView` as a filter input, it really adds two inputs: one is select with the name `name[]` and second is hidden input with name `name`. Second one is passed, when no value is selected.

In the case we have selected some value, query string will be: `name=&name[]=1&name[]=2`. That's correct. Now, if you deselect all values from select, `applyFilter` function will find only hidden's input value (because of `$(settings.filterSelector).serializeArray()`). So, when later it will try to override query string values, it will not override `&name[]=1&name[]=2` part because no key `name[]` will be in the `keysInFilter` variable. So my new pull-request is fixing with behavior
#10217
