### PR TITLE
#10574 - Changed signature for BaseArrayHelper::htmlEncode and added doubleEncode parameter

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -457,25 +457,23 @@ class BaseArrayHelper
      * @param array $data data to be encoded
      * @param boolean $valuesOnly whether to encode array values only. If false,
      * both the array keys and array values will be encoded.
-     * @param string $charset the charset that the data is using. If not set,
-     * [[\yii\base\Application::charset]] will be used.
+     * @param boolean $doubleEncode whether to encode HTML entities in `$data`. If false,
+     * HTML entities in `$data` will not be further encoded.
      * @return array the encoded data
      * @see http://www.php.net/manual/en/function.htmlspecialchars.php
      */
-    public static function htmlEncode($data, $valuesOnly = true, $charset = null)
+    public static function htmlEncode($data, $valuesOnly = true, $doubleEncode = true)
     {
-        if ($charset === null) {
-            $charset = Yii::$app->charset;
-        }
+        $charset = Yii::$app ? Yii::$app->charset : 'UTF-8';
         $d = [];
         foreach ($data as $key => $value) {
             if (!$valuesOnly && is_string($key)) {
-                $key = htmlspecialchars($key, ENT_QUOTES, $charset);
+                $key = htmlspecialchars($key, ENT_QUOTES | ENT_SUBSTITUTE, $charset, $doubleEncode);
             }
             if (is_string($value)) {
-                $d[$key] = htmlspecialchars($value, ENT_QUOTES, $charset);
+                $d[$key] = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, $charset, $doubleEncode);
             } elseif (is_array($value)) {
-                $d[$key] = static::htmlEncode($value, $valuesOnly, $charset);
+                $d[$key] = static::htmlEncode($value, $valuesOnly, $doubleEncode);
             } else {
                 $d[$key] = $value;
             }

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -421,7 +421,9 @@ class ArrayHelperTest extends TestCase
             [
                 '<>' => 'a<>b',
                 '23' => true,
-            ]
+            ],
+            'invalid' => "a\x80b",
+            'html_entity' => '&amp;'
         ];
         $this->assertEquals([
             'abc' => '123',
@@ -431,7 +433,9 @@ class ArrayHelperTest extends TestCase
             [
                 '<>' => 'a&lt;&gt;b',
                 '23' => true,
-            ]
+            ],
+            'invalid' => 'a�b',
+            'html_entity' => '&amp;amp;'
         ], ArrayHelper::htmlEncode($array));
         $this->assertEquals([
             'abc' => '123',
@@ -441,8 +445,22 @@ class ArrayHelperTest extends TestCase
             [
                 '&lt;&gt;' => 'a&lt;&gt;b',
                 '23' => true,
-            ]
+            ],
+            'invalid' => 'a�b',
+            'html_entity' => '&amp;amp;'
         ], ArrayHelper::htmlEncode($array, false));
+        $this->assertEquals([
+            'abc' => '123',
+            '&lt;' => '&gt;',
+            'cde' => false,
+            3 => 'blank',
+            [
+                '&lt;&gt;' => 'a&lt;&gt;b',
+                '23' => true,
+            ],
+            'invalid' => 'a�b',
+            'html_entity' => '&amp;'
+        ], ArrayHelper::htmlEncode($array, false, false));
     }
 
     public function testHtmlDecode()


### PR DESCRIPTION
Implementing #10574

Signature for `BaseArrayHelper::htmlEncode` was changed (made similar to `BaseHtml::encode`), we should be careful with it.

In addition now `ENT_SUBSTITUTE` is used for `htmlspecialchars` .
Added new tests for `BaseArrayHelper::htmlEncode` .
