### PR TITLE
Migration - added comment(), unsigned() methods. Supports only [MySQL]

### DIFF
--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -18,6 +18,11 @@ use yii\base\Object;
  * @author Vasenin Matvey <vaseninm@gmail.com>
  * @since 2.0.6
  */
+
+/**
+ * @method \yii\db\mysql\ColumnSchemaBuilder unsigned()  supports only [MySQL]
+ * @method \yii\db\mysql\ColumnSchemaBuilder comment() supports only [MySQL]
+ */
 class ColumnSchemaBuilder extends Object
 {
     /**

--- a/framework/db/mysql/ColumnSchemaBuilder.php
+++ b/framework/db/mysql/ColumnSchemaBuilder.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db\mysql;
+
+use yii\db\ColumnSchemaBuilder as AbstractColumnSchemaBuilder;
+
+/**
+ * ColumnSchemaBuilder is the schema builder for MySQL databases.
+ *
+ * @author Sanjar Khaytmetov <sanjar.khaytmetov@gmail.com>
+ * @since 2.0.6
+ */
+class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
+{
+    /**
+     * @var boolean whether the column is unsigned. If this is `true`, a `UNSIGNED` attribute will be added.
+     */
+    protected $isUnsigned = false;
+    /**
+     * @var string column comment.
+     */
+    protected $comment = '';
+
+    /**
+     * Adds a `UNSIGNED` to permit only nonnegative numbers.
+     * @return $this
+     */
+    public function unsigned()
+    {
+        $this->isUnsigned = true;
+        return $this;
+    }
+
+    /**
+     * Adds a `COMMENT '{comment}'` to a column.
+     * @return $this
+     */
+    public function comment($comment)
+    {
+        $this->comment = $comment;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __toString()
+    {
+        return
+            $this->type .
+            $this->buildLengthString() .
+            $this->buildUnsignedString() .
+            $this->buildDefaultString() .
+            $this->buildNotNullString() .
+            $this->buildCheckString() .
+            $this->buildCommentString();
+    }
+
+    /**
+     * Builds the unsigned attribute for the column.
+     * @return string returns 'UNSIGNED' if [[isUnsigned]] is true, otherwise it returns an empty string.
+     */
+    protected function buildUnsignedString()
+    {
+        return $this->isUnsigned ? ' UNSIGNED' : '';
+    }
+
+    /**
+     * Builds the comment for the column.
+     * @return string returns "COMMENT '{comment}'" if [[comment]] is not empty, otherwise it returns an empty string.
+     */
+    protected function buildCommentString()
+    {
+        return $this->comment ? "COMMENT '" . addslashes($this->comment) . "'" : '';
+    }
+
+}

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -23,7 +23,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * @var array mapping from abstract column types (keys) to physical column types (values).
      */
     public $typeMap = [
-        Schema::TYPE_PK => 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY',
+        Schema::TYPE_PK => 'int(11) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
         Schema::TYPE_BIGPK => 'bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY',
         Schema::TYPE_STRING => 'varchar(255)',
         Schema::TYPE_TEXT => 'text',

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -85,6 +85,14 @@ class Schema extends \yii\db\Schema
     }
 
     /**
+     * @inheritdoc
+     */
+    public function createColumnSchemaBuilder($type, $length = null)
+    {
+        return new ColumnSchemaBuilder($type, $length);
+    }
+
+    /**
      * Loads the metadata for the specified table.
      * @param string $name table name
      * @return TableSchema driver dependent table metadata. Null if the table does not exist.

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -84,9 +84,9 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         return [
             [Schema::TYPE_PK, $this->primaryKey(), 'int(11) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY'],
-            [Schema::TYPE_PK . '(8)', $this->primaryKey(8), 'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY'],
-            [Schema::TYPE_PK . ' CHECK (value > 5)', $this->primaryKey()->check('value > 5'), 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY CHECK (value > 5)'],
-            [Schema::TYPE_PK . '(8) CHECK (value > 5)', $this->primaryKey(8)->check('value > 5'), 'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY CHECK (value > 5)'],
+            [Schema::TYPE_PK . '(8)', $this->primaryKey(8), 'int(8) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY'],
+            [Schema::TYPE_PK . ' CHECK (value > 5)', $this->primaryKey()->check('value > 5'), 'int(11) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY CHECK (value > 5)'],
+            [Schema::TYPE_PK . '(8) CHECK (value > 5)', $this->primaryKey(8)->check('value > 5'), 'int(8) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY CHECK (value > 5)'],
             [Schema::TYPE_STRING, $this->string(), 'varchar(255)'],
             [Schema::TYPE_STRING . '(32)', $this->string(32), 'varchar(32)'],
             [Schema::TYPE_STRING . ' CHECK (value LIKE "test%")', $this->string()->check('value LIKE "test%"'), 'varchar(255) CHECK (value LIKE "test%")'],

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -83,7 +83,7 @@ class QueryBuilderTest extends DatabaseTestCase
     public function columnTypes()
     {
         return [
-            [Schema::TYPE_PK, $this->primaryKey(), 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY'],
+            [Schema::TYPE_PK, $this->primaryKey(), 'int(11) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY'],
             [Schema::TYPE_PK . '(8)', $this->primaryKey(8), 'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY'],
             [Schema::TYPE_PK . ' CHECK (value > 5)', $this->primaryKey()->check('value > 5'), 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY CHECK (value > 5)'],
             [Schema::TYPE_PK . '(8) CHECK (value > 5)', $this->primaryKey(8)->check('value > 5'), 'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY CHECK (value > 5)'],


### PR DESCRIPTION
1. All integer types can have an optional (nonstandard) attribute UNSIGNED. Unsigned type can be used to permit only nonnegative numbers in a column or when you need a larger upper numeric range for the column. For example, if an INT column is UNSIGNED, the size of the column's range is the same but its endpoints shift from -2147483648 and 2147483647 up to 0 and 4294967295.
2. Also added comment() method, more useful.

How to use:

$this->createTable('table', [
            'id' => $this->primaryKey(),
            'some_column' => $this->integer()->unsigned()->comment('Comment will be here.'),
            ...
        ]);
