### PR TITLE
Generate the javascript to validate the client only when really necessary

### DIFF
--- a/framework/validators/RequiredValidator.php
+++ b/framework/validators/RequiredValidator.php
@@ -88,6 +88,10 @@ class RequiredValidator extends Validator
      */
     public function clientValidateAttribute($model, $attribute, $view)
     {
+        if ($this->whenClient === null && $this->when !== null && !call_user_func($this->when, $model, $attribute)) {
+            return null;
+        }
+
         $options = [];
         if ($this->requiredValue !== null) {
             $options['message'] = Yii::$app->getI18n()->format($this->message, [


### PR DESCRIPTION
When we use the `RequiredValidator->when` and `RequiredValidator->whenClient`, we want to decide whether the field is required or not.

However, the generation of validation javascript code does not respect the rule when we have only the `RequiredValidator->when` set. Then the client will always validate the field as required.

In this PR, the validation on the client is only done when there is no `RequiredValidator->whenClient` rule and, having the `RequiredValidator->when` rule, the field is mandatory.

| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #7540 #7546 |
