### PR TITLE
Implicit run ColumnSchemaBuilder::null() when default value is set  to null.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 -----------------------
 
 - Enh #10422: Added `null` method on `yii\db\ColumnSchemaBuilder` to explicitly set column nullability (nevermnd)
+- Enh #9574: Implicit run `ColumnSchemaBuilder::null()` when default value is set to `null`. (rob006)
 - Enh #8795: Refactored `yii\web\User::loginByCookie()` in order to make it easier to override (maine-mike, silverfire)
 - Enh #9948: `yii\rbac\PhpManager` now invalidates script file cache performed by 'OPCache' or 'APC' on file saving (klimov-paul)
 - Enh #11195: Added ability to append custom string to schema builder column definition (df2, samdark)

--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -180,6 +180,10 @@ class ColumnSchemaBuilder extends Object
      */
     public function defaultValue($default)
     {
+        if ($default === null) {
+            $this->null();
+        }
+
         $this->default = $default;
         return $this;
     }
@@ -327,7 +331,7 @@ class ColumnSchemaBuilder extends Object
     protected function buildDefaultString()
     {
         if ($this->default === null) {
-            return '';
+            return $this->isNotNull === false ? ' DEFAULT NULL' : '';
         }
 
         $string = ' DEFAULT ';

--- a/tests/framework/db/ColumnSchemaBuilderTest.php
+++ b/tests/framework/db/ColumnSchemaBuilderTest.php
@@ -25,7 +25,7 @@ abstract class ColumnSchemaBuilderTest extends TestCase
     public function typesProvider()
     {
         return [
-            ['integer NULL', Schema::TYPE_INTEGER, null, [
+            ['integer NULL DEFAULT NULL', Schema::TYPE_INTEGER, null, [
                 ['unsigned'], ['null'],
             ]],
             ['integer(10)', Schema::TYPE_INTEGER, 10, [

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -877,6 +877,18 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 ],
             ],
             [
+                Schema::TYPE_TIMESTAMP . ' NULL DEFAULT NULL',
+                $this->timestamp()->defaultValue(null),
+                [
+                    'mysql' => 'timestamp NULL DEFAULT NULL',
+                    'postgres' => 'timestamp(0) NULL DEFAULT NULL',
+                    'sqlite' => 'timestamp NULL DEFAULT NULL',
+                    'oci' => 'TIMESTAMP NULL DEFAULT NULL',
+                    'sqlsrv' => 'timestamp NULL DEFAULT NULL',
+                    'cubrid' => 'timestamp NULL DEFAULT NULL',
+                ],
+            ],
+            [
                 Schema::TYPE_UPK,
                 $this->primaryKey()->unsigned(),
                 [


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #9574 |

fix #9574
see https://github.com/yiisoft/yii2/issues/9574#issuecomment-199385521 and https://github.com/yiisoft/yii2/issues/9574#issuecomment-199411265
