### PR TITLE
Issue 11088 field not quoted in joinwith condition

### DIFF
--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -169,7 +169,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             if ($this->via instanceof self) {
                 // via junction table
                 $viaModels = $this->via->findJunctionRows([$this->primaryModel]);
-                $this->filterByModels($viaModels);
+                $this->filterByModels($viaModels, $builder);
             } elseif (is_array($this->via)) {
                 // via relation
                 /* @var $viaQuery ActiveQuery */
@@ -182,9 +182,9 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                     $this->primaryModel->populateRelation($viaName, $model);
                     $viaModels = $model === null ? [] : [$model];
                 }
-                $this->filterByModels($viaModels);
+                $this->filterByModels($viaModels, $builder);
             } else {
-                $this->filterByModels([$this->primaryModel]);
+                $this->filterByModels([$this->primaryModel], $builder);
             }
 
             $query = Query::create($this);

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -419,9 +419,10 @@ trait ActiveRelationTrait
 
     /**
      * @param array $attributes the attributes to prefix
+     * @param QueryBuilder|null $builder
      * @return array
      */
-    private function prefixKeyColumns($attributes)
+    private function prefixKeyColumns($attributes, $builder = null)
     {
         if ($this instanceof ActiveQuery && (!empty($this->join) || !empty($this->joinWith))) {
             if (empty($this->from)) {
@@ -438,6 +439,11 @@ trait ActiveRelationTrait
             }
             if (isset($alias)) {
                 foreach ($attributes as $i => $attribute) {
+
+                    if (!empty($builder)) {
+                        $attribute = $builder->db->quoteColumnName($attribute);
+                    }
+
                     $attributes[$i] = "$alias.$attribute";
                 }
             }
@@ -447,12 +453,13 @@ trait ActiveRelationTrait
 
     /**
      * @param array $models
+     * @param QueryBuilder|null $builder
      */
-    private function filterByModels($models)
+    private function filterByModels($models, $builder = null)
     {
         $attributes = array_keys($this->link);
 
-        $attributes = $this->prefixKeyColumns($attributes);
+        $attributes = $this->prefixKeyColumns($attributes, $builder);
 
         $values = [];
         if (count($attributes) === 1) {

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -12,9 +12,11 @@ namespace yiiunit\data\ar;
  */
 class Order extends ActiveRecord
 {
+    public static $tableName;
+
     public static function tableName()
     {
-        return 'order';
+        return static::$tableName ?: 'order';
     }
 
     public function getCustomer()

--- a/tests/data/ar/OrderItem.php
+++ b/tests/data/ar/OrderItem.php
@@ -12,9 +12,11 @@ namespace yiiunit\data\ar;
  */
 class OrderItem extends ActiveRecord
 {
+    public static $tableName;
+
     public static function tableName()
     {
-        return 'order_item';
+        return static::$tableName ?: 'order_item';
     }
 
     public function getOrder()

--- a/tests/framework/db/DatabaseTestCase.php
+++ b/tests/framework/db/DatabaseTestCase.php
@@ -89,4 +89,26 @@ abstract class DatabaseTestCase extends TestCase
         }
         return $db;
     }
+
+    /**
+     * adjust dbms specific escaping
+     * @param $sql
+     * @return mixed
+     */
+    protected function replaceQuotes($sql)
+    {
+        switch ($this->driverName) {
+            case 'mysql':
+            case 'sqlite':
+                return str_replace(['[[', ']]'], '`', $sql);
+            case 'cubrid':
+            case 'pgsql':
+            case 'oci':
+                return str_replace(['[[', ']]'], '"', $sql);
+            case 'sqlsrv':
+                return str_replace(['[[', ']]'], ['[', ']'], $sql);
+            default:
+                return $sql;
+        }
+    }
 }

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -55,28 +55,6 @@ class QueryBuilderTest extends DatabaseTestCase
     }
 
     /**
-     * adjust dbms specific escaping
-     * @param $sql
-     * @return mixed
-     */
-    protected function replaceQuotes($sql)
-    {
-        switch ($this->driverName) {
-            case 'mysql':
-            case 'sqlite':
-                return str_replace(['[[', ']]'], '`', $sql);
-            case 'cubrid':
-            case 'pgsql':
-            case 'oci':
-                return str_replace(['[[', ']]'], '"', $sql);
-            case 'sqlsrv':
-                return str_replace(['[[', ']]'], ['[', ']'], $sql);
-            default:
-                return $sql;
-        }
-    }
-
-    /**
      * this is not used as a dataprovider for testGetColumnType to speed up the test
      * when used as dataprovider every single line will cause a reconnect with the database which is not needed here
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no? |
| Tests pass? | yes (tested only with pgsql) |
| Fixed issues | #11088; #11135 |

The only solution I found: it looks ugly, but must not break BC. Should be tested with other db-drivers and, probably, in other cases.
