### PR TITLE
ArrayDataProvider add options `sliceModels`

### DIFF
--- a/framework/data/ArrayDataProvider.php
+++ b/framework/data/ArrayDataProvider.php
@@ -64,8 +64,10 @@ class ArrayDataProvider extends BaseDataProvider
      */
     public $allModels;
     /**
-     * @var bool If the $allModels need is already part of the data set the value to false
-     * then [[prepareModels]] return all data from the $allModels
+     * @var boolean whether we need to slice [[allModels]] for pagination. Set to `false`,
+     * if [[allModels]] are already paginated. Works only when [[pagination]] is set. Defaults to `true`.
+     * @see pagination
+     * @since 2.0.7
      */
     public $sliceModels = true;
 

--- a/framework/data/ArrayDataProvider.php
+++ b/framework/data/ArrayDataProvider.php
@@ -63,6 +63,11 @@ class ArrayDataProvider extends BaseDataProvider
      * The array elements must use zero-based integer keys.
      */
     public $allModels;
+    /**
+     * @var bool If the $allModels need is already part of the data set the value to false
+     * then [[prepareModels]] return all data from the $allModels
+     */
+    public $sliceModels = true;
 
 
     /**
@@ -81,7 +86,7 @@ class ArrayDataProvider extends BaseDataProvider
         if (($pagination = $this->getPagination()) !== false) {
             $pagination->totalCount = $this->getTotalCount();
 
-            if ($pagination->getPageSize() > 0) {
+            if ($pagination->getPageSize() > 0 && $this->sliceModels === true) {
                 $models = array_slice($models, $pagination->getOffset(), $pagination->getLimit(), true);
             }
         }

--- a/tests/framework/data/ArrayDataProviderTest.php
+++ b/tests/framework/data/ArrayDataProviderTest.php
@@ -179,4 +179,33 @@ class ArrayDataProviderTest extends TestCase
         $dataProvider = new ArrayDataProvider(['allModels' => $mixedArray, 'pagination' => $pagination]);
         $this->assertEquals(['key1', 9], $dataProvider->getKeys());
     }
+
+    public function testSliceModels()
+    {
+        $simpleArray = [
+            ['title'=>'Zabbix', 'license'=>'GPL'],
+            ['title'=>'munin', 'license'=>'GPL'],
+            ['title'=>'Arch Linux', 'license'=>'GPL'],
+            ['title'=>'Nagios', 'license'=>'GPL'],
+            ['title'=>'zend framework', 'license'=>'BSD'],
+        ];
+
+        $dataProvider = new ArrayDataProvider([
+            'allModels' => $simpleArray,
+            'sliceModels' => false,
+            'totalCount' => 100500,
+            'pagination' => [
+                'pageSize' => 20,
+            ],
+        ]);
+
+        $dataProvider->prepare();
+        $this->assertEquals(5025, $dataProvider->pagination->getPageCount());
+
+        $this->assertEquals($simpleArray, $dataProvider->getModels());
+        $dataProvider->pagination->setPage(50);
+        $this->assertEquals($simpleArray, $dataProvider->getModels());
+        $dataProvider->pagination->setPage(5025);
+        $this->assertEquals($simpleArray, $dataProvider->getModels());
+    }
 } 


### PR DESCRIPTION
This option allows you to build proper paging when getting data from API

My example used

``` php
$pageSize = 20;
$page = Yii::$app->request->get('page', 1);

// request to the Yii2 rest api server
$response = Yii::$app->curl->get($this->api_url, [
    'per-page' => $pageSize,
    'page' => $page,
]);

$dataProvider = new ArrayDataProvider([
    'sliceModels' => false,
    'allModels' => Json::decode($response->body),
    'totalCount' => $response->headers['X-Pagination-Total-Count'],
    'pagination' => [
        'pageSize' => $pageSize,
    ],
]);

return $this->render('index', [
    'dataProvider' => $dataProvider
]);
```
