### PR TITLE
Fixed yii\widgets\ActiveField to handle AJAX validation for inputs with changed IDs

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 -----------------------
 
 - Bug #11196: Fixed VarDumper throws PHP Fatal when dumping __PHP_Incomplete_Class (DamianZ)
+- Bug #7627: Fixed `yii\widgets\ActiveField` to handle inputs AJAX validation with changed ID properly (dizeee)
 - Bug #9851: Fixed partial commit / rollback in nested transactions (sammousa)
 - Bug #10784: Fixed `yii\grid\CheckboxColumn` to set correct value when `yii\grid\CheckboxColumn::$checkboxOptions` closure is used (nukkumatti)
 - Bug #10850: Fixed unable to use 'definitions' and 'aliases' at `yii\widgets\MaskedInput` (rahimov, klimov-paul)

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -725,7 +725,7 @@ class ActiveField extends Component
         $options = [];
 
         $inputID = $this->getInputId();
-        $options['id'] = $inputID;
+        $options['id'] = Html::getInputId($this->model, $this->attribute);
         $options['name'] = $this->attribute;
 
         $options['container'] = isset($this->selectors['container']) ? $this->selectors['container'] : ".field-$inputID";

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -17,7 +17,7 @@ use yii\web\AssetManager;
 class ActiveFieldTest extends \yiiunit\TestCase
 {
     /**
-     * @var ActiveField
+     * @var ActiveFieldExtend
      */
     private $activeField;
     /**
@@ -93,6 +93,26 @@ EOD;
 EOD;
 
         $actualValue = $this->activeField->render($content);
+        $this->assertEqualsWithoutLE($expectedValue, $actualValue);
+    }
+
+    /**
+     * @link https://github.com/yiisoft/yii2/issues/7627
+     */
+    public function testRenderWithCustomInputId()
+    {
+        $expectedValue = <<<EOD
+<div class="form-group field-custom-input-id">
+<label class="control-label" for="custom-input-id">Attribute Name</label>
+<input type="text" id="custom-input-id" class="form-control" name="DynamicModel[{$this->attributeName}]">
+
+<div class="help-block"></div>
+</div>
+EOD;
+
+        $this->activeField->inputOptions['id'] = 'custom-input-id';
+
+        $actualValue = $this->activeField->render();
         $this->assertEqualsWithoutLE($expectedValue, $actualValue);
     }
 
@@ -349,6 +369,36 @@ EOD;
     {
         $this->activeField->fileInput();
         $this->assertEquals('multipart/form-data', $this->activeField->form->options['enctype']);
+    }
+
+    /**
+     * @link https://github.com/yiisoft/yii2/issues/7627
+     */
+    public function testGetClientOptionsWithCustomInputId()
+    {
+        $this->activeField->setClientOptionsEmpty(false);
+
+        $this->activeField->model->addRule($this->attributeName, 'yiiunit\framework\widgets\TestValidator');
+        $this->activeField->inputOptions['id'] = 'custom-input-id';
+        $this->activeField->textInput();
+        $actualValue = $this->activeField->getClientOptions();
+
+        $this->assertArraySubset([
+            'id' => 'dynamicmodel-attributename',
+            'name' => $this->attributeName,
+            'container' => '.field-custom-input-id',
+            'input' => '#custom-input-id',
+        ], $actualValue);
+
+        $this->activeField->textInput(['id' => 'custom-textinput-id']);
+        $actualValue = $this->activeField->getClientOptions();
+
+        $this->assertArraySubset([
+            'id' => 'dynamicmodel-attributename',
+            'name' => $this->attributeName,
+            'container' => '.field-custom-textinput-id',
+            'input' => '#custom-textinput-id',
+        ], $actualValue);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #7627 |

If `ActiveForm::$enableClientValidation` is set to `false` and `ActiveForm::$enableAjaxValidation` is set to `true`, than validation doesn't work no more because errors returned from the ajax validation are still formatted as `{"model-attribute": ["Error"]}`, but the attribute id in clientOptions is now set to `customid`, not `model-attribute`, so the script doesn't see the attribute errors in the response. I think the proper code in \yii\widgets\ActiveField::getClientOptions() should be:

```
$inputID = $this->getInputId();
$options['id'] = Html::getInputId($this->model, $this->attribute);
// not $options['id'] = $inputID
```

I'll tinker a bit with it and make a pull request if I'll find this working for both client and ajax validation.
Fix for the #7627 was already made by @dynasource and @cebe and the issue was closed, but it fixed only client validation while AJAX validation was left broken.
