### PR TITLE
Fixed #12810: getChildRoles() throws an exception when role has no children

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #12791: Fixed `yii\behaviors\AttributeTypecastBehavior` unable to automatically detect `attributeTypes`, triggering PHP Fatal Error (klimov-paul)
+- Bug #12810: Fixed `yii\rbac\DbManager::getChildRoles()` and `yii\rbac\PhpManager::getChildRoles()` throws an exception when role has no child roles (mysterydragon)
 - Enh #12790: Added `scrollToErrorOffset` option for `ActiveForm` which adds ability to specify offset in pixels when scrolling to error (mg-code)
 - Enh #12807: Added console controller checks for `yii\console\controllers\HelpController` (schmunk42)
 

--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -481,7 +481,7 @@ class DbManager extends BaseManager
             throw new InvalidParamException("Role \"$roleName\" not found.");
         }
 
-        /** @var $result Item[] */
+        $result = [];
         $this->getChildrenRecursive($roleName, $this->getChildrenList(), $result);
 
         $roles = [$roleName => $role];

--- a/framework/rbac/PhpManager.php
+++ b/framework/rbac/PhpManager.php
@@ -407,7 +407,7 @@ class PhpManager extends BaseManager
             throw new InvalidParamException("Role \"$roleName\" not found.");
         }
 
-        /** @var $result Item[] */
+        $result = [];
         $this->getChildrenRecursive($roleName, $result);
 
         $roles = [$roleName => $role];

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -223,6 +223,9 @@ abstract class ManagerTestCase extends TestCase
         $updateAnyPost->description = 'update any post';
         $this->auth->add($updateAnyPost);
 
+        $withoutChildren = $this->auth->createRole('withoutChildren');
+        $this->auth->add($withoutChildren);
+
         $reader = $this->auth->createRole('reader');
         $this->auth->add($reader);
         $this->auth->addChild($reader, $readPost);
@@ -291,6 +294,11 @@ abstract class ManagerTestCase extends TestCase
     public function testGetChildRoles()
     {
         $this->prepareData();
+
+        $roles = $this->auth->getChildRoles('withoutChildren');
+        $this->assertCount(1, $roles);
+        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertTrue(reset($roles)->name === 'withoutChildren');
 
         $roles = $this->auth->getChildRoles('reader');
         $this->assertCount(1, $roles);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #12810 |
