### PR TITLE
allow disabilng client validators by setting 'whenClient' = false

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.7 under development
 -----------------------
 
+- Enh #7546: Add possibility to disable `whenClient` option on input
 - Bug #6351: Find MySQL FK constraints from `information_schema` tables instead of `SHOW CREATE TABLE` to improve reliability (nineinchnick)
 - Bug #6363, #8301, #8582, #9566: Fixed data methods and PJAX issues when used together (derekisbusy)
 - Bug #6876: Fixed RBAC migration MSSQL cascade problem (thejahweh)

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -156,13 +156,14 @@ class Validator extends Component
      */
     public $when;
     /**
-     * @var string a JavaScript function name whose return value determines whether this validator should be applied
+     * @var string|false a JavaScript function name whose return value determines whether this validator should be applied
      * on the client side. The signature of the function should be `function (attribute, value)`, where
      * `attribute` is an object describing the attribute being validated (see [[clientValidateAttribute()]])
      * and `value` the current value of the attribute.
      *
      * This property is mainly provided to support conditional validation on the client side.
      * If this property is not set, this validator will be always applied on the client side.
+     * If this property is false, client validator will be skipped.
      *
      * The following example will enable the validator only when the country currently selected is USA:
      *

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -707,7 +707,7 @@ class ActiveField extends Component
             foreach ($this->model->getActiveValidators($attribute) as $validator) {
                 /* @var $validator \yii\validators\Validator */
                 $js = $validator->clientValidateAttribute($this->model, $attribute, $this->form->getView());
-                if ($validator->enableClientValidation && $js != '') {
+                if ($validator->enableClientValidation && $validator->whenClient !== false && $js != '') {
                     if ($validator->whenClient !== null) {
                         $js = "if (({$validator->whenClient})(attribute, value)) { $js }";
                     }

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -341,6 +341,21 @@ EOD;
         $this->assertEquals($expectedJsExpression, $actualValue['validate']->expression);
     }
 
+    public function testGetClientOptionsValidatorWhenClientDisabled()
+    {
+        $this->activeField->setClientOptionsEmpty(false);
+        $this->activeField->enableAjaxValidation = true;
+        $this->activeField->model->addRule($this->attributeName, 'yiiunit\framework\widgets\TestValidator');
+
+        foreach($this->activeField->model->validators as $validator) {
+            $validator->whenClient = false; // disabling client validation
+        }
+
+        $actualValue = $this->activeField->getClientOptions();
+
+        $this->assertTrue(!isset($actualValue['validate']));
+    }
+
     /**
      * Helper methods
      */


### PR DESCRIPTION
Based on proposal https://github.com/yiisoft/yii2/issues/7546

`whenClient` enchancement. Allow disable client validators by seting `'whenClient' => false` in AR's rules.
Pull request little differs from the original issue: `whenClient` **MUST** be set to `false`. Its because of backward compatibility.
