### PR TITLE
trim pathInfo slashes

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -736,9 +736,7 @@ class Request extends \yii\base\Request
             throw new InvalidConfigException('Unable to determine the path info of the current request.');
         }
 
-        if (substr($pathInfo, 0, 1) === '/') {
-            $pathInfo = substr($pathInfo, 1);
-        }
+        $pathInfo = trim($pathInfo, '/');
 
         return (string) $pathInfo;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |

Not both removed as described
- The starting and ending slashes are both removed.
