### PR TITLE
array_key_exists problem

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -189,7 +189,7 @@ class BaseArrayHelper
             $key = $lastKey;
         }
 
-        if (is_array($array) && array_key_exists($key, $array)) {
+        if (is_array($array) && (isset($array[$key]) || array_key_exists($key, $array)) ) {
             return $array[$key];
         }
 
@@ -203,7 +203,7 @@ class BaseArrayHelper
             // it is not reliably possible to check whether a property is accessable beforehand
             return $array->$key;
         } elseif (is_array($array)) {
-            return array_key_exists($key, $array) ? $array[$key] : $default;
+            return (isset($array[$key]) || array_key_exists($key, $array)) ? $array[$key] : $default;
         } else {
             return $default;
         }


### PR DESCRIPTION
Double/Float key will be automatically translated to an int. So when
you do $array[1.0] = 2;, $array[1] will be defined.But for
array_key_exists(), this conversion is not done automatically. I
encountered this problem with key 660019  under a weird  environment.

To take the speed advantage of isset() while keeping the reliable
result from array_key_exists(), Perhaps the below code works the best:
isset($array[$key]) || array_key_exists($key, $array)
