### PR TITLE
Remove (parentheses)

### DIFF
--- a/framework/db/mysql/ColumnSchemaBuilder.php
+++ b/framework/db/mysql/ColumnSchemaBuilder.php
@@ -31,7 +31,7 @@ class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
     protected function buildAfterString()
     {
         return $this->after !== null ?
-            ' AFTER (' . $this->db->quoteColumnName($this->after) . ')' :
+            ' AFTER ' . $this->db->quoteColumnName($this->after) :
             '';
     }
 

--- a/tests/framework/db/mysql/MysqlQueryBuilderTest.php
+++ b/tests/framework/db/mysql/MysqlQueryBuilderTest.php
@@ -19,7 +19,7 @@ class MysqlQueryBuilderTest extends QueryBuilderTest
     {
         return array_merge(parent::columnTypes(), [
         	[
-        	    Schema::TYPE_PK . ' AFTER (`col_before`)',
+        	    Schema::TYPE_PK . ' AFTER `col_before`',
         	    $this->primaryKey()->after('col_before'),
         	    'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER `col_before`'
         	],
@@ -34,7 +34,7 @@ class MysqlQueryBuilderTest extends QueryBuilderTest
         	    'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST'
         	],
         	[
-        	    Schema::TYPE_PK . '(8) AFTER (`col_before`)',
+        	    Schema::TYPE_PK . '(8) AFTER `col_before`',
         	    $this->primaryKey(8)->after('col_before'),
         	    'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER `col_before`'
         	],

--- a/tests/framework/db/mysql/MysqlQueryBuilderTest.php
+++ b/tests/framework/db/mysql/MysqlQueryBuilderTest.php
@@ -21,7 +21,7 @@ class MysqlQueryBuilderTest extends QueryBuilderTest
         	[
         	    Schema::TYPE_PK . ' AFTER (`col_before`)',
         	    $this->primaryKey()->after('col_before'),
-        	    'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER (`col_before`)'
+        	    'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER `col_before`'
         	],
         	[
         	    Schema::TYPE_PK . ' FIRST',
@@ -36,7 +36,7 @@ class MysqlQueryBuilderTest extends QueryBuilderTest
         	[
         	    Schema::TYPE_PK . '(8) AFTER (`col_before`)',
         	    $this->primaryKey(8)->after('col_before'),
-        	    'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER (`col_before`)'
+        	    'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER `col_before`'
         	],
         	[
         	    Schema::TYPE_PK . '(8) FIRST',


### PR DESCRIPTION
As it is, this method causes an error in the database.

According to the [reference](http://dev.mysql.com/doc/refman/5.7/en/alter-table.html), you should not use parentheses.

| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
