### PR TITLE
Add `beforeRow` and `afterRow`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -80,6 +80,7 @@ Yii Framework 2 Change Log
 - Enh #12440: Added `yii\base\Event::offAll()` method allowing clear all registered class-level event handlers (klimov-paul)
 - Enh #12580: Make `yii.js` comply with strict and non-strict javascript mode to allow concatenation with external code (mikehaertl)
 - Enh #12664: Added support for wildcards for `optional` at `yii\filters\auth\AuthMethod` (mg-code)
+- Enh #12710: Added `beforeItem` and `afterItem` at `yii\widgets\ListView` (mdmunir)
 - Enh: Method `yii\console\controllers\AssetController::getAssetManager()` automatically enables `yii\web\AssetManager::forceCopy` in case it is not explicitly specified (pana1990, klimov-paul)
 
 

--- a/framework/widgets/ListView.php
+++ b/framework/widgets/ListView.php
@@ -62,6 +62,28 @@ class ListView extends BaseListView
      * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
      */
     public $options = ['class' => 'list-view'];
+    /**
+     * @var Closure an anonymous function that is called once BEFORE rendering each data model.
+     * It should have the following signature:
+     *
+     * ```php
+     * function ($model, $key, $index, $widget)
+     * ```
+     *
+     * - `$model`: the current data model being rendered
+     * - `$key`: the key value associated with the current data model
+     * - `$index`: the zero-based index of the data model in the model array returned by [[dataProvider]]
+     * - `$widget`: the ListView object
+     *
+     * The return result of the function will be rendered directly.
+     */
+    public $beforeRow;
+    /**
+     * @var Closure an anonymous function that is called once AFTER rendering each data model.
+     * It should have the similar signature as [[beforeRow]]. The return result of the function
+     * will be rendered directly.
+     */
+    public $afterRow;
 
 
     /**
@@ -74,7 +96,22 @@ class ListView extends BaseListView
         $keys = $this->dataProvider->getKeys();
         $rows = [];
         foreach (array_values($models) as $index => $model) {
-            $rows[] = $this->renderItem($model, $keys[$index], $index);
+            $key = $keys[$index];
+            if ($this->beforeRow !== null) {
+                $row = call_user_func($this->beforeRow, $model, $key, $index, $this);
+                if (!empty($row)) {
+                    $rows[] = $row;
+                }
+            }
+
+            $rows[] = $this->renderItem($model, $key, $index);
+
+            if ($this->afterRow !== null) {
+                $row = call_user_func($this->afterRow, $model, $key, $index, $this);
+                if (!empty($row)) {
+                    $rows[] = $row;
+                }
+            }
         }
 
         return implode($this->separator, $rows);

--- a/framework/widgets/ListView.php
+++ b/framework/widgets/ListView.php
@@ -76,14 +76,16 @@ class ListView extends BaseListView
      * - `$widget`: the ListView object
      *
      * The return result of the function will be rendered directly.
+     * @since 2.0.10
      */
-    public $beforeRow;
+    public $beforeItem;
     /**
      * @var Closure an anonymous function that is called once AFTER rendering each data model.
-     * It should have the similar signature as [[beforeRow]]. The return result of the function
+     * It should have the similar signature as [[beforeItem]]. The return result of the function
      * will be rendered directly.
+     * @since 2.0.10
      */
-    public $afterRow;
+    public $afterItem;
 
 
     /**
@@ -97,18 +99,18 @@ class ListView extends BaseListView
         $rows = [];
         foreach (array_values($models) as $index => $model) {
             $key = $keys[$index];
-            if ($this->beforeRow !== null) {
-                $row = call_user_func($this->beforeRow, $model, $key, $index, $this);
-                if (!empty($row)) {
+            if ($this->beforeItem !== null) {
+                $row = call_user_func($this->beforeItem, $model, $key, $index, $this);
+                if ($row !== null && $row !== false) {
                     $rows[] = $row;
                 }
             }
 
             $rows[] = $this->renderItem($model, $key, $index);
 
-            if ($this->afterRow !== null) {
-                $row = call_user_func($this->afterRow, $model, $key, $index, $this);
-                if (!empty($row)) {
+            if ($this->afterItem !== null) {
+                $row = call_user_func($this->afterItem, $model, $key, $index, $this);
+                if ($row !== null && $row !== false) {
                     $rows[] = $row;
                 }
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? |  |
| Fixed issues |  |
# Usage

``` php
ListView::widget([
    'dataProvider' => $dataProvider,
    'itemOptions' => ['class' => 'col-md-4'],
    'beforeRow' => function($model, $key, $index) {
        if ($index % 3 === 0) {
            return '<div class="row">';
        }
    },
   'afterRow' => function($model, $key, $index) use($dataProvider) {
        if ($index % 3 === 2 || $index === $dataProvider->count - 1) {
            return '</div>';
        }
    },
]);
```
