### PR TITLE
Fix incorrect formatting in documentation

### DIFF
--- a/framework/helpers/BaseConsole.php
+++ b/framework/helpers/BaseConsole.php
@@ -238,7 +238,7 @@ class BaseConsole
      * Returns the ANSI format code.
      *
      * @param array $format An array containing formatting values.
-     * You can pass any of the FG_*, BG_* and TEXT_* constants
+     * You can pass any of the `FG_*`, `BG_*` and `TEXT_*` constants
      * and also [[xtermFgColor]] and [[xtermBgColor]] to specify a format.
      * @return string The ANSI format code according to the given formatting constants.
      */
@@ -251,7 +251,7 @@ class BaseConsole
      * Echoes an ANSI format code that affects the formatting of any text that is printed afterwards.
      *
      * @param array $format An array containing formatting values.
-     * You can pass any of the FG_*, BG_* and TEXT_* constants
+     * You can pass any of the `FG_*`, `BG_*` and `TEXT_*` constants
      * and also [[xtermFgColor]] and [[xtermBgColor]] to specify a format.
      * @see ansiFormatCode()
      * @see endAnsiFormat()
@@ -280,7 +280,7 @@ class BaseConsole
      *
      * @param string $string the string to be formatted
      * @param array $format An array containing formatting values.
-     * You can pass any of the FG_*, BG_* and TEXT_* constants
+     * You can pass any of the `FG_*`, `BG_*` and `TEXT_*` constants
      * and also [[xtermFgColor]] and [[xtermBgColor]] to specify a format.
      * @return string
      */
@@ -347,7 +347,7 @@ class BaseConsole
      *
      * @param string $string the string to convert.
      * @param array $styleMap an optional mapping of ANSI control codes such as
-     * [[FG_COLOR]] or [[BOLD]] to a set of css style definitions.
+     * FG\_*COLOR* or [[BOLD]] to a set of css style definitions.
      * The CSS style definitions are represented as an array where the array keys correspond
      * to the css style attribute names and the values are the css values.
      * values may be arrays that will be merged and imploded with `' '` when rendered.


### PR DESCRIPTION
The asterisks and underscores were interpreted as markdown formatting, which wasn't intended.

Also fix invalid link to FG_COLOR.

This is how it looks after this patch:

![screenshot from 2016-07-01 18-08-44](https://cloud.githubusercontent.com/assets/2269242/16527412/01853d30-3fb7-11e6-970d-6c25be6fa43a.png)

![screenshot from 2016-07-01 18-08-50](https://cloud.githubusercontent.com/assets/2269242/16527416/0545d330-3fb7-11e6-8efe-e049d70910a0.png)
