### PR TITLE
Force direction in Sort::createUrl(), Sort::link() and Sort::createSortParam()

### DIFF
--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -304,7 +304,7 @@ class Sort extends Object
             }
         }
 
-        $url = $this->createUrl($attribute, $direction);
+        $url = $this->createUrl($attribute, false, $direction);
         $options['data-sort'] = $this->createSortParam($attribute, $direction);
 
         if (isset($options['label'])) {

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -370,11 +370,11 @@ class Sort extends Object
         if ($direction === null) {
             if (isset($directions[$attribute])) {
                 $direction = $directions[$attribute] === SORT_DESC ? SORT_ASC : SORT_DESC;
-                unset($directions[$attribute]);
             } else {
                 $direction = isset($definition['default']) ? $definition['default'] : SORT_ASC;
             }
         }
+        unset($directions[$attribute]);
 
         if ($this->enableMultiSort) {
             $directions = array_merge([$attribute => $direction], $directions);

--- a/tests/framework/data/SortTest.php
+++ b/tests/framework/data/SortTest.php
@@ -120,6 +120,8 @@ class SortTest extends TestCase
 
         $this->assertEquals('-age,-name', $sort->createSortParam('age'));
         $this->assertEquals('name,age', $sort->createSortParam('name'));
+        $this->assertEquals('-age,-name', $sort->createSortParam('age', SORT_DESC));
+        $this->assertEquals('-name,age', $sort->createSortParam('name', SORT_DESC));
     }
 
     public function testCreateUrl()
@@ -148,6 +150,8 @@ class SortTest extends TestCase
 
         $this->assertEquals('/index.php?r=site%2Findex&sort=-age%2C-name', $sort->createUrl('age'));
         $this->assertEquals('/index.php?r=site%2Findex&sort=name%2Cage', $sort->createUrl('name'));
+        $this->assertEquals('/index.php?r=site%2Findex&sort=age%2C-name', $sort->createUrl('age', false, SORT_ASC));
+        $this->assertEquals('/index.php?r=site%2Findex&sort=name%2Cage', $sort->createUrl('name', false, SORT_ASC));
     }
 
     public function testLink()
@@ -176,5 +180,7 @@ class SortTest extends TestCase
         ]);
 
         $this->assertEquals('<a class="asc" href="/index.php?r=site%2Findex&amp;sort=-age%2C-name" data-sort="-age,-name">Age</a>', $sort->link('age'));
+        $this->assertEquals('<a class="asc" href="/index.php?r=site%2Findex&amp;sort=age%2C-name" data-sort="age,-name">Age</a>', $sort->link('age', [], SORT_ASC));
+        $this->assertEquals('<a class="desc" href="/index.php?r=site%2Findex&amp;sort=-name%2Cage" data-sort="-name,age">Name</a>', $sort->link('name', [], SORT_DESC));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | ? |
| Fixed issues | #8456 |
