### PR TITLE
Fixed #9796: Initialization of not existing yii\grid\ActionColumn default buttons

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Enh #12807: Added console controller checks for `yii\console\controllers\HelpController` (schmunk42)
 - Bug #12824: Enabled usage of `yii\mutex\FileMutex` on Windows systems (davidsonalencar)
 - Enh #11037 yii.js and yii.validation.js should use Regexp.test instead of String.match (arogachev, nkovacs)
+- Bug #9796: Initialization of not existing `yii\grid\ActionColumn` default buttons (arogachev)
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -153,6 +153,7 @@ class ActionColumn extends Column
      * @param string $name Button name as it's written in template
      * @param string $iconName The part of Bootstrap glyphicon class that makes it unique
      * @param array $additionalOptions Array of additional options
+     * @since 2.0.11
      */
     protected function initDefaultButton($name, $iconName, $additionalOptions = [])
     {

--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -120,7 +120,7 @@ class ActionColumn extends Column
      */
     public $urlCreator;
     /**
-     * @var array html options to be applied to the [[initDefaultButtons()|default buttons]].
+     * @var array html options to be applied to the [[initDefaultButton()|default button]].
      * @since 2.0.4
      */
     public $buttonOptions = [];
@@ -140,36 +140,32 @@ class ActionColumn extends Column
      */
     protected function initDefaultButtons()
     {
-        if (!isset($this->buttons['view'])) {
-            $this->buttons['view'] = function ($url, $model, $key) {
+        $this->initDefaultButton('view', 'eye-open');
+        $this->initDefaultButton('update', 'pencil');
+        $this->initDefaultButton('delete', 'trash', [
+            'data-confirm' => Yii::t('yii', 'Are you sure you want to delete this item?'),
+            'data-method' => 'post',
+        ]);
+    }
+
+    /**
+     * Initializes the default button rendering callback for single button
+     * @param string $name Button name as it's written in template
+     * @param string $iconName The part of Bootstrap glyphicon class that makes it unique
+     * @param array $additionalOptions Array of additional options
+     */
+    protected function initDefaultButton($name, $iconName, $additionalOptions = [])
+    {
+        if (!isset($this->buttons[$name]) && strpos($this->template, $name) !== false) {
+            $this->buttons[$name] = function ($url, $model, $key) use ($name, $iconName, $additionalOptions) {
+                $title = Yii::t('yii', ucfirst($name));
                 $options = array_merge([
-                    'title' => Yii::t('yii', 'View'),
-                    'aria-label' => Yii::t('yii', 'View'),
+                    'title' => $title,
+                    'aria-label' => $title,
                     'data-pjax' => '0',
-                ], $this->buttonOptions);
-                return Html::a('<span class="glyphicon glyphicon-eye-open"></span>', $url, $options);
-            };
-        }
-        if (!isset($this->buttons['update'])) {
-            $this->buttons['update'] = function ($url, $model, $key) {
-                $options = array_merge([
-                    'title' => Yii::t('yii', 'Update'),
-                    'aria-label' => Yii::t('yii', 'Update'),
-                    'data-pjax' => '0',
-                ], $this->buttonOptions);
-                return Html::a('<span class="glyphicon glyphicon-pencil"></span>', $url, $options);
-            };
-        }
-        if (!isset($this->buttons['delete'])) {
-            $this->buttons['delete'] = function ($url, $model, $key) {
-                $options = array_merge([
-                    'title' => Yii::t('yii', 'Delete'),
-                    'aria-label' => Yii::t('yii', 'Delete'),
-                    'data-confirm' => Yii::t('yii', 'Are you sure you want to delete this item?'),
-                    'data-method' => 'post',
-                    'data-pjax' => '0',
-                ], $this->buttonOptions);
-                return Html::a('<span class="glyphicon glyphicon-trash"></span>', $url, $options);
+                ], $additionalOptions, $this->buttonOptions);
+                $icon = Html::tag('span', '', ['class' => "glyphicon glyphicon-$iconName"]);
+                return Html::a($icon, $url, $options);
             };
         }
     }

--- a/tests/framework/grid/ActionColumnTest.php
+++ b/tests/framework/grid/ActionColumnTest.php
@@ -17,13 +17,13 @@ class ActionColumnTest extends \yiiunit\TestCase
     public function testInit()
     {
         $column = new ActionColumn();
-        $this->assertCount(3, $column->buttons);
+        $this->assertEquals(['view', 'update', 'delete'], array_keys($column->buttons));
 
         $column = new ActionColumn(['template' => '{show} {edit} {delete}']);
-        $this->assertCount(1, $column->buttons);
+        $this->assertEquals(['delete'], array_keys($column->buttons));
 
         $column = new ActionColumn(['template' => '{show} {edit} {remove}']);
-        $this->assertCount(0, $column->buttons);
+        $this->assertEmpty($column->buttons);
     }
 
     public function testRenderDataCell()

--- a/tests/framework/grid/ActionColumnTest.php
+++ b/tests/framework/grid/ActionColumnTest.php
@@ -14,8 +14,31 @@ use yii\grid\ActionColumn;
  */
 class ActionColumnTest extends \yiiunit\TestCase
 {
+    public function testInit()
+    {
+        $column = new ActionColumn();
+        $this->assertCount(3, $column->buttons);
+
+        $column = new ActionColumn(['template' => '{show} {edit} {delete}']);
+        $this->assertCount(1, $column->buttons);
+
+        $column = new ActionColumn(['template' => '{show} {edit} {remove}']);
+        $this->assertCount(0, $column->buttons);
+    }
+
     public function testRenderDataCell()
     {
+        $column = new ActionColumn();
+        $column->urlCreator = function($model, $key, $index) {
+            return 'http://test.com';
+        };
+        $columnContents = $column->renderDataCell(['id' => 1], 1, 0);
+        $viewButton = '<a href="http://test.com" title="View" aria-label="View" data-pjax="0"><span class="glyphicon glyphicon-eye-open"></span></a>';
+        $updateButton = '<a href="http://test.com" title="Update" aria-label="Update" data-pjax="0"><span class="glyphicon glyphicon-pencil"></span></a>';
+        $deleteButton = '<a href="http://test.com" title="Delete" aria-label="Delete" data-pjax="0" data-confirm="Are you sure you want to delete this item?" data-method="post"><span class="glyphicon glyphicon-trash"></span></a>';
+        $expectedHtml = "<td>$viewButton $updateButton $deleteButton</td>";
+        $this->assertEquals($expectedHtml, $columnContents);
+
         $column = new ActionColumn();
         $column->urlCreator = function($model, $key, $index) {
             return 'http://test.com';
@@ -60,4 +83,4 @@ class ActionColumnTest extends \yiiunit\TestCase
         $this->assertNotContains('update_button', $columnContents);
 
     }
-} 
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #9796 |

Also refactored `initDefaultButtons` method mostly because of copy paste. Otherwise the amount of copy pasted code would be even more after this fix.

Added tests for that and test to ensure that we get correct html in case of using default template.

And fixed code style trifles - last line had extra whitespace after closing bracket and linebreak at the very end of the file was missing.
