### PR TITLE
DBMS specific workarounds for unsupported SQL92 form of `SELECT EXISTS()`

### DIFF
--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -363,7 +363,7 @@ class Query extends Component implements QueryInterface
         if ($db === null) {
             $db = Yii::$app->getDb();
         }
-        $command = $db->createCommand('SELECT EXISTS(' . $this->createCommand()->getRawSql() . ')');
+        $command = $db->createCommand($db->getQueryBuilder()->selectExists($this->createCommand()->getRawSql()));
         return (boolean)$command->queryScalar();
     }
 

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -1340,4 +1340,14 @@ class QueryBuilder extends \yii\base\Object
             return "$column $operator $phName";
         }
     }
+    
+    /**
+     * Creates a SELECT EXISTS() SQL statement.
+     * @param string $rawSql the subquery in a raw form to select from.
+     * @return string the SELECT EXISTS() SQL statement.
+     */
+    public function selectExists($rawSql)
+    {
+        return 'SELECT EXISTS(' . $rawSql . ')';
+    }
 }

--- a/framework/db/cubrid/QueryBuilder.php
+++ b/framework/db/cubrid/QueryBuilder.php
@@ -94,4 +94,12 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
         return $sql;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function selectExists($rawSql)
+    {
+        return 'SELECT CASE WHEN EXISTS(' . $rawSql . ') THEN 1 ELSE 0 END';
+    }
 }

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -268,4 +268,12 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
         return '(' . implode($operator === 'IN' ? ' OR ' : ' AND ', $vss) . ')';
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function selectExists($rawSql)
+    {
+        return 'SELECT CASE WHEN EXISTS(' . $rawSql . ') THEN 1 ELSE 0 END';
+    }
 }

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -265,6 +265,6 @@ EOD;
      */
     public function selectExists($rawSql)
     {
-        return 'SELECT CASE WHEN EXISTS(' . $rawSql . ') THEN 1 ELSE 0 END FROM dual';
+        return 'SELECT CASE WHEN EXISTS(' . $rawSql . ') THEN 1 ELSE 0 END FROM DUAL';
     }
 }

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -259,4 +259,12 @@ EOD;
 
         return 'INSERT ALL ' . $tableAndColumns . implode($tableAndColumns, $values) . ' SELECT 1 FROM SYS.DUAL';
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function selectExists($rawSql)
+    {
+        return 'SELECT CASE WHEN EXISTS(' . $rawSql . ') THEN 1 ELSE 0 END FROM dual';
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | 9425 |

Continuation of https://github.com/yiisoft/yii2/pull/11363.
DBMS specific workarounds for DBMSes not supporting SQL92 standard form of `SELECT EXISTS()` statement.
