### PR TITLE
Allows BaseHtml::activeListInput to override the field value

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -35,6 +35,7 @@ Yii Framework 2 Change Log
 - Bug #11973: Fixed `yii\helpers\BaseHtml::getAttributeValue()` to work with `items[]` notation correctly (silverfire)
 - Bug #12100: Fixed `yii\filters\HttpCache` was sending an empty Pragma header (sergeymakinen)
 - Bug #12107: Fixed REST Serializer to validate input for 'expand' and 'fields' parameter, which crashed on array input (njspok, cebe)
+- Enh #12230: Allows BaseHtml::activeListInput to override the field value (RangelReale)
 
 
 2.0.9 July 11, 2016

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1648,7 +1648,7 @@ class BaseHtml
     protected static function activeListInput($type, $model, $attribute, $items, $options = [])
     {
         $name = isset($options['name']) ? $options['name'] : static::getInputName($model, $attribute);
-        $selection = static::getAttributeValue($model, $attribute);
+        $selection = isset($options['value']) ? $options['value'] : static::getAttributeValue($model, $attribute);
         if (!array_key_exists('unselect', $options)) {
             $options['unselect'] = '';
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |
- Allows BaseHtml::activeListInput to override the field value, to follow BaseHtml::activeInput which already allows it.

My use case:
Generating new fields loaded via ajax, I can let Yii generate the exact same layout for the fields with model data, setting value = '', so it doesn't call the model to load a field which does not exists.
