### PR TITLE
Fixed client-side IP validator

### DIFF
--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -341,9 +341,9 @@ yii.validation = (function ($) {
 
             var matches = new RegExp(options.ipParsePattern).exec(value);
             if (matches) {
-                negation = (matches[1] !== '') ? matches[1] : null;
-                cidr = (matches[4] !== '') ? matches[4] : null;
+                negation = matches[1] || null;
                 value = matches[2];
+                cidr = matches[4] || null;
             }
 
             if (options.subnet === true && cidr === null) {


### PR DESCRIPTION
I found a problem with client-side IP validation.
When the validated value does not have a CIDR, the `matches[4]` that represents CIDR part is `undefined` instead of expected empty string.
It leads to a wrong comparison in the if statement below, causing invalid behavior.
My patch fixes the default value for the described case and restores expected behavior. 
