### PR TITLE
#10825 Fixed `yii\validators\EachValidator` does not respect `skipOnEmpty` when using model

### DIFF
--- a/framework/validators/EachValidator.php
+++ b/framework/validators/EachValidator.php
@@ -129,7 +129,9 @@ class EachValidator extends Validator
         $filteredValue = [];
         foreach ($value as $k => $v) {
             $model->$attribute = $v;
-            $validator->validateAttribute($model, $attribute);
+            if (!$validator->skipOnEmpty || !$validator->isEmpty($v)) {
+                $validator->validateAttribute($model, $attribute);
+            }
             $filteredValue[$k] = $model->$attribute;
             if ($model->hasErrors($attribute)) {
                 $validationErrors = $model->getErrors($attribute);

--- a/tests/framework/validators/EachValidatorTest.php
+++ b/tests/framework/validators/EachValidatorTest.php
@@ -107,6 +107,20 @@ class EachValidatorTest extends TestCase
 
         $validator = new EachValidator(['rule' => ['integer', 'skipOnEmpty' => false]]);
         $this->assertFalse($validator->validate(['']));
+
+        $model = FakedValidationModel::createWithAttributes([
+            'attr_one' => [
+                ''
+            ],
+        ]);
+        $validator = new EachValidator(['rule' => ['integer', 'skipOnEmpty' => true]]);
+        $validator->validateAttribute($model, 'attr_one');
+        $this->assertFalse($model->hasErrors('attr_one'));
+
+        $model->clearErrors();
+        $validator = new EachValidator(['rule' => ['integer', 'skipOnEmpty' => false]]);
+        $validator->validateAttribute($model, 'attr_one');
+        $this->assertTrue($model->hasErrors('attr_one'));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #10825 |
