### PR TITLE
Allow remove of previous URL when recovered

### DIFF
--- a/framework/helpers/BaseUrl.php
+++ b/framework/helpers/BaseUrl.php
@@ -309,16 +309,22 @@ class BaseUrl
      * Returns the URL previously [[remember()|remembered]].
      *
      * @param string $name the named associated with the URL that was remembered previously.
+     * @param boolean $clear Clear after recover previous url
      * If not set, it will use [[\yii\web\User::returnUrlParam]].
      * @return string|null the URL previously remembered. Null is returned if no URL was remembered with the given name.
      * @see remember()
      */
-    public static function previous($name = null)
+    public static function previous($name = null,$clear=false)
     {
         if ($name === null) {
             return Yii::$app->getUser()->getReturnUrl();
         } else {
-            return Yii::$app->getSession()->get($name);
+            $previousUrl=Yii::$app->getSession()->get($name);
+            if($clear){
+                Yii::$app->getSession()->remove($name);
+            }
+            
+            return $previousUrl;
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    |no
| New feature?  | no
| Breaks BC?    |no
| Tests pass?   | yes
| Fixed issues  | 

Customized previous URL is persistent, that makes impossible to condition display of previous link. I explain.

I have a web with products, they are listed in home and in search view. When you click on a product (open product view) in search results i want to show a "back to results" link, but when click on a product in Main page i don´t want to show this link.
The problem is that as the links is stored in session it is always displayed one time it is defined.
This modification allows to clear previous url value just when it is recovered. 
To condition display of backlink in my project i do "if($prev=Url::previous('name')) {//display link}"