### PR TITLE
Added first() method to ActiveRecord and Query classes.

### DIFF
--- a/framework/db/ActiveRecordInterface.php
+++ b/framework/db/ActiveRecordInterface.php
@@ -185,6 +185,40 @@ interface ActiveRecordInterface
     public static function findOne($condition);
 
     /**
+     * Returns a first single active record model instance by a primary key or an array of column values.
+     *
+     * The method accepts:
+     *
+     *  - a scalar value (integer or string): query by a single primary key value and return the
+     *    corresponding record (or null if not found).
+     *  - a non-associative array: query by a list of primary key values and return the
+     *    first record (or null if not found).
+     *  - an associative array of name-value pairs: query by a set of attribute values and return a single record
+     *    matching all of them (or null if not found). Note that `['id' => 1, 2]` is treated as a non-associative array.
+     *
+     * That this method will automatically call the `first()` method and return an [[ActiveRecordInterface|ActiveRecord]]
+     * instance. For example,
+     *
+     * ```php
+     * // find a single customer whose primary key value is 10
+     * $customer = Customer::findFirst(10);
+     *
+     * // the above code is equivalent to:
+     * $customer = Customer::find()->where(['id' => 10])->first();
+     *
+     * // find the first customer whose age is 30 and whose status is 1
+     * $customer = Customer::findFirst(['age' => 30, 'status' => 1]);
+     *
+     * // the above code is equivalent to:
+     * $customer = Customer::find()->where(['age' => 30, 'status' => 1])->first();
+     * ```
+     *
+     * @param mixed $condition primary key value or a set of column values
+     * @return static|null ActiveRecord instance matching the condition, or null if nothing matches.
+     */
+    public static function findFirst($condition);
+
+    /**
      * Returns a list of active record models that match the specified primary key value(s) or a set of column values.
      *
      * The method accepts:

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -104,6 +104,15 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
 
     /**
      * @inheritdoc
+     * @return static|null ActiveRecord instance matching the condition, or `null` if nothing matches.
+     */
+    public static function findFirst($condition)
+    {
+        return static::findByCondition($condition)->first();
+    }
+
+    /**
+     * @inheritdoc
      * @return static[] an array of ActiveRecord instances, or an empty array if nothing matches.
      */
     public static function findAll($condition)

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -248,6 +248,19 @@ class Query extends Component implements QueryInterface
     }
 
     /**
+     * Executes the query and returns a first single row of result.
+     * @param Connection $db the database connection used to generate the SQL statement.
+     * If this parameter is not given, the `db` application component will be used.
+     * @return array|boolean the first row (in terms of an array) of the query result. False is returned if the query
+     * results in nothing.
+     */
+    public function first($db = null)
+    {
+        $query = clone $this;
+        return $query->limit(1)->one($db);
+    }
+
+    /**
      * Returns the query result as a scalar value.
      * The value returned will be the first column in the first row of the query results.
      * @param Connection $db the database connection used to generate the SQL statement.

--- a/framework/db/QueryInterface.php
+++ b/framework/db/QueryInterface.php
@@ -40,6 +40,15 @@ interface QueryInterface
     public function one($db = null);
 
     /**
+      * Executes the query and returns a first single row of result.
+      * @param Connection $db the database connection used to execute the query.
+      * If this parameter is not given, the `db` application component will be used.
+      * @return array|boolean the first row (in terms of an array) of the query result. False is returned if the query
+      * results in nothing.
+      */
+     public function first($db = null);
+
+    /**
      * Returns the number of records.
      * @param string $q the COUNT expression. Defaults to '*'.
      * @param Connection $db the database connection used to execute the query.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |

Find one selects all data from DB and then reduce it to one record.
Find first set limit to returned data.

For example, you can execute this:
`
$lastLog = BigLogTable::find()->orderBy(['insert_stamp' => SORT_DESC])->one();
`
And you do not suspect that all entries will be selected before result truncated to one record.

This speciality discussed on yii forums, but not included in repository yet.
