### PR TITLE
Throw InvalidConfigException when 'roles' isn´t an array

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -57,6 +57,7 @@ Yii Framework 2 Change Log
 - Enh #12881: Added `removeValue` method to `yii\helpers\BaseArrayHelper` (nilsburg)
 - Enh #12901: Added `getDefaultHelpHeader` method to the `yii\console\controllers\HelpController` class to be able to override default help header in a class heir (diezztsk)
 - Enh #13035: Use ArrayHelper::getValue() in SluggableBehavior::getValue() (thyseus)
+- Enh #13192: Throw InvalidConfigException in filters/AccessRule.php when 'roles' isn´t an array (thyseus)
 - Enh #13036: Added shortcut methods `asJson()` and `asXml()` for returning JSON and XML data in web controller actions (cebe)
 - Enh #13020: Added `disabledListItemSubTagOptions` attribute for `yii\widgets\LinkPager` in order to customize the disabled list item sub tag element (nadar)
 - Enh #12988: Changed `textarea` method within the `yii\helpers\BaseHtml` class to allow users to control whether html entities found within `$value` will be double-encoded or not (cyphix333)

--- a/framework/filters/AccessRule.php
+++ b/framework/filters/AccessRule.php
@@ -9,6 +9,7 @@ namespace yii\filters;
 
 use yii\base\Component;
 use yii\base\Action;
+use yii\base\InvalidConfigException;
 use yii\web\User;
 use yii\web\Request;
 use yii\base\Controller;
@@ -139,6 +140,10 @@ class AccessRule extends Component
         if (empty($this->roles)) {
             return true;
         }
+
+        if(!is_array($this->roles))
+            throw new InvalidConfigException('The "roles" configuration option needs to be an array.');
+
         foreach ($this->roles as $role) {
             if ($role === '?') {
                 if ($user->getIsGuest()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | /no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

Throw InvalidConfigException when 'roles' isn´t an array. Would have saved me a lot of debugging time.
This is another approach to https://github.com/yiisoft/yii2/pull/13168 .
