### PR TITLE
Closes #7420: Attributes for prompt generated with `renderSelectOptions` of `\yii\helpers\Html` helper

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -22,6 +22,7 @@ Yii Framework 2 Change Log
 - Bug #12939: Hard coded table names for MSSQL in RBAC migration (arogachev)
 - Bug #12974: Fixed incorrect order of migrations history in case `yii\console\controllers\MigrateController::$migrationNamespaces` is in use (evgen-d, klimov-paul)
 - Enh #6809: Added `\yii\caching\Cache::$defaultDuration` property, allowing to set custom default cache duration (sdkiller)
+- Enh #7420: Attributes for prompt generated with `renderSelectOptions` of `\yii\helpers\Html` helper (arogachev)
 - Enh #11037: `yii.js` and `yii.validation.js` use `Regexp.test()` instead of `String.match()` (arogachev, nkovacs)
 - Enh #11756: Added type mapping for `varbinary` data type in MySQL DBMS (silverfire)
 - Enh #11929: Changed `type` column type from `int` to `smallInt` in RBAC migrations (silverfire)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -754,7 +754,13 @@ class BaseHtml
      * the labels will also be HTML-encoded.
      * @param array $options the tag options in terms of name-value pairs. The following options are specially handled:
      *
-     * - prompt: string, a prompt text to be displayed as the first option;
+     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use array to
+     * override value and set other tag attributes:
+     *
+     * ```php
+     * ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
+     * ```
+     *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,
      *
@@ -803,7 +809,13 @@ class BaseHtml
      * the labels will also be HTML-encoded.
      * @param array $options the tag options in terms of name-value pairs. The following options are specially handled:
      *
-     * - prompt: string, a prompt text to be displayed as the first option;
+     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use array to
+     * override value and set other tag attributes:
+     *
+     * ```php
+     * ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
+     * ```
+     *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,
      *
@@ -1477,7 +1489,13 @@ class BaseHtml
      * the labels will also be HTML-encoded.
      * @param array $options the tag options in terms of name-value pairs. The following options are specially handled:
      *
-     * - prompt: string, a prompt text to be displayed as the first option;
+     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use array to
+     * override value and set other tag attributes:
+     *
+     * ```php
+     * ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
+     * ```
+     *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,
      *
@@ -1526,7 +1544,13 @@ class BaseHtml
      * the labels will also be HTML-encoded.
      * @param array $options the tag options in terms of name-value pairs. The following options are specially handled:
      *
-     * - prompt: string, a prompt text to be displayed as the first option;
+     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use array to
+     * override value and set other tag attributes:
+     *
+     * ```php
+     * ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
+     * ```
+     *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,
      *

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -754,12 +754,12 @@ class BaseHtml
      * the labels will also be HTML-encoded.
      * @param array $options the tag options in terms of name-value pairs. The following options are specially handled:
      *
-     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use array to
-     * override value and set other tag attributes:
+     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use an array
+     *   to override the value and to set other tag attributes:
      *
-     * ```php
-     * ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
-     * ```
+     *   ```php
+     *   ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
+     *   ```
      *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,
@@ -809,12 +809,12 @@ class BaseHtml
      * the labels will also be HTML-encoded.
      * @param array $options the tag options in terms of name-value pairs. The following options are specially handled:
      *
-     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use array to
-     * override value and set other tag attributes:
+     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use an array
+     *   to override the value and to set other tag attributes:
      *
-     * ```php
-     * ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
-     * ```
+     *   ```php
+     *   ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
+     *   ```
      *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,
@@ -1489,12 +1489,12 @@ class BaseHtml
      * the labels will also be HTML-encoded.
      * @param array $options the tag options in terms of name-value pairs. The following options are specially handled:
      *
-     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use array to
-     * override value and set other tag attributes:
+     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use an array
+     *   to override the value and to set other tag attributes:
      *
-     * ```php
-     * ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
-     * ```
+     *   ```php
+     *   ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
+     *   ```
      *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,
@@ -1544,12 +1544,12 @@ class BaseHtml
      * the labels will also be HTML-encoded.
      * @param array $options the tag options in terms of name-value pairs. The following options are specially handled:
      *
-     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use array to
-     * override value and set other tag attributes:
+     * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use an array
+     *   to override the value and to set other tag attributes:
      *
