### PR TITLE
Cosmetic changes in DocBlocks

### DIFF
--- a/framework/i18n/I18N.php
+++ b/framework/i18n/I18N.php
@@ -31,18 +31,18 @@ class I18N extends Component
      * category patterns, and the array values are the corresponding [[MessageSource]] objects or the configurations
      * for creating the [[MessageSource]] objects.
      *
-     * The message category patterns can contain the wildcard '*' at the end to match multiple categories with the same prefix.
-     * For example, 'app/*' matches both 'app/cat1' and 'app/cat2'.
+     * The message category patterns can contain the wildcard `*` at the end to match multiple categories with the same prefix.
+     * For example, `app/*` matches both `app/cat1` and `app/cat2`.
      *
-     * The '*' category pattern will match all categories that do not match any other category patterns.
+     * The `*` category pattern will match all categories that do not match any other category patterns.
      *
      * This property may be modified on the fly by extensions who want to have their own message sources
      * registered under their own namespaces.
      *
-     * The category "yii" and "app" are always defined. The former refers to the messages used in the Yii core
+     * The category `yii` and `app` are always defined. The former refers to the messages used in the Yii core
      * framework code, while the latter refers to the default message category for custom application code.
      * By default, both of these categories use [[PhpMessageSource]] and the corresponding message files are
-     * stored under "@yii/messages" and "@app/messages", respectively.
+     * stored under `@yii/messages` and `@app/messages`, respectively.
      *
      * You may override the configuration of both categories.
      */


### PR DESCRIPTION
In addition, it ('\*') has caused an parsing "error": http://www.yiiframework.com/doc-2.0/yii-i18n-i18n.html#$translations-detail

