### PR TITLE
Model->getFirstErrors() - Ensure that the first error is a string

### DIFF
--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -580,7 +580,10 @@ class Model extends Component implements IteratorAggregate, ArrayAccess, Arrayab
             $errors = [];
             foreach ($this->_errors as $name => $es) {
                 if (!empty($es)) {
-                    $errors[$name] = reset($es);
+                    while (is_array($es)) {
+                        $es = reset($es);
+                    }
+                    $errors[$name] = $es;
                 }
             }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |

Use case:

``` PHP
$model->addErrors(['relation' => $relation->getErrors()]);
```
