### PR TITLE
Enable use of yii2 inside of PHAR packaged console applications

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.8 under development
 -----------------------
 
+- Bug #11262: Enabled use of yii2 inside of PHAR packaged console applications (hiqsol)
 - Bug #11196: Fixed VarDumper throws PHP Fatal when dumping __PHP_Incomplete_Class (DamianZ)
 - Bug #9851: Fixed partial commit / rollback in nested transactions (sammousa)
 - Bug #10784: Fixed `yii\grid\CheckboxColumn` to set correct value when `yii\grid\CheckboxColumn::$checkboxOptions` closure is used (nukkumatti)

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -217,7 +217,7 @@ class Module extends ServiceLocator
     public function setBasePath($path)
     {
         $path = Yii::getAlias($path);
-        $p = realpath($path);
+        $p = strncmp($path, 'phar://', 7) === 0 ? $path : realpath($path);
         if ($p !== false && is_dir($p)) {
             $this->_basePath = $p;
         } else {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |

This fix doesn't solve the PHAR question completely but fixes the main stopper.
Unfortunately `realpath` is not suitable for `phar://` pathes [PHPBUG#52769](https://bugs.php.net/bug.php?id=52769)
