### PR TITLE
phpDoc: Fix example for ActiveRelationTrait::via()

### DIFF
--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -83,15 +83,16 @@ trait ActiveRelationTrait
      * Use this method to specify a pivot record/table when declaring a relation in the [[ActiveRecord]] class:
      *
      * ```php
-     * public function getOrders()
+     * class Order extends ActiveRecord
      * {
-     *     return $this->hasOne(Order::className(), ['id' => 'order_id']);
-     * }
-     *
-     * public function getOrderItems()
-     * {
-     *     return $this->hasMany(Item::className(), ['id' => 'item_id'])
-     *                 ->via('orders');
+     *    public function getOrderItems() {
+     *        return $this->hasMany(OrderItem::className(), ['order_id' => 'id']);
+     *    }
+     * 
+     *    public function getItems() {
+     *        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+     *                    ->via('orderItems');
+     *    }
      * }
      * ```
      *


### PR DESCRIPTION
Original example:

```php
      public function getOrders() // must be Order or hasMany and $link is bad #ololo
      {
          return $this->hasOne(Order::className(), ['id' => 'order_id']);
      }
     
      public function getOrderItems()
      {
         return $this->hasMany(Item::className(), ['id' => 'item_id'])
                      ->via('orders');
      }
```

I can't imagine structure of tables for this example. ^_^

PR replaces this example to [example from documentation](http://www.yiiframework.com/doc-2.0/guide-db-active-record.html#junction-table)