### PR TITLE
Fix phpdoc for constants in db\Schema [skip ci]

### DIFF
--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -37,9 +37,7 @@ use yii\caching\TagDependency;
  */
 abstract class Schema extends Object
 {
-    /**
-     * The following are the supported abstract column data types.
-     */
+    // The following are the supported abstract column data types.
     const TYPE_PK = 'pk';
     const TYPE_UPK = 'upk';
     const TYPE_BIGPK = 'bigpk';


### PR DESCRIPTION
Phpdoc affects only one element - it should not be used for documenting group of constants.

![244cb24d](https://cloud.githubusercontent.com/assets/5972388/18143141/195100a4-6fc1-11e6-8fd1-1c0db059e070.png)
