### PR TITLE
fix BaseArrayHelper::isIn() in strict mode

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -699,7 +699,7 @@ class BaseArrayHelper
     {
         if ($haystack instanceof \Traversable) {
             foreach ($haystack as $value) {
-                if ($needle == $value && (!$strict || $needle === $haystack)) {
+                if ($needle == $value && (!$strict || $needle === $value)) {
                     return true;
                 }
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | yes? |
| Tests pass? | yes |
| Fixed issues | none |
