### PR TITLE
fixes #11333 avoid serializing php7 errors

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #9935: Fixed `yii\validators\EachValidator` does not invoke `validateAttribute()` method of the embedded validator (klimov-paul)
 - Bug #11270: Fixed `BaseActiveRecord::link()` method in order to support closure in `indexBy` for relations declaration (iushev)
+- Bug #11333: Avoid serializing PHP 7 errors (zuozp8)
 - Bug #11262: Enabled use of yii2 inside of PHAR packaged console applications (hiqsol)
 - Bug #11196: Fixed VarDumper throws PHP Fatal when dumping `__PHP_Incomplete_Class` (DamianZ)
 - Bug #7627: Fixed `yii\widgets\ActiveField` to handle inputs AJAX validation with changed ID properly (dizeee)

--- a/framework/log/DbTarget.php
+++ b/framework/log/DbTarget.php
@@ -68,7 +68,7 @@ class DbTarget extends Target
             list($text, $level, $category, $timestamp) = $message;
             if (!is_string($text)) {
                 // exceptions may not be serializable if in the call stack somewhere is a Closure
-                if ($text instanceof \Exception) {
+                if ($text instanceof \Throwable || $text instanceof \Exception) {
                     $text = (string) $text;
                 } else {
                     $text = VarDumper::export($text);

--- a/framework/log/SyslogTarget.php
+++ b/framework/log/SyslogTarget.php
@@ -61,7 +61,7 @@ class SyslogTarget extends Target
         $level = Logger::getLevelName($level);
         if (!is_string($text)) {
             // exceptions may not be serializable if in the call stack somewhere is a Closure
-            if ($text instanceof \Exception) {
+            if ($text instanceof \Throwable || $text instanceof \Exception) {
                 $text = (string) $text;
             } else {
                 $text = VarDumper::export($text);

--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -239,7 +239,7 @@ abstract class Target extends Component
         $level = Logger::getLevelName($level);
         if (!is_string($text)) {
             // exceptions may not be serializable if in the call stack somewhere is a Closure
-            if ($text instanceof \Exception) {
+            if ($text instanceof \Throwable || $text instanceof \Exception) {
                 $text = (string) $text;
             } else {
                 $text = VarDumper::export($text);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | i didn't have db prepared, so i run only `phpunit --group=base,log` and it passed |
| Fixed issues | #11333 |
