### PR TITLE
Fix code sample indentation in Polish guide [skip ci]

### DIFF
--- a/docs/guide-pl/start-installation.md
+++ b/docs/guide-pl/start-installation.md
@@ -67,7 +67,7 @@ Instalacja Yii z pliku archiwum składa się z trzech kroków:
 3. Zmodyfikowanie pliku `config/web.php` przez dodanie sekretnego klucza do elementu konfiguracji `cookieValidationKey`
    (jest to wykonywane automatycznie, jeśli instalujesz Yii używając Composera):
 
-    ```php
+   ```php
    // !!! wprowadź sekretny klucz tutaj - jest to wymagane do walidacji ciasteczek
    'cookieValidationKey' => 'enter your secret key here',
    ```


### PR DESCRIPTION
This probably should fix missing highliting in PDF:

![aa6e640c](https://cloud.githubusercontent.com/assets/5972388/17909210/bae99eec-6983-11e6-9541-8769b0821154.png)

vs

![3843b591](https://cloud.githubusercontent.com/assets/5972388/17909221/cc09d99e-6983-11e6-8963-ad9a705b4012.png)
