### PR TITLE
Fixes PageCacheTest: requestedRoute is not set up

### DIFF
--- a/tests/framework/filters/PageCacheTest.php
+++ b/tests/framework/filters/PageCacheTest.php
@@ -296,6 +296,7 @@ class PageCacheTest extends TestCase
             $this->mockWebApplication();
             $controller = new Controller('test', Yii::$app);
             $action = new Action('test', $controller);
+            Yii::$app->requestedRoute = $action->uniqueId;
             $filter = new PageCache([
                 'cache' => $cache = new ArrayCache(),
                 'view' => new View(),
@@ -317,6 +318,7 @@ class PageCacheTest extends TestCase
             $this->mockWebApplication();
             $controller = new Controller('test', Yii::$app);
             $action = new Action('test2', $controller);
+            Yii::$app->requestedRoute = $action->uniqueId;
             $filter = new PageCache([
                 'cache' => $cache,
                 'view' => new View(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13149 

It fixes `Yii::$app->requestedRoute` was not set in tests: the current version of `PageCache` [directly gets](https://github.com/yiisoft/yii2/blob/master/framework/filters/PageCache.php#L161) an action ID while #12145 relies on `calculateCacheKey()` which relies on `Yii::$app->requestedRoute`.

After this PR is merged #12145 passes the tests. :)