### PR TITLE
Fix for using CompareValidator inside EachValidator #9935

### DIFF
--- a/framework/validators/EachValidator.php
+++ b/framework/validators/EachValidator.php
@@ -116,6 +116,15 @@ class EachValidator extends Validator
     {
         $value = $model->$attribute;
         $validator = $this->getValidator();
+
+        if ($validator instanceof CompareValidator &&
+            $validator->compareValue === null &&
+            $validator->compareAttribute !== null
+        ) {
+            $compareAttribute = $validator->compareAttribute;
+            $validator->compareValue = $model->$compareAttribute;
+        }
+
         if ($validator instanceof FilterValidator && is_array($value)) {
             $filteredValue = [];
             foreach ($value as $k => $v) {

--- a/tests/framework/validators/EachValidatorTest.php
+++ b/tests/framework/validators/EachValidatorTest.php
@@ -72,4 +72,34 @@ class EachValidatorTest extends TestCase
         $validator->validateAttribute($model, 'attr_one');
         $this->assertNotContains('integer', $model->getFirstError('attr_one'));
     }
+
+    public function testWithCompareValidator()
+    {
+        $validModel = FakedValidationModel::createWithAttributes([
+            'attr_foo' => [
+                'text1',
+                'text2',
+                'text3'
+            ],
+            'attr_bar' => 'text'
+        ]);
+
+        $invalidModel = FakedValidationModel::createWithAttributes([
+            'attr_foo' => [
+                'text',
+                'text2',
+                'text3'
+            ],
+            'attr_bar' => 'text'
+        ]);
+
+        // each element in $this->attr_foo[] is not equal to $this->attr_bar
+        $validator = new EachValidator(['rule' => ['compare', 'compareAttribute' => 'attr_bar', 'operator' => '!=']]);
+
+        $validator->validateAttribute($validModel, 'attr_foo');
+        $this->assertEmpty($validModel->getErrors());
+
+        $validator->validateAttribute($invalidModel, 'attr_foo');
+        $this->assertNotEmpty($invalidModel->getErrors());
+    }
 }


### PR DESCRIPTION
As solution for issue it was decided to check inside `EachValidator` if we use `CompareValidator`.

If we do and `compareValue` property is not set for this validator, but only `compareAttribute` is set, then we are manually set `compareValue` to corresponding value of model `compareAttribute`
