### PR TITLE
Allowing customize others params request formats in descendant class

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -743,16 +743,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.30",
+            "version": "4.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a534e04d0bd39c557c2881c341efd06fa6f1292a"
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a534e04d0bd39c557c2881c341efd06fa6f1292a",
-                "reference": "a534e04d0bd39c557c2881c341efd06fa6f1292a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
                 "shasum": ""
             },
             "require": {
@@ -811,7 +811,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-01 17:05:48"
+            "time": "2016-12-09 02:45:31"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "30a97926034335c40273795ce316f36c",
-    "content-hash": "58ccdf60f6da90c6d1623d9755c0b830",
+    "hash": "ac2d72db530375a5ce1f845022b13701",
+    "content-hash": "cc4b01a602c948040169ebbc1ac30186",
     "packages": [
         {
             "name": "bower-asset/jquery",
@@ -44,12 +44,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/RobinHerbots/jquery.inputmask.git",
-                "reference": "5a72c563b502b8e05958a524cdfffafe9987be38"
+                "reference": "ec7726993217ee7b01023ad4f7f1b6a51446a39d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RobinHerbots/jquery.inputmask/zipball/5a72c563b502b8e05958a524cdfffafe9987be38",
-                "reference": "5a72c563b502b8e05958a524cdfffafe9987be38",
+                "url": "https://api.github.com/repos/RobinHerbots/jquery.inputmask/zipball/ec7726993217ee7b01023ad4f7f1b6a51446a39d",
+                "reference": "ec7726993217ee7b01023ad4f7f1b6a51446a39d",
                 "shasum": ""
             },
             "require": {
@@ -114,16 +114,16 @@
         },
         {
             "name": "bower-asset/yii2-pjax",
-            "version": "dev-master",
+            "version": "v2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/jquery-pjax.git",
-                "reference": "3f20897307cca046fca5323b318475ae9dac0ca0"
+                "reference": "60728da6ade5879e807a49ce59ef9a72039b8978"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/jquery-pjax/zipball/3f20897307cca046fca5323b318475ae9dac0ca0",
-                "reference": "3f20897307cca046fca5323b318475ae9dac0ca0",
+                "url": "https://api.github.com/repos/yiisoft/jquery-pjax/zipball/60728da6ade5879e807a49ce59ef9a72039b8978",
+                "reference": "60728da6ade5879e807a49ce59ef9a72039b8978",
                 "shasum": ""
             },
             "require": {
@@ -136,18 +136,15 @@
                     ".travis.yml",
                     "Gemfile",
                     "Gemfile.lock",
+                    "CONTRIBUTING.md",
                     "vendor/",
                     "script/",
                     "test/"
-                ],
-                "branch-alias": {
-                    "dev-master": "2.0.3-dev"
-                }
+                ]
             },
             "license": [
                 "MIT"
-            ],
-            "time": "2015-03-08 21:03:11"
+            ]
         },
         {
             "name": "cebe/markdown",
@@ -440,16 +437,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
@@ -457,10 +454,11 @@
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
@@ -498,7 +496,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -564,16 +562,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -607,7 +605,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -696,16 +694,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
                 "shasum": ""
             },
             "require": {
@@ -741,20 +739,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2016-11-15 14:06:22"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.27",
+            "version": "4.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
+                "reference": "a534e04d0bd39c557c2881c341efd06fa6f1292a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a534e04d0bd39c557c2881c341efd06fa6f1292a",
+                "reference": "a534e04d0bd39c557c2881c341efd06fa6f1292a",
                 "shasum": ""
             },
             "require": {
@@ -770,7 +768,7 @@
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
                 "sebastian/exporter": "~1.2",
@@ -813,7 +811,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-21 06:48:14"
+            "time": "2016-12-01 17:05:48"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -873,22 +871,22 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -933,7 +931,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2016-11-19 09:18:40"
         },
         {
             "name": "sebastian/diff",
@@ -1245,16 +1243,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.13",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "396784cd06b91f3db576f248f2402d547a077787"
+                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/396784cd06b91f3db576f248f2402d547a077787",
-                "reference": "396784cd06b91f3db576f248f2402d547a077787",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/befb26a3713c97af90d25dd12e75621ef14d91ff",
+                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff",
                 "shasum": ""
             },
             "require": {
@@ -1290,7 +1288,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-21 20:59:10"
+            "time": "2016-11-14 16:15:57"
         }
     ],
     "aliases": [],

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -39,6 +39,7 @@ Yii Framework 2 Change Log
 - Enh #11037: `yii.js` and `yii.validation.js` use `Regexp.test()` instead of `String.match()` (arogachev, nkovacs)
 - Enh #11163: Added separate method for client-side validation options in `yii\validators\Validator` (arogachev)
 - Enh #11756: Added type mapping for `varbinary` data type in MySQL DBMS (silverfire)
