### PR TITLE
Handles alias in nested relations

### DIFF
--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -502,9 +502,18 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             while (($pos = strpos($name, '.')) !== false) {
                 $childName = substr($name, $pos + 1);
                 $name = substr($name, 0, $pos);
+             
+                $alias = null;
+                if (preg_match('/^(.*?)(?:\s+AS\s+|\s+)(\w+)$/i', $name, $matches)) {
+                    // relation is defined with an alias, adjust $name and extract alias
+                    list(, $name, $alias) = $matches;
+                }
+
                 $fullName = $prefix === '' ? $name : "$prefix.$name";
                 if (!isset($relations[$fullName])) {
                     $relations[$fullName] = $relation = $primaryModel->getRelation($name);
+                    if (!empty($alias))
+                        $relation->alias( $alias );
                     $this->joinWithRelation($parent, $relation, $this->getJoinType($joinType, $fullName));
                 } else {
                     $relation = $relations[$fullName];


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | not written yet |
| Fixed issues | #10878 |

Make it possible to write simple alias syntax with nested relations like:

``` php
$customer = Customer::find()
                   ->alias('c')
                   ->innerJoinWith('order o.product p') 
                   ->addOnCondition('o.amount' => 100)
```

As proposed in issue #10878
