### PR TITLE
Fixes uncorrect comparsion of directories

### DIFF
--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -253,7 +253,10 @@ class BaseFileHelper
      */
     public static function copyDirectory($src, $dst, $options = [])
     {
-        if ($src === $dst || strpos($dst, $src) === 0) {
+        $src = static::normalizePath($src);
+        $dst = static::normalizePath($dst);
+
+        if ($src === $dst || strpos($dst, $src . DIRECTORY_SEPARATOR) === 0) {
             throw new InvalidParamException('Trying to copy a directory to itself or a subdirectory.');
         }
         if (!is_dir($dst)) {

--- a/tests/framework/helpers/FileHelperTest.php
+++ b/tests/framework/helpers/FileHelperTest.php
@@ -332,6 +332,22 @@ class FileHelperTest extends TestCase
         );
     }
 
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/10710
+     */
+    public function testCopyDirWithSameName()
+    {
+        $this->createFileStructure([
+            'data' => [],
+            'data-backup' => []
+        ]);
+
+        FileHelper::copyDirectory(
+            $this->testFilePath . DIRECTORY_SEPARATOR . 'data',
+            $this->testFilePath . DIRECTORY_SEPARATOR . 'data-backup'
+        );
+    }
+
     public function testRemoveDirectory()
     {
         $dirName = 'test_dir_for_remove';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |

Example

```
FileHelper::copyDirectory('/some/path/directory', '/some/path/directory-backup/some');
```
