### PR TITLE
Handle `_table` and `_column` suffixes on migration creation.

### DIFF
--- a/docs/guide-es/db-migrations.md
+++ b/docs/guide-es/db-migrations.md
@@ -185,14 +185,14 @@ Existe una lista de todos los métodos disponibles para la definición de tipos 
 
 Desde la versión 2.0.7 la consola provee una manera muy conveniente de generar migraciones.
 
-Si el nombre de la migración tiene una forma especial, por ejemplo `create_xxx` o `drop_xxx` entonces el archivo de la migración generada
+Si el nombre de la migración tiene una forma especial, por ejemplo `create_xxx_table` o `drop_xxx_table` entonces el archivo de la migración generada
 contendrá código extra, en este caso para crear/eliminar tablas.
 A continuación se describen todas estas variantes.
 
 ### Crear Tabla
 
 ```php
-yii migrate/create create_post
+yii migrate/create create_post_table
 ```
 
 esto genera
@@ -201,7 +201,7 @@ esto genera
 /**
  * Handles the creation for table `post`.
  */
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -226,7 +226,7 @@ class m150811_220037_create_post extends Migration
 Para crear las columnas en ese momento, las puedes especificar vía la opción `--fields`.
 
 ```php
-yii migrate/create create_post --fields="title:string,body:text"
+yii migrate/create create_post_table --fields="title:string,body:text"
 ```
 
 genera
@@ -235,7 +235,7 @@ genera
 /**
  * Handles the creation for table `post`.
  */
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -263,7 +263,7 @@ class m150811_220037_create_post extends Migration
 Puedes especificar más parámetros para las columnas.
 
 ```php
-yii migrate/create create_post --fields="title:string(12):notNull:unique,body:text"
+yii migrate/create create_post_table --fields="title:string(12):notNull:unique,body:text"
 ```
 
 genera
@@ -272,7 +272,7 @@ genera
 /**
  * Handles the creation for table `post`.
  */
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -304,7 +304,7 @@ class m150811_220037_create_post extends Migration
 Desde 2.0.8 el generador soporta claves foráneas utilizando la palabra clave `foreignKey`.
 
 ```php
-yii migrate/create create_post --fields="author_id:integer:notNull:foreignKey(user),category_id:integer:defaultValue(1):foreignKey,title:string,body:text"
+yii migrate/create create_post_table --fields="author_id:integer:notNull:foreignKey(user),category_id:integer:defaultValue(1):foreignKey,title:string,body:text"
 ```
 
 genera
@@ -317,7 +317,7 @@ genera
  * - `user`
  * - `category`
  */
-class m160328_040430_create_post extends Migration
+class m160328_040430_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -422,13 +422,13 @@ una columna llamada `author_id` con una clave foránea a la tabla `user` mientra
 ### Eliminar Tabla
 
 ```php
-yii migrate/create drop_post --fields="title:string(12):notNull:unique,body:text"
+yii migrate/create drop_post_table --fields="title:string(12):notNull:unique,body:text"
 ```
 
 genera
 
 ```php
-class m150811_220037_drop_post extends Migration
+class m150811_220037_drop_post_table extends Migration
 {
     public function up()
     {
@@ -448,19 +448,19 @@ class m150811_220037_drop_post extends Migration
 
 ### Agregar Columna
 
-Si el nombre de la migración está en la forma `add_xxx_to_yyy` entonces el archivo generado contendrá
+Si el nombre de la migración está en la forma `add_xxx_column_to_yyy_table` entonces el archivo generado contendrá
 las declaraciones `addColumn` y `dropColumn` necesarias.
 
 Para agregar una columna:
 
 ```php
-yii migrate/create add_position_to_post --fields="position:integer"
+yii migrate/create add_position_column_to_post_table --fields="position:integer"
 ```
 
 genera
 
 ```php
