### PR TITLE
Obsolete translation teams removed

### DIFF
--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -17,7 +17,6 @@ Documentation
 -------------
 
 - [Translation Status](translation-status.md) - which documents are ready for translation.
-- [Translation teams](translation-teams.md)
 - [Translation workflow](translation-workflow.md)
 
 


### PR DESCRIPTION
In favour of translators.json. See #12321 #12323
