### PR TITLE
Enh Dependency getHasChanged

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,8 +6,6 @@ Yii Framework 2 Change Log
 
 - Bug #4113: Error page stacktrace was generating links to private methods which are not part of the API docs (samdark)
 - Bug #9796: Initialization of not existing `yii\grid\ActionColumn` default buttons (arogachev)
-- Enh #12798: Changed `yii\cache\Dependency::getHasChanged()` (deprecated in 2.1) to `yii\cache\Dependency::isChanged()` (dynasource)
-- Enh #12798: Changed `yii\cache\Dependency::getHasChanged()` (to be deprecated in 2.1) to `yii\cache\Dependency::isChanged()` (dynasource)
 - Enh #12798: Changed `yii\cache\Dependency::getHasChanged()` (deprecated, to be removed in 2.1) to `yii\cache\Dependency::isChanged()` (dynasource)
 - Bug #12791: Fixed `yii\behaviors\AttributeTypecastBehavior` unable to automatically detect `attributeTypes`, triggering PHP Fatal Error (klimov-paul)
 - Bug #12803, #12921: Fixed BC break in `yii.activeForm.js` introduced in #11999. Reverted commit 3ba72da (silverfire)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #4113: Error page stacktrace was generating links to private methods which are not part of the API docs (samdark)
 - Bug #9796: Initialization of not existing `yii\grid\ActionColumn` default buttons (arogachev)
 - Enh #12798: Changed `yii\cache\Dependency::getHasChanged()` (deprecated in 2.1) to `yii\cache\Dependency::isChanged()` (dynasource)
+- Enh #12798: Changed `yii\cache\Dependency::getHasChanged()` (to be deprecated in 2.1) to `yii\cache\Dependency::isChanged()` (dynasource)
 - Bug #12791: Fixed `yii\behaviors\AttributeTypecastBehavior` unable to automatically detect `attributeTypes`, triggering PHP Fatal Error (klimov-paul)
 - Bug #12803, #12921: Fixed BC break in `yii.activeForm.js` introduced in #11999. Reverted commit 3ba72da (silverfire)
 - Bug #12810: Fixed `yii\rbac\DbManager::getChildRoles()` and `yii\rbac\PhpManager::getChildRoles()` throws an exception when role has no child roles (mysterydragon)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #4113: Error page stacktrace was generating links to private methods which are not part of the API docs (samdark)
 - Bug #9796: Initialization of not existing `yii\grid\ActionColumn` default buttons (arogachev)
+- Enh #12798: Changed `yii\cache\Dependency::getHasChanged()` (deprecated in 2.1) to `yii\cache\Dependency::isChanged()` (dynasource)
 - Bug #12791: Fixed `yii\behaviors\AttributeTypecastBehavior` unable to automatically detect `attributeTypes`, triggering PHP Fatal Error (klimov-paul)
 - Bug #12803, #12921: Fixed BC break in `yii.activeForm.js` introduced in #11999. Reverted commit 3ba72da (silverfire)
 - Bug #12810: Fixed `yii\rbac\DbManager::getChildRoles()` and `yii\rbac\PhpManager::getChildRoles()` throws an exception when role has no child roles (mysterydragon)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Bug #9796: Initialization of not existing `yii\grid\ActionColumn` default buttons (arogachev)
 - Enh #12798: Changed `yii\cache\Dependency::getHasChanged()` (deprecated in 2.1) to `yii\cache\Dependency::isChanged()` (dynasource)
 - Enh #12798: Changed `yii\cache\Dependency::getHasChanged()` (to be deprecated in 2.1) to `yii\cache\Dependency::isChanged()` (dynasource)
+- Enh #12798: Changed `yii\cache\Dependency::getHasChanged()` (deprecated, to be removed in 2.1) to `yii\cache\Dependency::isChanged()` (dynasource)
 - Bug #12791: Fixed `yii\behaviors\AttributeTypecastBehavior` unable to automatically detect `attributeTypes`, triggering PHP Fatal Error (klimov-paul)
 - Bug #12803, #12921: Fixed BC break in `yii.activeForm.js` introduced in #11999. Reverted commit 3ba72da (silverfire)
 - Bug #12810: Fixed `yii\rbac\DbManager::getChildRoles()` and `yii\rbac\PhpManager::getChildRoles()` throws an exception when role has no child roles (mysterydragon)

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -112,7 +112,7 @@ abstract class Cache extends Component implements \ArrayAccess
         } else {
             $value = call_user_func($this->serializer[1], $value);
         }
