### PR TITLE
Override template per attribute in widget config

### DIFF
--- a/framework/widgets/DetailView.php
+++ b/framework/widgets/DetailView.php
@@ -153,13 +153,14 @@ class DetailView extends Widget
      */
     protected function renderAttribute($attribute, $index)
     {
-        if (is_string($this->template)) {
-            return strtr($this->template, [
+        $template = (empty($attribute['template'])) ? $this->template : $attribute['template'];
+        if (is_string($template)) {
+            return strtr($template, [
                 '{label}' => $attribute['label'],
                 '{value}' => $this->formatter->format($attribute['value'], $attribute['format']),
             ]);
         } else {
-            return call_user_func($this->template, $attribute, $index, $this);
+            return call_user_func($template, $attribute, $index, $this);
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |

This change allows to override the rendering template per attribute for just one or a few attributes. Use case: a DetailView widget containing one full width image without label. This could be achieved to set a template attribute in the relevant config row like this: 

```
'photo' => [
        'attribute' => 'photo',
        'template' => '<tr><td colspan="2">{value}</td></tr>',
        'value' => Html::img($model->photo),
        'format' => 'raw',
    ]
```
