### PR TITLE
ColumnSchemaBuilder can not work with custom types

### DIFF
--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -390,7 +390,7 @@ class ColumnSchemaBuilder extends Object
      */
     protected function getTypeCategory()
     {
-        return $this->categoryMap[$this->type];
+        return isset($this->categoryMap[$this->type]) ? $this->categoryMap[$this->type] : null;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | unknown |
| Fixed issues | unknown |

In our project we use trait with custom types, example:

``` php
trait MigrationToolTrait
{
    protected function dateTimeWithTZ ($precision = null)
    {
        if ('pgsql' === $this->db->driverName) {
            return $this->getDb()->getSchema()->createColumnSchemaBuilder(sprintf('timestamp(%d) with time zone', $precision));
        }

        return $this->dateTime($precision);
    }
}
```

usage:

``` php
class m160516_161900_init
{
    use MigrationToolTrait;
    public function safeUp ()
    {
        $this->createTable('testing', [
            'id' => $this->primaryKey(),
            'startDate' => $this->dateTimeWithTZ()->notNull()->defaultExpression('now()'),
        ]);
    }
    public function safeDown ()
    {
        $this->dropTable('testing');
    }
}
```

In version 2.0.8 MigrateController generate notice:
PHP Notice 'yii\base\ErrorException' with message 'Undefined index: timestamp(0) with time zone' in vendor/yiisoft/yii2/db/ColumnSchemaBuilder.php:366

We offer our change to fix it.
