### PR TITLE
Allow resetting dependency registered as singleton

### DIFF
--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -265,6 +265,7 @@ class Container extends Component
      *
      * @param string $class class name, interface name or alias name
      * @param mixed $definition the definition associated with `$class`. See [[set()]] for more details.
+     * If `null`, next call to [[get()]] behaves in the same way as if the instance was never created.
      * @param array $params the list of constructor parameters. The parameters will be passed to the class
      * constructor when [[get()]] is called.
      * @return $this the container itself
@@ -272,9 +273,13 @@ class Container extends Component
      */
     public function setSingleton($class, $definition = [], array $params = [])
     {
-        $this->_definitions[$class] = $this->normalizeDefinition($class, $definition);
-        $this->_params[$class] = $params;
-        $this->_singletons[$class] = null;
+        if ($definition !== null) {
+            $this->_definitions[$class] = $this->normalizeDefinition($class, $definition);
+            $this->_params[$class] = $params;
+            $this->_singletons[$class] = null;
+        } elseif (isset($this->_singletons[$class])) {
+            $this->_singletons[$class] = null;
+        }
         return $this;
     }
 

--- a/tests/framework/di/ContainerTest.php
+++ b/tests/framework/di/ContainerTest.php
@@ -108,6 +108,39 @@ class ContainerTest extends TestCase
         $this->assertEquals(4, $qux->a);
     }
 
+    public function testSetSingleton()
+    {
+        $namespace = __NAMESPACE__ . '\stubs';
+        $QuxInterface = "$namespace\\QuxInterface";
+        $Qux = Qux::className();
+
+        $container = new Container;
+
+        $container->setSingleton($QuxInterface, null);
+        $this->assertFalse($container->hasSingleton($QuxInterface));
+
+        $container->setSingleton($QuxInterface, $Qux);
+        $this->assertTrue($container->hasSingleton($QuxInterface));
+        $this->assertFalse($container->hasSingleton($QuxInterface, true));
+
+        $qux = $container->get($QuxInterface);
+        $this->assertTrue($qux instanceof $Qux);
+        $this->assertTrue($container->hasSingleton($QuxInterface, true));
+
+        $qux2 = $container->get($QuxInterface);
+        $this->assertTrue($qux === $qux2);
+
+        $container->setSingleton($QuxInterface, null);
+        $this->assertTrue($container->hasSingleton($QuxInterface));
+        $this->assertFalse($container->hasSingleton($QuxInterface, true));
+
+        $qux3 = $container->get($QuxInterface);
+        $this->assertFalse($qux2 === $qux3);
+
+        $qux4 = $container->get($QuxInterface);
+        $this->assertTrue($qux3 === $qux4);
+    }
+
     public function testInvoke()
     {
         $this->mockApplication([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

If `null` passed to `yii\di\Container::setSingleton()` as dependency definition, next call to `yii\di\Container::get()` will generate new instance of dependency.
