### PR TITLE
Use composer install instead of composer update in Travis (#12947)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
         - phpenv config-rm xdebug.ini || echo "xdebug is not installed"
         - travis_retry composer self-update && composer --version
         - travis_retry composer global require "fxp/composer-asset-plugin:^1.2.0" --no-plugins
-        - travis_retry composer update --prefer-dist --no-interaction
+        - travis_retry composer install --prefer-dist --no-interaction
       before_script:
         - node --version
         - npm --version
@@ -111,7 +111,7 @@ install:
   - travis_retry composer global require "fxp/composer-asset-plugin:^1.2.0" --no-plugins
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
 # core framework:
-  - travis_retry composer update --prefer-dist --no-interaction
+  - travis_retry composer install --prefer-dist --no-interaction
   - tests/data/travis/apc-setup.sh
   - tests/data/travis/memcache-setup.sh
   - tests/data/travis/imagick-setup.sh


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #12947 

This was fixed in docs (https://github.com/yiisoft/yii2/issues/12947#issuecomment-259284148), but in Travis we still use `composer update` to install packages, even #12946 was fixed and `composer.lock` is valid and can be used for installation.