+- Enh #11758: Implemented Dependency Injection Container configuration using Application configuration array (silverfire)
 - Enh #11929: Changed `type` column type from `int` to `smallInt` in RBAC migrations (silverfire)
 - Enh #12015: Changed visibility `yii\db\ActiveQueryTrait::createModels()` from private to protected (ArekX, dynasource)
 - Enh #12399: Added `ActiveField::addAriaAttributes` property for `aria-required` and `aria-invalid` attributes rendering (Oxyaction, samdark)
@@ -62,8 +63,7 @@ Yii Framework 2 Change Log
 - Enh #12988: Changed `textarea` method within the `yii\helpers\BaseHtml` class to allow users to control whether html entities found within `$value` will be double-encoded or not (cyphix333)
 - Enh #13050: Added `yii\filters\HostControl` allowing protection against 'host header' attacks (klimov-paul, rob006)
 - Enh #13074: Improved `yii\log\SyslogTarget` with `$options` to be able to change the default `openlog` options. (timbeks)
-- Enh #11758: Implemented Dependency Injection Container configuration using Application configuration array (silverfire)
-- Enh: Added `yii\data\Sort::parseSortAttributes` allowing customize others params request formats in descendant class (leandrogehlen)
+- Enh #13179: Added `yii\data\Sort::parseSortParam` allowing customize sort param in descendant class (leandrogehlen)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
 - Enh #12854: Added `RangeNotSatisfiableHttpException` to cover HTTP error 416 file request exceptions (zalatov)
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -63,6 +63,7 @@ Yii Framework 2 Change Log
 - Enh #13050: Added `yii\filters\HostControl` allowing protection against 'host header' attacks (klimov-paul, rob006)
 - Enh #13074: Improved `yii\log\SyslogTarget` with `$options` to be able to change the default `openlog` options. (timbeks)
 - Enh #11758: Implemented Dependency Injection Container configuration using Application configuration array (silverfire)
+- Enh: Added `yii\data\Sort::parseSortAttributes` allowing customize others params request formats in descendant class (leandrogehlen)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
 - Enh #12854: Added `RangeNotSatisfiableHttpException` to cover HTTP error 416 file request exceptions (zalatov)
 

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -441,6 +441,7 @@ class Sort extends Object
      * @param array $params the value of the [[sortParam]].
      * @return array the sort attributes.
      * @since 2.0.11
