### PR TITLE
Fixed #11037: yii.js and yii.validation.js should use Regexp.test instead of String.match

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Enh #12816: Added `columnSchemaClass` option for `yii\db\Schema` which adds ability to specify custom `\yii\db\ColumnSchema` class (nanodesu88)
 - Enh #12807: Added console controller checks for `yii\console\controllers\HelpController` (schmunk42)
 - Bug #12824: Enabled usage of `yii\mutex\FileMutex` on Windows systems (davidsonalencar)
+- Enh #11037 yii.js and yii.validation.js should use Regexp.test instead of String.match (arogachev, nkovacs)
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -208,7 +208,8 @@ window.yii = (function ($) {
 
             var newForm = !$form.length;
             if (newForm) {
-                if (!action || !action.match(/(^\/|:\/\/)/)) {
+                var regexp = /(^\/|:\/\/)/;
+                if (!action || !regexp.test(action)) {
                     action = window.location.href;
                 }
                 $form = $('<form/>', {method: method, action: action});
@@ -216,11 +217,13 @@ window.yii = (function ($) {
                 if (target) {
                     $form.attr('target', target);
                 }
-                if (!method.match(/(get|post)/i)) {
+                regexp = /(get|post)/i;
+                if (!regexp.test(method)) {
                     $form.append($('<input/>', {name: '_method', value: method, type: 'hidden'}));
                     method = 'POST';
                 }
-                if (!method.match(/(get|head|options)/i)) {
+                regexp = /(get|head|options)/i;
+                if (!regexp.test(method)) {
                     var csrfParam = pub.getCsrfParam();
                     if (csrfParam) {
                         $form.append($('<input/>', {name: csrfParam, value: pub.getCsrfToken(), type: 'hidden'}));

--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -136,7 +136,7 @@ yii.validation = (function ($) {
                 return;
             }
 
-            if (typeof value === 'string' && !value.match(options.pattern)) {
+            if (typeof value === 'string' && !options.pattern.test(value)) {
                 pub.addMessage(messages, options.message, value);
                 return;
             }
@@ -180,7 +180,7 @@ yii.validation = (function ($) {
                 return;
             }
 
-            if (!options.not && !value.match(options.pattern) || options.not && value.match(options.pattern)) {
+            if (!options.not && !options.pattern.test(value) || options.not && options.pattern.test(value)) {
                 pub.addMessage(messages, options.message, value);
             }
         },
@@ -211,7 +211,7 @@ yii.validation = (function ($) {
                 } else if ((matches[5] + '@' + matches[6]).length > 254) {
                     valid = false;
                 } else {
-                    valid = value.match(options.pattern) || (options.allowName && value.match(options.fullPattern));
+                    valid = options.pattern.test(value) || (options.allowName && options.fullPattern.test(value));
                 }
             }
 
@@ -225,15 +225,16 @@ yii.validation = (function ($) {
                 return;
             }
 
-            if (options.defaultScheme && !value.match(/:\/\//)) {
+            var regexp = /:\/\//;
+            if (options.defaultScheme && !regexp.test(value)) {
                 value = options.defaultScheme + '://' + value;
             }
 
             var valid = true;
 
             if (options.enableIDN) {
-                var regexp = /^([^:]+):\/\/([^\/]+)(.*)$/,
-                    matches = regexp.exec(value);
+                regexp = /^([^:]+):\/\/([^\/]+)(.*)$/;
+                matches = regexp.exec(value);
                 if (matches === null) {
                     valid = false;
                 } else {
@@ -241,7 +242,7 @@ yii.validation = (function ($) {
                 }
             }
 
-            if (!valid || !value.match(options.pattern)) {
+            if (!valid || !options.pattern.test(value)) {
                 pub.addMessage(messages, options.message, value);
             }
         },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11037 |
