### PR TITLE
Activequery::joinWith() alias

### DIFF
--- a/docs/guide/db-active-record.md
+++ b/docs/guide/db-active-record.md
@@ -1089,7 +1089,28 @@ Note that this differs from our earlier example which only brings back customers
 > Info: When [[yii\db\ActiveQuery]] is specified with a condition via [[yii\db\ActiveQuery::onCondition()|onCondition()]],
   the condition will be put in the `ON` part if the query involves a JOIN query. If the query does not involve
   JOIN, the on-condition will be automatically appended to the `WHERE` part of the query.
+  Thus it may only contain conditions including columns of the related table.
 
+#### Relation table aliases <span id="relation-table-aliases"></span>
+
+As noted before, when using JOIN in a query, we need to disambiguate column names. Therefor often an alias is
+defined for a table. Setting an alias for the relational query would be possible by customizing the relation query in the following way:
+
+```php
+$query->joinWith([
+    'orders' => function ($q) {
+        $q->from(['o' => Order::tableName()]);
+    },
+])
+```
+
+This however looks very complicated and involves either hardcoding the related objects table name or calling `Order::tableName()`.
+Since version 2.0.7, Yii provides a shortcut for this. You may now define and use the alias for the relation table like the following:
+
+```php
+// join the orders relation and sort the result by orders.id
+$query->joinWith(['orders o'])->orderBy('o.id');
+```
 
 ### Inverse Relations <span id="inverse-relations"></span>
 

--- a/docs/guide/db-dao.md
+++ b/docs/guide/db-dao.md
@@ -278,7 +278,7 @@ $count = Yii::$app->db->createCommand("SELECT COUNT([[id]]) FROM {{employee}}")
 If most of your DB tables names share a common prefix, you may use the table prefix feature provided
 by Yii DAO.
 
-First, specify the table prefix via the [[yii\db\Connection::tablePrefix]] property:
+First, specify the table prefix via the [[yii\db\Connection::tablePrefix]] property in the application config:
 
 ```php
 return [

--- a/docs/guide/output-data-widgets.md
+++ b/docs/guide/output-data-widgets.md
@@ -339,13 +339,14 @@ echo GridView::widget([
 
 ### Filtering data
 
-For filtering data the GridView needs a [model](structure-models.md) to take the input from and the filtering
-form that adjusts the query of the dataProvider to respect the search criteria.
+For filtering data, the GridView needs a [model](structure-models.md) that represents the search criteria which is
+usually taken from the filter fields in the GridView table.
 A common practice when using [active records](db-active-record.md) is to create a search Model class
 that provides needed functionality (it can be generated for you by [Gii](start-gii.md)). This class defines the validation 
-rules for the search and provides a `search()` method that will return the data provider.
+rules for the search and provides a `search()` method that will return the data provider with an
+adjusted query that respects the search criteria.
 
-To add the search capability for the `Post` model, we can create `PostSearch` like the following example:
+To add the search capability for the `Post` model, we can create a `PostSearch` model like the following example:
 
 ```php
 <?php
