### PR TITLE
calling getValue() for each attribute in AttributeBehavior

### DIFF
--- a/framework/behaviors/BlameableBehavior.php
+++ b/framework/behaviors/BlameableBehavior.php
@@ -94,13 +94,13 @@ class BlameableBehavior extends AttributeBehavior
      *
      * In case, when the [[value]] property is `null`, the value of `Yii::$app->user->id` will be used as the value.
      */
-    protected function getValue($event)
+    protected function getValue($event, $attributeName)
     {
         if ($this->value === null) {
             $user = Yii::$app->get('user', false);
             return $user && !$user->isGuest ? $user->id : null;
         }
 
-        return parent::getValue($event);
+        return parent::getValue($event, $attributeName);
     }
 }

--- a/framework/behaviors/SluggableBehavior.php
+++ b/framework/behaviors/SluggableBehavior.php
@@ -133,7 +133,7 @@ class SluggableBehavior extends AttributeBehavior
     /**
      * @inheritdoc
      */
-    protected function getValue($event)
+    protected function getValue($event, $attributeName)
     {
         if ($this->attribute !== null) {
             if ($this->isNewSlugNeeded()) {
@@ -147,7 +147,7 @@ class SluggableBehavior extends AttributeBehavior
                 return $this->owner->{$this->slugAttribute};
             }
         } else {
-            $slug = parent::getValue($event);
+            $slug = parent::getValue($event, $attributeName);
         }
 
         return $this->ensureUnique ? $this->makeUnique($slug) : $slug;

--- a/framework/behaviors/TimestampBehavior.php
+++ b/framework/behaviors/TimestampBehavior.php
@@ -111,12 +111,12 @@ class TimestampBehavior extends AttributeBehavior
      * In case, when the [[value]] is `null`, the result of the PHP function [time()](http://php.net/manual/en/function.time.php)
      * will be used as value.
      */
-    protected function getValue($event)
+    protected function getValue($event, $attributeName)
     {
         if ($this->value === null) {
             return time();
         }
-        return parent::getValue($event);
+        return parent::getValue($event, $attributeName);
     }
 
     /**
@@ -135,6 +135,6 @@ class TimestampBehavior extends AttributeBehavior
         if ($owner->getIsNewRecord()) {
             throw new InvalidCallException('Updating the timestamp is not possible on a new record.');
         }
-        $owner->updateAttributes(array_fill_keys((array) $attribute, $this->getValue(null)));
+        $owner->updateAttributes(array_fill_keys((array) $attribute, $this->getValue(null, null)));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | I hope not |
| Tests pass? | haven't checked |
| Fixed issues | none |

calling getValue() for each attribute (instead of once for all attributes) and passing attribute name along as a parameter to value function so that value function can return different values depending on current attribute
