### PR TITLE
Update  shortcut format for GridView:columns

### DIFF
--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -546,15 +546,21 @@ class GridView extends BaseListView
      */
     protected function createDataColumn($text)
     {
-        if (!preg_match('/^([^:]+)(:(\w*))?(:(.*))?$/', $text, $matches)) {
+        if (!preg_match('/^([^:]+)(:([\s\w,:\\\\\/-]*\w))?(:(.*))?$/', $text, $matches)) {
             throw new InvalidConfigException('The column must be specified in the format of "attribute", "attribute:format" or "attribute:format:label"');
+        }
+
+        if (isset($matches[3])) {
+            $format = explode(',',$matches[3]);
+        } else {
+            $format = 'text';
         }
 
         return Yii::createObject([
             'class' => $this->dataColumnClass ? : DataColumn::className(),
             'grid' => $this,
             'attribute' => $matches[1],
-            'format' => isset($matches[3]) ? $matches[3] : 'text',
+            'format' => $format,
             'label' => isset($matches[5]) ? $matches[5] : null,
         ]);
     }


### PR DESCRIPTION
PR improve the shortcut format the configuration for columns of GridView and allows to do:

``` php
'columns' => [
       'name:text:Name item',
       'created_at:date,php:Y-m-d: created at', // 2016-02-16
       'update_at:datetime,eeee dd/MM/y h:mm a', // Tuesday 16/02/2016 12:08 PM
       'total_price:currency,usd:Price', // 200 $
]
```

BC does not break.
PR is preview to :
- [ ] add tests
- [ ] improve regexp
- [ ] documentation

Should done this? 

P.S.
Some opinions:
https://github.com/yiisoft/yii2/issues/2854
