### PR TITLE
passing properties to recursive call 

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -93,7 +93,7 @@ class BaseArrayHelper
                 }
             }
 
-            return $recursive ? static::toArray($result) : $result;
+            return $recursive ? static::toArray($result, $properties) : $result;
         } else {
             return [$object];
         }

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -27,6 +27,7 @@ class Post2 extends Object
 class Post3 extends Object
 {
     public $id = 33;
+    /** @var Object */
     public $subObject;
 
     public function init()
@@ -88,6 +89,45 @@ class ArrayHelperTest extends TestCase
                 'content' => 'test',
             ],
         ], ArrayHelper::toArray($object));
+
+        //recursive with attributes of object and subobject
+        $this->assertEquals([
+            'id' => 33,
+            'id_plus_1' => 34,
+            'subObject' => [
+                'id' => 123,
+                'id_plus_1' => 124,
+            ],
+        ], ArrayHelper::toArray($object, [
+            $object->className() => [
+                'id', 'subObject',
+                'id_plus_1' => function ($post) {
+                    return $post->id+1;
+                }
+            ],
+            $object->subObject->className() => [
+                'id',
+                'id_plus_1' => function ($post) {
+                    return $post->id+1;
+                }
+            ],
+        ]));
+
+        //recursive with attributes of subobject only
+        $this->assertEquals([
+            'id' => 33,
+            'subObject' => [
+                'id' => 123,
+                'id_plus_1' => 124,
+            ],
+        ], ArrayHelper::toArray($object, [
+            $object->subObject->className() => [
+                'id',
+                'id_plus_1' => function ($post) {
+                    return $post->id+1;
+                }
+            ],
+        ]));
     }
 
     public function testRemove()


### PR DESCRIPTION
if properties of top object are not specified
#7717

Call in the first line was already fixed. 
