### PR TITLE
Support Traversable objects in HtmlHelper

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Enh #10451: Check of existence of `$_SERVER` in `\yii\web\Request` before using it (quantum13)
 - Enh #10610: Added `BaseUrl::$urlManager` to be able to set URL manager used for creating URLs (samdark)
 - Enh #10764: `yii\helpers\Html::tag()` and `::beginTag()` return content without any HTML when the `$tag` attribute is `false` or `null` (pana1990)
+- Enh #10941: Added `yii\helpers\ArrayHelper::isTraversable`, added support for traversable selections for dropdownList, radioList and checkboxList in `yii\helpers\Html`.
 - Chg: HTMLPurifier dependency updated to `~4.6` (samdark)
 
 2.0.7 February 14, 2016

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -625,13 +625,14 @@ class BaseArrayHelper
     }
 
     /**
-     * Check whether a variable is an array or [[\Traversable]].
+     * Checks whether a variable is an array or [[\Traversable]].
      *
      * This method does the same as the PHP function [is_array()](http://php.net/manual/en/function.is-array.php)
      * but it does not only work for arrays but also objects that implement the [[\Traversable]] interface.
      * @param mixed $var The variable being evaluated.
-     * @return boolean `true` if `$var` has an array-like value.
+     * @return boolean whether $var is array-like
      * @see http://php.net/manual/en/function.is_array.php
+     * @since 2.0.8
      */
     public static function isTraversable($var)
     {

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -625,6 +625,20 @@ class BaseArrayHelper
     }
 
     /**
+     * Check whether a variable is an array or [[\Traversable]].
+     *
+     * This method does the same as the PHP function [in_array()](http://php.net/manual/en/function.in-array.php)
+     * but it does not only work for arrays but also objects that implement the [[\Traversable]] interface.
+     * @param mixed $var The variable being evaluated.
+     * @return boolean `true` if `$var` has an array-like value.
+     * @see http://php.net/manual/en/function.is_array.php
+     */
+    public static function isArray($var)
+    {
+        return is_array($var) || $var instanceof \Traversable;
+    }
+
+    /**
      * Checks whether an array or [[\Traversable]] is a subset of another array or [[\Traversable]].
      *
      * This method will return `true`, if all elements of `$needles` are contained in

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -633,7 +633,7 @@ class BaseArrayHelper
      * @return boolean `true` if `$var` has an array-like value.
      * @see http://php.net/manual/en/function.is_array.php
      */
