### PR TITLE
Added dynamic alias '@alias' in ActiveQuery

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.14 under development
 ------------------------
 
+- Enh #7263: Added dynamic alias placeholder `@alias` to address current alias of table name in query (cedricYii)
 - Bug #11401: Fixed `yii\web\DbSession` concurrency issues when writing and regenerating IDs (samdark, andreasanta, cebe)
 - Bug #15523: `yii\web\Session` settings could now be configured after session is started (StalkAlex, rob006, daniel1302, samdark)
 - Enh #15216: Added `yii\web\ErrorHandler::$traceLine` to allow opening file at line clicked in IDE (vladis84)

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -184,6 +184,12 @@ abstract class Application extends Module
      * @var array list of loaded modules indexed by their class names.
      */
     public $loadedModules = [];
+    /**
+     * @var bool whether to enable dynamic alias feature in ActiveQuery. Defaults to false.
+     * Enable only if you want to use this feature in your application.
+     * @since 2.0.14
+     */
+    public $enableAliasDynamic = false;
 
 
     /**

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -79,7 +79,6 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      * @event Event an event that is triggered when the query is initialized via [[init()]].
      */
     const EVENT_INIT = 'init';
-
     /**
      * string placeholder to be replaced by the table alias of a query.
      */
@@ -160,8 +159,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             if ($this->getIsAliasDynamicEnabled()) {
                 $this->select = ['@alias.*'];
             } else {
-                $alias = $this->getTableAlias();
-                $this->select = ["$alias.*"];
+                $this->select = [$this->getTableAlias() . '.*'];
             }
         }
 
@@ -897,7 +895,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     protected function normalizeAliasInQuery()
     {
-        //Skip normalisation if dynamic alias feature is not enabled (to save speed)
+        //Skip normalisation if dynamic alias feature is not enabled
         if (!$this->getIsAliasDynamicEnabled()) {
             return $this;
         }
@@ -911,8 +909,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         $this->orderBy = self::replaceAliasPlaceholder($this->orderBy, $alias);
         $this->groupBy = self::replaceAliasPlaceholder($this->groupBy, $alias);
         if (!empty($this->join)) {
-            foreach ($this->join as &$join) {
-                $join = self::replaceAliasPlaceholder($join, $alias);
+            foreach ($this->join as $key => $join) {
+                $this->join[$key] = self::replaceAliasPlaceholder($join, $alias);
             }
         }
 

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -870,7 +870,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 $value = self::replaceAliasPlaceholder($value, $aliasName);
                 $conditionNew[$key] = $value;
             }
-            $condition = $conditionNew;
+            return $conditionNew;
         } elseif ($condition instanceof \yii\db\Expression) {
             $condition->expression = self::replaceAliasPlaceholder($condition->expression, $aliasName);
         }

--- a/tests/data/ar/Item.php
+++ b/tests/data/ar/Item.php
@@ -25,4 +25,11 @@ class Item extends ActiveRecord
     {
         return $this->hasOne(Category::className(), ['id' => 'category_id']);
     }
+
+    //relation with dynamic alias
+    public function getCategoryWithAlias()
+    {
+        return $this->hasOne(Category::className(), ['id' => 'category_id'])
+              ->andOncondition(['like', '@alias.name', 'o']);
+    }
 }

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -8,7 +8,7 @@
 namespace yiiunit\data\ar;
 
 /**
- * Class Order
+ * Class Order.
  *
  * @property int $id
  * @property int $customer_id

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -8,7 +8,7 @@
 namespace yiiunit\data\ar;
 
 /**
- * Class Order.
+ * Class Order
  *
  * @property int $id
  * @property int $customer_id
@@ -44,6 +44,13 @@ class Order extends ActiveRecord
     public function getCustomer2()
     {
         return $this->hasOne(Customer::className(), ['id' => 'customer_id'])->inverseOf('orders2');
+    }
+
+    //relation with dynamic alias
+    public function getCustomerWithAlias()
+    {
+        return $this->hasOne(Customer::className(), ['id' => 'customer_id'])
+            ->orderBy('@alias.id');
     }
 
     public function getOrderItems()
@@ -176,6 +183,13 @@ class Order extends ActiveRecord
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
+    public function getBookItemsWithAlias()
+    {
+        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+            ->onCondition(['@alias.category_id' => 1])
+            ->viaTable('order_item oib', ['order_id' => 'id']);
+    }
+
     public function getMovieItems()
     {
         return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('movies')
@@ -188,6 +202,14 @@ class Order extends ActiveRecord
         return $this->hasMany(Item::className(), ['id' => 'item_id'])
             ->onCondition(['item.id' => [3, 5]])
             ->via('orderItems');
+    }
+
+    public function getMovieItemsWithAlias()
+    {
+        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('movies')
+            ->onCondition(['@alias.category_id' => 2])
+            ->viaTable('order_item oim', ['order_id' => 'id'])
+            ->addOrderBy(['@alias.id' => SORT_DESC]);
     }
 
     public function beforeSave($insert)
@@ -214,5 +236,15 @@ class Order extends ActiveRecord
         return [
             0 => 'customer_id',
         ];
+    }
+
+    //Overloading find method with dynamic alias placeholder to test replacement
+    public static function findWithAlias()
+    {
+        return parent::find()
+            ->where([
+                '<>', '@alias.id', 0,
+            ])
+            ->orderBy( '@alias.id' );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #7263, #10883 |

The `@alias` placeholder enables to address dynamicaly the alias of the current table name in an active query or in a relation (without knowing it in advance).

Example:

``` php
class Order {
...
  public static function find()
  {
    return parent::find()->orderBy( '@alias.id' );
  }

  //relation with table COMPANY
  public function getCustomer()
  {
    return $this->hasOne( Company::className(), ['id' => 'customerid'] )
                ->andOnCondition( [ '@alias.type' => 'customer' ] );
  }
...
}
```

Then

``` php
$orders = Order::find()->alias('o');
```

Build the query:

``` sql
select * from order o order by o.id
```

And

``` php
$orders = Order::find()->alias('o')->joinWith('customer c');
```

Build the query:

``` sql
select o.* from order o 
left join company c on c.id = o.customerid and c.type = 'customer'
order by o.id
```
