### PR TITLE
Fix error in docs

### DIFF
--- a/docs/guide/runtime-handling-errors.md
+++ b/docs/guide/runtime-handling-errors.md
@@ -148,6 +148,7 @@ the following variables if the error action is defined as [[yii\web\ErrorAction]
 the error action and the error view are already defined for you.
 
 > Note: If you need to redirect in an error handler, do it the following way:
+>
 > ```php
 > Yii::$app->getResponse()->redirect($url)->send();
 > return;

--- a/docs/guide/runtime-handling-errors.md
+++ b/docs/guide/runtime-handling-errors.md
@@ -150,7 +150,7 @@ the error action and the error view are already defined for you.
 > Note: If you need to redirect in an error handler, do it the following way:
 >
 > ```php
-> Yii::$app->getResponse()->redirect($url)->send();
+> Yii::$app->response->redirect($url)->send();
 > return;
 > ```
 


### PR DESCRIPTION
I found error in formating in guide http://www.yiiframework.com/doc-2.0/guide-runtime-handling-errors.html#using-error-actions. In note "If you need to redirect in an error handler, do ..." code block displays wrong. In github this block displays correctly https://github.com/yiisoft/yii2/blob/master/docs/guide/runtime-handling-errors.md#using-error-actions-.

I found similar block in http://www.yiiframework.com/doc-2.0/guide-runtime-sessions-cookies.html#flash-data which displays correctly and add one line before code block by analogy. I hope this will fix the error, hoverer I am not sure.
