### PR TITLE
The ability to add a parameters to a method of obtaining relation

### DIFF
--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -97,6 +97,10 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      * @var array a list of relations that this query should be joined with
      */
     public $joinWith;
+    /**
+     * @var array
+     */
+    public $relationParams = [];
 
 
     /**
@@ -429,6 +433,12 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         return $this;
     }
 
+    public function bindRelationParams($params)
+    {
+        $this->relationParams = $params;
+        return $this;
+    }
+
     private function buildJoinWith()
     {
         $join = $this->join;
@@ -509,7 +519,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 $name = substr($name, 0, $pos);
                 $fullName = $prefix === '' ? $name : "$prefix.$name";
                 if (!isset($relations[$fullName])) {
-                    $relations[$fullName] = $relation = $primaryModel->getRelation($name);
+                    $relations[$fullName] = $relation = $primaryModel->getRelation($name, true, $this->relationParams);
                     $this->joinWithRelation($parent, $relation, $this->getJoinType($joinType, $fullName));
                 } else {
                     $relation = $relations[$fullName];
@@ -522,7 +532,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 
             $fullName = $prefix === '' ? $name : "$prefix.$name";
             if (!isset($relations[$fullName])) {
-                $relations[$fullName] = $relation = $primaryModel->getRelation($name);
+                $relations[$fullName] = $relation = $primaryModel->getRelation($name, true, $this->relationParams);
                 if ($callback !== null) {
                     call_user_func($callback, $relation);
                 }

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -196,7 +196,7 @@ trait ActiveQueryTrait
             }
 
             if (!isset($relations[$name])) {
-                $relation = $model->getRelation($name);
+                $relation = $model->getRelation($name, true, $this->relationParams);
                 $relation->primaryModel = null;
                 $relations[$name] = $relation;
             } else {

--- a/framework/db/ActiveRecordInterface.php
+++ b/framework/db/ActiveRecordInterface.php
@@ -359,9 +359,10 @@ interface ActiveRecordInterface
      * It can be declared in either the ActiveRecord class itself or one of its behaviors.
      * @param string $name the relation name
      * @param boolean $throwException whether to throw exception if the relation does not exist.
+     * @param array $relationParams array of params which use in related methods
      * @return ActiveQueryInterface the relational query object
      */
-    public function getRelation($name, $throwException = true);
+    public function getRelation($name, $throwException = true, $relationParams = []);
 
     /**
      * Populates the named relation with the related records.

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1131,16 +1131,22 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * It can be declared in either the Active Record class itself or one of its behaviors.
      * @param string $name the relation name
      * @param boolean $throwException whether to throw exception if the relation does not exist.
+     * @param array $relationParams array of params which use in related methods
      * @return ActiveQueryInterface|ActiveQuery the relational query object. If the relation does not exist
      * and `$throwException` is `false`, `null` will be returned.
      * @throws InvalidParamException if the named relation does not exist.
      */
-    public function getRelation($name, $throwException = true)
+    public function getRelation($name, $throwException = true, $relationParams = [])
     {
         $getter = 'get' . $name;
         try {
             // the relation could be defined in a behavior
-            $relation = $this->$getter();
+            $method = new \ReflectionMethod($this, $getter);
+            $necessaryPartOfParams = [];
+            foreach ($method->getParameters() as $parameter) {
+                $necessaryPartOfParams[] = array_key_exists($parameter->name, $relationParams) ? $relationParams[$parameter->name] : null;
+            }
+            $relation = call_user_func_array([$this, $getter], $necessaryPartOfParams);
         } catch (UnknownMethodException $e) {
             if ($throwException) {
                 throw new InvalidParamException(get_class($this) . ' has no relation named "' . $name . '".', 0, $e);
@@ -1158,7 +1164,6 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
 
         if (method_exists($this, $getter)) {
             // relation name is case sensitive, trying to validate it when the relation is defined within this class
-            $method = new \ReflectionMethod($this, $getter);
             $realName = lcfirst(substr($method->getName(), 3));
             if ($realName !== $name) {
                 if ($throwException) {
@@ -1193,7 +1198,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function link($name, $model, $extraColumns = [])
     {
-        $relation = $this->getRelation($name);
+        $relation = $this->getRelation($name, true, $this->relationParams);
 
         if ($relation->via !== null) {
             if ($this->getIsNewRecord() || $model->getIsNewRecord()) {
@@ -1286,7 +1291,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function unlink($name, $model, $delete = false)
     {
-        $relation = $this->getRelation($name);
+        $relation = $this->getRelation($name, true, $this->relationParams);
 
         if ($relation->via !== null) {
             if (is_array($relation->via)) {
@@ -1381,7 +1386,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function unlinkAll($name, $delete = false)
     {
-        $relation = $this->getRelation($name);
+        $relation = $this->getRelation($name, true, $this->relationParams);
 
         if ($relation->via !== null) {
             if (is_array($relation->via)) {
@@ -1507,7 +1512,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
                     $relatedModel = $relatedModel->$relationName;
                 } else {
                     try {
-                        $relation = $relatedModel->getRelation($relationName);
+                        $relation = $relatedModel->getRelation($relationName, true, $this->relationParams);
                     } catch (InvalidParamException $e) {
                         return $this->generateAttributeLabel($attribute);
                     }
@@ -1547,7 +1552,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
                     $relatedModel = $relatedModel->$relationName;
                 } else {
                     try {
-                        $relation = $relatedModel->getRelation($relationName);
+                        $relation = $relatedModel->getRelation($relationName, true, $this->relationParams);
                     } catch (InvalidParamException $e) {
                         return '';
                     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | yes |
| Tests pass? | no |
| Fixed issues |  |

Sometimes we use relation with params. As example:

``` php
class Document
{
    publick function getUserDocument($user_id)
    {
        return hasOne(UserDocument::class, ['document_id' => 'id'])
            ->andOnCondition(['user_id' => $user_id]);
    }
}
```

This relationship does not make sense without the parameter. But we can not specify this param when use `joinWith` method and instead use:

``` php
class Document
{
    publick function getUserDocuments()
    {
        return hasMany(UserDocument::class, ['document_id' => 'id']);
    }
}

class PlantController
{
    publick function actionGetUserDocuments()
    {
        $user_id = Yii::$app->getRequest()->getQueryParam('user_id');
        return Document::find()->joinWith(['userDocuments' => function ($q) {
            $q->andWhere(['user_id' => $user_id])
        }]);
    }
}
```

In the latter example, there are two problems: 
1. relationship has no useful effect, and will always be used only with the user parameter. 
2. the setting of the recording is quite complicated. 

The changes I propose to solve this problem:

``` php
class Document
{
    publick function getUserDocument($user_id)
    {
        return hasMany(UserDocument::class, ['document_id' => 'id'])
            ->andOnCondition(['user_id' => $user_id]);
    }
}

class PlantController
{
    publick function actionGetUserDocuments()
    {
        $user_id = Yii::$app->getRequest()->getQueryParam('user_id');
        return Document::find()
            ->joinWith('userDocuments')
            ->bindRelationParams(['user_id' => $user_id]);
    }
}
```
