### PR TITLE
consistent behavior for Yii::$app->controller and ->action

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Bug #12714: Fixed `yii\validation\EmailValidator` to prevent false-positives checks when property `checkDns` is set to `true` (silverfire)
 - Bug #12735: Fixed `yii\console\controllers\MigrateController` creating multiple primary keys for field `bigPrimaryKey:unsigned` (SG5)
 - Bug #12791: Fixed `yii\behaviors\AttributeTypecastBehavior` unable to automatically detect `attributeTypes`, triggering PHP Fatal Error (klimov-paul)
+- Bug #12795: Fixed inconsistency, `Yii::$app->controller` is available after handling the request since 2.0.10, this is now also the case for `Yii::$app->controller->action` (cebe)
 - Bug #12803, #12921: Fixed BC break in `yii.activeForm.js` introduced in #11999. Reverted commit 3ba72da (silverfire)
 - Bug #12810: Fixed `yii\rbac\DbManager::getChildRoles()` and `yii\rbac\PhpManager::getChildRoles()` throws an exception when role has no child roles (mysterydragon)
 - Bug #12822: Fixed `yii\i18n\Formatter::asTimestamp()` to process timestamp with miliseconds correctly (h311ion)

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -164,7 +164,9 @@ class Controller extends Component implements ViewContextInterface
             }
         }
 
-        $this->action = $oldAction;
+        if ($oldAction !== null) {
+            $this->action = $oldAction;
+        }
 
         return $result;
     }

--- a/tests/framework/base/ControllerTest.php
+++ b/tests/framework/base/ControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace yiiunit\framework\base;
+
+use Yii;
+use yii\base\Controller;
+use yiiunit\TestCase;
+
+/**
+ * @group base
+ */
+class ControllerTest extends TestCase
+{
+    public static $actionRuns = [];
+
+    public function testRunAction()
+    {
+        $this->mockApplication();
+
+        static::$actionRuns = [];
+        $controller = new TestController('test-controller', Yii::$app);
+        $this->assertNull($controller->action);
+        $result = $controller->runAction('test1');
+        $this->assertEquals('test1', $result);
+        $this->assertEquals([
+            'test-controller/test1',
+        ], static::$actionRuns);
+        $this->assertNotNull($controller->action);
+        $this->assertEquals('test1', $controller->action->id);
+        $this->assertEquals('test-controller/test1', $controller->action->uniqueId);
+
+        $result = $controller->runAction('test2');
+        $this->assertEquals('test2', $result);
+        $this->assertEquals([
+            'test-controller/test1',
+            'test-controller/test2',
+        ], static::$actionRuns);
+        $this->assertNotNull($controller->action);
+        $this->assertEquals('test1', $controller->action->id);
+        $this->assertEquals('test-controller/test1', $controller->action->uniqueId);
+    }
+}
+
+
+class TestController extends Controller
+{
+    public function actionTest1()
+    {
+        ControllerTest::$actionRuns[] = $this->action->uniqueId;
+        return 'test1';
+    }
+    public function actionTest2()
+    {
+        ControllerTest::$actionRuns[] = $this->action->uniqueId;
+        return 'test2';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| Breaks BC?    | probably not
| Tests pass?   | yes
| Fixed issues  | #12795

Fixed inconsistency, `Yii::$app->controller` is available
after handling the request since 2.0.10, this is now also the case for
`Yii::$app->controller->action`.

fixes #12795