### PR TITLE
(fix) UrlManager not cached rules correctly.

### DIFF
--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -335,14 +335,9 @@ class UrlManager extends Component
             }
 
             if ($url === false) {
-                $cacheable = true;
                 foreach ($this->rules as $rule) {
-                    if (!empty($rule->defaults) && $rule->mode !== UrlRule::PARSING_ONLY) {
-                        // if there is a rule with default values involved, the matching result may not be cached
-                        $cacheable = false;
-                    }
                     if (($url = $rule->createUrl($this, $route, $params)) !== false) {
-                        if ($cacheable) {
+                        if (false === (!empty($rule->defaults) && $rule->mode !== UrlRule::PARSING_ONLY)) {
                             $this->_ruleCache[$cacheKey][] = $rule;
                         }
                         break;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | no |
| Fixed issues |  |

It's appears when UrlManager processing rule with defaults or parsingOnly attributes.
