### PR TITLE
Fix yii\rest\Serializer serialize ArrayDataProvider with pagination bug #11987

### DIFF
--- a/framework/rest/Serializer.php
+++ b/framework/rest/Serializer.php
@@ -109,6 +109,10 @@ class Serializer extends Component
      * @var Response the response to be sent. If not set, the `response` application component will be used.
      */
     public $response;
+    /**
+     * @var bool keep the key elements in a serialization data. Used in `serializeDataProvider`.
+     */
+    public $saveKeys = true;
 
 
     /**
@@ -171,7 +175,11 @@ class Serializer extends Component
      */
     protected function serializeDataProvider($dataProvider)
     {
-        $models = $this->serializeModels(array_values($dataProvider->getModels()));
+        $models = $dataProvider->getModels();
+        if ($this->saveKeys !== true) {
+            $models = array_values($models);
+        }
+        $models = $this->serializeModels($models);
 
         if (($pagination = $dataProvider->getPagination()) !== false) {
             $this->addPaginationHeaders($pagination);

--- a/tests/framework/rest/SerializerTest.php
+++ b/tests/framework/rest/SerializerTest.php
@@ -185,6 +185,56 @@ class SerializerTest extends TestCase
                     ['id' => 2, 'username' => 'Tom']
                 ]
             ],
+            [
+                new ArrayDataProvider([
+                    'allModels' => [
+                        'Bob' => ['id' => 1, 'username' => 'Bob'],
+                        'Tom' => ['id' => 2, 'username' => 'Tom']
+                    ],
+                    'pagination' => [
+                        'route' => '/',
+                        'pageSize' => 1,
+                        'page' => 1
+                    ],
+                ]),
+                [
+                    ['id' => 2, 'username' => 'Tom']
+                ]
+            ],
+            [
+                new ArrayDataProvider([
+                    'allModels' => [
+                        ['id' => 1, 'username' => 'Bob'],
+                        ['id' => 2, 'username' => 'Tom']
+                    ],
+                    'pagination' => [
+                        'route' => '/',
+                        'pageSize' => 1,
+                        'page' => 1
+                    ],
+                ]),
+                [
+                    1 => ['id' => 2, 'username' => 'Tom']
+                ],
+                true,
+            ],
+            [
+                new ArrayDataProvider([
+                    'allModels' => [
+                        'Bob' => ['id' => 1, 'username' => 'Bob'],
+                        'Tom' => ['id' => 2, 'username' => 'Tom'],
+                    ],
+                    'pagination' => [
+                        'route' => '/',
+                        'pageSize' => 1,
+                        'page' => 1
+                    ],
+                ]),
+                [
+                    'Tom' => ['id' => 2, 'username' => 'Tom']
+                ],
+                true,
+            ],
             /*[
                 new ArrayDataProvider([
                     'allModels' => [
@@ -210,10 +260,12 @@ class SerializerTest extends TestCase
      *
      * @param \yii\data\DataProviderInterface $dataProvider
      * @param array $expectedResult
+     * @param boolean $saveKeys
      */
-    public function testSerializeDataProvider($dataProvider, $expectedResult)
+    public function testSerializeDataProvider($dataProvider, $expectedResult, $saveKeys = false)
     {
         $serializer = new Serializer();
+        $serializer->saveKeys = $saveKeys;
 
         $this->assertEquals($expectedResult, $serializer->serialize($dataProvider));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11977 |
| Fixed pull | #11987 |

To solve the problem I propose to introduce the parameter `$saveKeys` who will be responsible for the behavior of the class of `\yii\rest\Serializer`
