### PR TITLE
[POC] Add host validation to `yii\web\Request`

### DIFF
--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -27,6 +27,20 @@ class Controller extends \yii\base\Controller
      */
     public $enableCsrfValidation = true;
     /**
+     * @var bool whether to enable host info validation for the actions in this controller, to protect against
+     * ['host header' attacks](https://www.acunetix.com/vulnerabilities/web/host-header-attack).
+     * Host info validation is enabled only when this property is true and [[\yii\web\Request::$allowedHosts]] is not empty.
+     */
+    public $enableHostInfoValidation = true;
+    /**
+     * @var callable|false a callback that will be called if the current host does not match [[\yii\web\Request::$allowedHosts]].
+     * If not set, [[\yii\web\Request::$invalidHostCallback]] will be called.
+     *
+     * > Note: while implementing your own host deny processing, make sure you avoid usage of the current requested
+     * host name, creation of absolute URL links, caching page parts and so on.
+     */
+    public $invalidHostCallback;
+    /**
      * @var array the parameters bound to the current action.
      */
     public $actionParams = [];
@@ -108,12 +122,15 @@ class Controller extends \yii\base\Controller
     public function beforeAction($action)
     {
         if (parent::beforeAction($action)) {
+            if ($this->enableHostInfoValidation && Yii::$app->getErrorHandler()->exception === null) {
+                Yii::$app->getRequest()->validateHostInfo($this->invalidHostCallback);
+            }
             if ($this->enableCsrfValidation && Yii::$app->getErrorHandler()->exception === null && !Yii::$app->getRequest()->validateCsrfToken()) {
                 throw new BadRequestHttpException(Yii::t('yii', 'Unable to verify your data submission.'));
             }
             return true;
         }
-        
+
         return false;
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,7 @@ error_reporting(-1);
 
 define('YII_ENABLE_ERROR_HANDLER', false);
 define('YII_DEBUG', true);
+define('YII_ENV', 'test');
 $_SERVER['SCRIPT_NAME'] = '/' . __DIR__;
 $_SERVER['SCRIPT_FILENAME'] = __FILE__;
 

--- a/tests/framework/web/RequestTest.php
+++ b/tests/framework/web/RequestTest.php
@@ -7,6 +7,8 @@
 
 namespace yiiunit\framework\web;
 
+use Yii;
+use yii\base\ExitException;
 use yii\web\Request;
 use yiiunit\TestCase;
 
@@ -15,6 +17,16 @@ use yiiunit\TestCase;
  */
 class RequestTest extends TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $_SERVER['SCRIPT_FILENAME'] = "/index.php";
+        $_SERVER['SCRIPT_NAME'] = "/index.php";
+
+        $this->mockWebApplication();
+    }
+
     public function testParseAcceptHeader()
     {
         $request = new Request;
@@ -295,5 +307,83 @@ class RequestTest extends TestCase
 
         unset($_SERVER['SERVER_PORT']);
         $this->assertEquals(null, $request->getServerPort());
+    }
+
+    /**
+     * @dataProvider hostInfoValidationDataProvider
+     *
+     * @param mixed $allowedHosts
+     * @param string $host
+     * @param bool $allowed
+     */
+    public function testHostInfoValidation($allowedHosts, $host, $allowed)
+    {
+        $request = new Request();
+        $request->hostInfo = 'http://' . $host;
+        $request->allowedHosts = $allowedHosts;
+
+        if ($allowed) {
+            $this->assertTrue($request->validateHostInfo());
+        } else {
+            ob_start();
+            ob_implicit_flush(false);
+
+            $isExit = false;
+
+            try {
+                $request->validateHostInfo();
+            } catch (ExitException $e) {
+                $isExit = true;
+            }
+
+            ob_get_clean();
+
+            $this->assertTrue($isExit);
+            $this->assertEquals(404, Yii::$app->response->getStatusCode());
+        }
+    }
+
+
+    /**
+     * @return array test data.
+     */
+    public function hostInfoValidationDataProvider()
+    {
+        return [
+            [
+                ['example.com'],
+                'example.com',
+                true
+            ],
+            [
+                ['example.com'],
+                'domain.com',
+                false
+            ],
+            [
+                ['*.example.com'],
+                'en.example.com',
+                true
+            ],
+            [
+                ['*.example.com'],
+                'fake.com',
+                false
+            ],
+            [
+                function () {
+                    return ['example.com'];
+                },
+                'example.com',
+                true
+            ],
+            [
+                function () {
+                    return ['example.com'];
+                },
+                'fake.com',
+                false
+            ],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13050

Closes #13050

Alternative to #13063 with approach more similar to CSRF validation. It still fails by default if host is invalid, but there are no additional filters -  allowed hosts are set at `Request` level which makes configuration easier and (IMO) more logical. Also validation is performed in `Request::getHostInfo()` so there is no risk that we will have corrupted host in `Request::$hostInfo` - at worst case it will be empty (`false` to be exact).

It still is only POC and mostly copy-paste from #13063. If there will be interest of this approach, I will update phpdoc and add more test cases.

