### PR TITLE
Make simple url rule with default parameter

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Enh #10583: Do not silence session errors in debug mode (samdark)
 - Enh #12048: Improved message extraction command performance (samdark)
 - Enh #12038: Introduced `yii\base\ViewNotFoundException` which is thrown when views file doesn't exists, used it in `ViewAction` (samdark)
+- Enh #12059: Make simple url rule with default parameter (mdmunir)
 
 2.0.9 July 11, 2016
 -------------------

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -205,10 +205,14 @@ class UrlManager extends Component
         foreach ($rules as $key => $rule) {
             if (is_string($rule) || (is_array($rule) && isset($rule[0]))) {
                 $rule = (array) $rule;
-                $rule = [
-                    'route' => $rule[0],
-                    'defaults' => array_slice($rule, 1),
-                ];
+                if(is_string($rule)){
+                    $rule = ['route' => $rule];
+                } else {
+                    $rule = [
+                        'route' => $rule[0],
+                        'defaults' => array_slice($rule, 1),
+                    ];
+                }
                 
                 if (preg_match("/^((?:($verbs),)*($verbs))\\s+(.*)$/", $key, $matches)) {
                     $rule['verb'] = explode(',', $matches[1]);

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -204,7 +204,6 @@ class UrlManager extends Component
         $verbs = 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS';
         foreach ($rules as $key => $rule) {
             if (is_string($rule) || (is_array($rule) && isset($rule[0]))) {
-                $rule = (array) $rule;
                 if(is_string($rule)){
                     $rule = ['route' => $rule];
                 } else {

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -82,6 +82,7 @@ class UrlManager extends Component
      * ```php
      * [
      *     'dashboard' => 'site/index',
+     *     'about' => ['site/page', 'view' => 'about'],
      *
      *     'POST <controller:[\w-]+>s' => '<controller>/create',
      *     '<controller:[\w-]+>s' => '<controller>/index',
@@ -202,8 +203,13 @@ class UrlManager extends Component
         $compiledRules = [];
         $verbs = 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS';
         foreach ($rules as $key => $rule) {
-            if (is_string($rule)) {
-                $rule = ['route' => $rule];
+            if (is_string($rule) || (is_array($rule) && isset($rule[0]))) {
+                $rule = (array) $rule;
+                $rule = [
+                    'route' => $rule[0],
+                    'defaults' => array_slice($rule, 1),
+                ];
+                
                 if (preg_match("/^((?:($verbs),)*($verbs))\\s+(.*)$/", $key, $matches)) {
                     $rule['verb'] = explode(',', $matches[1]);
                     // rules that do not apply for GET requests should not be use to create urls

--- a/tests/framework/web/UrlManagerTest.php
+++ b/tests/framework/web/UrlManagerTest.php
@@ -180,6 +180,7 @@ class UrlManagerTest extends TestCase
                     'defaults' => ['view' => 'about-me']
                 ],
                 'page/<view>' => 'site/page',
+                '' => ['profile/view', 'id' => 3426]
             ],
             'baseUrl' => '/test',
             'scriptUrl' => '/test',
@@ -190,6 +191,8 @@ class UrlManagerTest extends TestCase
         $this->assertEquals('/test/tentang-aku', $url);
         $url = $manager->createUrl(['site/page', 'view' => 'other-page']);
         $this->assertEquals('/test/page/other-page', $url);
+        $url = $manager->createUrl(['profile/view', 'id' => 3426]);
+        $this->assertEquals('/test/', $url);
     }
 
     /**
@@ -437,6 +440,7 @@ class UrlManagerTest extends TestCase
                     'defaults' => ['view' => 'about-me']
                 ],
                 'page/<view>' => 'site/page',
+                '' => ['profile/view', 'id' => 3426]
             ],
         ]);
         // matching pathinfo
@@ -451,6 +455,10 @@ class UrlManagerTest extends TestCase
         $request->pathInfo = 'page/other-page';
         $result = $manager->parseRequest($request);
         $this->assertEquals(['site/page', ['view' => 'other-page']], $result);
+
+        $request->pathInfo = '';
+        $result = $manager->parseRequest($request);
+        $this->assertEquals(['profile/view', ['id' => 3426]], $result);
     }
 
     public function testParseRESTRequest()

--- a/tests/framework/web/UrlManagerTest.php
+++ b/tests/framework/web/UrlManagerTest.php
@@ -167,6 +167,29 @@ class UrlManagerTest extends TestCase
         $this->assertEquals('/test/page/services', $url);
         $url = $manager->createUrl(['frontend/page/view', 'slug' => 'index']);
         $this->assertEquals('/test/', $url);
+
+        // create url with simple params/defaults
+        $manager = new UrlManager([
+            'enablePrettyUrl' => true,
+            'cache' => null,
+            'rules' => [
+                'about' => ['site/page', 'view' => 'about'],
+                [
+                    'pattern' => 'tentang-aku',
+                    'route' => 'site/page',
+                    'defaults' => ['view' => 'about-me']
+                ],
+                'page/<view>' => 'site/page',
+            ],
+            'baseUrl' => '/test',
+            'scriptUrl' => '/test',
+        ]);
+        $url = $manager->createUrl(['site/page', 'view' => 'about']);
+        $this->assertEquals('/test/about', $url);
+        $url = $manager->createUrl(['site/page', 'view' => 'about-me']);
+        $this->assertEquals('/test/tentang-aku', $url);
+        $url = $manager->createUrl(['site/page', 'view' => 'other-page']);
+        $this->assertEquals('/test/page/other-page', $url);
     }
 
     /**
@@ -400,6 +423,34 @@ class UrlManagerTest extends TestCase
         $request->pathInfo = 'site/index.html';
         $result = $manager->parseRequest($request);
         $this->assertFalse($result);
+
+
+        // url with simple defaults/params
+        $manager = new UrlManager([
+            'enablePrettyUrl' => true,
+            'cache' => null,
+            'rules' => [
+                'about' => ['site/page', 'view' => 'about'],
+                [
+                    'pattern' => 'tentang-aku',
+                    'route' => 'site/page',
+                    'defaults' => ['view' => 'about-me']
+                ],
+                'page/<view>' => 'site/page',
+            ],
+        ]);
+        // matching pathinfo
+        $request->pathInfo = 'about';
+        $result = $manager->parseRequest($request);
+        $this->assertEquals(['site/page', ['view' => 'about']], $result);
+
+        $request->pathInfo = 'tentang-aku';
+        $result = $manager->parseRequest($request);
+        $this->assertEquals(['site/page', ['view' => 'about-me']], $result);
+
+        $request->pathInfo = 'page/other-page';
+        $result = $manager->parseRequest($request);
+        $this->assertEquals(['site/page', ['view' => 'other-page']], $result);
     }
 
     public function testParseRESTRequest()


### PR DESCRIPTION
Currently, to make url rule with default parameter, we must do this

``` php
'rules' => [
    ...
    [
        'pattern' => 'about',
        'route' => 'site/page',
        'defaults' => ['view' => 'about']
    ]
]
```

IMO, its more simple if we just do this

``` php
'rules' => [
    'about' => ['site/page', 'view' => 'about']
]
```

| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |
