### PR TITLE
Keeping queries more inexpensive

### DIFF
--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -254,6 +254,7 @@ SELECT
     kcu.referenced_table_name,
     kcu.referenced_column_name
 FROM information_schema.referential_constraints AS rc
+INNER JOIN (SELECT 1) AS tmp ON rc.constraint_schema = database() AND rc.table_name = :tableName
 JOIN information_schema.key_column_usage AS kcu ON
     (
         kcu.constraint_catalog = rc.constraint_catalog OR
@@ -261,8 +262,7 @@ JOIN information_schema.key_column_usage AS kcu ON
     ) AND
     kcu.constraint_schema = rc.constraint_schema AND
     kcu.constraint_name = rc.constraint_name
-WHERE rc.constraint_schema = database() AND kcu.table_schema = database()
-AND rc.table_name = :tableName AND kcu.table_name = :tableName1
+WHERE kcu.table_schema = database() AND kcu.table_name = :tableName1
 SQL;
 
         try {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | no |
| Fixed issues | comma-separated list of tickets # fixed by the PR, if any |

In different parts of app repetitive cross joins are expensive. An intermediate inner join will enhance it :
(10 + 10)where... < (10 \* 10)where...
We have similar thing in the ActiveQuery. The child queries could be a sub query for a cleaner join but they are merged into the parent query which means multiplication of the number of rows instead of adding the number of rows.

And actually if we use joinWith , the eager loading won't work properly and it still makes two queries instead of one single join query (tracked up to ActiveQueryTrait::findWith -> ActiveRelationTrait::popuplateRelation ... $this->one() and $this->all() without any condition about joinWith). To check it we can make some passive breakpoints (echo without exit) in the Command::queryInternal to see how much load is on an active query command including information_schema.
