### PR TITLE
Fixes #13071: Help option for commands was not working in modules

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -21,7 +21,7 @@ Yii Framework 2 Change Log
 - Bug #12904: Fixed lowercase table name in migrations (zlakomanoff)
 - Bug #12939: Hard coded table names for MSSQL in RBAC migration (arogachev)
 - Bug #12974: Fixed incorrect order of migrations history in case `yii\console\controllers\MigrateController::$migrationNamespaces` is in use (evgen-d, klimov-paul)
-- Bug #13071: Help option for commands was not working in modules (haimanman, arogachev)
+- Bug #13071: Help option for commands was not working in modules (arogachev, haimanman)
 - Enh #6809: Added `\yii\caching\Cache::$defaultDuration` property, allowing to set custom default cache duration (sdkiller)
 - Enh #7333: Improved error message for `yii\di\Instance::ensure()` when a component does not exist (cebe)
 - Enh #7420: Attributes for prompt generated with `renderSelectOptions` of `\yii\helpers\Html` helper (arogachev)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -21,6 +21,7 @@ Yii Framework 2 Change Log
 - Bug #12904: Fixed lowercase table name in migrations (zlakomanoff)
 - Bug #12939: Hard coded table names for MSSQL in RBAC migration (arogachev)
 - Bug #12974: Fixed incorrect order of migrations history in case `yii\console\controllers\MigrateController::$migrationNamespaces` is in use (evgen-d, klimov-paul)
+- Bug #13071: Help option for commands was not working in modules (haimanman, arogachev)
 - Enh #6809: Added `\yii\caching\Cache::$defaultDuration` property, allowing to set custom default cache duration (sdkiller)
 - Enh #7333: Improved error message for `yii\di\Instance::ensure()` when a component does not exist (cebe)
 - Enh #7420: Attributes for prompt generated with `renderSelectOptions` of `\yii\helpers\Html` helper (arogachev)

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -122,7 +122,7 @@ class Controller extends \yii\base\Controller
             }
         }
         if ($this->help) {
-            $route = $this->id . '/' . $id;
+            $route = $this->getUniqueId() . '/' . $id;
             return Yii::$app->runAction('help', [$route]);
         }
         return parent::runAction($id, $params);

--- a/tests/framework/console/FakeController.php
+++ b/tests/framework/console/FakeController.php
@@ -22,6 +22,16 @@ class FakeController extends Controller
 
     public $alias;
 
+    private static $_wasActionIndexCalled = false;
+
+    public static function getWasActionIndexCalled()
+    {
+        $wasCalled = self::$_wasActionIndexCalled;
+        self::$_wasActionIndexCalled = false;
+
+        return $wasCalled;
+    }
+
     public function options($actionID)
     {
         return array_merge(parent::options($actionID), [
@@ -38,6 +48,11 @@ class FakeController extends Controller
             'ta' => 'testArray',
             'a' => 'alias'
         ];
+    }
+
+    public function actionIndex()
+    {
+        self::$_wasActionIndexCalled = true;
     }
 
     public function actionAksi1($fromParam, $other = 'default')

--- a/tests/framework/console/FakeHelpController.php
+++ b/tests/framework/console/FakeHelpController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace yiiunit\framework\console;
+
+use yii\console\controllers\HelpController;
+
+class FakeHelpController extends HelpController
+{
+    private static $_actionIndexLastCallParams;
+
+    public function actionIndex($command = null)
+    {
+        self::$_actionIndexLastCallParams = func_get_args();
+    }
+
+    public static function getActionIndexLastCallParams()
+    {
+        $params = self::$_actionIndexLastCallParams;
+        self::$_actionIndexLastCallParams = null;
+
+        return $params;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13071 

