### PR TITLE
Methods mset, mget and madd have been marked as deprecated

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -79,7 +79,7 @@ Yii Framework 2 Change Log
 - Chg #9953: `TimestampBehavior::getValue()` changed to make value processing consistent with `AttributeBehavior::getValue()` (silverfire)
 - Chg #6419: Added `yii\web\ErrorHandler::displayVars` make list of displayed vars customizable. `$_ENV` and `$_SERVER` are not displayed by default anymore (silverfire)
 - Chg #9528: Traversable objects are now formatted as arrays in `yii\web\XmlResponseFormatter` to support SPL objects and Generators (MaXL-ru)
-- Chg #10296: Methods mset, mget and madd of \yii\caching\Cache have been marked as deprecated (trejder, githubjeka)
+- Chg #10296: Methods mset, mget and madd of `\yii\caching\Cache` have been marked as deprecated (trejder, githubjeka)
 - New #10083: Added wrapper for PHP webserver (samdark)
 - New: Added new requirement: ICU Data version >= 49.1 (SilverFire)
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -79,6 +79,7 @@ Yii Framework 2 Change Log
 - Chg #9953: `TimestampBehavior::getValue()` changed to make value processing consistent with `AttributeBehavior::getValue()` (silverfire)
 - Chg #6419: Added `yii\web\ErrorHandler::displayVars` make list of displayed vars customizable. `$_ENV` and `$_SERVER` are not displayed by default anymore (silverfire)
 - Chg #9528: Traversable objects are now formatted as arrays in `yii\web\XmlResponseFormatter` to support SPL objects and Generators (MaXL-ru)
+- Chg #10296: Methods mset, mget and madd have been marked as deprecated (trejder, githubjeka)
 - New #10083: Added wrapper for PHP webserver (samdark)
 - New: Added new requirement: ICU Data version >= 49.1 (SilverFire)
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -79,7 +79,7 @@ Yii Framework 2 Change Log
 - Chg #9953: `TimestampBehavior::getValue()` changed to make value processing consistent with `AttributeBehavior::getValue()` (silverfire)
 - Chg #6419: Added `yii\web\ErrorHandler::displayVars` make list of displayed vars customizable. `$_ENV` and `$_SERVER` are not displayed by default anymore (silverfire)
 - Chg #9528: Traversable objects are now formatted as arrays in `yii\web\XmlResponseFormatter` to support SPL objects and Generators (MaXL-ru)
-- Chg #10296: Methods mset, mget and madd have been marked as deprecated (trejder, githubjeka)
+- Chg #10296: Methods mset, mget and madd of \yii\caching\Cache have been marked as deprecated (trejder, githubjeka)
 - New #10083: Added wrapper for PHP webserver (samdark)
 - New: Added new requirement: ICU Data version >= 49.1 (SilverFire)
 

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -141,12 +141,29 @@ abstract class Cache extends Component implements \ArrayAccess
      * Some caches (such as memcache, apc) allow retrieving multiple cached values at the same time,
      * which may improve the performance. In case a cache does not support this feature natively,
      * this method will try to simulate it.
+     *
+     * @deprecated This method is alias as [[multiGet()]] and will be removed in 2.1.0.
      * @param string[] $keys list of string keys identifying the cached values
      * @return array list of cached values corresponding to the specified keys. The array
      * is returned in terms of (key, value) pairs.
      * If a value is not cached or expired, the corresponding array value will be false.
      */
     public function mget($keys)
