### PR TITLE
Disable serialization by default for ArrayCache for increased performance

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -35,7 +35,7 @@ Yii Framework 2 Change Log
 - Enh #12901: Added `getDefaultHelpHeader` method to the `yii\console\controllers\HelpController` class to be able to override default help header in a class heir (diezztsk)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
 - Bug #12974: Changed order of migrations history in `yii\console\controllers\MigrateController::getMigrationHistory()` (evgen-d)
-
+- Enh #12984: Disabled serialization by default for `yii\caching\ArrayCache` for increased performance (rhertogh)
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -50,7 +50,15 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to follow the instructions
 for both A and B.
 
+Upgrade from Yii 2.0.10
+-----------------------
 
+* The `serializer` property for `yii\caching\ArrayCache` has been changed form `null` to `false`, this disables serialization
+  by default for increased performance. However, this also means that the `dependency` parameter for `yii\caching\Cache::set()`
+  and `yii\caching\Cache::multiSet()` will be ignored by default. If you are using `yii\caching\ArrayCache` in combination with
+  dependencies you should set `yii\caching\ArrayCache::$serializer` to `null`.
+  
+  
 Upgrade from Yii 2.0.9
 ----------------------
 

--- a/framework/caching/ArrayCache.php
+++ b/framework/caching/ArrayCache.php
@@ -23,10 +23,9 @@ namespace yii\caching;
 class ArrayCache extends Cache
 {
     /**
-     * Serialization is disabled by default for ArrayCache for increased performance
+     * Serialization is disabled by default for [[ArrayCache]] for increased performance
      *
-     * @var null|array|false The functions used to serialize and unserialize cached data.
-     * @see Cache::serializer
+     * @inheritdoc
      */
     public $serializer = false;
     

--- a/framework/caching/ArrayCache.php
+++ b/framework/caching/ArrayCache.php
@@ -22,6 +22,14 @@ namespace yii\caching;
  */
 class ArrayCache extends Cache
 {
+    /**
+     * Serialization is disabled by default for ArrayCache for increased performance
+     *
+     * @var null|array|false The functions used to serialize and unserialize cached data.
+     * @see Cache::serializer
+     */
+    public $serializer = false;
+    
     private $_cache;
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | -

I would expect the ArrayCache to be optimized for speed since it's only used during a single requests, but the serialization is turned on by default which has a major performance impact (see test below).
Turning the serialization off might brake backwards compatibilty due to the check in the yii/caching/Cache class: ```if ($dependency !== null && $this->serializer !== false) {```

Test results:
unserialized: 9.3 ms
serialized: 3391.6 ms

Test data: two dimensional array (100x100)

Test run: 100 x 1 write, 10 reads

Test:

```
$data = array_fill(0, 100, array_fill(0, 100, rand(0, 10000)));

Yii::$app->arrayCache->serializer = false;
Yii::beginProfile('cacheTest-unserialized');
for ($i = 1; $i <= 100; $i++) {
    Yii::$app->arrayCache->set("cacheTest-unserialized-$i", $data);
    for ($j = 1; $j <= 10; $j++) {
        Yii::$app->arrayCache->get("cacheTest-unserialized-$i");
    }
}
Yii::endProfile('cacheTest-unserialized');

Yii::$app->arrayCache->serializer = null;
Yii::beginProfile('cacheTest-serialized');
for ($i = 1; $i <= 100; $i++) {
    Yii::$app->arrayCache->set("cacheTest-serialized-$i", $data);
    for ($j = 1; $j <= 10; $j++) {
        Yii::$app->arrayCache->get("cacheTest-serialized-$i");
    }
}
Yii::endProfile('cacheTest-serialized');
```