### PR TITLE
Redirect 301 on missing URL suffix

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -64,6 +64,7 @@ Yii Framework 2 Change Log
 - Enh #7405: Added `yii\filters\auth\AuthMethod::optional` for optional authentification in all child classes (SilverFire)
 - Enh #7566: Improved `\yii\validators\CompareValidator` default messages (slinstj)
 - Enh #7581: Added ability to specify range using anonymous function in `RangeValidator` (RomeroMsk)
+- Enh #7670: `yii\web\Request`: forces redirect when unresolved URL matches an URL with suffix (klimov-paul)
 - Enh #8284: Added `\yii\captcha\CaptchaAction::$imageLibrary` property allowing to set image rendering library (AnatolyRugalev)
 - Enh #8329: Added support of options for `message` console command (vchenin)
 - Enh #8613: `yii\widgets\FragmentCache` will not store empty content anymore which fixes some problems related to `yii\filters\PageCache` (kidol)

--- a/framework/web/Application.php
+++ b/framework/web/Application.php
@@ -74,8 +74,8 @@ class Application extends \yii\base\Application
         if (empty($this->catchAll)) {
             try {
                 list ($route, $params) = $request->resolve();
-            } catch (RedirectException $exception) {
-                return $this->getResponse()->redirect($exception->url, $exception->statusCode);
+            } catch (RedirectException $e) {
+                return $this->getResponse()->redirect($e->url, $e->statusCode);
             }
         } else {
             $route = $this->catchAll[0];
@@ -96,8 +96,8 @@ class Application extends \yii\base\Application
 
                 return $response;
             }
-        } catch (InvalidRouteException $exception) {
-            throw new NotFoundHttpException(Yii::t('yii', 'Page not found.'), $exception->getCode(), $exception);
+        } catch (InvalidRouteException $e) {
+            throw new NotFoundHttpException(Yii::t('yii', 'Page not found.'), $e->getCode(), $e);
         }
     }
 

--- a/framework/web/Application.php
+++ b/framework/web/Application.php
@@ -72,7 +72,11 @@ class Application extends \yii\base\Application
     public function handleRequest($request)
     {
         if (empty($this->catchAll)) {
-            list ($route, $params) = $request->resolve();
+            try {
+                list ($route, $params) = $request->resolve();
+            } catch (RedirectException $exception) {
+                return $this->getResponse()->redirect($exception->url, $exception->statusCode);
+            }
         } else {
             $route = $this->catchAll[0];
             $params = $this->catchAll;
@@ -92,8 +96,8 @@ class Application extends \yii\base\Application
 
                 return $response;
             }
-        } catch (InvalidRouteException $e) {
-            throw new NotFoundHttpException(Yii::t('yii', 'Page not found.'), $e->getCode(), $e);
+        } catch (InvalidRouteException $exception) {
+            throw new NotFoundHttpException(Yii::t('yii', 'Page not found.'), $exception->getCode(), $exception);
         }
     }
 

--- a/framework/web/RedirectException.php
+++ b/framework/web/RedirectException.php
@@ -13,7 +13,7 @@ use yii\base\Exception;
  * RedirectException represents an information for the HTTP location redirect.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
