### PR TITLE
Fixed issue #7674

### DIFF
--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -339,7 +339,7 @@ class Connection extends Component
     public $masters = [];
 
     /**
-     * @var string|array| the class name of the [[command]] object.
+     * @var string the class name of the [[command]] object.
      */
     public $commandClass = 'yii\db\Command';
 

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -337,6 +337,13 @@ class Connection extends Component
      * @see masterConfig
      */
     public $masters = [];
+
+    /**
+     * @var string the class name of the [[command]] object.
+     */
+    public $commandClass = '\yii\db\Command';
+
+
     /**
      * @var array the configuration that should be merged with every master configuration listed in [[masters]].
      * For example,
@@ -618,9 +625,10 @@ class Connection extends Component
      */
     public function createCommand($sql = null, $params = [])
     {
-        $command = new Command([
+        $command = \Yii::createObject([
+            'class' => $this->commandClass,
             'db' => $this,
-            'sql' => $sql,
+            'sql' => $sql
         ]);
 
         return $command->bindValues($params);

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -339,9 +339,9 @@ class Connection extends Component
     public $masters = [];
 
     /**
-     * @var string the class name of the [[command]] object.
+     * @var string|array| the class name of the [[command]] object.
      */
-    public $commandClass = '\yii\db\Command';
+    public $commandClass = 'yii\db\Command';
 
 
     /**

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -337,7 +337,6 @@ class Connection extends Component
      * @see masterConfig
      */
     public $masters = [];
-
     /**
      * @var string the class name of the [[Command]] object.
      */
@@ -625,7 +624,7 @@ class Connection extends Component
      */
     public function createCommand($sql = null, $params = [])
     {
-        $command = \Yii::createObject([
+        $command = Yii::createObject([
             'class' => $this->commandClass,
             'db' => $this,
             'sql' => $sql

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -339,7 +339,7 @@ class Connection extends Component
     public $masters = [];
 
     /**
-     * @var string the class name of the [[command]] object.
+     * @var string the class name of the [[Command]] object.
      */
     public $commandClass = 'yii\db\Command';
 


### PR DESCRIPTION
This fix allows to configure a command class to be used by the connection component.
Also it uses the DI container instead of creating the object on its own.
