### PR TITLE
Added removeValue method to ArrayHelper

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -17,6 +17,7 @@ Yii Framework 2 Change Log
 - Enh #11037 yii.js and yii.validation.js should use Regexp.test instead of String.match (arogachev, nkovacs)
 - Bug #9796: Initialization of not existing `yii\grid\ActionColumn` default buttons (arogachev)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
+- Enh #12881: Added `removeValue` method to `yii\helpers\BaseArrayHelper` (nilsburg)
 
 
 2.0.10 October 20, 2016

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -247,6 +247,38 @@ class BaseArrayHelper
     }
 
     /**
+     * Removes items with matching values from the array and returns the removed items.
+     *
+     * Example,
+     *
+     * ```php
+     * $array = ['Bob' => 'Dylan', 'Michael' => 'Jackson', 'Mick' => 'Jagger', 'Janet' => 'Jackson'];
+     * $removed = \yii\helpers\ArrayHelper::removeValue($array, 'Jackson');
+     * // result:
+     * // $array = ['Bob' => 'Dylan', 'Mick' => 'Jagger'];
+     * // $removed = ['Michael' => 'Jackson', 'Janet' => 'Jackson'];
+     * ```
+     *
+     * @param array $array the array where to look the value from
+     * @param string $value the value to remove from the array
+     * @return array the items that were removed from the array
+     * @since 2.0.11
+     */
+    public static function removeValue(&$array, $value)
+    {
+        $result = [];
+        if (is_array($array)) {
+            foreach ($array as $key => $val) {
+                if ($val === $value) {
+                    $result[$key] = $val;
+                    unset($array[$key]);
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
      * Indexes and/or groups the array according to a specified key.
      * The input should be either multidimensional array or an array of objects.
      *

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -142,6 +142,47 @@ class ArrayHelperTest extends TestCase
         $this->assertEquals('defaultValue', $default);
     }
 
+    public function testRemoveValueMultiple()
+    {
+        $array = [
+            'Bob' => 'Dylan',
+            'Michael' => 'Jackson',
+            'Mick' => 'Jagger',
+            'Janet' => 'Jackson'
+        ];
+
+        $removed = ArrayHelper::removeValue($array, 'Jackson');
+
+        $this->assertEquals([
+            'Bob' => 'Dylan',
+            'Mick' => 'Jagger'
+        ], $array);
+        $this->assertEquals([
+            'Michael' => 'Jackson',
+            'Janet' => 'Jackson'
+        ], $removed);
+    }
+
+    public function testRemoveValueNotExisting()
+    {
+        $array = [
+            'Bob' => 'Dylan',
+            'Michael' => 'Jackson',
+            'Mick' => 'Jagger',
+            'Janet' => 'Jackson'
+        ];
+
+        $removed = ArrayHelper::removeValue($array, 'Marley');
+
+        $this->assertEquals([
+            'Bob' => 'Dylan',
+            'Michael' => 'Jackson',
+            'Mick' => 'Jagger',
+            'Janet' => 'Jackson'
+        ], $array);
+        $this->assertEquals([], $removed);
+    }
+
     public function testMultisort()
     {
         // single key


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

New method in ArrayHelper to remove an item by value.

```php
// $array = ['value1', 'value2'];
$key = \yii\helpers\ArrayHelper::removeValue($array, 'value2');
// result:
// $array = ['value1']