-class m150811_220037_add_position_to_post extends Migration
+class m150811_220037_add_position_column_to_post_table extends Migration
 {
     public function up()
     {
@@ -476,17 +476,17 @@ class m150811_220037_add_position_to_post extends Migration
 
 ### Eliminar Columna
 
-Si el nombre de la migración está en la forma `drop_xxx_from_yyy` entonces el archivo generado contendrá
+Si el nombre de la migración está en la forma `drop_xxx_column_from_yyy_table` entonces el archivo generado contendrá
 las declaraciones `addColumn` y `dropColumn` necesarias.
 
 ```php
-yii migrate/create drop_position_from_post --fields="position:integer"
+yii migrate/create drop_position_column_from_post_table --fields="position:integer"
 ```
 
 genera
 
 ```php
-class m150811_220037_drop_position_from_post extends Migration
+class m150811_220037_drop_position_column_from_post_table extends Migration
 {
     public function up()
     {
@@ -502,11 +502,11 @@ class m150811_220037_drop_position_from_post extends Migration
 
 ### Agregar Tabla de Unión
 
-Si el nombre de la migración está en la forma `create_junction_xxx_and_yyy` entonces se generará el código necesario
+Si el nombre de la migración está en la forma `create_junction_table_for_xxx_and_yyy_tables` entonces se generará el código necesario
 para una tabla de unión.
 
 ```php
-yii migrate/create create_junction_post_and_tag --fields="created_at:dateTime"
+yii migrate/create create_junction_table_for_post_and_tag_tables --fields="created_at:dateTime"
 ```
 
 genera
@@ -519,7 +519,7 @@ genera
  * - `post`
  * - `tag`
  */
-class m160328_041642_create_junction_post_and_tag extends Migration
+class m160328_041642_create_junction_table_for_post_and_tag_tables extends Migration
 {
     /**
      * @inheritdoc

--- a/docs/guide-ja/db-migrations.md
+++ b/docs/guide-ja/db-migrations.md
@@ -177,14 +177,14 @@ class m150101_185401_create_news_table extends Migration
 バージョン 2.0.7 以降では、マイグレーション・コンソールがマイグレーションを生成する便利な方法を提供しています。
 
 マイグレーションの名前が特定の形式である場合は、生成されるマイグレーション・ファイルに追加のコードが書き込まれます。
-例えば、`create_xxx` や `drop_xxx` であれば、テーブルの作成や削除をするコードが追加されます。
+例えば、`create_xxx_table` や `drop_xxx_table` であれば、テーブルの作成や削除をするコードが追加されます。
 以下で、この機能の全ての変種を説明します。
 
 
 ### テーブルの作成
 
 ```php
-yii migrate/create create_post
+yii migrate/create create_post_table
 ``` 
 
 上記のコマンドは、次のコードを生成します。
@@ -193,7 +193,7 @@ yii migrate/create create_post
 /**
  * Handles the creation for table `post`.
  */
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -218,7 +218,7 @@ class m150811_220037_create_post extends Migration
 テーブルのフィールドも直接に生成したい場合は、`--fields` オプションでフィールドを指定します。
  
 ```php
-yii migrate/create create_post --fields="title:string,body:text"
+yii migrate/create create_post_table --fields="title:string,body:text"
 ``` 
 
 これは、次のコードを生成します。
@@ -227,7 +227,7 @@ yii migrate/create create_post --fields="title:string,body:text"
 /**
  * Handles the creation for table `post`.
  */
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -255,7 +255,7 @@ class m150811_220037_create_post extends Migration
 さらに多くのフィールド・パラメータを指定することも出来ます。
 
 ```php
-yii migrate/create create_post --fields="title:string(12):notNull:unique,body:text"
+yii migrate/create create_post_table --fields="title:string(12):notNull:unique,body:text"
 ``` 
 
 これは、次のコードを生成します。
@@ -264,7 +264,7 @@ yii migrate/create create_post --fields="title:string(12):notNull:unique,body:te
 /**
  * Handles the creation for table `post`.
  */
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -297,7 +297,7 @@ class m150811_220037_create_post extends Migration
 バージョン 2.0.8 からは、`foreignKey` キーワードを使って外部キーを生成することができます。
 
 ```php
-yii migrate/create create_post --fields="author_id:integer:notNull:foreignKey(user),category_id:integer:defaultValue(1):foreignKey,title:string,body:text"
+yii migrate/create create_post_table --fields="author_id:integer:notNull:foreignKey(user),category_id:integer:defaultValue(1):foreignKey,title:string,body:text"
 ```
 
 これは、次のコードを生成します。
@@ -310,7 +310,7 @@ yii migrate/create create_post --fields="author_id:integer:notNull:foreignKey(us
  * - `user`
  * - `category`
  */
-class m160328_040430_create_post extends Migration
+class m160328_040430_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -413,13 +413,13 @@ class m160328_040430_create_post extends Migration
 ### テーブルを削除する
 
 ```php
-yii migrate/create drop_post --fields="title:string(12):notNull:unique,body:text"
+yii migrate/create drop_post_table --fields="title:string(12):notNull:unique,body:text"
 ``` 
 
 これは、次のコードを生成します。
 
 ```php
-class m150811_220037_drop_post extends Migration
+class m150811_220037_drop_post_table extends Migration
 {
     public function up()
     {
@@ -439,18 +439,18 @@ class m150811_220037_drop_post extends Migration
 
 ### カラムを追加する
 
-マイグレーションの名前が `add_xxx_to_yyy` の形式である場合、ファイルの内容は、必要となる `addColumn` と `dropColumn` を含むことになります。
+マイグレーションの名前が `add_xxx_column_to_yyy_table` の形式である場合、ファイルの内容は、必要となる `addColumn` と `dropColumn` を含むことになります。
 
 カラムを追加するためには、次のようにします。
 
 ```php
-yii migrate/create add_position_to_post --fields="position:integer"
+yii migrate/create add_position_column_to_post_table --fields="position:integer"
 ```
 
 これが次のコードを生成します。
 
 ```php
-class m150811_220037_add_position_to_post extends Migration
+class m150811_220037_add_position_column_to_post_table extends Migration
 {
     public function up()
     {
@@ -466,16 +466,16 @@ class m150811_220037_add_position_to_post extends Migration
 
 ### カラムを削除する
 
-マイグレーションの名前が `drop_xxx_from_yyy` の形式である場合、ファイルの内容は、必要となる `addColumn` と `dropColumn` を含むことになります。
+マイグレーションの名前が `drop_xxx_column_from_yyy_table` の形式である場合、ファイルの内容は、必要となる `addColumn` と `dropColumn` を含むことになります。
 
 ```php
-yii migrate/create drop_position_from_post --fields="position:integer"
+yii migrate/create drop_position_column_from_post_table --fields="position:integer"
 ```
 
 これは、次のコードを生成します。
 
 ```php
-class m150811_220037_drop_position_from_post extends Migration
+class m150811_220037_drop_position_column_from_post_table extends Migration
 {
     public function up()
     {
@@ -491,10 +491,10 @@ class m150811_220037_drop_position_from_post extends Migration
 
 ### 中間テーブルを追加する
 
-マイグレーションの名前が `create_junction_xxx_and_yyy` の形式である場合は、中間テーブルを作成するのに必要となるコードが生成されます。
+マイグレーションの名前が `create_junction_table_for_xxx_and_yyy_tables` の形式である場合は、中間テーブルを作成するのに必要となるコードが生成されます。
 
 ```php
-yii migrate/create create_junction_post_and_tag --fields="created_at:dateTime"
+yii migrate/create create_junction_table_for_post_and_tag_tables --fields="created_at:dateTime"
 ```
 
 これは、次のコードを生成します。
@@ -507,7 +507,7 @@ yii migrate/create create_junction_post_and_tag --fields="created_at:dateTime"
  * - `post`
  * - `tag`
  */
-class m160328_041642_create_junction_post_and_tag extends Migration
+class m160328_041642_create_junction_table_for_post_and_tag_tables extends Migration
 {
     /**
      * @inheritdoc

--- a/docs/guide-ru/db-migrations.md
+++ b/docs/guide-ru/db-migrations.md
@@ -160,19 +160,19 @@ class m150101_185401_create_news_table extends Migration
 
 Начиная с версии 2.0.7 появился удобный способ создания миграций из консоли.
 
-В том случае, если миграция названа особым образом, таким как, например, `create_xxx` или `drop_xxx` сгенерированный
+В том случае, если миграция названа особым образом, таким как, например, `create_xxx_table` или `drop_xxx_table` сгенерированный
 файл миграции будет содержать дополнительный код.
 
 ### Создание таблицы
 
 ```php
-yii migrate/create create_post
+yii migrate/create create_post_table
 ``` 
 
 сгенерирует
 
 ```php
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     public function up()
     {
@@ -191,13 +191,13 @@ class m150811_220037_create_post extends Migration
 Чтобы сразу создать поля таблицы, укажите их через опцию `--fields`.
  
 ```php
-yii migrate/create create_post --fields=title:string,body:text
+yii migrate/create create_post_table --fields=title:string,body:text
 ``` 
 
 сгенерирует
 
 ```php
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     public function up()
     {
@@ -218,13 +218,13 @@ class m150811_220037_create_post extends Migration
 Можно указать дополнительные параметры.
 
 ```php
-yii migrate/create create_post --fields=title:string(12):notNull:unique,body:text
+yii migrate/create create_post_table --fields=title:string(12):notNull:unique,body:text
 ``` 
 
 сгенерирует
 
 ```php
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     public function up()
     {
@@ -249,13 +249,13 @@ class m150811_220037_create_post extends Migration
 ### Удаление таблицы
 
 ```php
-yii migrate/create drop_post --fields=title:string(12):notNull:unique,body:text
+yii migrate/create drop_post_table --fields=title:string(12):notNull:unique,body:text
 ``` 
 
 сгенерирует
 
 ```php
-class m150811_220037_drop_post extends Migration
+class m150811_220037_drop_post_table extends Migration
 {
     public function up()
     {
@@ -275,18 +275,18 @@ class m150811_220037_drop_post extends Migration
 
 ### Добавление столбца
 
-Если имя миграции задано как `add_xxx_to_yyy`, файл будет содержать необходимые методы `addColumn` и `dropColumn`.
+Если имя миграции задано как `add_xxx_column_to_yyy_table`, файл будет содержать необходимые методы `addColumn` и `dropColumn`.
 
 Для добавления столбца:
 
 ```php
-yii migrate/create add_position_to_post --fields=position:integer
+yii migrate/create add_position_column_to_post_table --fields=position:integer
 ```
 
 сгенерирует
 
 ```php
-class m150811_220037_add_position_to_post extends Migration
+class m150811_220037_add_position_column_to_post_table extends Migration
 {
     public function up()
     {
@@ -302,16 +302,16 @@ class m150811_220037_add_position_to_post extends Migration
 
 ### Удаление столбца
 
-Если имя миграции задано как `drop_xxx_from_yyy`, файл будет содержать необходимые методы `addColumn` и `dropColumn`.
+Если имя миграции задано как `drop_xxx_column_from_yyy_table`, файл будет содержать необходимые методы `addColumn` и `dropColumn`.
 
 ```php
-yii migrate/create drop_position_from_post --fields=position:integer
+yii migrate/create drop_position_column_from_post_table --fields=position:integer
 ```
 
 сгенерирует
 
 ```php
-class m150811_220037_drop_position_from_post extends Migration
+class m150811_220037_drop_position_column_from_post_table extends Migration
 {
     public function up()
     {
@@ -327,10 +327,10 @@ class m150811_220037_drop_position_from_post extends Migration
 
 ### Добавление промежуточной таблицы
 
-Если имя миграции задано как `create_junction_xxx_and_yyy`, файл будет содержать код для создания промежуточной таблцы.
+Если имя миграции задано как `create_junction_table_for_xxx_and_yyy_tables`, файл будет содержать код для создания промежуточной таблцы.
 
 ```php
-yii migrate/create create_junction_post_and_tag
+yii migrate/create create_junction_table_for_post_and_tag_tables
 ```
 
 сгенерирует

--- a/docs/guide/db-migrations.md
+++ b/docs/guide/db-migrations.md
@@ -186,7 +186,8 @@ A list of all available methods for defining the column types is available in th
 Since version 2.0.7 migration console provides a convenient way to create migrations.
 
 If the migration name is of a special form, for example `create_xxx` or `drop_xxx` then the generated migration
-file will contain extra code, in this case for creating/dropping tables.
+file will contain extra code, in this case for creating/dropping tables. Since 2.0.9 more explicit names are
+available, for example `create_xxx_table` or `drop_xxx_table`.
 In the following all variants of this feature are described.
 
 ### Create Table
@@ -448,8 +449,8 @@ class m150811_220037_drop_post extends Migration
 
 ### Add Column
 
-If the migration name is of the form `add_xxx_to_yyy` then the file content would contain `addColumn` and `dropColumn`
-statements necessary.
+If the migration name is of the form `add_xxx_to_yyy` or `add_xxx_column_to_yyy_table` then the file
+content would contain `addColumn` and `dropColumn` statements necessary.
 
 To add column:
 
@@ -476,8 +477,8 @@ class m150811_220037_add_position_to_post extends Migration
 
 ### Drop Column
 
-If the migration name is of the form `drop_xxx_from_yyy` then the file content would contain `addColumn` and `dropColumn`
-statements necessary.
+If the migration name is of the form `drop_xxx_from_yyy` or `drop_xxx_column_from_yyy_table` then
+the file content would contain `addColumn` and `dropColumn` statements necessary.
 
 ```php
 yii migrate/create drop_position_from_post --fields="position:integer"
@@ -502,8 +503,8 @@ class m150811_220037_drop_position_from_post extends Migration
 
 ### Add Junction Table
 
-If the migration name is in if the form of `create_junction_xxx_and_yyy` then code necessary to create junction table
-will be generated.
+If the migration name is of the form `create_junction_xxx_and_yyy` or `create_junction_table_for_xxx_and_yyy_tables`
+then code necessary to create junction table will be generated.
 
 ```php
 yii migrate/create create_junction_post_and_tag --fields="created_at:dateTime"

--- a/docs/guide/db-migrations.md
+++ b/docs/guide/db-migrations.md
@@ -185,15 +185,14 @@ A list of all available methods for defining the column types is available in th
 
 Since version 2.0.7 migration console provides a convenient way to create migrations.
 
-If the migration name is of a special form, for example `create_xxx` or `drop_xxx` then the generated migration
-file will contain extra code, in this case for creating/dropping tables. Since 2.0.9 more explicit names are
-available, for example `create_xxx_table` or `drop_xxx_table`.
+If the migration name is of a special form, for example `create_xxx_table` then the generated migration
+file will contain extra code, in this case for creating/dropping tables.
 In the following all variants of this feature are described.
 
 ### Create Table
 
 ```php
-yii migrate/create create_post
+yii migrate/create create_post_table
 ```
 
 generates
@@ -202,7 +201,7 @@ generates
 /**
  * Handles the creation for table `post`.
  */
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -227,7 +226,7 @@ class m150811_220037_create_post extends Migration
 To create table fields right away, specify them via `--fields` option.
 
 ```php
-yii migrate/create create_post --fields="title:string,body:text"
+yii migrate/create create_post_table --fields="title:string,body:text"
 ```
 
 generates
@@ -236,7 +235,7 @@ generates
 /**
  * Handles the creation for table `post`.
  */
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -264,7 +263,7 @@ class m150811_220037_create_post extends Migration
 You can specify more field parameters.
 
 ```php
-yii migrate/create create_post --fields="title:string(12):notNull:unique,body:text"
+yii migrate/create create_post_table --fields="title:string(12):notNull:unique,body:text"
 ```
 
 generates
@@ -273,7 +272,7 @@ generates
 /**
  * Handles the creation for table `post`.
  */
-class m150811_220037_create_post extends Migration
+class m150811_220037_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -305,7 +304,7 @@ class m150811_220037_create_post extends Migration
 Since 2.0.8 the generator supports foreign keys using the `foreignKey` keyword.
 
 ```php
-yii migrate/create create_post --fields="author_id:integer:notNull:foreignKey(user),category_id:integer:defaultValue(1):foreignKey,title:string,body:text"
+yii migrate/create create_post_table --fields="author_id:integer:notNull:foreignKey(user),category_id:integer:defaultValue(1):foreignKey,title:string,body:text"
 ```
 
 generates
@@ -318,7 +317,7 @@ generates
  * - `user`
  * - `category`
  */
-class m160328_040430_create_post extends Migration
+class m160328_040430_create_post_table extends Migration
 {
     /**
      * @inheritdoc
@@ -423,13 +422,13 @@ column named `author_id` with a foreign key to the `user` table while
 ### Drop Table
 
 ```php
-yii migrate/create drop_post --fields="title:string(12):notNull:unique,body:text"
+yii migrate/create drop_post_table --fields="title:string(12):notNull:unique,body:text"
 ```
 
 generates
 
 ```php
-class m150811_220037_drop_post extends Migration
+class m150811_220037_drop_post_table extends Migration
 {
     public function up()
     {
@@ -449,19 +448,19 @@ class m150811_220037_drop_post extends Migration
 
 ### Add Column
 
-If the migration name is of the form `add_xxx_to_yyy` or `add_xxx_column_to_yyy_table` then the file
+If the migration name is of the form `add_xxx_column_to_yyy_table` then the file
 content would contain `addColumn` and `dropColumn` statements necessary.
 
 To add column:
 
 ```php
-yii migrate/create add_position_to_post --fields="position:integer"
+yii migrate/create add_position_column_to_post_table --fields="position:integer"
 ```
 
 generates
 
 ```php
-class m150811_220037_add_position_to_post extends Migration
+class m150811_220037_add_position_column_to_post_table extends Migration
 {
     public function up()
     {
@@ -477,17 +476,17 @@ class m150811_220037_add_position_to_post extends Migration
 
 ### Drop Column
 
-If the migration name is of the form `drop_xxx_from_yyy` or `drop_xxx_column_from_yyy_table` then
+If the migration name is of the form `drop_xxx_column_from_yyy_table` then
 the file content would contain `addColumn` and `dropColumn` statements necessary.
 
 ```php
-yii migrate/create drop_position_from_post --fields="position:integer"
+yii migrate/create drop_position_column_from_post_table --fields="position:integer"
 ```
 
 generates
 
 ```php
-class m150811_220037_drop_position_from_post extends Migration
+class m150811_220037_drop_position_column_from_post_table extends Migration
 {
     public function up()
     {
@@ -503,11 +502,11 @@ class m150811_220037_drop_position_from_post extends Migration
 
 ### Add Junction Table
 
-If the migration name is of the form `create_junction_xxx_and_yyy` or `create_junction_table_for_xxx_and_yyy_tables`
+If the migration name is of the form `create_junction_table_for_xxx_and_yyy_tables` or `create_junction_xxx_and_yyy_tables`
 then code necessary to create junction table will be generated.
 
 ```php
-yii migrate/create create_junction_post_and_tag --fields="created_at:dateTime"
+yii migrate/create create_junction_table_for_post_and_tag_tables --fields="created_at:dateTime"
 ```
 
 generates
@@ -520,7 +519,7 @@ generates
  * - `post`
  * - `tag`
  */
-class m160328_041642_create_junction_post_and_tag extends Migration
+class m160328_041642_create_junction_table_for_post_and_tag_tables extends Migration
 {
     /**
      * @inheritdoc

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -43,7 +43,7 @@ Yii Framework 2 Change Log
 - Bug #11672: Fixed `yii\validators\NumberValidator` erroring when value is an object without `__toString()` method (SamMousa)
 - Bug #11561: Fixed DI container throwing exceptions for optional dependencies (SamMousa)
 - Enh #11168: `yii\helpers\BaseHtml` now uses abstracted `booleanInput()` and `activeBooleanInput()` methods to render `radio()`, `checkbox()`, `activeRadio()` and `activeCheckbox()` (cesarnicola)
-- Enh #11808: Handle `_table` and `_column` suffixes on migration creation (rob006)
+- Enh #11808: `_table` and `_column` suffixes are now required when generating migration (rob006)
 - Bug #11822: Fixed exception on non-string value provided as CSRF token (cebe)
 - Enh #11850: Introduced `yii\widgets\Pjax::$submitEvent` to be able to customize event triggering PJAX form submit (Bvanleeuwen)
 - Bug #11847: Fixed `yii\widgets\Pjax` to properly respond with partials when custom selector is used for container (pigochu, samdark)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -43,6 +43,7 @@ Yii Framework 2 Change Log
 - Bug #11672: Fixed `yii\validators\NumberValidator` erroring when value is an object without `__toString()` method (SamMousa)
 - Bug #11561: Fixed DI container throwing exceptions for optional dependencies (SamMousa)
 - Enh #11168: `yii\helpers\BaseHtml` now uses abstracted `booleanInput()` and `activeBooleanInput()` methods to render `radio()`, `checkbox()`, `activeRadio()` and `activeCheckbox()` (cesarnicola)
+- Enh #11808: Handle `_table` and `_column` suffixes on migration creation (rob006)
 - Bug #11822: Fixed exception on non-string value provided as CSRF token (cebe)
 - Enh #11850: Introduced `yii\widgets\Pjax::$submitEvent` to be able to customize event triggering PJAX form submit (Bvanleeuwen)
 - Bug #11847: Fixed `yii\widgets\Pjax` to properly respond with partials when custom selector is used for container (pigochu, samdark)

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -246,7 +246,7 @@ class MigrateController extends BaseMigrateController
 
         $templateFile = $this->templateFile;
         $table = null;
-        if (preg_match('/^create_junction(?:_table_for_|_)(.+)_and_(.+)(?:_tables?)?$/U', $name, $matches)) {
+        if (preg_match('/^create_junction(?:_table_for_|_for_|_)(.+)_and_(.+)_tables?$/', $name, $matches)) {
             $templateFile = $this->generatorTemplateFiles['create_junction'];
             $firstTable = mb_strtolower($matches[1], Yii::$app->charset);
             $secondTable = mb_strtolower($matches[2], Yii::$app->charset);
@@ -275,17 +275,17 @@ class MigrateController extends BaseMigrateController
             $foreignKeys[$firstTable . '_id'] = $firstTable;
             $foreignKeys[$secondTable . '_id'] = $secondTable;
             $table = $firstTable . '_' . $secondTable;
-        } elseif (preg_match('/^add_(.+)(?:_column)?_to_(.+)(?:_table)?$/U', $name, $matches)) {
+        } elseif (preg_match('/^add_(.+)_columns?_to_(.+)_table$/', $name, $matches)) {
             $templateFile = $this->generatorTemplateFiles['add_column'];
             $table = mb_strtolower($matches[2], Yii::$app->charset);
-        } elseif (preg_match('/^drop_(.+)(?:_column)?_from_(.+)(?:_table)?$/U', $name, $matches)) {
+        } elseif (preg_match('/^drop_(.+)_columns?_from_(.+)_table$/', $name, $matches)) {
             $templateFile = $this->generatorTemplateFiles['drop_column'];
             $table = mb_strtolower($matches[2], Yii::$app->charset);
-        } elseif (preg_match('/^create_(.+)(?:_table)?$/U', $name, $matches)) {
+        } elseif (preg_match('/^create_(.+)_table$/', $name, $matches)) {
             $this->addDefaultPrimaryKey($fields);
             $templateFile = $this->generatorTemplateFiles['create_table'];
             $table = mb_strtolower($matches[1], Yii::$app->charset);
-        } elseif (preg_match('/^drop_(.+)(?:_table)?$/U', $name, $matches)) {
+        } elseif (preg_match('/^drop_(.+)_table$/', $name, $matches)) {
             $this->addDefaultPrimaryKey($fields);
             $templateFile = $this->generatorTemplateFiles['drop_table'];
             $table = mb_strtolower($matches[1], Yii::$app->charset);

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -246,7 +246,7 @@ class MigrateController extends BaseMigrateController
 
         $templateFile = $this->templateFile;
         $table = null;
-        if (preg_match('/^create_junction_(.+)_and_(.+)$/', $name, $matches)) {
+        if (preg_match('/^create_junction(?:_table_for_|_)(.+)_and_(.+)(?:_tables?)?$/U', $name, $matches)) {
             $templateFile = $this->generatorTemplateFiles['create_junction'];
             $firstTable = mb_strtolower($matches[1], Yii::$app->charset);
             $secondTable = mb_strtolower($matches[2], Yii::$app->charset);
@@ -275,17 +275,17 @@ class MigrateController extends BaseMigrateController
             $foreignKeys[$firstTable . '_id'] = $firstTable;
             $foreignKeys[$secondTable . '_id'] = $secondTable;
             $table = $firstTable . '_' . $secondTable;
-        } elseif (preg_match('/^add_(.+)_to_(.+)$/', $name, $matches)) {
+        } elseif (preg_match('/^add_(.+)(?:_column)?_to_(.+)(?:_table)?$/U', $name, $matches)) {
             $templateFile = $this->generatorTemplateFiles['add_column'];
             $table = mb_strtolower($matches[2], Yii::$app->charset);
-        } elseif (preg_match('/^drop_(.+)_from_(.+)$/', $name, $matches)) {
+        } elseif (preg_match('/^drop_(.+)(?:_column)?_from_(.+)(?:_table)?$/U', $name, $matches)) {
             $templateFile = $this->generatorTemplateFiles['drop_column'];
             $table = mb_strtolower($matches[2], Yii::$app->charset);
-        } elseif (preg_match('/^create_(.+)$/', $name, $matches)) {
+        } elseif (preg_match('/^create_(.+)(?:_table)?$/U', $name, $matches)) {
             $this->addDefaultPrimaryKey($fields);
             $templateFile = $this->generatorTemplateFiles['create_table'];
             $table = mb_strtolower($matches[1], Yii::$app->charset);
-        } elseif (preg_match('/^drop_(.+)$/', $name, $matches)) {
+        } elseif (preg_match('/^drop_(.+)(?:_table)?$/U', $name, $matches)) {
             $this->addDefaultPrimaryKey($fields);
             $templateFile = $this->generatorTemplateFiles['drop_table'];
             $table = mb_strtolower($matches[1], Yii::$app->charset);

--- a/framework/views/addColumnMigration.php
+++ b/framework/views/addColumnMigration.php
@@ -7,7 +7,7 @@
 /* @var $table string the name table */
 /* @var $fields array the fields */
 
-preg_match('/^add_(.+)_to_(.+)$/', $name, $matches);
+preg_match('/^add_(.+)(?:_column)?_to_(.+)(?:_table)?$/U', $name, $matches);
 $columns = $matches[1];
 
 echo "<?php\n";

--- a/framework/views/addColumnMigration.php
+++ b/framework/views/addColumnMigration.php
@@ -7,7 +7,7 @@
 /* @var $table string the name table */
 /* @var $fields array the fields */
 
-preg_match('/^add_(.+)(?:_column)?_to_(.+)(?:_table)?$/U', $name, $matches);
+preg_match('/^add_(.+)_columns?_to_(.+)_table$/', $name, $matches);
 $columns = $matches[1];
 
 echo "<?php\n";

--- a/framework/views/dropColumnMigration.php
+++ b/framework/views/dropColumnMigration.php
@@ -6,7 +6,7 @@
 /* @var $className string the new migration class name */
 /* @var $table string the name table */
 /* @var $fields array the fields */
-preg_match('/^drop_(.+)(?:_column)?_from_(.+)(?:_table)?$/U', $name, $matches);
+preg_match('/^drop_(.+)_columns?_from_(.+)_table$/', $name, $matches);
 $columns = $matches[1];
 
 echo "<?php\n";

--- a/framework/views/dropColumnMigration.php
+++ b/framework/views/dropColumnMigration.php
@@ -6,7 +6,7 @@
 /* @var $className string the new migration class name */
 /* @var $table string the name table */
 /* @var $fields array the fields */
-preg_match('/^drop_(.+)_from_(.+)$/', $name, $matches);
+preg_match('/^drop_(.+)(?:_column)?_from_(.+)(?:_table)?$/U', $name, $matches);
 $columns = $matches[1];
 
 echo "<?php\n";

--- a/tests/data/console/migrate_create/create_products_from_store_table.php
+++ b/tests/data/console/migrate_create/create_products_from_store_table.php
@@ -1,0 +1,32 @@
+<?php
+
+return <<<CODE
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation for table `products_from_store`.
+ */
+class {$class} extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function up()
+    {
+        \$this->createTable('products_from_store', [
+            'id' => \$this->primaryKey(),
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function down()
+    {
+        \$this->dropTable('products_from_store');
+    }
+}
+
+CODE;

--- a/tests/data/console/migrate_create/drop_products_from_store_table.php
+++ b/tests/data/console/migrate_create/drop_products_from_store_table.php
@@ -1,0 +1,32 @@
+<?php
+
+return <<<CODE
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the dropping for table `products_from_store`.
+ */
+class {$class} extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function up()
+    {
+        \$this->dropTable('products_from_store');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function down()
+    {
+        \$this->createTable('products_from_store', [
+            'id' => \$this->primaryKey(),
+        ]);
+    }
+}
+
+CODE;

--- a/tests/framework/console/controllers/MigrateControllerTestTrait.php
+++ b/tests/framework/console/controllers/MigrateControllerTestTrait.php
@@ -194,93 +194,121 @@ CODE;
 
     public function testGenerateCreateMigration()
     {
-        $migrationName = 'create_test';
+        $migrationNames = [
+            'create_test',
+            'create_test_table',
+        ];
+        foreach ($migrationNames as $migrationName) {
+            $this->assertCommandCreatedFile('create_test', $migrationName);
 
-        $this->assertCommandCreatedFile('create_test', $migrationName);
+            $this->assertCommandCreatedFile('create_fields', $migrationName, [
+                'fields' => 'title:string(10):notNull:unique:defaultValue("test"),
+                    body:text:notNull,
+                    price:money(11,2):notNull'
+            ]);
 
-        $this->assertCommandCreatedFile('create_fields', $migrationName, [
-            'fields' => 'title:string(10):notNull:unique:defaultValue("test"),
-                body:text:notNull,
-                price:money(11,2):notNull'
-        ]);
+            $this->assertCommandCreatedFile('create_title_pk', $migrationName, [
+                'fields' => 'title:primaryKey,body:text:notNull,price:money(11,2)',
+            ]);
 
-        $this->assertCommandCreatedFile('create_title_pk', $migrationName, [
-            'fields' => 'title:primaryKey,body:text:notNull,price:money(11,2)',
-        ]);
+            $this->assertCommandCreatedFile('create_id_pk', $migrationName, [
+                'fields' => 'id:primaryKey,
+                    address:string,
+                    address2:string,
+                    email:string',
+            ]);
 
-        $this->assertCommandCreatedFile('create_id_pk', $migrationName, [
-            'fields' => 'id:primaryKey,
-                address:string,
-                address2:string,
-                email:string',
-        ]);
+            $this->assertCommandCreatedFile('create_foreign_key', $migrationName, [
+                'fields' => 'user_id:integer:foreignKey,
+                    product_id:foreignKey:integer:unsigned:notNull,
+                    order_id:integer:foreignKey(user_order):notNull,
+                    created_at:dateTime:notNull',
+            ]);
 
-        $this->assertCommandCreatedFile('create_foreign_key', $migrationName, [
-            'fields' => 'user_id:integer:foreignKey,
-                product_id:foreignKey:integer:unsigned:notNull,
-                order_id:integer:foreignKey(user_order):notNull,
-                created_at:dateTime:notNull',
-        ]);
-
-        $this->assertCommandCreatedFile('create_prefix', $migrationName, [
-            'useTablePrefix' => true,
-            'fields' => 'user_id:integer:foreignKey,
-                product_id:foreignKey:integer:unsigned:notNull,
-                order_id:integer:foreignKey(user_order):notNull,
-                created_at:dateTime:notNull',
-        ]);
+            $this->assertCommandCreatedFile('create_prefix', $migrationName, [
+                'useTablePrefix' => true,
+                'fields' => 'user_id:integer:foreignKey,
+                    product_id:foreignKey:integer:unsigned:notNull,
+                    order_id:integer:foreignKey(user_order):notNull,
+                    created_at:dateTime:notNull',
+            ]);
+        }
     }
 
     public function testGenerateDropMigration()
     {
-        $migrationName = 'drop_test';
-        $this->assertCommandCreatedFile('drop_test', $migrationName);
+        $migrationNames = [
+            'drop_test',
+            'drop_test_table',
+        ];
+        foreach ($migrationNames as $migrationName) {
+            $this->assertCommandCreatedFile('drop_test', $migrationName);
 
-        $this->assertCommandCreatedFile('drop_fields', $migrationName, [
-            'fields' => 'body:text:notNull,price:money(11,2)'
-        ]);
+            $this->assertCommandCreatedFile('drop_fields', $migrationName, [
+                'fields' => 'body:text:notNull,price:money(11,2)'
+            ]);
+        }
     }
 
     public function testGenerateAddColumnMigration()
     {
-        $migrationName = 'add_columns_to_test';
-        $this->assertCommandCreatedFile('add_columns_test', $migrationName, [
-            'fields' => 'title:string(10):notNull,
-                body:text:notNull,
-                price:money(11,2):notNull,
-                created_at:dateTime'
-        ]);
+        $migrationNames = [
+            'add_columns_to_test',
+            'add_columns_to_test_table',
+            'add_columns_column_to_test_table',
+        ];
+        foreach ($migrationNames as $migrationName) {
+            $this->assertCommandCreatedFile('add_columns_test', $migrationName, [
+                'fields' => 'title:string(10):notNull,
+                    body:text:notNull,
+                    price:money(11,2):notNull,
+                    created_at:dateTime'
+            ]);
 
-        $this->assertCommandCreatedFile('add_columns_fk', $migrationName, [
-            'fields' => 'user_id:integer:foreignKey,
-                product_id:foreignKey:integer:unsigned:notNull,
-                order_id:integer:foreignKey(user_order):notNull,
-                created_at:dateTime:notNull',
-        ]);
+            $this->assertCommandCreatedFile('add_columns_fk', $migrationName, [
+                'fields' => 'user_id:integer:foreignKey,
+                    product_id:foreignKey:integer:unsigned:notNull,
+                    order_id:integer:foreignKey(user_order):notNull,
+                    created_at:dateTime:notNull',
+            ]);
 
-        $this->assertCommandCreatedFile('add_columns_prefix', $migrationName, [
-            'useTablePrefix' => true,
-            'fields' => 'user_id:integer:foreignKey,
-                product_id:foreignKey:integer:unsigned:notNull,
-                order_id:integer:foreignKey(user_order):notNull,
-                created_at:dateTime:notNull',
-        ]);
+            $this->assertCommandCreatedFile('add_columns_prefix', $migrationName, [
+                'useTablePrefix' => true,
+                'fields' => 'user_id:integer:foreignKey,
+                    product_id:foreignKey:integer:unsigned:notNull,
+                    order_id:integer:foreignKey(user_order):notNull,
+                    created_at:dateTime:notNull',
+            ]);
+        }
     }
 
     public function testGenerateDropColumnMigration()
     {
-        $migrationName = 'drop_columns_from_test';
-        $this->assertCommandCreatedFile('drop_columns_test', $migrationName, [
-            'fields' => 'title:string(10):notNull,body:text:notNull,
-                price:money(11,2):notNull,
-                created_at:dateTime'
-        ]);
+        $migrationNames = [
+            'drop_columns_from_test',
+            'drop_columns_from_test_table',
+            'drop_columns_column_from_test_table',
+        ];
+        foreach ($migrationNames as $migrationName) {
+            $this->assertCommandCreatedFile('drop_columns_test', $migrationName, [
+                'fields' => 'title:string(10):notNull,body:text:notNull,
+                    price:money(11,2):notNull,
+                    created_at:dateTime'
+            ]);
+        }
     }
 
     public function testGenerateCreateJunctionMigration()
     {
-        $migrationName = 'create_junction_post_and_tag';
-        $this->assertCommandCreatedFile('junction_test', $migrationName);
+        $migrationNames = [
+            'create_junction_post_and_tag',
+            'create_junction_table_for_post_and_tag_tables',
+            'create_junction_table_for_post_and_tag_table',
+            'create_junction_post_and_tag_tables',
+        ];
+        foreach ($migrationNames as $migrationName) {
+            $this->assertCommandCreatedFile('junction_test', $migrationName);
+        }
     }
 
     public function testUp()

--- a/tests/framework/console/controllers/MigrateControllerTestTrait.php
+++ b/tests/framework/console/controllers/MigrateControllerTestTrait.php
@@ -195,7 +195,6 @@ CODE;
     public function testGenerateCreateMigration()
     {
         $migrationNames = [
-            'create_test',
             'create_test_table',
         ];
         foreach ($migrationNames as $migrationName) {
@@ -233,12 +232,14 @@ CODE;
                     created_at:dateTime:notNull',
             ]);
         }
+
+		// @see https://github.com/yiisoft/yii2/issues/10876
+		$this->assertCommandCreatedFile('create_products_from_store_table', 'create_products_from_store_table');
     }
 
     public function testGenerateDropMigration()
     {
         $migrationNames = [
-            'drop_test',
             'drop_test_table',
         ];
         foreach ($migrationNames as $migrationName) {
@@ -248,14 +249,16 @@ CODE;
                 'fields' => 'body:text:notNull,price:money(11,2)'
             ]);
         }
+		
+		// @see https://github.com/yiisoft/yii2/issues/10876
+		$this->assertCommandCreatedFile('drop_products_from_store_table', 'drop_products_from_store_table');
     }
 
     public function testGenerateAddColumnMigration()
     {
         $migrationNames = [
-            'add_columns_to_test',
-            'add_columns_to_test_table',
             'add_columns_column_to_test_table',
+            'add_columns_columns_to_test_table',
         ];
         foreach ($migrationNames as $migrationName) {
             $this->assertCommandCreatedFile('add_columns_test', $migrationName, [
@@ -285,9 +288,8 @@ CODE;
     public function testGenerateDropColumnMigration()
     {
         $migrationNames = [
-            'drop_columns_from_test',
-            'drop_columns_from_test_table',
             'drop_columns_column_from_test_table',
+            'drop_columns_columns_from_test_table',
         ];
         foreach ($migrationNames as $migrationName) {
             $this->assertCommandCreatedFile('drop_columns_test', $migrationName, [
@@ -301,10 +303,10 @@ CODE;
     public function testGenerateCreateJunctionMigration()
     {
         $migrationNames = [
-            'create_junction_post_and_tag',
+            'create_junction_post_and_tag_tables',
+            'create_junction_for_post_and_tag_tables',
             'create_junction_table_for_post_and_tag_tables',
             'create_junction_table_for_post_and_tag_table',
-            'create_junction_post_and_tag_tables',
         ];
         foreach ($migrationNames as $migrationName) {
             $this->assertCommandCreatedFile('junction_test', $migrationName);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | - |

This supports more explicit migration names, like:
- `create_user_table`,
- `add_name_column_to_user_table`,
- `create_junction_table_for_post_and_tag_tables`.
