### PR TITLE
Revamps PageCache to store data in one entry (#10506)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -42,6 +42,7 @@ Yii Framework 2 Change Log
 - Enh #11756: Added type mapping for `varbinary` data type in MySQL DBMS (silverfire)
 - Enh #11929: Changed `type` column type from `int` to `smallInt` in RBAC migrations (silverfire)
 - Enh #12015: Changed visibility `yii\db\ActiveQueryTrait::createModels()` from private to protected (ArekX, dynasource)
+- Enh #12145: Added `beforeCacheResponse` and `afterRestoreResponse` to `yii\filters\PageCache` to be more easily extendable (sergeymakinen)
 - Enh #12399: Added `ActiveField::addAriaAttributes` property for `aria-required` and `aria-invalid` attributes rendering (Oxyaction, samdark)
 - Enh #12390: Avoid creating queries with false where condition (`0=1`) when fetching relational data (klimov-paul)
 - Enh #12619: Added catch `Throwable` in `yii\base\ErrorHandler::handleException()` (rob006)

--- a/framework/filters/PageCache.php
+++ b/framework/filters/PageCache.php
@@ -8,8 +8,8 @@
 namespace yii\filters;
 
 use Yii;
-use yii\base\ActionFilter;
 use yii\base\Action;
+use yii\base\ActionFilter;
 use yii\caching\Cache;
 use yii\caching\Dependency;
 use yii\di\Instance;
@@ -46,13 +46,14 @@ use yii\web\Response;
  * ```
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
+ * @author Sergey Makinen <sergey@makinen.ru>
  * @since 2.0
  */
 class PageCache extends ActionFilter
 {
     /**
      * @var bool whether the content being cached should be differentiated according to the route.
-     * A route consists of the requested controller ID and action ID. Defaults to true.
+     * A route consists of the requested controller ID and action ID. Defaults to `true`.
      */
     public $varyByRoute = true;
     /**
@@ -64,7 +65,7 @@ class PageCache extends ActionFilter
     public $cache = 'cache';
     /**
      * @var int number of seconds that the data can remain valid in cache.
-     * Use 0 to indicate that the cached data will never expire.
+     * Use `0` to indicate that the cached data will never expire.
      */
     public $duration = 60;
     /**
@@ -123,6 +124,13 @@ class PageCache extends ActionFilter
      * @since 2.0.4
      */
     public $cacheHeaders = true;
+    /**
+     * @var array a list of placeholders for embedding dynamic contents. This property
+     * is used internally to implement the content caching feature. Do not modify it.
+     * @internal
+     * @since 2.0.11
+     */
+    public $dynamicPlaceholders;
 
 
     /**
@@ -154,57 +162,70 @@ class PageCache extends ActionFilter
             $this->dependency = Yii::createObject($this->dependency);
         }
 
-        $properties = [];
-        foreach (['cache', 'duration', 'dependency', 'variations'] as $name) {
-            $properties[$name] = $this->$name;
-        }
-        $id = $this->varyByRoute ? $action->getUniqueId() : __CLASS__;
         $response = Yii::$app->getResponse();
-        ob_start();
-        ob_implicit_flush(false);
-        if ($this->view->beginCache($id, $properties)) {
+        $data = $this->cache->get($this->calculateCacheKey());
+        if (!is_array($data) || !isset($data['cacheVersion']) || $data['cacheVersion'] !== 1) {
+            $this->view->cacheStack[] = $this;
+            ob_start();
+            ob_implicit_flush(false);
             $response->on(Response::EVENT_AFTER_SEND, [$this, 'cacheResponse']);
             Yii::trace('Valid page content is not found in the cache.', __METHOD__);
             return true;
         } else {
-            $data = $this->cache->get($this->calculateCacheKey());
-            if (is_array($data)) {
-                $this->restoreResponse($response, $data);
-            }
-            $response->content = ob_get_clean();
+            $this->restoreResponse($response, $data);
             Yii::trace('Valid page content is found in the cache.', __METHOD__);
             return false;
         }
     }
 
     /**
-     * Restores response properties from the given data
-     * @param Response $response the response to be restored
-     * @param array $data the response property data
+     * This method is invoked right before the response caching is to be started.
+     * You may override this method to cancel caching by returning `false` or store an additional data
+     * in a cache entry by returning an array instead of `true`.
+     * @return bool|array whether to cache or not, return an array instead of `true` to store an additional data.
+     * @since 2.0.11
+     */
+    public function beforeCacheResponse()
+    {
+        return true;
+    }
+
+    /**
+     * This method is invoked right after the response restoring is finished (but before the response is sent).
+     * You may override this method to do last-minute preparation before the response is sent.
+     * @param array|null $data an array of an additional data stored in a cache entry or `null`.
+     * @since 2.0.11
+     */
+    public function afterRestoreResponse($data)
+    {
+    }
+
+    /**
+     * Restores response properties from the given data.
+     * @param Response $response the response to be restored.
+     * @param array $data the response property data.
      * @since 2.0.3
      */
     protected function restoreResponse($response, $data)
     {
-        if (isset($data['format'])) {
-            $response->format = $data['format'];
+        foreach (['format', 'version', 'statusCode', 'statusText', 'content'] as $name) {
+            $response->{$name} = $data[$name];
         }
-        if (isset($data['version'])) {
-            $response->version = $data['version'];
+        foreach (['headers', 'cookies'] as $name) {
+            if (isset($data[$name]) && is_array($data[$name])) {
+                $response->{$name}->fromArray(array_merge($data[$name], $response->{$name}->toArray()));
+            }
         }
-        if (isset($data['statusCode'])) {
-            $response->statusCode = $data['statusCode'];
+        if (!empty($data['dynamicPlaceholders']) && is_array($data['dynamicPlaceholders'])) {
+            if (empty($this->view->cacheStack)) {
+                // outermost cache: replace placeholder with dynamic content
+                $response->content = $this->updateDynamicContent($response->content, $data['dynamicPlaceholders']);
+            }
+            foreach ($data['dynamicPlaceholders'] as $name => $statements) {
+                $this->view->addDynamicPlaceholder($name, $statements);
+            }
         }
-        if (isset($data['statusText'])) {
-            $response->statusText = $data['statusText'];
-        }
-        if (isset($data['headers']) && is_array($data['headers'])) {
-            $headers = $response->getHeaders()->toArray();
-            $response->getHeaders()->fromArray(array_merge($data['headers'], $headers));
-        }
-        if (isset($data['cookies']) && is_array($data['cookies'])) {
-            $cookies = $response->getCookies()->toArray();
-            $response->getCookies()->fromArray(array_merge($data['cookies'], $cookies));
-        }
+        $this->afterRestoreResponse(isset($data['cacheData']) ? $data['cacheData'] : null);
     }
 
     /**
@@ -213,43 +234,83 @@ class PageCache extends ActionFilter
      */
     public function cacheResponse()
     {
-        $this->view->endCache();
+        array_pop($this->view->cacheStack);
+        $beforeCacheResponseResult = $this->beforeCacheResponse();
+        if ($beforeCacheResponseResult === false) {
+            $content = ob_get_clean();
+            if (empty($this->view->cacheStack) && !empty($this->dynamicPlaceholders)) {
+                $content = $this->updateDynamicContent($content, $this->dynamicPlaceholders);
+            }
+            echo $content;
+            return;
+        }
+
         $response = Yii::$app->getResponse();
         $data = [
-            'format' => $response->format,
-            'version' => $response->version,
-            'statusCode' => $response->statusCode,
-            'statusText' => $response->statusText,
+            'cacheVersion' => 1,
+            'cacheData' => is_array($beforeCacheResponseResult) ? $beforeCacheResponseResult : null,
+            'content' => ob_get_clean()
         ];
-        if (!empty($this->cacheHeaders)) {
-            $headers = $response->getHeaders()->toArray();
-            if (is_array($this->cacheHeaders)) {
-                $filtered = [];
-                foreach ($this->cacheHeaders as $name) {
-                    $name = strtolower($name);
-                    if (isset($headers[$name])) {
-                        $filtered[$name] = $headers[$name];
-                    }
-                }
-                $headers = $filtered;
-            }
-            $data['headers'] = $headers;
+        if ($data['content'] === false || $data['content'] === '') {
+            return;
         }
-        if (!empty($this->cacheCookies)) {
-            $cookies = $response->getCookies()->toArray();
-            if (is_array($this->cacheCookies)) {
-                $filtered = [];
-                foreach ($this->cacheCookies as $name) {
-                    if (isset($cookies[$name])) {
-                        $filtered[$name] = $cookies[$name];
-                    }
-                }
-                $cookies = $filtered;
-            }
-            $data['cookies'] = $cookies;
+
+        $data['dynamicPlaceholders'] = $this->dynamicPlaceholders;
+        foreach (['format', 'version', 'statusCode', 'statusText'] as $name) {
+            $data[$name] = $response->{$name};
         }
+        $this->insertResponseCollectionIntoData($response, 'headers', $data);
+        $this->insertResponseCollectionIntoData($response, 'cookies', $data);
         $this->cache->set($this->calculateCacheKey(), $data, $this->duration, $this->dependency);
-        echo ob_get_clean();
+        if (empty($this->view->cacheStack) && !empty($this->dynamicPlaceholders)) {
+            $data['content'] = $this->updateDynamicContent($data['content'], $this->dynamicPlaceholders);
+        }
+        echo $data['content'];
+    }
+
+    /**
+     * Inserts (or filters/ignores according to config) response headers/cookies into a cache data array.
+     * @param Response $response the response.
+     * @param string $collectionName currently it's `headers` or `cookies`.
+     * @param array $data the cache data.
+     */
+    private function insertResponseCollectionIntoData(Response $response, $collectionName, array &$data)
+    {
+        $property = 'cache' . ucfirst($collectionName);
+        if ($this->{$property} === false) {
+            return;
+        }
+
+        $all = $response->{$collectionName}->toArray();
+        if (is_array($this->{$property})) {
+            $filtered = [];
+            foreach ($this->{$property} as $name) {
+                if ($collectionName === 'headers') {
+                    $name = strtolower($name);
+                }
+                if (isset($all[$name])) {
+                    $filtered[$name] = $all[$name];
+                }
+            }
+            $all = $filtered;
+        }
+        $data[$collectionName] = $all;
+    }
+
+    /**
+     * Replaces placeholders in content by results of evaluated dynamic statements.
+     * @param string $content content to be parsed.
+     * @param array $placeholders placeholders and their values.
+     * @return string final content.
+     * @since 2.0.11
+     */
+    protected function updateDynamicContent($content, $placeholders)
+    {
+        foreach ($placeholders as $name => $statements) {
+            $placeholders[$name] = $this->view->evaluateDynamicContent($statements);
+        }
+
+        return strtr($content, $placeholders);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #10506 |

This updated `PageCache` combines together `PageCache` and `FragmentCache` to provide caching in one entry.
### Features
- fully backwards compatible (incl. dynamic content)
- easy to be extended
- able to store/retrieve an additional data in `beforeCacheResponse` and `afterRestoreResponse` (_for example: I store Last-Modified in data and then retrieve it later in `HttpCache`_)
- all data is stored in one cache entry
- able to cancel caching by returning `false` in `beforeCacheResponse`
