### PR TITLE
fix #12969 pjax not working because of non insync ID

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -32,7 +32,7 @@ Yii Framework 2 Change Log
 - Enh #12881: Added `removeValue` method to `yii\helpers\BaseArrayHelper` (nilsburg)
 - Enh #12901: Added `getDefaultHelpHeader` method to the `yii\console\controllers\HelpController` class to be able to override default help header in a class heir (diezztsk)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
-
+- Bug #12969: Fixed Pjax result when no ID is supplied `yii\widgets\Pjax` (dynasource)
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -101,6 +101,18 @@ class Pjax extends Widget
 
     /**
      * @inheritdoc
+     * @since 2.0.11
+     */
+    public static function begin($config = [])
+    {
+        if (!isset($config['id'])) {
+            $config['id'] = md5(serialize(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2))); //fixes #12969
+        }
+        return parent::begin($config);
+    }
+
+    /**
+     * @inheritdoc
      */
     public function init()
     {

--- a/tests/framework/widgets/PjaxTest.php
+++ b/tests/framework/widgets/PjaxTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace yiiunit\framework\widgets;
+
+use Yii;
+use yii\web\Request;
+use yii\widgets\Pjax;
+
+/**
+ * @group widgets
+ */
+class PjaxTest extends \yiiunit\TestCase
+{
+    public function testSetDefaultIdByTrace()
+    {
+        $this->expectOutputRegex('~<div id="[a-zA-Z0-9]{32}".*>~');
+        Pjax::begin();
+    }
+
+    public function testCustomId()
+    {
+        $this->expectOutputRegex('~<div id="custom-id".*>~');
+        Pjax::begin([
+            'id' => 'custom-id'
+        ]);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mockApplication();
+        Yii::$app->set('request', new Request());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  |no
| Breaks BC?    |no
| Tests pass?   | yes
| Fixed issues  | #12969

This commit fixes the pjax `ID not set` issues out of the box. It is not required anymore to supply an unique ID to Pjax widgets anymore because the software is creating a truly unique one by itself. The algorithm to do this is based on the line & class (the trace) where the Pjax widget is called. This is unique for most Pjax::begin calls. When developers call this trough a pjax proxy (like i.e. a ->pjaxify), also the second trace is required, which is covered by this commit. MD5 does the rest.

