### PR TITLE
Fixes `after()` column string builder

### DIFF
--- a/framework/db/cubrid/ColumnSchemaBuilder.php
+++ b/framework/db/cubrid/ColumnSchemaBuilder.php
@@ -31,7 +31,7 @@ class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
     protected function buildAfterString()
     {
         return $this->after !== null ?
-            ' AFTER (' . $this->db->quoteColumnName($this->after) . ')' :
+            ' AFTER ' . $this->db->quoteColumnName($this->after) :
             '';
     }
 

--- a/framework/db/mysql/ColumnSchemaBuilder.php
+++ b/framework/db/mysql/ColumnSchemaBuilder.php
@@ -31,7 +31,7 @@ class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
     protected function buildAfterString()
     {
         return $this->after !== null ?
-            ' AFTER (' . $this->db->quoteColumnName($this->after) . ')' :
+            ' AFTER ' . $this->db->quoteColumnName($this->after) :
             '';
     }
 

--- a/framework/db/oci/ColumnSchemaBuilder.php
+++ b/framework/db/oci/ColumnSchemaBuilder.php
@@ -31,7 +31,7 @@ class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
     protected function buildAfterString()
     {
         return $this->after !== null ?
-            ' AFTER (' . $this->db->quoteColumnName($this->after) . ')' :
+            ' AFTER ' . $this->db->quoteColumnName($this->after) :
             '';
     }
 

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -80,15 +80,15 @@ abstract class QueryBuilderTest extends DatabaseTestCase
     {
         $items = [
             [
-                Schema::TYPE_BIGINT . ' CHECK (value > 5)',
-                $this->bigInteger()->check('value > 5'),
+                Schema::TYPE_BIGINT,
+                $this->bigInteger(),
                 [
-                    'mysql' => 'bigint(20) CHECK (value > 5)',
-                    'postgres' => 'bigint CHECK (value > 5)',
-                    'sqlite' => 'bigint CHECK (value > 5)',
-                    'oci' => 'NUMBER(20) CHECK (value > 5)',
-                    'sqlsrv' => 'bigint CHECK (value > 5)',
-                    'cubrid' => 'bigint CHECK (value > 5)',
+                    'mysql' => 'bigint(20)',
+                    'postgres' => 'bigint',
+                    'sqlite' => 'bigint',
+                    'oci' => 'NUMBER(20)',
+                    'sqlsrv' => 'bigint',
+                    'cubrid' => 'bigint',
                 ],
             ],
             [
@@ -104,13 +104,13 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 ],
             ],
             [
-                Schema::TYPE_BIGINT . '(8) CHECK (value > 5)',
-                $this->bigInteger(8)->check('value > 5'),
+                Schema::TYPE_BIGINT . ' CHECK (value > 5)',
+                $this->bigInteger()->check('value > 5'),
                 [
-                    'mysql' => 'bigint(8) CHECK (value > 5)',
+                    'mysql' => 'bigint(20) CHECK (value > 5)',
                     'postgres' => 'bigint CHECK (value > 5)',
                     'sqlite' => 'bigint CHECK (value > 5)',
-                    'oci' => 'NUMBER(8) CHECK (value > 5)',
+                    'oci' => 'NUMBER(20) CHECK (value > 5)',
                     'sqlsrv' => 'bigint CHECK (value > 5)',
                     'cubrid' => 'bigint CHECK (value > 5)',
                 ],
@@ -128,15 +128,15 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 ],
             ],
             [
-                Schema::TYPE_BIGINT,
-                $this->bigInteger(),
+                Schema::TYPE_BIGINT . '(8) CHECK (value > 5)',
+                $this->bigInteger(8)->check('value > 5'),
                 [
-                    'mysql' => 'bigint(20)',
-                    'postgres' => 'bigint',
-                    'sqlite' => 'bigint',
-                    'oci' => 'NUMBER(20)',
-                    'sqlsrv' => 'bigint',
-                    'cubrid' => 'bigint',
+                    'mysql' => 'bigint(8) CHECK (value > 5)',
+                    'postgres' => 'bigint CHECK (value > 5)',
+                    'sqlite' => 'bigint CHECK (value > 5)',
+                    'oci' => 'NUMBER(8) CHECK (value > 5)',
+                    'sqlsrv' => 'bigint CHECK (value > 5)',
+                    'cubrid' => 'bigint CHECK (value > 5)',
                 ],
             ],
             [

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -140,15 +140,6 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 ],
             ],
             [
-                Schema::TYPE_BIGINT . ' AFTER `colvalue`',
-                $this->bigInteger()->after('colvalue'),
-                [
-                    'mysql' => 'bigint(20) AFTER `colvalue`',
-                    'oci' => 'NUMBER(20) AFTER `colvalue`',
-                    'cubrid' => 'bigint AFTER `colvalue`',
-                ],
-            ],
-            [
                 Schema::TYPE_BIGPK,
                 $this->bigPrimaryKey(),
                 [
@@ -967,9 +958,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                   strncmp($column, Schema::TYPE_UPK, 3) === 0 ||
                   strncmp($column, Schema::TYPE_BIGPK, 5) === 0 ||
                   strncmp($column, Schema::TYPE_UBIGPK, 6) === 0)) {
-                $column = str_replace('CHECK (value', 'CHECK ([[col' . $i . ']]', $column);
-                $column = str_replace('AFTER `colvalue', 'AFTER `col' . $i, $column);
-                $columns['col' . ++$i] = $column;
+                $columns['col' . ++$i] = str_replace('CHECK (value', 'CHECK ([[col' . $i . ']]', $column);
             }
         }
         $this->getConnection(false)->createCommand($qb->createTable('column_type_table', $columns))->execute();

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -968,7 +968,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                   strncmp($column, Schema::TYPE_BIGPK, 5) === 0 ||
                   strncmp($column, Schema::TYPE_UBIGPK, 6) === 0)) {
                 $column = str_replace('CHECK (value', 'CHECK ([[col' . $i . ']]', $column);
-                $column = str_replace('AFTER `colvalue', 'AFTER `[[col' . $i . ']]', $column);
+                $column = str_replace('AFTER `colvalue', 'AFTER `col' . $i, $column);
                 $columns['col' . ++$i] = $column;
             }
         }

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -140,6 +140,15 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 ],
             ],
             [
+                Schema::TYPE_BIGINT . ' AFTER `colvalue`',
+                $this->bigInteger()->after('colvalue'),
+                [
+                    'mysql' => 'bigint(20) AFTER `colvalue`',
+                    'oci' => 'NUMBER(20) AFTER `colvalue`',
+                    'cubrid' => 'bigint AFTER `colvalue`',
+                ],
+            ],
+            [
                 Schema::TYPE_BIGPK,
                 $this->bigPrimaryKey(),
                 [
@@ -958,7 +967,9 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                   strncmp($column, Schema::TYPE_UPK, 3) === 0 ||
                   strncmp($column, Schema::TYPE_BIGPK, 5) === 0 ||
                   strncmp($column, Schema::TYPE_UBIGPK, 6) === 0)) {
-                $columns['col' . ++$i] = str_replace('CHECK (value', 'CHECK ([[col' . $i . ']]', $column);
+                $column = str_replace('CHECK (value', 'CHECK ([[col' . $i . ']]', $column);
+                $column = str_replace('AFTER `colvalue', 'AFTER `[[col' . $i . ']]', $column);
+                $columns['col' . ++$i] = $column;
             }
         }
         $this->getConnection(false)->createCommand($qb->createTable('column_type_table', $columns))->execute();

--- a/tests/framework/db/mysql/MysqlQueryBuilderTest.php
+++ b/tests/framework/db/mysql/MysqlQueryBuilderTest.php
@@ -19,9 +19,9 @@ class MysqlQueryBuilderTest extends QueryBuilderTest
     {
         return array_merge(parent::columnTypes(), [
         	[
-        	    Schema::TYPE_PK . ' AFTER (`col_before`)',
+        	    Schema::TYPE_PK . ' AFTER `col_before`',
         	    $this->primaryKey()->after('col_before'),
-        	    'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER (`col_before`)'
+        	    'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER `col_before`'
         	],
         	[
         	    Schema::TYPE_PK . ' FIRST',
@@ -34,9 +34,9 @@ class MysqlQueryBuilderTest extends QueryBuilderTest
         	    'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST'
         	],
         	[
-        	    Schema::TYPE_PK . '(8) AFTER (`col_before`)',
+        	    Schema::TYPE_PK . '(8) AFTER `col_before`',
         	    $this->primaryKey(8)->after('col_before'),
-        	    'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER (`col_before`)'
+        	    'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER `col_before`'
         	],
         	[
         	    Schema::TYPE_PK . '(8) FIRST',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11348 |
