### PR TITLE
Enh new property `skipUpdateOnClean` for `AttributeBehavior`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -56,7 +56,7 @@ Yii Framework 2 Change Log
 - Enh: Added `StringHelper::countWords()` that given a string returns number of words in it (samdark)
 - Enh #11207: migrate command can create foreign keys. (Faryshta)
 - Enh #11166: migrate command new option `useTablePrefix` (Faryshta)
-- Enh #11207: migrate command can create foreign keys. (faryshta)
+- Enh #11002: `AttributeBehavior::$skipUpdateOnClean` which determines whether to skip a behavior when the behavior owner has not been modified (Faryshta)
 - Chg #11283: `ActiveRecord::unlink()` is not setting FK to `null` before deleting itself anymore (samdark)
 - Chg: HTMLPurifier dependency updated to `~4.6` (samdark)
 - Chg #10726: Added `yii\rbac\ManagerInterface::canAddChild()` (dkhlystov, samdark)

--- a/framework/behaviors/AttributeBehavior.php
+++ b/framework/behaviors/AttributeBehavior.php
@@ -11,6 +11,7 @@ use Yii;
 use Closure;
 use yii\base\Behavior;
 use yii\base\Event;
+use yii\db\ActiveRecord;
 
 /**
  * AttributeBehavior automatically assigns a specified value to one or multiple attributes of an ActiveRecord
@@ -61,6 +62,7 @@ class AttributeBehavior extends Behavior
      * ```
      */
     public $attributes = [];
+
     /**
      * @var mixed the value that will be assigned to the current attributes. This can be an anonymous function,
      * callable in array format (e.g. `[$this, 'methodName']`), an [[Expression]] object representing a DB expression
@@ -77,13 +79,21 @@ class AttributeBehavior extends Behavior
      */
     public $value;
 
+    /**
+     * @var boolean wheter to skip this behavior when the `$owner` has not been
+     * modified
+     */
+    public $skipUpdateOnClean = true;
 
     /**
      * @inheritdoc
      */
     public function events()
     {
-        return array_fill_keys(array_keys($this->attributes), 'evaluateAttributes');
+        return array_fill_keys(
+            array_keys($this->attributes),
+            'evaluateAttributes'
+        );
     }
 
     /**
@@ -92,6 +102,13 @@ class AttributeBehavior extends Behavior
      */
     public function evaluateAttributes($event)
     {
+        if ($this->skipUpdateOnClean
+            && $event->name == ActiveRecord::EVENT_BEFORE_UPDATE
+            && empty($this->owner->dirtyAttributes)
+        ) {
+            return;
+        }
+
         if (!empty($this->attributes[$event->name])) {
             $attributes = (array) $this->attributes[$event->name];
             $value = $this->getValue($event);

--- a/framework/behaviors/AttributeBehavior.php
+++ b/framework/behaviors/AttributeBehavior.php
@@ -80,8 +80,9 @@ class AttributeBehavior extends Behavior
     public $value;
 
     /**
-     * @var boolean wheter to skip this behavior when the `$owner` has not been
+     * @var boolean whether to skip this behavior when the `$owner` has not been
      * modified
+     * @since 2.0.8
      */
     public $skipUpdateOnClean = true;
 

--- a/tests/framework/behaviors/TimestampBehaviorTest.php
+++ b/tests/framework/behaviors/TimestampBehaviorTest.php
@@ -100,10 +100,33 @@ class TimestampBehaviorTest extends TestCase
         $this->assertTrue($model->updated_at >= $currentTime, 'Update time has NOT been set on update!');
     }
 
+    /**
+     * @depends testNewRecord
+     */
+    public function testUpdateCleanRecord()
+    {
+        $currentTime = time();
+
+        ActiveRecordTimestamp::$behaviors = [
+            TimestampBehavior::className(),
+        ];
+        $model = new ActiveRecordTimestamp();
+        $model->save(false);
+
+        $model->on(
+            ActiveRecordTimestamp::EVENT_AFTER_UPDATE,
+            function ($event) {
+                $this->assertEmpty($event->changedAttributes);
+            }
+        );
+
+        $model->save(false);
+    }
+
     public function expressionProvider()
     {
         return [
-            [function() { return '2015-01-01'; }, '2015-01-01'],
+            [function () { return '2015-01-01'; }, '2015-01-01'],
             [new Expression("strftime('%Y')"), date('Y')],
             ['2015-10-20', '2015-10-20'],
             [time(), time()],


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | kind of |
| New feature? | yes |
| Breaks BC? | yes |
| Tests pass? | yes (new test added) |
| Fixed issues | #11002 |

Break BC since before this patch `$model->save()` would always execute an update query even when no  attributes were edited.