@@ -520,6 +521,7 @@ $dataProvider = new ActiveDataProvider([
 // join with relation `author` that is a relation to the table `users`
 // and set the table alias to be `author`
 $query->joinWith(['author' => function($query) { $query->from(['author' => 'users']); }]);
+// since version 2.0.7, the above line can be simplified to $query->joinWith('author AS author');
 // enable sorting for the related column
 $dataProvider->sort->attributes['author.name'] = [
     'asc' => ['author.name' => SORT_ASC],
@@ -561,8 +563,9 @@ $query->andFilterWhere(['LIKE', 'author.name', $this->getAttribute('author.name'
 > For example, if you use the alias `au` for the author relation table, the joinWith statement looks like the following:
 >
 > ```php
-> $query->joinWith(['author' => function($query) { $query->from(['au' => 'users']); }]);
+> $query->joinWith(['author au']);
 > ```
+>
 > It is also possible to just call `$query->joinWith(['author']);` when the alias is defined in the relation definition.
 >
 > The alias has to be used in the filter condition but the attribute name stays the same:

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -64,6 +64,7 @@ Yii Framework 2 Change Log
 - Bug: Fixed generation of canonical URLs for `ViewAction` pages (samdark)
 - Bug: Fixed `mb_*` functions calls to use `UTF-8` or `Yii::$app->charset` (silverfire)
 - Enh #3506: Added `yii\validators\IpValidator` to perform validation of IP addresses and subnets (SilverFire, samdark)
+- Enh #4972: Added `yii\db\ActiveQuery::alias()` to allow specifying a table alias for the model table without having to know the name (cebe, stepanselyuk)
 - Enh #5146: Added `yii\i18n\Formatter::asDuration()` method (nineinchnick, SilverFire)
 - Enh #5902: `yii\widgets\Pjax::options` now support special option `tag` to specify tag of container (Alex-Code)
 - Enh #6162, #9198: Added parameter visibleButtons for `yii\grid\ActionColumn` (fornit1917, silverfire)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -63,6 +63,7 @@ Yii Framework 2 Change Log
 - Bug #10760: `yii\widgets\DetailView::normalizeAttributes()` fixed for arrayable models (boehsermoe)
 - Bug: Fixed generation of canonical URLs for `ViewAction` pages (samdark)
 - Bug: Fixed `mb_*` functions calls to use `UTF-8` or `Yii::$app->charset` (silverfire)
+- Enh #2377: Allow specifying a table alias when joining relations via `joinWith()` (cebe, nainoon)
 - Enh #3506: Added `yii\validators\IpValidator` to perform validation of IP addresses and subnets (SilverFire, samdark)
 - Enh #4972: Added `yii\db\ActiveQuery::alias()` to allow specifying a table alias for the model table without having to know the name (cebe, stepanselyuk)
 - Enh #5146: Added `yii\i18n\Formatter::asDuration()` method (nineinchnick, SilverFire)

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -641,7 +641,6 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         if (!empty($child->join)) {
             foreach ($child->join as $join) {
                 $this->join[] = $join;
-                $this->populateAliases((array) $join[1]);
             }
         }
         if (!empty($child->union)) {

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -641,6 +641,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         if (!empty($child->join)) {
             foreach ($child->join as $join) {
                 $this->join[] = $join;
+                $this->populateAliases((array) $join[1]);
             }
         }
         if (!empty($child->union)) {

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -851,7 +851,7 @@ class Query extends Component implements QueryInterface
      */
     public static function create($from)
     {
-        return new self([
+        $query = new self([
             'where' => $from->where,
             'limit' => $from->limit,
             'offset' => $from->offset,
@@ -867,5 +867,7 @@ class Query extends Component implements QueryInterface
             'union' => $from->union,
             'params' => $from->params,
         ]);
+        $query->_aliases = $from->_aliases;
+        return $query;
     }
 }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -851,7 +851,7 @@ class Query extends Component implements QueryInterface
      */
     public static function create($from)
     {
-        $query = new self([
+        return new self([
             'where' => $from->where,
             'limit' => $from->limit,
             'offset' => $from->offset,
@@ -867,7 +867,5 @@ class Query extends Component implements QueryInterface
             'union' => $from->union,
             'params' => $from->params,
         ]);
-        $query->_aliases = $from->_aliases;
-        return $query;
     }
 }

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -115,12 +115,12 @@ class Order extends ActiveRecord
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
-    public function getBooksQuerysyntax()
-    {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
-            ->onCondition(['{{@item}}.category_id' => 1])
-            ->viaTable('order_item', ['order_id' => 'id']);
-    }
+//    public function getBooksQuerysyntax()
+//    {
+//        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+//            ->onCondition(['{{@item}}.category_id' => 1])
+//            ->viaTable('order_item', ['order_id' => 'id']);
+//    }
 
     public function getBooksExplicitA()
     {
@@ -129,12 +129,12 @@ class Order extends ActiveRecord
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
-    public function getBooksQuerysyntaxA()
-    {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('bo')
-            ->onCondition(['{{@item}}.category_id' => 1])
-            ->viaTable('order_item', ['order_id' => 'id']);
-    }
+//    public function getBooksQuerysyntaxA()
+//    {
+//        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('bo')
+//            ->onCondition(['{{@item}}.category_id' => 1])
+//            ->viaTable('order_item', ['order_id' => 'id']);
+//    }
 
     public function getBookItems()
     {

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -118,7 +118,35 @@ class Order extends ActiveRecord
     public function getBooksQuerysyntax()
     {
         return $this->hasMany(Item::className(), ['id' => 'item_id'])
-            ->onCondition(['{{@books}}.category_id' => 1])
+            ->onCondition(['{{@item}}.category_id' => 1])
+            ->viaTable('order_item', ['order_id' => 'id']);
+    }
+
+    public function getBooksExplicitA()
+    {
+        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('bo')
+            ->onCondition(['bo.category_id' => 1])
+            ->viaTable('order_item', ['order_id' => 'id']);
+    }
+
+    public function getBooksQuerysyntaxA()
+    {
+        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('bo')
+            ->onCondition(['{{@item}}.category_id' => 1])
+            ->viaTable('order_item', ['order_id' => 'id']);
+    }
+
+    public function getBookItems()
+    {
+        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('books')
+            ->onCondition(['books.category_id' => 1])
+            ->viaTable('order_item', ['order_id' => 'id']);
+    }
+
+    public function getMovieItems()
+    {
+        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('movies')
+            ->onCondition(['movies.category_id' => 2])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -108,6 +108,20 @@ class Order extends ActiveRecord
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
+    public function getBooksExplicit()
+    {
+        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+            ->onCondition(['category_id' => 1])
+            ->viaTable('order_item', ['order_id' => 'id']);
+    }
+
+    public function getBooksQuerysyntax()
+    {
+        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+            ->onCondition(['{{@books}}.category_id' => 1])
+            ->viaTable('order_item', ['order_id' => 'id']);
+    }
+
     public function beforeSave($insert)
     {
         if (parent::beforeSave($insert)) {

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -555,7 +555,7 @@ class ActiveRecordTest extends DatabaseTestCase
     {
         return [
             ['explicit'], // c
-            ['querysyntax'], // {{@customer}}
+//            ['querysyntax'], // {{@customer}}
 //            ['applyAlias'], // $query->applyAlias('customer', 'id') // _aliases are currently not being populated
             // later getRelationAlias() could be added
         ];
@@ -761,7 +761,7 @@ class ActiveRecordTest extends DatabaseTestCase
         // alias is defined in the relation definition
         // without eager loading
         $query = Order::find()
-            ->joinWith('bookItems', false)// TODO true
+            ->joinWith('bookItems', false)
             ->joinWith('movieItems', false)
             ->where(['movies.name' => 'Toy Story']);
         $orders = $query->all();

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace yiiunit\framework\db;
 
+use yii\db\ActiveQuery;
 use yiiunit\data\ar\ActiveRecord;
 use yiiunit\data\ar\BitValues;
 use yiiunit\data\ar\Category;
@@ -548,6 +549,27 @@ class ActiveRecordTest extends DatabaseTestCase
                 $q->orderBy('item.id');
             },
         ])->all();
+    }
+
+    public function testAlias()
+    {
+        $query = Order::find();
+        $this->assertNull($query->from);
+
+        $query = Order::find()->alias('o');
+        $this->assertEquals(['o' => Order::tableName()], $query->from);
+
+        $query = Order::find()->alias('o')->alias('ord');
+        $this->assertEquals(['ord' => Order::tableName()], $query->from);
+
+        $query = Order::find()->from([
+            'users',
+            'o' => Order::tableName(),
+        ])->alias('ord');
+        $this->assertEquals([
+            'users',
+            'ord' => Order::tableName(),
+        ], $query->from);
     }
 
     public function testInverseOf()

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -551,15 +551,33 @@ class ActiveRecordTest extends DatabaseTestCase
         ])->all();
     }
 
+    public function aliasMethodProvider()
+    {
+        return [
+            ['explicit'], // c
+            ['querysyntax'], // {{@customer}}
+            ['applyAlias'], // $query->applyAlias('customer', 'id')
+            // later getRelationAlias() could be added
+        ];
+    }
+
     /**
      * Tests the alias syntax for joinWith: 'alias' => 'relation'
+     * @dataProvider aliasMethodProvider
+     * @param string $aliasMethod whether alias is specified explicitly or using the query syntax {{@tablename}}
      */
-    public function testJoinWithAlias()
+    public function testJoinWithAlias($aliasMethod)
     {
         // left join and eager loading
         /** @var ActiveQuery $query */
         $query = Order::find()->joinWith(['customer c']);
-        $orders = $query->orderBy($query->applyRelationAlias('customer', 'id') /* c.id */ . ' DESC, order.id')->all();
+        if ($aliasMethod === 'explicit') {
+            $orders = $query->orderBy('c.id DESC, order.id')->all();
+        } elseif ($aliasMethod === 'querysyntax') {
+            $orders = $query->orderBy('{{@customer}}.id DESC, {{@order}}.id')->all();
+        } elseif ($aliasMethod === 'applyAlias') {
+            $orders = $query->orderBy($query->applyAlias('customer', 'id') . ' DESC,' . $query->applyAlias('order', 'id'))->all();
+        }
         $this->assertEquals(3, count($orders));
         $this->assertEquals(2, $orders[0]->id);
         $this->assertEquals(3, $orders[1]->id);
@@ -569,7 +587,14 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertTrue($orders[2]->isRelationPopulated('customer'));
 
         // inner join filtering and eager loading
-        $orders = Order::find()->innerJoinWith(['customer c'])->where('{{c}}.[[id]]=2')->orderBy('order.id')->all();
+        $query = Order::find()->innerJoinWith(['customer c']);
+        if ($aliasMethod === 'explicit') {
+            $orders = $query->where('{{c}}.[[id]]=2')->orderBy('order.id')->all();
+        } elseif ($aliasMethod === 'querysyntax') {
+            $orders = $query->where('{{@customer}}.[[id]]=2')->orderBy('{{@order}}.id')->all();
+        } elseif ($aliasMethod === 'applyAlias') {
+            $orders = $query->where([$query->applyAlias('customer', 'id') => 2])->orderBy($query->applyAlias('order', 'id'))->all();
+        }
         $this->assertEquals(2, count($orders));
         $this->assertEquals(2, $orders[0]->id);
         $this->assertEquals(3, $orders[1]->id);
@@ -577,7 +602,14 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertTrue($orders[1]->isRelationPopulated('customer'));
 
         // inner join filtering without eager loading
-        $orders = Order::find()->innerJoinWith(['customer c'], false)->where('{{c}}.[[id]]=2')->orderBy('order.id')->all();
+        $query = Order::find()->innerJoinWith(['customer c'], false);
+        if ($aliasMethod === 'explicit') {
+            $orders = $query->where('{{c}}.[[id]]=2')->orderBy('order.id')->all();
+        } elseif ($aliasMethod === 'querysyntax') {
+            $orders = $query->where('{{@customer}}.[[id]]=2')->orderBy('{{@order}}.id')->all();
+        } elseif ($aliasMethod === 'applyAlias') {
+            $orders = $query->where([$query->applyAlias('customer', 'id') => 2])->orderBy($query->applyAlias('order', 'id'))->all();
+        }
         $this->assertEquals(2, count($orders));
         $this->assertEquals(2, $orders[0]->id);
         $this->assertEquals(3, $orders[1]->id);
@@ -586,7 +618,13 @@ class ActiveRecordTest extends DatabaseTestCase
 
         // join with via-relation
         $query = Order::find()->innerJoinWith(['books b']);
-        $orders = $query->where([$query->getRelationAlias('books') . '.name' => 'Yii 1.1 Application Development Cookbook'])->orderBy($query->applyAlias('order', 'id'))->all();
+        if ($aliasMethod === 'explicit') {
+            $orders = $query->where(['b.name' => 'Yii 1.1 Application Development Cookbook'])->orderBy('order.id')->all();
+        } elseif ($aliasMethod === 'querysyntax') {
+            $orders = $query->where(['{{@book}}.name' => 'Yii 1.1 Application Development Cookbook'])->orderBy('{{@order}}.id')->all();
+        } elseif ($aliasMethod === 'applyAlias') {
+            $orders = $query->where([$query->applyAlias('book', 'name') => 'Yii 1.1 Application Development Cookbook'])->orderBy($query->applyAlias('order', 'id'))->all();
+        }
         $this->assertEquals(2, count($orders));
         $this->assertEquals(1, $orders[0]->id);
         $this->assertEquals(3, $orders[1]->id);
@@ -596,17 +634,36 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals(1, count($orders[1]->books));
 
 
-        $orders = Order::find()->innerJoinWith([
-            'items i' => function ($q) {
+        // joining sub relations
+        $query = Order::find()->innerJoinWith([
+            'items i' => function ($q) use ($aliasMethod) {
                 /** @var $q ActiveQuery */
-                $q->orderBy($q->applyAlias('item', 'id'));
+                if ($aliasMethod === 'explicit') {
+                    $q->orderBy('{{i}}.[[id]]');
+                } elseif ($aliasMethod === 'querysyntax') {
+                    $q->orderBy('{{@item}}.id');
+                } elseif ($aliasMethod === 'applyAlias') {
+                    $q->orderBy($q->applyAlias('item', 'id'));
+                }
             },
-            'items.category c' => function ($q) {
+            'items.category c' => function ($q) use ($aliasMethod) {
                     /** @var $q ActiveQuery */
-                    $q->where('{{c}}.[[id]] = 2');
+                    if ($aliasMethod === 'explicit') {
+                        $q->where('{{c}}.[[id]] = 2');
+                    } elseif ($aliasMethod === 'querysyntax') {
+                        $q->where('{{@category}}.[[id]] = 2');
+                    } elseif ($aliasMethod === 'applyAlias') {
+                        $q->where([$q->applyAlias('category', 'id') => 2]);
+                    }
                 },
-        ])->orderBy('i.id')->all();
-
+        ]);
+        if ($aliasMethod === 'explicit') {
+            $orders = $query->orderBy('{{i}}.id')->all();
+        } elseif ($aliasMethod === 'querysyntax') {
+            $orders = $query->orderBy('{{@item}}.id')->all();
+        } elseif ($aliasMethod === 'applyAlias') {
+            $orders = $query->orderBy($query->applyAlias('item', 'id'))->all();
+        }
         $this->assertEquals(1, count($orders));
         $this->assertTrue($orders[0]->isRelationPopulated('items'));
         $this->assertEquals(2, $orders[0]->id);
@@ -615,39 +672,62 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals(2, $orders[0]->items[0]->category->id);
 
         // join with ON condition
-        $orders = Order::find()->joinWith(['books2 b'])->orderBy('order.id')->all();
-        $this->assertEquals(3, count($orders));
-        $this->assertEquals(1, $orders[0]->id);
-        $this->assertEquals(2, $orders[1]->id);
-        $this->assertEquals(3, $orders[2]->id);
-        $this->assertTrue($orders[0]->isRelationPopulated('books2'));
-        $this->assertTrue($orders[1]->isRelationPopulated('books2'));
-        $this->assertTrue($orders[2]->isRelationPopulated('books2'));
-        $this->assertEquals(2, count($orders[0]->books2));
-        $this->assertEquals(0, count($orders[1]->books2));
-        $this->assertEquals(1, count($orders[2]->books2));
+        if ($aliasMethod === 'explicit' || $aliasMethod === 'querysyntax') {
+            $relationName = 'books' . ucfirst($aliasMethod);
+            $orders = Order::find()->joinWith(["$relationName b"])->orderBy('order.id')->all();
+            $this->assertEquals(3, count($orders));
+            $this->assertEquals(1, $orders[0]->id);
+            $this->assertEquals(2, $orders[1]->id);
+            $this->assertEquals(3, $orders[2]->id);
+            $this->assertTrue($orders[0]->isRelationPopulated($relationName));
+            $this->assertTrue($orders[1]->isRelationPopulated($relationName));
+            $this->assertTrue($orders[2]->isRelationPopulated($relationName));
+            $this->assertEquals(2, count($orders[0]->$relationName));
+            $this->assertEquals(0, count($orders[1]->$relationName));
+            $this->assertEquals(1, count($orders[2]->$relationName));
+        }
 
         // join with count and query
         /** @var $query ActiveQuery */
         $query = Order::find()->joinWith(['customer c']);
-        $count = $query->count('c.id');
+        if ($aliasMethod === 'explicit') {
+            $count = $query->count('c.id');
+        } elseif ($aliasMethod === 'querysyntax') {
+            $count = $query->count('{{@customer}}.id');
+        } elseif ($aliasMethod === 'applyAlias') {
+            $count = $query->count($query->applyAlias('customer', 'id'));
+        }
         $this->assertEquals(3, $count);
         $orders = $query->all();
         $this->assertEquals(3, count($orders));
 
         // relational query
+        /** @var $order Order */
         $order = Order::findOne(1);
-        $customer = $order->getCustomer()->innerJoinWith(['orders o'], false)->where(['o.id' => 1])->one();
+        $customerQuery = $order->getCustomer()->innerJoinWith(['orders o'], false);
+        if ($aliasMethod === 'explicit') {
+            $customer = $customerQuery->where(['o.id' => 1])->one();
+        } elseif ($aliasMethod === 'querysyntax') {
+            $customer = $customerQuery->where(['{{order}}.id' => 1])->one();
+        } elseif ($aliasMethod === 'applyAlias') {
+            $customer = $customerQuery->where([$query->applyAlias('order', 'id') => 1])->one();
+        }
         $this->assertNotNull($customer);
         $this->assertEquals(1, $customer->id);
 
         // join with sub-relation called inside Closure
         $orders = Order::find()->joinWith([
-            'items' => function ($q) {
-                    /** @var $q ActiveQuery */
-                    $q->orderBy('item.id');
-                    $q->joinWith(['category c']);
+            'items' => function ($q) use ($aliasMethod) {
+                /** @var $q ActiveQuery */
+                $q->orderBy('item.id');
+                $q->joinWith(['category c']);
+                if ($aliasMethod === 'explicit') {
                     $q->where('{{c}}.[[id]] = 2');
+                } elseif ($aliasMethod === 'querysyntax') {
+                    $q->where('{{@category}}.[[id]] = 2');
+                } elseif ($aliasMethod === 'applyAlias') {
+                    $q->where([$query->applyAlias('category', 'id') => 2]);
+                }
             },
         ])->orderBy('order.id')->all();
         $this->assertEquals(1, count($orders));

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -406,6 +406,32 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertTrue($orders[1]->isRelationPopulated('customer'));
         $this->assertTrue($orders[2]->isRelationPopulated('customer'));
 
+        // join with table alias
+        $orders = Order::find()->joinWith('customer as c')->orderBy('c.id DESC, order.id')->all();
+        $this->assertEquals(3, count($orders));
+        $this->assertEquals(2, $orders[0]->id);
+        $this->assertEquals(3, $orders[1]->id);
+        $this->assertEquals(1, $orders[2]->id);
+        $this->assertTrue($orders[0]->isRelationPopulated('customer'));
+        $this->assertTrue($orders[1]->isRelationPopulated('customer'));
+        $this->assertTrue($orders[2]->isRelationPopulated('customer'));
+
+        // join with table alias sub-relation
+        $orders = Order::find()->innerJoinWith([
+            'items as t' => function ($q) {
+                $q->orderBy('t.id');
+            },
+            'items.category as c' => function ($q) {
+                $q->where('{{c}}.[[id]] = 2');
+            },
+        ])->orderBy('order.id')->all();
+        $this->assertEquals(1, count($orders));
+        $this->assertTrue($orders[0]->isRelationPopulated('items'));
+        $this->assertEquals(2, $orders[0]->id);
+        $this->assertEquals(3, count($orders[0]->items));
+        $this->assertTrue($orders[0]->items[0]->isRelationPopulated('category'));
+        $this->assertEquals(2, $orders[0]->items[0]->category->id);
+
         // join with ON condition
         $orders = Order::find()->joinWith('books2')->orderBy('order.id')->all();
         $this->assertEquals(3, count($orders));


### PR DESCRIPTION
this is the final solution to fix #2377 and #4972.

replaces #10817.
- [x] TODO: agree on a name for `alias()` method. A short summary about discussion so far:

`alias()` is short and quite clear about what it does. it defines an alias for something.

`tableAlias()` adds no further information as we are deailing with tables only anyway here.
"alias" should be part of the name as that is what it does.
not sure if we can add a word that makes it clear that it is the alias for the base table and not for joined ones.

`modelTableAlias()` as proposed by @klimov-paul is very specific about what it does but a bit long.
we already have `modelClass` inside an `ActiveQuery`
thus he supposed it should be `modelTableAlias`

`baseAlias()` as proposed by @mdomba is shorter but maybe not clear enough about what `base` means.

@qiangxue @samdark @SilverFire can we have your input on the name?
