### PR TITLE
Batch query test

### DIFF
--- a/tests/framework/db/BatchQueryResultTest.php
+++ b/tests/framework/db/BatchQueryResultTest.php
@@ -160,13 +160,15 @@ class BatchQueryResultTest extends DatabaseTestCase
      * @var int defaults to 10 Mio records
      */
 //    protected static $largeTableCount = 10000000;
-    protected static $largeTableCount = 10000;
+    protected static $largeTableCount = 1000;
 
     /**
      * @dataProvider pdoAttributesProvider
      */
     public function testBatchHugeTable($pdoAttrs)
     {
+        $peakMemory = memory_get_peak_usage();
+
         $db = $this->getConnection(true, false);
         $this->assertFalse($db->isActive);
         $db->attributes = $pdoAttrs;
@@ -185,10 +187,10 @@ class BatchQueryResultTest extends DatabaseTestCase
         }
         Console::endProgress(true, false);
 
-        // peak memory should be less than 100MB
-        $this->assertLessThan(100 * 1024 * 1024, memory_get_peak_usage());
-        $memUsage = memory_get_peak_usage();
-        echo "batch memory: $memUsage\n";
+        // peak memory should be less than 25MB higher than before
+        $this->assertLessThan($peakMemory + 25 * 1024 * 1024, memory_get_peak_usage());
+        //$peakMemory = memory_get_peak_usage();
+        //echo "batch memory: $peakMemory\n";
 
         $query = (new Query)->select('*')->from('customer_large');
         Console::startProgress($c = 0, static::$largeTableCount, 'Running each() query... (Memory: ' . memory_get_usage() . ')');
@@ -200,10 +202,10 @@ class BatchQueryResultTest extends DatabaseTestCase
         }
         Console::endProgress(true, false);
 
-        // peak memory should be less than 100MB
-        $this->assertLessThan(100 * 1024 * 1024, memory_get_peak_usage());
-        $memUsage = memory_get_peak_usage();
-        echo "each() memory: $memUsage\n";
+        // peak memory should be less than 25MB higher than before
+        $this->assertLessThan($peakMemory + 25 * 1024 * 1024, memory_get_peak_usage());
+        //$peakMemory = memory_get_peak_usage();
+        //echo "each() memory: $peakMemory\n";
 
     }
 

--- a/tests/framework/db/pgsql/PostgreSQLBatchQueryResultTest.php
+++ b/tests/framework/db/pgsql/PostgreSQLBatchQueryResultTest.php
@@ -1,0 +1,13 @@
+<?php
+namespace yii\tests\unit\framework\db\pgsql;
+
+use yiiunit\framework\db\BatchQueryResultTest;
+
+/**
+ * @group db
+ * @group pgsql
+ */
+class PostgreSQLBatchQueryResultTest extends BatchQueryResultTest
+{
+    public $driverName = 'pgsql';
+}

--- a/tests/framework/db/sqlite/SqliteBatchQueryResultTest.php
+++ b/tests/framework/db/sqlite/SqliteBatchQueryResultTest.php
@@ -1,0 +1,14 @@
+<?php
+namespace yiiunit\framework\db\sqlite;
+
+use yiiunit\framework\db\BatchQueryResultTest;
+
+/**
+ * @group db
+ * @group sqlite
+ */
+class SqliteBatchQueryResultTest extends BatchQueryResultTest
+{
+    protected $driverName = 'sqlite';
+    public static $largeTableInsertBatch = 100;
+}


### PR DESCRIPTION
This adds a test for batch() and each() query with large table as some issues have been reported in the past. The default table will be created with 1000 records to not stress travis too much. You can try it locally by setting the table size to 100 000 or even 10 000 000. 

I was not able to reproduce the problem with this test on my machine, maybe someone else can run it and see what happens.

| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | lets wait for travis ;) |
| Related issues | #8420, #9269 |

/cc @particleflux can you try this test on your machine?
