### PR TITLE
Update BaseMigrateController.php

### DIFF
--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -122,7 +122,7 @@ abstract class BaseMigrateController extends Controller
     {
         $migrations = $this->getNewMigrations();
         if (empty($migrations)) {
-            $this->stdout("No new migration found. Your system is up-to-date.\n", Console::FG_GREEN);
+            $this->stdout("No new migrations found. Your system is up-to-date.\n", Console::FG_GREEN);
 
             return self::EXIT_CODE_NORMAL;
         }


### PR DESCRIPTION
I believe it's just typo.
Compare the two lines in `BaseMigrateController` at line 125:

```
$this->stdout("No new migration found. Your system is up-to-date.\n", Console::FG_GREEN);
```

and at line 462:

```
$this->stdout("No new migrations found. Your system is up-to-date.\n", Console::FG_GREEN);
```

The first one lost 's'.
It may seem unworthy of attention, but it complicates the parsing process of migration script result - I have to compare for different string for `migrate/up` and `migrate/new` commands. The PR suggests to make the stdout strings identical.
