### PR TITLE
Select only primary keys in UniqueValidator (#10896)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -29,6 +29,7 @@ Yii Framework 2 Change Log
 - Enh #7333: Improved error message for `yii\di\Instance::ensure()` when a component does not exist (cebe)
 - Enh #7420: Attributes for prompt generated with `renderSelectOptions` of `\yii\helpers\Html` helper (arogachev)
 - Enh #9162: Added support of closures in `value` for attributes in `yii\widgets\DetailView` (arogachev)
+- Enh #10896: Select only primary key when counting records in UniqueValidator (developeruz)
 - Enh #11037: `yii.js` and `yii.validation.js` use `Regexp.test()` instead of `String.match()` (arogachev, nkovacs)
 - Enh #11756: Added type mapping for `varbinary` data type in MySQL DBMS (silverfire)
 - Enh #11929: Changed `type` column type from `int` to `smallInt` in RBAC migrations (silverfire)
@@ -49,7 +50,6 @@ Yii Framework 2 Change Log
 - Enh #12988: Changed `textarea` method within the `yii\helpers\BaseHtml` class to allow users to control whether html entities found within `$value` will be double-encoded or not (cyphix333)
 - Enh #13074: Improved `\yii\log\SyslogTarget` with `$options` to be able to change the default `openlog` options. (timbeks)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
-
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -145,7 +145,7 @@ class UniqueValidator extends Validator
         } else {
             // if current $model is in the database already we can't use exists()
             /* @var $models ActiveRecordInterface[] */
-            $models = $query->limit(2)->all();
+            $models = $query->select($targetClass::primaryKey())->limit(2)->all();
             $n = count($models);
             if ($n === 1) {
                 $keys = array_keys($params);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #10896

Select only primary key when counting records.
Selected results are used only in these lines
```php 
$n = count($models);
...
reset($models)->getPrimaryKey()
```