### PR TITLE
允许在使用Url::to和Url::toRoute生成Url的时候指定urlManager。

### DIFF
--- a/framework/helpers/BaseUrl.php
+++ b/framework/helpers/BaseUrl.php
@@ -85,15 +85,16 @@ class BaseUrl
      * @return string the generated URL
      * @throws InvalidParamException a relative route is given while there is no active controller
      */
-    public static function toRoute($route, $scheme = false)
+    public static function toRoute($route, $scheme = false, $urlManager = null)
     {
         $route = (array) $route;
         $route[0] = static::normalizeRoute($route[0]);
 
+        $urlManager = $urlManager ?: Yii::$app->getUrlManager();
         if ($scheme) {
-            return Yii::$app->getUrlManager()->createAbsoluteUrl($route, is_string($scheme) ? $scheme : null);
+            return $urlManager->createAbsoluteUrl($route, is_string($scheme) ? $scheme : null);
         } else {
-            return Yii::$app->getUrlManager()->createUrl($route);
+            return $urlManager->createUrl($route);
         }
     }
 
@@ -196,7 +197,7 @@ class BaseUrl
      * @return string the generated URL
      * @throws InvalidParamException a relative route is given while there is no active controller
      */
-    public static function to($url = '', $scheme = false)
+    public static function to($url = '', $scheme = false, $urlManager = null)
     {
         if (is_array($url)) {
             return static::toRoute($url, $scheme);
@@ -218,7 +219,8 @@ class BaseUrl
 
         if (($pos = strpos($url, ':')) === false || !ctype_alpha(substr($url, 0, $pos))) {
             // turn relative URL into absolute
-            $url = Yii::$app->getUrlManager()->getHostInfo() . '/' . ltrim($url, '/');
+            $urlManager = $urlManager ?: Yii::$app->getUrlManager();
+            $url = $urlManager->getHostInfo() . '/' . ltrim($url, '/');
         }
 
         if (is_string($scheme) && ($pos = strpos($url, ':')) !== false) {


### PR DESCRIPTION
在使用Advanced Template 模板架构的时候会有很多应用，有时候会需要生成非当前应用的url，添加$urlManager参数可以很方便的达到此目的。
