### PR TITLE
Fix DOMException in XmlResponseFormatter::buildXml()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.11 under development
 ------------------------
 
+- Bug #10346: Fix DOMException: Invalid Character Error in XmlResponseFormatter::buildXml() (sasha-ch)
 - Bug #4113: Error page stacktrace was generating links to private methods which are not part of the API docs (samdark)
 - Bug #7727: Fixed `yii\helpers\StringHelper::truncateHtml()` leaving extra tags (developeruz)
 - Bug #9305: Fixed MSSQL `Schema::TYPE_TIMESTAMP` to be 'datetime' instead of 'timestamp', which is just an incremental number (nkovacs)

--- a/framework/web/XmlResponseFormatter.php
+++ b/framework/web/XmlResponseFormatter.php
@@ -10,6 +10,7 @@ namespace yii\web;
 use DOMDocument;
 use DOMElement;
 use DOMText;
+use DOMException;
 use yii\base\Arrayable;
 use yii\base\Component;
 use yii\helpers\StringHelper;
@@ -93,11 +94,11 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
                 if (is_int($name) && is_object($value)) {
                     $this->buildXml($element, $value);
                 } elseif (is_array($value) || is_object($value)) {
-                    $child = new DOMElement(is_int($name) ? $this->itemTag : $name);
+                    $child = new DOMElement($this->getElementName($name));
                     $element->appendChild($child);
                     $this->buildXml($child, $value);
                 } else {
-                    $child = new DOMElement(is_int($name) ? $this->itemTag : $name);
+                    $child = new DOMElement($this->getElementName($name));
                     $element->appendChild($child);
                     $child->appendChild(new DOMText($this->formatScalarValue($value)));
                 }
@@ -141,5 +142,29 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
         }
 
         return (string) $value;
+    }
+
+    /**
+     * @param mixed $name
+     * @return string
+     */
+    protected function getElementName($name)
+    {
+        return (empty($name) || is_int($name) || !$this->isValidXmlName($name)) ? $this->itemTag : $name;
+    }
+
+    /**
+     * @param mixed $name
+     * @return bool
+     * @see http://stackoverflow.com/questions/2519845/how-to-check-if-string-is-a-valid-xml-element-name/2519943#2519943
+     */
+    protected function isValidXmlName($name)
+    {
+        try {
+            new DOMElement($name);
+            return true;
+        } catch (DOMException $e) {
+            return false;
+        }
     }
 }

--- a/tests/framework/web/XmlResponseFormatterTest.php
+++ b/tests/framework/web/XmlResponseFormatterTest.php
@@ -69,6 +69,13 @@ class XmlResponseFormatterTest extends FormatterTest
                 'c' => [2, '<>'],
                 false,
             ], "<response><a>1</a><b>abc</b><c><item>2</item><item>&lt;&gt;</item></c><item>false</item></response>\n"],
+            [[
+                '' => 1,
+                '2015-06-18' => '2015-06-18',
+                'b:c' => 'b:c',
+                'a b c' => 'a b c',
+                'äøñ' => 'äøñ'
+            ], "<response><item>1</item><item>2015-06-18</item><item>b:c</item><item>a b c</item><äøñ>äøñ</äøñ></response>\n"],
         ]);
     }
 


### PR DESCRIPTION
If my output data to serialize contains empty key:

```
yii\web\Response Object
(
    [format] => xml
    ...
        [data] => Array        (
                    [] => 438
                    [1] => 748
                    [2] => 19
        )
)
```

I see:

``` xml
<response>
    <name>Exception</name>
    <message>Invalid Character Error</message>
    <code>5</code>
    <type>DOMException</type>
    <file>/var/www/dev2_polexpert/backend/vendor/yiisoft/yii2/web/XmlResponseFormatter.php</file>
    <line>96</line>
    <stack-trace>
        <item>#0 /var/www/dev2_polexpert/backend/vendor/yiisoft/yii2/web/XmlResponseFormatter.php(96): DOMElement->__construct('')</item>
        <item>#1 /var/www/dev2_polexpert/backend/vendor/yiisoft/yii2/web/XmlResponseFormatter.php(94): yii\web\XmlResponseFormatter->buildXml(Object(DOMElement), Array)</item>
        <item>#2 /var/www/dev2_polexpert/backend/vendor/yiisoft/yii2/web/XmlResponseFormatter.php(64): yii\web\XmlResponseFormatter->buildXml(Object(DOMElement), Array)</item>
        <item>#3 /var/www/dev2_polexpert/backend/vendor/yiisoft/yii2/web/Response.php(939): yii\web\XmlResponseFormatter->format(Object(yii\web\Response))</item>
    </stack-trace>
</response>
```

To fix problem we may replace empty key with -item- tag, like numeric keys.

PS: json formatter works ok.
