### PR TITLE
Changed UrlManagers rule cacheKey to be a protected property

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -82,6 +82,7 @@ Yii Framework 2 Change Log
 - Chg #9528: Traversable objects are now formatted as arrays in `yii\web\XmlResponseFormatter` to support SPL objects and Generators (MaXL-ru)
 - New #10083: Added wrapper for PHP webserver (samdark)
 - New: Added new requirement: ICU Data version >= 49.1 (SilverFire)
+- Enh: Changed UrlManagers rule cacheKey to be a protected property (lordthorzonus)
 
 
 2.0.6 August 05, 2015

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -126,6 +126,11 @@ class UrlManager extends Component
      */
     public $ruleConfig = ['class' => 'yii\web\UrlRule'];
 
+    /**
+     * @var string the cache key for cached rules.
+     */
+    protected $cacheKey = __CLASS__;
+
     private $_baseUrl;
     private $_scriptUrl;
     private $_hostInfo;
@@ -146,7 +151,7 @@ class UrlManager extends Component
             $this->cache = Yii::$app->get($this->cache, false);
         }
         if ($this->cache instanceof Cache) {
-            $cacheKey = __CLASS__;
+            $cacheKey = $this->cacheKey;
             $hash = md5(json_encode($this->rules));
             if (($data = $this->cache->get($cacheKey)) !== false && isset($data[1]) && $data[1] === $hash) {
                 $this->rules = $data[0];


### PR DESCRIPTION
I ran into an issue with route caching while extending the UrlManager in my project to load completely different sets of url rules per app locale. 

This enhancement makes the UrlManager and its descendants able to change the cache key with which the rules are stored and therefore allows it to be more easily extendable. 
