### PR TITLE
CheckboxColumn - Use CSS class to find the elements

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -17,7 +17,7 @@ Yii Framework 2 Change Log
 - Enh #11414: Files specified as `null` in `yii\web\AssetBundle` won't be registered (Razzwan)
 - Enh #11432: Added HTTP status 421 "Misdirected Request" to list of statuses in `yii\web\Response` (dasmfm)
 - Enh #11438: Configurable `yii\helpers\Markdown` default flavor (mdmunir)
-- Enh #11729: Added `yii\grid\CheckboxColumn::$cssClas` property to specify a class added to CheckboxColumn input (thiagotalma)
+- Enh #11729: Added `yii\grid\CheckboxColumn::$cssClas` property to specify a class added to checkbox input (thiagotalma)
 - Bug #11459: Fixed flash messages not destroyed when `session.auto_start = 1` set in php.ini (cartmanchen)
 - Bug #11498: Fixed inability to save serialized object into PostgreSQL binary column (klimov-paul)
 - Bug #11507: Fixed `yii\validators\EachValidator::validateAttribute()` does not respect `skipOnEmpty` rule parameter (webdevsega)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -17,6 +17,7 @@ Yii Framework 2 Change Log
 - Enh #11414: Files specified as `null` in `yii\web\AssetBundle` won't be registered (Razzwan)
 - Enh #11432: Added HTTP status 421 "Misdirected Request" to list of statuses in `yii\web\Response` (dasmfm)
 - Enh #11438: Configurable `yii\helpers\Markdown` default flavor (mdmunir)
+- Enh #11729: Added `yii\grid\CheckboxColumn::$cssClas` property to specify a class added to CheckboxColumn input (thiagotalma)
 - Bug #11459: Fixed flash messages not destroyed when `session.auto_start = 1` set in php.ini (cartmanchen)
 - Bug #11498: Fixed inability to save serialized object into PostgreSQL binary column (klimov-paul)
 - Bug #11507: Fixed `yii\validators\EachValidator::validateAttribute()` does not respect `skipOnEmpty` rule parameter (webdevsega)

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -155,12 +155,13 @@
                 return;
             }
             var checkAll = "#" + id + " input[name='" + options.checkAll + "']";
-            var inputs = "#" + id + " input[name='" + options.name + "']";
+            var inputs = "input." + options.class;
+            var inputsEnabled = "#" + id + " " + inputs + ":enabled";
             $(document).off('click.yiiGridView', checkAll).on('click.yiiGridView', checkAll, function () {
-                $grid.find("input[name='" + options.name + "']:enabled").prop('checked', this.checked);
+                $grid.find(inputs + ":enabled").prop('checked', this.checked);
             });
-            $(document).off('click.yiiGridView', inputs + ":enabled").on('click.yiiGridView', inputs + ":enabled", function () {
-                var all = $grid.find("input[name='" + options.name + "']").length == $grid.find("input[name='" + options.name + "']:checked").length;
+            $(document).off('click.yiiGridView', inputsEnabled).on('click.yiiGridView', inputsEnabled, function () {
+                var all = $grid.find(inputs).length == $grid.find(inputs + ":checked").length;
                 $grid.find("input[name='" + options.checkAll + "']").prop('checked', all);
             });
         },

--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -155,7 +155,7 @@
                 return;
             }
             var checkAll = "#" + id + " input[name='" + options.checkAll + "']";
-            var inputs = "input." + options.class;
+            var inputs = options.class ? "input." + options.class : "input[name='" + options.name + "']";
             var inputsEnabled = "#" + id + " " + inputs + ":enabled";
             $(document).off('click.yiiGridView', checkAll).on('click.yiiGridView', checkAll, function () {
                 $grid.find(inputs + ":enabled").prop('checked', this.checked);

--- a/framework/grid/CheckboxColumn.php
+++ b/framework/grid/CheckboxColumn.php
@@ -67,7 +67,10 @@ class CheckboxColumn extends Column
      * @var boolean whether it is possible to select multiple rows. Defaults to `true`.
      */
     public $multiple = true;
-
+    /**
+     * @var string the css class that will be used to find the checkboxes.
+     */
+    public $cssClass = 'yii-checkboxcolum-check';
 
     /**
      * @inheritdoc
@@ -116,6 +119,10 @@ class CheckboxColumn extends Column
             $options['value'] = is_array($key) ? Json::encode($key) : $key;
         }
 
+        if ($this->cssClass !== null) {
+            Html::addCssClass($options, $this->cssClass);
+        }
+
         return Html::checkbox($this->name, !empty($options['checked']), $options);
     }
 
@@ -148,6 +155,7 @@ class CheckboxColumn extends Column
         $id = $this->grid->options['id'];
         $options = Json::encode([
             'name' => $this->name,
+            'class' => $this->cssClass,
             'multiple' => $this->multiple,
             'checkAll' => $this->grid->showHeader ? $this->getHeaderCheckBoxName() : null,
         ]);

--- a/framework/grid/CheckboxColumn.php
+++ b/framework/grid/CheckboxColumn.php
@@ -70,7 +70,7 @@ class CheckboxColumn extends Column
     /**
      * @var string the css class that will be used to find the checkboxes.
      */
-    public $cssClass = 'yii-checkboxcolum-check';
+    public $cssClass;
 
     /**
      * @inheritdoc


### PR DESCRIPTION
Adds the ability to use CSS class as a filter for the function to check/uncheck all the rows.

By default, nothing is changed and the current operation is maintained.

| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |
