### PR TITLE
Skip pjax if data-pjax="0"

### DIFF
--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -164,7 +164,7 @@ window.yii = (function ($) {
                 pjaxContainer,
                 pjaxOptions = {};
 
-            if (pjax !== undefined && $.support.pjax) {
+            if (pjax !== undefined && pjax != 0 && $.support.pjax) {
                 if ($e.data('pjax-container')) {
                     pjaxContainer = $e.data('pjax-container');
                 } else {
@@ -190,13 +190,13 @@ window.yii = (function ($) {
 
             if (method === undefined) {
                 if (action && action != '#') {
-                    if (pjax !== undefined && $.support.pjax) {
+                    if (pjax !== undefined && pjax != 0 && $.support.pjax) {
                         $.pjax.click(event, pjaxOptions);
                     } else {
                         window.location = action;
                     }
                 } else if ($e.is(':submit') && $form.length) {
-                    if (pjax !== undefined && $.support.pjax) {
+                    if (pjax !== undefined && pjax != 0 && $.support.pjax) {
                         $form.on('submit',function(e){
                             $.pjax.submit(e, pjaxOptions);
                         })
@@ -249,7 +249,7 @@ window.yii = (function ($) {
                 oldAction = $form.attr('action');
                 $form.attr('action', action);
             }
-            if (pjax !== undefined && $.support.pjax) {
+            if (pjax !== undefined && pjax != 0 && $.support.pjax) {
                 $form.on('submit',function(e){
                     $.pjax.submit(e, pjaxOptions);
                 })

--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -154,6 +154,7 @@ window.yii = (function ($) {
                 action = $e.attr('href'),
                 params = $e.data('params'),
                 pjax = $e.data('pjax'),
+                usePjax = pjax !== undefined && pjax != 0 && $.support.pjax,
                 pjaxPushState = !!$e.data('pjax-push-state'),
                 pjaxReplaceState = !!$e.data('pjax-replace-state'),
                 pjaxTimeout = $e.data('pjax-timeout'),
@@ -164,7 +165,7 @@ window.yii = (function ($) {
                 pjaxContainer,
                 pjaxOptions = {};
 
-            if (pjax !== undefined && pjax != 0 && $.support.pjax) {
+            if (usePjax) {
                 if ($e.data('pjax-container')) {
                     pjaxContainer = $e.data('pjax-container');
                 } else {
@@ -190,13 +191,13 @@ window.yii = (function ($) {
 
             if (method === undefined) {
                 if (action && action != '#') {
-                    if (pjax !== undefined && pjax != 0 && $.support.pjax) {
+                    if (usePjax) {
                         $.pjax.click(event, pjaxOptions);
                     } else {
                         window.location = action;
                     }
                 } else if ($e.is(':submit') && $form.length) {
-                    if (pjax !== undefined && pjax != 0 && $.support.pjax) {
+                    if (usePjax) {
                         $form.on('submit',function(e){
                             $.pjax.submit(e, pjaxOptions);
                         })
@@ -249,7 +250,7 @@ window.yii = (function ($) {
                 oldAction = $form.attr('action');
                 $form.attr('action', action);
             }
-            if (pjax !== undefined && pjax != 0 && $.support.pjax) {
+            if (usePjax) {
                 $form.on('submit',function(e){
                     $.pjax.submit(e, pjaxOptions);
                 })


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |

This makes the behavior of links with data-pjax="0" consistent regardless of data-method property.
See https://github.com/yiisoft/jquery-pjax/blob/master/jquery.pjax.js#L78
