### PR TITLE
Documentation ActiveQueryInterface::one()

### DIFF
--- a/framework/db/ActiveQueryInterface.php
+++ b/framework/db/ActiveQueryInterface.php
@@ -32,9 +32,9 @@ interface ActiveQueryInterface extends QueryInterface
     /**
      * Executes query and returns a single row of result.
      * @param Connection $db the DB connection used to create the DB command.
-     * If null, the DB connection returned by [[modelClass]] will be used.
+     * If `null`, the DB connection returned by [[modelClass]] will be used.
      * @return ActiveRecordInterface|array|null a single row of query result. Depending on the setting of [[asArray]],
-     * the query result may be either an array or an ActiveRecord object. Null will be returned
+     * the query result may be either an array or an ActiveRecord object. `null` will be returned
      * if the query results in nothing.
      */
     public function one($db = null);

--- a/framework/db/ActiveQueryInterface.php
+++ b/framework/db/ActiveQueryInterface.php
@@ -28,6 +28,16 @@ interface ActiveQueryInterface extends QueryInterface
      * @return $this the query object itself
      */
     public function asArray($value = true);
+    
+    /**
+     * Executes query and returns a single row of result.
+     * @param Connection $db the DB connection used to create the DB command.
+     * If null, the DB connection returned by [[modelClass]] will be used.
+     * @return ActiveRecordInterface|array|null a single row of query result. Depending on the setting of [[asArray]],
+     * the query result may be either an array or an ActiveRecord object. Null will be returned
+     * if the query results in nothing.
+     */
+    public function one($db = null);
 
     /**
      * Sets the [[indexBy]] property.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |

Currently there is an issue when using `BaseActiveRecord::findOne()` because it uses the return type for `ActiveQueryInterface::one()` which is inherited from `QueryInterface::one()` which returns `array|false`

https://scrutinizer-ci.com/g/yiisoft/yii2/issues/master/files/framework/db/BaseActiveRecord.php?selectedAuthors%5B0%5D=angeldelcaos%40gmail.com&orderField=path&order=asc&honorSelectedPaths=0
