### PR TITLE
Fixed for arrayable models

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.7 under development
 -----------------------
 
+- Bug #10760: `yii\widgets\DetailView::normalizeAttributes()` fixed for arrayable models (boehsermoe)
 - Bug #6351: Find MySQL FK constraints from `information_schema` tables instead of `SHOW CREATE TABLE` to improve reliability (nineinchnick)
 - Bug #6363, #8301, #8582, #9566: Fixed data methods and PJAX issues when used together (derekisbusy)
 - Bug #6876: Fixed RBAC migration MSSQL cascade problem (thejahweh)

--- a/framework/widgets/DetailView.php
+++ b/framework/widgets/DetailView.php
@@ -173,7 +173,7 @@ class DetailView extends Widget
             if ($this->model instanceof Model) {
                 $this->attributes = $this->model->attributes();
             } elseif (is_object($this->model)) {
-                $this->attributes = $this->model instanceof Arrayable ? $this->model->toArray() : array_keys(get_object_vars($this->model));
+                $this->attributes = $this->model instanceof Arrayable ? array_keys($this->model->toArray()) : array_keys(get_object_vars($this->model));
             } elseif (is_array($this->model)) {
                 $this->attributes = array_keys($this->model);
             } else {

--- a/tests/framework/widgets/DetailViewTest.php
+++ b/tests/framework/widgets/DetailViewTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * @author Bennet Klarhoelter <boehsermoe@me.com>
+ */
+namespace yiiunit\framework\widgets;
+use yii\base\Arrayable;
+use yii\base\ArrayableTrait;
+use yii\base\DynamicModel;
+use yii\widgets\ActiveForm;
+use yii\widgets\DetailView;
+
+/**
+ * @group widgets
+ */
+class DetailViewTest extends \yiiunit\TestCase
+{
+	/** @var DetailView */
+	public $detailView;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->mockWebApplication();
+	}
+
+	public function testArrayableModel()
+	{
+		$expectedValue = [
+			[
+				'attribute' => 'id',
+				'format' => 'text',
+				'label' => 'Id',
+				'value' => 1
+			],
+			[
+				'attribute' => 'text',
+				'format' => 'text',
+				'label' => 'Text',
+				'value' => 'I`m arrayable'
+			],
+		];
+
+		$model = new ArrayableMock();
+		$model->id = 1;
+		$model->text = 'I`m arrayable';
+
+		$this->detailView = new DetailView([
+			'model' => $model,
+		]);
+
+		$this->assertEquals($expectedValue, $this->detailView->attributes);
+	}
+
+	public function testObjectModel()
+	{
+		$expectedValue = [
+			[
+				'attribute' => 'id',
+				'format' => 'text',
+				'label' => 'Id',
+				'value' => 1
+			],
+			[
+				'attribute' => 'text',
+				'format' => 'text',
+				'label' => 'Text',
+				'value' => 'I`m an object'
+			],
+		];
+
+		$model = new ObjectMock();
+		$model->id = 1;
+		$model->text = 'I`m an object';
+
+		$this->detailView = new DetailView([
+			'model' => $model,
+		]);
+
+		$this->assertEquals($expectedValue, $this->detailView->attributes);
+	}
+
+	public function testArrayModel()
+	{
+		$expectedValue = [
+			[
+				'attribute' => 'id',
+				'format' => 'text',
+				'label' => 'Id',
+				'value' => 1
+			],
+			[
+				'attribute' => 'text',
+				'format' => 'text',
+				'label' => 'Text',
+				'value' => 'I`m an array'
+			],
+		];
+
+		$model = [
+			'id' => 1,
+			'text' => 'I`m an array'
+		];
+
+		$this->detailView = new DetailView([
+			'model' => $model,
+		]);
+
+		$this->assertEquals($expectedValue, $this->detailView->attributes);
+	}
+}
+
+/**
+ * Helper Class
+ */
+class ArrayableMock implements Arrayable
+{
+	use ArrayableTrait;
+
+	public $id;
+
+	public $text;
+}
+
+/**
+ * Helper Class
+ */
+class ObjectMock
+{
+	public $id;
+
+	public $text;
+}


### PR DESCRIPTION
The toArray() function return [attribute => value] but there is need a list of attribute names.
