### PR TITLE
Fix #9101 resolve appendTimestamp to registerJsFile and registerCssFile

### DIFF
--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -371,6 +371,7 @@ class View extends \yii\base\View
      */
     public function registerCssFile($url, $options = [], $key = null)
     {
+        $url = $this->appendTimestamp($url);
         $url = Yii::getAlias($url);
         $key = $key ?: $url;
         $depends = ArrayHelper::remove($options, 'depends', []);
@@ -435,6 +436,7 @@ class View extends \yii\base\View
      */
     public function registerJsFile($url, $options = [], $key = null)
     {
+        $url = $this->appendTimestamp($url);
         $url = Yii::getAlias($url);
         $key = $key ?: $url;
         $depends = ArrayHelper::remove($options, 'depends', []);
@@ -547,5 +549,21 @@ class View extends \yii\base\View
         }
 
         return empty($lines) ? '' : implode("\n", $lines);
+    }
+
+    /**
+     * Append timestamp if the url starts with the alias 'web' and the configuration is turned on
+     *
+     * @param $url
+     * @return string
+     */
+    public function appendTimestamp($url)
+    {
+        if (Yii::$app->assetManager->appendTimestamp && strncmp($url, '@web/', 5) === 0) {
+            $fileToCacheBust = Yii::getAlias(str_replace('@web', '@webroot', $url));
+            if (($timestamp = @filemtime("$fileToCacheBust")) > 0)
+                $url .= "?v={$timestamp}";
+        }
+        return $url;
     }
 }


### PR DESCRIPTION
I couldn't find a way to call assetManager->getAssetUrl to get the appendedTimestamp back. Is there a better approach to solve this problem?
