### PR TITLE
fix links in input-forms guides

### DIFF
--- a/docs/guide-fr/input-forms.md
+++ b/docs/guide-fr/input-forms.md
@@ -139,9 +139,9 @@ Pjax::end();
 
 #### Valeurs dans les boutons de soumission et dans les chargement de fichiers sur le serveur
 
-Il y a des problèmes connus avec l'utilisation de `jQuery.serializeArray()` lorsqu'on manipule des [[https://github.com/jquery/jquery/issues/2321|fichiers]] et des [[https://github.com/jquery/jquery/issues/2321|valeurs de boutons de soumission]] qui ne peuvent être résolus et sont plutôt rendus obsolète en faveur de la classe `FormData` introduite en HTML5. 
+Il y a des problèmes connus avec l'utilisation de `jQuery.serializeArray()` lorsqu'on manipule des [fichiers](https://github.com/jquery/jquery/issues/2321) et des [valeurs de boutons de soumission](https://github.com/jquery/jquery/issues/2321) qui ne peuvent être résolus et sont plutôt rendus obsolète en faveur de la classe `FormData` introduite en HTML5. 
 
-Cela siginifie que la seule prise en charge officielle pour les fichiers et les valeurs de boutons de soumission avec ajax, ou en utilisant le composant graphique  [[yii\widgets\Pjax|Pjax]], dépend de la [[https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility|prise en charge par le navigateur]] de la classe `FormData`.
+Cela siginifie que la seule prise en charge officielle pour les fichiers et les valeurs de boutons de soumission avec ajax, ou en utilisant le composant graphique  [[yii\widgets\Pjax|Pjax]], dépend de la [prise en charge par le navigateur](https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility) de la classe `FormData`.
 
 Lectures d'approfondissement <span id="further-reading"></span>
 ----------------------------

--- a/docs/guide-ja/input-forms.md
+++ b/docs/guide-ja/input-forms.md
@@ -167,13 +167,13 @@ Pjax::end();
 #### 送信ボタンの値とファイルのアップロード
 
 `jQuery.serializeArray()` については、
-[[https://github.com/jquery/jquery/issues/2321|ファイル]] および
-[[https://github.com/jquery/jquery/issues/2321|送信ボタンの値]]
+[ファイル](https://github.com/jquery/jquery/issues/2321) および
+[送信ボタンの値](https://github.com/jquery/jquery/issues/2321)
 を扱うときに問題があることが知られています。
 この問題は解決される見込みがなく、関数自体も HTML5 で導入された `FormData` クラスによって置き換えられるべきものとして、廃止予定となっています。
 
 このことは、すなわち、ajax または [[yii\widgets\Pjax|Pjax]] ウィジェットを使う場合、ファイルと送信ボタンの値に対する唯一の公式なサポートは、
-`FormData` クラスに対する [[https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility|ブラウザのサポート]] に依存しているということを意味します。
+`FormData` クラスに対する [ブラウザのサポート](https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility) に依存しているということを意味します。
 
 
 さらに読むべき文書 <span id="further-reading"></span>

--- a/docs/guide/input-forms.md
+++ b/docs/guide/input-forms.md
@@ -175,14 +175,14 @@ Pjax::end();
 #### Values in Submit Buttons and File Upload
 
 There are known issues using `jQuery.serializeArray()` when dealing with
-[[https://github.com/jquery/jquery/issues/2321|files]] and
-[[https://github.com/jquery/jquery/issues/2321|submit button values]] which
+[files](https://github.com/jquery/jquery/issues/2321) and
+[submit button values](https://github.com/jquery/jquery/issues/2321) which
 won't be solved and are instead deprecated in favor of the `FormData` class
 introduced in HTML5.
 
 That means the only official support for files and submit button values with
 ajax or using the [[yii\widgets\Pjax|Pjax]] widget depends on the
-[[https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility|browser support]]
+[browser support](https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility)
 for the `FormData` class.
 
 Further Reading <span id="further-reading"></span>


### PR DESCRIPTION
Change external links format from `[[http://example.net/|This link]]` to `[This link](http://example.net/)` in guide http://www.yiiframework.com/doc-2.0/guide-input-forms.html#working-with-pjax
