### PR TITLE
MessageController output DB lost EOL when unused messages unchanged

### DIFF
--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -407,6 +407,8 @@ EOD;
                        ['in', 'id', $obsolete]
                    )->execute();
                 $this->stdout("updated.\n");
+            } else {
+                $this->stdout("kept untouched.\n");
             }
         }
     }


### PR DESCRIPTION
When storing messages to DB and neither `removeUnused`, nor `markUnused`
is enabled, then output about obsoleted messages won't say anything
about update results and lost EOL:

``` shell
[/path] $ ./yii message/extract ...
Extracting messages from <file>...

Extracting messages from <file>...

Inserting new messages...saved.
Updating obsoleted messages...[/path] $ _
```

Patched to explain what happened and fix EOL:

``` shell
...
Inserting new messages...saved.
Updating obsoleted messages...kept untouched.
[/path] $ _
```
