### PR TITLE
Test against HHVM 3.12 LTS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,24 @@ php:
   - 7.0
   - 7.1
   - nightly
-  # test against the HHVM version provided by travis by default
-  - hhvm
 
 matrix:
   fast_finish: true
   include:
+    # Test against HHVM 3.12 LTS version by using trusty
+    - php: hhvm-3.12
+      sudo: true
+      dist: trusty
+      group: edge # Use edge image until the next travis CI image update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+      env: CUBRID_VERSION=9.3.0/CUBRID-9.3.0.0206 CUBRID_PDO_VERSION=9.3.0.0001
     # test against the latest HHVM version by using a newer image
     - php: hhvm
       sudo: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes for travis hhvm version
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any adds hhvm 3.12 LTS to tests and removes 3.6.6

This provides Testing against HHVM 3.12 LTS version

If testing against other HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

Should be able to change to container based Trusty after Q1-17 https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/

Note: hhvm 3.15 is an LTS version but is also current until 3.16 is released. Both 3.15 and 3.16 include the PostgreSQL module that has a problem resulting in 2 pgsql db tests being skipped.