### PR TITLE
Fixes false positive on loadFilesRecursive

### DIFF
--- a/framework/web/UploadedFile.php
+++ b/framework/web/UploadedFile.php
@@ -224,7 +224,7 @@ class UploadedFile extends Object
             foreach ($names as $i => $name) {
                 self::loadFilesRecursive($key . '[' . $i . ']', $name, $tempNames[$i], $types[$i], $sizes[$i], $errors[$i]);
             }
-        } elseif ($errors !== UPLOAD_ERR_NO_FILE) {
+        } elseif (intval($errors) !== UPLOAD_ERR_NO_FILE) {
             self::$_files[$key] = new static([
                 'name' => $names,
                 'tempName' => $tempNames,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |

When running a functional test with codeception, I wasn't getting a null of UploadedFile::getInstance().

Examining further, I realized that the $errors variable type, on elseif, was a string and UPLOAD_ERR_NO_FILE was a integer, therefore the test was returning true ($errors !== UPLOAD_ERR_NO_FILE).

But the $errors value was "4" (string) and UPLOAD_ERR_NO_FILE is 4 (integer).

intval($errors) worked for me and I see no drawbacks on using it.
