### PR TITLE
Bugfix: @webroot appears on project-root

### DIFF
--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -518,7 +518,7 @@ class AssetManager extends Component
         $dstDir = $this->basePath . DIRECTORY_SEPARATOR . $dir;
         if ($this->linkAssets) {
             if (!is_dir($dstDir)) {
-                FileHelper::createDirectory(dirname($dstDir), $this->dirMode, true);
+                FileHelper::createDirectory(dirname(Yii::getAlias($dstDir)), $this->dirMode, true);
                 symlink($src, $dstDir);
             }
         } elseif (!empty($options['forceCopy']) || ($this->forceCopy && !isset($options['forceCopy'])) || !is_dir($dstDir)) {


### PR DESCRIPTION
BasePath contains mostly aliases '@..', which will be ignored by the directory-publishment. Leads to wrong folder creation '@whatever-alias/' to the project root.