### PR TITLE
Fix reset populated records after fetch other relations with via()

### DIFF
--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -174,13 +174,17 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 // via relation
                 /* @var $viaQuery ActiveQuery */
                 list($viaName, $viaQuery) = $this->via;
-                if ($viaQuery->multiple) {
-                    $viaModels = $viaQuery->all();
-                    $this->primaryModel->populateRelation($viaName, $viaModels);
+                if ($this->primaryModel->isRelationPopulated($viaName)) {
+                    $viaModels = $this->primaryModel->$viaName;
                 } else {
-                    $model = $viaQuery->one();
-                    $this->primaryModel->populateRelation($viaName, $model);
-                    $viaModels = $model === null ? [] : [$model];
+                    if ($viaQuery->multiple) {
+                        $viaModels = $viaQuery->all();
+                        $this->primaryModel->populateRelation($viaName, $viaModels);
+                    } else {
+                        $model = $viaQuery->one();
+                        $this->primaryModel->populateRelation($viaName, $model);
+                        $viaModels = $model === null ? [] : [$model];
+                    }
                 }
                 $this->filterByModels($viaModels);
             } else {


### PR DESCRIPTION
Scenario to reproduce bug:

Class with two relations. Second relation used first relation as junction.

``` php
class Act extends ActiveRecord {

    /**
     * @return \yii\db\ActiveQuery
     */
    public function getItems()
    {
        return $this->hasMany(ActItem::className(), ['actId' => 'id']);
    }

    /**
     * @return \yii\db\ActiveQuery
     */
    public function getWeightings() {
        return $this->hasMany(ActItemWeighting::className(), ['id' => 'weightingId'])
            ->via('items');

   ...
}

$model = Act::findOne(...);
$firstItem = $model->items[0]; // items - is relation
$model->weightings; // fetch other relation, which used via('items')
var_dump($firstItem === $model->items[0]); // false

```

| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | yes |
| Tests pass? | yes |
| Fixed issues | without issue |
