### PR TITLE
Added missing colon

### DIFF
--- a/docs/guide/structure-application-components.md
+++ b/docs/guide/structure-application-components.md
@@ -7,7 +7,7 @@ the `urlManager` component is responsible for routing Web requests to appropriat
 the `db` component provides DB-related services; and so on.
 
 Each application component has an ID that uniquely identifies itself among other application components
-in the same application. You can access an application component through the expression
+in the same application. You can access an application component through the expression:
 
 ```php
 \Yii::$app->componentID


### PR DESCRIPTION
It would be nice to add links from the relevant sections on `yiiframework.com/doc-2.0/guide-*` to  the editing on GitHub. For example, as is done on the JSR (JavaScript.Ru): https://learn.javascript.ru/intro (left bottom corner).
