### PR TITLE
Enhanced RBAC Rule assignment

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -47,6 +47,7 @@ Yii Framework 2 Change Log
 - Enh #11137: Added weak ETag support to `yii\filters\HttpCache`. It could be turned on via setting `$weakEtag` to `true` (particleflux)
 - Enh #11139: `yii\validators\EachValidator` injects specific attribute value in error message parameters (silverfire)
 - Enh #11187: migrate command now generates phpdoc for table migrations (Faryshta)
+- Enh #11254: Added ability to attach RBAC rule using class name (mdmunir)
 - Enh: Added `StringHelper::countWords()` that given a string returns number of words in it (samdark)
 - Chg: HTMLPurifier dependency updated to `~4.6` (samdark)
 - Chg #10726: Added `yii\rbac\ManagerInterface::canAddChild()` (dkhlystov, samdark)

--- a/framework/rbac/BaseManager.php
+++ b/framework/rbac/BaseManager.php
@@ -115,7 +115,7 @@ abstract class BaseManager extends Component implements ManagerInterface
     public function add($object)
     {
         if ($object instanceof Item) {
-            if($object->ruleName && $this->getRule($object->ruleName) === null){
+            if ($object->ruleName && $this->getRule($object->ruleName) === null) {
                 $rule = \Yii::createObject($object->ruleName);
                 $rule->name = $object->ruleName;
                 $this->addRule($rule);
@@ -148,7 +148,7 @@ abstract class BaseManager extends Component implements ManagerInterface
     public function update($name, $object)
     {
         if ($object instanceof Item) {
-            if($object->ruleName && $this->getRule($object->ruleName) === null){
+            if ($object->ruleName && $this->getRule($object->ruleName) === null) {
                 $rule = \Yii::createObject($object->ruleName);
                 $rule->name = $object->ruleName;
                 $this->addRule($rule);

--- a/framework/rbac/BaseManager.php
+++ b/framework/rbac/BaseManager.php
@@ -115,6 +115,11 @@ abstract class BaseManager extends Component implements ManagerInterface
     public function add($object)
     {
         if ($object instanceof Item) {
+            if($object->ruleName && $this->getRule($object->ruleName) === null){
+                $rule = \Yii::createObject($object->ruleName);
+                $rule->name = $object->ruleName;
+                $this->addRule($rule);
+            }
             return $this->addItem($object);
         } elseif ($object instanceof Rule) {
             return $this->addRule($object);
@@ -143,6 +148,11 @@ abstract class BaseManager extends Component implements ManagerInterface
     public function update($name, $object)
     {
         if ($object instanceof Item) {
+            if($object->ruleName && $this->getRule($object->ruleName) === null){
+                $rule = \Yii::createObject($object->ruleName);
+                $rule->name = $object->ruleName;
+                $this->addRule($rule);
+            }
             return $this->updateItem($name, $object);
         } elseif ($object instanceof Rule) {
             return $this->updateRule($name, $object);

--- a/tests/framework/rbac/ActionRule.php
+++ b/tests/framework/rbac/ActionRule.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace yiiunit\framework\rbac;
+
+/**
+ * Description of ActionRule
+ */
+class ActionRule extends \yii\rbac\Rule
+{
+    public $name = 'action_rule';
+    public $action = 'read';
+    public function execute($user, $item, $params)
+    {
+        return $this->action === 'all' || $this->action === $params['action'];
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11254 |

Directly attach rule with it class name

``` php
$role = $auth->createRole('Reader');
$role->ruleName = 'app\rbac\ActionRule';
$auth->add($role);

// using DI
Yii::$container->set('write_rule', ['class' => 'app\rbac\ActionRule', 'action' => 'write']);
$role = $auth->createRole('Writer');
$role->ruleName = 'write_rule';
$auth->add($role);
```
