### PR TITLE
Security enhancements

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -51,6 +51,10 @@ Yii Framework 2 Change Log
 - Enh #11139: `yii\validators\EachValidator` injects specific attribute value in error message parameters (silverfire)
 - Enh #11187: migrate command now generates phpdoc for table migrations (Faryshta)
 - Enh #11254: Added ability to attach RBAC rule using class name (mdmunir)
+- Enh #11285: `yii\base\Security` enhancements (tom--, samdark)
+  - Avoid reading too much from `/dev/urandom` and `/dev/random` not to waste entropy.
+  - Pefer `/dev/random` to `/dev/urandom` when running on FreeBSD.
+  - Better RNG performance.
 - Enh: Added `StringHelper::countWords()` that given a string returns number of words in it (samdark)
 - Enh #11207: migrate command can create foreign keys. (faryshta)
 - Chg: HTMLPurifier dependency updated to `~4.6` (samdark)

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -427,7 +427,7 @@ class Security extends Component
         return false;
     }
 
-    private $_libreSSL;
+    private $_useLibreSSL;
     private $_randomFile;
 
     /**

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -423,15 +423,8 @@ class Security extends Component
         return false;
     }
 
-    const DEV_URANDOM = '/dev/urandom';
-    const SOURCE_LIBRE_SSL = 'LibreSSL';
-    const SOURCE_MCRYPT = 'mcrypt';
-    const SOURCE_OPEN_SSL = 'OpenSSL';
-    const SOURCE_URANDOM = 'urandom';
-    /**
-     * @var string|null Identifies the random source of the last successful call of [[generateRandomKey]].
-     */
-    private $_randomSource;
+    private $_libreSSL;
+    private $_randomFile;
 
     /**
      * Generates specified number of random bytes.
@@ -456,73 +449,24 @@ class Security extends Component
             throw new InvalidParamException('First parameter ($length) must be greater than 0');
         }
 
-        // The recent LibreSSL RNGs are faster and better than /dev/urandom.
+        // The recent LibreSSL RNGs are faster and likely better than /dev/urandom.
         // Parse OPENSSL_VERSION_TEXT because OPENSSL_VERSION_NUMBER is no use for LibreSSL.
         // https://bugs.php.net/bug.php?id=71143
-        if ($this->_randomSource === self::SOURCE_LIBRE_SSL
-            || ($this->_randomSource === null
-                && defined('OPENSSL_VERSION_TEXT')
+        if ($this->_libreSSL === null) {
+            $this->_libreSSL = defined('OPENSSL_VERSION_TEXT')
                 && preg_match('{^LibreSSL (\d\d?)\.(\d\d?)\.(\d\d?)$}', OPENSSL_VERSION_TEXT, $matches)
-                && (10000 * $matches[1]) + (100 * $matches[2]) + $matches[3] >= 20105)
-        ) {
-            $key = openssl_random_pseudo_bytes($length, $cryptoStrong);
-            if ($cryptoStrong === false) {
-                throw new Exception(
-                    'openssl_random_pseudo_bytes() set $crypto_strong false. Your PHP setup is insecure.'
-                );
-            }
-            if ($key !== false && StringHelper::byteLength($key) === $length) {
-                $this->_randomSource = self::SOURCE_LIBRE_SSL;
-
-                return $key;
-            }
-
-            $this->_randomSource = null;
-        }
-
-        // mcrypt_create_iv() does not use libmcrypt. Since PHP 5.3.7 it directly reads
-        // CrypGenRandom on Windows. Elsewhere it directly reads /dev/urandom.
-        if ($this->_randomSource === self::SOURCE_MCRYPT
-            || ($this->_randomSource === null
-                && PHP_VERSION_ID >= 50307
-                && function_exists('mcrypt_create_iv'))
-        ) {
-            $key = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
-            if (StringHelper::byteLength($key) === $length) {
-                $this->_randomSource = self::SOURCE_MCRYPT;
-
-                return $key;
-            }
-
-            $this->_randomSource = null;
-        }
-
-        // If not on Windows, test for a /dev/urandom device.
-        if ($this->_randomSource === null && DIRECTORY_SEPARATOR === '/') {
-            // Check it for speacial character device protection mode. Do not follow
-            // symbolic link at '/dev/urandom', as such would be suspicious. With lstat()
-            // (as opposed to stat()) the test fails if it is.
-            $lstat = @lstat(self::DEV_URANDOM);
-            $urandomDevice = $lstat !== false && ($lstat['mode'] & 0170000) === 020000;
-        } else {
-            $urandomDevice = false;
-        }
-        if ($this->_randomSource === self::SOURCE_URANDOM || $urandomDevice) {
-            $key = @file_get_contents(self::DEV_URANDOM, false, null, 0, $length);
-
-            if ($key !== false && StringHelper::byteLength($key) === $length) {
-                $this->_randomSource = self::SOURCE_URANDOM;
-
-                return $key;
-            }
-
-            $this->_randomSource = null;
+                && (10000 * $matches[1]) + (100 * $matches[2]) + $matches[3] >= 20105;
         }
 
         // Since 5.4.0, openssl_random_pseudo_bytes() reads from CryptGenRandom on Windows instead
-        // of using OpenSSL library. Don't use OpenSSL on other platforms.
-        if ($this->_randomSource === self::SOURCE_OPEN_SSL
-            || (DIRECTORY_SEPARATOR !== '/' && PHP_VERSION_ID >= 50400)
+        // of using OpenSSL library. LibreSSL is ok everywhere but don't use OpenSSL on non-Windows.
+        if ($this->_libreSSL
+            || (
+                DIRECTORY_SEPARATOR !== '/'
+                && PHP_VERSION_ID >= 50400
+                && substr_compare(PHP_OS, 'win', 0, 3, true) === 0
+                && function_exists('openssl_random_pseudo_bytes')
+            )
         ) {
             $key = openssl_random_pseudo_bytes($length, $cryptoStrong);
             if ($cryptoStrong === false) {
@@ -531,12 +475,47 @@ class Security extends Component
                 );
             }
             if ($key !== false && StringHelper::byteLength($key) === $length) {
-                $this->_randomSource = self::SOURCE_OPEN_SSL;
-
                 return $key;
             }
+        }
 
-            $this->_randomSource = null;
+        // mcrypt_create_iv() does not use libmcrypt. Since PHP 5.3.7 it directly reads
+        // CryptGenRandom on Windows. Elsewhere it directly reads /dev/urandom.
+        if (PHP_VERSION_ID >= 50307 && function_exists('mcrypt_create_iv')) {
+            $key = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
+            if (StringHelper::byteLength($key) === $length) {
+                return $key;
+            }
+        }
+
+        // If not on Windows, try to open a random device.
+        if ($this->_randomFile === null && DIRECTORY_SEPARATOR === '/') {
+            // urandom is a symlink to random on FreeBSD.
+            $device = PHP_OS === 'FreeBSD' ? '/dev/random' : '/dev/urandom';
+            // Check random device for special character device protection mode. Use lstat()
+            // instead of stat() in case an attacker arranges a symlink to a fake device.
+            $lstat = @lstat($device);
+            if ($lstat !== false && ($lstat['mode'] & 0170000) === 020000) {
+                $this->_randomFile = fopen($device, 'r') ?: null;
+            }
+        }
+
+        if (is_resource($this->_randomFile)) {
+            $buffer = '';
+            $stillNeed = $length;
+            while ($stillNeed > 0) {
+                $someBytes = fread($this->_randomFile, $stillNeed);
+                if ($someBytes === false) {
+                    break;
+                }
+                $buffer .= $someBytes;
+                $stillNeed = $length - StringHelper::byteLength($buffer);
+                if ($stillNeed === 0) {
+                    return $buffer;
+                }
+            }
+            fclose($this->_randomFile);
+            $this->_randomFile = null;
         }
 
         throw new Exception('Unable to generate a random key');


### PR DESCRIPTION
Based on @tom-- #11146 with `fread` commit applied on top. I've made some changes:
- Removed PHP version checks since both are met by default because Yii requires 5.4.0+.
- Limit PHP fread buffer in order to prevent entropy wasting.
- Fixed incorrect bytes to read calculation.
- Added more notes explaining decisions.

| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | no |
| Fixed issues | #11111, #11146 |
