### PR TITLE
[docs] [skip ci] the name method default() is incorrect

### DIFF
--- a/docs/guide/db-migrations.md
+++ b/docs/guide/db-migrations.md
@@ -417,8 +417,8 @@ is passed then the table name will be deduced from the column name.
 In the
 example above `author_id:integer:notNull:foreignKey(user)` will generate a
 column named `author_id` with a foreign key to the `user` table while
-`category_id:integer:default(1):foreignKey` will generate a column `category_id`
-with a foreign key to the `category` table.
+`category_id:integer:defaultValue(1):foreignKey` will generate a column
+`category_id` with a foreign key to the `category` table.
 
 ### Drop Table
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |
