### PR TITLE
Add missing documentation for getSort

### DIFF
--- a/framework/data/BaseDataProvider.php
+++ b/framework/data/BaseDataProvider.php
@@ -203,6 +203,7 @@ abstract class BaseDataProvider extends Component implements DataProviderInterfa
     }
 
     /**
+     * Returns the sorting object used by this data provider.
      * @return Sort|boolean the sorting object. If this is false, it means the sorting is disabled.
      */
     public function getSort()


### PR DESCRIPTION
This looks redundant when looking at the code, but without this, the description field is empty on the generated documentation page: http://www.yiiframework.com/doc-2.0/yii-data-arraydataprovider.html
