### PR TITLE
fixed serializer to not convert objects

### DIFF
--- a/framework/rest/Serializer.php
+++ b/framework/rest/Serializer.php
@@ -242,7 +242,7 @@ class Serializer extends Component
             return null;
         } else {
             list ($fields, $expand) = $this->getRequestedFields();
-            return $model->toArray($fields, $expand);
+            return $model->toArray($fields, $expand, false);
         }
     }
 

--- a/tests/framework/rest/SerializerTest.php
+++ b/tests/framework/rest/SerializerTest.php
@@ -4,6 +4,7 @@ namespace yiiunit\framework\rest;
 
 use yii\base\Model;
 use yii\data\ArrayDataProvider;
+use yii\helpers\Json;
 use yii\rest\Serializer;
 use yiiunit\TestCase;
 
@@ -72,6 +73,19 @@ class SerializerTest extends TestCase
         $this->assertSame([
             'field1' => 'test',
         ], $serializer->serialize($model));
+    }
+
+    public function testSerializeModelDataEmptyObject()
+    {
+        TestModel::$fields = ['field1' => function() {
+            return new \stdClass();
+        }];
+        TestModel::$extraFields = [];
+
+        $serializer = new Serializer();
+        $model = new TestModel();
+
+        $this->assertSame('{"field1":{}}', Json::encode($serializer->serialize($model)));
     }
 
     public function testExpand()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | yes |
| Tests pass? | yes |
| Fixed issues | #12394 |

currently it will recursively convert objects to arrays.
This is the more expected way imo and would fix #12394.

It breaks BC however.
