### PR TITLE
Catch `\Throwable` in critical places

### DIFF
--- a/docs/guide/db-active-record.md
+++ b/docs/guide/db-active-record.md
@@ -633,11 +633,18 @@ try {
     $customer->save();
     // ...other DB operations...
     $transaction->commit();
-} catch(\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
+} catch(\Exception $e) {
+    $transaction->rollBack();
+    throw $e;
+} catch(\Throwable $e) {
     $transaction->rollBack();
     throw $e;
 }
 ```
+
+> Note: in the above code we have two catch-blocks for compatibility 
+> with PHP 5.x and PHP 7.x. `\Exception` implements the [`\Throwable` interface](http://php.net/manual/en/class.throwable.php)
+> since PHP 7.0, so you can skip the part with `\Exception` if your app uses only PHP 7.0 and higher.
 
 The second way is to list the DB operations that require transactional support in the [[yii\db\ActiveRecord::transactions()]]
 method. For example,

--- a/docs/guide/db-active-record.md
+++ b/docs/guide/db-active-record.md
@@ -633,7 +633,7 @@ try {
     $customer->save();
     // ...other DB operations...
     $transaction->commit();
-} catch(\Exception $e) {
+} catch(\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
     $transaction->rollBack();
     throw $e;
 }

--- a/docs/guide/db-dao.md
+++ b/docs/guide/db-dao.md
@@ -336,7 +336,7 @@ try {
     
     $transaction->commit();
     
-} catch(\Exception $e) {
+} catch(\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
 
     $transaction->rollBack();
     
@@ -421,13 +421,13 @@ try {
     try {
         $db->createCommand($sql2)->execute();
         $innerTransaction->commit();
-    } catch (\Exception $e) {
+    } catch (\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
         $innerTransaction->rollBack();
         throw $e;
     }
 
     $outerTransaction->commit();
-} catch (\Exception $e) {
+} catch (\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
     $outerTransaction->rollBack();
     throw $e;
 }
@@ -570,7 +570,7 @@ try {
     $db->createCommand("UPDATE user SET username='demo' WHERE id=1")->execute();
 
     $transaction->commit();
-} catch(\Exception $e) {
+} catch(\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
     $transaction->rollBack();
     throw $e;
 }

--- a/docs/guide/db-dao.md
+++ b/docs/guide/db-dao.md
@@ -328,18 +328,17 @@ The above code is equivalent to the following, which gives you more control abou
 ```php
 $db = Yii::$app->db;
 $transaction = $db->beginTransaction();
