### PR TITLE
Fixes #11739 ArrayHelper::index() converts float keys to string

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -363,6 +363,9 @@ class BaseArrayHelper
             } else {
                 $value = static::getValue($element, $key);
                 if ($value !== null) {
+                    if (is_float($value)) {
+                        $value = (string) $value;
+                    }
                     $lastArray[$value] = $element;
                 }
             }

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -424,6 +424,30 @@ class ArrayHelperTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/11739
+     */
+    public function testIndexFloat()
+    {
+        $array = [
+            ['id' => 1e6],
+            ['id' => 1e32],
+            ['id' => 1e64],
+            ['id' => 1465540807.522109],
+        ];
+
+        $expected = [
+            '1000000' => ['id' => 1e6],
+            '1.0E+32' => ['id' => 1e32],
+            '1.0E+64' => ['id' => 1e64],
+            '1465540807.5221' => ['id' => 1465540807.522109],
+        ];
+
+        $result = ArrayHelper::index($array, 'id');
+
+        $this->assertEquals($expected, $result);
+    }
+
     public function testGetColumn()
     {
         $array = [


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | ? |
| Breaks BC? | ? |
| Tests pass? | yes |
| Fixed issues | #11739 |
