### PR TITLE
fix BaseArrayHelper::getValue() to work with '' (empty string) keys

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -195,7 +195,7 @@ class BaseArrayHelper
 
         if (($pos = strrpos($key, '.')) !== false) {
             $array = static::getValue($array, substr($key, 0, $pos), $default);
-            $key = substr($key, $pos + 1);
+            $key = (string)substr($key, $pos + 1);
         }
 
         if (is_object($array) && isset($array->$key)) {


### PR DESCRIPTION
fix `BaseArrayHelper::getValue()` to work with '' (empty string) keys after "."

text example:
    `\yii\helpers\BaseArrayHelper::getValue( [ 'key1' => [ '' => 'val2' ] ], 'key1.' )`
should return 'val2'
