### PR TITLE
Added `foreignKey` method for `yii\db\ColumnSchemaBuilder`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -38,6 +38,7 @@ Yii Framework 2 Change Log
 - Enh #12881: Added `removeValue` method to `yii\helpers\BaseArrayHelper` (nilsburg)
 - Enh #12901: Added `getDefaultHelpHeader` method to the `yii\console\controllers\HelpController` class to be able to override default help header in a class heir (diezztsk)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
+- Enh #13016: Added `foreignKey` method for `yii\db\ColumnSchemaBuilder` (kfreiman)
 
 
 2.0.10 October 20, 2016

--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -115,6 +115,26 @@ class ColumnSchemaBuilder extends Object
      * @since 2.0.8
      */
     public $comment;
+    /**
+     * @var string the name of the foreign key constraint.
+     */
+    public $foreignKeyName;
+    /**
+     * @var string the table that the foreign key references to.
+     */
+    public $refTable;
+    /**
+     * @var string the name of the column that the foreign key references to.
+     */
+    public $refColumn;
+    /**
+     * @var string the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION,
+     */
+    public $delete;
+    /**
+     * @var string the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION,
+     */
+    public $update;
 
     /**
      * Create a column schema builder instance giving the type and value precision.
@@ -266,6 +286,25 @@ class ColumnSchemaBuilder extends Object
     public function append($sql)
     {
         $this->append = $sql;
+        return $this;
+    }
+
+    /**
+     * Sets a foreign key for the column
+     * @param string $foreignKeyName the name of the foreign key constraint.
+     * @param string $refTable the table that the foreign key references to.
+     * @param string $refColumn the name of the column that the foreign key references to.
+     * @param string $delete the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
+     * @param string $update the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
+     * @return $this
+     */
+    public function foreignKey($foreignKeyName, $refTable, $refColumn, $delete=null, $update=null)
+    {
+        $this->refTable = $refTable;
+        $this->foreignKeyName = $foreignKeyName;
+        $this->refColumn = $refColumn;
+        $this->delete = $delete;
+        $this->update = $update;
         return $this;
     }
 

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -265,6 +265,18 @@ class Migration extends Component implements MigrationInterface
             if ($type instanceof ColumnSchemaBuilder && $type->comment !== null) {
                 $this->db->createCommand()->addCommentOnColumn($table, $column, $type->comment)->execute();
             }
+
+            if ($type instanceof ColumnSchemaBuilder && $type->foreignKeyName !== null) {
+                $this->db->createCommand()->addForeignKey(
+                    $type->foreignKeyName,
+                    $table,
+                    $column,
+                    $type->refTable,
+                    $type->refColumn,
+                    $type->delete,
+                    $type->update
+                )->execute();
+            }
         }
         echo ' done (time: ' . sprintf('%.3f', microtime(true) - $time) . "s)\n";
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13016, #8163

