### PR TITLE
Turn off checkExtensionByMimeType if FileValidator::mimeTypes is not …

### DIFF
--- a/framework/validators/FileValidator.php
+++ b/framework/validators/FileValidator.php
@@ -351,7 +351,7 @@ class FileValidator extends Validator
     {
         $extension = mb_strtolower($file->extension, 'UTF-8');
 
-        if ($this->checkExtensionByMimeType) {
+        if ($this->checkExtensionByMimeType && empty($this->mimeTypes)) {
 
             $mimeType = FileHelper::getMimeType($file->tempName, null, false);
             if ($mimeType === null) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11588 |
