### PR TITLE
replace all occurrences of migration class

### DIFF
--- a/tests/framework/console/controllers/MigrateControllerTestTrait.php
+++ b/tests/framework/console/controllers/MigrateControllerTestTrait.php
@@ -117,7 +117,10 @@ CODE;
     protected function parseNameClassMigration($class)
     {
         $files = FileHelper::findFiles($this->migrationPath);
-        $file = preg_replace('/class (m\d+_\d+_.*) extends Migration/', "class $class extends Migration", file_get_contents($files[0]));
+        $file = file_get_contents($files[0]);
+        if (preg_match('/class (m\d+_\d+_.*) extends Migration/', $file, $match)) {
+            $file = str_replace($match[1], $class, $file);
+        }
         $this->tearDownMigrationPath();
         return $file;
     }


### PR DESCRIPTION
Class was replaced only in definition of migration class.
In testGenerateDefaultMigration classname used in error message (https://github.com/yiisoft/yii2/blob/31cf978f385b1ffb16aaf3ff04175d5b65922948/tests/framework/console/controllers/MigrateControllerTestTrait.php#L188), so sometimes this test failed: https://travis-ci.org/quantum13/yii2/jobs/111687879
