### PR TITLE
Small refactor to queryScalar

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -1,6 +1,12 @@
 Yii Framework 2 Change Log
 ==========================
 
+2.0.12 under development
+--------------------------
+
+- Enh #13144: Refactor to `queryScalar` (Alex-Code)
+
+
 2.0.11 under development
 ------------------------
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.12 under development
 --------------------------
 
-- Enh #13144: Refactor to `queryScalar` (Alex-Code)
+- Enh #13144: Refactored `queryScalar` (Alex-Code)
 
 
 2.0.11 under development

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -330,14 +330,16 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     protected function queryScalar($selectExpression, $db)
     {
-        if ($this->sql === null) {
-            return parent::queryScalar($selectExpression, $db);
-        }
         /* @var $modelClass ActiveRecord */
         $modelClass = $this->modelClass;
         if ($db === null) {
             $db = $modelClass::getDb();
         }
+        
+        if ($this->sql === null) {
+            return parent::queryScalar($selectExpression, $db);
+        }
+        
         return (new Query)->select([$selectExpression])
             ->from(['c' => "({$this->sql})"])
             ->params($this->params)

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -408,25 +408,25 @@ class Query extends Component implements QueryInterface
             return null;
         }
 
-        $select = $this->select;
-        $limit = $this->limit;
-        $offset = $this->offset;
-
-        $this->select = [$selectExpression];
-        $this->limit = null;
-        $this->offset = null;
-        $command = $this->createCommand($db);
-
-        $this->select = $select;
-        $this->limit = $limit;
-        $this->offset = $offset;
-
         if (empty($this->groupBy) && empty($this->having) && empty($this->union) && !$this->distinct) {
+            $select = $this->select;
+            $limit = $this->limit;
+            $offset = $this->offset;
+
+            $this->select = [$selectExpression];
+            $this->limit = null;
+            $this->offset = null;
+            $command = $this->createCommand($db);
+
+            $this->select = $select;
+            $this->limit = $limit;
+            $this->offset = $offset;
+            
             return $command->queryScalar();
         } else {
             return (new Query)->select([$selectExpression])
                 ->from(['c' => $this])
-                ->createCommand($command->db)
+                ->createCommand($db)
                 ->queryScalar();
         }
     }


### PR DESCRIPTION
The subquery count in `Query::queryScalar` doesn't need all the code that precedes it to run so moved it inside the `if` block.