### PR TITLE
#10545 - Fix for XMLResponseFormatter to format models in a proper way

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -106,6 +106,7 @@ Yii Framework 2 Change Log
 - Enh #10359: Support wildcard category name in `yii/console/controllers/MessageController` (rmrevin)
 - Enh #10390: Added ability to disable outer tag for `\yii\helpers\BaseHtml::radiolist()`, `::checkboxList()` (TianJinRong, githubjeka, silverfire)
 - Enh #10535: Allow passing a `yii\db\Expression` to `Query::orderBy()` and `Query::groupBy()` (andrewnester, cebe)
+- Enh #10545: `yii\web\XMLResponseFormatter` changed to format models in a proper way (andrewnester)
 - Enh: Added last resort measure for `FileHelper::removeDirectory()` fail to unlink symlinks under Windows (samdark)
 - Chg #9369: `Yii::$app->user->can()` now returns `false` instead of erroring in case `authManager` component is not configured (creocoder)
 - Chg #9411: `DetailView` now automatically sets container tag ID in case it's not specified (samdark)

--- a/framework/web/XmlResponseFormatter.php
+++ b/framework/web/XmlResponseFormatter.php
@@ -77,7 +77,9 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
      */
     protected function buildXml($element, $data)
     {
-        if (is_array($data) || $data instanceof \Traversable && $this->useTraversableAsArray) {
+        if (is_array($data) ||
+            ($data instanceof \Traversable && $this->useTraversableAsArray && !$data instanceof Arrayable)
+        ) {
             foreach ($data as $name => $value) {
                 if (is_int($name) && is_object($value)) {
                     $this->buildXml($element, $value);

--- a/tests/framework/web/FormatterTest.php
+++ b/tests/framework/web/FormatterTest.php
@@ -86,4 +86,16 @@ abstract class FormatterTest extends \yiiunit\TestCase
         $this->formatter->format($this->response);
         $this->assertEquals($json, $this->response->content);
     }
+
+    /**
+     * @param mixed  $data the data to be formatted
+     * @param string $expectedResult the expected body
+     * @dataProvider formatModelDataProvider
+     */
+    public function testFormatModels($data, $expectedResult)
+    {
+        $this->response->data = $data;
+        $this->formatter->format($this->response);
+        $this->assertEquals($expectedResult, $this->response->content);
+    }
 }

--- a/tests/framework/web/JsonResponseFormatterTest.php
+++ b/tests/framework/web/JsonResponseFormatterTest.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\web;
 
 use yii\web\JsonResponseFormatter;
+use yiiunit\framework\web\stubs\ModelStub;
 
 /**
  * @author Alexander Makarov <sam@rmcreative.ru>
@@ -84,6 +85,13 @@ class JsonResponseFormatterTest extends FormatterTest
 
         return [
             [$postsStack, '{"1":{"id":456,"title":"record2"},"0":{"id":915,"title":"record1"}}']
+        ];
+    }
+
+    public function formatModelDataProvider()
+    {
+        return [
+            [new ModelStub(['id' => 123, 'title' => 'abc', 'hidden' => 'hidden']), '{"id":123,"title":"abc"}']
         ];
     }
 

--- a/tests/framework/web/XmlResponseFormatterTest.php
+++ b/tests/framework/web/XmlResponseFormatterTest.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\web;
 
 use yii\web\XmlResponseFormatter;
+use yiiunit\framework\web\stubs\ModelStub;
 
 /**
  * @author Qiang Xue <qiang.xue@gmail.com>
@@ -102,6 +103,16 @@ class XmlResponseFormatterTest extends FormatterTest
                 new Post(123, '<>'),
                 'a' => new Post(456, 'def'),
             ], "<response><Post><id>123</id><title>&lt;&gt;</title></Post><a><Post><id>456</id><title>def</title></Post></a></response>\n"],
+        ]);
+    }
+
+    public function formatModelDataProvider()
+    {
+        return $this->addXmlHead([
+            [
+                new ModelStub(['id' => 123, 'title' => 'abc', 'hidden' => 'hidden']),
+                "<response><ModelStub><id>123</id><title>abc</title></ModelStub></response>\n"
+            ]
         ]);
     }
 }

--- a/tests/framework/web/stubs/ModelStub.php
+++ b/tests/framework/web/stubs/ModelStub.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace yiiunit\framework\web\stubs;
+
+use yii\base\Model;
+
+class ModelStub extends Model
+{
+    public $id;
+    public $title;
+    public $hidden;
+
+    public function toArray(array $fields = [], array $expand = [], $recursive = true)
+    {
+        return ['id' => $this->id, 'title' => $this->title];
+    }
+}


### PR DESCRIPTION
Fix for #10545

Now if data passed to formatter is `Arrayable`, then it is using `toArray()` method to get data for formatting.

Actually, it is kind of security fix because in corresponding issue we can see that in XML response return password hashed that is supposed to be hidden
