### PR TITLE
Fix #11120 "Expected array for frame 0" error for PHP7+Xdebug

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -25,6 +25,7 @@ Yii Framework 2 Change Log
 - Bug #11571: Fixed `yii\db\ColumnSchemaBuilder` to work with custom column types (andrey-mokhov, silverfire)
 - Bug #11662: Fixed `schema-oci.sql` for RBAC (jonny7)
 - Bug #11527: Fixed `bigPrimaryKey()` for SQLite (dynasource)
+- Bug #11723: Fixed PHP7+Xdebug error handling problem #11120 displaying "Expected array for frame 0" (tanakahisateru)
 
 
 2.0.8 April 28, 2016

--- a/framework/base/ErrorException.php
+++ b/framework/base/ErrorException.php
@@ -44,7 +44,8 @@ class ErrorException extends \ErrorException
 
         if (function_exists('xdebug_get_function_stack')) {
             $trace = array_slice(array_reverse(xdebug_get_function_stack()), 3, -1);
-            foreach ($trace as &$frame) {
+            $phpCompatibleTrace = [];
+            foreach ($trace as $frame) {
                 if (!isset($frame['function'])) {
                     $frame['function'] = 'unknown';
                 }
@@ -60,11 +61,12 @@ class ErrorException extends \ErrorException
                 if (isset($frame['params']) && !isset($frame['args'])) {
                     $frame['args'] = $frame['params'];
                 }
+                $phpCompatibleTrace[] = $frame;
             }
 
             $ref = new \ReflectionProperty('Exception', 'trace');
             $ref->setAccessible(true);
-            $ref->setValue($this, $trace);
+            $ref->setValue($this, $phpCompatibleTrace);
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11120 |

PHP7 `--grounp=base`

```
Tests: 146, Assertions: 2939, Skipped: 1.
```

PHP7 with Xdebug `--grounp=base`

```
Tests: 146, Assertions: 2939, Skipped: 1.
```

PHP7 with Xdebug `--group=ar,base,behaviors,caching,console,di,filters,grid,log,mail,mutex,rbac,requirements,rest,web,widgets`

```
Tests: 1155, Assertions: 4793, Skipped: 114.
```

I guess PHP7's trace string generator was affected from array optimization, then lacks compatibility for referenced zval.
