### PR TITLE
RBAC migration: Changed `data` column type from `text` to `blob`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -51,6 +51,7 @@ Yii Framework 2 Change Log
 - Bug #12629: Fixed `yii\widgets\ActiveField::widget()` to call `adjustLabelFor()` for `InputWidget` descendants (coderlex)
 - Bug #12649: Fixed consistency of `indexBy` handling for `yii\db\Query::column()` (silverfire)
 - Bug #11921: Fixed URL decoding in `yii.getQueryParams()` to handle `+` (plus) character properly (silverfire)
+- Bug #12681: Changed `data` column type from `text` to `blob` to handle null-byte (`\0`) in serialized RBAC rule properly (silverfire)
 - Enh #384: Added ability to run migration from several locations via `yii\console\controllers\BaseMigrateController::$migrationNamespaces` (klimov-paul)
 - Enh #6996: Added `yii\web\MultipartFormDataParser`, which allows proper processing of 'multipart/form-data' encoded non POST requests (klimov-paul)
 - Enh #8719: Add support for HTML5 attributes on submitbutton (formaction/formmethod...) for ActiveForm (VirtualRJ)

--- a/framework/rbac/migrations/m140506_102106_rbac_init.php
+++ b/framework/rbac/migrations/m140506_102106_rbac_init.php
@@ -53,7 +53,7 @@ class m140506_102106_rbac_init extends \yii\db\Migration
 
         $this->createTable($authManager->ruleTable, [
             'name' => $this->string(64)->notNull(),
-            'data' => $this->text(),
+            'data' => $this->binary(),
             'created_at' => $this->integer(),
             'updated_at' => $this->integer(),
             'PRIMARY KEY (name)',
@@ -64,7 +64,7 @@ class m140506_102106_rbac_init extends \yii\db\Migration
             'type' => $this->integer()->notNull(),
             'description' => $this->text(),
             'rule_name' => $this->string(64),
-            'data' => $this->text(),
+            'data' => $this->binary(),
             'created_at' => $this->integer(),
             'updated_at' => $this->integer(),
             'PRIMARY KEY (name)',

--- a/framework/rbac/migrations/schema-mssql.sql
+++ b/framework/rbac/migrations/schema-mssql.sql
@@ -17,7 +17,7 @@ drop table [auth_rule];
 create table [auth_rule]
 (
     [name]  varchar(64) not null,
-    [data]  text,
+    [data]  blob,
     [created_at]           integer,
     [updated_at]           integer,
     primary key ([name])
@@ -29,7 +29,7 @@ create table [auth_item]
    [type]                 integer not null,
    [description]          text,
    [rule_name]            varchar(64),
-   [data]                 text,
+   [data]                 blob,
    [created_at]           integer,
    [updated_at]           integer,
    primary key ([name]),

--- a/framework/rbac/migrations/schema-mysql.sql
+++ b/framework/rbac/migrations/schema-mysql.sql
@@ -17,7 +17,7 @@ drop table if exists `auth_rule`;
 create table `auth_rule`
 (
    `name`                 varchar(64) not null,
-   `data`                 text,
+   `data`                 blob,
    `created_at`           integer,
    `updated_at`           integer,
     primary key (`name`)
@@ -29,7 +29,7 @@ create table `auth_item`
    `type`                 integer not null,
    `description`          text,
    `rule_name`            varchar(64),
-   `data`                 text,
+   `data`                 blob,
    `created_at`           integer,
    `updated_at`           integer,
    primary key (`name`),

--- a/framework/rbac/migrations/schema-oci.sql
+++ b/framework/rbac/migrations/schema-oci.sql
@@ -18,7 +18,7 @@ drop table "auth_rule";
 create table "auth_rule"
 (
    "name"  varchar(64) not null,
-   "data"  varchar(1000),
+   "data"  BYTEA,
    "created_at"           integer,
    "updated_at"           integer,
     primary key ("name")
@@ -31,8 +31,7 @@ create table "auth_item"
    "type"                 integer not null,
    "description"          varchar(1000),
    "rule_name"            varchar(64),
-   "data"                 varchar(1000),
-   "created_at"           integer,
+   "data"                 BYTEA,
    "updated_at"           integer,
         foreign key ("rule_name") references "auth_rule"("name") on delete set null,
         primary key ("name")

--- a/framework/rbac/migrations/schema-pgsql.sql
+++ b/framework/rbac/migrations/schema-pgsql.sql
@@ -17,7 +17,7 @@ drop table if exists "auth_rule";
 create table "auth_rule"
 (
     "name"  varchar(64) not null,
-    "data"  text,
+    "data"  bytea,
     "created_at"           integer,
     "updated_at"           integer,
     primary key ("name")
@@ -29,7 +29,7 @@ create table "auth_item"
    "type"                 integer not null,
    "description"          text,
    "rule_name"            varchar(64),
-   "data"                 text,
+   "data"                 bytea,
    "created_at"           integer,
    "updated_at"           integer,
    primary key ("name"),

--- a/framework/rbac/migrations/schema-sqlite.sql
+++ b/framework/rbac/migrations/schema-sqlite.sql
@@ -17,7 +17,7 @@ drop table if exists "auth_rule";
 create table "auth_rule"
 (
     "name"  varchar(64) not null,
-    "data"  text,
+    "data"  blob,
     "created_at"           integer,
     "updated_at"           integer,
     primary key ("name")
@@ -29,7 +29,7 @@ create table "auth_item"
    "type"                 integer not null,
    "description"          text,
    "rule_name"            varchar(64),
-   "data"                 text,
+   "data"                 blob,
    "created_at"           integer,
    "updated_at"           integer,
    primary key ("name"),

--- a/tests/framework/rbac/ActionRule.php
+++ b/tests/framework/rbac/ActionRule.php
@@ -2,13 +2,19 @@
 
 namespace yiiunit\framework\rbac;
 
+use yii\rbac\Rule;
+
 /**
  * Description of ActionRule
  */
-class ActionRule extends \yii\rbac\Rule
+class ActionRule extends Rule
 {
     public $name = 'action_rule';
     public $action = 'read';
+
+    private $somePrivateProperty;
+    protected $someProtectedProperty;
+
     public function execute($user, $item, $params)
     {
         return $this->action === 'all' || $this->action === $params['action'];

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -472,4 +472,22 @@ abstract class ManagerTestCase extends TestCase
         $auth->update('Reader', $role);
         $this->assertTrue($auth->checkAccess($userId, 'AdminPost', ['action' => 'print']));
     }
+
+    /**
+     * https://github.com/yiisoft/yii2/issues/10176
+     * https://github.com/yiisoft/yii2/issues/12681
+     */
+    public function testRuleWithPrivateFields()
+    {
+        $auth = $this->auth;
+
+        $auth->removeAll();
+
+        $rule = new ActionRule();
+        $auth->add($rule);
+
+        /** @var ActionRule $rule */
+        $rule = $this->auth->getRule('action_rule');
+        $this->assertTrue($rule instanceof ActionRule);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #12681 |

Changed `data` column type from `text` to `blob` to handle null-byte (`\0`) in serialized RBAC rule properly

Closes #12681
