### PR TITLE
Provide options for the span element.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -37,6 +37,7 @@ Yii Framework 2 Change Log
 - Enh #12816: Added `columnSchemaClass` option for `yii\db\Schema` which adds ability to specify custom `yii\db\ColumnSchema` class (nanodesu88)
 - Enh #12881: Added `removeValue` method to `yii\helpers\BaseArrayHelper` (nilsburg)
 - Enh #12901: Added `getDefaultHelpHeader` method to the `yii\console\controllers\HelpController` class to be able to override default help header in a class heir (diezztsk)
+- Enh #13020: Added `disabledPageElementOptions` attribute for `yii\widgets\LinkPager` in order to customize the disabled tag element (nadar)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
 
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -37,7 +37,7 @@ Yii Framework 2 Change Log
 - Enh #12816: Added `columnSchemaClass` option for `yii\db\Schema` which adds ability to specify custom `yii\db\ColumnSchema` class (nanodesu88)
 - Enh #12881: Added `removeValue` method to `yii\helpers\BaseArrayHelper` (nilsburg)
 - Enh #12901: Added `getDefaultHelpHeader` method to the `yii\console\controllers\HelpController` class to be able to override default help header in a class heir (diezztsk)
-- Enh #13020: Added `disabledPageElementOptions` attribute for `yii\widgets\LinkPager` in order to customize the disabled tag element (nadar)
+- Enh #13020: Added `disabledListItemSubTagOptions` attribute for `yii\widgets\LinkPager` in order to customize the disabled list item sub tag element (nadar)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
 
 

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -74,6 +74,12 @@ class LinkPager extends Widget
      * @var string the CSS class for the disabled page buttons.
      */
     public $disabledPageCssClass = 'disabled';
+    
+    /**
+     * @var array An array with options to pass to the span tag which is generated inside the disabled list element.
+     */
+    public $disabledSpanOptions = [];
+    
     /**
      * @var int maximum number of page buttons that can be displayed. Defaults to 10.
      */
@@ -218,7 +224,7 @@ class LinkPager extends Widget
         if ($disabled) {
             Html::addCssClass($options, $this->disabledPageCssClass);
 
-            return Html::tag('li', Html::tag('span', $label), $options);
+            return Html::tag('li', Html::tag('span', $label, $this->disabledSpanOptions), $options);
         }
         $linkOptions = $this->linkOptions;
         $linkOptions['data-page'] = $page;

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -77,8 +77,8 @@ class LinkPager extends Widget
     public $disabledPageCssClass = 'disabled';
     
     /**
-     * @var array An array with options to pass to the disabled tag which is generated inside the disabled list element.
-     * In order to to customize the tag name itself use the array key `tag` and value for its tag name value.
+     * @var array the options for the disabled tag to be generated inside the disabled list element.
+     * In order to customize the html tag, please use the tag key.
      * 
      * ```php
      * $disabledPageElementOptions = ['tag' => 'div', 'class' => 'disabled-div'];

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -83,6 +83,7 @@ class LinkPager extends Widget
      * ```php
      * $disabledPageElementOptions = ['tag' => 'div', 'class' => 'disabled-div'];
      * ```
+     * @since 2.0.11
      */
     public $disabledPageElementOptions = [];
     

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -12,6 +12,7 @@ use yii\base\InvalidConfigException;
 use yii\helpers\Html;
 use yii\base\Widget;
 use yii\data\Pagination;
+use yii\helpers\ArrayHelper;
 
 /**
  * LinkPager displays a list of hyperlinks that lead to different pages of target.
@@ -76,9 +77,9 @@ class LinkPager extends Widget
     public $disabledPageCssClass = 'disabled';
     
     /**
-     * @var array An array with options to pass to the span tag which is generated inside the disabled list element.
+     * @var array An array with options to pass to the disabled tag which is generated inside the disabled list element.
      */
-    public $disabledSpanOptions = [];
+    public $disabledPageElementOptions = [];
     
     /**
      * @var int maximum number of page buttons that can be displayed. Defaults to 10.
@@ -223,8 +224,8 @@ class LinkPager extends Widget
         }
         if ($disabled) {
             Html::addCssClass($options, $this->disabledPageCssClass);
-
-            return Html::tag('li', Html::tag('span', $label, $this->disabledSpanOptions), $options);
+            $tag = ArrayHelper::remove($this->disabledPageElementOptions, 'tag', 'span');
+            return Html::tag('li', Html::tag($tag, $label, $this->disabledPageElementOptions), $options);
         }
         $linkOptions = $this->linkOptions;
         $linkOptions['data-page'] = $page;

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -81,11 +81,11 @@ class LinkPager extends Widget
      * In order to customize the html tag, please use the tag key.
      * 
      * ```php
-     * $disabledPageElementOptions = ['tag' => 'div', 'class' => 'disabled-div'];
+     * $disabledListItemSubTagOptions = ['tag' => 'div', 'class' => 'disabled-div'];
      * ```
      * @since 2.0.11
      */
