### PR TITLE
Added `QueryInterface::emulateExecution()`

### DIFF
--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -464,7 +464,7 @@ trait ActiveRelationTrait
                 }
             }
             if (empty($values)) {
-                $this->preventExecution();
+                $this->emulateExecution();
             }
         } else {
             // composite keys
@@ -481,7 +481,7 @@ trait ActiveRelationTrait
                 }
                 $values[] = $v;
                 if (empty($v)) {
-                    $this->preventExecution();
+                    $this->emulateExecution();
                 }
             }
         }

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -464,7 +464,7 @@ trait ActiveRelationTrait
                 }
             }
             if (empty($values)) {
-                $this->cancel();
+                $this->preventExecution();
             }
         } else {
             // composite keys
@@ -481,7 +481,7 @@ trait ActiveRelationTrait
                 }
                 $values[] = $v;
                 if (empty($v)) {
-                    $this->cancel();
+                    $this->preventExecution();
                 }
             }
         }

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -463,6 +463,9 @@ trait ActiveRelationTrait
                     }
                 }
             }
+            if (empty($values)) {
+                $this->cancel();
+            }
         } else {
             // composite keys
 
@@ -477,6 +480,9 @@ trait ActiveRelationTrait
                     $v[$attribute] = $model[$link];
                 }
                 $values[] = $v;
