### PR TITLE
Fixed issue #11712: DbSessionTest is now skipped when SQLite is not a…

### DIFF
--- a/tests/framework/web/DbSessionTest.php
+++ b/tests/framework/web/DbSessionTest.php
@@ -17,6 +17,13 @@ class DbSessionTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
+        /**
+         * @todo Optionally do fallback to some other database, however this might be overkill for tests only since
+         * sqlite is always available on travis.
+         */
+        if (!in_array('sqlite', \PDO::getAvailableDrivers())) {
+            $this->markTestIncomplete('DbSessionTest requires SQLite!');
+        }
         $this->mockApplication();
         Yii::$app->set('db', [
             'class' => Connection::className(),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11712 |

…vailable.