- * @since 2.0
+ * @since 2.0.7
  */
 class RedirectException extends Exception
 {

--- a/framework/web/RedirectException.php
+++ b/framework/web/RedirectException.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\web;
+
+use yii\base\Exception;
+
+/**
+ * RedirectException represents an information for the HTTP location redirect.
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 2.0
+ */
+class RedirectException extends Exception
+{
+    /**
+     * @var string  the URL to be redirected to.
+     */
+    public $url;
+    /**
+     * @var integer the HTTP status code.
+     */
+    public $statusCode;
+
+    /**
+     * Constructor.
+     * @param string $url the URL to be redirected to
+     * @param integer $statusCode the HTTP status code. Defaults to 302.
+     * @param string $message error message
+     * @param integer $code error code
+     * @param \Exception $previous The previous exception used for the exception chaining.
+     */
+    public function __construct($url, $statusCode = 302, $message = null, $code = 0, \Exception $previous = null)
+    {
+        $this->url = $url;
+        $this->statusCode = $statusCode;
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -193,15 +193,17 @@ class Request extends \yii\base\Request
                 $suffix = Yii::$app->getUrlManager()->suffix;
                 $n = strlen($suffix);
                 if (substr_compare($pathInfo, $suffix, -$n, $n) !== 0) {
-                    $this->setPathInfo($pathInfo . $suffix);
+                    $suffixedPathInfo = $pathInfo . $suffix;
+                    $this->setPathInfo($suffixedPathInfo);
                     $result = Yii::$app->getUrlManager()->parseRequest($this);
+                    $this->setPathInfo($pathInfo); // restore original state
                     if ($result !== false) {
-                        $url = $this->getBaseUrl() . '/' . $this->getPathInfo();
+                        $baseUrl = Yii::$app->getUrlManager()->showScriptName ? $this->getScriptUrl() : $this->getBaseUrl();
+                        $url = $baseUrl . '/' . $suffixedPathInfo;
                         $queryString = $this->getQueryString();
                         if (!empty($queryString)) {
                             $url .= '?' . $queryString;
                         }
-                        $this->setPathInfo($pathInfo); // restore original state
                         throw new RedirectException($url, 301);
                     }
                 }

--- a/tests/framework/web/RequestTest.php
+++ b/tests/framework/web/RequestTest.php
@@ -167,7 +167,7 @@ class RequestTest extends TestCase
         $request = new Request();
         $request->hostInfo = 'http://example.com/';
         $request->pathInfo = 'posts/list';
-        $request->baseUrl = '';
+        $request->scriptUrl = 'index.php';
 
         try {
             $request->resolve();
@@ -176,6 +176,37 @@ class RequestTest extends TestCase
         }
         $this->assertTrue(isset($exception));
         $this->assertEquals('/posts/list/', $exception->url);
+        $this->assertEquals(301, $exception->statusCode);
+    }
+
+    public function testResolveSuffixRedirectWithScriptName()
+    {
+        $this->mockWebApplication([
+            'components' => [
+                'urlManager' => [
+                    'enablePrettyUrl' => true,
+                    'showScriptName' => true,
+                    'cache' => null,
+                    'suffix' => '/',
+                    'rules' => [
+                        'posts' => 'post/list',
+                    ],
+                ]
+            ]
+        ]);
+
+        $request = new Request();
+        $request->hostInfo = 'http://example.com/';
+        $request->pathInfo = 'posts/list';
+        $request->scriptUrl = 'index.php';
+
+        try {
+            $request->resolve();
+        } catch (RedirectException $exception) {
+            // catch redirect exception
+        }
+        $this->assertTrue(isset($exception));
+        $this->assertEquals('/index.php/posts/list/', $exception->url);
         $this->assertEquals(301, $exception->statusCode);
     }
 }

--- a/tests/framework/web/RequestTest.php
+++ b/tests/framework/web/RequestTest.php
@@ -7,6 +7,7 @@
 
 namespace yiiunit\framework\web;
 
+use yii\web\RedirectException;
 use yii\web\Request;
 use yiiunit\TestCase;
 
@@ -145,5 +146,36 @@ class RequestTest extends TestCase
         $result = $request->resolve();
         $this->assertEquals(['post/view', ['id' => 21, 'token' => 'secret']], $result);
         $this->assertEquals($_GET, ['id' => 63]);
+    }
+
+    public function testResolveSuffixRedirect()
+    {
+        $this->mockWebApplication([
+            'components' => [
+                'urlManager' => [
+                    'enablePrettyUrl' => true,
+                    'showScriptName' => false,
+                    'cache' => null,
+                    'suffix' => '/',
+                    'rules' => [
+                        'posts' => 'post/list',
+                    ],
+                ]
+            ]
+        ]);
+
+        $request = new Request();
+        $request->hostInfo = 'http://example.com/';
+        $request->pathInfo = 'posts/list';
+        $request->baseUrl = '';
+
+        try {
+            $request->resolve();
+        } catch (RedirectException $exception) {
+            // catch redirect exception
+        }
+        $this->assertTrue(isset($exception));
+        $this->assertEquals('/posts/list/', $exception->url);
+        $this->assertEquals(301, $exception->statusCode);
     }
 }


### PR DESCRIPTION
Fixes #7670 :`yii\web\Request`: forces redirect when unresolved URL matches an URL with suffix
