### PR TITLE
Consistent behavior for ServiceLocator::__isset()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #9305: Fixed MSSQL `Schema::TYPE_TIMESTAMP` to be 'datetime' instead of 'timestamp', which is just an incremental number (nkovacs)
 - Bug #9616: Fixed mysql\Schema::loadColumnSchema to set enumValues attribute correctly if enum definition contains commas (fphammerle)
 - Bug #9796: Initialization of not existing `yii\grid\ActionColumn` default buttons (arogachev)
+- Bug #11771: Fixed semantics of `yii\di\ServiceLocator::__isset()` to match the behavior of `__get()` which fixes inconsistent behavior on newer PHP versions (cebe)
 - Bug #12213: Fixed `yii\db\ActiveRecord::unlinkAll()` to respect `onCondition()` of the relational query (silverfire)
 - Bug #12681: Changed `data` column type from `text` to `blob` to handle null-byte (`\0`) in serialized RBAC rule properly (silverfire)
 - Bug #12714: Fixed `yii\validation\EmailValidator` to prevent false-positives checks when property `checkDns` is set to `true` (silverfire)

--- a/framework/di/ServiceLocator.php
+++ b/framework/di/ServiceLocator.php
@@ -84,7 +84,7 @@ class ServiceLocator extends Component
      */
     public function __isset($name)
     {
-        if ($this->has($name, true)) {
+        if ($this->has($name)) {
             return true;
         } else {
             return parent::__isset($name);

--- a/tests/framework/di/ServiceLocatorTest.php
+++ b/tests/framework/di/ServiceLocatorTest.php
@@ -86,4 +86,29 @@ class ServiceLocatorTest extends TestCase
         $this->assertTrue($object2 instanceof $className);
         $this->assertTrue($object === $object2);
     }
+
+    /**
+     * https://github.com/yiisoft/yii2/issues/11771
+     */
+    public function testModulePropertyIsset()
+    {
+        $config = [
+            'components' => [
+                'captcha' => [
+                    'name' => 'foo bar',
+                    'class' => 'yii\captcha\Captcha',
+                ],
+            ],
+        ];
+
+        $app = new ServiceLocator($config);
+
+        $this->assertTrue(isset($app->captcha->name));
+        $this->assertFalse(empty($app->captcha->name));
+
+        $this->assertEquals('foo bar', $app->captcha->name);
+
+        $this->assertTrue(isset($app->captcha->name));
+        $this->assertFalse(empty($app->captcha->name));
+    }
 }


### PR DESCRIPTION
Fixed semantics of `yii\di\ServiceLocator::__isset()` to match the behavior of `__get()` which fixes inconsistent behavior on newer PHP versions

fixes #11771
