### PR TITLE
Validation in rest delete action

### DIFF
--- a/framework/rest/DeleteAction.php
+++ b/framework/rest/DeleteAction.php
@@ -8,6 +8,7 @@
 namespace yii\rest;
 
 use Yii;
+use yii\db\ActiveRecord;
 use yii\web\ServerErrorHttpException;
 
 /**
@@ -21,10 +22,12 @@ class DeleteAction extends Action
     /**
      * Deletes a model.
      * @param mixed $id id of the model to be deleted.
+     * @return ActiveRecord|null
      * @throws ServerErrorHttpException on failure.
      */
     public function run($id)
     {
+        /* @var $model ActiveRecord */
         $model = $this->findModel($id);
 
         if ($this->checkAccess) {
@@ -32,7 +35,11 @@ class DeleteAction extends Action
         }
 
         if ($model->delete() === false) {
-            throw new ServerErrorHttpException('Failed to delete the object for unknown reason.');
+            if ($model->hasErrors()) {
+                return $model;
+            } else {
+                throw new ServerErrorHttpException('Failed to delete the object for unknown reason.');
+            }
         }
 
         Yii::$app->getResponse()->setStatusCode(204);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |

Some records shouldn't be deleted in some business cases. The current implementation yii\rest\DeleteAction does not handle validation errors.

So, currently when I implement validation:

``` php
public function beforeDelete()
{
    if (!$this->validate()) {
        return false;
    }
    return parent::beforeDelete();
}
```

 I get 500 internal server error.
