### PR TITLE
Avoid `new $this->modelClass` in ActiveQuery::findWith()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 -----------------------
 
 - Bug #9851: Fixed partial commit / rollback in nested transactions (sammousa)
+- Enh #8639: Improve ActiveRecord to not create new instances of classes when objects are available (cebe)
 - Enh #10451: Check of existence of `$_SERVER` in `\yii\web\Request` before using it (quantum13)
 - Enh #10610: Added `BaseUrl::$urlManager` to be able to set URL manager used for creating URLs (samdark)
 - Enh #10764: `yii\helpers\Html::tag()` and `::beginTag()` return content without any HTML when the `$tag` attribute is `false` or `null` (pana1990)

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -159,7 +159,10 @@ trait ActiveQueryTrait
      */
     public function findWith($with, &$models)
     {
-        $primaryModel = new $this->modelClass;
+        $primaryModel = reset($models);
+        if (!$primaryModel instanceof ActiveRecordInterface) {
+            $primaryModel = new $this->modelClass;
+        }
         $relations = $this->normalizeRelations($primaryModel, $with);
         /* @var $relation ActiveQuery */
         foreach ($relations as $name => $relation) {


### PR DESCRIPTION
reduces the issue described in #8639 to `joinWith()` and `asArray()`. Everything else should work then.
