### PR TITLE
Making internal UrlManager cache protected(instead of private) to all…

### DIFF
--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -312,28 +312,19 @@ class UrlManager extends Component
         if ($this->enablePrettyUrl) {
             $cacheKey = $route . '?' . implode('&', array_keys($params));
 
-            /* @var $rule UrlRule */
-            $url = false;
-            if (isset($this->_ruleCache[$cacheKey])) {
-                foreach ($this->_ruleCache[$cacheKey] as $rule) {
-                    if (($url = $rule->createUrl($this, $route, $params)) !== false) {
-                        break;
-                    }
-                }
-            } else {
-                $this->_ruleCache[$cacheKey] = [];
-            }
+            $url = $this->getUrlFromInternalCache($cacheKey, $route, $params);
 
             if ($url === false) {
                 $cacheable = true;
                 foreach ($this->rules as $rule) {
+                    /* @var $rule UrlRule */
                     if (!empty($rule->defaults) && $rule->mode !== UrlRule::PARSING_ONLY) {
                         // if there is a rule with default values involved, the matching result may not be cached
                         $cacheable = false;
                     }
                     if (($url = $rule->createUrl($this, $route, $params)) !== false) {
                         if ($cacheable) {
-                            $this->_ruleCache[$cacheKey][] = $rule;
+                            $this->setRuleToInternalCache($cacheKey, $rule);
                         }
                         break;
                     }
@@ -368,6 +359,41 @@ class UrlManager extends Component
 
             return $url . $anchor;
         }
+    }
+
+    /**
+     * Geting url from internal cache if exists
+     * @param string $cacheKey generated cache key to store data.
+     * @param string $route the route (e.g. `site/index`).
+     * @param array $params rule params.
+     * @return bool|string the created URL
+     * @see createUrl()
+     * @since 2.0.8
+     */
+    protected function getUrlFromInternalCache($cacheKey, $route, $params)
+    {
+        if (!empty($this->_ruleCache[$cacheKey])) {
+            foreach ($this->_ruleCache[$cacheKey] as $rule) {
+                /* @var $rule UrlRule */
+                if (($url = $rule->createUrl($this, $route, $params)) !== false) {
+                    return $url;
+                }
+            }
+        } else {
+            $this->_ruleCache[$cacheKey] = [];
+        }
+        return false;
+    }
+
+    /**
+     * Store rule (e.g. [[UrlRule]]) to internal cache.
+     * @param $cacheKey
+     * @param UrlRuleInterface $rule
+     * @since 2.0.8
+     */
+    protected function setRuleToInternalCache($cacheKey, UrlRuleInterface $rule)
+    {
+        $this->_ruleCache[$cacheKey][] = $rule;
     }
 
     /**


### PR DESCRIPTION
There is an rare issue with UrlManager internal private cache. For example we have this rule configuration:

``` php
 'urlManager' => [
    'class' => 'yii\web\UrlManager',
    'enablePrettyUrl' => true,
    'showScriptName' => false,
    'hostInfo' => 'http://www.test.dev',
    'baseUrl' => '/',
    'suffix' => '/',
    'rules' => [
        [
            'pattern' => '/special-cities/<city:(moscow|kazan|barcelona)+>',
            'route' => 'company/index',
        ],
        [
            'pattern' => '<city:[\w-]+>/cities',
            'route' => 'company/index'
        ],

    ]
```

We have special rule for 3 cities and the second universal rule. If we start generating our urls with URL that matched by second rule (for example "London"), than ALL other cities, including cities from the first rule we by matched by second rule (NOT the first one). That is how internal cache work - it just saves the first matched rule in private property and than use it for same routes.

For example:

``` php
  echo Url::to(['company/index', 'city' => 'kazan'], true) . "\n";
  echo Url::to(['company/index', 'city' => 'moscow'], true) . "\n";
  echo Url::to(['company/index', 'city' => 'london'], true) . "\n";
```

will be: 
http://www.test.dev/special-cities/kazan/
http://www.test.dev/special-cities/moscow/
http://www.test.dev/london/cities/

**Its correct!** But if we use:

``` php
echo Url::to(['company/index', 'city' => 'london'], true) . "\n";
echo Url::to(['company/index', 'city' => 'kazan'], true) . "\n";
echo Url::to(['company/index', 'city' => 'moscow'], true) . "\n";
```

the result will be:
_http://www.test.dev/london/cities/
http://www.test.dev/kazan/cities/
http://www.test.dev/moscow/cities/_

Its **incorrect** because of internal cache.
### Fix

We can implement some public settings. Like `$useCache` in UrlRule or `$useInternalCache` in UrlManager. But the case is pretty rare and I think it is not it worth it. Better just to make cache _overridable_ (protected instead of private) so the developers could override it or turn it off. 

So I made it in this pull request.
