### PR TITLE
Improvements for handling redirections produced by UrlNormalizer

### DIFF
--- a/framework/web/Application.php
+++ b/framework/web/Application.php
@@ -8,6 +8,7 @@
 namespace yii\web;
 
 use Yii;
+use yii\helpers\Url;
 use yii\base\InvalidRouteException;
 
 /**
@@ -78,8 +79,15 @@ class Application extends \yii\base\Application
             try {
                 list ($route, $params) = $request->resolve();
             } catch (UrlNormalizerRedirectException $e) {
-                $url = [$e->route] + $e->params + $request->getQueryParams();
-                return $this->getResponse()->redirect($url, $e->statusCode);
+                $url = $e->url;
+                if (is_array($url)) {
+                    if (isset($url[0])) {
+                        // ensure the route is absolute
+                        $url[0] = '/' . ltrim($url[0], '/');
+                    }
+                    $url += $request->getQueryParams();
+                }
+                return $this->getResponse()->redirect(Url::to($url, $e->scheme), $e->statusCode);
             }
         } else {
             $route = $this->catchAll[0];

--- a/framework/web/UrlNormalizer.php
+++ b/framework/web/UrlNormalizer.php
@@ -82,7 +82,7 @@ class UrlNormalizer extends Object
             return $route;
         } elseif ($this->action === static::ACTION_REDIRECT_PERMANENT
                 || $this->action === static::ACTION_REDIRECT_TEMPORARY) {
-            throw new UrlNormalizerRedirectException($route[0], $route[1], $this->action);
+            throw new UrlNormalizerRedirectException([$route[0]] + $route[1], $this->action);
         } elseif ($this->action === static::ACTION_NOT_FOUND) {
             throw new NotFoundHttpException(Yii::t('yii', 'Page not found.'));
         } elseif (is_callable($this->action)) {

--- a/framework/web/UrlNormalizerRedirectException.php
+++ b/framework/web/UrlNormalizerRedirectException.php
@@ -18,30 +18,34 @@ namespace yii\web;
 class UrlNormalizerRedirectException extends \yii\base\Exception
 {
     /**
-     * @var string route used to generate URL for redirection
+     * @var array|string the parameter to be used to generate a valid URL for redirection
+     * @see [[\yii\helpers\Url::to()]]
      */
-    public $route;
+    public $url;
     /**
-     * @var array params used to generate URL for redirection
+     * @var boolean|string the URI scheme to use in the generated URL for redirection
+     * @see [[\yii\helpers\Url::to()]]
      */
-    public $params;
+    public $scheme;
     /**
      * @var integer the HTTP status code
      */
     public $statusCode;
 
     /**
-     * @param string $route route used to generate URL for redirection
-     * @param string $params params used to generate URL for redirection
+     * @param array|string $url the parameter to be used to generate a valid URL for redirection.
+     * This will be used as first parameter for [[\yii\helpers\Url::to()]]
      * @param integer $statusCode HTTP status code used for redirection
+     * @param boolean|string $scheme the URI scheme to use in the generated URL for redirection.
+     * This will be used as second parameter for [[\yii\helpers\Url::to()]]
      * @param string $message the error message
      * @param integer $code the error code
      * @param \Exception $previous the previous exception used for the exception chaining
      */
-    public function __construct($route, $params = [], $statusCode = 302, $message = null, $code = 0, \Exception $previous = null)
+    public function __construct($url, $statusCode = 302, $scheme = false, $message = null, $code = 0, \Exception $previous = null)
     {
-        $this->route = $route;
-        $this->params = $params;
+        $this->url = $url;
+        $this->scheme = $scheme;
         $this->statusCode = $statusCode;
         parent::__construct($message, $code, $previous);
     }

--- a/tests/framework/web/UrlNormalizerTest.php
+++ b/tests/framework/web/UrlNormalizerTest.php
@@ -69,7 +69,7 @@ class UrlNormalizerTest extends TestCase
 
         // 301 redirect as default action
         $normalizer->action = UrlNormalizer::ACTION_REDIRECT_PERMANENT;
-        $expected = new UrlNormalizerRedirectException($route[0], $route[1], 301);
+        $expected = new UrlNormalizerRedirectException([$route[0]] + $route[1], 301);
         try {
             $result = $normalizer->normalizeRoute($route);
             $this->fail('Expected throwing UrlNormalizerRedirectException');
@@ -79,7 +79,7 @@ class UrlNormalizerTest extends TestCase
 
         // 302 redirect as default action
         $normalizer->action = UrlNormalizer::ACTION_REDIRECT_TEMPORARY;
-        $expected = new UrlNormalizerRedirectException($route[0], $route[1], 302);
+        $expected = new UrlNormalizerRedirectException([$route[0]] + $route[1], 302);
         try {
             $result = $normalizer->normalizeRoute($route);
             $this->fail('Expected throwing UrlNormalizerRedirectException');

--- a/tests/framework/web/UrlRuleTest.php
+++ b/tests/framework/web/UrlRuleTest.php
@@ -81,7 +81,7 @@ class UrlRuleTest extends TestCase
                         $this->assertEquals($expected, $result, "Test#$i-$j: $name");
                     }
                 } catch (UrlNormalizerRedirectException $exc) {
-                    $this->assertEquals($expected, [$exc->route, $exc->params], "Test#$i-$j: $name");
+                    $this->assertEquals([$expected[0]] + $expected[1], $exc->url, "Test#$i-$j: $name");
                 }
             }
         }
@@ -113,7 +113,7 @@ class UrlRuleTest extends TestCase
                     }
                 } catch (UrlNormalizerRedirectException $exc) {
                     $this->assertEquals(UrlNormalizer::ACTION_REDIRECT_PERMANENT, $exc->statusCode, "Test-statusCode#$i-$j: $name");
-                    $this->assertEquals($expected, [$exc->route, $exc->params], "Test#$i-$j: $name");
+                    $this->assertEquals([$expected[0]] + $expected[1], $exc->url, "Test#$i-$j: $name");
                 }
             }
         }
@@ -142,7 +142,7 @@ class UrlRuleTest extends TestCase
                     }
                 } catch (UrlNormalizerRedirectException $exc) {
                     $this->assertEquals(UrlNormalizer::ACTION_REDIRECT_TEMPORARY, $exc->statusCode, "Test-statusCode#$i-$j: $name");
-                    $this->assertEquals($expected, [$exc->route, $exc->params], "Test#$i-$j: $name");
+                    $this->assertEquals([$expected[0]] + $expected[1], $exc->url, "Test#$i-$j: $name");
                 }
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no (if merged before 2.0.10 release) |
| Tests pass? | yes |
| Fixed issues | - |

replaces #12450

I was wondering how to solve https://github.com/yiisoft/yii2/issues/3047, and I realized that the current implementation of redirections produced by UrlNormalizera is very limited. It should be improved before 2.0.10 will be released, to avoid BC trap.
