### PR TITLE
Update ActiveDataProvider.php

### DIFF
--- a/framework/data/ActiveDataProvider.php
+++ b/framework/data/ActiveDataProvider.php
@@ -173,7 +173,7 @@ class ActiveDataProvider extends BaseDataProvider
         parent::setSort($value);
         if (($sort = $this->getSort()) !== false && $this->query instanceof ActiveQueryInterface) {
             /* @var $model Model */
-            $model = new $this->query->modelClass;
+            $model = Yii::createObject($this->query->modelClass);
             if (empty($sort->attributes)) {
                 foreach ($model->attributes() as $attribute) {
                     $sort->attributes[$attribute] = [


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | no |

Changed to Yii::createObject() because in case of a custom constructor with some parameters and dependencies, the DI container is not called.
