### PR TITLE
Simplify ready callback

### DIFF
--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -411,7 +411,7 @@ yii = (function ($) {
     return pub;
 })(jQuery);
 
-jQuery(document).ready(function () {
+jQuery(function () {
     yii.initModule(yii);
 });
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | none |

Besides it is useless to call `jQuery.ready()` when it is possible to just call `jQuery()`, it is also going to be deprecated upstream soon: https://github.com/jquery/jquery/issues/3025
