### PR TITLE
Allow overriding 'app' messages by wildcard category

### DIFF
--- a/framework/i18n/I18N.php
+++ b/framework/i18n/I18N.php
@@ -62,7 +62,7 @@ class I18N extends Component
                 'basePath' => '@yii/messages',
             ];
         }
-        if (!isset($this->translations['app']) && !isset($this->translations['app*'])) {
+        if (!isset($this->translations['app']) && !isset($this->translations['app*']) && !isset($this->translations['*'])) {
             $this->translations['app'] = [
                 'class' => 'yii\i18n\PhpMessageSource',
                 'sourceLanguage' => Yii::$app->sourceLanguage,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | probably not |
| Tests pass? | most likely |
| Fixed issues | comma-separated list of tickets # fixed by the PR, if any |

When a wildcard '*' message category is specified in config, the messages for category 'app' are still hard-coded to PhpMessageSource with default configuration. This is confusing.

This patch applies the configuration for '*' to category 'app' as well.