+                if (empty($v)) {
+                    $this->cancel();
+                }
             }
         }
         $this->andWhere(['in', $attributes, array_unique($values, SORT_REGULAR)]);

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -207,7 +207,7 @@ class Query extends Component implements QueryInterface
      */
     public function all($db = null)
     {
-        if ($this->canceled) {
+        if ($this->preventExecution) {
             return [];
         }
         $rows = $this->createCommand($db)->queryAll();
@@ -247,7 +247,7 @@ class Query extends Component implements QueryInterface
      */
     public function one($db = null)
     {
-        if ($this->canceled) {
+        if ($this->preventExecution) {
             return false;
         }
         return $this->createCommand($db)->queryOne();
@@ -263,7 +263,7 @@ class Query extends Component implements QueryInterface
      */
     public function scalar($db = null)
     {
-        if ($this->canceled) {
+        if ($this->preventExecution) {
             return null;
         }
         return $this->createCommand($db)->queryScalar();
@@ -277,7 +277,7 @@ class Query extends Component implements QueryInterface
      */
     public function column($db = null)
     {
-        if ($this->canceled) {
+        if ($this->preventExecution) {
             return [];
         }
 
@@ -313,7 +313,7 @@ class Query extends Component implements QueryInterface
      */
     public function count($q = '*', $db = null)
     {
-        if ($this->canceled) {
+        if ($this->preventExecution) {
             return 0;
         }
         return $this->queryScalar("COUNT($q)", $db);
@@ -329,7 +329,7 @@ class Query extends Component implements QueryInterface
      */
     public function sum($q, $db = null)
     {
-        if ($this->canceled) {
+        if ($this->preventExecution) {
             return 0;
         }
         return $this->queryScalar("SUM($q)", $db);
@@ -345,7 +345,7 @@ class Query extends Component implements QueryInterface
      */
     public function average($q, $db = null)
     {
-        if ($this->canceled) {
+        if ($this->preventExecution) {
             return 0;
         }
         return $this->queryScalar("AVG($q)", $db);
@@ -385,7 +385,7 @@ class Query extends Component implements QueryInterface
      */
     public function exists($db = null)
     {
-        if ($this->canceled) {
+        if ($this->preventExecution) {
             return false;
         }
         $command = $this->createCommand($db);
@@ -404,7 +404,7 @@ class Query extends Component implements QueryInterface
      */
     protected function queryScalar($selectExpression, $db)
     {
-        if ($this->canceled) {
+        if ($this->preventExecution) {
             return null;
         }
 

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -207,7 +207,7 @@ class Query extends Component implements QueryInterface
      */
     public function all($db = null)
     {
-        if ($this->preventExecution) {
+        if ($this->emulateExecution) {
             return [];
         }
         $rows = $this->createCommand($db)->queryAll();
@@ -247,7 +247,7 @@ class Query extends Component implements QueryInterface
      */
     public function one($db = null)
     {
-        if ($this->preventExecution) {
+        if ($this->emulateExecution) {
             return false;
         }
         return $this->createCommand($db)->queryOne();
@@ -263,7 +263,7 @@ class Query extends Component implements QueryInterface
      */
     public function scalar($db = null)
     {
-        if ($this->preventExecution) {
+        if ($this->emulateExecution) {
             return null;
         }
         return $this->createCommand($db)->queryScalar();
@@ -277,7 +277,7 @@ class Query extends Component implements QueryInterface
      */
     public function column($db = null)
     {
-        if ($this->preventExecution) {
+        if ($this->emulateExecution) {
             return [];
         }
 
@@ -313,7 +313,7 @@ class Query extends Component implements QueryInterface
      */
     public function count($q = '*', $db = null)
     {
-        if ($this->preventExecution) {
+        if ($this->emulateExecution) {
             return 0;
         }
         return $this->queryScalar("COUNT($q)", $db);
@@ -329,7 +329,7 @@ class Query extends Component implements QueryInterface
      */
     public function sum($q, $db = null)
     {
-        if ($this->preventExecution) {
+        if ($this->emulateExecution) {
             return 0;
         }
         return $this->queryScalar("SUM($q)", $db);
@@ -345,7 +345,7 @@ class Query extends Component implements QueryInterface
      */
     public function average($q, $db = null)
     {
-        if ($this->preventExecution) {
+        if ($this->emulateExecution) {
             return 0;
         }
         return $this->queryScalar("AVG($q)", $db);
@@ -385,7 +385,7 @@ class Query extends Component implements QueryInterface
      */
     public function exists($db = null)
     {
-        if ($this->preventExecution) {
+        if ($this->emulateExecution) {
             return false;
         }
         $command = $this->createCommand($db);
@@ -404,7 +404,7 @@ class Query extends Component implements QueryInterface
      */
     protected function queryScalar($selectExpression, $db)
     {
-        if ($this->preventExecution) {
+        if ($this->emulateExecution) {
             return null;
         }
 

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -207,6 +207,9 @@ class Query extends Component implements QueryInterface
      */
     public function all($db = null)
     {
+        if ($this->canceled) {
+            return [];
+        }
         $rows = $this->createCommand($db)->queryAll();
         return $this->populate($rows);
     }
@@ -244,6 +247,9 @@ class Query extends Component implements QueryInterface
      */
     public function one($db = null)
     {
+        if ($this->canceled) {
+            return false;
+        }
         return $this->createCommand($db)->queryOne();
     }
 
@@ -257,6 +263,9 @@ class Query extends Component implements QueryInterface
      */
     public function scalar($db = null)
     {
+        if ($this->canceled) {
+            return null;
+        }
         return $this->createCommand($db)->queryScalar();
     }
 
@@ -268,6 +277,10 @@ class Query extends Component implements QueryInterface
      */
     public function column($db = null)
     {
+        if ($this->canceled) {
+            return [];
+        }
+
         if ($this->indexBy === null) {
             return $this->createCommand($db)->queryColumn();
         }
@@ -300,6 +313,9 @@ class Query extends Component implements QueryInterface
      */
     public function count($q = '*', $db = null)
     {
+        if ($this->canceled) {
+            return 0;
+        }
         return $this->queryScalar("COUNT($q)", $db);
     }
 
@@ -313,6 +329,9 @@ class Query extends Component implements QueryInterface
      */
     public function sum($q, $db = null)
     {
+        if ($this->canceled) {
+            return 0;
+        }
         return $this->queryScalar("SUM($q)", $db);
     }
 
@@ -326,6 +345,9 @@ class Query extends Component implements QueryInterface
      */
     public function average($q, $db = null)
     {
+        if ($this->canceled) {
+            return 0;
+        }
         return $this->queryScalar("AVG($q)", $db);
     }
 
@@ -363,6 +385,9 @@ class Query extends Component implements QueryInterface
      */
     public function exists($db = null)
     {
+        if ($this->canceled) {
+            return false;
+        }
         $command = $this->createCommand($db);
         $params = $command->params;
         $command->setSql($command->db->getQueryBuilder()->selectExists($command->getSql()));
@@ -379,6 +404,10 @@ class Query extends Component implements QueryInterface
      */
     protected function queryScalar($selectExpression, $db)
     {
+        if ($this->canceled) {
+            return null;
+        }
+
         $select = $this->select;
         $limit = $this->limit;
         $offset = $this->offset;

--- a/framework/db/QueryInterface.php
+++ b/framework/db/QueryInterface.php
@@ -254,14 +254,14 @@ interface QueryInterface
     public function offset($offset);
 
     /**
-     * Cancels the query actual execution, preventing interaction with data storage.
-     * After this method is triggered, methods, returning query results like [[one()]], [[all()]], [[exists()]]
+     * Sets whether to emulate query execution, preventing any interaction with data storage.
+     * After this mode is enabled, methods, returning query results like [[one()]], [[all()]], [[exists()]]
      * and so on, will return empty or false values.
      * You should use this method in case your program logic indicates query should not return any results, like
      * in case you set false where condition like `0=1`.
      * @param boolean $value whether to prevent query execution.
-     * @return $this the query object itself
+     * @return $this the query object itself.
      * @since 2.0.11
      */
-    public function preventExecution($value = true);
+    public function emulateExecution($value = true);
 }

--- a/framework/db/QueryInterface.php
+++ b/framework/db/QueryInterface.php
@@ -252,4 +252,15 @@ interface QueryInterface
      * @return $this the query object itself
      */
     public function offset($offset);
+
+    /**
+     * Cancels the query actual execution, prevention interaction with data storage.
+     * After this method is triggered, methods, returning query results like [[one()]], [[all()]], [[exists()]]
+     * and so on will return empty or false values.
+     * You should use this method in case your program logic indicates query should not return any results, like
+     * in case you set false where condition like `0=1`.
+     * @return $this the query object itself
+     * @since 2.0.11
+     */
+    public function cancel();
 }

--- a/framework/db/QueryInterface.php
+++ b/framework/db/QueryInterface.php
@@ -254,13 +254,14 @@ interface QueryInterface
     public function offset($offset);
 
     /**
-     * Cancels the query actual execution, prevention interaction with data storage.
+     * Cancels the query actual execution, preventing interaction with data storage.
      * After this method is triggered, methods, returning query results like [[one()]], [[all()]], [[exists()]]
-     * and so on will return empty or false values.
+     * and so on, will return empty or false values.
      * You should use this method in case your program logic indicates query should not return any results, like
      * in case you set false where condition like `0=1`.
+     * @param boolean $value whether to prevent query execution.
      * @return $this the query object itself
      * @since 2.0.11
      */
-    public function cancel();
+    public function preventExecution($value = true);
 }

--- a/framework/db/QueryTrait.php
+++ b/framework/db/QueryTrait.php
@@ -50,6 +50,12 @@ trait QueryTrait
      * row data. For more details, see [[indexBy()]]. This property is only used by [[QueryInterface::all()|all()]].
      */
     public $indexBy;
+    /**
+     * @var boolean whether actual execution of the query is canceled.
+     * @see cancel()
+     * @since 2.0.11
+     */
+    public $canceled = false;
 
 
     /**
@@ -386,6 +392,21 @@ trait QueryTrait
     public function offset($offset)
     {
         $this->offset = $offset;
+        return $this;
+    }
+
+    /**
+     * Cancels the query actual execution, prevention interaction with data storage.
+     * After this method is triggered, methods, returning query results like [[one()]], [[all()]], [[exists()]]
+     * and so on will return empty or false values.
+     * You should use this method in case your program logic indicates query should not return any results, like
+     * in case you set false where condition like `0=1`.
+     * @return $this the query object itself
+     * @since 2.0.11
+     */
+    public function cancel()
+    {
+        $this->canceled = true;
         return $this;
     }
 }

--- a/framework/db/QueryTrait.php
+++ b/framework/db/QueryTrait.php
@@ -52,10 +52,10 @@ trait QueryTrait
     public $indexBy;
     /**
      * @var boolean whether actual execution of the query is canceled.
-     * @see cancel()
+     * @see preventExecution()
      * @since 2.0.11
      */
-    public $canceled = false;
+    public $preventExecution = false;
 
 
     /**
@@ -396,17 +396,18 @@ trait QueryTrait
     }
 
     /**
-     * Cancels the query actual execution, prevention interaction with data storage.
+     * Cancels the query actual execution, preventing interaction with data storage.
      * After this method is triggered, methods, returning query results like [[one()]], [[all()]], [[exists()]]
-     * and so on will return empty or false values.
+     * and so on, will return empty or false values.
      * You should use this method in case your program logic indicates query should not return any results, like
      * in case you set false where condition like `0=1`.
+     * @param boolean $value whether to prevent query execution.
      * @return $this the query object itself
      * @since 2.0.11
      */
-    public function cancel()
+    public function preventExecution($value = true)
     {
-        $this->canceled = true;
+        $this->preventExecution = $value;
         return $this;
     }
 }

--- a/framework/db/QueryTrait.php
+++ b/framework/db/QueryTrait.php
@@ -51,11 +51,11 @@ trait QueryTrait
      */
     public $indexBy;
     /**
-     * @var boolean whether actual execution of the query is canceled.
-     * @see preventExecution()
+     * @var boolean whether to emulate the actual query execution, returning empty or false results.
+     * @see emulateExecution()
      * @since 2.0.11
      */
-    public $preventExecution = false;
+    public $emulateExecution = false;
 
 
     /**
@@ -396,18 +396,18 @@ trait QueryTrait
     }
 
     /**
-     * Cancels the query actual execution, preventing interaction with data storage.
-     * After this method is triggered, methods, returning query results like [[one()]], [[all()]], [[exists()]]
+     * Sets whether to emulate query execution, preventing any interaction with data storage.
+     * After this mode is enabled, methods, returning query results like [[one()]], [[all()]], [[exists()]]
      * and so on, will return empty or false values.
      * You should use this method in case your program logic indicates query should not return any results, like
      * in case you set false where condition like `0=1`.
      * @param boolean $value whether to prevent query execution.
-     * @return $this the query object itself
+     * @return $this the query object itself.
      * @since 2.0.11
      */
-    public function preventExecution($value = true)
+    public function emulateExecution($value = true)
     {
-        $this->preventExecution = $value;
+        $this->emulateExecution = $value;
         return $this;
     }
 }

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1313,67 +1313,67 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertFalse($baseModel->hasProperty('unExistingColumn'));
     }
 
-    public function testCancelQuery()
+    public function testEmulateExecution()
     {
         $rows = Customer::find()
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->all();
         $this->assertSame([], $rows);
 
         $row = Customer::find()
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->one();
         $this->assertSame(null, $row);
 
         $exists = Customer::find()
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->exists();
         $this->assertSame(false, $exists);
 
         $count = Customer::find()
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->count();
         $this->assertSame(0, $count);
 
         $sum = Customer::find()
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->sum('id');
         $this->assertSame(0, $sum);
 
         $sum = Customer::find()
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->average('id');
         $this->assertSame(0, $sum);
 
         $max = Customer::find()
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->max('id');
         $this->assertSame(null, $max);
 
         $min = Customer::find()
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->min('id');
         $this->assertSame(null, $min);
 
         $scalar = Customer::find()
             ->select(['id'])
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->scalar();
         $this->assertSame(null, $scalar);
 
         $column = Customer::find()
             ->select(['id'])
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->column();
         $this->assertSame([], $column);
     }

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1312,4 +1312,69 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $baseModel = new ActiveRecord();
         $this->assertFalse($baseModel->hasProperty('unExistingColumn'));
     }
+
+    public function testCancelQuery()
+    {
+        $rows = Customer::find()
+            ->from('customer')
+            ->cancel()
+            ->all();
+        $this->assertSame([], $rows);
+
+        $row = Customer::find()
+            ->from('customer')
+            ->cancel()
+            ->one();
+        $this->assertSame(null, $row);
+
+        $exists = Customer::find()
+            ->from('customer')
+            ->cancel()
+            ->exists();
+        $this->assertSame(false, $exists);
+
+        $count = Customer::find()
+            ->from('customer')
+            ->cancel()
+            ->count();
+        $this->assertSame(0, $count);
+
+        $sum = Customer::find()
+            ->from('customer')
+            ->cancel()
+            ->sum('id');
+        $this->assertSame(0, $sum);
+
+        $sum = Customer::find()
+            ->from('customer')
+            ->cancel()
+            ->average('id');
+        $this->assertSame(0, $sum);
+
+        $max = Customer::find()
+            ->from('customer')
+            ->cancel()
+            ->max('id');
+        $this->assertSame(null, $max);
+
+        $min = Customer::find()
+            ->from('customer')
+            ->cancel()
+            ->min('id');
+        $this->assertSame(null, $min);
+
+        $scalar = Customer::find()
+            ->select(['id'])
+            ->from('customer')
+            ->cancel()
+            ->scalar();
+        $this->assertSame(null, $scalar);
+
+        $column = Customer::find()
+            ->select(['id'])
+            ->from('customer')
+            ->cancel()
+            ->column();
+        $this->assertSame([], $column);
+    }
 }

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1317,63 +1317,63 @@ abstract class ActiveRecordTest extends DatabaseTestCase
     {
         $rows = Customer::find()
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->all();
         $this->assertSame([], $rows);
 
         $row = Customer::find()
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->one();
         $this->assertSame(null, $row);
 
         $exists = Customer::find()
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->exists();
         $this->assertSame(false, $exists);
 
         $count = Customer::find()
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->count();
         $this->assertSame(0, $count);
 
         $sum = Customer::find()
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->sum('id');
         $this->assertSame(0, $sum);
 
         $sum = Customer::find()
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->average('id');
         $this->assertSame(0, $sum);
 
         $max = Customer::find()
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->max('id');
         $this->assertSame(null, $max);
 
         $min = Customer::find()
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->min('id');
         $this->assertSame(null, $min);
 
         $scalar = Customer::find()
             ->select(['id'])
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->scalar();
         $this->assertSame(null, $scalar);
 
         $column = Customer::find()
             ->select(['id'])
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->column();
         $this->assertSame([], $column);
     }

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -318,7 +318,7 @@ abstract class QueryTest extends DatabaseTestCase
         $this->assertEquals(1, $count);
     }
 
-    public function testCancel()
+    public function testPreventExecution()
     {
         $db = $this->getConnection();
 

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -324,63 +324,63 @@ abstract class QueryTest extends DatabaseTestCase
 
         $rows = (new Query())
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->all($db);
         $this->assertSame([], $rows);
 
         $row = (new Query())
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->one($db);
         $this->assertSame(false, $row);
 
         $exists = (new Query())
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->exists($db);
         $this->assertSame(false, $exists);
 
         $count = (new Query())
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->count($db);
         $this->assertSame(0, $count);
 
         $sum = (new Query())
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->sum('id', $db);
         $this->assertSame(0, $sum);
 
         $sum = (new Query())
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->average('id', $db);
         $this->assertSame(0, $sum);
 
         $max = (new Query())
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->max('id', $db);
         $this->assertSame(null, $max);
 
         $min = (new Query())
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->min('id', $db);
         $this->assertSame(null, $min);
 
         $scalar = (new Query())
             ->select(['id'])
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->scalar($db);
         $this->assertSame(null, $scalar);
 
         $column = (new Query())
             ->select(['id'])
             ->from('customer')
-            ->cancel()
+            ->preventExecution()
             ->column($db);
         $this->assertSame([], $column);
     }

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -317,4 +317,71 @@ abstract class QueryTest extends DatabaseTestCase
         $count = (new Query)->from('customer')->having(['status' => 2])->count('*', $db);
         $this->assertEquals(1, $count);
     }
+
+    public function testCancel()
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->from('customer')
+            ->cancel()
+            ->all($db);
+        $this->assertSame([], $rows);
+
+        $row = (new Query())
+            ->from('customer')
+            ->cancel()
+            ->one($db);
+        $this->assertSame(false, $row);
+
+        $exists = (new Query())
+            ->from('customer')
+            ->cancel()
+            ->exists($db);
+        $this->assertSame(false, $exists);
+
+        $count = (new Query())
+            ->from('customer')
+            ->cancel()
+            ->count($db);
+        $this->assertSame(0, $count);
+
+        $sum = (new Query())
+            ->from('customer')
+            ->cancel()
+            ->sum('id', $db);
+        $this->assertSame(0, $sum);
+
+        $sum = (new Query())
+            ->from('customer')
+            ->cancel()
+            ->average('id', $db);
+        $this->assertSame(0, $sum);
+
+        $max = (new Query())
+            ->from('customer')
+            ->cancel()
+            ->max('id', $db);
+        $this->assertSame(null, $max);
+
+        $min = (new Query())
+            ->from('customer')
+            ->cancel()
+            ->min('id', $db);
+        $this->assertSame(null, $min);
+
+        $scalar = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->cancel()
+            ->scalar($db);
+        $this->assertSame(null, $scalar);
+
+        $column = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->cancel()
+            ->column($db);
+        $this->assertSame([], $column);
+    }
 }

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -2,6 +2,7 @@
 
 namespace yiiunit\framework\db;
 
+use yii\db\Connection;
 use yii\db\Expression;
 use yii\db\Query;
 
@@ -318,69 +319,69 @@ abstract class QueryTest extends DatabaseTestCase
         $this->assertEquals(1, $count);
     }
 
-    public function testPreventExecution()
+    public function testEmulateExecution()
     {
         $db = $this->getConnection();
 
         $rows = (new Query())
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->all($db);
         $this->assertSame([], $rows);
 
         $row = (new Query())
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->one($db);
         $this->assertSame(false, $row);
 
         $exists = (new Query())
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->exists($db);
         $this->assertSame(false, $exists);
 
         $count = (new Query())
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->count($db);
         $this->assertSame(0, $count);
 
         $sum = (new Query())
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->sum('id', $db);
         $this->assertSame(0, $sum);
 
         $sum = (new Query())
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->average('id', $db);
         $this->assertSame(0, $sum);
 
         $max = (new Query())
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->max('id', $db);
         $this->assertSame(null, $max);
 
         $min = (new Query())
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->min('id', $db);
         $this->assertSame(null, $min);
 
         $scalar = (new Query())
             ->select(['id'])
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->scalar($db);
         $this->assertSame(null, $scalar);
 
         $column = (new Query())
             ->select(['id'])
             ->from('customer')
-            ->preventExecution()
+            ->emulateExecution()
             ->column($db);
         $this->assertSame([], $column);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | yes |
| Tests pass? | yes |
| Fixed issues | #6373, #12390 |

Added `QueryInterface::emulateExecution()`, which allows preventing of the actual query execution.
This allows to cancel `DataProvider` preventing search query execution in case search model is invalid:

``` php
public function search($params)
    {
        $query = Item::find();

        $dataProvider = new ActiveDataProvider([
            'query' => $query,
        ]);

        $this->load($params);

        if (!$this->validate()) {
            $query->where('0=1');
            $query->emulateExecution(); // No SQL execution will be done
            return $dataProvider;
        }
```

This also fix unecessary query in case of `via()` usage. See #12390.

Note: this PR produces minor BC break as it alters `yii\db\QueryInterface`, however the implementation of new method is present at `yii\db\QueryTrait` - thus it is less likely to produce a trouble.
