### PR TITLE
JSON_ERROR_SYNTAX fix for json_decode(null) in PHP 7

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -28,6 +28,7 @@ Yii Framework 2 Change Log
 - Bug #11040: Check parameter 'recursive' and disable recursive copying with option 'recursive' => false in method BaseFileHelper::copyDirectory (Ni-san)
 - Chg: HTMLPurifier dependency updated to `~4.6` (samdark)
 - Chg #11071: `yii\helpers\BaseArrayHelper::isIn()` and `isTraversable()` since now throw `\yii\base\InvalidParamException` instead of `\InvalidArgumentException` (nukkumatti)
+- Bug #11125: Fixed JSON_ERROR_SYNTAX for json_decode(null) in PHP 7
 
 2.0.7 February 14, 2016
 -----------------------

--- a/framework/helpers/BaseJson.php
+++ b/framework/helpers/BaseJson.php
@@ -90,6 +90,8 @@ class BaseJson
     {
         if (is_array($json)) {
             throw new InvalidParamException('Invalid JSON data.');
+        } elseif ((string) $json === '') {
+            return null;
         }
         $decode = json_decode((string) $json, $asArray);
         static::handleJsonError(json_last_error());

--- a/framework/helpers/BaseJson.php
+++ b/framework/helpers/BaseJson.php
@@ -90,7 +90,7 @@ class BaseJson
     {
         if (is_array($json)) {
             throw new InvalidParamException('Invalid JSON data.');
-        } elseif ((string) $json === '') {
+        } elseif ($json === null || $json === '') {
             return null;
         }
         $decode = json_decode((string) $json, $asArray);


### PR DESCRIPTION
json_decode produce error when decoding `null` or empty string in PHP 7.

Example.

``` php
var_dump(json_decode(null));
var_dump(json_last_error());
```

PHP 5.4.0 - 5.6.19, hhvm-3.6.1 - 3.12.0 returns:

```
NULL
int(0)
```

PHP 7.0.0 - 7.0.4 returns:

```
NULL
int(4)
```

I think we must exclude `null` and epmty string from a decode function becouse json_decode returns a right value.
What do you think about it?
