### PR TITLE
When db don't support comments, then show warning instead throw excep…

### DIFF
--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -255,15 +255,19 @@ class Migration extends Component implements MigrationInterface
      */
     public function createTable($table, $columns, $options = null)
     {
-        echo "    > create table $table ...";
+        echo "    > create table $table ...\n";
         $time = microtime(true);
         $this->db->createCommand()->createTable($table, $columns, $options)->execute();
         foreach ($columns as $column => $type) {
             if ($type instanceof ColumnSchemaBuilder && $type->comment !== null) {
-                $this->db->createCommand()->addCommentOnColumn($table, $column, $type->comment)->execute();
+                try {
+                    $this->db->createCommand()->addCommentOnColumn($table, $column, $type->comment)->execute();
+                } catch (\yii\base\NotSupportedException $e) {
+                    echo "    > " . $this->db->driverName . " does not support comments\n";
+                }
             }
         }
-        echo " done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
+        echo "    > done (time: " . sprintf('%.3f', microtime(true) - $time) . "s)\n";
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | ? |
| New feature? | ? |
| Breaks BC? | ? |
| Tests pass? | yes |
| Fixed issues | #11841 |

Migration

```
<?php

use yii\db\Migration;

class m160705_104733_test_sqlite extends Migration
{
    public function up()
    {
                $this->createTable('some', [
                        'column' => $this->string()->comment('hay hay'),
                ]);
    }

    public function down()
    {
        echo "m160705_104733_test_sqlite cannot be reverted.\n";

        return false;
    }
}
```

Before

```
Yii Migration Tool (based on Yii v2.0.9-dev)

Creating migration history table "migration"...Done.
Total 1 new migration to be applied:
    m160705_104733_test_sqlite

Apply the above migration? (yes|no) [no]:yes
*** applying m160705_104733_test_sqlite
    > create table some ...
Exception 'yii\base\UnknownMethodException' with message 'Calling unknown method: m160705_104733_test_sqlite::db()'

in /var/www/at.anikanov.me/yiihack/web/vendor/yiisoft/yii2/base/Component.php:285

Stack trace:
...
```

After

```
Yii Migration Tool (based on Yii v2.0.9-dev)

Creating migration history table "migration"...Done.
Total 1 new migration to be applied:
    m160705_104733_test_sqlite

Apply the above migration? (yes|no) [no]:yes
*** applying m160705_104733_test_sqlite
    > create table some ...
    > sqlite is not support comments
    > done (time: 0.011s)
*** applied m160705_104733_test_sqlite (time: 0.032s)


1 migration was applied.

Migrated up successfully.

```
