### PR TITLE
#10483 Response::redirect() uses 200 status code for IE 11

### DIFF
--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -760,7 +760,7 @@ class Response extends \yii\base\Response
         }
 
         if ($checkAjax) {
-            if (Yii::$app->getRequest()->getIsPjax()) {
+            if (Yii::$app->getRequest()->getIsAjax()) {
                 if (Yii::$app->getRequest()->getHeaders()->get('X-Ie-Redirect-Compatibility') !== null && $statusCode === 302) {
                     $statusCode = 200; // override status code for IE, but only, if it is not explicitly specified
                 }

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -759,11 +759,16 @@ class Response extends \yii\base\Response
             $url = Yii::$app->getRequest()->getHostInfo() . $url;
         }
 
-        if ($checkAjax && Yii::$app->getRequest()->getHeaders()->get('X-Ie-Redirect-Compatibility') === null) {
+        if ($checkAjax) {
             if (Yii::$app->getRequest()->getIsPjax()) {
-                $this->getHeaders()->set('X-Pjax-Url', $url);
-            } elseif (Yii::$app->getRequest()->getIsAjax()) {
-                $this->getHeaders()->set('X-Redirect', $url);
+                if (Yii::$app->getRequest()->getHeaders()->get('X-Ie-Redirect-Compatibility') !== null && func_num_args() < 2) {
+                    $statusCode = 200; // override status code for IE, but only, if it is not explicitly passed
+                }
+                if (Yii::$app->getRequest()->getIsPjax()) {
+                    $this->getHeaders()->set('X-Pjax-Url', $url);
+                } else {
+                    $this->getHeaders()->set('X-Redirect', $url);
+                }
             } else {
                 $this->getHeaders()->set('Location', $url);
             }

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -761,8 +761,8 @@ class Response extends \yii\base\Response
 
         if ($checkAjax) {
             if (Yii::$app->getRequest()->getIsPjax()) {
-                if (Yii::$app->getRequest()->getHeaders()->get('X-Ie-Redirect-Compatibility') !== null && func_num_args() < 2) {
-                    $statusCode = 200; // override status code for IE, but only, if it is not explicitly passed
+                if (Yii::$app->getRequest()->getHeaders()->get('X-Ie-Redirect-Compatibility') !== null && $statusCode === 302) {
+                    $statusCode = 200; // override status code for IE, but only, if it is not explicitly specified
                 }
                 if (Yii::$app->getRequest()->getIsPjax()) {
                     $this->getHeaders()->set('X-Pjax-Url', $url);

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -762,7 +762,8 @@ class Response extends \yii\base\Response
         if ($checkAjax) {
             if (Yii::$app->getRequest()->getIsAjax()) {
                 if (Yii::$app->getRequest()->getHeaders()->get('X-Ie-Redirect-Compatibility') !== null && $statusCode === 302) {
-                    $statusCode = 200; // override status code for IE, but only, if it is not explicitly specified
+                    // Ajax 302 redirect in IE does not work. Change status code to 200. See https://github.com/yiisoft/yii2/issues/9670
+                    $statusCode = 200;
                 }
                 if (Yii::$app->getRequest()->getIsPjax()) {
                     $this->getHeaders()->set('X-Pjax-Url', $url);


### PR DESCRIPTION
Adjustments for #10483
`Response::redirect()` uses 200 status code if 'X-Ie-Redirect-Compatibility' header sent
