### PR TITLE
Fixed pageCount in ActiveDataProvider pagination #11647

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -23,6 +23,7 @@ Yii Framework 2 Change Log
 - Bug #11523: Fixed `yii\web\User::checkRedirectAcceptable()` to treat acceptable content type `*/*` as `*` (silverfire)
 - Bug #11532: Fixed casting of empty char value to `null` resulting in integrity constraint violation for not null columns (samdark)
 - Bug #11571: Fixed `yii\db\ColumnSchemaBuilder` to work with custom column types (andrey-mokhov, silverfire)
+- Bug #11647: Fixed pageCount in ActiveDataProvider pagination (Nex-Otaku)
 
 
 2.0.8 April 28, 2016

--- a/framework/data/BaseDataProvider.php
+++ b/framework/data/BaseDataProvider.php
@@ -200,6 +200,9 @@ abstract class BaseDataProvider extends Component implements DataProviderInterfa
         } else {
             throw new InvalidParamException('Only Pagination instance, configuration array or false is allowed.');
         }
+        if ($this->_pagination !== false) {
+            $this->_pagination->totalCount = $this->getTotalCount();
+        }
     }
 
     /**


### PR DESCRIPTION
BaseDataProvider should set pagination totalCount, otherwise pagination will return wrong pageCount.

We set it in setPagination. 

| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | not checked |
| Tests pass? | not checked |
| Fixed issues | #11647 |
