### PR TITLE
Default cache ttl (duration) property (fixes #6809)

### DIFF
--- a/docs/guide/caching-data.md
+++ b/docs/guide/caching-data.md
@@ -204,6 +204,9 @@ if ($data === false) {
 }
 ```
 
+Since 2.0.11 you may set [[yii\caching\Cache::$ttl|ttl]] value in your cache component configuration if you need default cache duration other than 0.
+This will allow you not to pass custom `duration` parameter to [[yii\caching\Cache::set()|set()]] each time.
+
 
 ### Cache Dependencies <span id="cache-dependencies"></span>
 

--- a/docs/guide/caching-data.md
+++ b/docs/guide/caching-data.md
@@ -204,7 +204,8 @@ if ($data === false) {
 }
 ```
 
-Since 2.0.11 you may set [[yii\caching\Cache::$ttl|ttl]] value in your cache component configuration if you need default cache duration other than 0.
+Since 2.0.11 you may set [[yii\caching\Cache::$ttl|ttl]] value in your cache component configuration if you prefer a custom cache duration
+over the default unlimited duration.
 This will allow you not to pass custom `duration` parameter to [[yii\caching\Cache::set()|set()]] each time.
 
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -38,6 +38,7 @@ Yii Framework 2 Change Log
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
 - Bug #12974: Fixed incorrect order of migrations history in case `yii\console\controllers\MigrateController::$migrationNamespaces` is in use (evgen-d, klimov-paul)
 - Enh #6809: Added `\yii\caching\Cache::$ttl` property, allowing to set custom default cache duration (sdkiller)
+- Enh #6809: Added `\yii\caching\Cache::$ttl` property, allowing to set custom default cache duration (sdkiller, dynasource)
 - Bug #12974: Changed order of migrations history in `yii\console\controllers\MigrateController::getMigrationHistory()` (evgen-d)
 
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -37,6 +37,8 @@ Yii Framework 2 Change Log
 - Enh #12901: Added `getDefaultHelpHeader` method to the `yii\console\controllers\HelpController` class to be able to override default help header in a class heir (diezztsk)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
 - Bug #12974: Fixed incorrect order of migrations history in case `yii\console\controllers\MigrateController::$migrationNamespaces` is in use (evgen-d, klimov-paul)
+- Enh #6809: Added `\yii\caching\Cache::$ttl` property, allowing to set custom default cache duration (sdkiller)
+- Bug #12974: Changed order of migrations history in `yii\console\controllers\MigrateController::getMigrationHistory()` (evgen-d)
 
 
 2.0.10 October 20, 2016

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -71,6 +71,14 @@ abstract class Cache extends Component implements \ArrayAccess
      * implementations of the cache can not correctly save and retrieve data different from a string type.
      */
     public $serializer;
+    /**
+     * @var integer default ttl of cached value (the number of seconds in which the cached value will expire) -
+     * if it was not defined explicitly in [[set()]].
+     * Default value is 0, depending on implementation which means never expire or maximum ttl supported by cache engine
+     * (e.g. it is 1 year for [[\yii\caching\FileCache]]).
+     * @since 2.0.11
+     */
+    public $ttl = 0;
 
 
     /**
@@ -202,14 +210,19 @@ abstract class Cache extends Component implements \ArrayAccess
      * @param mixed $key a key identifying the value to be cached. This can be a simple string or
      * a complex data structure consisting of factors representing the key.
      * @param mixed $value the value to be cached
-     * @param int $duration the number of seconds in which the cached value will expire. 0 means never expire.
+     * @param int $duration the number of seconds in which the cached value will expire. If not set - the value of [[ttl]] is used,
+     * which defaults to 0 (never expire).
      * @param Dependency $dependency dependency of the cached item. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return bool whether the value is successfully stored into cache
      */
-    public function set($key, $value, $duration = 0, $dependency = null)
+    public function set($key, $value, $duration = null, $dependency = null)
     {
+        if ($duration === null) {
+            $duration = $this->ttl;
+        }
+
         if ($dependency !== null && $this->serializer !== false) {
             $dependency->evaluateDependency($this);
         }

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -72,10 +72,7 @@ abstract class Cache extends Component implements \ArrayAccess
      */
     public $serializer;
     /**
-     * @var integer default ttl of cached value (the number of seconds in which the cached value will expire) -
-     * if it was not defined explicitly in [[set()]].
-     * Default value is 0, depending on implementation which means never expire or maximum ttl supported by cache engine
-     * (e.g. it is 1 year for [[\yii\caching\FileCache]]).
+     * @var integer default duration in seconds before the cache will expire. Default value is 0, meaning infinity.
      * @since 2.0.11
      */
     public $ttl = 0;
@@ -210,16 +207,17 @@ abstract class Cache extends Component implements \ArrayAccess
      * @param mixed $key a key identifying the value to be cached. This can be a simple string or
      * a complex data structure consisting of factors representing the key.
      * @param mixed $value the value to be cached
-     * @param int $duration the number of seconds in which the cached value will expire. If not set - the value of [[ttl]] is used,
-     * which defaults to 0 (never expire).
+     * @param int $duration default duration in seconds before the cache will expire. Default value is 0, meaning infinity.
      * @param Dependency $dependency dependency of the cached item. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return bool whether the value is successfully stored into cache
      */
-    public function set($key, $value, $duration = null, $dependency = null)
+    public function set($key, $value, $duration = 0, $dependency = null)
     {
-        if ($duration === null) {
+        $args = func_get_args();
+        if (!isset($args[2])) {
+            // https://github.com/yiisoft/yii2/pull/12990#discussion_r87715643
             $duration = $this->ttl;
         }
 

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -207,17 +207,16 @@ abstract class Cache extends Component implements \ArrayAccess
      * @param mixed $key a key identifying the value to be cached. This can be a simple string or
      * a complex data structure consisting of factors representing the key.
      * @param mixed $value the value to be cached
-     * @param int $duration default duration in seconds before the cache will expire. Default value is 0, meaning infinity.
+     * @param int $duration default duration in seconds before the cache will expire. If not set,
+     * default [[ttl]] value is used.
      * @param Dependency $dependency dependency of the cached item. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return bool whether the value is successfully stored into cache
      */
-    public function set($key, $value, $duration = 0, $dependency = null)
+    public function set($key, $value, $duration = null, $dependency = null)
     {
-        $args = func_get_args();
-        if (!isset($args[2])) {
-            // https://github.com/yiisoft/yii2/pull/12990#discussion_r87715643
+        if ($duration === null) {
             $duration = $this->ttl;
         }
 

--- a/tests/framework/caching/CacheTestCase.php
+++ b/tests/framework/caching/CacheTestCase.php
@@ -181,7 +181,7 @@ abstract class CacheTestCase extends TestCase
     {
         $cache = $this->getCacheInstance();
 
-        $this->assertEquals(0, $cache->ttl);
+        $this->assertSame(0, $cache->ttl);
     }
 
     public function testExpire()

--- a/tests/framework/caching/CacheTestCase.php
+++ b/tests/framework/caching/CacheTestCase.php
@@ -177,6 +177,13 @@ abstract class CacheTestCase extends TestCase
         $this->assertEquals(['number_test' => 42, 'non_existent_key' => null], $cache->mget(['number_test', 'non_existent_key']));
     }
 
+    public function testDefaultTtl()
+    {
+        $cache = $this->getCacheInstance();
+
+        $this->assertEquals(0, $cache->ttl);
+    }
+
     public function testExpire()
     {
         $cache = $this->getCacheInstance();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #6809 

Some PROS in addition to discussion in #6809

- from the prorposed https://github.com/php-fig/fig-standards/blob/master/proposed/simplecache.md
> If no value is sent and the driver supports TTL then the library may set a default value for it or let the driver take care of that.

Althow it is not obvious from the draft, that default value cannot be hardcoded, IMO everyone expects it should be configurable.

- there are examples of configurable defaults among other frameworks, e.g. https://github.com/zendframework/zend-cache/blob/master/src/Storage/Adapter/AdapterOptions.php#L66

BC: to keep BC default value is 0, proposed change should not affect implementations, which extend `\yii\caching\Cache`.

Note about tests: 
as of now all tests for core cache classes do not suppose setting cache configuration or passing params to `\yiiunit\framework\caching\DbCacheTest::getCacheInstance`