### PR TITLE
Multidimensional Superglobals in request

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -440,7 +440,18 @@ class Request extends \yii\base\Request
     {
         $params = $this->getBodyParams();
 
-        return isset($params[$name]) ? $params[$name] : $defaultValue;
+        if (is_array($name)) {
+            foreach ($name as $n) {
+                if (isset($params[$n])) {
+                    $params = $params[$n];
+                } else {
+                    return $defaultValue;
+                }
+            }
+            return $params;
+        } else {
+            return isset($params[$name]) ? $params[$name] : $defaultValue;
+        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes (also used for months in large live environment) |
| Fixed issues | Multidimensional Superglobals can now be written/read |

Currently, users can only read one dimensional $_GET $_POST etc.. SUPERGLOBALS. Such as 

`Yii::$app->request->post('item');`

With this change users can also read multidimensional GET/POST etc..

An array can be provided as parameter now:

`Yii::$app->request->post(['item', 'description'])`

or

`Yii::$app->request->get(['user', 'profile', 'name'])`

There is no limit (outside HTML form HTTP header limitations) on the depth of dimensions that can be accessed.

**Most importantly: The current functionality is fully maintained, this addition only extends with new functionality.**
