### PR TITLE
Capability to hide root tag and model tag in xml responser

### DIFF
--- a/framework/web/XmlResponseFormatter.php
+++ b/framework/web/XmlResponseFormatter.php
@@ -37,7 +37,7 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
      */
     public $encoding;
     /**
-     * @var string the name of the root element.
+     * @var string the name of the root element or null.
      */
     public $rootTag = 'response';
     /**
@@ -50,7 +50,10 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
      * @since 2.0.7
      */
     public $useTraversableAsArray = true;
-
+    /**
+     *  @var boolean mandatory addition of the tag of model name
+     */
+    public $modelTag = true;
 
     /**
      * Formats the specified response.
@@ -65,9 +68,13 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
         $response->getHeaders()->set('Content-Type', $this->contentType);
         if ($response->data !== null) {
             $dom = new DOMDocument($this->version, $charset);
-            $root = new DOMElement($this->rootTag);
-            $dom->appendChild($root);
-            $this->buildXml($root, $response->data);
+            if ($this->rootTag !== null) {
+                $root = new DOMElement($this->rootTag);
+                $dom->appendChild($root);
+                $this->buildXml($root, $response->data);
+            } else {
+                $this->buildXml($dom, $response->data);
+            }
             $response->content = $dom->saveXML();
         }
     }
@@ -95,8 +102,12 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
                 }
             }
         } elseif (is_object($data)) {
-            $child = new DOMElement(StringHelper::basename(get_class($data)));
-            $element->appendChild($child);
+            if ($this->modelTag) {
+                $child = new DOMElement(StringHelper::basename(get_class($data)));
+                $element->appendChild($child);    
+            } else {
+                $child = $element;
+            }
             if ($data instanceof Arrayable) {
                 $this->buildXml($child, $data->toArray());
             } else {

--- a/framework/web/XmlResponseFormatter.php
+++ b/framework/web/XmlResponseFormatter.php
@@ -51,9 +51,9 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
      */
     public $useTraversableAsArray = true;
     /**
-     *  @var boolean mandatory addition of the tag of model name
+     *  @var boolean mandatory addition of the tag of object name
      */
-    public $modelTag = true;
+    public $objectTags = true;
 
     /**
      * Formats the specified response.
@@ -102,7 +102,7 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
                 }
             }
         } elseif (is_object($data)) {
-            if ($this->modelTag) {
+            if ($this->objectTags) {
                 $child = new DOMElement(StringHelper::basename(get_class($data)));
                 $element->appendChild($child);    
             } else {


### PR DESCRIPTION
### Usage:

``` php
        Yii::$app->response->formatters['xml'] = [
            'class' => \yii\web\XmlResponseFormatter::className(),
            'rootTag' => null,
            'objectTags' => false,
        ];        
        Yii::$app->response->format = \yii\web\Response::FORMAT_XML;
```

Very helpful for working with strict xml api.
