### PR TITLE
Fixes #11038: handling of intervals of 0 seconds in yii\i18n\Formatter::asDuration().

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Bug #10946: Fixed parameters binding to the SQL query in `yii\db\mysqlSchema::findConstraints()` (silverfire)
 - Bug #10969: Fixed generator migration tool with decimal params in column (pana1990)
 - Bug #10974: `yii.js` - fixed error in ajaxPrefilter event handler, caused by blocked frame (maximal)
+- Bug #11038: Fixed handling of intervals of 0 seconds in `yii\i18n\Formatter::asDuration()` (VirtualRJ)
 - Bug: SQlite querybuilder did not create primary key with bigint for `TYPE_BIGPK` (cebe)
 - Enh #5469: Add mimetype validation by mask in FileValidator (kirsenn, samdark, silverfire)
 - Enh #8602: `yii\validators\DateValidator` skip validation for `timestampAttribute`, if it is already in correct format (klimov-paul)

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -874,7 +874,7 @@ class Formatter extends Component
             $parts[] = Yii::t('yii', '{delta, plural, =1{1 minute} other{# minutes}}', ['delta' => $interval->i], $this->locale);
         }
         if ($interval->s > 0 || ($interval->s === 0 && empty($parts))) {
-            if(empty($parts)){
+            if($interval->s === 0 && empty($parts)){
                 $isNegative = false;
             }
             $parts[] = Yii::t('yii', '{delta, plural, =1{1 second} other{# seconds}}', ['delta' => $interval->s], $this->locale);

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -873,12 +873,11 @@ class Formatter extends Component
         if ($interval->i > 0) {
             $parts[] = Yii::t('yii', '{delta, plural, =1{1 minute} other{# minutes}}', ['delta' => $interval->i], $this->locale);
         }
-        if ($interval->s > 0) {
+        if ($interval->s > 0 || ($interval->s === 0 && empty($parts))) {
+            if(empty($parts)){
+                $isNegative = false;
+            }
             $parts[] = Yii::t('yii', '{delta, plural, =1{1 second} other{# seconds}}', ['delta' => $interval->s], $this->locale);
-        }
-        if ($interval->s === 0 && empty($parts)) {
-            $parts[] = Yii::t('yii', '{delta} seconds', ['delta' => $interval->s], $this->locale);
-            $isNegative = false;
         }
 
         return empty($parts) ? $this->nullDisplay : (($isNegative ? $negativeSign : '') . implode($implodeString, $parts));

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -877,7 +877,7 @@ class Formatter extends Component
             $parts[] = Yii::t('yii', '{delta, plural, =1{1 second} other{# seconds}}', ['delta' => $interval->s], $this->locale);
         }
         if ($interval->s === 0 && empty($parts)) {
-            $parts[] = Yii::t('yii', '{delta} seconds', ['delta' => $interval->s], $this->locale);
+            $parts[] = Yii::t('yii', '{delta, plural, =1{1 second} other{# seconds}}', ['delta' => $interval->s], $this->locale);
             $isNegative = false;
         }
 

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -873,11 +873,12 @@ class Formatter extends Component
         if ($interval->i > 0) {
             $parts[] = Yii::t('yii', '{delta, plural, =1{1 minute} other{# minutes}}', ['delta' => $interval->i], $this->locale);
         }
-        if ($interval->s > 0 || ($interval->s === 0 && empty($parts))) {
-            if($interval->s === 0 && empty($parts)){
-                $isNegative = false;
-            }
+        if ($interval->s > 0) {
             $parts[] = Yii::t('yii', '{delta, plural, =1{1 second} other{# seconds}}', ['delta' => $interval->s], $this->locale);
+        }
+        if ($interval->s === 0 && empty($parts)) {
+            $parts[] = Yii::t('yii', '{delta} seconds', ['delta' => $interval->s], $this->locale);
+            $isNegative = false;
         }
 
         return empty($parts) ? $this->nullDisplay : (($isNegative ? $negativeSign : '') . implode($implodeString, $parts));

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -876,6 +876,10 @@ class Formatter extends Component
         if ($interval->s > 0) {
             $parts[] = Yii::t('yii', '{delta, plural, =1{1 second} other{# seconds}}', ['delta' => $interval->s], $this->locale);
         }
+        if ($interval->s === 0 && empty($parts)) {
+            $parts[] = Yii::t('yii', '{delta} seconds', ['delta' => $interval->s], $this->locale);
+            $isNegative = false;
+        }
 
         return empty($parts) ? $this->nullDisplay : (($isNegative ? $negativeSign : '') . implode($implodeString, $parts));
     }

--- a/tests/framework/i18n/FormatterDateTest.php
+++ b/tests/framework/i18n/FormatterDateTest.php
@@ -405,6 +405,7 @@ class FormatterDateTest extends TestCase
 
     public function testAsDuration()
     {
+        $interval_0_seconds   = new DateInterval("PT0S");
         $interval_1_second    = new DateInterval("PT1S");
         $interval_244_seconds = new DateInterval("PT244S");
         $interval_1_minute    = new DateInterval("PT1M");
@@ -419,6 +420,7 @@ class FormatterDateTest extends TestCase
         $interval_12_years    = new DateInterval("P12Y");
 
         // Pass a DateInterval
+        $this->assertSame('0 seconds', $this->formatter->asDuration($interval_0_seconds));
         $this->assertSame('1 second', $this->formatter->asDuration($interval_1_second));
         $this->assertSame('244 seconds', $this->formatter->asDuration($interval_244_seconds));
         $this->assertSame('1 minute', $this->formatter->asDuration($interval_1_minute));
@@ -431,6 +433,16 @@ class FormatterDateTest extends TestCase
         $this->assertSame('5 months', $this->formatter->asDuration($interval_5_months));
         $this->assertSame('1 year', $this->formatter->asDuration($interval_1_year));
         $this->assertSame('12 years', $this->formatter->asDuration($interval_12_years));
+        
+        // Pass a numeric value
+        $this->assertSame('0 seconds', $this->formatter->asDuration(0));
+        $this->assertSame('1 second', $this->formatter->asDuration(1));
+        $this->assertSame('4 minutes, 4 seconds', $this->formatter->asDuration(244));
+        $this->assertSame('1 minute', $this->formatter->asDuration(60));
+        $this->assertSame('33 minutes', $this->formatter->asDuration(1980));
+        $this->assertSame('1 hour', $this->formatter->asDuration(3600));
+        $this->assertSame('6 hours', $this->formatter->asDuration(21600));
+        $this->assertSame('1 day', $this->formatter->asDuration(86400));
 
         // Pass a DateInterval string
         $this->assertSame('1 year, 2 months, 10 days, 2 hours, 30 minutes', $this->formatter->asDuration('2007-03-01T13:00:00Z/2008-05-11T15:30:00Z'));
@@ -442,6 +454,7 @@ class FormatterDateTest extends TestCase
         $this->assertSame('-94 months', $this->formatter->asDuration('P-94M'));
 
         // Invert all the DateIntervals
+        $interval_0_seconds->invert = true;
         $interval_1_second->invert = true;
         $interval_244_seconds->invert = true;
         $interval_1_minute->invert = true;
@@ -456,6 +469,7 @@ class FormatterDateTest extends TestCase
         $interval_12_years->invert = true;
 
         // Pass a inverted DateInterval
+        $this->assertSame('0 seconds', $this->formatter->asDuration($interval_0_seconds));
         $this->assertSame('-1 second', $this->formatter->asDuration($interval_1_second));
         $this->assertSame('-244 seconds', $this->formatter->asDuration($interval_244_seconds));
         $this->assertSame('-1 minute', $this->formatter->asDuration($interval_1_minute));


### PR DESCRIPTION
- Fixed handling of intervals of 0 seconds in `yii\i18n\Formatter::asDuration()`.
- Added unit tests for handling 0 second intervals and numeric values for `yii\i18n\Formatter::asDuration()`.
#11038
