### PR TITLE
Disable `Controversial/CamelCasePropertyName` codeclimate check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,7 +14,9 @@ engines:
     enabled: true
     checks:
         CleanCode/StaticAccess:
-            enabled: false
+          enabled: false
+        Controversial/CamelCasePropertyName:
+          enabled: false  
 ratings:
   paths:
   - "**.js"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,10 +13,10 @@ engines:
   phpmd:
     enabled: true
     checks:
-        CleanCode/StaticAccess:
-          enabled: false
-        Controversial/CamelCasePropertyName:
-          enabled: false  
+      CleanCode/StaticAccess:
+        enabled: false
+      Controversial/CamelCasePropertyName:
+        enabled: false  
 ratings:
   paths:
   - "**.js"


### PR DESCRIPTION
This rule is conflicting with properties prefixed by `_`.  See https://codeclimate.com/github/yiisoft/yii2/pull/13117 .
