### PR TITLE
Correct MSIE8 reserved word error

### DIFF
--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -155,7 +155,7 @@
                 return;
             }
             var checkAll = "#" + id + " input[name='" + options.checkAll + "']";
-            var inputs = options.class ? "input." + options.class : "input[name='" + options.name + "']";
+            var inputs = options['class'] ? "input." + options['class'] : "input[name='" + options.name + "']";
             var inputsEnabled = "#" + id + " " + inputs + ":enabled";
             $(document).off('click.yiiGridView', checkAll).on('click.yiiGridView', checkAll, function () {
                 $grid.find(inputs + ":enabled").prop('checked', this.checked);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |

In MSIE8 and below, yii.gridView file is not loaded and GridView widget is not working (throws Identifier expected error). The reason is that the variable name 'class' is a reserved word. To correct this, the variable name should be changed into an array key, which eliminates the error.

More info about the causes of error: https://tiffanybbrown.com/2013/09/10/expected-identifier-bug-in-internet-explorer-8/
