### PR TITLE
added check for console controller

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,7 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #12791: Fixed `yii\behaviors\AttributeTypecastBehavior` unable to automatically detect `attributeTypes`, triggering PHP Fatal Error (klimov-paul)
 - Enh #12790: Added `scrollToErrorOffset` option for `ActiveForm` which adds ability to specify offset in pixels when scrolling to error (mg-code)
-
+- Enh #12807: Added console controller checks for `yii\console\controllers\HelpController` (schmunk42)
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/console/controllers/HelpController.php
+++ b/framework/console/controllers/HelpController.php
@@ -90,7 +90,7 @@ class HelpController extends Controller
             $description = '';
 
             $result = Yii::$app->createController($command);
-            if ($result !== false) {
+            if ($result !== false && $result[0] instanceof Controller) {
                 list($controller, $actionID) = $result;
                 /** @var Controller $controller */
                 $description = $controller->getHelpSummary();
@@ -188,7 +188,7 @@ class HelpController extends Controller
             $len = 0;
             foreach ($commands as $command => $description) {
                 $result = Yii::$app->createController($command);
-                if ($result !== false) {
+                if ($result !== false && $result[0] instanceof Controller) {
                     /** @var $controller Controller */
                     list($controller, $actionID) = $result;
                     $actions = $this->getActions($controller);
@@ -215,7 +215,7 @@ class HelpController extends Controller
                 $this->stdout("\n");
 
                 $result = Yii::$app->createController($command);
-                if ($result !== false) {
+                if ($result !== false && $result[0] instanceof Controller) {
                     list($controller, $actionID) = $result;
                     $actions = $this->getActions($controller);
                     if (!empty($actions)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no(t really) |
| Tests pass? | see travis |

This addresses errors when using command maps for the application or modules.
The help command scans i.e. command maps of modules and may pick up web controllers, which usually do not have this method.

```
root@106bd7de9315:/app# yii
Exception 'yii\base\UnknownMethodException' with message 'Calling unknown method: app\controllers\user\ProfileController::getHelpSummary()'

in /app/vendor/yiisoft/yii2/base/Component.php:285

Stack trace:
#0 /app/vendor/yiisoft/yii2/console/controllers/HelpController.php(96): yii\base\Component->__call('getHelpSummary', Array)
#1 /app/vendor/yiisoft/yii2/console/controllers/HelpController.php(184): yii\console\controllers\HelpController->getCommandDescriptions()
#2 /app/vendor/yiisoft/yii2/console/controllers/HelpController.php(67): yii\console\controllers\HelpController->getDefaultHelp()
#3 [internal function]: yii\console\controllers\HelpController->actionIndex(NULL)
#4 /app/vendor/yiisoft/yii2/base/InlineAction.php(55): call_user_func_array(Array, Array)
#5 /app/vendor/yiisoft/yii2/base/Controller.php(154): yii\base\InlineAction->runWithParams(Array)
#6 /app/vendor/yiisoft/yii2/console/Controller.php(119): yii\base\Controller->runAction('', Array)
#7 /app/vendor/yiisoft/yii2/base/Module.php(454): yii\console\Controller->runAction('', Array)
#8 /app/vendor/yiisoft/yii2/console/Application.php(176): yii\base\Module->runAction('', Array)
#9 /app/vendor/yiisoft/yii2/console/Application.php(143): yii\console\Application->runAction('', Array)
#10 /app/vendor/yiisoft/yii2/base/Application.php(375): yii\console\Application->handleRequest(Object(yii\console\Request))
#11 /app/yii(27): yii\base\Application->run()
#12 {main}
```
