### PR TITLE
fixes #9561 canGetProperty and canSetProperty on ActiveRecord checks attributes

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -423,6 +423,42 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
     }
 
     /**
+     * Returns a value indicating whether a property can be read.
+     * This method is overridden as the attributes can be accessed like properties.
+     *
+     * @param string $name the property name
+     * @param boolean $checkVars whether to treat member variables as properties
+     * @param boolean $checkBehaviors whether to treat behaviors' properties as properties of this component
+     * @return boolean whether the property can be written
+     */
+    public function canGetProperty($name, $checkVars = true, $checkBehaviors = true)
+    {
+        if ($this->hasAttribute($name) || isset($this->_related[$name]) || array_key_exists($name, $this->_related)) {
+            return true;
+        } else {
+            return parent::canGetProperty($name, $checkVars, $checkBehaviors);
+        }
+    }
+
+    /**
+     * Returns a value indicating whether a property can be set.
+     * This method is overridden as the attributes can be accessed like properties.
+     *
+     * @param string $name the property name
+     * @param boolean $checkVars whether to treat member variables as properties
+     * @param boolean $checkBehaviors whether to treat behaviors' properties as properties of this component
+     * @return boolean whether the property can be written
+     */
+    public function canSetProperty($name, $checkVars = true, $checkBehaviors = true)
+    {
+        if ($this->hasAttribute($name)) {
+            return true;
+        } else {
+            return parent::canSetProperty($name, $checkVars, $checkBehaviors);
+        }
+    }
+
+    /**
      * Returns the named attribute value.
      * If this record is the result of a query and the attribute is not loaded,
      * null will be returned.

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1142,4 +1142,46 @@ class ActiveRecordTest extends DatabaseTestCase
         $trueBit = BitValues::findOne(2);
         $this->assertEquals(true, $trueBit->val);
     }
+
+    public function testCanGetProperty()
+    {
+        /* @var $customerClass \yii\db\ActiveRecordInterface */
+        $customerClass = $this->getCustomerClass();
+
+        /* @var $customer ActiveRecord */
+        $customer = new $customerClass();
+        $this->assertTrue($customer instanceof $customerClass);
+
+        $this->assertTrue($customer->canGetProperty('id'));
+        $this->assertTrue($customer->canSetProperty('id'));
+
+        // tests that we really can get and set this property
+        $this->assertNull($customer->id);
+        $customer->id = 10;
+        $this->assertNotNull($customer->id);
+
+        // Let's test relations
+        $this->assertTrue($customer->canGetProperty('orderItems'));
+        $this->assertFalse($customer->canSetProperty('orderItems'));
+
+        // Newly created model must have empty relation
+        $this->assertSame([], $customer->orderItems);
+
+        try {
+
+            $customer->orderItems = [new Item()];
+            // setter call above MUST throw Exception
+            $this->assertTrue(false);
+
+        } catch (\Exception $e) {
+            // catch exception "Setting read-only property"
+            $this->assertInstanceOf('yii\base\InvalidCallException', $e);
+        }
+
+        // related attribute $customer->orderItems didn't change cause it's read-only
+        $this->assertSame([], $customer->orderItems);
+
+        $this->assertFalse($customer->canGetProperty('non_existing_property'));
+        $this->assertFalse($customer->canSetProperty('non_existing_property'));
+    }
 }


### PR DESCRIPTION
Maybe need to add more tests for readonly/writeonly properties and "related"?
