### PR TITLE
The test is not being used

### DIFF
--- a/tests/framework/ar/ActiveRecordTestTrait.php
+++ b/tests/framework/ar/ActiveRecordTestTrait.php
@@ -163,6 +163,8 @@ trait ActiveRecordTestTrait
 
     public function testFindScalar()
     {
+        throw new \Exception('The test is not being used');
+
         /* @var $customerClass \yii\db\ActiveRecordInterface */
         $customerClass = $this->getCustomerClass();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

The test `\yiiunit\framework\ar\ActiveRecordTestTrait::testFindScalar()` is not being used
There are other tests of a trait are not used.