-
 try {
     $db->createCommand($sql1)->execute();
     $db->createCommand($sql2)->execute();
     // ... executing other SQL statements ...
     
     $transaction->commit();
-    
-} catch(\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
-
+} catch(\Exception $e) {
     $transaction->rollBack();
-    
+    throw $e;
+} catch(\Throwable $e) {
+    $transaction->rollBack();
     throw $e;
 }
 ```
@@ -351,6 +350,10 @@ the [[yii\db\Transaction::commit()|commit()]] method is called to commit the tra
 will be triggered and caught, the [[yii\db\Transaction::rollBack()|rollBack()]] method is called to roll back
 the changes made by the queries prior to that failed query in the transaction. `throw $e` will then re-throw the
 exception as if we had not caught it, so the normal error handling process will take care of it.
+
+> Note: in the above code we have two catch-blocks for compatibility 
+> with PHP 5.x and PHP 7.x. `\Exception` implements the [`\Throwable` interface](http://php.net/manual/en/class.throwable.php)
+> since PHP 7.0, so you can skip the part with `\Exception` if your app uses only PHP 7.0 and higher.
 
 
 ### Specifying Isolation Levels <span id="specifying-isolation-levels"></span>
@@ -421,13 +424,19 @@ try {
     try {
         $db->createCommand($sql2)->execute();
         $innerTransaction->commit();
-    } catch (\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
+    } catch (\Exception $e) {
+        $innerTransaction->rollBack();
+        throw $e;
+    } catch (\Throwable $e) {
         $innerTransaction->rollBack();
         throw $e;
     }
 
     $outerTransaction->commit();
-} catch (\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
+} catch (\Exception $e) {
+    $outerTransaction->rollBack();
+    throw $e;
+} catch (\Throwable $e) {
     $outerTransaction->rollBack();
     throw $e;
 }
@@ -570,7 +579,10 @@ try {
     $db->createCommand("UPDATE user SET username='demo' WHERE id=1")->execute();
 
     $transaction->commit();
-} catch(\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
+} catch(\Exception $e) {
+    $transaction->rollBack();
+    throw $e;
+} catch(\Throwable $e) {
     $transaction->rollBack();
     throw $e;
 }

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -54,7 +54,7 @@ Yii Framework 2 Change Log
 - Enh #12145: Added `beforeCacheResponse` and `afterRestoreResponse` to `yii\filters\PageCache` to be more easily extendable (sergeymakinen)
 - Enh #12390: Avoid creating queries with false where condition (`0=1`) when fetching relational data (klimov-paul)
 - Enh #12399: Added `ActiveField::addAriaAttributes` property for `aria-required` and `aria-invalid` attributes rendering (Oxyaction, samdark)
-- Enh #12619: Added catch `Throwable` in `yii\base\ErrorHandler::handleException()` (rob006)
+- Enh #12619: Added catch `Throwable` in `yii\base\ErrorHandler::handleException()`, transactions and simlar places where consistency must be kept after exception (rob006, cebe)
 - Enh #12659: Suggest alternatives when console command was not found (mdmunir, cebe)
 - Enh #12726: `yii\base\Application::$version` converted to `yii\base\Module::$version` virtual property, allowing to specify version as a PHP callback (klimov-paul)
 - Enh #12732: Added `is_dir()` validation to `yii\helpers\BaseFileHelper::findFiles()` method (zalatov, silverfire)

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -439,6 +439,9 @@ class ActiveRecord extends BaseActiveRecord
         } catch (\Exception $e) {
             $transaction->rollBack();
             throw $e;
+        } catch (\Throwable $e) {
+            $transaction->rollBack();
+            throw $e;
         }
     }
 
@@ -545,6 +548,9 @@ class ActiveRecord extends BaseActiveRecord
         } catch (\Exception $e) {
             $transaction->rollBack();
             throw $e;
+        } catch (\Throwable $e) {
+            $transaction->rollBack();
+            throw $e;
         }
     }
 
@@ -583,6 +589,9 @@ class ActiveRecord extends BaseActiveRecord
             }
             return $result;
         } catch (\Exception $e) {
+            $transaction->rollBack();
+            throw $e;
+        } catch (\Throwable $e) {
             $transaction->rollBack();
             throw $e;
         }

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -95,15 +95,16 @@ class Migration extends Component implements MigrationInterface
         try {
             if ($this->safeUp() === false) {
                 $transaction->rollBack();
-
                 return false;
             }
             $transaction->commit();
         } catch (\Exception $e) {
-            echo 'Exception: ' . $e->getMessage() . ' (' . $e->getFile() . ':' . $e->getLine() . ")\n";
-            echo $e->getTraceAsString() . "\n";
+            $this->printException($e);
             $transaction->rollBack();
-
+            return false;
+        } catch (\Throwable $e) {
+            $this->printException($e);
+            $transaction->rollBack();
             return false;
         }
 
@@ -123,19 +124,29 @@ class Migration extends Component implements MigrationInterface
         try {
             if ($this->safeDown() === false) {
                 $transaction->rollBack();
-
                 return false;
             }
             $transaction->commit();
         } catch (\Exception $e) {
-            echo 'Exception: ' . $e->getMessage() . ' (' . $e->getFile() . ':' . $e->getLine() . ")\n";
-            echo $e->getTraceAsString() . "\n";
+            $this->printException($e);
             $transaction->rollBack();
-
+            return false;
+        } catch (\Throwable $e) {
+            $this->printException($e);
+            $transaction->rollBack();
             return false;
         }
 
         return null;
+    }
+
+    /**
+     * @param \Throwable|\Exception $e
+     */
+    private function printException($e)
+    {
+        echo 'Exception: ' . $e->getMessage() . ' (' . $e->getFile() . ':' . $e->getLine() . ")\n";
+        echo $e->getTraceAsString() . "\n";
     }
 
     /**

--- a/framework/db/Transaction.php
+++ b/framework/db/Transaction.php
@@ -25,7 +25,7 @@ use yii\base\InvalidConfigException;
  *     $connection->createCommand($sql2)->execute();
  *     //.... other SQL executions
  *     $transaction->commit();
- * } catch (\Exception $e) {
+ * } catch (\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
  *     $transaction->rollBack();
  *     throw $e;
  * }

--- a/framework/db/Transaction.php
+++ b/framework/db/Transaction.php
@@ -25,11 +25,18 @@ use yii\base\InvalidConfigException;
  *     $connection->createCommand($sql2)->execute();
  *     //.... other SQL executions
  *     $transaction->commit();
- * } catch (\Exception $e) { // replace \Exception with \Throwable when you are using PHP 7
+ * } catch (\Exception $e) {
+ *     $transaction->rollBack();
+ *     throw $e;
+ * } catch (\Throwable $e) {
  *     $transaction->rollBack();
  *     throw $e;
  * }
  * ```
+ *
+ * > Note: in the above code we have two catch-blocks for compatibility
+ * > with PHP 5.x and PHP 7.x. `\Exception` implements the [`\Throwable` interface](http://php.net/manual/en/class.throwable.php)
+ * > since PHP 7.0, so you can skip the part with `\Exception` if your app uses only PHP 7.0 and higher.
  *
  * @property bool $isActive Whether this transaction is active. Only an active transaction can [[commit()]]
  * or [[rollBack()]]. This property is read-only.


### PR DESCRIPTION
Added catch `\Throwable` to be compatible with PHP7.
Added it in cases where object state needs to be kept consistent.

Mainly on transactions but also some other places where some values are
reset before exiting.

Most of them could probably be refactored by using `finally` in 2.1, as
that requires PHP 5.5.

fixes #12619