### PR TITLE
Do not register the file whith asset bundle if is null

### DIFF
--- a/framework/web/AssetBundle.php
+++ b/framework/web/AssetBundle.php
@@ -153,10 +153,9 @@ class AssetBundle extends Object
                 $options = ArrayHelper::merge($this->jsOptions, $js);
                 $view->registerJsFile($manager->getAssetUrl($this, $file), $options);
             } else {
-                if (is_null($js)) {
-                    continue;
+                if (!is_null($js)) {
+                    $view->registerJsFile($manager->getAssetUrl($this, $js), $this->jsOptions);
                 }
-                $view->registerJsFile($manager->getAssetUrl($this, $js), $this->jsOptions);
             }
         }
         foreach ($this->css as $css) {
@@ -165,10 +164,9 @@ class AssetBundle extends Object
                 $options = ArrayHelper::merge($this->cssOptions, $css);
                 $view->registerCssFile($manager->getAssetUrl($this, $file), $options);
             } else {
-                if (is_null($css)) {
-                    continue;
+                if (!is_null($css)) {
+                    $view->registerCssFile($manager->getAssetUrl($this, $css), $this->cssOptions);
                 }
-                $view->registerCssFile($manager->getAssetUrl($this, $css), $this->cssOptions);
             }
         }
     }

--- a/framework/web/AssetBundle.php
+++ b/framework/web/AssetBundle.php
@@ -153,6 +153,9 @@ class AssetBundle extends Object
                 $options = ArrayHelper::merge($this->jsOptions, $js);
                 $view->registerJsFile($manager->getAssetUrl($this, $file), $options);
             } else {
+                if (is_null($js)) {
+                    continue;
+                }
                 $view->registerJsFile($manager->getAssetUrl($this, $js), $this->jsOptions);
             }
         }
@@ -162,6 +165,9 @@ class AssetBundle extends Object
                 $options = ArrayHelper::merge($this->cssOptions, $css);
                 $view->registerCssFile($manager->getAssetUrl($this, $file), $options);
             } else {
+                if (is_null($css)) {
+                    continue;
+                }
                 $view->registerCssFile($manager->getAssetUrl($this, $css), $this->cssOptions);
             }
         }

--- a/framework/web/AssetBundle.php
+++ b/framework/web/AssetBundle.php
@@ -153,7 +153,7 @@ class AssetBundle extends Object
                 $options = ArrayHelper::merge($this->jsOptions, $js);
                 $view->registerJsFile($manager->getAssetUrl($this, $file), $options);
             } else {
-                if (!is_null($js)) {
+                if ($js !== null) {
                     $view->registerJsFile($manager->getAssetUrl($this, $js), $this->jsOptions);
                 }
             }
@@ -164,7 +164,7 @@ class AssetBundle extends Object
                 $options = ArrayHelper::merge($this->cssOptions, $css);
                 $view->registerCssFile($manager->getAssetUrl($this, $file), $options);
             } else {
-                if (!is_null($css)) {
+                if ($css !== null) {
                     $view->registerCssFile($manager->getAssetUrl($this, $css), $this->cssOptions);
                 }
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | no |
| Fixed issues | empty |

I whant to register the asset file in my develop environment only and I'm writing:

``` php
<?php
namespace common\assets;

use yii\web\AssetBundle;

/**
 * @author Razzwan Lomov <razvanlomov@gmail.com>
 * @since  2.1
 */
class ReactAsset extends AssetBundle
{
    public $sourcePath = null;

    public $js = [
        YII_ENV_DEV ? "//fb.me/react-15.0.1.js" : "//fb.me/react-15.0.1.min.js",
        YII_ENV_DEV ? "//fb.me/react-dom-15.0.1.js" : "//fb.me/react-dom-15.0.1.min.js",
        YII_ENV_DEV ? "//cdnjs.cloudflare.com/ajax/libs/babel-core/5.6.15/browser.js" : null,
    ];
}
```

But it work wrong. I propose to fix it.