-        if (is_array($value) && !($value[1] instanceof Dependency && $value[1]->getHasChanged($this))) {
+        if (is_array($value) && !($value[1] instanceof Dependency && $value[1]->isChanged($this))) {
             return $value[0];
         } else {
             return false;
@@ -184,7 +184,7 @@ abstract class Cache extends Component implements \ArrayAccess
                     $value = $this->serializer === null ? unserialize($values[$newKey])
                         : call_user_func($this->serializer[1], $values[$newKey]);
 
-                    if (is_array($value) && !($value[1] instanceof Dependency && $value[1]->getHasChanged($this))) {
+                    if (is_array($value) && !($value[1] instanceof Dependency && $value[1]->isChanged($this))) {
                         $results[$key] = $value[0];
                     }
                 }

--- a/framework/caching/ChainedDependency.php
+++ b/framework/caching/ChainedDependency.php
@@ -58,22 +58,17 @@ class ChainedDependency extends Dependency
     }
 
     /**
-     * Performs the actual dependency checking.
-     * This method returns true if any of the dependency objects
-     * reports a dependency change.
-     * @param Cache $cache the cache component that is currently evaluating this dependency
-     * @return bool whether the dependency is changed or not.
+     * @inheritdoc
      */
-    public function getHasChanged($cache)
+    public function isChanged($cache)
     {
         foreach ($this->dependencies as $dependency) {
-            if ($this->dependOnAll && $dependency->getHasChanged($cache)) {
+            if ($this->dependOnAll && $dependency->isChanged($cache)) {
                 return true;
-            } elseif (!$this->dependOnAll && !$dependency->getHasChanged($cache)) {
+            } elseif (!$this->dependOnAll && !$dependency->isChanged($cache)) {
                 return false;
             }
         }
-
         return !$this->dependOnAll;
     }
 }

--- a/framework/caching/Dependency.php
+++ b/framework/caching/Dependency.php
@@ -58,11 +58,19 @@ abstract class Dependency extends \yii\base\Object
     }
 
     /**
-     * Returns a value indicating whether the dependency has changed.
+     * @deprecated since version 2.0.11. Will be removed in version 2.1
+     */
+    public function getHasChanged($cache)
+    {
+        return $this->isChanged($cache);
+    }
+
+    /**
+     * Checks whether the dependency is changed
      * @param Cache $cache the cache component that is currently evaluating this dependency
      * @return bool whether the dependency has changed.
      */
