### PR TITLE
Unsafe attribute event

### DIFF
--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -69,6 +69,10 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      * @event Event an event raised at the end of [[validate()]]
      */
     const EVENT_AFTER_VALIDATE = 'afterValidate';
+    /**
+     * @event ModelUnsafeAttributeEvent an event raised when setting and unsafe attribute
+     */
+    const EVENT_UNSAFE_ATTRIBUTE = 'unsafeAttribute';
 
     /**
      * @var array validation errors (attribute name => array of errors)
@@ -712,8 +716,13 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
      */
     public function onUnsafeAttribute($name, $value)
     {
-        if (YII_DEBUG) {
-            Yii::trace("Failed to set unsafe attribute '$name' in '" . get_class($this) . "'.", __METHOD__);
+        $event = new ModelUnsafeAttributeEvent($name, $value);
+        $this->trigger(self::EVENT_UNSAFE_ATTRIBUTE, $event);
+
+        if (!$event->isSafe) {
+            if (YII_DEBUG) {
+                Yii::trace("Failed to set unsafe attribute '$name' in '" . get_class($this) . "'.", __METHOD__);
+            }
         }
     }
 

--- a/framework/base/ModelUnsafeAttributeEvent.php
+++ b/framework/base/ModelUnsafeAttributeEvent.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\base;
+
+/**
+ * ModelUnsafeAttributeEvent represents the parameter needed by [[Model]] unsafe attribute event.
+ *
+ * @author Rangel Reale <rangelspam@gmail.com>
+ * @since 2.0.6
+ */
+class ModelUnsafeAttributeEvent extends Event
+{
+    /**
+     * Constructor.
+     * @param string $attributeName unsafe attribute name
+     * @param mixed $attributeValue unsafe attribute value
+     * @param array $config name-value pairs that will be used to initialize the object properties
+     */
+    public function __construct($attributeName, $attributeValue, $config = array()) 
+    {
+        parent::__construct($config);
+        $this->attributeName = $attributeName;
+        $this->attributeValue = $attributeValue;
+    }
+    
+    /**
+     * @var boolean whether the attribute is safe. Defaults to false.
+     */
+    public $isSafe = false;
+
+    /**
+     * The unsafe attribute name.
+     * @var string
+     */
+    public $attributeName;
+    
+    /**
+     * The unsafe attribute value.
+     * @var mixed
+     */
+    public $attributeValue;
+}


### PR DESCRIPTION
This enables behaviours to override unsafe attribute setting, allowing for example setting values in a nested model.
