### PR TITLE
two primarykey one value default find first value

### DIFF
--- a/framework/rest/Action.php
+++ b/framework/rest/Action.php
@@ -92,6 +92,8 @@ class Action extends \yii\base\Action
             $values = explode(',', $id);
             if (count($keys) === count($values)) {
                 $model = $modelClass::findOne(array_combine($keys, $values));
+            }else{
+                $model = $modelClass::findOne($id);
             }
         } elseif ($id !== null) {
             $model = $modelClass::findOne($id);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

when table have two primarykey,I can't get model with restful url like this http://www.a.com/api/orders/5
bootstrap set 'GET api/orders/<id>' => 'appapi/orders/view',