### PR TITLE
All words in h3 in docs must start with capital letter (#13183)

### DIFF
--- a/docs/guide/db-migrations.md
+++ b/docs/guide/db-migrations.md
@@ -891,7 +891,7 @@ will be used to record the migration history. You no longer need to specify it v
 command-line option.
 
 
-### Separated migrations <span id="separated-migrations"></span>
+### Separated Migrations <span id="separated-migrations"></span>
 
 Sometimes you may need to use migrations from a different namespace. It can be some extension or module in your own
 project. One of such examples is migrations for [RBAC component](security-authorization.md#configuring-rbac).


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13183 

Capitalized "migrations" in "Separated migrations" header for consistency. Missed that in #13183, sorry. @SilverFire fixed the reference in RBAC docs (https://github.com/yiisoft/yii2/pull/13201/commits/bc9c9f4c190c1b19340d851f56b7c9010a3a7d19), but did not notice that the header itself had this problem too.

