### PR TITLE
Fix migration junction template file name

### DIFF
--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -80,7 +80,7 @@ class MigrateController extends BaseMigrateController
         'drop_table' => '@yii/views/dropTableMigration.php',
         'add_column' => '@yii/views/addColumnMigration.php',
         'drop_column' => '@yii/views/dropColumnMigration.php',
-        'create_junction' => '@yii/views/createTableMigration.php',
+        'create_junction' => '@yii/views/createJunctionMigration.php',
     ];
     /**
      * @var boolean indicates whether the table names generated should consider


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? |  |
| Fixed issues |  |

Fix name of the junction template file name in migration console controller.
