### PR TITLE
#10218 - Fix for session regenerate id issue after user logged out

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -43,6 +43,7 @@ Yii Framework 2 Change Log
 - Bug #10052: Fixed `yii\i18n\Formatter` to work with huge numbers on 32-bit arch (necrox87, silverfire)
 - Bug #10101: Fixed assignments saving on role removing in `\yii\rbac\PhpManager` (rezident1307)
 - Bug #10142: Fixed `yii\validators\EmailValidator` to check the length of email properly (silverfire)
+- Bug #10218: Fixed Flash messages not showing after logging out a user (andrewnester)
 - Bug #10263: Fixed `yii\validators\UniqueValidator` to work properly when model is not instance of `targetClass` (bupy7, githubjeka, silverfire)
 - Bug #10278: Fixed `yii\helpers\BaseJson` support \SimpleXMLElement data (SilverFire, LAV45)
 - Bug #10302: Fixed JS function `yii.getQueryParams`, which parsed array variables incorrectly (servocoder, silverfire)

--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -182,7 +182,9 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
     {
         if ($this->getIsActive()) {
             @session_unset();
+            $sessionId = session_id();
             @session_destroy();
+            @session_id($sessionId);
         }
     }
 

--- a/tests/framework/web/SessionTest.php
+++ b/tests/framework/web/SessionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace yiiunit\framework\web;
+
+use yii\web\Session;
+use yiiunit\TestCase;
+
+/**
+ * @group web
+ */
+class SessionTest extends TestCase
+{
+    /**
+     * Test to prove that Session::destroy generates session with new identifier
+     */
+    public function testDestroySessionId()
+    {
+        $session = new Session();
+        $session->open();
+        $oldSessionId = @session_id();
+
+        $this->assertNotEmpty($oldSessionId);
+
+        $session->destroy();
+
+        $newSessionId = @session_id();
+        $this->assertNotEmpty($newSessionId);
+        $this->assertEquals($oldSessionId, $newSessionId);
+    }
+}

--- a/tests/framework/web/SessionTest.php
+++ b/tests/framework/web/SessionTest.php
@@ -11,7 +11,7 @@ use yiiunit\TestCase;
 class SessionTest extends TestCase
 {
     /**
-     * Test to prove that Session::destroy generates session with new identifier
+     * Test to prove that after Session::destroy session id set to old value
      */
     public function testDestroySessionId()
     {


### PR DESCRIPTION
This is fix for #10218 
It is based on solution @klimov-paul offered in conversation for this ticket
