### PR TITLE
Allow single role in filters/AccessRule.php

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -57,6 +57,7 @@ Yii Framework 2 Change Log
 - Enh #12881: Added `removeValue` method to `yii\helpers\BaseArrayHelper` (nilsburg)
 - Enh #12901: Added `getDefaultHelpHeader` method to the `yii\console\controllers\HelpController` class to be able to override default help header in a class heir (diezztsk)
 - Enh #13035: Use ArrayHelper::getValue() in SluggableBehavior::getValue() (thyseus)
+- Enh #13168: Allow assignment of single role in filters/AccessRule.php. Allows 'roles' => '@' in addition to 'roles' => ['@'] (thyseus)
 - Enh #13036: Added shortcut methods `asJson()` and `asXml()` for returning JSON and XML data in web controller actions (cebe)
 - Enh #13020: Added `disabledListItemSubTagOptions` attribute for `yii\widgets\LinkPager` in order to customize the disabled list item sub tag element (nadar)
 - Enh #12988: Changed `textarea` method within the `yii\helpers\BaseHtml` class to allow users to control whether html entities found within `$value` will be double-encoded or not (cyphix333)

--- a/framework/filters/AccessRule.php
+++ b/framework/filters/AccessRule.php
@@ -36,7 +36,7 @@ class AccessRule extends Component
      */
     public $controllers;
     /**
-     * @var array list of roles that this rule applies to. Two special roles are recognized, and
+     * @var array|string list of roles or single role that this rule applies to. Two special roles are recognized, and
      * they are checked via [[User::isGuest]]:
      *
      * - `?`: matches a guest user (not authenticated yet)
@@ -139,6 +139,10 @@ class AccessRule extends Component
         if (empty($this->roles)) {
             return true;
         }
+
+        if(is_string($this->roles))
+            $this->roles = [$this->roles];
+
         foreach ($this->roles as $role) {
             if ($role === '?') {
                 if ($user->getIsGuest()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | n/a

Allows

'roles' => '@'

in addition to

'roles' => ['@']

in AccessRule.php. Tests are not yet available since 'roles' are not tested.