### PR TITLE
Enhance `yii\rbac\ManagerInterface::getUserIdsByRole()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 2.0.9 under development
 -----------------------
 
+- Enh #11895: Added `$recursive` option to `yii\rbac\ManagerInterface::getUserIdsByRole()` and its implementations. (Kolyunya)
 - Bug #11896: Fix for DROP TRIGGER in migrations from RBAC. (barradas-alberto)
 - Enh #11725: Added indexes on message tables (OndrejVasicek)
 - Enh #10422: Added `null` method on `yii\db\ColumnSchemaBuilder` to explicitly set column nullability (nevermnd)

--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -984,8 +984,11 @@ class DbManager extends BaseManager
 
     /**
      * Returns all role assignment information for the specified role.
-     * @param string $roleName
-     * @param string $recursive
+     * Only users having a direct assignment to the specified role are returned if
+     * `$recursive` is false. Otherwise a recursive search over roles hierarchy is performed
+     * and all users having an assignment to each of parent roles are returned.
+     * @param string $roleName role name.
+     * @param string $recursive whether to perform a recursive search over parent roles.
      * @return Assignment[] the assignments. An empty array will be
      * returned if role is not assigned to any user.
      * @since 2.0.7

--- a/framework/rbac/ManagerInterface.php
+++ b/framework/rbac/ManagerInterface.php
@@ -164,6 +164,8 @@ interface ManagerInterface extends CheckAccessInterface
      * Returns the parent permissions and/or roles.
      * @param string $name the child name
      * @return Item[] the parent permissions and/or roles
+     *
+     * @since 2.0.10
      */
     public function getParents($name);
 
@@ -218,8 +220,12 @@ interface ManagerInterface extends CheckAccessInterface
 
     /**
      * Returns all user IDs assigned to the role specified.
-     * @param string $roleName
-     * @param string $recursive
+     * Only users having a direct assignment to the specified role are returned if
+     * `$recursive` is false. Otherwise a recursive search over roles hierarchy is performed
+     * and all users having an assignment to each of parent roles are returned.
+     *
+     * @param string $roleName role name.
+     * @param string $recursive whether to perform a recursive search over parent roles.
      * @return array array of user ID strings
      * @since 2.0.7
      */

--- a/framework/rbac/ManagerInterface.php
+++ b/framework/rbac/ManagerInterface.php
@@ -161,6 +161,13 @@ interface ManagerInterface extends CheckAccessInterface
     public function hasChild($parent, $child);
 
     /**
+     * Returns the parent permissions and/or roles.
+     * @param string $name the child name
+     * @return Item[] the parent permissions and/or roles
+     */
+    public function getParents($name);
+
+    /**
      * Returns the child permissions and/or roles.
      * @param string $name the parent name
      * @return Item[] the child permissions and/or roles
@@ -212,10 +219,11 @@ interface ManagerInterface extends CheckAccessInterface
     /**
      * Returns all user IDs assigned to the role specified.
      * @param string $roleName
+     * @param string $recursive
      * @return array array of user ID strings
      * @since 2.0.7
      */
-    public function getUserIdsByRole($roleName);
+    public function getUserIdsByRole($roleName, $recursive);
 
     /**
      * Removes all authorization data, including roles, permissions, rules, and assignments.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11895 |

It is now possible to get users by role recursively.
