### PR TITLE
message/extract - support for multiple sourcePath

### DIFF
--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -282,12 +282,22 @@ EOD;
             $configFileContent,
             $this->getPassedOptionValues()
         );
-        $config['sourcePath'] = Yii::getAlias($config['sourcePath']);
-        $config['messagePath'] = Yii::getAlias($config['messagePath']);
 
         if (!isset($config['sourcePath'], $config['languages'])) {
             throw new Exception('The configuration file must specify "sourcePath" and "languages".');
         }
+
+        if (!is_array($config['sourcePath'])) {
+            $config['sourcePath'] = (array)$config['sourcePath'];
+        }
+
+        foreach ($config['sourcePath'] as &$path) {
+            $path = Yii::getAlias($path);
+            unset($path);
+        }
+
+        $config['messagePath'] = Yii::getAlias($config['messagePath']);
+
         if (!is_dir($config['sourcePath'])) {
             throw new Exception("The source path {$config['sourcePath']} is not a valid directory.");
         }
@@ -305,7 +315,10 @@ EOD;
             throw new Exception('Languages cannot be empty.');
         }
 
-        $files = FileHelper::findFiles(realpath($config['sourcePath']), $config);
+        $files = [];
+        foreach ($config['sourcePath'] as $path) {
+            $files = array_merge($files, FileHelper::findFiles(realpath($path), $config));
+        }
 
         $messages = [];
         foreach ($files as $file) {

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -298,8 +298,10 @@ EOD;
 
         $config['messagePath'] = Yii::getAlias($config['messagePath']);
 
-        if (!is_dir($config['sourcePath'])) {
-            throw new Exception("The source path {$config['sourcePath']} is not a valid directory.");
+        foreach ($config['sourcePath'] as $path) {
+            if (!is_dir($path)) {
+                throw new Exception("The source path {$path} is not a valid directory.");
+            }
         }
         if (empty($config['format']) || !in_array($config['format'], ['php', 'po', 'pot', 'db'])) {
             throw new Exception('Format should be either "php", "po", "pot" or "db".');


### PR DESCRIPTION
Added support for multiple paths as `sourcePath` for the `console:message/extract`. Because sometimes it makes more sense to add 2 or 3 sourcePaths instead of adding 25 except cases :)

| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | comma-separated list of tickets # fixed by the PR, if any |
