### PR TITLE
use /dev/random on FreeBSD

### DIFF
--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -432,7 +432,7 @@ class Security extends Component
      *
      * @param integer $length the number of bytes to generate
      * @return string the generated random bytes
-     * @throws \Exception on failure.
+     * @throws Exception on failure.
      */
     public function generateRandomKey($length = 32)
     {
@@ -458,7 +458,7 @@ class Security extends Component
         }
 
         // Since 5.4.0, openssl_random_pseudo_bytes() reads from CryptGenRandom on Windows instead
-        // of using OpenSSL library. Don't use OpenSSL on other platforms.
+        // of using OpenSSL library. LibreSSL is ok everywhere but don't use OpenSSL on non-Windows.
         if ($this->_libreSSL
             || (DIRECTORY_SEPARATOR !== '/'
                 && PHP_VERSION_ID >= 50400

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -458,7 +458,7 @@ class Security extends Component
 
         // Since 5.4.0, openssl_random_pseudo_bytes() reads from CryptGenRandom on Windows instead
         // of using OpenSSL library. Don't use OpenSSL on other platforms.
-        if ($libreSSL || (DIRECTORY_SEPARATOR !== '/' && PHP_VERSION_ID >= 50400)) {
+        if ($libreSSL || (DIRECTORY_SEPARATOR === '\\' && PHP_VERSION_ID >= 50400)) {
             $key = openssl_random_pseudo_bytes($length, $cryptoStrong);
             if ($cryptoStrong === false) {
                 throw new Exception(

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -459,8 +459,11 @@ class Security extends Component
 
         // Since 5.4.0, openssl_random_pseudo_bytes() reads from CryptGenRandom on Windows instead
         // of using OpenSSL library. Don't use OpenSSL on other platforms.
-        if ($this->_libreSSL || (DIRECTORY_SEPARATOR !== '/'
-                && substr_compare(PHP_OS, 'win', 0, 3, true) === 0 && PHP_VERSION_ID >= 50400)
+        if ($this->_libreSSL
+            || (DIRECTORY_SEPARATOR !== '/'
+                && PHP_VERSION_ID >= 50400
+                && substr_compare(PHP_OS, 'win', 0, 3, true) === 0
+                && function_exists('openssl_random_pseudo_bytes'))
         ) {
             $key = openssl_random_pseudo_bytes($length, $cryptoStrong);
             if ($cryptoStrong === false) {

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -489,7 +489,7 @@ class Security extends Component
         if (DIRECTORY_SEPARATOR === '/') {
             // urandom is a symlink to random on FreeBSD.
             $device = PHP_OS === 'FreeBSD' ? '/dev/random' : '/dev/urandom';
-            // Check random device for speacial character device protection mode. Use lstat()
+            // Check random device for special character device protection mode. Use lstat()
             // instead of stat() in case an attacker arranges a symlink to a fake device.
             $lstat = @lstat($device);
             if ($lstat !== false && ($lstat['mode'] & 0170000) === 020000) {

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -459,7 +459,9 @@ class Security extends Component
 
         // Since 5.4.0, openssl_random_pseudo_bytes() reads from CryptGenRandom on Windows instead
         // of using OpenSSL library. Don't use OpenSSL on other platforms.
-        if ($this->_libreSSL || (DIRECTORY_SEPARATOR === '\\' && PHP_VERSION_ID >= 50400)) {
+        if ($this->_libreSSL || (DIRECTORY_SEPARATOR !== '/'
+                && substr_compare(PHP_OS, 'win', 0, 3, true) === 0 && PHP_VERSION_ID >= 50400)
+        ) {
             $key = openssl_random_pseudo_bytes($length, $cryptoStrong);
             if ($cryptoStrong === false) {
                 throw new Exception(

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -423,6 +423,8 @@ class Security extends Component
         return false;
     }
 
+    private $_libreSSL;
+
     /**
      * Generates specified number of random bytes.
      * Note that output may not be ASCII.
@@ -449,16 +451,15 @@ class Security extends Component
         // The recent LibreSSL RNGs are faster and likely better than /dev/urandom.
         // Parse OPENSSL_VERSION_TEXT because OPENSSL_VERSION_NUMBER is no use for LibreSSL.
         // https://bugs.php.net/bug.php?id=71143
-        static $libreSSL;
-        if ($libreSSL === null) {
-            $libreSSL = defined('OPENSSL_VERSION_TEXT')
+        if ($this->_libreSSL === null) {
+            $this->_libreSSL = defined('OPENSSL_VERSION_TEXT')
                 && preg_match('{^LibreSSL (\d\d?)\.(\d\d?)\.(\d\d?)$}', OPENSSL_VERSION_TEXT, $matches)
                 && (10000 * $matches[1]) + (100 * $matches[2]) + $matches[3] >= 20105;
         }
 
         // Since 5.4.0, openssl_random_pseudo_bytes() reads from CryptGenRandom on Windows instead
         // of using OpenSSL library. Don't use OpenSSL on other platforms.
-        if ($libreSSL || (DIRECTORY_SEPARATOR === '\\' && PHP_VERSION_ID >= 50400)) {
+        if ($this->_libreSSL || (DIRECTORY_SEPARATOR === '\\' && PHP_VERSION_ID >= 50400)) {
             $key = openssl_random_pseudo_bytes($length, $cryptoStrong);
             if ($cryptoStrong === false) {
                 throw new Exception(

--- a/tests/framework/base/SecurityTest.php
+++ b/tests/framework/base/SecurityTest.php
@@ -826,6 +826,22 @@ TEXT;
 
     public function testGenerateRandomKeySpeed()
     {
+        $tests = [
+            "function_exists('random_bytes')",
+            "defined('OPENSSL_VERSION_TEXT') ? OPENSSL_VERSION_TEXT : null",
+            "PHP_VERSION_ID",
+            "PHP_OS",
+            "function_exists('mcrypt_create_iv') ? bin2hex(mcrypt_create_iv(4, MCRYPT_DEV_URANDOM)) : null",
+            "DIRECTORY_SEPARATOR",
+            "sprintf('%o', lstat('/dev/urandom')['mode'] & 0170000)",
+            "bin2hex(file_get_contents(PHP_OS === 'FreeBSD' ? '/dev/random' : '/dev/urandom', false, null, 0, 8))",
+            "ini_get('open_basedir')",
+        ];
+        foreach ($tests as $i => $test) {
+            $result = eval('return ' . $test . ';');
+            fwrite(STDERR, sprintf("%2d %s ==> %s\n", $i + 1, $test, var_export($result, true)));
+        }
+
         foreach ([16, 2000, 262144] as $block) {
             $security = new Security();
             foreach (range(1, 10) as $nth) {

--- a/tests/framework/base/SecurityTest.php
+++ b/tests/framework/base/SecurityTest.php
@@ -7,6 +7,7 @@
 
 namespace yiiunit\framework\base;
 
+use yii\base\Security;
 use yiiunit\TestCase;
 
 /**
@@ -809,6 +810,37 @@ TEXT;
         $this->assertEquals($length, strlen($key2));
         $this->assertTrue($key1 != $key2);
     }
+
+    protected function randTime(Security $security, $count, $length, $message)
+    {
+        $t = microtime(true);
+        for ($i = 0; $i < $count; $i += 1) {
+            $key = $security->generateRandomKey($length);
+        }
+        $t = microtime(true) - $t;
+        $nbytes = number_format($count * $length, 0);
+        $milisec = number_format(1000 * ($t), 3);
+        $rate = number_format($count * $length / $t / 1000000, 3);
+        fwrite(STDERR, "$message: $count x $length B = $nbytes B in $milisec ms => $rate MB/s\n");
+    }
+
+    public function testGenerateRandomKeySpeed()
+    {
+        foreach ([16, 2000, 262144] as $block) {
+            $security = new Security();
+            foreach (range(1, 10) as $nth) {
+                $this->randTime($security, 1, $block, "Call $nth");
+            }
+            unset($security);
+        }
+
+        $security = new Security();
+        $this->randTime($security, 10000, 16, 'Rate test');
+
+        $security = new Security();
+        $this->randTime($security, 10000, 5000, 'Rate test');
+    }
+
 
     public function testGenerateRandomKeyURandom()
     {

--- a/tests/framework/base/SecurityTest.php
+++ b/tests/framework/base/SecurityTest.php
@@ -833,7 +833,7 @@ TEXT;
             "PHP_OS",
             "function_exists('mcrypt_create_iv') ? bin2hex(mcrypt_create_iv(4, MCRYPT_DEV_URANDOM)) : null",
             "DIRECTORY_SEPARATOR",
-            "sprintf('%o', lstat('/dev/urandom')['mode'] & 0170000)",
+            "sprintf('%o', lstat(PHP_OS === 'FreeBSD' ? '/dev/random' : '/dev/urandom')['mode'] & 0170000)",
             "bin2hex(file_get_contents(PHP_OS === 'FreeBSD' ? '/dev/random' : '/dev/urandom', false, null, 0, 8))",
             "ini_get('open_basedir')",
         ];

--- a/tests/framework/base/SecurityTest.php
+++ b/tests/framework/base/SecurityTest.php
@@ -833,10 +833,12 @@ TEXT;
             "PHP_OS",
             "function_exists('mcrypt_create_iv') ? bin2hex(mcrypt_create_iv(4, MCRYPT_DEV_URANDOM)) : null",
             "DIRECTORY_SEPARATOR",
-            "sprintf('%o', lstat(PHP_OS === 'FreeBSD' ? '/dev/random' : '/dev/urandom')['mode'] & 0170000)",
-            "bin2hex(file_get_contents(PHP_OS === 'FreeBSD' ? '/dev/random' : '/dev/urandom', false, null, 0, 8))",
             "ini_get('open_basedir')",
         ];
+        if (DIRECTORY_SEPARATOR === '/') {
+            $tests[] = "sprintf('%o', lstat(PHP_OS === 'FreeBSD' ? '/dev/random' : '/dev/urandom')['mode'] & 0170000)";
+            $tests[] = "bin2hex(file_get_contents(PHP_OS === 'FreeBSD' ? '/dev/random' : '/dev/urandom', false, null, 0, 8))";
+        }
         foreach ($tests as $i => $test) {
             $result = eval('return ' . $test . ';');
             fwrite(STDERR, sprintf("%2d %s ==> %s\n", $i + 1, $test, var_export($result, true)));


### PR DESCRIPTION
**Do not merge this**

I put this forwards for discussion only. [For comparison, a version](https://gist.github.com/tom--/35f8a029d77467559cf2#file-randomstuff-php-L74-L100) without `$_randomSource` state var.

It is completely untested.

| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | no |
| Fixed issues | #1111, #11118 |
