### PR TITLE
Fix incorrect behaviour of number validator in some locales

### DIFF
--- a/framework/validators/NumberValidator.php
+++ b/framework/validators/NumberValidator.php
@@ -85,7 +85,8 @@ class NumberValidator extends Validator
             return;
         }
         $pattern = $this->integerOnly ? $this->integerPattern : $this->numberPattern;
-        if (!preg_match($pattern, "$value")) {
+
+        if (!preg_match($pattern, $this->getStringValue($value))) {
             $this->addError($model, $attribute, $this->message);
         }
         if ($this->min !== null && $value < $this->min) {
@@ -105,7 +106,7 @@ class NumberValidator extends Validator
             return [Yii::t('yii', '{attribute} is invalid.'), []];
         }
         $pattern = $this->integerOnly ? $this->integerPattern : $this->numberPattern;
-        if (!preg_match($pattern, "$value")) {
+        if (!preg_match($pattern, $this->getStringValue($value))) {
             return [$this->message, []];
         } elseif ($this->min !== null && $value < $this->min) {
             return [$this->tooSmall, ['min' => $this->min]];
@@ -113,6 +114,22 @@ class NumberValidator extends Validator
             return [$this->tooBig, ['max' => $this->max]];
         } else {
             return null;
+        }
+    }
+
+    /**
+     * Returns string represenation of number value with replaced commas to dots, if decimal point
+     * of current locale is comma
+     * @param $value
+     * @return string
+     */
+    private function getStringValue($value)
+    {
+        $localeInfo = localeconv();
+        if (isset($localeInfo['decimal_point']) && $localeInfo['decimal_point'] ==',') {
+            return str_replace(',', '.', "$value");
+        } else {
+            return "$value";
         }
     }
 

--- a/tests/framework/validators/NumberValidatorTest.php
+++ b/tests/framework/validators/NumberValidatorTest.php
@@ -70,6 +70,21 @@ class NumberValidatorTest extends TestCase
         $this->assertFalse($val->validate('12.23^4'));
     }
 
+    public function testValidateValueWithLocaleWhereDecimalPointIsComma()
+    {
+        $val = new NumberValidator();
+
+        $oldLocale = setlocale(LC_ALL, "0");
+
+        setlocale(LC_ALL, "en_US.UTF-8");
+        $this->assertTrue($val->validate(.5));
+
+        setlocale(LC_ALL, "en_DK.UTF-8"); //decimal point is comma
+        $this->assertTrue($val->validate(.5));
+
+        setlocale(LC_ALL, $oldLocale);
+    }
+
     public function testValidateValueMin()
     {
         $val = new NumberValidator(['min' => 1]);
@@ -150,6 +165,25 @@ class NumberValidatorTest extends TestCase
         $model = FakedValidationModel::createWithAttributes(['attr_num' => [1, 2, 3]]);
         $val->validateAttribute($model, 'attr_num');
         $this->assertTrue($model->hasErrors('attr_num'));
+    }
+
+    public function testValidateAttributeWithLocaleWhereDecimalPointIsComma()
+    {
+        $val = new NumberValidator();
+        $model = new FakedValidationModel();
+        $model->attr_number = 0.5;
+
+        $oldLocale = setlocale(LC_ALL, "0");
+
+        setlocale(LC_ALL, "en_US.UTF-8");
+        $val->validateAttribute($model, 'attr_number');
+        $this->assertFalse($model->hasErrors('attr_number'));
+
+        setlocale(LC_ALL, "en_DK.UTF-8"); //decimal point is comma
+        $val->validateAttribute($model, 'attr_number');
+        $this->assertFalse($model->hasErrors('attr_number'));
+
+        setlocale(LC_ALL, $oldLocale);
     }
 
     public function testEnsureCustomMessageIsSetOnValidateAttribute()

--- a/tests/framework/validators/NumberValidatorTest.php
+++ b/tests/framework/validators/NumberValidatorTest.php
@@ -37,7 +37,14 @@ class NumberValidatorTest extends TestCase
         $this->assertTrue($val->validate(-20));
         $this->assertTrue($val->validate('20'));
         $this->assertTrue($val->validate(25.45));
+
+        $oldLocale = setlocale(LC_ALL, "0");
+        setlocale(LC_ALL, "en_US.UTF-8");
         $this->assertFalse($val->validate('25,45'));
+        setlocale(LC_ALL, "en_DK.UTF-8"); //decimal point is comma
+        $this->assertTrue($val->validate('25,45'));
+        setlocale(LC_ALL, $oldLocale);
+
         $this->assertFalse($val->validate('12:45'));
         $val = new NumberValidator(['integerOnly' => true]);
         $this->assertTrue($val->validate(20));


### PR DESCRIPTION
In some locales (ru for example) decimal point is comma, so number validator didn't work properly in this locales, because string representation of floats in this locale contains comma instead of dot.

``` php
$val = 0.5;
print "$val"; // "0,5"
```

Build of commit with failing tests: https://travis-ci.org/quantum13/yii2/builds/99038650
