### PR TITLE
#11498: Fixed unable to saved serialized object into PostgreSQL binary column

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Enh #11432: Added HTTP status 421 "Misdirected Request" to list of statuses in `yii\web\Response` (dasmfm)
 - Enh #11438: Configurable `yii\helpers\Markdown` default flavor (mdmunir)
 - Bug #11459: Fixed flash messages not destroyed when `session.auto_start = 1` set in php.ini (cartmanchen)
+- Bug #11498: Fixed unable to saved serialized object into PostgreSQL binary column (klimov-paul)
 
 
 2.0.8 April 28, 2016

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,7 +12,7 @@ Yii Framework 2 Change Log
 - Enh #11432: Added HTTP status 421 "Misdirected Request" to list of statuses in `yii\web\Response` (dasmfm)
 - Enh #11438: Configurable `yii\helpers\Markdown` default flavor (mdmunir)
 - Bug #11459: Fixed flash messages not destroyed when `session.auto_start = 1` set in php.ini (cartmanchen)
-- Bug #11498: Fixed unable to saved serialized object into PostgreSQL binary column (klimov-paul)
+- Bug #11498: Fixed inability to save serialized object into PostgreSQL binary column (klimov-paul)
 
 
 2.0.8 April 28, 2016

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -245,6 +245,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * @param string $table the table that data will be saved into.
      * @param array $columns the column data (name => value) to be saved into the table.
      * @return array normalized columns
+     * @since 2.0.9
      */
     private function normalizeTableRowData($table, $columns)
     {

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -227,6 +227,41 @@ class QueryBuilder extends \yii\db\QueryBuilder
     /**
      * @inheritdoc
      */
+    public function insert($table, $columns, &$params)
+    {
+        return parent::insert($table, $this->normalizeTableRowData($table, $columns), $params);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function update($table, $columns, $condition, &$params)
+    {
+        return parent::update($table, $this->normalizeTableRowData($table, $columns), $condition, $params);
+    }
+
+    /**
+     * Normalizes data to be saved into the table, performing extra preparations and type converting, if necessary.
+     * @param string $table the table that data will be saved into.
+     * @param array $columns the column data (name => value) to be saved into the table.
+     * @return array normalized columns
+     */
+    private function normalizeTableRowData($table, $columns)
+    {
+        if (($tableSchema = $this->db->getSchema()->getTableSchema($table)) !== null) {
+            $columnSchemas = $tableSchema->columns;
+            foreach ($columns as $name => $value) {
+                if (isset($columnSchemas[$name]) && $columnSchemas[$name]->type === Schema::TYPE_BINARY && is_string($value)) {
+                    $columns[$name] = [$value, \PDO::PARAM_LOB]; // explicitly setup PDO param type for binary column
+                }
+            }
+        }
+        return $columns;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function batchInsert($table, $columns, $rows)
     {
         $schema = $this->db->getSchema();

--- a/tests/framework/db/pgsql/PostgreSQLCommandTest.php
+++ b/tests/framework/db/pgsql/PostgreSQLCommandTest.php
@@ -69,4 +69,26 @@ class PostgreSQLCommandTest extends CommandTest
         $command->execute();
         $this->assertEquals(3, $db->getSchema()->getLastInsertID('schema1.profile_id_seq'));
     }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/11498
+     */
+    public function testSaveSerializedObject()
+    {
+        $db = $this->getConnection();
+
+        $command = $db->createCommand()->insert('type', [
+            'int_col' => 1,
+            'char_col' => 'serialize',
+            'float_col' => 5.6,
+            'bool_col' => true,
+            'blob_col' => serialize($db),
+        ]);
+        $this->assertEquals(1, $command->execute());
+
+        $command = $db->createCommand()->update('type', [
+            'blob_col' => serialize($this),
+        ], ['char_col' => 'serialize']);
+        $this->assertEquals(1, $command->execute());
+    }
 }

--- a/tests/framework/db/pgsql/PostgreSQLCommandTest.php
+++ b/tests/framework/db/pgsql/PostgreSQLCommandTest.php
@@ -87,7 +87,7 @@ class PostgreSQLCommandTest extends CommandTest
         $this->assertEquals(1, $command->execute());
 
         $command = $db->createCommand()->update('type', [
-            'blob_col' => serialize($this),
+            'blob_col' => serialize($db),
         ], ['char_col' => 'serialize']);
         $this->assertEquals(1, $command->execute());
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11498, #6173 |
