### PR TITLE
Update yii.js

### DIFF
--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -146,7 +146,7 @@ yii = (function ($) {
         handleAction: function ($e, event) {
             var $form = $e.attr('data-form') ? $('#' + $e.attr('data-form')) : $e.closest('form'),
                 method = !$e.data('method') && $form ? $form.attr('method') : $e.data('method'),
-                action = $e.attr('href'),
+                action = $e.attr('href') || $e.data('href'),
                 params = $e.data('params'),
                 pjax = $e.data('pjax'),
                 pjaxPushState = !!$e.data('pjax-push-state'),
@@ -366,6 +366,17 @@ yii = (function ($) {
         // handle data-confirm and data-method for clickable and changeable elements
         $(document).on('click.yii', pub.clickableSelector, handler)
             .on('change.yii', pub.changeableSelector, handler);
+            
+        var selectors = pub.clickableSelector.split(',');
+        $.each(selectors, function(index, item) {
+            selectors[index] = item + "[data-method]";
+        })
+
+        $(selectors.join()).each(function(index, item) {
+            $(item).attr('data-href', $(item).attr('href'));
+            $(item).removeAttr('href');
+            $(item).css('cursor', 'pointer');
+        });    
     }
 
     function initScriptFilter() {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |

Fixes handling middle or right click on element with data-method (usually POST link). Opening this link in new tab often caused errors (404, method not allowed - when switched to GET on new tab). This solution swap href into data-href disabling other click on element. If element doesn't have a data-method defined nothing happens.
