### PR TITLE
Fix grammar in migration template docblocks.

### DIFF
--- a/framework/views/createTableMigration.php
+++ b/framework/views/createTableMigration.php
@@ -14,7 +14,7 @@ echo "<?php\n";
 use yii\db\Migration;
 
 /**
- * Handles the creation for table `<?= $table ?>`.
+ * Handles the creation of table `<?= $table ?>`.
 <?= $this->render('_foreignTables', [
     'foreignKeys' => $foreignKeys,
 ]) ?>

--- a/framework/views/dropTableMigration.php
+++ b/framework/views/dropTableMigration.php
@@ -13,7 +13,7 @@ echo "<?php\n";
 use yii\db\Migration;
 
 /**
- * Handles the dropping for table `<?= $table ?>`.
+ * Handles the dropping of table `<?= $table ?>`.
 <?= $this->render('_foreignTables', [
     'foreignKeys' => $foreignKeys,
 ]) ?>

--- a/tests/data/console/migrate_create/create_fields.php
+++ b/tests/data/console/migrate_create/create_fields.php
@@ -6,7 +6,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation for table `test`.
+ * Handles the creation of table `test`.
  */
 class {$class} extends Migration
 {

--- a/tests/data/console/migrate_create/create_foreign_key.php
+++ b/tests/data/console/migrate_create/create_foreign_key.php
@@ -6,7 +6,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation for table `test`.
+ * Handles the creation of table `test`.
  * Has foreign keys to the tables:
  *
  * - `user`

--- a/tests/data/console/migrate_create/create_id_pk.php
+++ b/tests/data/console/migrate_create/create_id_pk.php
@@ -6,7 +6,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation for table `test`.
+ * Handles the creation of table `test`.
  */
 class {$class} extends Migration
 {

--- a/tests/data/console/migrate_create/create_prefix.php
+++ b/tests/data/console/migrate_create/create_prefix.php
@@ -6,7 +6,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation for table `{{%test}}`.
+ * Handles the creation of table `{{%test}}`.
  * Has foreign keys to the tables:
  *
  * - `{{%user}}`

--- a/tests/data/console/migrate_create/create_products_from_store_table.php
+++ b/tests/data/console/migrate_create/create_products_from_store_table.php
@@ -6,7 +6,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation for table `products_from_store`.
+ * Handles the creation of table `products_from_store`.
  */
 class {$class} extends Migration
 {

--- a/tests/data/console/migrate_create/create_test.php
+++ b/tests/data/console/migrate_create/create_test.php
@@ -6,7 +6,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation for table `test`.
+ * Handles the creation of table `test`.
  */
 class {$class} extends Migration
 {

--- a/tests/data/console/migrate_create/create_title_pk.php
+++ b/tests/data/console/migrate_create/create_title_pk.php
@@ -6,7 +6,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation for table `test`.
+ * Handles the creation of table `test`.
  */
 class {$class} extends Migration
 {

--- a/tests/data/console/migrate_create/create_title_with_comma_default_values.php
+++ b/tests/data/console/migrate_create/create_title_with_comma_default_values.php
@@ -6,7 +6,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation for table `test`.
+ * Handles the creation of table `test`.
  */
 class {$class} extends Migration
 {

--- a/tests/data/console/migrate_create/drop_fields.php
+++ b/tests/data/console/migrate_create/drop_fields.php
@@ -6,7 +6,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the dropping for table `test`.
+ * Handles the dropping of table `test`.
  */
 class {$class} extends Migration
 {

--- a/tests/data/console/migrate_create/drop_products_from_store_table.php
+++ b/tests/data/console/migrate_create/drop_products_from_store_table.php
@@ -6,7 +6,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the dropping for table `products_from_store`.
+ * Handles the dropping of table `products_from_store`.
  */
 class {$class} extends Migration
 {

--- a/tests/data/console/migrate_create/drop_test.php
+++ b/tests/data/console/migrate_create/drop_test.php
@@ -6,7 +6,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the dropping for table `test`.
+ * Handles the dropping of table `test`.
  */
 class {$class} extends Migration
 {

--- a/tests/data/console/migrate_create/junction_test.php
+++ b/tests/data/console/migrate_create/junction_test.php
@@ -7,7 +7,7 @@ return
 use yii\db\Migration;
 
 /**
- * Handles the creation for table `post_tag`.
+ * Handles the creation of table `post_tag`.
  * Has foreign keys to the tables:
  *
  * - `post`

--- a/tests/framework/console/controllers/MigrateControllerTestTrait.php
+++ b/tests/framework/console/controllers/MigrateControllerTestTrait.php
@@ -237,7 +237,7 @@ CODE;
 		$this->assertCommandCreatedFile('create_products_from_store_table', 'create_products_from_store_table');
 
         // @see https://github.com/yiisoft/yii2/issues/11461
-        $this->assertCommandCreatedFile('create_titlte_with_comma_default_values', 'create_test_table', [
+        $this->assertCommandCreatedFile('create_title_with_comma_default_values', 'create_test_table', [
             'fields' => 'title:string(10):notNull:unique:defaultValue(",te,st"),
              body:text:notNull:defaultValue(",test"),
              test:custom(11,2,"s"):notNull',


### PR DESCRIPTION
Also fixed a typo in a test file's name.

| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |
