### PR TITLE
Fixed a wrong method calling.

### DIFF
--- a/docs/guide/db-active-record.md
+++ b/docs/guide/db-active-record.md
@@ -1221,7 +1221,7 @@ The opposite operation to [[yii\db\ActiveRecord::link()|link()]] is [[yii\db\Act
 which breaks an existing relationship between two Active Record instances. For example,
 
 ```php
-$customer = Customer::find()->with('orders')->all();
+$customer = Customer::find()->with('orders')->one();
 $customer->unlink('orders', $customer->orders[0]);
 ```
 


### PR DESCRIPTION
If using `all()`, the value of `$customer` will be an array of
`Customer` instances, not a `Customer` instance.  Consequently,

```
$customer->unlink('orders', $customer->orders[0]);
```

will throw a PHP Fatal Error: Call to a member function unlink() on array.
