### PR TITLE
better unit test for generateRandomBytes()

### DIFF
--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -438,16 +438,17 @@ class Security extends Component
      */
     public function generateRandomKey($length = 32)
     {
-        if (function_exists('random_bytes')) {
-            return random_bytes($length);
-        }
-
         if (!is_int($length)) {
             throw new InvalidParamException('First parameter ($length) must be an integer');
         }
 
         if ($length < 1) {
             throw new InvalidParamException('First parameter ($length) must be greater than 0');
+        }
+
+        // always use random_bytes() if it is available
+        if (function_exists('random_bytes')) {
+            return random_bytes($length);
         }
 
         // The recent LibreSSL RNGs are faster and likely better than /dev/urandom.

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -525,7 +525,7 @@ class Security extends Component
                     break;
                 }
                 $buffer .= $someBytes;
-                $stillNeed -= StringHelper::byteLength($buffer);
+                $stillNeed -= StringHelper::byteLength($someBytes);
                 if ($stillNeed === 0) {
                     // Leaving file pointer open in order to make next generation faster by reusing it.
                     return $buffer;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,9 @@
 			</testsuite>
 		</testsuites>
 		<filter>
+            <whitelist>
+                <directory suffix=".php">framework/</directory>
+            </whitelist>
 			<blacklist>
 				<file>framework/helpers/Json.php</file>
 				<file>framework/helpers/StringHelper.php</file>

--- a/tests/framework/base/SecurityTest.php
+++ b/tests/framework/base/SecurityTest.php
@@ -932,7 +932,7 @@ TEXT;
             }
         }
         // there is no /dev/urandom on windows so we expect this to fail
-        if (PHP_OS == 'win' && $functions['random_bytes'] == false && $functions['openssl_random_pseudo_bytes'] == false && $functions['mcrypt_create_iv'] === false ) {
+        if (DIRECTORY_SEPARATOR === '\\' && $functions['random_bytes'] === false && $functions['openssl_random_pseudo_bytes'] === false && $functions['mcrypt_create_iv'] === false ) {
             $this->setExpectedException('yii\base\Exception', 'Unable to generate a random key');
         }
         static::$functions = $functions;


### PR DESCRIPTION
This is a better test for `generateRandomBytes()` which tries to test as much branches of the method as possible using some tricks with overriding `function_exists()`.

tests are passing locally for me, want to check what travis says and it would be nice if someone could check which cases are not testable on windows.

There is also one line of code in the new implementatoin which I am unsure about:
https://github.com/yiisoft/yii2/blob/master/framework/base/Security.php#L527
I could not come up with a failing test but I believe it must be 

``` php
                $stillNeed -= StringHelper::byteLength($someBytes);
```

and not `$buffer`.

@tom-- @yiisoft/core-developers could you please verify this?

Postponing the 2.0.8 release until this is sorted out.
