### PR TITLE
Fixed #12939: Hard coded table names for MSSQL in RBAC migration

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -25,12 +25,8 @@ Yii Framework 2 Change Log
 - Enh #12816: Added `columnSchemaClass` option for `yii\db\Schema` which adds ability to specify custom `yii\db\ColumnSchema` class (nanodesu88)
 - Enh #12881: Added `removeValue` method to `yii\helpers\BaseArrayHelper` (nilsburg)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
-
--- Enh #12748: Added Migration tool automatic generation reference column for foreignKey (MKiselev)
-- Enh #12790: Added `scrollToErrorOffset` option for `ActiveForm` which adds ability to specify offset in pixels when scrolling to error (mg-code)
-- Enh #12748: Migration generator now tries to fetch reference column name for foreignKey from schema if it's not set explicitly (MKiselev)
-- Bug #4113: Error page stacktrace was generating links to private methods which are not part of the API docs (samdark)
 - Enh #12901: Added `getDefaultHelpHeader` method to the `yii\console\controllers\HelpController` class to be able to override default help header in a class heir (diezztsk)
+- Bug #12939: Hard coded table names for MSSQL in RBAC migration (arogachev)
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/rbac/migrations/m140506_102106_rbac_init.php
+++ b/framework/rbac/migrations/m140506_102106_rbac_init.php
@@ -103,10 +103,10 @@ class m140506_102106_rbac_init extends \yii\db\Migration
                 BEGIN
                     IF @old_name <> @new_name
                     BEGIN
-                        ALTER TABLE auth_item_child NOCHECK CONSTRAINT FK__auth_item__child;
-                        UPDATE auth_item_child SET child = @new_name WHERE child = @old_name;
+                        ALTER TABLE {$authManager->itemChildTable} NOCHECK CONSTRAINT FK__auth_item__child;
+                        UPDATE {$authManager->itemChildTable} SET child = @new_name WHERE child = @old_name;
                     END
-                UPDATE auth_item
+                UPDATE {$authManager->itemTable}
                 SET name = (SELECT name FROM inserted),
                 type = (SELECT type FROM inserted),
                 description = (SELECT description FROM inserted),
@@ -117,7 +117,7 @@ class m140506_102106_rbac_init extends \yii\db\Migration
                 WHERE name IN (SELECT name FROM deleted)
                 IF @old_name <> @new_name
                     BEGIN
-                        ALTER TABLE auth_item_child CHECK CONSTRAINT FK__auth_item__child;
+                        ALTER TABLE {$authManager->itemChildTable} CHECK CONSTRAINT FK__auth_item__child;
                     END
                 END
                 ELSE


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #12939

Not sure if `dbo.` prefix is needed here, left it as it was, just removed hard coded values.