### PR TITLE
Refactoring \yii\db\Connection::getDriverName

### DIFF
--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -816,7 +816,7 @@ class Connection extends Component
         }
 
         $foundDSN = strstr($this->dsn, ':', true);
-        if ($foundDSN !== false) {
+        if ($foundDSN === false) {
             $foundDSN = $this->getSlavePdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
         }
 

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -811,13 +811,16 @@ class Connection extends Component
      */
     public function getDriverName()
     {
-        if ($this->_driverName === null) {
-            if (($pos = strpos($this->dsn, ':')) !== false) {
-                $this->_driverName = strtolower(substr($this->dsn, 0, $pos));
-            } else {
-                $this->_driverName = strtolower($this->getSlavePdo()->getAttribute(PDO::ATTR_DRIVER_NAME));
-            }
+        if ($this->_driverName !== null) {
+            return $this->_driverName;
         }
+
+        $foundDSN = strstr($this->dsn, ':', true);
+        if ($foundDSN !== false) {
+            $foundDSN = $this->getSlavePdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        }
+
+        $this->_driverName = strtolower($foundDSN);
         return $this->_driverName;
     }
 


### PR DESCRIPTION
To bit increase performance.
Old code:

```
$dnsString = 'sqlsrv:Server=localhost;Database=test';

if (($pos = strpos($dnsString, ':')) !== false) {
    echo strtolower(substr($dnsString, 0, $pos));
}
```

Now

```
if (($foundDSN = strstr($dnsString, ':', true)) !== false) {
    echo strtolower($foundDSN);
}
```

|  | Old | Now |
| --- | --- | --- |
| time | 2.1934509277344E-5 | 1.5020370483398E-5 |
| memory | 370328 | 370320 |

|
|
