### PR TITLE
Fix PHP notice on changelog sort command

### DIFF
--- a/build/controllers/ReleaseController.php
+++ b/build/controllers/ReleaseController.php
@@ -318,7 +318,7 @@ class ReleaseController extends Controller
         }
         $this->validateWhat($what, ['framework', 'ext'], false);
 
-        $version = reset($this->getNextVersions($this->getCurrentVersions($what), self::PATCH));
+        $version = array_values($this->getNextVersions($this->getCurrentVersions($what), self::PATCH))[0];
         $this->stdout('sorting CHANGELOG of ');
         $this->stdout(reset($what), Console::BOLD);
         $this->stdout(" for version ");


### PR DESCRIPTION
``` shell
robert@robert-laptop:~/NetBeansProjects/GitHub/yii2-dev$ ./build/build release/sort-changelog framework
PHP Notice 'yii\base\ErrorException' with message 'Only variables should be passed by reference'

in /home/robert/NetBeansProjects/GitHub/yii2-dev/build/controllers/ReleaseController.php:321

```
