### PR TITLE
Fix for non US-ASCII characters in Content-Disposition header

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.10 under development
 ------------------------
 
+- Bug #12047: Fixed file sending methods in the `Response` class that could generate HTTP Content-Disposition header with invalid characters (PowerGamer1)
 - Bug #11461: Fixed migration tool error when create migrate with comma in defaultValue (pana1990, s-o-f)
 - Bug #11912: Fixed PostgreSQL Schema to support negative default values for integer/float/decimal columns (nsknewbie)
 - Bug #11947: Fixed `gridData` initialization in `yii.gridView.js` (pavlm)

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -98,7 +98,7 @@ class ResponseTest extends \yiiunit\TestCase
         static::assertEquals(200, $this->response->statusCode);
         $headers = $this->response->headers;
         static::assertEquals('application/octet-stream', $headers->get('Content-Type'));
-        static::assertEquals('attachment; filename="test.txt"', $headers->get('Content-Disposition'));
+        static::assertEquals('attachment; filename*=UTF-8\'\'test.txt', $headers->get('Content-Disposition'));
         static::assertEquals(4, $headers->get('Content-Length'));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | yes |
| Tests pass? | yes |
| Fixed issues | https://github.com/yiisoft/yii2/issues/12047, https://github.com/yiisoft/yii2/issues/10563, https://github.com/yiisoft/yii2/issues/11953 |

Fix for non US-ASCII characters in Content-Disposition header.
