### PR TITLE
Fix double space after array key

### DIFF
--- a/docs/internals/core-code-style.md
+++ b/docs/internals/core-code-style.md
@@ -236,7 +236,7 @@ Use the following format for associative arrays:
 
 ```php
 $config = [
-    'name'  => 'Yii',
+    'name' => 'Yii',
     'options' => ['usePHP' => true],
 ];
 ```


### PR DESCRIPTION
I'm pretty sure one space after the key was the originally intended style.
