### PR TITLE
Update AccessControl.php

### DIFF
--- a/framework/filters/AccessControl.php
+++ b/framework/filters/AccessControl.php
@@ -147,6 +147,7 @@ class AccessControl extends ActionFilter
     {
         if ($user->getIsGuest()) {
             $user->loginRequired();
+            Yii::$app->end(); //to prevent controller/action resolving
         } else {
             throw new ForbiddenHttpException(Yii::t('yii', 'You are not allowed to perform this action.'));
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | comma-separated list of tickets # fixed by the PR, if any |

As you see, if you are a guest, then loginRequired logic are involved. 
BUT! this logic do nothing except adding header with redirect to response. And... Further works standard mechanism of resolving controller/action, action creation and firing it. So, even you do not see result of action work because of redirect, it works. And works very well. You can, for example, delete some record, if you are familiar with yii, you have an idea about database schema (controller user will be good example), even you are the guest and you do not have any idea about the administrator account.
We have fixed this misconception by simple adding of Yii::$app->end() after $user->loginRequired(); in our project.
Please, take action
