### PR TITLE
reverted c00b97a/#9915, this is expected behavior

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -35,7 +35,6 @@ Yii Framework 2 Change Log
 - Bug #9874: Fixed outputting exception stacktrace in non-debug mode when `Response::FORMAT_RAW` is used (nainoon)
 - Bug #9883: Passing a single `yii\db\Expression` to `Query::select()` or `::addSelect()` was not handled correctly in all cases (cebe)
 - Bug #9911: Fixed `yii\helpers\BaseStringHelper::explode()` code so it doesn't remove items equal to 0 when `skip_empty` is true (silverfire, kidol)
-- Bug #9915: `yii\helpers\ArrayHelper::getValue()` was erroring instead of returning `null` for non-existing object properties (totaldev, samdark)
 - Bug #9924: Fixed `yii.js` handleAction corrupted parameter values containing quote (") character (silverfire)
 - Bug #9984: Fixed wrong captcha color in case Imagick is used (DrDeath72)
 - Bug #9999: Fixed `yii\web\UrlRule` to allow route parameter names with `-`, `_`, `.`characters (silverfire)

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -198,7 +198,9 @@ class BaseArrayHelper
             $key = substr($key, $pos + 1);
         }
 
-        if (is_object($array) && isset($array->$key)) {
+        if (is_object($array)) {
+            // this is expected to fail if the property does not exist, or __get() is not implemented
+            // it is not reliably possible to check whether a property is accessable beforehand
             return $array->$key;
         } elseif (is_array($array)) {
             return array_key_exists($key, $array) ? $array[$key] : $default;

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -387,9 +387,31 @@ class ArrayHelperTest extends TestCase
 
     public function testGetValueObjects()
     {
+        $arrayObject = new \ArrayObject(['id' => 23], \ArrayObject::ARRAY_AS_PROPS);
+        $this->assertEquals(23, ArrayHelper::getValue($arrayObject, 'id'));
+
         $object = new Post1();
         $this->assertEquals(23, ArrayHelper::getValue($object, 'id'));
+    }
+
+    /**
+     * This is expected to result in a PHP error
+     * @expectedException \PHPUnit_Framework_Error
+     */
+    public function testGetValueNonexistingProperties1()
+    {
+        $object = new Post1();
         $this->assertEquals(null, ArrayHelper::getValue($object, 'nonExisting'));
+    }
+
+    /**
+     * This is expected to result in a PHP error
+     * @expectedException \PHPUnit_Framework_Error
+     */
+    public function testGetValueNonexistingProperties2()
+    {
+        $arrayObject = new \ArrayObject(['id' => 23], \ArrayObject::ARRAY_AS_PROPS);
+        $this->assertEquals(23, ArrayHelper::getValue($arrayObject, 'nonExisting'));
     }
 
     public function testIsAssociative()


### PR DESCRIPTION
reverted c00b97a/#9915

When accessing non-existing properties it is [expected behavior to throw an error](https://github.com/yiisoft/yii2/issues/7193#issuecomment-73287156).
This is the case in all other places of the framework.

It is also not reliably possible to determine whether a property exists beforehand.
it is not sufficient to call `property_exists()` as it may be available via `__get()`.

Instead of `property_exists()` or `isset()` it should call `$object->canGetProperty()` but this is not
guaranteed to be implemented and therefor doing such a check will not work in 2.0.x as it breaks BC.

calling isset() may break code that works through __get() but has not implemented __isset() properly.

We may discuss this for 2.1 again but I am in favor of keeping it as is.
