### PR TITLE
Added ability for ArrayDataProvider to generate column labels when data array is empty

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 2.0.9 under development
 -----------------------
 
+- Enh #4146: Added `yii\data\ArrayDataProvider::$modelClass` property to specify a model used to provide column labels even when data array is empty (PowerGamer1)
 - Enh #11428: Speedup SQL query in `yii\db\oci\Schema::findColumns()` (SSiwek)
 - Enh #11414: Files specified as `null` in `yii\web\AssetBundle` won't be registered (Razzwan)
 - Enh #11432: Added HTTP status 421 "Misdirected Request" to list of statuses in `yii\web\Response` (dasmfm)

--- a/framework/data/ArrayDataProvider.php
+++ b/framework/data/ArrayDataProvider.php
@@ -63,7 +63,11 @@ class ArrayDataProvider extends BaseDataProvider
      * The array elements must use zero-based integer keys.
      */
     public $allModels;
-
+	/**
+	 * @var string the name of the \yii\base\Model based class used to provide column labels.
+	 * @since 2.0.9
+	 */
+	public $modelClass;
 
     /**
      * @inheritdoc

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -9,6 +9,7 @@ namespace yii\grid;
 
 use yii\base\Model;
 use yii\data\ActiveDataProvider;
+use yii\data\ArrayDataProvider;
 use yii\db\ActiveQueryInterface;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
@@ -143,6 +144,10 @@ class DataColumn extends Column
                 /* @var $model Model */
                 $model = new $provider->query->modelClass;
                 $label = $model->getAttributeLabel($this->attribute);
+            } else if($provider instanceof ArrayDataProvider && $provider->modelClass !== null) {
+	            /* @var $model Model */
+	            $model = new $provider->modelClass;
+	            $label = $model->getAttributeLabel($this->attribute);
             } else {
                 $models = $provider->getModels();
                 if (($model = reset($models)) instanceof Model) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11490, #9950, #6373 |

Implementation of https://github.com/yiisoft/yii2/issues/11490.
