### PR TITLE
Reverted fix of beforeValidate event calling in `yii.activeForm.js`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Bug #12037: Fixed 2.0.7 regression in memcahe/memcached cache backend (samdark)
 - Bug #12043: Fixed `yii\helpers\Json::encode()` encodes empty array returned by `JsonSerializable::jsonSerialize()` as object (klimov-paul)
 - Bug #12045: Added missing `LEVEL_PROFILE` to `yii\log\Logger::getLevelName()` map (Mak-Di)
+- Bug #10681: Reverted fix of beforeValidate event calling in `yii.activeForm.js` (silverfire)
 - Enh #10583: Do not silence session errors in debug mode (samdark)
 - Enh #12048: Improved message extraction command performance (samdark)
 - Enh #12038: Introduced `yii\base\ViewNotFoundException` which is thrown when views file doesn't exists, used it in `ViewAction` (samdark)

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -290,9 +290,10 @@
                 deferreds = deferredArray(),
                 submitting = data.submitting;
 
-            var event = $.Event(events.beforeValidate);
-            $form.trigger(event, [messages, deferreds]);
             if (submitting) {
+                var event = $.Event(events.beforeValidate);
+                $form.trigger(event, [messages, deferreds]);
+
                 if (event.result === false) {
                     data.submitting = false;
                     submitFinalize($form);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | yes (fixes) |
| Fixed issues | #10681, #11972, probably #11992 |

I'm reverting @lynicidn commit e8bcb93 because it introduces buggy behavior. The problem that was reported in #10681 is not a bug indeed.
1. From the docs: 
   > beforeValidate event is triggered before validating the whole form
2. AJAX validation is being executed each time for all available inputs, but the result of AJAX validation will be used for each particular input only when it was touched at least once. It means, that each AJAX validation call does not mean full form validation.
3. For Ajax validation we have `ajaxBeforeSend` and `ajaxComplete` events

@nkovacs, @samdark, @githkim, @lynicidn - if you have something to add - feel free to text your ideas. Otherwise, the PR will be merged in 3 days.

Thank you
