### PR TITLE
Add short validator names `time` and `datetime`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -30,6 +30,7 @@ Yii Framework 2 Change Log
 - Enh #12082: Used `jQuery.on(` instead of event method to ensure forwards compatibility (newerton)
 - Enh #12028: Add -h|--help option to console command to display help information (pana1990)
 - Enh #12099: HttpCache no longer returns 304 HTTP code when callbacks return null (sergeymakinen)
+- Enh #12198: Added `time` and `datetime` validator short names (nkovacs)
 - Bug #12053: `./yii migrate/create` was generating wrong code when using `bigPrimaryKey` (VojtechH, samdark)
 - Bug #11907: Fixed `yii\helpers\Console::getScreenSize()` on Windows was giving out width and height swapped (Spell6inder, samdark, cebe)
 - Bug #11973: Fixed `yii\helpers\BaseHtml::getAttributeValue()` to work with `items[]` notation correctly (silverfire)

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -25,6 +25,8 @@ use yii\base\NotSupportedException;
  * - `captcha`: [[\yii\captcha\CaptchaValidator]]
  * - `compare`: [[CompareValidator]]
  * - `date`: [[DateValidator]]
+ * - `datetime`: [[DateValidator]]
+ * - `time`: [[DateValidator]]
  * - `default`: [[DefaultValueValidator]]
  * - `double`: [[NumberValidator]]
  * - `each`: [[EachValidator]]
@@ -57,6 +59,14 @@ class Validator extends Component
         'captcha' => 'yii\captcha\CaptchaValidator',
         'compare' => 'yii\validators\CompareValidator',
         'date' => 'yii\validators\DateValidator',
+        'datetime' => [
+            'class' => 'yii\validators\DateValidator',
+            'type' => DateValidator::TYPE_DATETIME,
+        ],
+        'time' => [
+            'class' => 'yii\validators\DateValidator',
+            'type' => DateValidator::TYPE_TIME,
+        ],
         'default' => 'yii\validators\DefaultValueValidator',
         'double' => 'yii\validators\NumberValidator',
         'each' => 'yii\validators\EachValidator',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | yes, but highly unlikely in practice (see below) |
| Tests pass? | yes |
| Fixed issues |  |

These map to `DateValidator` with `$type` set to
TYPE_TIME and TYPE_DATETIME.

Looking at [Validator::createValidator](https://github.com/yiisoft/yii2/blob/2.0.9/framework/validators/Validator.php#L190), if the model has a method called `time` or `datetime`, this won't override it, but if there's a class called `time` or `datetime`, it will override the class. This is extremely unlikely, since classes are usually uppercased and namespaced.
