### PR TITLE
More control over check access for create action

### DIFF
--- a/framework/rest/CreateAction.php
+++ b/framework/rest/CreateAction.php
@@ -37,16 +37,17 @@ class CreateAction extends Action
      */
     public function run()
     {
-        if ($this->checkAccess) {
-            call_user_func($this->checkAccess, $this->id);
-        }
-
         /* @var $model \yii\db\ActiveRecord */
         $model = new $this->modelClass([
             'scenario' => $this->scenario,
         ]);
 
         $model->load(Yii::$app->getRequest()->getBodyParams(), '');
+
+        if ($this->checkAccess) {
+            call_user_func($this->checkAccess, $this->id, $model);
+        }
+
         if ($model->save()) {
             $response = Yii::$app->getResponse();
             $response->setStatusCode(201);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |

For example we create a review and passing 3 parameters in our request: `productId`, `reviewerId`, `rating`
Currently there is no ability to check that `reviewerId` is equal to ID of authenticated user, or perform any other check access based on received data.
