### PR TITLE
Added hint index support in queries with join relations #11807

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 
 2.0.9 under development
 -----------------------
+- Enh #11807: Added support for hint index in queries with join relations (fdezmc)
 - Enh #11725: Added indexes on message tables (OndrejVasicek)
 - Enh #10422: Added `null` method on `yii\db\ColumnSchemaBuilder` to explicitly set column nullability (nevermnd)
 - Enh #9574: Implicit run `ColumnSchemaBuilder::null()` when default value is set to `null`. (rob006)

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -566,8 +566,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                     $tableName = $defaultTableName;
                     $alias = $fromAlias;
                 } elseif ($fromTableName instanceof Expression) {
-                    $tableName = $defaultTableName;
-                    $alias = $this->getQueryTableNameAlias($fromTableName);
+                    $alias = $defaultTableName;
+                    $tableName = $this->getQueryTableNameAlias($fromTableName);
                 } else {
                     $tableName = $fromTableName;
                     $alias = $this->getQueryTableNameAlias($fromTableName);

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -566,8 +566,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                     $tableName = $defaultTableName;
                     $alias = $fromAlias;
                 } elseif ($fromTableName instanceof Expression) {
-                    $alias = $defaultTableName;
-                    $tableName = $this->getQueryTableNameAlias($fromTableName);
+                    $tableName = $defaultTableName;
+                    $alias = $this->getQueryTableNameAlias($fromTableName);
                 } else {
                     $tableName = $fromTableName;
                     $alias = $this->getQueryTableNameAlias($fromTableName);


### PR DESCRIPTION
This pull add feature for using expressions in activeRecord from clause with joinWith relations, allowing hint index support in queries with join relations. See #11807
