### PR TITLE
#9425: ActiveQuery::exists() should generate SELECT EXISTS()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.8 under development
 -----------------------
 
+- Enh #9425: `yii\db\Query::exists()` now uses SQL standard `SELECT EXISTS()` query improving performance in some cases (PowerGamer1)
 - Bug #9935: Fixed `yii\validators\EachValidator` does not invoke `validateAttribute()` method of the embedded validator (klimov-paul)
 - Bug #11270: Fixed `BaseActiveRecord::link()` method in order to support closure in `indexBy` for relations declaration (iushev)
 - Bug #11333: Avoid serializing PHP 7 errors (zuozp8)

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -789,4 +789,17 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         }
         return $this;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function exists($db = null)
+    {
+        if($db === null) {
+            /* @var $modelClass ActiveRecord */
+            $modelClass = $this->modelClass;
+            $db = $modelClass::getDb();
+        }
+        return parent::exists($db);
+    }
 }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -374,7 +374,7 @@ class Query extends Component implements QueryInterface
             $db = Yii::$app->getDb();
         }
         $command = $db->createCommand('SELECT EXISTS(' . $this->createCommand()->getRawSql() . ')');
-        return boolval($command->queryScalar());
+        return (boolean)$command->queryScalar();
     }
 
     /**

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -360,11 +360,11 @@ class Query extends Component implements QueryInterface
      */
     public function exists($db = null)
     {
-        $select = $this->select;
-        $this->select = [new Expression('1')];
-        $command = $this->createCommand($db);
-        $this->select = $select;
-        return $command->queryScalar() !== false;
+        if ($db === null) {
+            $db = Yii::$app->getDb();
+        }
+        $command = $db->createCommand('SELECT EXISTS(' . $this->createCommand()->getRawSql() . ')');
+        return boolval($command->queryScalar());
     }
 
     /**

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -360,6 +360,16 @@ class Query extends Component implements QueryInterface
      */
     public function exists($db = null)
     {
+        // Workaround for making unit tests work.
+        if ($this instanceof ActiveQuery) {
+            /* @var $modelClass ActiveRecord */
+            $modelClass = $this->modelClass;
+            if ($db === null) {
+                $db = $modelClass::getDb();
+            }
+        } else if ($db === null) {
+            $db = Yii::$app->getDb();
+        }
         if ($db === null) {
             $db = Yii::$app->getDb();
         }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -360,16 +360,6 @@ class Query extends Component implements QueryInterface
      */
     public function exists($db = null)
     {
-        // Workaround for making unit tests work.
-        if ($this instanceof ActiveQuery) {
-            /* @var $modelClass ActiveRecord */
-            $modelClass = $this->modelClass;
-            if ($db === null) {
-                $db = $modelClass::getDb();
-            }
-        } else if ($db === null) {
-            $db = Yii::$app->getDb();
-        }
         if ($db === null) {
             $db = Yii::$app->getDb();
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | 9425 |

Implementation of https://github.com/yiisoft/yii2/issues/9425.
