### PR TITLE
added basic support for database views

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -320,6 +320,10 @@ Yii Framework 2 Change Log
 - Enh #12744: Added `afterInit` event to `yii.activeForm.js` (werew01f)
 - Enh: Method `yii\console\controllers\AssetController::getAssetManager()` automatically enables `yii\web\AssetManager::forceCopy` in case it is not explicitly specified (pana1990, klimov-paul)
 
+- Bug #12053: `./yii migrate/create` was generating wrong code when using `bigPrimaryKey` (VojtechH, samdark)
+- Bug #11907: Fixed `yii\helpers\Console::getScreenSize()` on Windows was giving out width and height swapped (Spell6inder, samdark, cebe)
+- Bug #11973: Fixed `yii\helpers\BaseHtml::getAttributeValue()` to work with `items[]` notation correctly (silverfire)
+- Enh #8347: Added basic support for working with database views (igravity)
 
 2.0.9 July 11, 2016
 -------------------

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -947,4 +947,27 @@ class Command extends Component
             $this->db->getSchema()->refreshTableSchema($this->_refreshTableName);
         }
     }
+
+    /**
+     * Creates an SQL View
+     * @param string $viewName the name of the view to be created
+     * @param string $subquery the select statement which defines the view
+     */
+    public function createView($viewName, $subquery)
+    {
+        $sql = $this->db->getQueryBuilder()->createView($viewName, $subquery);
+
+        return $this->setSql($sql);
+    }
+
+    /**
+     * Removes an SQL View
+     * @param string $viewName
+     */
+    public function dropView($viewName)
+    {
+        $sql = $this->db->getQueryBuilder()->dropView($viewName);
+
+        return $this->setSql($sql)->requireTableSchemaRefresh($viewName);
+    }
 }

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -1487,4 +1487,26 @@ class QueryBuilder extends \yii\base\Object
     {
         return 'SELECT EXISTS(' . $rawSql . ')';
     }
+
+    /**
+     * Creates a view
+     * @param string $viewName the name of the view to be created
+     * @param \yii\db\Query $subquery the select statement which defines the view
+     * @return string the CREATE VIEW SQL statement
+     */
+    public function createView($viewName, $subquery)
+    {
+        return 'CREATE VIEW ' . $this->db->quoteTableName($viewName) . ' AS ' . $subquery->createCommand($this->db)->getSql();
+    }
+
+    /**
+     * Creates a view
+     * @param string $viewName the name of the view to be created
+     * @param \yii\db\Query $subquery the select statement which defines the view
+     * @return string the CREATE VIEW SQL statement
+     */
+    public function dropView($viewName)
+    {
+        return 'DROP VIEW ' . $this->db->quoteTableName($viewName);
+    }
 }

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -841,6 +841,7 @@ SQL;
         $db->createCommand()->createTable('testCreateViewTable', ['id' => Schema::TYPE_PK, 'bar' => Schema::TYPE_INTEGER])->execute();
         $db->createCommand()->insert('testCreateViewTable', ['bar' => 1])->execute();
 
+        $db->createCommand()->dropView('testCreateView')->execute();
         $db->createCommand()->createView('testCreateView', $subquery)->execute();
         $records = $db->createCommand('SELECT [[bar]] FROM {{testCreateView}};')->queryAll();
         $this->assertEquals([['bar' => 1]], $records);

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -841,7 +841,9 @@ SQL;
         $db->createCommand()->createTable('testCreateViewTable', ['id' => Schema::TYPE_PK, 'bar' => Schema::TYPE_INTEGER])->execute();
         $db->createCommand()->insert('testCreateViewTable', ['bar' => 1])->execute();
 
-        $db->createCommand()->dropView('testCreateView')->execute();
+        if ($db->getSchema()->getTableSchema('testCreateView') !== null) {
+          $db->createCommand()->dropView('testCreateView')->execute();
+        }
         $db->createCommand()->createView('testCreateView', $subquery)->execute();
         $records = $db->createCommand('SELECT [[bar]] FROM {{testCreateView}};')->queryAll();
         $this->assertEquals([['bar' => 1]], $records);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |

This support only handles creating the basic view and dropping the
view. This is in response to issue #8347

An enhancement to this may be to create views with specific keywords
for specific databases.

Syntax:
- create: `$command->createView(string $name, \yii\db\Query $subquery)`
- drop: `$command->dropView(string $name)`
