### PR TITLE
custom db column schema

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,7 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #12791: Fixed `yii\behaviors\AttributeTypecastBehavior` unable to automatically detect `attributeTypes`, triggering PHP Fatal Error (klimov-paul)
 - Enh #12790: Added `scrollToErrorOffset` option for `ActiveForm` which adds ability to specify offset in pixels when scrolling to error (mg-code)
-- Eng #12816: Added `columnSchemaClass` option for `yii\db\Schema` which adds ability to specify custom `\yii\db\ColumnSchema` class (nanodesu88)
+- Enh #12816: Added `columnSchemaClass` option for `yii\db\Schema` which adds ability to specify custom `\yii\db\ColumnSchema` class (nanodesu88)
 
 
 2.0.10 October 20, 2016

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #12791: Fixed `yii\behaviors\AttributeTypecastBehavior` unable to automatically detect `attributeTypes`, triggering PHP Fatal Error (klimov-paul)
 - Enh #12790: Added `scrollToErrorOffset` option for `ActiveForm` which adds ability to specify offset in pixels when scrolling to error (mg-code)
+- Eng #12816: Added `columnSchemaClass` option for `yii\db\Schema` which adds ability to specify custom `\yii\db\ColumnSchema` class (nanodesu88)
 
 
 2.0.10 October 20, 2016

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -76,7 +76,8 @@ abstract class Schema extends Object
     ];
 
     /**
-     * @var string
+     * @var string column schema class
+     * @since 2.0.11
      */
     public $columnSchemaClass = 'yii\db\ColumnSchema';
 

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -76,6 +76,11 @@ abstract class Schema extends Object
     ];
 
     /**
+     * @var string
+     */
+    public $columnSchemaClass = 'yii\db\ColumnSchema';
+
+    /**
      * @var array list of ALL schema names in the database, except system schemas
      */
     private $_schemaNames;
@@ -99,7 +104,7 @@ abstract class Schema extends Object
      */
     protected function createColumnSchema()
     {
-        return Yii::createObject('yii\db\ColumnSchema');
+        return Yii::createObject($this->columnSchemaClass);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |

What about CustomColumnSchema? Primary for db typecasting.

Allows to do something like this:

Record.php

``` php
public function behaviors()
{
    return [
        'class' => \yii\behaviors\AttributeTypecastBehavior::class,
        'attributeTypes' => [
            'datetime' => function($value){
                if(!$value instanceof \DateTime){
                    $value = \DateTime::createFromFormat(?, $value);
                }

                return $value;
            }
        ],
        'typecastAfterFind' => true,
        'typecastAfterValidate' => false
    ];
}
```

CustomColumnSchema.php

``` php
class ColumnSchema extends \yii\db\ColumnSchema
{
    public function dbTypecast($value)
    {
        if($value instanceof \DateTime){
            return $value->format(?);
        }

        return parent::dbTypecast($value);
    }
}
```

config-db.php

``` php
'db' => [
    'class' => 'yii\db\Connection',
    'schemaMap' => [
        'pgsql' => [
            'class' => \yii\db\pgsql\Schema::class,
            'columnSchemaClass' => \common\CustomColumnSchema::class
        ]
    ]
 ]
```
