### PR TITLE
Add is_dir() validation for BaseFileHelper::findFiles()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,6 +15,7 @@ Yii Framework 2 Change Log
 - Bug #12824: Enabled usage of `yii\mutex\FileMutex` on Windows systems (davidsonalencar)
 - Enh #11037 yii.js and yii.validation.js should use Regexp.test instead of String.match (arogachev, nkovacs)
 - Bug #9796: Initialization of not existing `yii\grid\ActionColumn` default buttons (arogachev)
+- Enh: Added `is_dir()` validation to `BaseFileHelper::findFiles` method (zalatov)
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -411,7 +411,7 @@ class BaseFileHelper
             if (static::filterPath($path, $options)) {
                 if (is_file($path)) {
                     $list[] = $path;
-                } elseif (!isset($options['recursive']) || $options['recursive']) {
+                } elseif (is_dir($path) && (!isset($options['recursive']) || $options['recursive'])) {
                     $list = array_merge($list, static::findFiles($path, $options));
                 }
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |

Add is_dir() validation for BaseFileHelper::findFiles().
Sometimes it throws exception when file/directory is deleted or moved while executing script.
