### PR TITLE
Fix i18n gettext fallback language message loading

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -50,6 +50,7 @@ Yii Framework 2 Change Log
 - Enh #11857: `yii\filters\AccessRule::$verbs` can now be configured in upper and lowercase (DrDeath72, samdark)
 - Bug #11863: Fixed usage of `mb_substr` with PHP < 5.4.8 where length of NULL was treated the same as 0 (samdark)
 - Bug #11865: Fixed setting `selected` for dropdown list using options (samdark)
+- Bug #11878: Fixed i18n gettext fallback language message loading (stevekr)
 
 2.0.8 April 28, 2016
 --------------------

--- a/framework/i18n/GettextMessageSource.php
+++ b/framework/i18n/GettextMessageSource.php
@@ -73,7 +73,7 @@ class GettextMessageSource extends MessageSource
         $fallbackSourceLanguage = substr($this->sourceLanguage, 0, 2);
 
         if ($fallbackLanguage !== $language) {
-            $this->loadFallbackMessages($category, $fallbackLanguage, $messages, $messageFile);
+            $messages = $this->loadFallbackMessages($category, $fallbackLanguage, $messages, $messageFile);
         } elseif ($language === $fallbackSourceLanguage) {
             $messages = $this->loadFallbackMessages($category, $this->sourceLanguage, $messages, $messageFile);
         } else {


### PR DESCRIPTION
Fallback language messages didn't get assigned to `$messages` variable in `yii\i18n\GettextMessageSource::loadMessages()`.