+     * @see separator
      */
     protected function parseSortParam($params)
     {

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -244,7 +244,7 @@ class Sort extends Object
                 $params = $request instanceof Request ? $request->getQueryParams() : [];
             }
             if (isset($params[$this->sortParam])) {
-                $attributes = $this->parseSortAttributes($params[$this->sortParam]);
+                $attributes = $this->parseSortParam($params[$this->sortParam]);
                 foreach ($attributes as $attribute) {
                     $descending = false;
                     if (strncmp($attribute, '-', 1) === 0) {
@@ -442,7 +442,7 @@ class Sort extends Object
      * @return array the sort attributes.
      * @since 2.0.11
      */
-    protected function parseSortAttributes($params)
+    protected function parseSortParam($params)
     {
         return is_scalar($params) ? explode($this->separator, $params) : [];
     }

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -424,20 +424,22 @@ class Sort extends Object
     }
 
     /**
-     * Parse params into valid sort format.
-     * The format must be:
-     * - Ascending: only attribute name
-     * - Descending: attribute name ends with `-`
+     * Parses [[sortParam]] into an array of sort attributes.
      *
-     * Example:
+     * The format must be:
+     * - Ascending: only attribute name, e.g. 'category'
+     * - Descending: attribute name is prefixed with `-`, e.g. '-category'
+     *
+     * The following return value will result in ascending sort by `category` and descending sort by `created_at`:
+     *
      * ```php
      * [
      *     'category',
-     *     'created_at-'
+     *     '-created_at'
      * ]
      * ```
-     * @param array $params The request params
-     * @return array the valid sort attributes format
+     * @param array $params the value of the [[sortParam]].
+     * @return array the sort attributes.
      * @since 2.0.11
      */
     protected function parseSortAttributes($params)

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -243,8 +243,8 @@ class Sort extends Object
                 $request = Yii::$app->getRequest();
                 $params = $request instanceof Request ? $request->getQueryParams() : [];
             }
-            if (isset($params[$this->sortParam]) && is_scalar($params[$this->sortParam])) {
-                $attributes = explode($this->separator, $params[$this->sortParam]);
+            if (isset($params[$this->sortParam])) {
+                $attributes = $this->parseSortAttributes($params[$this->sortParam]);
                 foreach ($attributes as $attribute) {
                     $descending = false;
                     if (strncmp($attribute, '-', 1) === 0) {
@@ -421,5 +421,27 @@ class Sort extends Object
     public function hasAttribute($name)
     {
         return isset($this->attributes[$name]);
+    }
+
+    /**
+     * Parse params into valid sort format.
+     * The format must be:
+     * - Ascending: only attribute name
+     * - Descending: attribute name ends with `-`
+     *
+     * Example:
+     * ```php
+     * [
+     *     'category',
+     *     'created_at-'
+     * ]
+     * ```
+     * @param array $params The request params
+     * @return array the valid sort attributes format
+     * @since 2.0.11
+     */
+    protected function parseSortAttributes($params)
+    {
+        return is_scalar($params) ? explode($this->separator, $params) : [];
     }
 }

--- a/tests/framework/data/SortTest.php
+++ b/tests/framework/data/SortTest.php
@@ -225,4 +225,36 @@ class SortTest extends TestCase
 
         $this->assertEquals('<a class="asc" href="/index.php?r=site%2Findex&amp;sort=-age%2C-name" data-sort="-age,-name">Age</a>', $sort->link('age'));
     }
+
+    public function testParseSortParam()
+    {
+        $sort = new CustomSort([
+            'attributes' => [
+                'age',
+                'name'
+            ],
+            'params' => [
+                'sort' => [
+                    ['field' => 'age', 'dir' => 'asc'],
+                    ['field' => 'name', 'dir' => 'desc']
+                ]
+            ],
+            'enableMultiSort' => true
+        ]);
+
+        $this->assertEquals(SORT_ASC, $sort->getAttributeOrder('age'));
+        $this->assertEquals(SORT_DESC, $sort->getAttributeOrder('name'));
+    }
+}
+
+class CustomSort extends Sort
+{
+    protected function parseSortParam($params)
+    {
+        $attributes = [];
+        foreach ($params as $item) {
+             $attributes[] = ($item['dir'] == 'desc') ? '-' . $item['field'] : $item['field'];
+        }
+        return $attributes;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Using visual js libraries like [jQuery Kendo UI](http://www.telerik.com/kendo-ui) or [jQuery EasyUI](http://www.jeasyui.com/) the sort request params are sent in the following format:
```php
[
    ['field' => 'category', 'dir' => 'asc'],
    ['field' => 'created_at', 'dir' => 'desc']
]
```

thus, is necessary to convert this format to "Yii sort params format". For this, now, is possible to write a
descendant class like:
```php
<?php

namespace app\components;

use yii\web\Request;
use Yii;

class Sort extends \yii\data\Sort
{
    /**
     * @inheritdoc
     */
    public $enableMultiSort = true;

    /**
     * @inheritdoc
     */
    protected function parseSortAttributes($params)
    {
        $attributes = [];
        foreach ($params as $item) {
             $attributes[] = ($item['dir'] == 'desc') ? $item['field'] . '-' : $item['field'];
        }
        return $attributes;
    }
}
```

and set this like  default class in `config/web.php`:

```php
<?php

$config = [
    'id' => 'yii2-basic-web',
    'basePath' => dirname(__DIR__),
    'bootstrap' => ['log'],
    'components' => [
         ... 
     ]
];

Yii::$container->set('yii\data\Sort', 'app\components\Sort');

return $config;
```








