### PR TITLE
Prefixes for yii.activeForm.js event names

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 2.0.9 under development
 -----------------------
 
+- Bug #11032: Fixed double `ajaxComplete` event in `yii.activeForm.js` by namespacing event names; `yii.gridView.js` events also namespaced (dizeee)
 - Enh #11725: Added indexes on message tables (OndrejVasicek)
 - Enh #10422: Added `null` method on `yii\db\ColumnSchemaBuilder` to explicitly set column nullability (nevermnd)
 - Enh #9574: Implicit run `ColumnSchemaBuilder::null()` when default value is set to `null`. (rob006)

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -24,7 +24,7 @@
 
     var events = {
         /**
-         * beforeValidate event is triggered before validating the whole form.
+         * beforeValidate.yiiActiveForm event is triggered before validating the whole form.
          * The signature of the event handler should be:
          *     function (event, messages, deferreds)
          * where
@@ -36,9 +36,9 @@
          * If the handler returns a boolean false, it will stop further form validation after this event. And as
          * a result, afterValidate event will not be triggered.
          */
-        beforeValidate: 'beforeValidate',
+        beforeValidate: 'beforeValidate.yiiActiveForm',
         /**
-         * afterValidate event is triggered after validating the whole form.
+         * afterValidate.yiiActiveForm event is triggered after validating the whole form.
          * The signature of the event handler should be:
          *     function (event, messages, errorAttributes)
          * where
@@ -47,9 +47,9 @@
          *    for the corresponding attributes.
          *  - errorAttributes: an array of attributes that have validation errors. Please refer to attributeDefaults for the structure of this parameter.
          */
-        afterValidate: 'afterValidate',
+        afterValidate: 'afterValidate.yiiActiveForm',
         /**
-         * beforeValidateAttribute event is triggered before validating an attribute.
+         * beforeValidateAttribute.yiiActiveForm event is triggered before validating an attribute.
          * The signature of the event handler should be:
          *     function (event, attribute, messages, deferreds)
          * where
@@ -61,9 +61,9 @@
          * If the handler returns a boolean false, it will stop further validation of the specified attribute.
          * And as a result, afterValidateAttribute event will not be triggered.
          */
-        beforeValidateAttribute: 'beforeValidateAttribute',
+        beforeValidateAttribute: 'beforeValidateAttribute.yiiActiveForm',
         /**
-         * afterValidateAttribute event is triggered after validating the whole form and each attribute.
+         * afterValidateAttribute.yiiActiveForm event is triggered after validating the whole form and each attribute.
          * The signature of the event handler should be:
          *     function (event, attribute, messages)
          * where
@@ -71,18 +71,18 @@
          *  - attribute: the attribute being validated. Please refer to attributeDefaults for the structure of this parameter.
          *  - messages: an array to which you can add additional validation error messages for the specified attribute.
          */
-        afterValidateAttribute: 'afterValidateAttribute',
+        afterValidateAttribute: 'afterValidateAttribute.yiiActiveForm',
         /**
-         * beforeSubmit event is triggered before submitting the form after all validations have passed.
+         * beforeSubmit.yiiActiveForm event is triggered before submitting the form after all validations have passed.
          * The signature of the event handler should be:
          *     function (event)
          * where event is an Event object.
          *
          * If the handler returns a boolean false, it will stop form submission.
          */
-        beforeSubmit: 'beforeSubmit',
+        beforeSubmit: 'beforeSubmit.yiiActiveForm',
         /**
-         * ajaxBeforeSend event is triggered before sending an AJAX request for AJAX-based validation.
+         * ajaxBeforeSend.yiiActiveForm event is triggered before sending an AJAX request for AJAX-based validation.
          * The signature of the event handler should be:
          *     function (event, jqXHR, settings)
          * where
@@ -90,9 +90,9 @@
          *  - jqXHR: a jqXHR object
          *  - settings: the settings for the AJAX request
          */
-        ajaxBeforeSend: 'ajaxBeforeSend',
+        ajaxBeforeSend: 'ajaxBeforeSend.yiiActiveForm',
         /**
-         * ajaxComplete event is triggered after completing an AJAX request for AJAX-based validation.
+         * ajaxComplete.yiiActiveForm event is triggered after completing an AJAX request for AJAX-based validation.
          * The signature of the event handler should be:
          *     function (event, jqXHR, textStatus)
          * where
@@ -100,7 +100,7 @@
          *  - jqXHR: a jqXHR object
          *  - textStatus: the status of the request ("success", "notmodified", "error", "timeout", "abort", or "parsererror").
          */
-        ajaxComplete: 'ajaxComplete'
+        ajaxComplete: 'ajaxComplete.yiiActiveForm'
     };
 
     // NOTE: If you change any of these defaults, make sure you update yii\widgets\ActiveForm::getClientOptions() as well

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -30,7 +30,7 @@
 
     var gridEvents = {
         /**
-         * beforeFilter event is triggered before filtering the grid.
+         * beforeFilter.yiiGridView event is triggered before filtering the grid.
          * The signature of the event handler should be:
          *     function (event)
          * where
@@ -39,15 +39,15 @@
          * If the handler returns a boolean false, it will stop filter form submission after this event. As
          * a result, afterFilter event will not be triggered.
          */
-        beforeFilter: 'beforeFilter',
+        beforeFilter: 'beforeFilter.yiiGridView',
         /**
-         * afterFilter event is triggered after filtering the grid and filtered results are fetched.
+         * afterFilter.yiiGridView event is triggered after filtering the grid and filtered results are fetched.
          * The signature of the event handler should be:
          *     function (event)
          * where
          *  - event: an Event object.
          */
-        afterFilter: 'afterFilter'
+        afterFilter: 'afterFilter.yiiGridView'
     };
 
     var methods = {


### PR DESCRIPTION
The yii.activeForm.js script triggers `ajaxComplete` event named the same as jQuery's `ajaxComplete` which causes duplicate `$(document).ajaxComplete()` handlers execution.

For example the built in ajax redirect (`initRedirectHandler()` in yii.js) is triggered two times, which makes `Yii::$app->session->setFlash()` useless at least with Firefox 43.0.4 browser because it makes two requests but aborts the first one so the flash data is lost. In Chrome 47 the redirect is OK but still duplicate handlers execution.

Using prefixes in custom event names is a good practice.

![screenshot](https://cloud.githubusercontent.com/assets/845698/12213980/33e42b0c-b695-11e5-901f-6c4e4adaa163.jpg)
