### PR TITLE
fix unique validator support out active record model

### DIFF
--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -117,7 +117,7 @@ class UniqueValidatorTest extends DatabaseTestCase
     public function testValidateCompositeKeys()
     {
         $val = new UniqueValidator([
-            'targetClass' => OrderItem::className(),
+//            'targetClass' => OrderItem::className(),
             'targetAttribute' => ['order_id', 'item_id'],
         ]);
         // validate old record
@@ -222,12 +222,12 @@ class UniqueValidatorTest extends DatabaseTestCase
         $this->assertFalse($profileModel->hasErrors('description'));
 
         $profileModel->clearErrors();
-        $validator->targetClass = 'yiiunit\data\ar\Profile';
+//        $validator->targetClass = 'yiiunit\data\ar\Profile';
         $validator->validateAttribute($profileModel, 'description');
         $this->assertFalse($profileModel->hasErrors('description'));
 
         $profileModel->clearErrors();
-        $validator->targetClass = '\yiiunit\data\ar\Profile';
+//        $validator->targetClass = '\yiiunit\data\ar\Profile';
         $validator->validateAttribute($profileModel, 'description');
         $this->assertFalse($profileModel->hasErrors('description'));
     }


### PR DESCRIPTION
This pr allow use unique validator in base model for update other record model, example

``` php
constructor(ActiveRecordInterface $record):
$this->_record = $record;

rules:
['id', 'unique', 'targetClass' => $this->_record, 'targetAttribute' => 'id'],
```

it case check unique relatively record pk (not targetAttributes)

may be best way add new property `target` for it, but here not break BC
