### PR TITLE
Fix code block in phpDoc of BaseArrayHelper::filter

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -782,7 +782,6 @@ class BaseArrayHelper
      * //     'A' => [1, 2],
      * //     'B' => ['C' => 1],
      * // ]
-     * ```
      *
      * $result = \yii\helpers\ArrayHelper::filter($array, ['B', '!B.C']);
      * // $result will be:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no

Removed unnecessary ```.

