### PR TITLE
Fixed grammar in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ phpunit.phar
 # local phpunit config
 /phpunit.xml
 
-# ignore sub directory for dev installed apps and extensions
+# ignore dev installed apps and extensions
 /apps
 /extensions
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

Correct variation is "sub directories", but it's better to remove mention of sub directories completely because we need to exclude everything for "installed apps and extensions" including root folder, also to be consistent with other entries.