-    public static function isArray($var)
+    public static function isTraversable($var)
     {
         return is_array($var) || $var instanceof \Traversable;
     }

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -627,7 +627,7 @@ class BaseArrayHelper
     /**
      * Check whether a variable is an array or [[\Traversable]].
      *
-     * This method does the same as the PHP function [in_array()](http://php.net/manual/en/function.in-array.php)
+     * This method does the same as the PHP function [is_array()](http://php.net/manual/en/function.is-array.php)
      * but it does not only work for arrays but also objects that implement the [[\Traversable]] interface.
      * @param mixed $var The variable being evaluated.
      * @return boolean `true` if `$var` has an array-like value.

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -598,7 +598,7 @@ class BaseArrayHelper
      * Check whether an array or [[\Traversable]] contains an element.
      *
      * This method does the same as the PHP function [in_array()](http://php.net/manual/en/function.in-array.php)
-     * but it does not only work for arrays but also objects that implement the [[\Traversable]] interface.
+     * but additionally works for objects that implement the [[\Traversable]] interface.
      * @param mixed $needle The value to look for.
      * @param array|\Traversable $haystack The set of values to search.
      * @param boolean $strict Whether to enable strict (`===`) comparison.
@@ -628,7 +628,7 @@ class BaseArrayHelper
      * Checks whether a variable is an array or [[\Traversable]].
      *
      * This method does the same as the PHP function [is_array()](http://php.net/manual/en/function.is-array.php)
-     * but it does not only work for arrays but also objects that implement the [[\Traversable]] interface.
+     * but additionally works objects that implement the [[\Traversable]] interface.
      * @param mixed $var The variable being evaluated.
      * @return boolean whether $var is array-like
      * @see http://php.net/manual/en/function.is_array.php

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -906,8 +906,8 @@ class BaseHtml
         $index = 0;
         foreach ($items as $value => $label) {
             $checked = $selection !== null &&
-                (!is_array($selection) && !strcmp($value, $selection)
-                    || is_array($selection) && in_array($value, $selection));
+                (!ArrayHelper::isTraversable($selection) && !strcmp($value, $selection)
+                    || ArrayHelper::isTraversable($selection) && ArrayHelper::isIn($value, $selection));
             if ($formatter !== null) {
                 $lines[] = call_user_func($formatter, $index, $label, $name, $checked, $value);
             } else {
@@ -984,8 +984,8 @@ class BaseHtml
         $index = 0;
         foreach ($items as $value => $label) {
             $checked = $selection !== null &&
-                (!is_array($selection) && !strcmp($value, $selection)
-                    || is_array($selection) && in_array($value, $selection));
+                (!ArrayHelper::isTraversable($selection) && !strcmp($value, $selection)
+                    || ArrayHelper::isTraversable($selection) && ArrayHelper::isIn($value, $selection));
             if ($formatter !== null) {
                 $lines[] = call_user_func($formatter, $index, $label, $name, $checked, $value);
             } else {
@@ -1737,8 +1737,8 @@ class BaseHtml
                 $attrs = isset($options[$key]) ? $options[$key] : [];
                 $attrs['value'] = (string) $key;
                 $attrs['selected'] = $selection !== null &&
-                        (!is_array($selection) && !strcmp($key, $selection)
-                        || is_array($selection) && in_array($key, $selection));
+                        (!ArrayHelper::isTraversable($selection) && !strcmp($key, $selection)
+                        || ArrayHelper::isTraversable($selection) && ArrayHelper::isIn($key, $selection));
                 $text = $encode ? static::encode($value) : $value;
                 if ($encodeSpaces) {
                     $text = str_replace(' ', '&nbsp;', $text);

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -570,11 +570,11 @@ class ArrayHelperTest extends TestCase
 
     public function testIsArray()
     {
-        $this->assertTrue(ArrayHelper::isArray(['a']));
-        $this->assertTrue(ArrayHelper::isArray(new \ArrayObject(['1'])));
-        $this->assertFalse(ArrayHelper::isArray(new \stdClass()));
-        $this->assertFalse(ArrayHelper::isArray("A,B,C"));
-        $this->assertFalse(ArrayHelper::isArray(12));
+        $this->assertTrue(ArrayHelper::isTraversable(['a']));
+        $this->assertTrue(ArrayHelper::isTraversable(new \ArrayObject(['1'])));
+        $this->assertFalse(ArrayHelper::isTraversable(new \stdClass()));
+        $this->assertFalse(ArrayHelper::isTraversable("A,B,C"));
+        $this->assertFalse(ArrayHelper::isTraversable(12));
         $this->assertFalse(false);
     }
 

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -568,5 +568,15 @@ class ArrayHelperTest extends TestCase
 
     }
 
+    public function testIsArray()
+    {
+        $this->assertTrue(ArrayHelper::isArray(['a']));
+        $this->assertTrue(ArrayHelper::isArray(new \ArrayObject(['1'])));
+        $this->assertFalse(ArrayHelper::isArray(new \stdClass()));
+        $this->assertFalse(ArrayHelper::isArray("A,B,C"));
+        $this->assertFalse(ArrayHelper::isArray(12));
+        $this->assertFalse(false);
+    }
+
 
 }

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -354,6 +354,14 @@ EOD;
 </select>
 EOD;
         $this->assertEqualsWithoutLE($expected, Html::listBox('test', '', [], ['unselect' => '0']));
+
+        $expected = <<<EOD
+<select name="test" size="4">
+<option value="value1" selected>text1</option>
+<option value="value2" selected>text2</option>
+</select>
+EOD;
+        $this->assertEqualsWithoutLE($expected, Html::listBox('test', new \ArrayObject(['value1', 'value2']), $this->getDataItems()));
     }
 
     public function testCheckboxList()
@@ -402,6 +410,15 @@ EOD;
             },
             'tag' => false
         ]));
+
+
+        $this->assertEqualsWithoutLE($expected, Html::checkboxList('test', new \ArrayObject(['value2']), $this->getDataItems(), [
+            'item' => function ($index, $label, $name, $checked, $value) {
+                return $index . Html::label($label . ' ' . Html::checkbox($name, $checked, ['value' => $value]));
+            },
+            'tag' => false
+        ]));
+
     }
 
     public function testRadioList()
@@ -444,6 +461,13 @@ EOD;
 1<label>text2 <input type="radio" name="test" value="value2" checked></label>
 EOD;
         $this->assertEqualsWithoutLE($expected, Html::radioList('test', ['value2'], $this->getDataItems(), [
+            'item' => function ($index, $label, $name, $checked, $value) {
+                return $index . Html::label($label . ' ' . Html::radio($name, $checked, ['value' => $value]));
+            },
+            'tag' => false
+        ]));
+
+        $this->assertEqualsWithoutLE($expected, Html::radioList('test', new \ArrayObject(['value2']), $this->getDataItems(), [
             'item' => function ($index, $label, $name, $checked, $value) {
                 return $index . Html::label($label . ' ' . Html::radio($name, $checked, ['value' => $value]));
             },


### PR DESCRIPTION
This PR adds support for `Traversable` objects in all selection params in `yii\helpers\BaseHtml`.
Selection params are used by `checkboxList`, `dropdownList` and similar functions.
