### PR TITLE
Fixed `quoteColumnName` for table start with `{{` or `[[`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -25,6 +25,7 @@ Yii Framework 2 Change Log
 - Bug #11188: Fixed wrong index usage in `CaptchaAction` when calling `imagefilledrectangle` (alsopub)
 - Bug #11221: Boolean validator generates incorrect error message (azaikin, githubjeka)
 - Bug: SQlite querybuilder did not create primary key with bigint for `TYPE_BIGPK` (cebe)
+- Bug: Fixed `quoteColumnName` for table start with `{{` or `[[` (edgardmessias)
 - Enh #5469: Add mimetype validation by mask in FileValidator (kirsenn, samdark, silverfire)
 - Enh #8145, #8139, #10234 #11153: `yii\validators\Validator::$attributes` property now supports `!attribute` notation to validate attribute, but do not mark it as safe (mdmunir)
 - Enh #8602: `yii\validators\DateValidator` skip validation for `timestampAttribute`, if it is already in correct format (klimov-paul)

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -522,7 +522,7 @@ abstract class Schema extends Object
      */
     public function quoteColumnName($name)
     {
-        if (strpos($name, '(') !== false || strpos($name, '[[') !== false || strpos($name, '{{') !== false) {
+        if (strpos($name, '(') !== false) {
             return $name;
         }
         if (($pos = strrpos($name, '.')) !== false) {
@@ -530,6 +530,10 @@ abstract class Schema extends Object
             $name = substr($name, $pos + 1);
         } else {
             $prefix = '';
+        }
+
+        if (strpos($name, '[[') !== false || strpos($name, '{{') !== false) {
+            return $prefix . $name;
         }
 
         return $prefix . $this->quoteSimpleColumnName($name);

--- a/tests/framework/db/ConnectionTest.php
+++ b/tests/framework/db/ConnectionTest.php
@@ -88,6 +88,9 @@ class ConnectionTest extends DatabaseTestCase
         $this->assertEquals('`table`.`column`', $connection->quoteColumnName('table.`column`'));
         $this->assertEquals('[[column]]', $connection->quoteColumnName('[[column]]'));
         $this->assertEquals('{{column}}', $connection->quoteColumnName('{{column}}'));
+        $this->assertEquals('{{table}}.`column`', $connection->quoteColumnName('{{table}}.column'));
+        $this->assertEquals('{{table}}.`column`', $connection->quoteColumnName('{{table}}.`column`'));
+        $this->assertEquals('{{table}}.[[column]]', $connection->quoteColumnName('{{table}}.[[column]]'));
         $this->assertEquals('(column)', $connection->quoteColumnName('(column)'));
     }
 

--- a/tests/framework/db/cubrid/CubridConnectionTest.php
+++ b/tests/framework/db/cubrid/CubridConnectionTest.php
@@ -39,6 +39,9 @@ class CubridConnectionTest extends ConnectionTest
         $this->assertEquals('"table"."column"', $connection->quoteColumnName('table."column"'));
         $this->assertEquals('[[column]]', $connection->quoteColumnName('[[column]]'));
         $this->assertEquals('{{column}}', $connection->quoteColumnName('{{column}}'));
+        $this->assertEquals('{{table}}."column"', $connection->quoteColumnName('{{table}}.column'));
+        $this->assertEquals('{{table}}."column"', $connection->quoteColumnName('{{table}}."column"'));
+        $this->assertEquals('{{table}}.[[column]]', $connection->quoteColumnName('{{table}}.[[column]]'));
         $this->assertEquals('(column)', $connection->quoteColumnName('(column)'));
     }
 }

--- a/tests/framework/db/mssql/MssqlConnectionTest.php
+++ b/tests/framework/db/mssql/MssqlConnectionTest.php
@@ -40,6 +40,9 @@ class MssqlConnectionTest extends ConnectionTest
         $this->assertEquals('[table].[column]', $connection->quoteColumnName('table.[column]'));
         $this->assertEquals('[[column]]', $connection->quoteColumnName('[[column]]'));
         $this->assertEquals('{{column}}', $connection->quoteColumnName('{{column}}'));
+        $this->assertEquals('{{table}}.[column]', $connection->quoteColumnName('{{table}}.column'));
+        $this->assertEquals('{{table}}.[column]', $connection->quoteColumnName('{{table}}.[column]'));
+        $this->assertEquals('{{table}}.[[column]]', $connection->quoteColumnName('{{table}}.[[column]]'));
         $this->assertEquals('(column)', $connection->quoteColumnName('(column)'));
     }
 }

--- a/tests/framework/db/pgsql/PostgreSQLConnectionTest.php
+++ b/tests/framework/db/pgsql/PostgreSQLConnectionTest.php
@@ -47,6 +47,9 @@ class PostgreSQLConnectionTest extends ConnectionTest
         $this->assertEquals('"table"."column"', $connection->quoteColumnName('"table"."column"'));
         $this->assertEquals('[[column]]', $connection->quoteColumnName('[[column]]'));
         $this->assertEquals('{{column}}', $connection->quoteColumnName('{{column}}'));
+        $this->assertEquals('{{table}}."column"', $connection->quoteColumnName('{{table}}.column'));
+        $this->assertEquals('{{table}}."column"', $connection->quoteColumnName('{{table}}."column"'));
+        $this->assertEquals('{{table}}.[[column]]', $connection->quoteColumnName('{{table}}.[[column]]'));
         $this->assertEquals('(column)', $connection->quoteColumnName('(column)'));
     }
 

--- a/tests/framework/db/sqlite/SqliteConnectionTest.php
+++ b/tests/framework/db/sqlite/SqliteConnectionTest.php
@@ -47,6 +47,8 @@ class SqliteConnectionTest extends ConnectionTest
         $this->assertEquals("`table`.`column`", $connection->quoteColumnName('table.column'));
         $this->assertEquals('[[column]]', $connection->quoteColumnName('[[column]]'));
         $this->assertEquals('{{column}}', $connection->quoteColumnName('{{column}}'));
+        $this->assertEquals('{{table}}.`column`', $connection->quoteColumnName('{{table}}.column'));
+        $this->assertEquals('{{table}}.[[column]]', $connection->quoteColumnName('{{table}}.[[column]]'));
         $this->assertEquals('(column)', $connection->quoteColumnName('(column)'));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11088; #11135 |
