### PR TITLE
improved error message for Instance::ensure() when component does not exist

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -22,6 +22,7 @@ Yii Framework 2 Change Log
 - Bug #12939: Hard coded table names for MSSQL in RBAC migration (arogachev)
 - Bug #12974: Fixed incorrect order of migrations history in case `yii\console\controllers\MigrateController::$migrationNamespaces` is in use (evgen-d, klimov-paul)
 - Enh #6809: Added `\yii\caching\Cache::$defaultDuration` property, allowing to set custom default cache duration (sdkiller)
+- Enh #7333: Improved error message for `yii\di\Instance::ensure()` when a component does not exist (cebe)
 - Enh #7420: Attributes for prompt generated with `renderSelectOptions` of `\yii\helpers\Html` helper (arogachev)
 - Enh #9162: Added support of closures in `value` for attributes in `yii\widgets\DetailView` (arogachev)
 - Enh #11037: `yii.js` and `yii.validation.js` use `Regexp.test()` instead of `String.match()` (arogachev, nkovacs)

--- a/framework/di/Instance.php
+++ b/framework/di/Instance.php
@@ -128,7 +128,11 @@ class Instance
         }
 
         if ($reference instanceof self) {
-            $component = $reference->get($container);
+            try {
+                $component = $reference->get($container);
+            } catch(\ReflectionException $e) {
+                throw new InvalidConfigException('Failed to instantiate component or class "' . $reference->id . '".', 0, $e);
+            }
             if ($type === null || $component instanceof $type) {
                 return $component;
             } else {

--- a/tests/framework/di/InstanceTest.php
+++ b/tests/framework/di/InstanceTest.php
@@ -46,7 +46,27 @@ class InstanceTest extends TestCase
         $this->assertTrue(Instance::ensure(['class' => 'yii\db\Connection', 'dsn' => 'test'], 'yii\db\Connection', $container) instanceof Connection);
     }
 
-    public function testEnsureWithoutType()
+    /**
+     * ensure an InvalidConfigException is thrown when a component does not exist.
+     */
+    public function testEnsure_NonExistingComponentException()
+    {
+        $container = new Container;
+        $this->setExpectedExceptionRegExp('yii\base\InvalidConfigException', '/^Failed to instantiate component or class/i');
+        Instance::ensure('cache', 'yii\cache\Cache', $container);
+    }
+
+    /**
+     * ensure an InvalidConfigException is thrown when a class does not exist.
+     */
+    public function testEnsure_NonExistingClassException()
+    {
+        $container = new Container;
+        $this->setExpectedExceptionRegExp('yii\base\InvalidConfigException', '/^Failed to instantiate component or class/i');
+        Instance::ensure('yii\cache\DoesNotExist', 'yii\cache\Cache', $container);
+    }
+
+    public function testEnsure_WithoutType()
     {
         $container = new Container;
         $container->set('db', [
@@ -59,7 +79,7 @@ class InstanceTest extends TestCase
         $this->assertTrue(Instance::ensure(['class' => 'yii\db\Connection', 'dsn' => 'test'], null, $container) instanceof Connection);
     }
 
-    public function testEnsureMinimalSettings()
+    public function testEnsure_MinimalSettings()
     {
         Yii::$container->set('db', [
             'class' => 'yii\db\Connection',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

fixes #7333 

- Better error message
- and the Instance::ensure() call is on the second line in the stack trace which makes it easier to locate the source of the problem:
    ![bildschirmfoto von 2016-11-10 22 13 48](https://cloud.githubusercontent.com/assets/189796/20194946/c006fbfa-a794-11e6-9401-0e232fcefc8d.png)
