### PR TITLE
fix ArrayHelper::getValue() to throw exception on invalid input

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -25,6 +25,7 @@ Yii Framework 2 Change Log
 - Bug #12879: Console progress bar was not working properly in Windows terminals (samdark, kids-return)
 - Bug #12880: Fixed `yii\behaviors\AttributeTypecastBehavior` marks attributes with `null` value as 'dirty' (klimov-paul)
 - Bug #12904: Fixed lowercase table name in migrations (zlakomanoff)
+- Bug #12927: `ArrayHelper::getValue()` did not throw exception if the input was neither an object nor an array, even though it was documented (cebe)
 - Bug #12939: Hard coded table names for MSSQL in RBAC migration (arogachev)
 - Bug #12974: Fixed incorrect order of migrations history in case `yii\console\controllers\MigrateController::$migrationNamespaces` is in use (evgen-d, klimov-paul)
 - Bug #13071: Help option for commands was not working in modules (arogachev, haimanman)

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -178,10 +178,15 @@ class BaseArrayHelper
      * The possibility to pass an array of keys is available since version 2.0.4.
      * @param mixed $default the default value to be returned if the specified array key does not exist. Not used when
      * getting value from an object.
-     * @return mixed the value of the element if found, default value otherwise
+     * @return mixed the value of the element if found, default value otherwise.
+     * @throws InvalidParamException if $array is neither an array nor an object.
      */
     public static function getValue($array, $key, $default = null)
     {
+        if (!is_array($array) && !is_object($array)) {
+            throw new InvalidParamException('Argument passed to getValue() must be an array or object.');
+        }
+
         if ($key instanceof \Closure) {
             return $key($array, $default);
         }

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace yiiunit\framework\helpers;
 
+use yii\base\InvalidParamException;
 use yii\base\Object;
 use yii\helpers\ArrayHelper;
 use yiiunit\TestCase;
@@ -732,6 +733,36 @@ class ArrayHelperTest extends TestCase
     {
         $arrayObject = new \ArrayObject(['id' => 23], \ArrayObject::ARRAY_AS_PROPS);
         $this->assertEquals(23, ArrayHelper::getValue($arrayObject, 'nonExisting'));
+    }
+
+    public function invalidArgumentProvider()
+    {
+        return [
+            [null],
+            [false],
+            [true],
+            [42],
+            [''],
+            ['not an object'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidArgumentProvider
+     * @expectedException \yii\base\InvalidParamException
+     */
+    public function testGetValueInvalidArgumentWithoutDefaultValue($arg)
+    {
+        ArrayHelper::getValue($arg, 'test');
+    }
+
+    /**
+     * @dataProvider invalidArgumentProvider
+     * @expectedException \yii\base\InvalidParamException
+     */
+    public function testGetValueInvalidArgumentWithDefaultValue($arg)
+    {
+        ArrayHelper::getValue($arg, 'test', 'default');
     }
 
     public function testIsAssociative()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | only if people program against the documentation. result was kind of undefined. See #12927 
| Tests pass?   | yes
| Fixed issues  | #12927

fixes #12927