### PR TITLE
Make validator getClientOptions public

### DIFF
--- a/docs/guide/input-validation.md
+++ b/docs/guide/input-validation.md
@@ -895,13 +895,13 @@ the former will take precedence.
 > - if you want to implement your own custom client-side validation but leave the synchronization with server-side
 > validator options;
 > - to extend or customize to fit your specific needs:
-> 
+>
 > ```php
-> protected function getClientOptions($model, $attribute)
+> public function getClientOptions($model, $attribute)
 > {
 >     $options = parent::getClientOptions($model, $attribute);
 >     // Modify $options here
-> 
+>
 >     return $options;
 > }
 > ```

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -29,14 +29,14 @@ The simple way to upgrade Yii, for example to version 2.0.10 (replace this with 
     composer require "yiisoft/yii2:~2.0.10"
 
 This however may fail due to changes in the dependencies of yiisoft/yii2, which may change due to security updates
-in other libraries or by adding support for newer versions. `composer require` will not update any other packages 
+in other libraries or by adding support for newer versions. `composer require` will not update any other packages
 as a safety feature.
 
 The better way to upgrade is to change the `composer.json` file to require the new Yii version and then
 run `composer update` by specifying all packages that are allowed to be updated.
 
     composer update yiisoft/yii2 yiisoft/yii2-composer bower-asset/jquery.inputmask
-    
+
 The above command will only update the specified packages and leave the versions of all other dependencies intact.
 This helps to update packages step by step without causing a lot of package version changes that might break in some way.
 If you feel lucky you can of course update everything to the latest version by running `composer update` without
@@ -56,6 +56,9 @@ Upgrade from Yii 2.0.10
 * A new method `public function emulateExecution($value = true);` has been added to the `yii\db\QueryInterace`.
   This method is implemented in the `yii\db\QueryTrait`, so this only affects your code if you implement QueryInterface
   in a class that does not use the trait.
+
+* `yii\validators\FileValidator::getClientOptions()` and `yii\validators\ImageValidator::getClientOptions()` are now public.
+  If you extend from these classes and override these methods, you must make them public as well.
 
 Upgrade from Yii 2.0.9
 ----------------------

--- a/framework/captcha/CaptchaValidator.php
+++ b/framework/captcha/CaptchaValidator.php
@@ -95,7 +95,7 @@ class CaptchaValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $captcha = $this->createCaptchaAction();
         $code = $captcha->getVerifyCode(false);

--- a/framework/validators/BooleanValidator.php
+++ b/framework/validators/BooleanValidator.php
@@ -79,7 +79,7 @@ class BooleanValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $options = [
             'trueValue' => $this->trueValue,

--- a/framework/validators/CompareValidator.php
+++ b/framework/validators/CompareValidator.php
@@ -234,7 +234,7 @@ class CompareValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $options = [
             'operator' => $this->operator,

--- a/framework/validators/EmailValidator.php
+++ b/framework/validators/EmailValidator.php
@@ -121,7 +121,7 @@ class EmailValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $options = [
             'pattern' => new JsExpression($this->pattern),

--- a/framework/validators/FileValidator.php
+++ b/framework/validators/FileValidator.php
@@ -386,7 +386,7 @@ class FileValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $label = $model->getAttributeLabel($attribute);
 

--- a/framework/validators/FilterValidator.php
+++ b/framework/validators/FilterValidator.php
@@ -97,7 +97,7 @@ class FilterValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $options = [];
         if ($this->skipOnEmpty) {

--- a/framework/validators/ImageValidator.php
+++ b/framework/validators/ImageValidator.php
@@ -172,7 +172,7 @@ class ImageValidator extends FileValidator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $options = parent::getClientOptions($model, $attribute);
 

--- a/framework/validators/IpValidator.php
+++ b/framework/validators/IpValidator.php
@@ -597,7 +597,7 @@ class IpValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $messages = [
             'ipv6NotAllowed' => $this->ipv6NotAllowed,

--- a/framework/validators/NumberValidator.php
+++ b/framework/validators/NumberValidator.php
@@ -130,7 +130,7 @@ class NumberValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $label = $model->getAttributeLabel($attribute);
 

--- a/framework/validators/RangeValidator.php
+++ b/framework/validators/RangeValidator.php
@@ -117,7 +117,7 @@ class RangeValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $range = [];
         foreach ($this->range as $value) {

--- a/framework/validators/RegularExpressionValidator.php
+++ b/framework/validators/RegularExpressionValidator.php
@@ -74,7 +74,7 @@ class RegularExpressionValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $pattern = Html::escapeJsRegularExpression($this->pattern);
 

--- a/framework/validators/RequiredValidator.php
+++ b/framework/validators/RequiredValidator.php
@@ -97,7 +97,7 @@ class RequiredValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $options = [];
         if ($this->requiredValue !== null) {

--- a/framework/validators/StringValidator.php
+++ b/framework/validators/StringValidator.php
@@ -159,7 +159,7 @@ class StringValidator extends Validator
         return 'yii.validation.string(value, messages, ' . json_encode($options, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . ');';
     }
 
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         $label = $model->getAttributeLabel($attribute);
 

--- a/framework/validators/UrlValidator.php
+++ b/framework/validators/UrlValidator.php
@@ -125,7 +125,7 @@ class UrlValidator extends Validator
     /**
      * @inheritdoc
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         if (strpos($this->pattern, '{schemes}') !== false) {
             $pattern = str_replace('{schemes}', '(' . implode('|', $this->validSchemes) . ')', $this->pattern);

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -372,7 +372,7 @@ class Validator extends Component
      * @return array the client-side validation options
      * @since 2.0.11
      */
-    protected function getClientOptions($model, $attribute)
+    public function getClientOptions($model, $attribute)
     {
         return [];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | #11163 

This allows implementing custom client-side validation
without extending every validator.

The backwards compatibility break is caused by the change in ImageValidator. `ImageValidator::getClientOptions` was protected since 2.0.0 (https://github.com/yiisoft/yii2/commit/6dd2203a5c0db168f51369cab206ff07e3c1fd04#diff-504fd084646834cd27fce3dbdce26bbeR350), so if you extended the class and overrode the method with a protected method, the visibility change will cause a fatal error (because you can't make a public method protected in a subclass).

Fixes #11163