### PR TITLE
Fix Yii::createObject 

### DIFF
--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -430,7 +430,7 @@ class Container extends Component
                     $dependencies[] = $param->getDefaultValue();
                 } else {
                     $c = $param->getClass();
-                    $dependencies[] = Instance::of($c === null ? null : $c->getName());
+                    $dependencies[] = $c === null ? null : Instance::of($c->getName());
                 }
             }
         }

--- a/tests/framework/BaseYiiTest.php
+++ b/tests/framework/BaseYiiTest.php
@@ -65,6 +65,19 @@ class BaseYiiTest extends TestCase
         $this->assertTrue(is_string(Yii::powered()));
     }
 
+    public function testCreateObjectSetConstructorParams()
+    {
+        $object = Yii::createObject([
+            'class' => '\yii\db\Expression',
+            'expression' => '[[quantity]]+:bp0',
+            'params' => [
+                ':bp0' => -1
+            ]
+        ]);
+
+        $this->assertTrue($object instanceof \yii\db\Expression);
+    }
+
     public function testCreateObjectCallable()
     {
         Yii::$container = new Container();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | 

If passed the parameters to be passed to the constructor `Yii::createObject` simply ignores them.