-    public $disabledPageElementOptions = [];
+    public $disabledListItemSubTagOptions = [];
     
     /**
      * @var int maximum number of page buttons that can be displayed. Defaults to 10.
@@ -230,9 +230,9 @@ class LinkPager extends Widget
         }
         if ($disabled) {
             Html::addCssClass($options, $this->disabledPageCssClass);
-            $tag = ArrayHelper::remove($this->disabledPageElementOptions, 'tag', 'span');
+            $tag = ArrayHelper::remove($this->disabledListItemSubTagOptions, 'tag', 'span');
             
-            return Html::tag('li', Html::tag($tag, $label, $this->disabledPageElementOptions), $options);
+            return Html::tag('li', Html::tag($tag, $label, $this->disabledListItemSubTagOptions), $options);
         }
         $linkOptions = $this->linkOptions;
         $linkOptions['data-page'] = $page;

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -78,6 +78,11 @@ class LinkPager extends Widget
     
     /**
      * @var array An array with options to pass to the disabled tag which is generated inside the disabled list element.
+     * In order to to customize the tag name itself use the array key `tag` and value for its tag name value.
+     * 
+     * ```php
+     * $disabledPageElementOptions = ['tag' => 'div', 'class' => 'disabled-div'];
+     * ```
      */
     public $disabledPageElementOptions = [];
     
@@ -225,6 +230,7 @@ class LinkPager extends Widget
         if ($disabled) {
             Html::addCssClass($options, $this->disabledPageCssClass);
             $tag = ArrayHelper::remove($this->disabledPageElementOptions, 'tag', 'span');
+            
             return Html::tag('li', Html::tag($tag, $label, $this->disabledPageElementOptions), $options);
         }
         $linkOptions = $this->linkOptions;

--- a/tests/framework/widgets/LinkPagerTest.php
+++ b/tests/framework/widgets/LinkPagerTest.php
@@ -59,31 +59,31 @@ class LinkPagerTest extends \yiiunit\TestCase
     
     public function testDisabledPageElementOptions()
     {
-    	$pagination = new Pagination();
+        $pagination = new Pagination();
         $pagination->setPage(0);
         $pagination->totalCount = 50;
         $pagination->route = 'test';
 
         $output = LinkPager::widget([
             'pagination' => $pagination,
-        	'disabledPageElementOptions' => ['class' => 'foo-bar'],
+            'disabledPageElementOptions' => ['class' => 'foo-bar'],
         ]);
         
-		static::assertContains('<span class="foo-bar">&laquo;</span>', $output);
+        static::assertContains('<span class="foo-bar">&laquo;</span>', $output);
     }
     
 	public function testDisabledPageElementOptionsWithTagOption()
     {
-    	$pagination = new Pagination();
+        $pagination = new Pagination();
         $pagination->setPage(0);
         $pagination->totalCount = 50;
         $pagination->route = 'test';
 
         $output = LinkPager::widget([
             'pagination' => $pagination,
-        	'disabledPageElementOptions' => ['class' => 'foo-bar', 'tag' => 'div'],
+            'disabledPageElementOptions' => ['class' => 'foo-bar', 'tag' => 'div'],
         ]);
         
-		static::assertContains('<div class="foo-bar">&laquo;</div>', $output);
+        static::assertContains('<div class="foo-bar">&laquo;</div>', $output);
     }
 }

--- a/tests/framework/widgets/LinkPagerTest.php
+++ b/tests/framework/widgets/LinkPagerTest.php
@@ -66,7 +66,7 @@ class LinkPagerTest extends \yiiunit\TestCase
 
         $output = LinkPager::widget([
             'pagination' => $pagination,
-            'disabledPageElementOptions' => ['class' => 'foo-bar'],
+            'disabledListItemSubTagOptions' => ['class' => 'foo-bar'],
         ]);
         
         static::assertContains('<span class="foo-bar">&laquo;</span>', $output);
@@ -81,7 +81,7 @@ class LinkPagerTest extends \yiiunit\TestCase
 
         $output = LinkPager::widget([
             'pagination' => $pagination,
-            'disabledPageElementOptions' => ['class' => 'foo-bar', 'tag' => 'div'],
+            'disabledListItemSubTagOptions' => ['class' => 'foo-bar', 'tag' => 'div'],
         ]);
         
         static::assertContains('<div class="foo-bar">&laquo;</div>', $output);

--- a/tests/framework/widgets/LinkPagerTest.php
+++ b/tests/framework/widgets/LinkPagerTest.php
@@ -56,4 +56,34 @@ class LinkPagerTest extends \yiiunit\TestCase
         static::assertNotContains('<li class="first">', $output);
         static::assertNotContains('<li class="last">', $output);
     }
+    
+    public function testDisabledPageElementOptions()
+    {
+    	$pagination = new Pagination();
+        $pagination->setPage(0);
+        $pagination->totalCount = 50;
+        $pagination->route = 'test';
+
+        $output = LinkPager::widget([
+            'pagination' => $pagination,
+        	'disabledPageElementOptions' => ['class' => 'foo-bar'],
+        ]);
+        
+		static::assertContains('<span class="foo-bar">&laquo;</span>', $output);
+    }
+    
+	public function testDisabledPageElementOptionsWithTagOption()
+    {
+    	$pagination = new Pagination();
+        $pagination->setPage(0);
+        $pagination->totalCount = 50;
+        $pagination->route = 'test';
+
+        $output = LinkPager::widget([
+            'pagination' => $pagination,
+        	'disabledPageElementOptions' => ['class' => 'foo-bar', 'tag' => 'div'],
+        ]);
+        
+		static::assertContains('<div class="foo-bar">&laquo;</div>', $output);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no

It should be possibile to provide optional classes for the disable state list item. 

(As we are currently building all widgets for bootstrap 4, the pagination element looks different, there for we need more options to configure)