-     * ```php
-     * ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
-     * ```
+     *   ```php
+     *   ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
+     *   ```
      *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1719,16 +1719,16 @@ class BaseHtml
         if (isset($tagOptions['prompt'])) {
             $promptOptions = ['value' => ''];
             if (is_string($tagOptions['prompt'])) {
-                $text = $tagOptions['prompt'];
+                $promptText = $tagOptions['prompt'];
             } else {
-                $text = $tagOptions['prompt']['text'];
+                $promptText = $tagOptions['prompt']['text'];
                 $promptOptions = array_merge($promptOptions, $tagOptions['prompt']['options']);
             }
-            $text = $encode ? static::encode($text) : $text;
+            $promptText = $encode ? static::encode($promptText) : $promptText;
             if ($encodeSpaces) {
-                $text = str_replace(' ', '&nbsp;', $text);
+                $promptText = str_replace(' ', '&nbsp;', $promptText);
             }
-            $lines[] = static::tag('option', $text, $promptOptions);
+            $lines[] = static::tag('option', $promptText, $promptOptions);
         }
 
         $options = isset($tagOptions['options']) ? $tagOptions['options'] : [];

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1693,11 +1693,18 @@ class BaseHtml
         $encodeSpaces = ArrayHelper::remove($tagOptions, 'encodeSpaces', false);
         $encode = ArrayHelper::remove($tagOptions, 'encode', true);
         if (isset($tagOptions['prompt'])) {
-            $prompt = $encode ? static::encode($tagOptions['prompt']) : $tagOptions['prompt'];
-            if ($encodeSpaces) {
-                $prompt = str_replace(' ', '&nbsp;', $prompt);
+            $attrs = ['value' => ''];
+            if (is_string($tagOptions['prompt'])) {
+                $text = $tagOptions['prompt'];
+            } else {
+                $text = $tagOptions['prompt']['text'];
+                $attrs = array_merge($attrs, $tagOptions['prompt']['options']);
             }
-            $lines[] = static::tag('option', $prompt, ['value' => '']);
+            $text = $encode ? static::encode($text) : $text;
+            if ($encodeSpaces) {
+                $text = str_replace(' ', '&nbsp;', $text);
+            }
+            $lines[] = static::tag('option', $text, $attrs);
         }
 
         $options = isset($tagOptions['options']) ? $tagOptions['options'] : [];

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1693,18 +1693,18 @@ class BaseHtml
         $encodeSpaces = ArrayHelper::remove($tagOptions, 'encodeSpaces', false);
         $encode = ArrayHelper::remove($tagOptions, 'encode', true);
         if (isset($tagOptions['prompt'])) {
-            $attrs = ['value' => ''];
+            $promptOptions = ['value' => ''];
             if (is_string($tagOptions['prompt'])) {
                 $text = $tagOptions['prompt'];
             } else {
                 $text = $tagOptions['prompt']['text'];
-                $attrs = array_merge($attrs, $tagOptions['prompt']['options']);
+                $promptOptions = array_merge($promptOptions, $tagOptions['prompt']['options']);
             }
             $text = $encode ? static::encode($text) : $text;
             if ($encodeSpaces) {
                 $text = str_replace(' ', '&nbsp;', $text);
             }
-            $lines[] = static::tag('option', $text, $attrs);
+            $lines[] = static::tag('option', $text, $promptOptions);
         }
 
         $options = isset($tagOptions['options']) ? $tagOptions['options'] : [];

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -603,6 +603,24 @@ EOD;
             ],
         ];
         $this->assertEqualsWithoutLE(str_replace('&nbsp;', ' ', $expected), Html::renderSelectOptions(['value111', 'value1'], $data, $attributes));
+
+        // Attributes for prompt (https://github.com/yiisoft/yii2/issues/7420)
+
+        $data = [
+            'value1' => 'label1',
+            'value2' => 'label2',
+        ];
+        $expected = <<<EOD
+<option class="prompt" value="-1" label="None">Please select</option>
+<option value="value1" selected>label1</option>
+<option value="value2">label2</option>
+EOD;
+        $attributes = [
+            'prompt' => [
+                'text' => 'Please select', 'options' => ['class' => 'prompt', 'value' => '-1', 'label' => 'None'],
+            ],
+        ];
+        $this->assertEqualsWithoutLE($expected, Html::renderSelectOptions(['value1'], $data, $attributes));
     }
 
     public function testRenderAttributes()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #7420

We have the following options of implementing this:

- Initial suggestion from @nkovacs (https://github.com/yiisoft/yii2/issues/7420#issue-58740067), adding separate additional array element:

```php
echo $form->field($model, 'foo')->dropDownList(['value1' => 'One', 'value2' => 'Two'], [
    'prompt' => 'please choose',
    'promptOptions' => [
        'class' => 'drop-down-prompt',
    ],
]);
```

- Method suggested by @Faryshta (https://github.com/yiisoft/yii2/issues/7420#issuecomment-75860925), using one array, storing prompt text under `label` key and the other attributes under according keys in the same array:

```php
'prompt' => ['label' => 'Please Choose', 'class' => 'drop-down-prompt', 'value' => '-1'];
```

Rendering option without content inside of a tag [will work](http://www.w3schools.com/tags/att_option_label.asp):

```html
<option label="Please Choose", "class"="drop-down-prompt", "value"="-1"></option>
```

But with this method there are some problems with older browsers, also putting text inside of a tag is more traditional way and it's consistent with other options.

Using `label` for both `label` attribute and tag content is not good idea too, because the label attribute value is intended to be shorter form of tag content. Example:

```html
<select>
  <option label="Volvo">Volvo (Latin for "I roll")</option>
  <option label="Saab">Saab (Swedish Aeroplane AB)</option>
  <option label="Mercedes">Mercedes (Mercedes-Benz)</option>
  <option label="Audi">Audi (Auto Union Deutschland Ingolstadt)</option>
</select>
```

So if user decides to specify custom `label` we can't distinguish between them.

As a workaround we can use some other special key like `text`, use it as tag content and use the rest of array as tag attributes:

```php
'prompt' => ['label' => 'Choose', 'text' => 'Please Choose', 'class' => 'drop-down-prompt', 'value' => '-1'];
```

Rendering result:

```html
<option label="Choose", "class"="drop-down-prompt", "value"="-1">Please Choose</option>
```

However such mixing is not clear in my opinion.

- Solution I implemented in this PR. Use `text` for content tag and specify options as subarray.

```php
'prompt' => [
    'text' => 'Please select', 'options' => ['class' => 'prompt', 'value' => '-1', 'label' => 'None'],
],
```

Rendering result:

```html
<option class="prompt" value="-1" label="None">Please select</option>
```

- Also I was thinking about shorter form without associative array at the top level, something like that:

```php
'prompt' => ['Please select', ['class' => 'prompt', 'value' => '-1', 'label' => 'None']],
```

But this adds strict order and inconsistent with config style in other places.