### PR TITLE
Adds indexes on message tables which partly fixes #11725

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 
 2.0.9 under development
 -----------------------
-
+- Enh #11725: Added indexes on message tables (OndrejVasicek)
 - Enh #10422: Added `null` method on `yii\db\ColumnSchemaBuilder` to explicitly set column nullability (nevermnd)
 - Enh #8795: Refactored `yii\web\User::loginByCookie()` in order to make it easier to override (maine-mike, silverfire)
 - Enh #9948: `yii\rbac\PhpManager` now invalidates script file cache performed by 'OPCache' or 'APC' on file saving (klimov-paul)

--- a/framework/i18n/migrations/m150207_210500_i18n_init.php
+++ b/framework/i18n/migrations/m150207_210500_i18n_init.php
@@ -39,6 +39,8 @@ class m150207_210500_i18n_init extends Migration
 
         $this->addPrimaryKey('pk_message_id_language', '{{%message}}', ['id', 'language']);
         $this->addForeignKey('fk_message_source_message', '{{%message}}', 'id', '{{%source_message}}', 'id', 'CASCADE', 'RESTRICT');
+        $this->createIndex('idx_source_message_category', '{{%source_message}}', 'category');
+        $this->createIndex('idx_message_language', '{{%message}}', 'language');
     }
 
     public function down()

--- a/framework/i18n/migrations/schema-mssql.sql
+++ b/framework/i18n/migrations/schema-mssql.sql
@@ -27,3 +27,6 @@ CREATE TABLE [message]
 
 ALTER TABLE [message] ADD CONSTRAINT [pk_message_id_language] PRIMARY KEY ([id], [language]);
 ALTER TABLE [message] ADD CONSTRAINT [fk_message_source_message] FOREIGN KEY ([id]) REFERENCES [source_message] ([id]) ON UPDATE CASCADE ON DELETE NO ACTION;
+
+CREATE INDEX [idx_message_language] on [message] ([language]);
+CREATE INDEX [idx_source_message_category] on [source_message] ([category]);

--- a/framework/i18n/migrations/schema-mysql.sql
+++ b/framework/i18n/migrations/schema-mysql.sql
@@ -28,3 +28,6 @@ CREATE TABLE `message`
 
 ALTER TABLE `message` ADD CONSTRAINT `pk_message_id_language` PRIMARY KEY (`id`, `language`);
 ALTER TABLE `message` ADD CONSTRAINT `fk_message_source_message` FOREIGN KEY (`id`) REFERENCES `source_message` (`id`) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+CREATE INDEX idx_message_language ON message (language);
+CREATE INDEX idx_source_message_category ON source_message (category);

--- a/framework/i18n/migrations/schema-oci.sql
+++ b/framework/i18n/migrations/schema-oci.sql
@@ -28,3 +28,6 @@ CREATE TABLE "message"
 	primary key ("id", "language"),
 	foreign key ("id") references "source_message" ("id") on delete cascade
 );
+
+CREATE INDEX idx_message_language ON "message"("language");
+CREATE INDEX idx_source_message_category ON "source_message"("category");

--- a/framework/i18n/migrations/schema-pgsql.sql
+++ b/framework/i18n/migrations/schema-pgsql.sql
@@ -30,3 +30,9 @@ CREATE TABLE "message"
 
 ALTER TABLE "message" ADD CONSTRAINT "pk_message_id_language" PRIMARY KEY ("id", "language");
 ALTER TABLE "message" ADD CONSTRAINT "fk_message_source_message" FOREIGN KEY ("id") REFERENCES "source_message" ("id") ON UPDATE CASCADE ON DELETE RESTRICT;
+
+CREATE INDEX "idx_message_language" ON "message" USING btree (language);
+ALTER TABLE "message" CLUSTER ON "idx_message_language";
+
+CREATE INDEX "idx_source_message_category" ON "source_message" USING btree (category);
+ALTER TABLE "source_message" CLUSTER ON "idx_source_message_category";

--- a/framework/i18n/migrations/schema-sqlite.sql
+++ b/framework/i18n/migrations/schema-sqlite.sql
@@ -26,3 +26,5 @@ CREATE TABLE `message`
    PRIMARY KEY (`id`, `language`)
 );
 
+CREATE INDEX idx_message_language ON message (language);
+CREATE INDEX idx_source_message_category ON source_message (category);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | enhancement |
| Breaks BC? | no |
| Tests pass? | - |
| Fixed issues | #11725 |

I added message indexes into the migration script and tested it.

I also added indexes into the SQL file for PostgreSQL. I used “clustered” (see https://www.postgresql.org/docs/9.1/static/sql-cluster.html), which isn’t possible via migration method, but it’s welcome here. Also tested.

I’m afraid I don’t have enough knowledge to complete other languages. Is it generated or made manually? Do you think you could complete it?

DBs support:
- [x] PostgreSQL
- [x] MySQL
- [x] MSSQL
- [x] SQLite
- [x] Oracle
