### PR TITLE
Fix accidental `getResponseHeader()` fails

### DIFF
--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -324,7 +324,7 @@ yii = (function ($) {
     function initRedirectHandler() {
         // handle AJAX redirection
         $(document).ajaxComplete(function (event, xhr, settings) {
-            var url = xhr.getResponseHeader('X-Redirect');
+            var url = xhr && xhr.getResponseHeader('X-Redirect');
             if (url) {
                 window.location = url;
             }


### PR DESCRIPTION
![exc](https://cloud.githubusercontent.com/assets/980679/13351834/8cb53962-dc9a-11e5-80dc-f691fe3bd320.png)
