### PR TITLE
Divide by zero prevention.

### DIFF
--- a/framework/helpers/BaseConsole.php
+++ b/framework/helpers/BaseConsole.php
@@ -954,7 +954,7 @@ class BaseConsole
             self::$_progressEtaLastUpdate = time();
         } elseif ($done < $total) {
             // update ETA once per second to avoid flapping
-            if (time() - self::$_progressEtaLastUpdate > 1) {
+            if (time() - self::$_progressEtaLastUpdate > 1 && $done > self::$_progressEtaLastDone) {
                 $rate = (time() - (self::$_progressEtaLastUpdate ?: self::$_progressStart)) / ($done - self::$_progressEtaLastDone);
                 self::$_progressEta = $rate * ($total - $done);
                 self::$_progressEtaLastUpdate = time();


### PR DESCRIPTION
There can be a situation when `BaseConsole::$_progressEtaLastDone` is equal to `$done`, so it can throw a "Division by zero" exception.
