### PR TITLE
Guide: Customizing Query Classes

### DIFF
--- a/docs/guide/db-active-record.md
+++ b/docs/guide/db-active-record.md
@@ -1349,13 +1349,15 @@ class Comment extends ActiveRecord
         return new CommentQuery(get_called_class());
     }
 }
-````
+```
+
 Now whenever you are performing a query (e.g. `find()`, `findOne()`) or defining a relation (e.g. `hasOne()`)
 with `Comment`, you will be calling an instance of `CommentQuery` instead of `ActiveQuery`.
 
 You can customize the `CommentQuery` class in many creative ways to improve your query building experience. For example,
 you can define new query building methods:
-````php
+
+```php
 // file CommentQuery.php
 namespace app\models;
 
@@ -1377,7 +1379,6 @@ class CommentQuery extends ActiveQuery
     }
 }
 ```
-
 
 > Tip: In big projects, it is recommended that you use customized query classes to hold most query-related code
   so that the Active Record classes can be kept clean.
@@ -1403,7 +1404,7 @@ class Customer extends \yii\db\ActiveRecord
     }
 }
 
-$customers = Customer::find()->with('activeComments')->all();
+$customers = Customer::find()->joinWith('activeComments')->all();
 
 // or alternatively
 class Customer extends \yii\db\ActiveRecord
@@ -1414,7 +1415,7 @@ class Customer extends \yii\db\ActiveRecord
     }
 }
 
-$customers = Customer::find()->with([
+$customers = Customer::find()->joinWith([
     'comments' => function($q) {
         $q->active();
     }

--- a/docs/guide/db-active-record.md
+++ b/docs/guide/db-active-record.md
@@ -1335,13 +1335,12 @@ You can use most of the relational query features that have been described in th
 By default, all Active Record queries are supported by [[yii\db\ActiveQuery]]. To use a customized query class
 in an Active Record class, you should override the [[yii\db\ActiveRecord::find()]] method and return an instance
 of your customized query class. For example,
- 
+
 ```php
 // file Comment.php
 namespace app\models;
 
 use yii\db\ActiveRecord;
-use yii\db\ActiveQuery;
 
 class Comment extends ActiveRecord
 {
@@ -1350,41 +1349,44 @@ class Comment extends ActiveRecord
         return new CommentQuery(get_called_class());
     }
 }
+````
+Now whenever you are performing a query (e.g. `find()`, `findOne()`) or defining a relation (e.g. `hasOne()`)
+with `Comment`, you will be calling an instance of `CommentQuery` instead of `ActiveQuery`.
 
+You can customize the `CommentQuery` class in many creative ways to improve your query building experience. For example,
+you can define new query building methods:
+````php
 // file CommentQuery.php
 namespace app\models;
 
+use yii\db\ActiveQuery;
+
 class CommentQuery extends ActiveQuery
 {
+    // conditions appended by default (can be skipped)
+    public function init()
+    {
+        return $this->andOnCondition(['deleted' => false]);
+    }
+
     // ... add customized query methods here ...
-}
-```
 
-Now whenever you are performing a query (e.g. `find()`, `findOne()`) or defining a relation (e.g. `hasOne()`) 
-with `Comment`, you will be working with an instance of `CommentQuery` instead of `ActiveQuery`.
-
-You can customize a query class in many creative ways to improve your query building experience. For example,
-you can define new query building methods in a customized query class: 
-
-```php
-class CommentQuery extends ActiveQuery
-{
     public function active($state = true)
     {
-        return $this->andWhere(['active' => $state]);
+        return $this->andOnCondition(['active' => $state]);
     }
 }
 ```
 
+
 > Tip: In big projects, it is recommended that you use customized query classes to hold most query-related code
   so that the Active Record classes can be kept clean.
 
-> Note: Instead of calling [[yii\db\ActiveQuery::where()|where()]], you usually should call
-  [[yii\db\ActiveQuery::andWhere()|andWhere()]] or [[yii\db\ActiveQuery::orWhere()|orWhere()]] to append additional
-  conditions when defining new query building methods so that any existing conditions are not overwritten.
+> Note: Instead of calling [[yii\db\ActiveQuery::onCondition()|onCondition()]], you usually should call
+  [[yii\db\ActiveQuery::andOnCondition()|andOnCondition()]] or [[yii\db\ActiveQuery::orOnCondition()|orOnCondition()]] to append additional conditions when defining new query building methods so that any existing conditions are not overwritten.
 
 This allows you to write query building code like the following:
- 
+
 ```php
 $comments = Comment::find()->active()->all();
 $inactiveComments = Comment::find()->active(false)->all();
@@ -1404,7 +1406,14 @@ class Customer extends \yii\db\ActiveRecord
 $customers = Customer::find()->with('activeComments')->all();
 
 // or alternatively
- 
+class Customer extends \yii\db\ActiveRecord
+{
+    public function getComments()
+    {
+        return $this->hasMany(Comment::className(), ['customer_id' => 'id']);
+    }
+}
+
 $customers = Customer::find()->with([
     'comments' => function($q) {
         $q->active();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | no |
| Fixed issues | #12462 |

Clearly separate classes' definition.
Add information for default query condition with init().
Suggest using andOnCondition() instead of andWhere() as it didn't work
with the left join example provided.
