### PR TITLE
[Enh] getClass() method

### DIFF
--- a/framework/base/Object.php
+++ b/framework/base/Object.php
@@ -77,6 +77,15 @@ use Yii;
 class Object implements Configurable
 {
     /**
+     * Returns the fully qualified name of this class.
+     * @return string the fully qualified name of this class.
+     */
+    public static function getClass()
+    {
+        return static::class;
+    }
+
+    /**
      * Constructor.
      * The default implementation does two things:
      *

--- a/tests/framework/base/ObjectTest.php
+++ b/tests/framework/base/ObjectTest.php
@@ -35,6 +35,7 @@ class ObjectTest extends TestCase
         $this->assertTrue($this->object->hasProperty('content'));
         $this->assertFalse($this->object->hasProperty('content', false));
         $this->assertFalse($this->object->hasProperty('Content'));
+        $this->assertTrue($this->object->hasProperty('class'));
     }
 
     public function testCanGetProperty()
@@ -60,7 +61,8 @@ class ObjectTest extends TestCase
 
     public function testGetProperty()
     {
-        $this->assertTrue('default' === $this->object->Text);
+        $this->assertEquals('default', $this->object->Text);
+        $this->assertEquals(NewObject::class, $this->object::class);
         $this->setExpectedException('yii\base\UnknownPropertyException');
         $value2 = $this->object->Caption;
     }
@@ -190,5 +192,7 @@ class NewObject extends Object
         return $this->_items;
     }
 
-    public function setWriteOnly() {}
+    public function setWriteOnly()
+    {
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes (new test added) |

instead of `get_class($model)` we can obtain the class of a model by `$model->class` if this is approved i will make another pr to modify all the `get_class($object)` calls
