### PR TITLE
Add support of verbs in actions naming

### DIFF
--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -222,6 +222,10 @@ class Controller extends Component implements ViewContextInterface
             return Yii::createObject($actionMap[$id], [$id, $this]);
         } elseif (preg_match('/^[a-z0-9\\-_]+$/', $id) && strpos($id, '--') === false && trim($id, '-') === $id) {
             $methodName = 'action' . str_replace(' ', '', ucwords(implode(' ', explode('-', $id))));
+            $verbMethodName = mb_strtolower(\yii::$app->request->getMethod()) . ucfirst($methodName);
+            if (method_exists($this, $verbMethodName)) {
+                $methodName = $verbMethodName;
+            }
             if (method_exists($this, $methodName)) {
                 $method = new \ReflectionMethod($this, $methodName);
                 if ($method->isPublic() && $method->getName() === $methodName) {


### PR DESCRIPTION
Pretty often we have huge if-else blocks in our actions, e.g. 

``` php
if (\yii::$app->request->isPost)  { 
    ... 
} elseif (\yii::$app->request->isDelete) {
    ... 
} else {
    ... 
}
```

I propose to implement support on verbs in actions naming, e.g. `postActionPage()`, `deleteActionPage()`, etc. Simple `actionPage()` will be called of no verb-related action is found.
