### PR TITLE
AccessRule should do more than just string comparison to match IPs

### DIFF
--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -202,4 +202,29 @@ class AccessRuleTest extends \yiiunit\TestCase
         $this->assertNull($rule->allows($action, $user, $request));
     }
 
+    public function testMatchIPExpandIpv6()
+    {
+        /** @var $action Action */
+        /** @var $user User */
+        /** @var $request Request */
+        list($action, $user, $request) = $this->mockObjects();
+
+        $rule = new AccessRule();
+
+        // match, IPv6
+        $_SERVER['REMOTE_ADDR'] = '2a01:04f8:0120:7202:0000:0000:0000:0002';
+        $rule->ips = ['2a01:4f8:120:7202::2'];
+        $rule->allow = true;
+        $this->assertTrue($rule->allows($action, $user, $request));
+        $rule->allow = false;
+        $this->assertFalse($rule->allows($action, $user, $request));
+
+        $_SERVER['REMOTE_ADDR'] = '2a01:4f8:120:7202:0:0:0:2';
+        $rule->ips = ['2a01:4f8:120:7202::2'];
+        $rule->allow = true;
+        $this->assertTrue($rule->allows($action, $user, $request));
+        $rule->allow = false;
+        $this->assertFalse($rule->allows($action, $user, $request));
+    }
+
 }


### PR DESCRIPTION
See for example on IPv6, the same address may be written in different formats:
- `2a01:04f8:0120:7202:0000:0000:0000:0002`
- `2a01:04f8:120:7202:0:0:0:2`
- `2a01:4f8:120:7202::2`

See also http://v6decode.com/#address=2a01%3A4f8%3A120%3A7202%3A%3A2

This only adds a failing test, no implementation, so do not merge. If someone wants to work on this, feel free to do so.
