### PR TITLE
Use `github-no-api` option for asset-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,10 @@
         "asset-installer-paths": {
             "npm-asset-library": "vendor/npm",
             "bower-asset-library": "vendor/bower"
-        }
+        },
+        "asset-vcs-driver-options": {
+            "github-no-api": true
+        },
+        "asset-pattern-skip-version": "(-build|-patch)"
     }
 }


### PR DESCRIPTION
Possible fix for #12987. At least for me it fixes travis tests on my fork: https://travis-ci.org/rob006/yii2-dev/branches.

References: 
* http://www.yiiframework.com/wiki/843/boost-composer-asset-plugin-update-speed/
* https://github.com/fxpio/composer-asset-plugin/issues/226
