### PR TITLE
Fixing VarDumper for throwing PHP Fatal when dumping __PHP_Incomplete…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.8 under development
 -----------------------
 
+- Bug #11196: Fixed VarDumper throws PHP Fatal when dumping __PHP_Incomplete_Class (DamianZ)
 - Bug #9851: Fixed partial commit / rollback in nested transactions (sammousa)
 - Bug #10784: Fixed `yii\grid\CheckboxColumn` to set correct value when `yii\grid\CheckboxColumn::$checkboxOptions` closure is used (nukkumatti)
 - Bug #10850: Fixed unable to use 'definitions' and 'aliases' at `yii\widgets\MaskedInput` (rahimov, klimov-paul)

--- a/framework/helpers/BaseVarDumper.php
+++ b/framework/helpers/BaseVarDumper.php
@@ -117,7 +117,7 @@ class BaseVarDumper
                     $className = get_class($var);
                     $spaces = str_repeat(' ', $level * 4);
                     self::$_output .= "$className#$id\n" . $spaces . '(';
-                    if (method_exists($var, '__debugInfo')) {
+                    if ('__PHP_Incomplete_Class' !== get_class($var) && method_exists($var, '__debugInfo')) {
                         $dumpValues = $var->__debugInfo();
                         if (!is_array($dumpValues)) {
                             throw new InvalidValueException('__debuginfo() must return an array');
@@ -208,7 +208,7 @@ class BaseVarDumper
                             }
                             self::exportInternal($varAsArray, $level);
                             return;
-                        } elseif (method_exists($var, '__toString')) {
+                        } elseif ('__PHP_Incomplete_Class' !== get_class($var) && method_exists($var, '__toString')) {
                             $output = var_export($var->__toString(), true);
                         } else {
                             $outputBackup = self::$_output;

--- a/tests/framework/helpers/VarDumperTest.php
+++ b/tests/framework/helpers/VarDumperTest.php
@@ -10,6 +10,23 @@ use yiiunit\TestCase;
  */
 class VarDumperTest extends TestCase
 {
+    public function testDumpIncompleteObject()
+    {
+        $serializedObj = 'O:16:"nonExistingClass":0:{}';
+        $incompleteObj = unserialize($serializedObj);
+        $dumpResult = VarDumper::dumpAsString($incompleteObj);
+        $this->assertContains("__PHP_Incomplete_Class#1\n(", $dumpResult);
+        $this->assertContains("nonExistingClass", $dumpResult);
+    }
+
+    public function testExportIncompleteObject()
+    {
+        $serializedObj = 'O:16:"nonExistingClass":0:{}';
+        $incompleteObj = unserialize($serializedObj);
+        $exportResult = VarDumper::export($incompleteObj);
+        $this->assertContains("nonExistingClass", $exportResult);
+    }
+    
     public function testDumpObject()
     {
         $obj = new \StdClass();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11196 |