+    {
+        return $this->multiGet($keys);
+    }
+
+    /**
+     * Retrieves multiple values from cache with the specified keys.
+     * Some caches (such as memcache, apc) allow retrieving multiple cached values at the same time,
+     * which may improve the performance. In case a cache does not support this feature natively,
+     * this method will try to simulate it.
+     * @param string[] $keys list of string keys identifying the cached values
+     * @return array list of cached values corresponding to the specified keys. The array
+     * is returned in terms of (key, value) pairs.
+     * If a value is not cached or expired, the corresponding array value will be false.
+     */
+    public function multiGet($keys)
     {
         $keyMap = [];
         foreach ($keys as $key) {
@@ -207,6 +224,7 @@ abstract class Cache extends Component implements \ArrayAccess
      * If the cache already contains such a key, the existing value and
      * expiration time will be replaced with the new ones, respectively.
      *
+     * @deprecated This method is alias as [[multiSet()]] and will be removed in 2.1.0.     *
      * @param array $items the items to be cached, as key-value pairs.
      * @param integer $duration default number of seconds in which the cached values will expire. 0 means never expire.
      * @param Dependency $dependency dependency of the cached items. If the dependency changes,
@@ -215,6 +233,23 @@ abstract class Cache extends Component implements \ArrayAccess
      * @return boolean whether the items are successfully stored into cache
      */
     public function mset($items, $duration = 0, $dependency = null)
+    {
+        return $this->multiSet($items, $duration, $dependency);
+    }
+
+    /**
+     * Stores multiple items in cache. Each item contains a value identified by a key.
+     * If the cache already contains such a key, the existing value and
+     * expiration time will be replaced with the new ones, respectively.
+     *
+     * @param array $items the items to be cached, as key-value pairs.
+     * @param integer $duration default number of seconds in which the cached values will expire. 0 means never expire.
+     * @param Dependency $dependency dependency of the cached items. If the dependency changes,
+     * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
+     * This parameter is ignored if [[serializer]] is false.
+     * @return boolean whether the items are successfully stored into cache
+     */
+    public function multiSet($items, $duration = 0, $dependency = null)
     {
         if ($dependency !== null && $this->serializer !== false) {
             $dependency->evaluateDependency($this);
@@ -239,6 +274,7 @@ abstract class Cache extends Component implements \ArrayAccess
      * Stores multiple items in cache. Each item contains a value identified by a key.
      * If the cache already contains such a key, the existing value and expiration time will be preserved.
      *
+     * @deprecated This method is alias as [[multiAdd()]] and will be removed in 2.1.0.
      * @param array $items the items to be cached, as key-value pairs.
      * @param integer $duration default number of seconds in which the cached values will expire. 0 means never expire.
      * @param Dependency $dependency dependency of the cached items. If the dependency changes,
@@ -247,6 +283,22 @@ abstract class Cache extends Component implements \ArrayAccess
      * @return boolean whether the items are successfully stored into cache
      */
     public function madd($items, $duration = 0, $dependency = null)
+    {
+        return $this->multiAdd($items, $duration, $dependency);
+    }
+
+    /**
+     * Stores multiple items in cache. Each item contains a value identified by a key.
+     * If the cache already contains such a key, the existing value and expiration time will be preserved.
+     *
+     * @param array $items the items to be cached, as key-value pairs.
+     * @param integer $duration default number of seconds in which the cached values will expire. 0 means never expire.
+     * @param Dependency $dependency dependency of the cached items. If the dependency changes,
+     * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
+     * This parameter is ignored if [[serializer]] is false.
+     * @return boolean whether the items are successfully stored into cache
+     */
+    public function multiAdd($items, $duration = 0, $dependency = null)
     {
         if ($dependency !== null && $this->serializer !== false) {
             $dependency->evaluateDependency($this);

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -224,7 +224,7 @@ abstract class Cache extends Component implements \ArrayAccess
      * If the cache already contains such a key, the existing value and
      * expiration time will be replaced with the new ones, respectively.
      *
-     * @deprecated This method is alias as [[multiSet()]] and will be removed in 2.1.0.     *
+     * @deprecated This method is alias as [[multiSet()]] and will be removed in 2.1.0.
      * @param array $items the items to be cached, as key-value pairs.
      * @param integer $duration default number of seconds in which the cached values will expire. 0 means never expire.
      * @param Dependency $dependency dependency of the cached items. If the dependency changes,


### PR DESCRIPTION
http://stackoverflow.com/questions/34008096/why-yii2-uses-abbreviated-methods-names-in-yii-caching-cache
