### PR TITLE
fix #10563, #11953 current implementation of file download does not encode UTF8 filenames correctly

### DIFF
--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -438,6 +438,7 @@ class Response extends \yii\base\Response
         }
         if ($attachmentName === null) {
             $attachmentName = basename($filePath);
+            $this->headers->setDefault('Content-Disposition', "attachment; filename=\"$attachmentName\"");
         }
         $handle = fopen($filePath, 'rb');
         $this->sendStreamAsFile($handle, $attachmentName, $options);
@@ -563,7 +564,7 @@ class Response extends \yii\base\Response
             ->setDefault('Accept-Ranges', 'bytes')
             ->setDefault('Expires', '0')
             ->setDefault('Cache-Control', 'must-revalidate, post-check=0, pre-check=0')
-            ->setDefault('Content-Disposition', "$disposition; filename=\"$attachmentName\"");
+            ->setDefault('Content-Disposition', "$disposition; filename=\"$attachmentName\"; filename*=utf-8''" . rawurlencode($attachmentName));
 
         if ($mimeType !== null) {
             $headers->setDefault('Content-Type', $mimeType);

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -98,7 +98,7 @@ class ResponseTest extends \yiiunit\TestCase
         static::assertEquals(200, $this->response->statusCode);
         $headers = $this->response->headers;
         static::assertEquals('application/octet-stream', $headers->get('Content-Type'));
-        static::assertEquals('attachment; filename="test.txt"', $headers->get('Content-Disposition'));
+        static::assertEquals('attachment; filename="test.txt"; filename*=utf-8\'\'test.txt', $headers->get('Content-Disposition'));
         static::assertEquals(4, $headers->get('Content-Length'));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | no |
| Fixed issues | #10563, #11953 |
