### PR TITLE
Activerecord where exists relation

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Bug #11947: Fixed `gridData` initialization in `yii.gridView.js` (pavlm)
 - Bug #11949: Fixed `ActiveField::end` generates close tag when it's `option['tag']` is null (egorio)
 - Enh #11950: Improve BaseArrayHelper::keyExists speed (egorio)
+- Enh #11993: Improve ActiveQuery (nanodesu88)
 
 2.0.9 July 11, 2016
 -------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,7 +8,7 @@ Yii Framework 2 Change Log
 - Bug #11947: Fixed `gridData` initialization in `yii.gridView.js` (pavlm)
 - Bug #11949: Fixed `ActiveField::end` generates close tag when it's `option['tag']` is null (egorio)
 - Enh #11950: Improve BaseArrayHelper::keyExists speed (egorio)
-- Enh #11993: Improve ActiveQuery (nanodesu88)
+- Enh #11993: Allows to use relations in exists/not exists where clause in ActiveQuery (nanodesu88)
 
 2.0.9 July 11, 2016
 -------------------

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -159,7 +159,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             $this->select = ["$alias.*"];
         }
 
-        if(!empty($this->where)){
+        if (!empty($this->where)) {
             $this->where = $this->buildExistsRelations($this->where);
         }
 
@@ -732,41 +732,43 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     }
 
     /**
-     * Transform all relation names in exists/not exists conditions to Query objects
+     * Transform all relation names in exists/not exists conditions to Query objects.
      * @param mixed $where
      * @return array
      */
     private function buildExistsRelations($where)
     {
-        if(!isset($where[0]) || !is_array($where)){
+        if (!isset($where[0]) || !is_array($where)) {
             return $where;
         }
 
         $operator = array_shift($where);
         /** @var ActiveRecord $model */
         $model = new $this->modelClass;
-        if(in_array($operator, ['exists', 'not exists'])){
+        if (in_array($operator, ['exists', 'not exists'])) {
             list($name, $callback) = [key($where), current($where)];
-            if(is_int($name)){
+
+            if (is_int($name)) {
                 $name = $callback;
                 $callback = null;
             }
 
-            if($callback instanceof QueryInterface || $name instanceof QueryInterface){
+            if ($callback instanceof QueryInterface || $name instanceof QueryInterface) {
                 array_unshift($where, $operator);
                 return $where;
             }
 
             unset($where[key($where)]);
             $relation = $model->getRelation($name);
-            if(is_callable($callback)){
+
+            if (is_callable($callback)) {
                 call_user_func($callback, $relation);
             }
 
             $this->buildExistsRelation($relation);
             $where[] = $relation;
-        }else{
-            foreach($where as $key => $value){
+        } else {
+            foreach ($where as $key => $value) {
                 $where[$key] = $this->buildExistsRelations($value);
             }
         }
@@ -776,6 +778,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     }
 
     /**
+     * Transform links to where condition.
      * @param ActiveQuery $relation
      * @param \Closure|null $callback
      */
@@ -787,6 +790,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         if (strpos($parentAlias, '{{') === false) {
             $parentAlias = '{{' . $parentAlias . '}}';
         }
+
         if (strpos($childAlias, '{{') === false) {
             $childAlias = '{{' . $childAlias . '}}';
         }
@@ -794,7 +798,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         foreach ($relation->link as $childColumn => $parentColumn) {
             $relation->andWhere("$parentAlias.[[$parentColumn]] = $childAlias.[[$childColumn]]");
         }
-
+        // cleaning
+        $relation->link = null;
         $relation->primaryModel = null;
     }
 

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -732,6 +732,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     }
 
     /**
+     * Transform all relation names in exists/not exists conditions to Query objects
      * @param mixed $where
      * @return array
      */
@@ -744,7 +745,6 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         $operator = array_shift($where);
         /** @var ActiveRecord $model */
         $model = new $this->modelClass;
-
         if(in_array($operator, ['exists', 'not exists'])){
             list($name, $callback) = [key($where), current($where)];
             if(is_int($name)){
@@ -756,8 +756,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 array_unshift($where, $operator);
                 return $where;
             }
-            unset($where[key($where)]);
 
+            unset($where[key($where)]);
             $relation = $model->getRelation($name);
             if(is_callable($callback)){
                 call_user_func($callback, $relation);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | ? |

Allows to use relations in exists where.

``` php
$document->andWhere(['exists', 'comments']);
```

result:

``` sql
SELECT * FROM {{%document}} WHERE EXISTS (SELECT * FROM {{%comment}} WHERE {{%document}}.[[id]] = {{%comment}}.[[doc_id]])
```

``` php
$document->andWhere(['and', ['exists', 'comments'], ['exists', 'opens']]);
```

result:

``` sql
SELECT * FROM {{%document}} WHERE (EXISTS (SELECT * FROM {{%comment}} WHERE {{%document}}.[[id]] = {{%comment}}.[[doc_id]])) AND (EXISTS (SELECT * FROM {{%open}} WHERE {{%document}}.[[id]] = {{%open}}.[[doc_id]]))
```

``` php
$document->andWhere(['exists', 'comments' => function(ActiveQuery $q){
    $q->alias('alias');
}]);
```

result:

``` sql
SELECT * FROM {{%document}} WHERE EXISTS (SELECT * FROM {{%comment}} `alias` WHERE {{%document}}.[[id]] = {{alias}}.[[doc_id]])
```
