### PR TITLE
enhanced BaseListView summary display with no result

### DIFF
--- a/framework/widgets/BaseListView.php
+++ b/framework/widgets/BaseListView.php
@@ -177,7 +177,7 @@ abstract class BaseListView extends Widget
     {
         $count = $this->dataProvider->getCount();
         if ($count <= 0) {
-            return '';
+            return Yii::t('yii', 'No results found.');;
         }
         $summaryOptions = $this->summaryOptions;
         $tag = ArrayHelper::remove($summaryOptions, 'tag', 'div');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | yes |
| Tests pass? | yes |
| Fixed issues | comma-separated list of tickets # fixed by the PR, if any |

if the dataProvider has no result, the summary div will be hidden. the outer list view div will move up.
