### PR TITLE
no longer render label by default in `ActiveField::hiddenInput()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 2.0.9 under development
 -----------------------
 
+- Enh #2990: `ActiveField::hiddenInput()` no longer renders label by default (lennartvdd)
 - Enh #8795: Refactored `yii\web\User::loginByCookie()` in order to make it easier to override (maine-mike, silverfire)
 - Enh #9948: `yii\rbac\PhpManager` now invalidates script file cache performed by 'OPCache' or 'APC' on file saving (klimov-paul)
 - Enh #11195: Added ability to append custom string to schema builder column definition (df2, samdark)

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -382,6 +382,7 @@ class ActiveField extends Component
      */
     public function hiddenInput($options = [])
     {
+        $this->label(false);
         $options = array_merge($this->inputOptions, $options);
         $this->adjustLabelFor($options);
         $this->parts['{input}'] = Html::activeHiddenInput($this->model, $this->attribute, $options);

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -251,6 +251,7 @@ EOD;
 EOD;
         $this->activeField->hiddenInput();
         $this->assertEquals($expectedValue, $this->activeField->parts['{input}']);
+        $this->assertEquals('', $this->activeField->parts['{label}']);
     }
 
     public function testListBox()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | yes |
| Tests pass? | yes |
| Fixed issues | #2990 |
