### PR TITLE
8348 - Fixed processing nested objects multisort in BaseArrayHelper 

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #6876: Fixed RBAC migration MSSQL cascade problem (thejahweh)
 - Bug #7627: Fixed `yii\widgets\ActiveField` to handle inputs validation with changed ID properly (dynasource, cebe)
 - Bug #7806: Fixed `yii\grid\CheckboxColumn` fixed `_all` checkbox column name generation (cebe, silverfire)
+- Bug #8348: Fixed `yii\helpers\BaseArrayHelper` fixed PHP Fatal Error: Nesting level too deep - recursive dependency? (andrewnester)
 - Bug #8466: Fixed `yii\validators\FileValidator` to display error for `tooBig` and `tooSmall` with formatted unit (silverfire)
 - Bug #8573: Fixed incorrect data type mapping for NUMBER to INTEGER or DECIMAL in Oracle (vbelogai)
 - Bug #8723: Fixed `yii\helpers\VarDumper::export()` unable to export circle referenced objects with `Closure` (klimov-paul)

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -447,6 +447,13 @@ class BaseArrayHelper
             $args[] = $direction[$i];
             $args[] = $flag;
         }
+
+        // This fix is used for cases when main sorting specified by columns has equal values
+        // Without it it will lead to Fatal Error: Nesting level too deep - recursive dependency?
+        $args[] = range(1, count($array));
+        $args[] = SORT_ASC;
+        $args[] = SORT_NUMERIC;
+
         $args[] = &$array;
         call_user_func_array('array_multisort', $args);
     }

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -147,6 +147,32 @@ class ArrayHelperTest extends TestCase
         $this->assertEquals(['name' => 'B', 'age' => 4], $array[3]);
     }
 
+    public function testMultisortNestedObjects()
+    {
+        $obj1 = new \stdClass();
+        $obj1->type = "def";
+        $obj1->owner = $obj1;
+
+        $obj2 = new \stdClass();
+        $obj2->type = "abc";
+        $obj2->owner = $obj2;
+
+        $obj3 = new \stdClass();
+        $obj3->type = "abc";
+        $obj3->owner = $obj3;
+
+        $models = [
+            $obj1,
+            $obj2,
+            $obj3
+        ];
+
+        ArrayHelper::multisort($models, 'type', SORT_ASC);
+        $this->assertEquals($obj2, $models[0]);
+        $this->assertEquals($obj3, $models[1]);
+        $this->assertEquals($obj1, $models[2]);
+    }
+
     public function testMultisortUseSort()
     {
         // single key


### PR DESCRIPTION
Fix for #8348 

When we have equal values for main sorted columns it will take in consideration added column of consecutive values and that's why objects themselves will not be compared between each other