-    public function getHasChanged($cache)
+    public function isChanged($cache)
     {
         if ($this->reusable) {
             $hash = $this->generateReusableHash();
@@ -99,7 +107,7 @@ abstract class Dependency extends \yii\base\Object
     }
 
     /**
-     * Generates the data needed to determine if dependency has been changed.
+     * Generates the data needed to determine if dependency is changed.
      * Derived classes should override this method to generate the actual dependency data.
      * @param Cache $cache the cache component that is currently evaluating this dependency
      * @return mixed the data needed to determine if dependency has been changed.

--- a/framework/caching/TagDependency.php
+++ b/framework/caching/TagDependency.php
@@ -58,11 +58,9 @@ class TagDependency extends Dependency
     }
 
     /**
-     * Performs the actual dependency checking.
-     * @param Cache $cache the cache component that is currently evaluating this dependency
-     * @return bool whether the dependency is changed or not.
+     * @inheritdoc
      */
-    public function getHasChanged($cache)
+    public function isChanged($cache)
     {
         $timestamps = $this->getTimestamps($cache, (array) $this->tags);
         return $timestamps !== $this->data;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -100,6 +100,14 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * Invokes a inaccessible method
+     * @param $object
+     * @param $method
+     * @param array $args
+     * @return mixed
+     * @since 2.0.11
+     */
     protected function invokeMethod($object, $method, $args = [])
     {
         $reflection = new \ReflectionClass($object->className());
@@ -107,6 +115,49 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         $method->setAccessible(true);
         return $method->invokeArgs($object, $args);
     }
+
+    /**
+     * Sets an inaccessible object property to a designated value
+     * @param $object
+     * @param $propertyName
+     * @param $value
+     * @param bool $revoke
+     * @since 2.0.11
+     */
+    protected function setInaccessibleProperty($object, $propertyName, $value, $revoke = true)
+    {
+        $class = new \ReflectionClass($object);
+        while (!$class->hasProperty($propertyName)) {
+            $class = $class->getParentClass();
+        }
+        $property = $class->getProperty($propertyName);
+        $property->setAccessible(true);
+        $property->setValue($value);
+        if($revoke){
+            $property->setAccessible(false);
+        }
+    }
+
+    /**
+     * Gets an inaccessible object property
+     * @param $object
+     * @param $propertyName
+     * @return mixed
+     */
+    protected function getInaccessibleProperty($object, $propertyName)
+    {
+        $class = new \ReflectionClass($object);
+        while (!$class->hasProperty($propertyName)) {
+            $class = $class->getParentClass();
+        }
+        $property = $class->getProperty($propertyName);
+        $property->setAccessible(true);
+        return $property->getValue($object);
+    }
+
+
+
+
 
 
 }

--- a/tests/data/cache/MockDependency.php
+++ b/tests/data/cache/MockDependency.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace yiiunit\data\cache;
+
+use yii\caching\Dependency;
+
+/**
+ * Class MockDependency
+ * @package tests\data\cache
+ *
+ * @author Boudewijn Vahrmeijer <vahrmeijer@gmail.com>
+ * @since 2.0.11
+ */
+class MockDependency extends Dependency
+{
+    protected function generateDependencyData($cache)
+    {
+        return $this->data;
+    }
+}

--- a/tests/framework/caching/DependencyTest.php
+++ b/tests/framework/caching/DependencyTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace yiiunit\framework\caching;
+
+
+use yii\caching\Cache;
+use yii\caching\Dependency;
+use yiiunit\data\cache\MockDependency;
+use yiiunit\TestCase;
+
+/**
+ * Dependency (abstract) tests
+ * @group caching
+ * @author Boudewijn Vahrmeijer <vahrmeijer@gmail.com>
+ * @since 2.0.11
+ */
+class DependencyTest extends TestCase
+{
+    public function testResetReusableData()
+    {
+        $value = ['dummy'];
+        $dependency = new MockDependency();
+        $this->setInaccessibleProperty($dependency, '_reusableData', $value, false);
+        $this->assertEquals($value, $this->getInaccessibleProperty($dependency, '_reusableData'));
+
+        $dependency->resetReusableData();
+
+        $this->assertEquals([], $this->getInaccessibleProperty($dependency, '_reusableData'));
+    }
+
+    public function testGenerateReusableHash()
+    {
+        $dependency = $this->getMockForAbstractClass(Dependency::class);
+        $dependency->data = 'dummy';
+
+        $result = $this->invokeMethod($dependency, 'generateReusableHash');
+        $this->assertEquals(5, strlen($dependency->data));
+        $this->assertEquals(40, strlen($result));
+    }
+
+    public function testisChanged()
+    {
+        $dependency = $this->getMockForAbstractClass(Dependency::class);
+        $cache = $this->getMockForAbstractClass(Cache::class);
+
+        $result = $dependency->isChanged($cache);
+        $this->assertFalse($result);
+
+        $dependency->data = 'changed';
+        $result = $dependency->isChanged($cache);
+        $this->assertTrue($result);
+    }
+}

--- a/tests/framework/caching/DependencyTest.php
+++ b/tests/framework/caching/DependencyTest.php
@@ -29,7 +29,7 @@ class DependencyTest extends TestCase
 
     public function testGenerateReusableHash()
     {
-        $dependency = $this->getMockForAbstractClass(Dependency::class);
+        $dependency = $this->getMockForAbstractClass(Dependency::className());
         $dependency->data = 'dummy';
 
         $result = $this->invokeMethod($dependency, 'generateReusableHash');
@@ -39,8 +39,8 @@ class DependencyTest extends TestCase
 
     public function testisChanged()
     {
-        $dependency = $this->getMockForAbstractClass(Dependency::class);
-        $cache = $this->getMockForAbstractClass(Cache::class);
+        $dependency = $this->getMockForAbstractClass(Dependency::className());
+        $cache = $this->getMockForAbstractClass(Cache::className());
 
         $result = $dependency->isChanged($cache);
         $this->assertFalse($result);


### PR DESCRIPTION
Fixes 2. of https://github.com/yiisoft/yii2/issues/12798

    - rename getHasChanged() to isChanged()
    - updated docs
    - added tests for Dependency
    - added useful helpers for inaccessible properties to TestCase