### PR TITLE
#10405 Attaching CORS filter by default to yii\rest\Controller 

### DIFF
--- a/framework/rest/Controller.php
+++ b/framework/rest/Controller.php
@@ -8,6 +8,7 @@
 namespace yii\rest;
 
 use Yii;
+use yii\filters\Cors;
 use yii\filters\auth\CompositeAuth;
 use yii\filters\ContentNegotiator;
 use yii\filters\RateLimiter;
@@ -19,11 +20,12 @@ use yii\filters\VerbFilter;
  *
  * Controller implements the following steps in a RESTful API request handling cycle:
  *
- * 1. Resolving response format (see [[ContentNegotiator]]);
+ * 1. Resolving response format (see [[ContentNegotiator]]).
  * 2. Validating request method (see [[verbs()]]).
- * 3. Authenticating user (see [[\yii\filters\auth\AuthInterface]]);
- * 4. Rate limiting (see [[RateLimiter]]);
- * 5. Formatting response data (see [[serializeData()]]).
+ * 3. Implementing CORS (see [[\yii\filters\Cors]]).
+ * 4. Authenticating user (see [[\yii\filters\auth\AuthInterface]]).
+ * 5. Rate limiting (see [[RateLimiter]]).
+ * 6. Formatting response data (see [[serializeData()]]).
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -56,6 +58,9 @@ class Controller extends \yii\web\Controller
             'verbFilter' => [
                 'class' => VerbFilter::className(),
                 'actions' => $this->verbs(),
+            ],
+            'corsFilter' => [
+                'class' => Cors::className(),
             ],
             'authenticator' => [
                 'class' => CompositeAuth::className(),


### PR DESCRIPTION
when following common docs examples on implementing behaviors by doing this: 

``` php
class TokenController extends \yii\rest\Controller
{

    public function behaviors()
    {
        $behaviors = parent::behaviors();

        $behaviors['corsFilter'] = [
            'class' => \yii\filters\Cors::className(),
        ];

        $behaviors['authenticator'] = [
            'class' => \yii\filters\auth\HttpBearerAuth::className(),
            'except' => ['options'],
        ];

        return $behaviors;
    }
```

the $behaviors outputs structure will look like this: 

```
Array
(
    [contentNegotiator] => Array(...)
    [verbFilter] => Array(...)
    [authenticator] => Array(...)
    [rateLimiter] => Array(...)
    [corsFilter] => Array(...)
)
```

`corsFilter` will always be sent to the bottom of the array and treated after `authenticator` because only `authenticator` is defined in the parent array at `yii\rest\Controller::behaviors()` (see code [here](https://github.com/yiisoft/yii2/blob/master/framework/rest/Controller.php#L46)) which raises those kind of errors in browsers:

```
XMLHttpRequest cannot load http://localhost/foundapps/backend/auth/token/revoke. Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:8079' is therefore not allowed access.
```

This is expected as it is already mentioned in CORS [docs](http://www.yiiframework.com/doc-2.0/guide-structure-filters.html#cors) :

> The Cors filter should be defined before Authentication / Authorization filters to make sure the CORS headers will always be sent.

It usually happens when authentication fails like a request header holding an expired token so CORS won't be reached. To prevent the issue we could merge arrays without defining keys as it is done in the CORS docs I just linked (authentication will be defined twice but the one we need will be sent to bottom and CORS will be treated) or we can simply define CORS in `yii\rest\Controller` with its default values (see [here](https://github.com/yiisoft/yii2/blob/master/framework/filters/Cors.php#L81-L88)) which I think it should be fine as it is a must do when doing REST web apps any way.

This may fix #10405, #6254 and #8626 and could also be related to  #6804 and #7966.
