### PR TITLE
Fix yii\rest\Serializer serialize ArrayDataProvider with pagination bug

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.10 under development
 ------------------------
 
+- Bug #11977: Fixed `yii\rest\Serializer::serialize` serialize ArrayDataProvider with pagination error (dcb9)
 - Bug #11912: Fixed PostgreSQL Schema to support negative default values for integer/float/decimal columns (nsknewbie)
 - Bug #11947: Fixed `gridData` initialization in `yii.gridView.js` (pavlm)
 - Bug #11949: Fixed `ActiveField::end` generates close tag when it's `option['tag']` is null (egorio)

--- a/framework/rest/Serializer.php
+++ b/framework/rest/Serializer.php
@@ -12,6 +12,7 @@ use yii\base\Arrayable;
 use yii\base\Component;
 use yii\base\Model;
 use yii\data\DataProviderInterface;
+use yii\data\ArrayDataProvider;
 use yii\data\Pagination;
 use yii\helpers\ArrayHelper;
 use yii\web\Link;
@@ -171,7 +172,11 @@ class Serializer extends Component
      */
     protected function serializeDataProvider($dataProvider)
     {
-        $models = $this->serializeModels($dataProvider->getModels());
+        $models = $dataProvider->getModels();
+        if ($dataProvider instanceof ArrayDataProvider) {
+            $models = array_values($models);
+        }
+        $models = $this->serializeModels($models);
 
         if (($pagination = $dataProvider->getPagination()) !== false) {
             $this->addPaginationHeaders($pagination);

--- a/tests/framework/rest/SerializerTest.php
+++ b/tests/framework/rest/SerializerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace yiiunit\framework\rest;
+
+use Yii;
+use yii\data\ArrayDataProvider;
+use yiiunit\TestCase;
+
+/**
+ * @group rest
+ */
+class SerializerTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mockWebApplication();
+    }
+
+    /**
+     * @dataProvider serializeDataProvider
+     */
+    public function testSerializeDataProvider($allModels, $page, $expectModels)
+    {
+        $dataProvider = new ArrayDataProvider([
+            'allModels' => $allModels,
+            'pagination' => [
+                'route' => '/',
+            ],
+        ]);
+        $serializer = Yii::createObject('yii\rest\Serializer');
+
+        Yii::$app->getRequest()->setQueryParams(['page' => $page, 'per-page' => 1]);
+        $result = $serializer->serialize($dataProvider);
+        $this->assertEquals($expectModels, $result);
+        $this->assertEquals(array_keys($expectModels), array_keys($result));
+    }
+
+    public function serializeDataProvider()
+    {
+        $model1 = ['id' => 1, 'username' => 'Bob'];
+        $model2 = ['id' => 2, 'username' => 'Tom'];
+        $models = [$model1, $model2];
+        return [
+            [
+                $models,
+                1,
+                [$model1],
+            ],
+            [
+                $models,
+                2,
+                [$model2],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | yes/no |
| Tests pass? | yes |
| Fixed issues | #11977 |

```
➜  yii2 git:(fixRestSerializeArrayDataProvider) ./vendor/bin/phpunit --group=rest
PHPUnit 4.8.24-15-g3c4becb by Sebastian Bergmann and contributors.

....

Time: 895 ms, Memory: 46.50Mb

OK (4 tests, 39 assertions)
```
