### PR TITLE
Fix bug GridView::guessColumns when used sub-array (has_many_relations)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -61,6 +61,7 @@ Yii Framework 2 Change Log
 - Bug #12605: Make 'safe' validator work on write-only properties (arthibald, CeBe)
 - Bug #12629: Fixed `yii\widgets\ActiveField::widget()` to call `adjustLabelFor()` for `InputWidget` descendants (coderlex)
 - Bug #12649: Fixed consistency of `indexBy` handling for `yii\db\Query::column()` (silverfire)
+- Bug #12828: Fixed handling of nested arrays, objects in `\yii\grid\GridView::guessColumns` (githubjeka)
 - Enh #384: Added ability to run migration from several locations via `yii\console\controllers\BaseMigrateController::$migrationNamespaces` (klimov-paul)
 - Enh #6996: Added `yii\web\MultipartFormDataParser`, which allows proper processing of 'multipart/form-data' encoded non POST requests (klimov-paul)
 - Enh #8719: Add support for HTML5 attributes on submitbutton (formaction/formmethod...) for ActiveForm (VirtualRJ)

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -569,7 +569,9 @@ class GridView extends BaseListView
         $model = reset($models);
         if (is_array($model) || is_object($model)) {
             foreach ($model as $name => $value) {
-                $this->columns[] = (string) $name;
+                if ($value === null || is_scalar($value) || is_callable([$value, '__toString'])) {
+                    $this->columns[] = (string) $name;
+                }
             }
         }
     }

--- a/tests/framework/grid/GridViewTest.php
+++ b/tests/framework/grid/GridViewTest.php
@@ -1,0 +1,62 @@
+<?php
+
+
+namespace yiiunit\framework\grid;
+
+use yii\data\ArrayDataProvider;
+use yii\grid\DataColumn;
+use yii\grid\GridView;
+
+/**
+ * @author Evgeniy Tkachenko <et.coder@gmail.com>
+ * @group grid
+ */
+class GridViewTest extends \yiiunit\TestCase
+{
+    public function testGuessColumns()
+    {
+        $this->mockApplication();
+        $row = ['id' => 1, 'name' => 'Name1', 'value' => 'Value1', 'description' => 'Description1',];
+
+        $grid = new GridView([
+            'dataProvider' => new ArrayDataProvider(
+                [
+                    'allModels' => [
+                        $row,
+                    ],
+                ]
+            ),
+        ]);
+
+        $columns = $grid->columns;
+        $this->assertCount(count($row), $columns);
+
+        foreach ($columns as $index => $column) {
+            $this->assertInstanceOf(DataColumn::className(), $column);
+            $this->assertArrayHasKey($column->attribute, $row);
+        }
+
+        $row = array_merge($row, ['relation' => ['id' => 1, 'name' => 'RelationName',],]);
+        $row = array_merge($row, ['otherRelation' => (object)$row['relation']]);
+
+        $grid = new GridView([
+            'dataProvider' => new ArrayDataProvider(
+                [
+                    'allModels' => [
+                        $row,
+                    ],
+                ]
+            ),
+        ]);
+
+        $columns = $grid->columns;
+        $this->assertCount(count($row) - 2, $columns);
+
+        foreach ($columns as $index => $column) {
+            $this->assertInstanceOf(DataColumn::className(), $column);
+            $this->assertArrayHasKey($column->attribute, $row);
+            $this->assertNotEquals('relation', $column->attribute);
+            $this->assertNotEquals('otherRelation', $column->attribute);
+        }
+    }
+}


### PR DESCRIPTION
> yii\base\ErrorException: htmlspecialchars() expects parameter 1 to be string, array given in

| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |

``` php
$query = MyModel::find()
    ->joinWith([
        'relationName' => function (ActiveQuery $query) {
            //...
        },
    ]);

$dataProvider = new ArrayDataProvider([
    'allModels' => $query->asArray()->all(),
    'pagination' => false,
]);
```

then

``` php
$models === [ ... ,'relationName'=>[...]]
```

that why I get error:

```
yii\base\ErrorException: htmlspecialchars() expects parameter 1 to be string, array given in
/var/www/html/site/yii2-app-advanced/vendor/yiisoft/yii2/helpers/BaseHtml.php:104
/var/www/html/site/yii2-app-advanced/vendor/yiisoft/yii2/i18n/Formatter.php(351):
yii\helpers\BaseHtml::encode(Array)
[internal function]: yii\i18n\Formatter->asText(Array)
/var/www/html/site/yii2-app-advanced/vendor/yiisoft/yii2/widgets/BaseListView.php(129):
/var/www/html/site/yii2-app-advanced/vendor/yiisoft/yii2/grid/GridView.php(288):
yii\widgets\BaseListView->run()
```
