### PR TITLE
Speed up hhvm unit tests - disable jit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,8 @@ install:
 #  - tests/data/travis/cubrid-setup.sh
 
 before_script:
+  # Disable the HHVM JIT for faster Unit Testing
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
   # show some versions and env information
   - php -r "echo INTL_ICU_VERSION . \"\n\";"
   - php -r "echo INTL_ICU_DATA_VERSION . \"\n\";"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | speeds up the hhvm unit tests

Turn off the hhvm JIT to speed up the hhvm unit tests.

Source for why the JIT is bad for unit testing: facebook/hhvm#6979