### PR TITLE
Added RangeNotSatisfiableHttpException that uses when the requested range is not satisfiable

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -45,7 +45,7 @@ Yii Framework 2 Change Log
 - Enh #13035: Use ArrayHelper::getValue() in SluggableBehavior::getValue() (thyseus)
 - Enh #13020: Added `disabledListItemSubTagOptions` attribute for `yii\widgets\LinkPager` in order to customize the disabled list item sub tag element (nadar)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
-
+- Enh #12854: Added `RangeNotSatisfiableHttpException` that uses when the requested range is not satisfiable (zalatov)
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/web/RangeNotSatisfiableHttpException.php
+++ b/framework/web/RangeNotSatisfiableHttpException.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\web;
+
+/**
+ * RangeNotSatisfiableHttpException represents an exception caused by an improper request of the end-user.
+ * This exception uses when the requested range is not satisfiable.
+ *
+ * Throwing an RangeNotSatisfiableHttpException like in the following example will result in the 416 page to be displayed.
+ *
+ * @author Zalatov Alexander <CaHbKa.Z@gmail.com>
+ *
+ * @since 2.0.11
+ */
+class RangeNotSatisfiableHttpException extends HttpException
+{
+    /**
+     * Constructor.
+     * @param string $message error message
+     * @param integer $code error code
+     * @param \Exception $previous The previous exception used for the exception chaining.
+     */
+    public function __construct($message = null, $code = 0, \Exception $previous = null)
+    {
+        parent::__construct(416, $message, $code, $previous);
+    }
+}

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -482,7 +482,7 @@ class Response extends \yii\base\Response
      *    meaning a download dialog will pop up.
      *
      * @return $this the response object itself
-     * @throws HttpException if the requested range is not satisfiable
+     * @throws RangeNotSatisfiableHttpException if the requested range is not satisfiable
      * @see sendFile() for an example implementation.
      */
     public function sendContentAsFile($content, $attachmentName, $options = [])
@@ -494,7 +494,7 @@ class Response extends \yii\base\Response
 
         if ($range === false) {
             $headers->set('Content-Range', "bytes */$contentLength");
-            throw new HttpException(416, 'Requested range not satisfiable');
+            throw new RangeNotSatisfiableHttpException();
         }
 
         list($begin, $end) = $range;
@@ -533,7 +533,7 @@ class Response extends \yii\base\Response
      *    This option is available since version 2.0.4.
      *
      * @return $this the response object itself
-     * @throws HttpException if the requested range cannot be satisfied.
+     * @throws RangeNotSatisfiableHttpException if the requested range cannot be satisfied.
      * @see sendFile() for an example implementation.
      */
     public function sendStreamAsFile($handle, $attachmentName, $options = [])
@@ -549,7 +549,7 @@ class Response extends \yii\base\Response
         $range = $this->getHttpRange($fileSize);
         if ($range === false) {
             $headers->set('Content-Range', "bytes */$fileSize");
-            throw new HttpException(416, 'Requested range not satisfiable');
+            throw new RangeNotSatisfiableHttpException();
         }
 
         list($begin, $end) = $range;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues |  |

It's need to catch this error.
For example, we can't need to log this error.
Now we can do `try...catch` or add it to exclude category.
