### PR TITLE
Fix scope for multiple forms file inputs

### DIFF
--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -302,6 +302,7 @@
 
             // client-side validation
             $.each(data.attributes, function () {
+                this.$form = $form;
                 if (!$(this.input).is(":disabled")) {
                     this.cancelled = false;
                     // perform validation only if the form is being submitted or if an attribute is pending validation

--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -383,7 +383,7 @@ yii.validation = (function ($) {
             return [];
         }
 
-        var files = $(attribute.input).get(0).files;
+        var files = $(attribute.input, attribute.$form).get(0).files;
         if (!files) {
             messages.push(options.message);
             return [];


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |

If there are multiple forms on a page (of the same model and with the same `formName`) and these forms contain file input, than JS validation will affect only file input of the first form and will ignore all the other.
