### PR TITLE
Update examples for events using interfaces

### DIFF
--- a/docs/guide/concept-events.md
+++ b/docs/guide/concept-events.md
@@ -296,11 +296,6 @@ pass the interface name as the first argument:
 Event::on('DanceEventInterface', DanceEventInterface::EVENT_DANCE, function ($event) {
     Yii::trace($event->sender->className . ' just danced'); // Will log that Dog or Developer danced
 });
-
-// or with fully qualified interface name
-Event::on(DanceEventInterface::class, DanceEventInterface::EVENT_DANCE, function ($event) {
-    Yii::trace($event->sender->className . ' just danced'); // Will log that Dog or Developer danced
-});
 ```
 
 You can trigger the event of those classes:

--- a/docs/guide/concept-events.md
+++ b/docs/guide/concept-events.md
@@ -295,13 +295,22 @@ pass the interface name as the first argument:
 ```php
 Event::on('DanceEventInterface', DanceEventInterface::EVENT_DANCE, function ($event) {
     Yii::trace($event->sender->className . ' just danced'); // Will log that Dog or Developer danced
-})
+});
+
+// or with fully qualified interface name
+Event::on(DanceEventInterface::class, DanceEventInterface::EVENT_DANCE, function ($event) {
+    Yii::trace($event->sender->className . ' just danced'); // Will log that Dog or Developer danced
+});
 ```
 
 You can trigger the event of those classes:
 
 ```php
-Event::trigger(DanceEventInterface::className(), DanceEventInterface::EVENT_DANCE);
+// trigger event for Dog class
+Event::trigger(Dog::className(), DanceEventInterface::EVENT_DANCE);
+
+// trigger event for Developer class
+Event::trigger(Developer::className(), DanceEventInterface::EVENT_DANCE);
 ```
 
 But please notice, that you can not trigger all the classes, that implement the interface:


### PR DESCRIPTION
Where was a mistake in example for events using interfaces. As events has no method [[className()]] and when called [[Event::trigger()]] we should pass first argument class name implemented this interface, not the interface itself.