### PR TITLE
Sluggablebehavior: use ArrayHelper::getValue for slugParts[]

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -37,6 +37,7 @@ Yii Framework 2 Change Log
 - Enh #12816: Added `columnSchemaClass` option for `yii\db\Schema` which adds ability to specify custom `yii\db\ColumnSchema` class (nanodesu88)
 - Enh #12881: Added `removeValue` method to `yii\helpers\BaseArrayHelper` (nilsburg)
 - Enh #12901: Added `getDefaultHelpHeader` method to the `yii\console\controllers\HelpController` class to be able to override default help header in a class heir (diezztsk)
+- Enh #13035: Use ArrayHelper::getValue() in SluggableBehavior::getValue() (thyseus)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
 
 

--- a/framework/behaviors/SluggableBehavior.php
+++ b/framework/behaviors/SluggableBehavior.php
@@ -9,6 +9,7 @@ namespace yii\behaviors;
 
 use yii\base\InvalidConfigException;
 use yii\db\BaseActiveRecord;
+use yii\helpers\ArrayHelper;
 use yii\helpers\Inflector;
 use yii\validators\UniqueValidator;
 use Yii;
@@ -139,7 +140,7 @@ class SluggableBehavior extends AttributeBehavior
             if ($this->isNewSlugNeeded()) {
                 $slugParts = [];
                 foreach ((array) $this->attribute as $attribute) {
-                    $slugParts[] = $this->owner->{$attribute};
+                    $slugParts[] = ArrayHelper::getValue($this->owner, $attribute);
                 }
 
                 $slug = $this->generateSlug($slugParts);

--- a/tests/framework/behaviors/SluggableBehaviorTest.php
+++ b/tests/framework/behaviors/SluggableBehaviorTest.php
@@ -44,8 +44,15 @@ class SluggableBehaviorTest extends TestCase
             'name' => 'string',
             'slug' => 'string',
             'category_id' => 'integer',
+            'belongs_to_id' => 'integer',
         ];
         Yii::$app->getDb()->createCommand()->createTable('test_slug', $columns)->execute();
+
+        $columns = [
+            'id' => 'pk',
+            'name' => 'string',
+        ];
+        Yii::$app->getDb()->createCommand()->createTable('test_slug_related', $columns)->execute();
     }
 
     public function tearDown()
@@ -78,6 +85,25 @@ class SluggableBehaviorTest extends TestCase
 
         $model->validate();
         $this->assertEquals('test-10', $model->slug);
+    }
+
+    /**
+     * @depends testSlug
+     */
+    public function testSlugRelatedAttribute()
+    {
+        $model = new ActiveRecordSluggable();
+        $model->getBehavior('sluggable')->attribute = 'related.name';
+
+        $relatedmodel = new ActiveRecordRelated();
+        $relatedmodel->name = 'I am an value inside an related activerecord model';
+        $relatedmodel->save(false);
+
+        $model->belongs_to_id = $relatedmodel->id;
+
+        $model->validate();
+
+        $this->assertEquals('i-am-an-value-inside-an-related-activerecord-model', $model->slug);
     }
 
     /**
@@ -175,6 +201,19 @@ class ActiveRecordSluggable extends ActiveRecord
     public function getSluggable()
     {
         return $this->getBehavior('sluggable');
+    }
+
+    public function getRelated()
+    {
+        return $this->hasOne(ActiveRecordRelated::className(), ['id' => 'belongs_to_id']);
+    }
+}
+
+class ActiveRecordRelated extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_slug_related';
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

Use yii\helpers\ArrayHelper::getValue() to determine the slugParts[] in the SluggableBehavior. This allows to use:

```php
[
    'class' => SluggableBehavior::className(),
    'attribute' => 'offer.title',
]
```

instead of/in addition to:

```php
 public function behaviors()
    {
        return [
                [
                'class' => SluggableBehavior::className(),
                'attribute' => 'title',
                ]
        ];
}

public function getTitle()
{
    return $this->offer->title;
}
```



