### PR TITLE
display the table when dropping index

### DIFF
--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -453,7 +453,7 @@ class Migration extends Component implements MigrationInterface
      */
     public function dropIndex($name, $table)
     {
-        echo "    > drop index $name ...";
+        echo "    > drop index $name on $table ...";
         $time = microtime(true);
         $this->db->createCommand()->dropIndex($name, $table)->execute();
         echo ' done (time: ' . sprintf('%.3f', microtime(true) - $time) . "s)\n";


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | - |

display the table, helping when dropping multiple indices with the same name
