### PR TITLE
Added braces check for initDefaultButton

### DIFF
--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -157,7 +157,7 @@ class ActionColumn extends Column
      */
     protected function initDefaultButton($name, $iconName, $additionalOptions = [])
     {
-        if (!isset($this->buttons[$name]) && strpos($this->template, $name) !== false) {
+        if (!isset($this->buttons[$name]) && strpos($this->template, '{' . $name . '}') !== false) {
             $this->buttons[$name] = function ($url, $model, $key) use ($name, $iconName, $additionalOptions) {
                 $title = Yii::t('yii', ucfirst($name));
                 $options = array_merge([

--- a/tests/framework/grid/ActionColumnTest.php
+++ b/tests/framework/grid/ActionColumnTest.php
@@ -24,6 +24,12 @@ class ActionColumnTest extends \yiiunit\TestCase
 
         $column = new ActionColumn(['template' => '{show} {edit} {remove}']);
         $this->assertEmpty($column->buttons);
+
+        $column = new ActionColumn(['template' => '{view-items} {update-items} {delete-items}']);
+        $this->assertEmpty($column->buttons);
+
+        $column = new ActionColumn(['template' => '{view} {view-items}']);
+        $this->assertEquals(['view'], array_keys($column->buttons));
     }
 
     public function testRenderDataCell()


### PR DESCRIPTION
Prevents init default button when the template contains similar names

| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #12859, #9796 |
