### PR TITLE
urlName don't contain module name. This is bug, if set prefix and con…

### DIFF
--- a/framework/rest/UrlRule.php
+++ b/framework/rest/UrlRule.php
@@ -151,6 +151,8 @@ class UrlRule extends CompositeUrlRule
         foreach ((array) $this->controller as $urlName => $controller) {
             if (is_int($urlName)) {
                 $urlName = $this->pluralize ? Inflector::pluralize($controller) : $controller;
+
+                $urlName = trim(substr($urlName, (int)strpos($urlName, '/')), '/');
             }
             $controllers[$urlName] = $controller;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | 

…troller contain module

```
class Module extends \yii\base\Module implements BootstrapInterface
{
    public static $controllerNamespace = 'frontend\modules\api_0_2\controllers';

    /**
     * @inheritdoc
     */
    public function bootstrap($app)
    {
        Yii::$app->urlManager->addRules([
            [
                'class' => 'yii\rest\UrlRule',
                'controller' => [
                    'api_0_2/test',
                ],
                'prefix' => 'api/0.2',
                'extraPatterns' => [
                    'GET test' => 'test',
                ]
            ]
        ]);
    }
}
```


```
rest/UrlRule:148
        $controllers = [];
        foreach ((array) $this->controller as $urlName => $controller) {
            if (is_int($urlName)) {
                $urlName = $this->pluralize ? Inflector::pluralize($controller) : $controller;
            }
            $controllers[$urlName] = $controller;
        }
        $this->controller = $controllers;
```
As a result, the variable $urlName equals "api_0_2/tests"

```
rest/UrlRule:172
            $prefix = trim($this->prefix . '/' . $urlName, '/');
```
As a result, the variable $prefix equals "api/0.2/api_0_2/tests" - this is bug