### PR TITLE
10555 - Fix for ActiveForm - When previous action doesn't reload page, this action will be triggered again when another submit button clicked

### DIFF
--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -393,6 +393,7 @@
                     submitFinalize($form);
                     return false;
                 }
+                updateHiddenButton($form);
                 return true;   // continue submitting the form since validation passes
             } else {
                 // First submit's call (from yii.js/handleAction) - execute validating
@@ -574,21 +575,6 @@
                 data.submitting = false;
             } else {
                 data.validated = true;
-                var $button = data.submitObject || $form.find(':submit:first');
-                // TODO: if the submission is caused by "change" event, it will not work
-                if ($button.length && $button.attr('type') == 'submit' && $button.attr('name')) {
-                    // simulate button input value
-                    var $hiddenButton = $('input[type="hidden"][name="' + $button.attr('name') + '"]', $form);
-                    if (!$hiddenButton.length) {
-                        $('<input>').attr({
-                            type: 'hidden',
-                            name: $button.attr('name'),
-                            value: $button.attr('value')
-                        }).appendTo($form);
-                    } else {
-                        $hiddenButton.attr('value', $button.attr('value'));
-                    }
-                }
                 $form.submit();
             }
         } else {
@@ -599,6 +585,29 @@
             });
         }
         submitFinalize($form);
+    };
+
+    /**
+     * Updates hidden field that represents clicked submit button.
+     * @param $form the form jQuery object.
+     */
+    var updateHiddenButton = function ($form) {
+        var data = $form.data('yiiActiveForm');
+        var $button = data.submitObject || $form.find(':submit:first');
+        // TODO: if the submission is caused by "change" event, it will not work
+        if ($button.length && $button.attr('type') == 'submit' && $button.attr('name')) {
+            // simulate button input value
+            var $hiddenButton = $('input[type="hidden"][name="' + $button.attr('name') + '"]', $form);
+            if (!$hiddenButton.length) {
+                $('<input>').attr({
+                    type: 'hidden',
+                    name: $button.attr('name'),
+                    value: $button.attr('value')
+                }).appendTo($form);
+            } else {
+                $hiddenButton.attr('value', $button.attr('value'));
+            }
+        }
     };
 
     /**


### PR DESCRIPTION
Updating hidden field that represents submit button was moved to separate method `updateHiddenButton`

This method now called in `submitForm` method after data is validated and valid.

It is used for cases when we have multiple submit buttons on one active form.
It relates to #10555

Also this fix is important for #10322 because otherwise after we click on Submit to a new window button it will be opened in new window but the page with form will not be reloaded. If after this we click on Submit button, form will be loaded in new window anyway.

This fix solves these problems by updating hidden field every time submit button clicked and form is sent
