### PR TITLE
MSSQL: Fix to NTEXT is being deprecated

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -58,6 +58,7 @@ Yii Framework 2 Change Log
 - Enh #11494: `yii.reloadableScripts` now support wildcards with `*` character (silverfire)
 - Enh #11658: Added argument to `yii\grid\ActionColumn::urlCreator` callback, which holds reference to the column instance (klimov-paul)
 - Enh #11804: Added `yii\behaviors\AttributeTypecastBehavior` for maintaining of strict ActiveRecord attribute types (klimov-paul)
+- Enh #11835: Fixed NTEXT in `\yii\db\mssql\QueryBuilder::$typeMap` that is being deprecated in MSSQL(githubjeka)
 - Enh #11950: Improve `yii\helpers\BaseArrayHelper::keyExists()` speed (egorio)
 - Enh #11979: Added `yii\mutex\OracleMutex` which implements mutex "lock" mechanism via Oracle locks (zlakomanoff)
 - Enh #12028: Add -h|--help option to console command to display help information (pana1990)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -58,7 +58,7 @@ Yii Framework 2 Change Log
 - Enh #11494: `yii.reloadableScripts` now support wildcards with `*` character (silverfire)
 - Enh #11658: Added argument to `yii\grid\ActionColumn::urlCreator` callback, which holds reference to the column instance (klimov-paul)
 - Enh #11804: Added `yii\behaviors\AttributeTypecastBehavior` for maintaining of strict ActiveRecord attribute types (klimov-paul)
-- Enh #11835: Fixed NTEXT in `\yii\db\mssql\QueryBuilder::$typeMap` that is being deprecated in MSSQL(githubjeka)
+- Enh #11835: Fixed NTEXT in `\yii\db\mssql\QueryBuilder::$typeMap` that is being deprecated in MSSQL (githubjeka)
 - Enh #11950: Improve `yii\helpers\BaseArrayHelper::keyExists()` speed (egorio)
 - Enh #11979: Added `yii\mutex\OracleMutex` which implements mutex "lock" mechanism via Oracle locks (zlakomanoff)
 - Enh #12028: Add -h|--help option to console command to display help information (pana1990)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -15,6 +15,14 @@ php composer.phar self-update
 php composer.phar global require "fxp/composer-asset-plugin:^1.2.0"
 ```
 
+Upgrade from Yii 2.0.9
+----------------------
+
+* MSSQL: NTEXT data type marked as deprecated. (https://msdn.microsoft.com/en-us/library/ms187993.aspx) 
+  Because `\yii\db\Schema::TYPE_TEXT` changed to `nvarchar` from `ntext`. By default nvarchar defines 4000 string length.
+  If you need `Schema::TYPE_TEXT = nvarchar(max)`, you can change in your code. Have not done it by default, because
+  MAX keyword is new to SQL Server 2005.
+  
 Upgrade from Yii 2.0.8
 ----------------------
 

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -18,10 +18,10 @@ php composer.phar global require "fxp/composer-asset-plugin:^1.2.0"
 Upgrade from Yii 2.0.9
 ----------------------
 
-* MSSQL: NTEXT data type marked as deprecated. (https://msdn.microsoft.com/en-us/library/ms187993.aspx) 
-  Because `\yii\db\Schema::TYPE_TEXT` changed to `nvarchar` from `ntext`. By default nvarchar defines 4000 string length.
-  If you need `Schema::TYPE_TEXT = nvarchar(max)`, you can change in your code. Have not done it by default, because
-  MAX keyword is new to SQL Server 2005.
+* NTEXT data type was marked as deprecated (https://msdn.microsoft.com/en-us/library/ms187993.aspx) so 
+  `\yii\db\Schema::TYPE_TEXT` was changed from `'ntext'` to `'nvarchar'`. By default `nvarchar` defines a 
+  string of length 4000. If you need `Schema::TYPE_TEXT = nvarchar(max)`, you can adjust it in your code. 
+  It's not like that by default because `MAX` keyword is new to SQL Server 2005.
   
 Upgrade from Yii 2.0.8
 ----------------------

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -28,7 +28,9 @@ class QueryBuilder extends \yii\db\QueryBuilder
         Schema::TYPE_UBIGPK => 'bigint IDENTITY PRIMARY KEY',
         Schema::TYPE_CHAR => 'nchar(1)',
         Schema::TYPE_STRING => 'nvarchar(255)',
-        Schema::TYPE_TEXT => 'ntext',
+        // If you need Schema::TYPE_TEXT = nvarchar(max), you can change in your code
+        // MAX keyword is new to SQL Server 2005 http://stackoverflow.com/questions/16472610/max-nvarchar-length
+        Schema::TYPE_TEXT => 'nvarchar(4000)',
         Schema::TYPE_SMALLINT => 'smallint',
         Schema::TYPE_INTEGER => 'int',
         Schema::TYPE_BIGINT => 'bigint',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11835 fixed by the PR |

Original issue request to use `NVARCHAR(MAX)` . But MAX keyword is unknown for old MSSQL . 
To avoid error `Incorrect syntax near 'MAX'` I use 4000 that is [max value for nvarchar](https://msdn.microsoft.com/en-us/library/ms186939%28SQL.90%29.aspx)
