### PR TITLE
Parameter "$file" can be a URL in method "getMimeType"

### DIFF
--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -145,7 +145,16 @@ class BaseFileHelper
         $info = finfo_open(FILEINFO_MIME_TYPE, $magicFile);
 
         if ($info) {
-            $result = finfo_file($info, $file);
+            
+            if(filter_var($file, FILTER_VALIDATE_URL)){
+
+                $result = finfo_buffer($info, file_get_contents($file));
+            }
+            else {
+
+                $result = finfo_file($info, $file);
+            }
+            
             finfo_close($info);
 
             if ($result !== false) {


### PR DESCRIPTION
If `$file` is url, finfo_file return error: "finfo_file(): Failed identify data 0:no magic files loaded". In this case, I propose to use this construction: `finfo_buffer($info, file_get_contents($file))`.
