### PR TITLE
Added support for wildcards for `optional` at `yii\filters\auth\AuthMethod`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -75,6 +75,7 @@ Yii Framework 2 Change Log
 - Enh #12440: Added `yii\base\Event::offAll()` method allowing clear all registered class-level event handlers (klimov-paul)
 - Enh #12580: Make `yii.js` comply with strict and non-strict javascript mode to allow concatenation with external code (mikehaertl)
 - Enh: Method `yii\console\controllers\AssetController::getAssetManager()` automatically enables `yii\web\AssetManager::forceCopy` in case it is not explicitly specified (pana1990, klimov-paul)
+- Enh: Added support for wildcards for `optional` at `yii\filters\auth\AuthMethod` (mg-code)
 
 
 2.0.9 July 11, 2016

--- a/framework/filters/auth/AuthMethod.php
+++ b/framework/filters/auth/AuthMethod.php
@@ -39,6 +39,9 @@ abstract class AuthMethod extends ActionFilter implements AuthInterface
      * @var array list of action IDs that this filter will be applied to, but auth failure will not lead to error.
      * It may be used for actions, that are allowed for public, but return some additional data for authenticated users.
      * Defaults to empty, meaning authentication is not optional for any action.
+     *
+     * Since version 2.0.10 action IDs can be specified as wildcards, e.g. `site/*`.
+     *
      * @see isOptional
      * @since 2.0.7
      */
@@ -101,6 +104,11 @@ abstract class AuthMethod extends ActionFilter implements AuthInterface
     protected function isOptional($action)
     {
         $id = $this->getActionId($action);
-        return in_array($id, $this->optional, true);
+        foreach ($this->optional as $pattern) {
+            if (fnmatch($pattern, $id)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
This option now works similar to `only` and `except`.
Logic of `only` and `except` was updated in release 2.0.9 by @klimov-paul, but this option left as it is.

| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
