### PR TITLE
Add support \yii\db\Expression attribute to \yii\data\Sort

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -105,6 +105,8 @@ Yii Framework 2 Change Log
 - Bug #13287: Fixed translating "and" separator in `UniqueValidator` error message (jetexe)
 - Enh #11464: Populate foreign key names from schema (joaoppereira)
 - Bug #13401: Fixed lack of escaping of request dump at exception screens (samdark)
+- Enh #13260: Added support for sorting by expression to `\yii\data\Sort` (LAV45)
+
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -107,8 +107,8 @@ class Sort extends Object
      * [
      *     'age',
      *     'name' => [
-     *         'asc' => ['[[last_name]] ASC NULLS FIRST'],
-     *         'desc' => ['[[last_name]] DESC NULLS LAST'],
+     *         'asc' => [new \yii\db\Expression('[[last_name]] ASC NULLS FIRST')],
+     *         'desc' => [new \yii\db\Expression('[[last_name]] DESC NULLS LAST')],
      *         'default' => SORT_DESC,
      *     ],
      * ]

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -100,6 +100,20 @@ class Sort extends Object
      * ]
      * ```
      *
+     * If you are using a PostgreSQL database, you may need to specify the sorting arbitrary expression.
+     * This syntax can be described using the following example:
+     *
+     * ```php
+     * [
+     *     'age',
+     *     'name' => [
+     *         'asc' => ['[[last_name]] ASC NULLS FIRST'],
+     *         'desc' => ['[[last_name]] DESC NULLS LAST'],
+     *         'default' => SORT_DESC,
+     *     ],
+     * ]
+     * ```
+     *
      * In the above, two attributes are declared: `age` and `name`. The `age` attribute is
      * a simple attribute which is equivalent to the following:
      *
@@ -216,7 +230,11 @@ class Sort extends Object
             $definition = $this->attributes[$attribute];
             $columns = $definition[$direction === SORT_ASC ? 'asc' : 'desc'];
             foreach ($columns as $name => $dir) {
-                $orders[$name] = $dir;
+                if (is_int($name)) {
+                    $orders[] = $dir;
+                } else {
+                    $orders[$name] = $dir;
+                }
             }
         }
 

--- a/tests/framework/data/SortTest.php
+++ b/tests/framework/data/SortTest.php
@@ -7,6 +7,7 @@
 
 namespace yiiunit\framework\data;
 
+use yii\db\Expression;
 use yii\web\UrlManager;
 use yiiunit\TestCase;
 use yii\data\Sort;
@@ -58,8 +59,8 @@ class SortTest extends TestCase
         $sort = new Sort([
             'attributes' => [
                 'name' => [
-                    'asc' => ['[[last_name]] ASC NULLS FIRST'],
-                    'desc' => ['[[last_name]] DESC NULLS LAST'],
+                    'asc' => [new Expression('[[last_name]] ASC NULLS FIRST')],
+                    'desc' => [new Expression('[[last_name]] DESC NULLS LAST')],
                 ],
             ],
         ]);

--- a/tests/framework/data/SortTest.php
+++ b/tests/framework/data/SortTest.php
@@ -53,6 +53,28 @@ class SortTest extends TestCase
         $this->assertEquals(SORT_ASC, $orders['age']);
     }
 
+    public function testGetExpressionOrders()
+    {
+        $sort = new Sort([
+            'attributes' => [
+                'name' => [
+                    'asc' => ['[[last_name]] ASC NULLS FIRST'],
+                    'desc' => ['[[last_name]] DESC NULLS LAST'],
+                ],
+            ],
+        ]);
+
+        $sort->params = ['sort' => '-name'];
+        $orders = $sort->getOrders();
+        $this->assertEquals(1, count($orders));
+        $this->assertEquals('[[last_name]] DESC NULLS LAST', $orders[0]);
+
+        $sort->params = ['sort' => 'name'];
+        $orders = $sort->getOrders(true);
+        $this->assertEquals(1, count($orders));
+        $this->assertEquals('[[last_name]] ASC NULLS FIRST', $orders[0]);
+    }
+
     /**
      * @depends testGetOrders
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

If you want to sort the data in an unusual way we usually use the class `\yii\db\Expression` as the wrapper of our expression.
```php
Product::find()
    ->orderBy(new Expression("[[price]] ASC NULLS LAST"))
   ->all();
```

But this option cannot be used when sorting settings `\yii\data\ActiveDataProvider`

I propose to extend the functionality of the class `\yii\data\Sort` to preserve the possibility to sort by an arbitrary expression.
```php
$dataProvider = new ActiveDataProvider([
    'query' => Product::find(),
]);
$dataProvider->sort->attributes['price'] = [
    'asc' => [new Expression("[[price]] ASC NULLS LAST")],
    'desc' => [new Expression("[[price]] DESC NULLS LAST")],
];
```