### PR TITLE
Fix bug when lock file was not removed after `yii\mutex\FileMutex::release()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -51,6 +51,7 @@ Yii Framework 2 Change Log
 - Bug #12331: Fixed bug with incorrect currency formatter output, when `$thousandSeparator` was explicitly set (cebe)
 - Bug #11347: Fixed `yii\widgets\Pjax::registerClientScript()` to pass custom `container` to the PJAX JS plugin (silverfire)
 - Bug #12293: Fixed MSSQL `Schema::resolveTableNames()` when using linked database tables (hAppywAy)
+- Bug #12431: Fix bug when lock file was not removed after `yii\mutex\FileMutex::release()` (rob006)
 - Enh: Method `yii\console\controllers\AssetController::getAssetManager()` automatically enables `yii\web\AssetManager::forceCopy` in case it is not explicitly specified (pana1990, klimov-paul)
 - Enh #12382: Changed `yii\widgets\MaskedInput` to use `jQuery` instead of `$` to prevent conflicts (samdark)
 

--- a/framework/mutex/FileMutex.php
+++ b/framework/mutex/FileMutex.php
@@ -89,13 +89,12 @@ class FileMutex extends Mutex
      */
     protected function acquireLock($name, $timeout = 0)
     {
-        $fileName = $this->mutexPath . '/' . md5($name) . '.lock';
-        $file = fopen($fileName, 'w+');
+        $file = fopen($this->getLockFilePath($name), 'w+');
         if ($file === false) {
             return false;
         }
         if ($this->fileMode !== null) {
-            @chmod($fileName, $this->fileMode);
+            @chmod($this->getLockFilePath($name), $this->fileMode);
         }
         $waitTime = 0;
         while (!flock($file, LOCK_EX | LOCK_NB)) {
@@ -123,9 +122,20 @@ class FileMutex extends Mutex
             return false;
         } else {
             fclose($this->_files[$name]);
+            unlink($this->getLockFilePath($name));
             unset($this->_files[$name]);
 
             return true;
         }
     }
+
+    /**
+     * Generate path for lock file.
+     * @param string $name
+     * @return string
+     * @since 2.0.10
+     */
+	protected function getLockFilePath($name) {
+		return $this->mutexPath . '/' . md5($name) . '.lock';
+	}
 }

--- a/tests/framework/mutex/FileMutexTest.php
+++ b/tests/framework/mutex/FileMutexTest.php
@@ -9,13 +9,13 @@ use yiiunit\TestCase;
  * Class FileMutexTest
  *
  * @group mutex
- * 
+ *
  * @package yii\tests\unit\framework\mutex
  */
 class FileMutexTest extends TestCase
 {
     use MutexTestTrait;
-    
+
     protected function setUp() {
         parent::setUp();
         if (DIRECTORY_SEPARATOR === '\\') {
@@ -34,4 +34,15 @@ class FileMutexTest extends TestCase
         ]);
     }
 
+    public function testDeleteLockFile()
+    {
+        $mutex = $this->createMutex();
+        $fileName = $mutex->mutexPath . '/' . md5(self::$mutexName) . '.lock';
+
+        $mutex->acquire(self::$mutexName);
+        $this->assertFileExists($fileName);
+
+        $mutex->release(self::$mutexName);
+        $this->assertFileNotExists($fileName);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | - |
