### PR TITLE
Changed pattern of URL to match appropriate URL's

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.7 under development
 -----------------------
-
+- Bug #10533: URL validator passed the tests but allowed incorrect values. Changed Patter to more reliable one with URI as options(Shadowmad; Max)
 - Bug #6351: Find MySQL FK constraints from `information_schema` tables instead of `SHOW CREATE TABLE` to improve reliability (nineinchnick)
 - Bug #6363, #8301, #8582, #9566: Fixed data methods and PJAX issues when used together (derekisbusy)
 - Bug #6876: Fixed RBAC migration MSSQL cascade problem (thejahweh)

--- a/framework/validators/UrlValidator.php
+++ b/framework/validators/UrlValidator.php
@@ -28,7 +28,7 @@ class UrlValidator extends Validator
      * The pattern may contain a `{schemes}` token that will be replaced
      * by a regular expression which represents the [[validSchemes]].
      */
-    public $pattern = '/^{schemes}:\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)/i';
+    public $pattern = '/^({schemes}:\\/\\/)(www\\.)?([0-9u0000-uFFFF]*\\.\\-)?([0-9u0000-uFFFF\\-]*)\\.([a-zA-Z]{2,6})?([u0000-uFFFF]{2,6})\\/?([u0000-uFFFF0-9_\\-\\?=\\.\\&])*?/i';
     /**
      * @var array list of URI schemes which should be considered valid. By default, http and https
      * are considered to be valid schemes.


### PR DESCRIPTION
I have changed pattern of the url validator to match correct URLs so that error #10533 would not occure again. As explained in 10533, URLs are passing the tests, but URLs are not correct, this issue was encountered dut to the pattern issues. I ran PHPUnit tests and now everything is passing as well as checked URL in variety of programs to check if URL is correct or not. Please review and let me know if I should re do it or accepted

Thank you! 
