### PR TITLE
Fix "Call to a member function getRoute() on null"

### DIFF
--- a/framework/helpers/BaseUrl.php
+++ b/framework/helpers/BaseUrl.php
@@ -385,7 +385,9 @@ class BaseUrl
     public static function current(array $params = [], $scheme = false)
     {
         $currentParams = Yii::$app->getRequest()->getQueryParams();
-        $currentParams[0] = '/' . Yii::$app->controller->getRoute();
+        if(Yii::$app->controller) {
+            $currentParams[0] = '/' . Yii::$app->controller->getRoute();
+        }
         $route = ArrayHelper::merge($currentParams, $params);
         return static::toRoute($route, $scheme);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | comma-separated list of tickets # fixed by the PR, if any |

When you try to use Url::current([], true)]) on page without controller (404 error) it cause " E_ERROR: Call to a member function getRoute() on null "
