### PR TITLE
Disable slaves when execute migrations to resolve master-slave replication no-sync

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -56,6 +56,7 @@ Yii Framework 2 Change Log
 - Bug #12431: Fix bug when lock file was not removed after `yii\mutex\FileMutex::release()` (rob006)
 - Enh: Method `yii\console\controllers\AssetController::getAssetManager()` automatically enables `yii\web\AssetManager::forceCopy` in case it is not explicitly specified (pana1990, klimov-paul)
 - Enh #12382: Changed `yii\widgets\MaskedInput` to use `jQuery` instead of `$` to prevent conflicts (samdark)
+- Bug #12446: Disable slaves when execute migrations to resolve master-slave replication no-sync (lichunqiang)
 
 
 2.0.9 July 11, 2016

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -69,6 +69,7 @@ class Migration extends Component implements MigrationInterface
         parent::init();
         $this->db = Instance::ensure($this->db, Connection::className());
         $this->db->getSchema()->refresh();
+        $this->db->enableSlaves = false;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #12446 |
