### PR TITLE
Docs: added missing string of YII_ENV definition

### DIFF
--- a/docs/guide/structure-entry-scripts.md
+++ b/docs/guide/structure-entry-scripts.md
@@ -63,6 +63,7 @@ Similarly, the following is the code for the entry script of a console applicati
  */
 
 defined('YII_DEBUG') or define('YII_DEBUG', true);
+defined('YII_ENV') or define('YII_ENV', 'dev');
 
 // register Composer autoloader
 require(__DIR__ . '/vendor/autoload.php');


### PR DESCRIPTION
In listing of console entry script.