### PR TITLE
Chg #11689 Using closures for View::renderDynamic()

### DIFF
--- a/docs/guide-ru/caching-fragment.md
+++ b/docs/guide-ru/caching-fragment.md
@@ -131,11 +131,13 @@ if ($this->beginCache($id1)) {
 в нужное место, как в примере ниже:
 
 ```php
-if ($this->beginCache($id1)) {
+if ($this->beginCache($id1, ['placeholders' => [
+    'username' => Yii::$app->user->identity->name
+]])) {
 
     // ...логика создания контента...
 
-    echo $this->renderDynamic('return Yii::$app->user->identity->name;');
+    echo $this->renderDynamic('username');
 
     // ...логика создания контента...
 
@@ -143,5 +145,18 @@ if ($this->beginCache($id1)) {
 }
 ```
 
-Метод [[yii\base\View::renderDynamic()|renderDynamic()]] принимает некоторую часть PHP кода как параметр.
+или с использованием анонимной функции:
+
+```php
+if ($this->beginCache($id1, ['placeholders' => [
+    'username' => function () {
+        return Yii::$app->user->identity->name;
+    }
+]])) {
+    echo $this->renderDynamic('username');
+    $this->endCache();
+}
+```
+
+Метод [[yii\base\View::renderDynamic()|renderDynamic()]] принимает ключ как параметр.
 Возвращаемое значение этого кода будет вставлено в динамическое содержимое. Этот PHP код будет выполняться для каждого запроса, независимо от того находится ли он внутри кэширования фрагмента или нет.

--- a/docs/guide/caching-fragment.md
+++ b/docs/guide/caching-fragment.md
@@ -159,11 +159,13 @@ You may call [[yii\base\View::renderDynamic()]] within a cached fragment to inse
 at the desired place, like the following,
 
 ```php
-if ($this->beginCache($id1)) {
+if ($this->beginCache($id1, ['placeholders' => [
+    'username' => Yii::$app->user->identity->name
+]])) {
 
     // ...content generation logic...
 
-    echo $this->renderDynamic('return Yii::$app->user->identity->name;');
+    echo $this->renderDynamic('username');
 
     // ...content generation logic...
 
@@ -171,6 +173,19 @@ if ($this->beginCache($id1)) {
 }
 ```
 
-The [[yii\base\View::renderDynamic()|renderDynamic()]] method takes a piece of PHP code as its parameter.
+or with closures:
+
+```php
+if ($this->beginCache($id1, ['placeholders' => [
+    'username' => function () {
+        return Yii::$app->user->identity->name;
+    }
+]])) {
+    echo $this->renderDynamic('username');
+    $this->endCache();
+}
+```
+
+The [[yii\base\View::renderDynamic()|renderDynamic()]] method takes a placeholder as its parameter.
 The return value of the PHP code is treated as the dynamic content. The same PHP code will be executed
 for every request, no matter the enclosing fragment is being served from cached or not.

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -31,7 +31,7 @@ Yii Framework 2 Change Log
 - Enh #12881: Added `removeValue` method to `yii\helpers\BaseArrayHelper` (nilsburg)
 - Enh #12901: Added `getDefaultHelpHeader` method to the `yii\console\controllers\HelpController` class to be able to override default help header in a class heir (diezztsk)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
-
+- Chg #11689: Changed `yii\base\View::beginCache()` and `yii\base\View::renderDynamic()` to work with closures instead of `eval()` (ElisDN)
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -51,6 +51,27 @@ version B between A and C, you need to follow the instructions
 for both A and B.
 
 
+Upgrade to Yii 2.1.0
+--------------------
+
+* `yii\base\View::beginCache()` and `yii\base\View::renderDynamic()` work with closures instead of `eval()` for dynamic content.
+  Move all PHP statements into values or closures and overwrite all `renderDynamic` calls to using placeholders:
+
+  ```php
+  if ($this->beginCache($id1, ['placeholders' => [
+      'username' => Yii::$app->user->identity->name;
+      'closure' => function () {
+          return Yii::$app->user->identity->name;
+      }
+  ])) {
+      // ...content generation logic...
+      echo $this->renderDynamic('username');
+      echo $this->renderDynamic('closure');
+      // ...content generation logic...
+      $this->endCache();
+  }
+  ```
+
 Upgrade from Yii 2.0.9
 ----------------------
 

--- a/tests/framework/widgets/FragmentCacheTest.php
+++ b/tests/framework/widgets/FragmentCacheTest.php
@@ -6,6 +6,7 @@ use Yii;
 use yii\caching\ArrayCache;
 use yii\base\View;
 use yii\widgets\Breadcrumbs;
+use yii\widgets\FragmentCache;
 
 /**
  * @group widgets
@@ -86,6 +87,67 @@ class FragmentCacheTest extends \yiiunit\TestCase
         $this->assertEquals($expectedLevel, ob_get_level(), 'Output buffer not closed correctly.');
     }
 
+    public function testDynamicContentScalar()
+    {
+        $expectedLevel = ob_get_level();
+        $view = new View();
+        $placeholders = [
+            'place' => 'dynamic'
+        ];
 
-    // TODO test dynamic replacements
+        ob_start();
+        ob_implicit_flush(false);
+        $this->assertTrue($view->beginCache('test', ['placeholders' => $placeholders]));
+
+        ob_start();
+        ob_implicit_flush(false);
+        echo "cached ";
+        echo $view->renderDynamic('place');
+        echo " fragment";
+        $this->assertEquals("cached " . FragmentCache::placeholderMarker('place') . " fragment", $rawContent = ob_get_clean());
+
+        echo $rawContent;
+        $view->endCache();
+        $this->assertEquals("cached dynamic fragment", ob_get_clean());
+
+        ob_start();
+        ob_implicit_flush(false);
+        $this->assertFalse($view->beginCache('test', ['placeholders' => $placeholders]));
+        $this->assertEquals("cached dynamic fragment", ob_get_clean());
+
+        $this->assertEquals($expectedLevel, ob_get_level(), 'Output buffer not closed correctly.');
+    }
+
+    public function testDynamicContentClosure()
+    {
+        $expectedLevel = ob_get_level();
+        $view = new View();
+        $placeholders = [
+            'place' => function () {
+                    return 'dynamic';
+                }
+        ];
+
+        ob_start();
+        ob_implicit_flush(false);
+        $this->assertTrue($view->beginCache('test', ['placeholders' => $placeholders]));
+
+        ob_start();
+        ob_implicit_flush(false);
+        echo "cached ";
+        echo $view->renderDynamic('place');
+        echo " fragment";
+        $this->assertEquals("cached " . FragmentCache::placeholderMarker('place') . " fragment", $rawContent = ob_get_clean());
+
+        echo $rawContent;
+        $view->endCache();
+        $this->assertEquals("cached dynamic fragment", ob_get_clean());
+
+        ob_start();
+        ob_implicit_flush(false);
+        $this->assertFalse($view->beginCache('test', ['placeholders' => $placeholders]));
+        $this->assertEquals("cached dynamic fragment", ob_get_clean());
+
+        $this->assertEquals($expectedLevel, ob_get_level(), 'Output buffer not closed correctly.');
+    }
 }


### PR DESCRIPTION
Changed `yii\base\View::beginCache()` and `yii\base\View::renderDynamic()` to work with placeholders and closures instead of `eval()`.

Before:

``` php
if ($this->beginCache($id)) {
    // ...
    echo $this->renderDynamic('return Yii::$app->user->identity->name');
    // ...
    $this->endCache();
}
```

After:

``` php
if ($this->beginCache($id, ['placeholders' => [
    'username' => Yii::$app->user->identity->name
]])) {
    // ...
    echo $this->renderDynamic('username');
    // ...
    $this->endCache();
}
```

or:

``` php
if ($this->beginCache($id, ['placeholders' => [
    'username' => function () {
        return Yii::$app->user->identity->name;
    }
]])) {
    // ...
    echo $this->renderDynamic('username');
    // ...
    $this->endCache();
}
```

| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | yes |
| Tests pass? | yes |
| Fixed issues | #11689 |
