### PR TITLE
Multidimensional Request Superglobals

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -440,7 +440,18 @@ class Request extends \yii\base\Request
     {
         $params = $this->getBodyParams();
 
-        return isset($params[$name]) ? $params[$name] : $defaultValue;
+        if (is_array($name)) {
+            foreach ($name as $n) {
+                if (isset($params[$n])) {
+                    $params = $params[$n];
+                } else {
+                    return $defaultValue;
+                }
+            }
+            return $params;
+        } else {
+            return isset($params[$name]) ? $params[$name] : $defaultValue;
+        }
     }
 
     /**
@@ -516,7 +527,18 @@ class Request extends \yii\base\Request
     {
         $params = $this->getQueryParams();
 
-        return isset($params[$name]) ? $params[$name] : $defaultValue;
+        if (is_array($name)) {
+            foreach ($name AS $n) {
+                if (isset($params[$n])) {
+                    $params = $params[$n];
+                } else {
+                    return $defaultValue;
+                }
+            }
+            return $params;
+        } else {
+            return isset($params[$name]) ? $params[$name] : $defaultValue;
+        }
     }
 
     private $_hostInfo;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | no |
| Fixed issues |  |
- Ability to read out multidimensional GET POST Superglobals
- Keeps current functionality by extending it
- Works by passing an array parameter instead of the usual string

Usage:

$_GET['item']['description'][0] now becomes:

Yii::$app->request->get(['item', 'description', '0']);

$_POST['test'] Stays:

Yii::$app->request->post('test');
