### PR TITLE
Update the rules for lists

### DIFF
--- a/docs/documentation_style_guide.md
+++ b/docs/documentation_style_guide.md
@@ -11,12 +11,15 @@ Guidelines to go by when writing or editing any Yii documentation.
 * Demonstrate ideas using code as much as possible.
 * Never use "we". It's the Yii development team or the Yii core team. Better yet to put things in terms of the framework or the guide.
 * Use the Oxford comma (e.g., "this, that, and the other" not "this, that and the other").
-* Numeric lists should be complete sentences that end with periods (or other punctuation).
-* Bullet lists should be fragments that don't end with periods.
 
 ## Formatting
 
 * Use *italics* for emphasis, never capitalization, bold, or underlines.
+
+## Lists
+
+* Numeric lists should be complete sentences that end with periods.
+* Bullet lists should be fragments that end with semicolon except the last item, which should end with a period.
 
 ## Blocks
 


### PR DESCRIPTION
Few examples ...

**Bullet list whithout any kind of punctution looks endless:**

![semicolon-1 shutter](https://cloud.githubusercontent.com/assets/14075412/18063923/c298d3ea-6e35-11e6-82c1-1b60436056d9.png)

**It is better:**

![semicolon-2 shutter](https://cloud.githubusercontent.com/assets/14075412/18063924/c2a00f70-6e35-11e6-9157-e0ea4da1bbde.png)

---

**Ugly (Maybe better not to use a colon before a numeric list?):**

![ol-ul-1 shutter](https://cloud.githubusercontent.com/assets/14075412/18064860/ea07bba4-6e39-11e6-92f0-bbee4af3af27.png)

**So-so (replaced colon and semicolons to periods):**

![ol-ul-2 shutter](https://cloud.githubusercontent.com/assets/14075412/18064861/ea1193b8-6e39-11e6-9149-557d11e2f74f.png)

**Excellent!..**

![ol-ul-3 shutter](https://cloud.githubusercontent.com/assets/14075412/18064862/ea1c3bc4-6e39-11e6-89ba-d1d0f2265103.png)