### PR TITLE
Update Session.php

### DIFF
--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -281,7 +281,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
             // add @ to inhibit possible warning due to race condition
             // https://github.com/yiisoft/yii2/pull/1812
             if (YII_DEBUG && !headers_sent()) {
-                session_regenerate_id($deleteOldSession);
+                @session_regenerate_id($deleteOldSession);
             } else {
                 @session_regenerate_id($deleteOldSession);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | 

If YII_DEBUG is true and cookie identity is set the error has occured after the session timeout: 
PHP Warning – yii\base\ErrorException
session_regenerate_id(): Session object destruction failed. ID: user (path: /tmp/php/sessions)
1. in /srv/http/vic/www/myshop/trunk/dev/src/vendor/yiisoft/yii2/web/Session.php at line 284

If set @session_regenerate_id at line 284 then error will be resolved.