### PR TITLE
Document and test ListView.showOnEmpty, see #11627

### DIFF
--- a/framework/widgets/BaseListView.php
+++ b/framework/widgets/BaseListView.php
@@ -69,7 +69,9 @@ abstract class BaseListView extends Widget
      */
     public $summaryOptions = ['class' => 'summary'];
     /**
-     * @var boolean whether to show the list view if [[dataProvider]] returns no data.
+     * @var boolean whether to show an empty list view if [[dataProvider]] returns no data.
+     * The default value is false which displays an element according to the `emptyText`
+     * and `emptyTextOptions` properties.
      */
     public $showOnEmpty = false;
     /**

--- a/tests/framework/widgets/ListViewTest.php
+++ b/tests/framework/widgets/ListViewTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace yiiunit\framework\widgets;
+
+use yii\data\ArrayDataProvider;
+use yii\widgets\ListView;
+
+/**
+ * @group widgets
+ */
+class ListViewTest extends \yiiunit\TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mockApplication();
+    }
+
+    public function testEmptyListShown()
+    {
+        $dataProvider = new ArrayDataProvider([
+            'allModels' => [],
+        ]);
+
+        ob_start();
+        echo ListView::widget([
+            'dataProvider' => $dataProvider,
+            'showOnEmpty' => false,
+            'emptyText' => "Nothing at all",
+        ]);
+        $actualHtml = ob_get_clean();
+
+        $this->assertTrue(strpos($actualHtml, "Nothing at all") !== false, "displays the empty message");
+        $this->assertTrue(strpos($actualHtml, '<div class="empty">') !== false, "adds the 'empty' class");
+        $this->assertTrue(strpos($actualHtml, '<div class="summary">') === false, "does not display the summary");
+    }
+
+    public function testEmptyListNotShown()
+    {
+        $dataProvider = new ArrayDataProvider([
+            'allModels' => [],
+        ]);
+
+        ob_start();
+        echo ListView::widget([
+            'dataProvider' => $dataProvider,
+            'showOnEmpty' => true,
+            'emptyText' => "Nothing at all",
+        ]);
+        $actualHtml = ob_get_clean();
+
+        $this->assertTrue(strpos($actualHtml, '<div class="empty">') === false, "does not add the 'empty' class");
+        $this->assertTrue(strpos($actualHtml, '<div class="summary">') === false, "does not display the summary");
+        $this->assertEmpty(trim(\strip_tags($actualHtml)), "contains no text");
+    }
+}


### PR DESCRIPTION
This addresses #11627 by completing the documentation without changing the behavior. Some basic unit tests are added on ListView to ensure this won't change unintentionnally.

That means a ListView widget with an empty provider and `showOnEmpty=true` will still display an empty element (by default, an empty "div.list-view").
