### PR TITLE
Fix ActiveField::end generates close tag when it's option['tag'] is null

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.10 under development
 ------------------------
 
+- Bug #11949: Fixed `ActiveField::end` generates close tag when it's `option['tag']` is null (egorio)
 - Bug #11912: Fixed PostgreSQL Schema to support negative default values for integer/float/decimal columns (nsknewbie)
 - Bug #11947: Fixed `gridData` initialization in `yii.gridView.js` (pavlm)
 

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -245,7 +245,7 @@ class ActiveField extends Component
      */
     public function end()
     {
-        return Html::endTag(isset($this->options['tag']) ? $this->options['tag'] : 'div');
+        return Html::endTag(ArrayHelper::keyExists('tag', $this->options) ? $this->options['tag'] : 'div');
     }
 
     /**

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -145,6 +145,18 @@ EOD;
         $actualValue = $this->activeField->begin();
 
         $this->assertEquals($expectedValue, $actualValue);
+
+        $expectedValue = "";
+        $this->activeField->options['tag'] = null;
+        $actualValue = $this->activeField->begin();
+
+        $this->assertEquals($expectedValue, $actualValue);
+
+        $expectedValue = "";
+        $this->activeField->options['tag'] = null;
+        $actualValue = $this->activeField->begin();
+
+        $this->assertEquals($expectedValue, $actualValue);
     }
 
     public function testEnd()
@@ -159,7 +171,19 @@ EOD;
         $this->activeField->options['tag'] = 'article';
         $actualValue = $this->activeField->end();
 
-        $this->assertTrue($actualValue === $expectedValue);
+        $this->assertEquals($expectedValue, $actualValue);
+
+        $expectedValue = "";
+        $this->activeField->options['tag'] = false;
+        $actualValue = $this->activeField->end();
+
+        $this->assertEquals($expectedValue, $actualValue);
+
+        $expectedValue = "";
+        $this->activeField->options['tag'] = null;
+        $actualValue = $this->activeField->end();
+
+        $this->assertEquals($expectedValue, $actualValue);
     }
 
     public function testLabel()

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -145,6 +145,14 @@ EOD;
         $actualValue = $this->activeField->begin();
 
         $this->assertEquals($expectedValue, $actualValue);
+    }
+
+    public function testBegin() {
+        $expectedValue = '<article class="form-group field-dynamicmodel-attributename">';
+        $this->activeField->options['tag'] = 'article';
+        $actualValue = $this->activeField->begin();
+
+        $this->assertEquals($expectedValue, $actualValue);
 
         $expectedValue = "";
         $this->activeField->options['tag'] = null;
@@ -153,7 +161,7 @@ EOD;
         $this->assertEquals($expectedValue, $actualValue);
 
         $expectedValue = "";
-        $this->activeField->options['tag'] = null;
+        $this->activeField->options['tag'] = false;
         $actualValue = $this->activeField->begin();
 
         $this->assertEquals($expectedValue, $actualValue);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11949 :) |

According to #10764, the code

```
$form->field($model, 'attribute', ['options' => [
    'tag' => null
]])->textField());
```

should not generate element surrounded by tag, but it generates `</div>` at the end.

This pull request fixes that.
