### PR TITLE
Changed `::className()` references to `::class` in the docs

### DIFF
--- a/docs/guide-es/concept-behaviors.md
+++ b/docs/guide-es/concept-behaviors.md
@@ -116,21 +116,21 @@ class User extends ActiveRecord
     {
         return [
             // anonymous behavior, behavior class name only
-            MyBehavior::className(),
+            MyBehavior::class,
 
             // named behavior, behavior class name only
-            'myBehavior2' => MyBehavior::className(),
+            'myBehavior2' => MyBehavior::class,
 
             // anonymous behavior, configuration array
             [
-                'class' => MyBehavior::className(),
+                'class' => MyBehavior::class,
                 'prop1' => 'value1',
                 'prop2' => 'value2',
             ],
 
             // named behavior, configuration array
             'myBehavior4' => [
-                'class' => MyBehavior::className(),
+                'class' => MyBehavior::class,
                 'prop1' => 'value1',
                 'prop2' => 'value2',
             ]
@@ -154,11 +154,11 @@ use app\components\MyBehavior;
 $component->attachBehavior('myBehavior1', new MyBehavior);
 
 // vincular una clase comportamiento
-$component->attachBehavior('myBehavior2', MyBehavior::className());
+$component->attachBehavior('myBehavior2', MyBehavior::class);
 
 // asociar una matriz de configuración
 $component->attachBehavior('myBehavior3', [
-    'class' => MyBehavior::className(),
+    'class' => MyBehavior::class,
     'prop1' => 'value1',
     'prop2' => 'value2',
 ]);
@@ -168,7 +168,7 @@ Puede vincular múltiples comportamientos a la vez mediante el uso del método [
 ```php
 $component->attachBehaviors([
     'myBehavior1' => new MyBehavior,  // un comportamiento nombrado
-    MyBehavior::className(),          // un comportamiento anónimo
+    MyBehavior::class,          // un comportamiento anónimo
 ]);
 ```
 
@@ -176,10 +176,10 @@ También puedes asociar comportamientos a traves de [configuraciones](concept-co
 
 ```php
 [
-    'as myBehavior2' => MyBehavior::className(),
+    'as myBehavior2' => MyBehavior::class,
 
     'as myBehavior3' => [
-        'class' => MyBehavior::className(),
+        'class' => MyBehavior::class,
         'prop1' => 'value1',
         'prop2' => 'value2',
     ],
@@ -270,7 +270,7 @@ class User extends ActiveRecord
     {
         return [
             [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'attributes' => [
                     ActiveRecord::EVENT_BEFORE_INSERT => ['created_at', 'updated_at'],
                     ActiveRecord::EVENT_BEFORE_UPDATE => ['updated_at'],

--- a/docs/guide-es/concept-components.md
+++ b/docs/guide-es/concept-components.md
@@ -67,7 +67,7 @@ Siguiendo esas directrices hará que tus componentes sean [configurables](concep
 $component = new MyClass(1, 2, ['prop1' => 3, 'prop2' => 4]);
 // alternativamente
 $component = \Yii::createObject([
-    'class' => MyClass::className(),
+    'class' => MyClass::class,
     'prop1' => 3,
     'prop2' => 4,
 ], [1, 2]);

--- a/docs/guide-es/concept-events.md
+++ b/docs/guide-es/concept-events.md
@@ -217,7 +217,7 @@ use Yii;
 use yii\base\Event;
 use yii\db\ActiveRecord;
 
-Event::on(ActiveRecord::className(), ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
+Event::on(ActiveRecord::class, ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
     Yii::trace(get_class($event->sender) . ' is inserted');
 });
 ```
@@ -236,11 +236,11 @@ invocación de los gestores de eventos a nivel de clase.
 ```php
 use yii\base\Event;
 
-Event::on(Foo::className(), Foo::EVENT_HELLO, function ($event) {
+Event::on(Foo::class, Foo::EVENT_HELLO, function ($event) {
     echo $event->sender;  // displays "app\models\Foo"
 });
 
-Event::trigger(Foo::className(), Foo::EVENT_HELLO);
+Event::trigger(Foo::class, Foo::EVENT_HELLO);
 ```
 
 Tenga en cuenta que en este caso, el `$event->sender` hace referencia al nombre de la clase que lanza el evento en
@@ -254,10 +254,10 @@ Para desadjuntar un gestor de eventos a nivel de clase, se tiene que llamar a [[
 
 ```php
 // desadjunta $handler
-Event::off(Foo::className(), Foo::EVENT_HELLO, $handler);
+Event::off(Foo::class, Foo::EVENT_HELLO, $handler);
 
 // desadjunta todos los gestores de Foo::EVENT_HELLO
-Event::off(Foo::className(), Foo::EVENT_HELLO);
+Event::off(Foo::class, Foo::EVENT_HELLO);
 ```
 
 Eventos Globales <span id="global-events"></span>

--- a/docs/guide-es/input-validation.md
+++ b/docs/guide-es/input-validation.md
@@ -433,7 +433,7 @@ class EntryForm extends Model
     {
         return [
             [['name', 'email'], 'required'],
-            ['country', CountryValidator::className()],
+            ['country', CountryValidator::class],
             ['email', 'email'],
         ];
     }

--- a/docs/guide-es/output-client-scripts.md
+++ b/docs/guide-es/output-client-scripts.md
@@ -30,7 +30,7 @@ en vez de agregar uno nuevo. En caso de no proveerlo, el código JS en sí será
 Un script externo puede ser agregado de esta manera:
 
 ```php
-$this->registerJsFile('http://example.com/js/main.js', ['depends' => [\yii\web\JqueryAsset::className()]]);
+$this->registerJsFile('http://example.com/js/main.js', ['depends' => [\yii\web\JqueryAsset::class]]);
 ```
 
 Los argumentos para [[yii\web\View::registerJsFile()|registerJsFile()]] son similares a los de
@@ -77,7 +77,7 @@ Si necesitas asegurarte que haya sólo una etiqueta style utiliza el cuarto argu
 
 ```php
 $this->registerCssFile("http://example.com/css/themes/black-and-white.css", [
-    'depends' => [BootstrapAsset::className()],
+    'depends' => [BootstrapAsset::class],
     'media' => 'print',
 ], 'css-print-theme');
 ```

--- a/docs/guide-es/rest-authentication.md
+++ b/docs/guide-es/rest-authentication.md
@@ -57,7 +57,7 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => HttpBasicAuth::className(),
+        'class' => HttpBasicAuth::class,
     ];
     return $behaviors;
 }
@@ -75,11 +75,11 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => CompositeAuth::className(),
+        'class' => CompositeAuth::class,
         'authMethods' => [
-            HttpBasicAuth::className(),
-            HttpBearerAuth::className(),
-            QueryParamAuth::className(),
+            HttpBasicAuth::class,
+            HttpBearerAuth::class,
+            QueryParamAuth::class,
         ],
     ];
     return $behaviors;

--- a/docs/guide-es/rest-controllers.md
+++ b/docs/guide-es/rest-controllers.md
@@ -69,7 +69,7 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => HttpBasicAuth::className(),
+        'class' => HttpBasicAuth::class,
     ];
     return $behaviors;
 }

--- a/docs/guide-es/security-authorization.md
+++ b/docs/guide-es/security-authorization.md
@@ -25,7 +25,7 @@ class SiteController extends Controller
     {
         return [
             'access' => [
-                'class' => AccessControl::className(),
+                'class' => AccessControl::class,
                 'only' => ['login', 'logout', 'signup'],
                 'rules' => [
                     [
@@ -70,7 +70,7 @@ Puedes personalizar este comportamiento configurando la propiedad [[yii\filters\
 
 ```php
 [
-    'class' => AccessControl::className(),
+    'class' => AccessControl::class,
     ...
     'denyCallback' => function ($rule, $action) {
         throw new \Exception('No tienes los suficientes permisos para acceder a esta página');
@@ -126,7 +126,7 @@ class SiteController extends Controller
     {
         return [
             'access' => [
-                'class' => AccessControl::className(),
+                'class' => AccessControl::class,
                 'only' => ['special-callback'],
                 'rules' => [
                     [

--- a/docs/guide-es/structure-filters.md
+++ b/docs/guide-es/structure-filters.md
@@ -124,7 +124,7 @@ public function behaviors()
 {
     return [
         'access' => [
-            'class' => AccessControl::className(),
+            'class' => AccessControl::class,
             'only' => ['create', 'update'],
             'rules' => [
                 // permitido para usuarios autenticados
@@ -160,7 +160,7 @@ public function behaviors()
 {
     return [
         'basicAuth' => [
-            'class' => HttpBasicAuth::className(),
+            'class' => HttpBasicAuth::class,
         ],
     ];
 }
@@ -185,7 +185,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -212,7 +212,7 @@ use yii\web\Response;
 [
     'bootstrap' => [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -242,7 +242,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => HttpCache::className(),
+            'class' => HttpCache::class,
             'only' => ['index'],
             'lastModified' => function ($action, $params) {
                 $q = new \yii\db\Query();
@@ -270,11 +270,11 @@ public function behaviors()
 {
     return [
         'pageCache' => [
-            'class' => PageCache::className(),
+            'class' => PageCache::class,
             'only' => ['index'],
             'duration' => 60,
             'dependency' => [
-                'class' => DbDependency::className(),
+                'class' => DbDependency::class,
                 'sql' => 'SELECT COUNT(*) FROM post',
             ],
             'variations' => [
@@ -307,7 +307,7 @@ public function behaviors()
 {
     return [
         'verbs' => [
-            'class' => VerbFilter::className(),
+            'class' => VerbFilter::class,
             'actions' => [
                 'index'  => ['get'],
                 'view'   => ['get'],
@@ -339,7 +339,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
         ],
     ], parent::behaviors());
 }
@@ -366,7 +366,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],
@@ -387,7 +387,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],

--- a/docs/guide-es/test-fixtures.md
+++ b/docs/guide-es/test-fixtures.md
@@ -129,7 +129,7 @@ class UserProfileTest extends DbTestCase
     public function fixtures()
     {
         return [
-            'profiles' => UserProfileFixture::className(),
+            'profiles' => UserProfileFixture::class,
         ];
     }
 

--- a/docs/guide-fr/structure-filters.md
+++ b/docs/guide-fr/structure-filters.md
@@ -95,7 +95,7 @@ public function behaviors()
 {
     return [
         'access' => [
-            'class' => AccessControl::className(),
+            'class' => AccessControl::class,
             'only' => ['create', 'update'],
             'rules' => [
                 // autoriser les utilisateurs authentifiés
@@ -127,7 +127,7 @@ public function behaviors()
 {
     return [
         'basicAuth' => [
-            'class' => HttpBasicAuth::className(),
+            'class' => HttpBasicAuth::class,
         ],
     ];
 }
@@ -149,7 +149,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -172,7 +172,7 @@ use yii\web\Response;
 [
     'bootstrap' => [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -202,7 +202,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => HttpCache::className(),
+            'class' => HttpCache::class,
             'only' => ['index'],
             'lastModified' => function ($action, $params) {
                 $q = new \yii\db\Query();
@@ -228,11 +228,11 @@ public function behaviors()
 {
     return [
         'pageCache' => [
-            'class' => PageCache::className(),
+            'class' => PageCache::class,
             'only' => ['index'],
             'duration' => 60,
             'dependency' => [
-                'class' => DbDependency::className(),
+                'class' => DbDependency::class,
                 'sql' => 'SELECT COUNT(*) FROM post',
             ],
             'variations' => [
@@ -262,7 +262,7 @@ public function behaviors()
 {
     return [
         'verbs' => [
-            'class' => VerbFilter::className(),
+            'class' => VerbFilter::class,
             'actions' => [
                 'index'  => ['get'],
                 'view'   => ['get'],
@@ -289,7 +289,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
         ],
     ], parent::behaviors());
 }
@@ -316,7 +316,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],
@@ -336,7 +336,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],

--- a/docs/guide-ja/concept-behaviors.md
+++ b/docs/guide-ja/concept-behaviors.md
@@ -121,21 +121,21 @@ class User extends ActiveRecord
     {
         return [
             // 無名ビヘイビア ビヘイビアクラス名のみ
-            MyBehavior::className(),
+            MyBehavior::class,
 
             // 名前付きビヘイビア ビヘイビアクラス名のみ
-            'myBehavior2' => MyBehavior::className(),
+            'myBehavior2' => MyBehavior::class,
 
             // 無名ビヘイビア 構成情報配列
             [
-                'class' => MyBehavior::className(),
+                'class' => MyBehavior::class,
                 'prop1' => 'value1',
                 'prop2' => 'value2',
             ],
 
             // 名前付きビヘイビア 構成情報配列
             'myBehavior4' => [
-                'class' => MyBehavior::className(),
+                'class' => MyBehavior::class,
                 'prop1' => 'value1',
                 'prop2' => 'value2',
             ]
@@ -157,11 +157,11 @@ use app\components\MyBehavior;
 $component->attachBehavior('myBehavior1', new MyBehavior);
 
 // ビヘイビアクラスをアタッチ
-$component->attachBehavior('myBehavior2', MyBehavior::className());
+$component->attachBehavior('myBehavior2', MyBehavior::class);
 
 // 構成情報配列をアタッチ
 $component->attachBehavior('myBehavior3', [
-    'class' => MyBehavior::className(),
+    'class' => MyBehavior::class,
     'prop1' => 'value1',
     'prop2' => 'value2',
 ]);
@@ -171,7 +171,7 @@ $component->attachBehavior('myBehavior3', [
 ```php
 $component->attachBehaviors([
     'myBehavior1' => new MyBehavior,  // 名前付きビヘイビア
-    MyBehavior::className(),          // 無名ビヘイビア
+    MyBehavior::class,          // 無名ビヘイビア
 ]);
 ```
 
@@ -179,10 +179,10 @@ $component->attachBehaviors([
 
 ```php
 [
-    'as myBehavior2' => MyBehavior::className(),
+    'as myBehavior2' => MyBehavior::class,
 
     'as myBehavior3' => [
-        'class' => MyBehavior::className(),
+        'class' => MyBehavior::class,
         'prop1' => 'value1',
         'prop2' => 'value2',
     ],
@@ -270,7 +270,7 @@ class User extends ActiveRecord
     {
         return [
             [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'attributes' => [
                     ActiveRecord::EVENT_BEFORE_INSERT => ['created_at', 'updated_at'],
                     ActiveRecord::EVENT_BEFORE_UPDATE => ['updated_at'],

--- a/docs/guide-ja/concept-components.md
+++ b/docs/guide-ja/concept-components.md
@@ -71,7 +71,7 @@ class MyClass extends Object
 $component = new MyClass(1, 2, ['prop1' => 3, 'prop2' => 4]);
 // とする代わりに
 $component = \Yii::createObject([
-    'class' => MyClass::className(),
+    'class' => MyClass::class,
     'prop1' => 3,
     'prop2' => 4,
 ], [1, 2]);

--- a/docs/guide-ja/concept-events.md
+++ b/docs/guide-ja/concept-events.md
@@ -208,7 +208,7 @@ use Yii;
 use yii\base\Event;
 use yii\db\ActiveRecord;
 
-Event::on(ActiveRecord::className(), ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
+Event::on(ActiveRecord::class, ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
     Yii::trace(get_class($event->sender) . ' が挿入されました');
 });
 ```
@@ -226,11 +226,11 @@ Event::on(ActiveRecord::className(), ActiveRecord::EVENT_AFTER_INSERT, function 
 ```php
 use yii\base\Event;
 
-Event::on(Foo::className(), Foo::EVENT_HELLO, function ($event) {
+Event::on(Foo::class, Foo::EVENT_HELLO, function ($event) {
     echo $event->sender;  // "app\models\Foo" を表示
 });
 
-Event::trigger(Foo::className(), Foo::EVENT_HELLO);
+Event::trigger(Foo::class, Foo::EVENT_HELLO);
 ```
 
 この場合、`$event->sender` は、オブジェクトインスタンスではなく、イベントをトリガするクラスの名前を指すことに注意してください。
@@ -242,10 +242,10 @@ Event::trigger(Foo::className(), Foo::EVENT_HELLO);
 
 ```php
 // $handler をデタッチ
-Event::off(Foo::className(), Foo::EVENT_HELLO, $handler);
+Event::off(Foo::class, Foo::EVENT_HELLO, $handler);
 
 // Foo::EVENT_HELLO のすべてのハンドラをデタッチ
-Event::off(Foo::className(), Foo::EVENT_HELLO);
+Event::off(Foo::class, Foo::EVENT_HELLO);
 ```
 
 
@@ -297,7 +297,7 @@ Event::on('DanceEventInterface', DanceEventInterface::EVENT_DANCE, function ($ev
 これらのクラスのイベントをトリガすることも出来ます。
 
 ```php
-Event::trigger(DanceEventInterface::className(), DanceEventInterface::EVENT_DANCE);
+Event::trigger(DanceEventInterface::class, DanceEventInterface::EVENT_DANCE);
 ```
 
 ただし、このインタフェイスを実装する全クラスのイベントをトリガすることは出来ない、ということに注意して下さい。

--- a/docs/guide-ja/db-active-record.md
+++ b/docs/guide-ja/db-active-record.md
@@ -666,7 +666,7 @@ class Customer extends ActiveRecord
 
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 
@@ -676,7 +676,7 @@ class Order extends ActiveRecord
 
     public function getCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 }
 ```
@@ -692,7 +692,7 @@ class Order extends ActiveRecord
 - リレーションの多重性: [[yii\db\ActiveRecord::hasMany()|hasMany()]] または [[yii\db\ActiveRecord::hasOne()|hasOne()]] のどちらかを呼ぶことによって指定されます。
   上記の例では、リレーションの宣言において、顧客は複数の注文を持ち得るが、一方、注文は一人の顧客しか持たない、ということが容易に読み取れます。
 - 関連するアクティブレコードクラスの名前: [[yii\db\ActiveRecord::hasMany()|hasMany()]] または [[yii\db\ActiveRecord::hasOne()|hasOne()]] の最初のパラメータとして指定されます。
-  クラス名を取得するのに `Xyz::className()` を呼ぶのが推奨されるプラクティスです。
+  クラス名を取得するのに `Xyz::class` を呼ぶのが推奨されるプラクティスです。
   そうすれば、IDE の自動補完のサポートを得ることことが出来るだけでなく、コンパイル段階でエラーを検出することが出来ます。
 - 二つのデータタイプ間のリンク: 二つのデータタイプの関連付けに用いられるカラムを指定します。
   配列の値は主たるデータ (リレーションを宣言しているアクティブレコードクラスによって表されるデータ) のカラムであり、配列のキーは関連するデータのカラムです。
@@ -760,7 +760,7 @@ class Customer extends ActiveRecord
 {
     public function getBigOrders($threshold = 100)
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])
             ->where('subtotal > :threshold', [':threshold' => $threshold])
             ->orderBy('id');
     }
@@ -793,7 +793,7 @@ class Order extends ActiveRecord
 {
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 }
@@ -806,12 +806,12 @@ class Order extends ActiveRecord
 {
     public function getOrderItems()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id']);
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id']);
     }
 
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems');
     }
 }
@@ -1062,7 +1062,7 @@ class Customer extends ActiveRecord
 {
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 
@@ -1070,7 +1070,7 @@ class Order extends ActiveRecord
 {
     public function getCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 }
 ```
@@ -1197,7 +1197,7 @@ class Customer extends \yii\db\ActiveRecord
     public function getComments()
     {
         // Customer は多くの Comment を持つ
-        return $this->hasMany(Comment::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Comment::class, ['customer_id' => 'id']);
     }
 }
 
@@ -1212,7 +1212,7 @@ class Comment extends \yii\mongodb\ActiveRecord
     public function getCustomer()
     {
         // Comment は 一つの Customer を持つ
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 }
 
@@ -1285,7 +1285,7 @@ class Customer extends \yii\db\ActiveRecord
 {
     public function getActiveComments()
     {
-        return $this->hasMany(Comment::className(), ['customer_id' => 'id'])->active();
+        return $this->hasMany(Comment::class, ['customer_id' => 'id'])->active();
     }
 }
 
@@ -1355,7 +1355,7 @@ class Customer extends \yii\db\ActiveRecord
 
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 ```
@@ -1447,7 +1447,7 @@ class Customer extends \yii\db\ActiveRecord
 
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 ```

--- a/docs/guide-ja/input-validation.md
+++ b/docs/guide-ja/input-validation.md
@@ -410,7 +410,7 @@ class EntryForm extends Model
     {
         return [
             [['name', 'email'], 'required'],
-            ['country', CountryValidator::className()],
+            ['country', CountryValidator::class],
             ['email', 'email'],
         ];
     }

--- a/docs/guide-ja/output-client-scripts.md
+++ b/docs/guide-ja/output-client-scripts.md
@@ -31,7 +31,7 @@ ID を指定しない場合は、JS コードそれ自身が ID として扱わ�
 外部スクリプトは次のようにして追加することが出来ます。
 
 ```php
-$this->registerJsFile('http://example.com/js/main.js', ['depends' => [\yii\web\JqueryAsset::className()]]);
+$this->registerJsFile('http://example.com/js/main.js', ['depends' => [\yii\web\JqueryAsset::class]]);
 ```
 
 [[yii\web\View::registerJsFile()|registerJsFile()]] の引数は [[yii\web\View::registerCssFile()|registerCssFile()]] のそれと同じです。
@@ -77,7 +77,7 @@ body { background: #f00; }
 
 ```php
 $this->registerCssFile("http://example.com/css/themes/black-and-white.css", [
-    'depends' => [BootstrapAsset::className()],
+    'depends' => [BootstrapAsset::class],
     'media' => 'print',
 ], 'css-print-theme');
 ```

--- a/docs/guide-ja/rest-authentication.md
+++ b/docs/guide-ja/rest-authentication.md
@@ -48,7 +48,7 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => HttpBasicAuth::className(),
+        'class' => HttpBasicAuth::class,
     ];
     return $behaviors;
 }
@@ -66,11 +66,11 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => CompositeAuth::className(),
+        'class' => CompositeAuth::class,
         'authMethods' => [
-            HttpBasicAuth::className(),
-            HttpBearerAuth::className(),
-            QueryParamAuth::className(),
+            HttpBasicAuth::class,
+            HttpBearerAuth::class,
+            QueryParamAuth::class,
         ],
     ];
     return $behaviors;

--- a/docs/guide-ja/rest-controllers.md
+++ b/docs/guide-ja/rest-controllers.md
@@ -65,7 +65,7 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => HttpBasicAuth::className(),
+        'class' => HttpBasicAuth::class,
     ];
     return $behaviors;
 }
@@ -93,7 +93,7 @@ public function behaviors()
     
     // CORS フィルタを追加する
     $behaviors['corsFilter'] = [
-        'class' => \yii\filters\Cors::className(),
+        'class' => \yii\filters\Cors::class,
     ];
     
     // 認証フィルタを再度追加する

--- a/docs/guide-ja/security-authorization.md
+++ b/docs/guide-ja/security-authorization.md
@@ -24,7 +24,7 @@ class SiteController extends Controller
     {
         return [
             'access' => [
-                'class' => AccessControl::className(),
+                'class' => AccessControl::class,
                 'only' => ['login', 'logout', 'signup'],
                 'rules' => [
                     [
@@ -69,7 +69,7 @@ ACF が権限のチェックを実行するときには、規則を一つずつ�
 
 ```php
 [
-    'class' => AccessControl::className(),
+    'class' => AccessControl::class,
     ...
     'denyCallback' => function ($rule, $action) {
         throw new \Exception('このページにアクセスする権限がありません。');
@@ -128,7 +128,7 @@ class SiteController extends Controller
     {
         return [
             'access' => [
-                'class' => AccessControl::className(),
+                'class' => AccessControl::class,
                 'only' => ['special-callback'],
                 'rules' => [
                     [
@@ -448,7 +448,7 @@ public function behaviors()
 {
     return [
         'access' => [
-            'class' => AccessControl::className(),
+            'class' => AccessControl::class,
             'rules' => [
                 [
                     'allow' => true,

--- a/docs/guide-ja/structure-filters.md
+++ b/docs/guide-ja/structure-filters.md
@@ -112,7 +112,7 @@ public function behaviors()
 {
     return [
         'access' => [
-            'class' => AccessControl::className(),
+            'class' => AccessControl::class,
             'only' => ['create', 'update'],
             'rules' => [
                 // 認証されたユーザに許可する
@@ -147,7 +147,7 @@ public function behaviors()
 {
     return [
         'basicAuth' => [
-            'class' => HttpBasicAuth::className(),
+            'class' => HttpBasicAuth::class,
         ],
     ];
 }
@@ -172,7 +172,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -197,7 +197,7 @@ use yii\web\Response;
 [
     'bootstrap' => [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -226,7 +226,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => HttpCache::className(),
+            'class' => HttpCache::class,
             'only' => ['index'],
             'lastModified' => function ($action, $params) {
                 $q = new \yii\db\Query();
@@ -254,11 +254,11 @@ public function behaviors()
 {
     return [
         'pageCache' => [
-            'class' => PageCache::className(),
+            'class' => PageCache::class,
             'only' => ['index'],
             'duration' => 60,
             'dependency' => [
-                'class' => DbDependency::className(),
+                'class' => DbDependency::class,
                 'sql' => 'SELECT COUNT(*) FROM post',
             ],
             'variations' => [
@@ -292,7 +292,7 @@ public function behaviors()
 {
     return [
         'verbs' => [
-            'class' => VerbFilter::className(),
+            'class' => VerbFilter::class,
             'actions' => [
                 'index'  => ['get'],
                 'view'   => ['get'],
@@ -322,7 +322,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
         ],
     ], parent::behaviors());
 }
@@ -352,7 +352,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],
@@ -373,7 +373,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],

--- a/docs/guide-ja/test-fixtures.md
+++ b/docs/guide-ja/test-fixtures.md
@@ -126,7 +126,7 @@ class UserProfileTest extends DbTestCase
     public function fixtures()
     {
         return [
-            'profiles' => UserProfileFixture::className(),
+            'profiles' => UserProfileFixture::class,
         ];
     }
 

--- a/docs/guide-pl/concept-components.md
+++ b/docs/guide-pl/concept-components.md
@@ -73,7 +73,7 @@ Postępowanie zgodnie z tymi zasadami zapewni [konfigurowalność](concept-confi
 $component = new MyClass(1, 2, ['prop1' => 3, 'prop2' => 4]);
 // lub alternatywnie
 $component = \Yii::createObject([
-    'class' => MyClass::className(),
+    'class' => MyClass::class,
     'prop1' => 3,
     'prop2' => 4,
 ], [1, 2]);

--- a/docs/guide-pl/db-active-record.md
+++ b/docs/guide-pl/db-active-record.md
@@ -675,7 +675,7 @@ class Customer extends ActiveRecord
 {
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 
@@ -683,7 +683,7 @@ class Order extends ActiveRecord
 {
     public function getCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 }
 ```
@@ -700,7 +700,7 @@ Deklarując relację powinno się zwrócić uwagę na następujące dane:
   klient może mieć wiele zamówień, podczas gdy zamówienie ma tylko jednego klienta.
 - nazwę powiązanej klasy Active Record: określoną jako pierwszy argument w [[yii\db\ActiveRecord::hasMany()|hasMany()]] lub 
   [[yii\db\ActiveRecord::hasOne()|hasOne()]].
-  Rekomendowany sposób uzyskania nazwy klasy to wywołanie `Xyz::className()`, dzięki czemu możemy posiłkować się wsparciem autouzupełniania IDE 
+  Rekomendowany sposób uzyskania nazwy klasy to wywołanie `Xyz::class`, dzięki czemu możemy posiłkować się wsparciem autouzupełniania IDE 
   i wykrywaniem błędów na poziomie kompilacji. 
 - powiązanie pomiędzy dwoma rodzajami danych: określone jako kolumna(y), poprzez którą dane nawiązują relację.
   Wartości tablicy są kolumnami głównych danych (reprezentowanymi przez klasę Active Record, w której deklaruje się relacje), a klucze tablicy są 
@@ -774,7 +774,7 @@ class Customer extends ActiveRecord
 {
     public function getBigOrders($threshold = 100)
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])
             ->where('subtotal > :threshold', [':threshold' => $threshold])
             ->orderBy('id');
     }
@@ -808,7 +808,7 @@ class Order extends ActiveRecord
 {
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 }
@@ -821,12 +821,12 @@ class Order extends ActiveRecord
 {
     public function getOrderItems()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id']);
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id']);
     }
 
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems');
     }
 }
@@ -1069,7 +1069,7 @@ class Customer extends ActiveRecord
 {
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 
@@ -1077,7 +1077,7 @@ class Order extends ActiveRecord
 {
     public function getCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 }
 ```
@@ -1109,7 +1109,7 @@ class Customer extends ActiveRecord
 {
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])->inverseOf('customer');
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])->inverseOf('customer');
     }
 }
 ```
@@ -1213,7 +1213,7 @@ class Customer extends \yii\db\ActiveRecord
     public function getComments()
     {
         // klient posiada wiele komentarzy
-        return $this->hasMany(Comment::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Comment::class, ['customer_id' => 'id']);
     }
 }
 
@@ -1228,7 +1228,7 @@ class Comment extends \yii\mongodb\ActiveRecord
     public function getCustomer()
     {
         // komentarz jest przypisany do jednego klienta
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 }
 
@@ -1302,7 +1302,7 @@ class Customer extends \yii\db\ActiveRecord
 {
     public function getActiveComments()
     {
-        return $this->hasMany(Comment::className(), ['customer_id' => 'id'])->active();
+        return $this->hasMany(Comment::class, ['customer_id' => 'id'])->active();
     }
 }
 
@@ -1370,7 +1370,7 @@ class Customer extends \yii\db\ActiveRecord
 
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 ```

--- a/docs/guide-pl/input-validation.md
+++ b/docs/guide-pl/input-validation.md
@@ -388,7 +388,7 @@ class EntryForm extends Model
     {
         return [
             [['name', 'email'], 'required'],
-            ['country', CountryValidator::className()],
+            ['country', CountryValidator::class],
             ['email', 'email'],
         ];
     }

--- a/docs/guide-pl/output-client-scripts.md
+++ b/docs/guide-pl/output-client-scripts.md
@@ -29,7 +29,7 @@ Jeśli ten argument nie zostanie podany, kod JavaScript zostanie użyty jako ID.
 Skrypt zewnętrzny może zostać dodany następująco:
 
 ```php
-$this->registerJsFile('http://example.com/js/main.js', ['depends' => [\yii\web\JqueryAsset::className()]]);
+$this->registerJsFile('http://example.com/js/main.js', ['depends' => [\yii\web\JqueryAsset::class]]);
 ```
 
 Argumenty dla metod [[yii\web\View::registerCssFile()|registerCssFile()]] są podobne do [[yii\web\View::registerJsFile()|registerJsFile()]].
@@ -73,7 +73,7 @@ Jeśli chcesz się upewnić, że jest tylko jeden tag `style`, użyj trzeciego a
 
 ```php
 $this->registerCssFile("http://example.com/css/themes/black-and-white.css", [
-    'depends' => [BootstrapAsset::className()],
+    'depends' => [BootstrapAsset::class],
     'media' => 'print',
 ], 'css-print-theme');
 ```

--- a/docs/guide-pt-BR/concept-behaviors.md
+++ b/docs/guide-pt-BR/concept-behaviors.md
@@ -111,21 +111,21 @@ class User extends ActiveRecord
    {
        return [
            // behavior anônimo, somente o nome da classe
-           MyBehavior::className(),
+           MyBehavior::class,
 
            // behavior nomeado, somente o nome da classe
-           'myBehavior2' => MyBehavior::className(),
+           'myBehavior2' => MyBehavior::class,
 
            // behavior anônimo, array de configuração
            [
-               'class' => MyBehavior::className(),
+               'class' => MyBehavior::class,
                'prop1' => 'value1',
                'prop2' => 'value2',
            ],
 
            // behavior nomeado, array de configuração
            'myBehavior4' => [
-               'class' => MyBehavior::className(),
+               'class' => MyBehavior::class,
                'prop1' => 'value1',
                'prop2' => 'value2',
            ]
@@ -145,11 +145,11 @@ use app\components\MyBehavior;
 $component->attachBehavior('myBehavior1', new MyBehavior);
 
 // anexando uma classe behavior 
-$component->attachBehavior('myBehavior2', MyBehavior::className());
+$component->attachBehavior('myBehavior2', MyBehavior::class);
 
 // anexando através de um array de configuração
 $component->attachBehavior('myBehavior3', [
-   'class' => MyBehavior::className(),
+   'class' => MyBehavior::class,
    'prop1' => 'value1',
    'prop2' => 'value2',
 ]);
@@ -160,7 +160,7 @@ Você pode anexar vários behaviors de uma só vez usando o método [[yii\base\C
 ```php
 $component->attachBehaviors([
    'myBehavior1' => new MyBehavior,  // um behavior nomeado
-   MyBehavior::className(),          // um behavior anônimo 
+   MyBehavior::class,          // um behavior anônimo 
 ]);
 ```
 
@@ -168,10 +168,10 @@ Você também pode anexar behaviors através de [configurações](concept-config
 
 ```php
 [
-   'as myBehavior2' => MyBehavior::className(),
+   'as myBehavior2' => MyBehavior::class,
 
    'as myBehavior3' => [
-       'class' => MyBehavior::className(),
+       'class' => MyBehavior::class,
        'prop1' => 'value1',
        'prop2' => 'value2',
    ],
@@ -255,7 +255,7 @@ class User extends ActiveRecord
    {
        return [
            [
-               'class' => TimestampBehavior::className(),
+               'class' => TimestampBehavior::class,
                'attributes' => [
                    ActiveRecord::EVENT_BEFORE_INSERT => ['created_at', 'updated_at'],
                    ActiveRecord::EVENT_BEFORE_UPDATE => ['updated_at'],

--- a/docs/guide-pt-BR/concept-components.md
+++ b/docs/guide-pt-BR/concept-components.md
@@ -68,7 +68,7 @@ Seguindo essas orientações fará com que seus componentes sejam [configurávei
 $component = new MyClass(1, 2, ['prop1' => 3, 'prop2' => 4]);
 // alternatively
 $component = \Yii::createObject([
-   'class' => MyClass::className(),
+   'class' => MyClass::class,
    'prop1' => 3,
    'prop2' => 4,
 ], [1, 2]);

--- a/docs/guide-pt-BR/concept-events.md
+++ b/docs/guide-pt-BR/concept-events.md
@@ -191,7 +191,7 @@ use Yii;
 use yii\base\Event;
 use yii\db\ActiveRecord;
 
-Event::on(ActiveRecord::className(), ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
+Event::on(ActiveRecord::class, ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
    Yii::trace(get_class($event->sender) . ' is inserted');
 });
 ```
@@ -205,11 +205,11 @@ Você pode disparar um evento de *nível de classe* chamando o método estático
 ```php
 use yii\base\Event;
 
-Event::on(Foo::className(), Foo::EVENT_HELLO, function ($event) {
+Event::on(Foo::class, Foo::EVENT_HELLO, function ($event) {
    echo $event->sender;  // displays "app\models\Foo"
 });
 
-Event::trigger(Foo::className(), Foo::EVENT_HELLO);
+Event::trigger(Foo::class, Foo::EVENT_HELLO);
 ```
 
 Note que, neste caso, `$event->sender` refere-se ao nome da classe acionando o evento em vez de uma instância do objeto.
@@ -220,10 +220,10 @@ Para desvincular um manipulador de evento de nível de classe, chame [[yii\base\
 
 ```php
 // desvincula $handler
-Event::off(Foo::className(), Foo::EVENT_HELLO, $handler);
+Event::off(Foo::class, Foo::EVENT_HELLO, $handler);
 
 // Desvincula todos os manipuladores de Foo::EVENT_HELLO
-Event::off(Foo::className(), Foo::EVENT_HELLO);
+Event::off(Foo::class, Foo::EVENT_HELLO);
 ```
 
 

--- a/docs/guide-pt-BR/db-active-record.md
+++ b/docs/guide-pt-BR/db-active-record.md
@@ -576,7 +576,7 @@ class Customer extends ActiveRecord
 {
    public function getOrders()
    {
-       return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+       return $this->hasMany(Order::class, ['customer_id' => 'id']);
    }
 }
 
@@ -584,7 +584,7 @@ class Order extends ActiveRecord
 {
    public function getCustomer()
    {
-       return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+       return $this->hasOne(Customer::class, ['id' => 'customer_id']);
    }
 }
 ```
@@ -596,7 +596,7 @@ Cada método de relação deve ser nomeado como `getXyz`. Nós chamamos de `xyz`
 Ao declarar uma relação, você deve especificar as seguintes informações:
 
 - A multiplicidade da relação: especificada chamando tanto o método [[yii\db\ActiveRecord::hasMany()|hasMany()]] quanto o método [[yii\db\ActiveRecord::hasOne()|hasOne()]]. No exemplo acima você pode facilmente ler nas declarações de relação que um `customer` tem vários `orders` enquanto uma `order` só tem um `customer`.
-- O nome da classe Active Record relacionada: especificada no primeiro parâmetro dos métodos [[yii\db\ActiveRecord::hasMany()|hasMany()]] e [[yii\db\ActiveRecord::hasOne()|hasOne()]]. Uma prática recomendada é chamar `Xyz::className()` para obter o nome da classe para que você possa receber suporte do preenchimento automático de IDEs bem como detecção de erros. 
+- O nome da classe Active Record relacionada: especificada no primeiro parâmetro dos métodos [[yii\db\ActiveRecord::hasMany()|hasMany()]] e [[yii\db\ActiveRecord::hasOne()|hasOne()]]. Uma prática recomendada é chamar `Xyz::class` para obter o nome da classe para que você possa receber suporte do preenchimento automático de IDEs bem como detecção de erros. 
 - A ligação entre os dois tipos de dados: especifica a(s) coluna(s) por meio do qual os dois tipos de dados se relacionam. Os valores do array são as colunas da tabela primária (representada pela classe Active Record que você declarou as relações), enquanto as chaves do array são as colunas da tabela relacionada.
 
 Uma regra fácil de lembrar é, como você pode ver no exemplo acima, você escreve a coluna que pertence ao Active Record relacionado diretamente ao lado dele. Você pode ver que `customer_id` é uma propriedade de `Order` e `id` é uma propriedade de  `Customer`.
@@ -654,7 +654,7 @@ class Customer extends ActiveRecord
 {
    public function getBigOrders($threshold = 100)
    {
-       return $this->hasMany(Order::className(), ['customer_id' => 'id'])
+       return $this->hasMany(Order::class, ['customer_id' => 'id'])
            ->where('subtotal > :threshold', [':threshold' => $threshold])
            ->orderBy('id');
    }
@@ -683,7 +683,7 @@ class Order extends ActiveRecord
 {
    public function getItems()
    {
-       return $this->hasMany(Item::className(), ['id' => 'item_id'])
+       return $this->hasMany(Item::class, ['id' => 'item_id'])
            ->viaTable('order_item', ['order_id' => 'id']);
    }
 }
@@ -696,12 +696,12 @@ class Order extends ActiveRecord
 {
    public function getOrderItems()
    {
-       return $this->hasMany(OrderItem::className(), ['order_id' => 'id']);
+       return $this->hasMany(OrderItem::class, ['order_id' => 'id']);
    }
 
    public function getItems()
    {
-       return $this->hasMany(Item::className(), ['id' => 'item_id'])
+       return $this->hasMany(Item::class, ['id' => 'item_id'])
            ->via('orderItems');
    }
 }
@@ -892,7 +892,7 @@ class Customer extends ActiveRecord
 {
    public function getOrders()
    {
-       return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+       return $this->hasMany(Order::class, ['customer_id' => 'id']);
    }
 }
 
@@ -900,7 +900,7 @@ class Order extends ActiveRecord
 {
    public function getCustomer()
    {
-       return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+       return $this->hasOne(Customer::class, ['id' => 'customer_id']);
    }
 }
 ```
@@ -930,7 +930,7 @@ class Customer extends ActiveRecord
 {
    public function getOrders()
    {
-       return $this->hasMany(Order::className(), ['customer_id' => 'id'])->inverseOf('customer');
+       return $this->hasMany(Order::class, ['customer_id' => 'id'])->inverseOf('customer');
    }
 }
 ```
@@ -1023,7 +1023,7 @@ class Customer extends \yii\db\ActiveRecord
    public function getComments()
    {
        // a customer tem muitos comments
-       return $this->hasMany(Comment::className(), ['customer_id' => 'id']);
+       return $this->hasMany(Comment::class, ['customer_id' => 'id']);
    }
 }
 
@@ -1038,7 +1038,7 @@ class Comment extends \yii\mongodb\ActiveRecord
    public function getCustomer()
    {
        // um comment tem um customer
-       return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+       return $this->hasOne(Customer::class, ['id' => 'customer_id']);
    }
 }
 
@@ -1106,7 +1106,7 @@ class Customer extends \yii\db\ActiveRecord
 {
    public function getActiveComments()
    {
-       return $this->hasMany(Comment::className(), ['customer_id' => 'id'])->active();
+       return $this->hasMany(Comment::class, ['customer_id' => 'id'])->active();
    }
 }
 
@@ -1166,7 +1166,7 @@ class Customer extends \yii\db\ActiveRecord
 
    public function getOrders()
    {
-       return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+       return $this->hasMany(Order::class, ['customer_id' => 'id']);
    }
 }
 ```

--- a/docs/guide-pt-BR/rest-authentication.md
+++ b/docs/guide-pt-BR/rest-authentication.md
@@ -42,7 +42,7 @@ public function behaviors()
 {
    $behaviors = parent::behaviors();
    $behaviors['authenticator'] = [
-       'class' => HttpBasicAuth::className(),
+       'class' => HttpBasicAuth::class,
    ];
    return $behaviors;
 }
@@ -60,11 +60,11 @@ public function behaviors()
 {
    $behaviors = parent::behaviors();
    $behaviors['authenticator'] = [
-       'class' => CompositeAuth::className(),
+       'class' => CompositeAuth::class,
        'authMethods' => [
-           HttpBasicAuth::className(),
-           HttpBearerAuth::className(),
-           QueryParamAuth::className(),
+           HttpBasicAuth::class,
+           HttpBearerAuth::class,
+           QueryParamAuth::class,
        ],
    ];
    return $behaviors;

--- a/docs/guide-pt-BR/rest-controllers.md
+++ b/docs/guide-pt-BR/rest-controllers.md
@@ -51,7 +51,7 @@ public function behaviors()
 {
    $behaviors = parent::behaviors();
    $behaviors['authenticator'] = [
-       'class' => HttpBasicAuth::className(),
+       'class' => HttpBasicAuth::class,
    ];
    return $behaviors;
 }

--- a/docs/guide-pt-BR/security-authorization.md
+++ b/docs/guide-pt-BR/security-authorization.md
@@ -20,7 +20,7 @@ class SiteController extends Controller
    {
        return [
            'access' => [
-               'class' => AccessControl::className(),
+               'class' => AccessControl::class,
                'only' => ['login', 'logout', 'signup'],
                'rules' => [
                    [
@@ -59,7 +59,7 @@ Você pode personalizar este behavior configurando a propriedade  [[yii\filters\
 
 ```php
 [
-   'class' => AccessControl::className(),
+   'class' => AccessControl::class,
    ...
    'denyCallback' => function ($rule, $action) {
        throw new \Exception('Você não está autorizado a acessar esta página');
@@ -103,7 +103,7 @@ class SiteController extends Controller
    {
        return [
            'access' => [
-               'class' => AccessControl::className(),
+               'class' => AccessControl::class,
                'only' => ['special-callback'],
                'rules' => [
                    [

--- a/docs/guide-pt-BR/structure-filters.md
+++ b/docs/guide-pt-BR/structure-filters.md
@@ -140,7 +140,7 @@ public function behaviors()
 {
     return [
         'access' => [
-            'class' => AccessControl::className(),
+            'class' => AccessControl::class,
             'only' => ['create', 'update'],
             'rules' => [
                 // permite aos usuários autenticados
@@ -180,7 +180,7 @@ public function behaviors()
 {
     return [
         'basicAuth' => [
-            'class' => HttpBasicAuth::className(),
+            'class' => HttpBasicAuth::class,
         ],
     ];
 }
@@ -208,7 +208,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -238,7 +238,7 @@ use yii\web\Response;
 [
     'bootstrap' => [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -270,7 +270,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => HttpCache::className(),
+            'class' => HttpCache::class,
             'only' => ['index'],
             'lastModified' => function ($action, $params) {
                 $q = new \yii\db\Query();
@@ -301,11 +301,11 @@ public function behaviors()
 {
     return [
         'pageCache' => [
-            'class' => PageCache::className(),
+            'class' => PageCache::class,
             'only' => ['index'],
             'duration' => 60,
             'dependency' => [
-                'class' => DbDependency::className(),
+                'class' => DbDependency::class,
                 'sql' => 'SELECT COUNT(*) FROM post',
             ],
             'variations' => [
@@ -343,7 +343,7 @@ public function behaviors()
 {
     return [
         'verbs' => [
-            'class' => VerbFilter::className(),
+            'class' => VerbFilter::class,
             'actions' => [
                 'index'  => ['get'],
                 'view'   => ['get'],
@@ -380,7 +380,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
         ],
     ], parent::behaviors());
 }
@@ -414,7 +414,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],
@@ -436,7 +436,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],

--- a/docs/guide-ru/concept-behaviors.md
+++ b/docs/guide-ru/concept-behaviors.md
@@ -126,21 +126,21 @@ class User extends ActiveRecord
     {
         return [
             // анонимное поведение, прикрепленное по имени класса
-            MyBehavior::className(),
+            MyBehavior::class,
 
             // именованное поведение, прикрепленное по имени класса
-            'myBehavior2' => MyBehavior::className(),
+            'myBehavior2' => MyBehavior::class,
 
             // анонимное поведение, сконфигурированное с использованием массива
             [
-                'class' => MyBehavior::className(),
+                'class' => MyBehavior::class,
                 'prop1' => 'value1',
                 'prop2' => 'value2',
             ],
 
             // именованное поведение, сконфигурированное с использованием массива
             'myBehavior4' => [
-                'class' => MyBehavior::className(),
+                'class' => MyBehavior::class,
                 'prop1' => 'value1',
                 'prop2' => 'value2',
             ]
@@ -164,11 +164,11 @@ use app\components\MyBehavior;
 $component->attachBehavior('myBehavior1', new MyBehavior);
 
 // прикрепляем по имени класса поведения
-$component->attachBehavior('myBehavior2', MyBehavior::className());
+$component->attachBehavior('myBehavior2', MyBehavior::class);
 
 // прикрепляем используя массив конфигураций
 $component->attachBehavior('myBehavior3', [
-    'class' => MyBehavior::className(),
+    'class' => MyBehavior::class,
     'prop1' => 'value1',
     'prop2' => 'value2',
 ]);
@@ -180,7 +180,7 @@ $component->attachBehavior('myBehavior3', [
 ```php
 $component->attachBehaviors([
     'myBehavior1' => new MyBehavior,  // именованное поведение
-    MyBehavior::className(),          // анонимное поведение
+    MyBehavior::class,          // анонимное поведение
 ]);
 ```
 
@@ -188,10 +188,10 @@ $component->attachBehaviors([
 
 ```php
 [
-    'as myBehavior2' => MyBehavior::className(),
+    'as myBehavior2' => MyBehavior::class,
 
     'as myBehavior3' => [
-        'class' => MyBehavior::className(),
+        'class' => MyBehavior::class,
         'prop1' => 'value1',
         'prop2' => 'value2',
     ],
@@ -280,7 +280,7 @@ class User extends ActiveRecord
     {
         return [
             [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'attributes' => [
                     ActiveRecord::EVENT_BEFORE_INSERT => ['created_at', 'updated_at'],
                     ActiveRecord::EVENT_BEFORE_UPDATE => ['updated_at'],

--- a/docs/guide-ru/concept-components.md
+++ b/docs/guide-ru/concept-components.md
@@ -77,7 +77,7 @@ class MyClass extends Object
 $component = new MyClass(1, 2, ['prop1' => 3, 'prop2' => 4]);
 // альтернативный способ
 $component = \Yii::createObject([
-    'class' => MyClass::className(),
+    'class' => MyClass::class,
     'prop1' => 3,
     'prop2' => 4,
 ], [1, 2]);

--- a/docs/guide-ru/concept-events.md
+++ b/docs/guide-ru/concept-events.md
@@ -187,7 +187,7 @@ use Yii;
 use yii\base\Event;
 use yii\db\ActiveRecord;
 
-Event::on(ActiveRecord::className(), ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
+Event::on(ActiveRecord::class, ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
     Yii::trace(get_class($event->sender) . ' добавлен');
 });
 ```
@@ -201,11 +201,11 @@ Event::on(ActiveRecord::className(), ActiveRecord::EVENT_AFTER_INSERT, function 
 ```php
 use yii\base\Event;
 
-Event::on(Foo::className(), Foo::EVENT_HELLO, function ($event) {
+Event::on(Foo::class, Foo::EVENT_HELLO, function ($event) {
     echo $event->sender;  // выводит "app\models\Foo"
 });
 
-Event::trigger(Foo::className(), Foo::EVENT_HELLO);
+Event::trigger(Foo::class, Foo::EVENT_HELLO);
 ```
 
 Обратите внимание, что в данном случае `$event->sender` ссылается на имя класса, который инициировал событие, а не на его экземпляр.
@@ -216,10 +216,10 @@ Event::trigger(Foo::className(), Foo::EVENT_HELLO);
 
 ```php
 // отсоединение $handler
-Event::off(Foo::className(), Foo::EVENT_HELLO, $handler);
+Event::off(Foo::class, Foo::EVENT_HELLO, $handler);
 
 // отсоединяются все обработчики Foo::EVENT_HELLO
-Event::off(Foo::className(), Foo::EVENT_HELLO);
+Event::off(Foo::class, Foo::EVENT_HELLO);
 ```
 
 Обработчики событий на уровне интерфейсов <span id="interface-level-event-handlers"></span>
@@ -271,7 +271,7 @@ Event::on('DanceEventInterface', DanceEventInterface::EVENT_DANCE, function ($ev
 Вы можете также инициализировать эти события:
 
 ```php
-Event::trigger(DanceEventInterface::className(), DanceEventInterface::EVENT_DANCE);
+Event::trigger(DanceEventInterface::class, DanceEventInterface::EVENT_DANCE);
 ```
 
 Однако, невозможно инициализировать событие во всех классах, которые реализуют интерфейс:

--- a/docs/guide-ru/db-active-record.md
+++ b/docs/guide-ru/db-active-record.md
@@ -727,7 +727,7 @@ class Customer extends ActiveRecord
 {
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 
@@ -735,7 +735,7 @@ class Order extends ActiveRecord
 {
     public function getCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 }
 ```
@@ -752,7 +752,7 @@ class Order extends ActiveRecord
   что покупатель может иметь много заказов в то время, как заказ может быть сделан лишь одним покупателем.
 - название связного Active Record класса: указывается в качестве первого параметра для метода 
   [[yii\db\ActiveRecord::hasMany()|hasMany()]] или для метода [[yii\db\ActiveRecord::hasOne()|hasOne()]]. Рекомендуется
-  использовать код `Xyz::className()`, чтобы получить строку с именем класса, при этом вы сможете воспользоваться
+  использовать код `Xyz::class`, чтобы получить строку с именем класса, при этом вы сможете воспользоваться
   возможностями авто-дополнения кода, встроенного в IDE, а также получите обработку ошибок на этапе компиляции.
 - связь между двумя типами данных: указываются столбцы с помощью которых два типа данных связаны. Значения массива - это
   столбцы  основного объекта данных (представлен классом Active Record, в котором объявляется связь), в то время как
@@ -828,7 +828,7 @@ class Customer extends ActiveRecord
 {
     public function getBigOrders($threshold = 100)
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])
             ->where('subtotal > :threshold', [':threshold' => $threshold])
             ->orderBy('id');
     }
@@ -864,7 +864,7 @@ class Order extends ActiveRecord
 {
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 }
@@ -877,12 +877,12 @@ class Order extends ActiveRecord
 {
     public function getOrderItems()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id']);
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id']);
     }
 
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems');
     }
 }
@@ -1122,7 +1122,7 @@ class Customer extends ActiveRecord
 {
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 
@@ -1130,7 +1130,7 @@ class Order extends ActiveRecord
 {
     public function getCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 }
 ```
@@ -1164,7 +1164,7 @@ class Customer extends ActiveRecord
 {
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])->inverseOf('customer');
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])->inverseOf('customer');
     }
 }
 ```
@@ -1277,7 +1277,7 @@ class Customer extends \yii\db\ActiveRecord
     public function getComments()
     {
         // у покупателя может быть много комментариев
-        return $this->hasMany(Comment::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Comment::class, ['customer_id' => 'id']);
     }
 }
 
@@ -1292,7 +1292,7 @@ class Comment extends \yii\mongodb\ActiveRecord
     public function getCustomer()
     {
         // комментарий принадлежит одному покупателю
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 }
 
@@ -1372,7 +1372,7 @@ class Customer extends \yii\db\ActiveRecord
 {
     public function getActiveComments()
     {
-        return $this->hasMany(Comment::className(), ['customer_id' => 'id'])->active();
+        return $this->hasMany(Comment::class, ['customer_id' => 'id'])->active();
     }
 }
 
@@ -1443,7 +1443,7 @@ class Customer extends \yii\db\ActiveRecord
 
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 ```

--- a/docs/guide-ru/rest-authentication.md
+++ b/docs/guide-ru/rest-authentication.md
@@ -56,7 +56,7 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => HttpBasicAuth::className(),
+        'class' => HttpBasicAuth::class,
     ];
     return $behaviors;
 }
@@ -74,11 +74,11 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => CompositeAuth::className(),
+        'class' => CompositeAuth::class,
         'authMethods' => [
-            HttpBasicAuth::className(),
-            HttpBearerAuth::className(),
-            QueryParamAuth::className(),
+            HttpBasicAuth::class,
+            HttpBearerAuth::class,
+            QueryParamAuth::class,
         ],
     ];
     return $behaviors;

--- a/docs/guide-ru/rest-controllers.md
+++ b/docs/guide-ru/rest-controllers.md
@@ -70,7 +70,7 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => HttpBasicAuth::className(),
+        'class' => HttpBasicAuth::class,
     ];
     return $behaviors;
 }

--- a/docs/guide-ru/security-authorization.md
+++ b/docs/guide-ru/security-authorization.md
@@ -25,7 +25,7 @@ class SiteController extends Controller
     {
         return [
             'access' => [
-                'class' => AccessControl::className(),
+                'class' => AccessControl::class,
                 'only' => ['login', 'logout', 'signup'],
                 'rules' => [
                     [
@@ -68,7 +68,7 @@ class SiteController extends Controller
 
 ```php
 [
-    'class' => AccessControl::className(),
+    'class' => AccessControl::class,
     'denyCallback' => function ($rule, $action) {
         throw new \Exception('У вас нет доступа к этой странице');
     }
@@ -122,7 +122,7 @@ class SiteController extends Controller
     {
         return [
             'access' => [
-                'class' => AccessControl::className(),
+                'class' => AccessControl::class,
                 'only' => ['special-callback'],
                 'rules' => [
                     [

--- a/docs/guide-ru/structure-filters.md
+++ b/docs/guide-ru/structure-filters.md
@@ -118,7 +118,7 @@ public function behaviors()
 {
     return [
         'access' => [
-            'class' => AccessControl::className(),
+            'class' => AccessControl::class,
             'only' => ['create', 'update'],
             'rules' => [
                 // разрешаем аутентифицированным пользователям
@@ -154,7 +154,7 @@ public function behaviors()
 {
     return [
         'basicAuth' => [
-            'class' => HttpBasicAuth::className(),
+            'class' => HttpBasicAuth::class,
         ],
     ];
 }
@@ -180,7 +180,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -206,7 +206,7 @@ use yii\web\Response;
 [
     'bootstrap' => [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -236,7 +236,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => HttpCache::className(),
+            'class' => HttpCache::class,
             'only' => ['index'],
             'lastModified' => function ($action, $params) {
                 $q = new \yii\db\Query();
@@ -264,11 +264,11 @@ public function behaviors()
 {
     return [
         'pageCache' => [
-            'class' => PageCache::className(),
+            'class' => PageCache::class,
             'only' => ['index'],
             'duration' => 60,
             'dependency' => [
-                'class' => DbDependency::className(),
+                'class' => DbDependency::class,
                 'sql' => 'SELECT COUNT(*) FROM post',
             ],
             'variations' => [
@@ -302,7 +302,7 @@ public function behaviors()
 {
     return [
         'verbs' => [
-            'class' => VerbFilter::className(),
+            'class' => VerbFilter::class,
             'actions' => [
                 'index'  => ['get'],
                 'view'   => ['get'],
@@ -334,7 +334,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
         ],
     ], parent::behaviors());
 }
@@ -362,7 +362,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],
@@ -384,7 +384,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],

--- a/docs/guide-ru/test-fixtures.md
+++ b/docs/guide-ru/test-fixtures.md
@@ -128,7 +128,7 @@ class UserProfileTest extends DbTestCase
     public function fixtures()
     {
         return [
-            'profiles' => UserProfileFixture::className(),
+            'profiles' => UserProfileFixture::class,
         ];
     }
 

--- a/docs/guide-zh-CN/concept-behaviors.md
+++ b/docs/guide-zh-CN/concept-behaviors.md
@@ -104,21 +104,21 @@ class User extends ActiveRecord
     {
         return [
             // 匿名行为，只有行为类名
-            MyBehavior::className(),
+            MyBehavior::class,
 
             // 命名行为，只有行为类名
-            'myBehavior2' => MyBehavior::className(),
+            'myBehavior2' => MyBehavior::class,
 
             // 匿名行为，配置数组
             [
-                'class' => MyBehavior::className(),
+                'class' => MyBehavior::class,
                 'prop1' => 'value1',
                 'prop2' => 'value2',
             ],
 
             // 命名行为，配置数组
             'myBehavior4' => [
-                'class' => MyBehavior::className(),
+                'class' => MyBehavior::class,
                 'prop1' => 'value1',
                 'prop2' => 'value2',
             ]
@@ -138,11 +138,11 @@ use app\components\MyBehavior;
 $component->attachBehavior('myBehavior1', new MyBehavior);
 
 // 附加行为类
-$component->attachBehavior('myBehavior2', MyBehavior::className());
+$component->attachBehavior('myBehavior2', MyBehavior::class);
 
 // 附加配置数组
 $component->attachBehavior('myBehavior3', [
-    'class' => MyBehavior::className(),
+    'class' => MyBehavior::class,
     'prop1' => 'value1',
     'prop2' => 'value2',
 ]);
@@ -153,7 +153,7 @@ $component->attachBehavior('myBehavior3', [
 ```php
 $component->attachBehaviors([
     'myBehavior1' => new MyBehavior,  // 命名行为
-    MyBehavior::className(),          // 匿名行为
+    MyBehavior::class,          // 匿名行为
 ]);
 ```
 
@@ -161,10 +161,10 @@ $component->attachBehaviors([
 
 ```php
 [
-    'as myBehavior2' => MyBehavior::className(),
+    'as myBehavior2' => MyBehavior::class,
 
     'as myBehavior3' => [
-        'class' => MyBehavior::className(),
+        'class' => MyBehavior::class,
         'prop1' => 'value1',
         'prop2' => 'value2',
     ],
@@ -248,7 +248,7 @@ class User extends ActiveRecord
     {
         return [
             [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'attributes' => [
                     ActiveRecord::EVENT_BEFORE_INSERT => ['created_at', 'updated_at'],
                     ActiveRecord::EVENT_BEFORE_UPDATE => ['updated_at'],

--- a/docs/guide-zh-CN/concept-components.md
+++ b/docs/guide-zh-CN/concept-components.md
@@ -65,7 +65,7 @@ class MyClass extends Object
 $component = new MyClass(1, 2, ['prop1' => 3, 'prop2' => 4]);
 // 方法二：
 $component = \Yii::createObject([
-    'class' => MyClass::className(),
+    'class' => MyClass::class,
     'prop1' => 3,
     'prop2' => 4,
 ], [1, 2]);

--- a/docs/guide-zh-CN/concept-events.md
+++ b/docs/guide-zh-CN/concept-events.md
@@ -181,7 +181,7 @@ use Yii;
 use yii\base\Event;
 use yii\db\ActiveRecord;
 
-Event::on(ActiveRecord::className(), ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
+Event::on(ActiveRecord::class, ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
     Yii::trace(get_class($event->sender) . ' is inserted');
 });
 ```
@@ -195,11 +195,11 @@ Event::on(ActiveRecord::className(), ActiveRecord::EVENT_AFTER_INSERT, function 
 ```php
 use yii\base\Event;
 
-Event::on(Foo::className(), Foo::EVENT_HELLO, function ($event) {
+Event::on(Foo::class, Foo::EVENT_HELLO, function ($event) {
     echo $event->sender;  // 显示 "app\models\Foo"
 });
 
-Event::trigger(Foo::className(), Foo::EVENT_HELLO);
+Event::trigger(Foo::class, Foo::EVENT_HELLO);
 ```
 
 注意这种情况下 `$event->sender` 指向触发事件的类名而不是对象实例。
@@ -210,10 +210,10 @@ Event::trigger(Foo::className(), Foo::EVENT_HELLO);
 
 ```php
 // 移除 $handler
-Event::off(Foo::className(), Foo::EVENT_HELLO, $handler);
+Event::off(Foo::class, Foo::EVENT_HELLO, $handler);
 
 // 移除 Foo::EVENT_HELLO 事件的全部处理器
-Event::off(Foo::className(), Foo::EVENT_HELLO);
+Event::off(Foo::class, Foo::EVENT_HELLO);
 ```
 
 

--- a/docs/guide-zh-CN/db-active-record.md
+++ b/docs/guide-zh-CN/db-active-record.md
@@ -364,7 +364,7 @@ class Customer extends \yii\db\ActiveRecord
     public function getOrders()
     {
         // 客户和订单通过 Order.customer_id -> id 关联建立一对多关系
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 
@@ -373,7 +373,7 @@ class Order extends \yii\db\ActiveRecord
     // 订单和客户通过 Customer.id -> customer_id 关联建立一对一关系
     public function getCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 }
 ```
@@ -419,7 +419,7 @@ class Customer extends \yii\db\ActiveRecord
 {
     public function getBigOrders($threshold = 100)
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])
             ->where('subtotal > :threshold', [':threshold' => $threshold])
             ->orderBy('id');
     }
@@ -455,7 +455,7 @@ class Order extends \yii\db\ActiveRecord
 {
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 }
@@ -468,12 +468,12 @@ class Order extends \yii\db\ActiveRecord
 {
     public function getOrderItems()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id']);
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id']);
     }
 
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems');
     }
 }
@@ -560,7 +560,7 @@ class Customer extends ActiveRecord
     ....
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 }
 
@@ -569,7 +569,7 @@ class Order extends ActiveRecord
     ....
     public function getCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 }
 ```
@@ -597,7 +597,7 @@ class Customer extends ActiveRecord
     ....
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])->inverseOf('customer');
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])->inverseOf('customer');
     }
 }
 ```
@@ -707,7 +707,7 @@ class User extends ActiveRecord
 {
     public function getBooks()
     {
-        return $this->hasMany(Item::className(), ['owner_id' => 'id'])->onCondition(['category_id' => 1]);
+        return $this->hasMany(Item::class, ['owner_id' => 'id'])->onCondition(['category_id' => 1]);
     }
 }
 ```
@@ -820,7 +820,7 @@ class Post extends \yii\db\ActiveRecord
 {
     public function getActiveComments()
     {
-        return $this->hasMany(Comment::className(), ['post_id' => 'id'])->active();
+        return $this->hasMany(Comment::class, ['post_id' => 'id'])->active();
 
     }
 }
@@ -868,7 +868,7 @@ class Feature extends \yii\db\ActiveRecord
 
     public function getProduct()
     {
-        return $this->hasOne(Product::className(), ['id' => 'product_id']);
+        return $this->hasOne(Product::class, ['id' => 'product_id']);
     }
 }
 
@@ -878,7 +878,7 @@ class Product extends \yii\db\ActiveRecord
 
     public function getFeatures()
     {
-        return $this->hasMany(Feature::className(), ['product_id' => 'id']);
+        return $this->hasMany(Feature::class, ['product_id' => 'id']);
     }
 }
 ```
@@ -917,7 +917,7 @@ class Feature extends \yii\db\ActiveRecord
 
     public function getProduct()
     {
-        return $this->hasOne(Product::className(), ['product_id' => 'id']);
+        return $this->hasOne(Product::class, ['product_id' => 'id']);
     }
 
     public function scenarios()
@@ -937,7 +937,7 @@ class Product extends \yii\db\ActiveRecord
 
     public function getFeatures()
     {
-        return $this->hasMany(Feature::className(), ['id' => 'product_id']);
+        return $this->hasMany(Feature::class, ['id' => 'product_id']);
     }
 
     public function scenarios()

--- a/docs/guide-zh-CN/rest-authentication.md
+++ b/docs/guide-zh-CN/rest-authentication.md
@@ -49,7 +49,7 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => HttpBasicAuth::className(),
+        'class' => HttpBasicAuth::class,
     ];
     return $behaviors;
 }
@@ -67,11 +67,11 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => CompositeAuth::className(),
+        'class' => CompositeAuth::class,
         'authMethods' => [
-            HttpBasicAuth::className(),
-            HttpBearerAuth::className(),
-            QueryParamAuth::className(),
+            HttpBasicAuth::class,
+            HttpBearerAuth::class,
+            QueryParamAuth::class,
         ],
     ];
     return $behaviors;

--- a/docs/guide-zh-CN/rest-controllers.md
+++ b/docs/guide-zh-CN/rest-controllers.md
@@ -60,7 +60,7 @@ public function behaviors()
 {
     $behaviors = parent::behaviors();
     $behaviors['authenticator'] = [
-        'class' => HttpBasicAuth::className(),
+        'class' => HttpBasicAuth::class,
     ];
     return $behaviors;
 }

--- a/docs/guide-zh-CN/structure-filters.md
+++ b/docs/guide-zh-CN/structure-filters.md
@@ -111,7 +111,7 @@ public function behaviors()
 {
     return [
         'access' => [
-            'class' => AccessControl::className(),
+            'class' => AccessControl::class,
             'only' => ['create', 'update'],
             'rules' => [
                 // 允许认证用户
@@ -145,7 +145,7 @@ public function behaviors()
 {
     return [
         'basicAuth' => [
-            'class' => HttpBasicAuth::className(),
+            'class' => HttpBasicAuth::class,
         ],
     ];
 }
@@ -169,7 +169,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -194,7 +194,7 @@ use yii\web\Response;
 [
     'bootstrap' => [
         [
-            'class' => ContentNegotiator::className(),
+            'class' => ContentNegotiator::class,
             'formats' => [
                 'application/json' => Response::FORMAT_JSON,
                 'application/xml' => Response::FORMAT_XML,
@@ -223,7 +223,7 @@ public function behaviors()
 {
     return [
         [
-            'class' => HttpCache::className(),
+            'class' => HttpCache::class,
             'only' => ['index'],
             'lastModified' => function ($action, $params) {
                 $q = new \yii\db\Query();
@@ -250,11 +250,11 @@ public function behaviors()
 {
     return [
         'pageCache' => [
-            'class' => PageCache::className(),
+            'class' => PageCache::class,
             'only' => ['index'],
             'duration' => 60,
             'dependency' => [
-                'class' => DbDependency::className(),
+                'class' => DbDependency::class,
                 'sql' => 'SELECT COUNT(*) FROM post',
             ],
             'variations' => [
@@ -286,7 +286,7 @@ public function behaviors()
 {
     return [
         'verbs' => [
-            'class' => VerbFilter::className(),
+            'class' => VerbFilter::class,
             'actions' => [
                 'index'  => ['get'],
                 'view'   => ['get'],
@@ -316,7 +316,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
         ],
     ], parent::behaviors());
 }
@@ -340,7 +340,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],
@@ -360,7 +360,7 @@ public function behaviors()
 {
     return ArrayHelper::merge([
         [
-            'class' => Cors::className(),
+            'class' => Cors::class,
             'cors' => [
                 'Origin' => ['http://www.myserver.net'],
                 'Access-Control-Request-Method' => ['GET', 'HEAD', 'OPTIONS'],

--- a/docs/guide/rest-controllers.md
+++ b/docs/guide/rest-controllers.md
@@ -98,7 +98,7 @@ public function behaviors()
     
     // add CORS filter
     $behaviors['corsFilter'] = [
-        'class' => \yii\filters\Cors::className(),
+        'class' => \yii\filters\Cors::class,
     ];
     
     // re-add authentication filter

--- a/docs/guide/security-authorization.md
+++ b/docs/guide/security-authorization.md
@@ -448,7 +448,7 @@ public function behaviors()
 {
     return [
         'access' => [
-            'class' => AccessControl::className(),
+            'class' => AccessControl::class,
             'rules' => [
                 [
                     'allow' => true,


### PR DESCRIPTION
Object::className() was removed for Yii 2.1 in favor of PHP's ::class keyword, but that change was not reflected in the docs yet.

| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |
