### PR TITLE
Protect remember()/previous() in own session Var

### DIFF
--- a/framework/helpers/BaseUrl.php
+++ b/framework/helpers/BaseUrl.php
@@ -301,7 +301,8 @@ class BaseUrl
         if ($name === null) {
             Yii::$app->getUser()->setReturnUrl($url);
         } else {
-            Yii::$app->getSession()->set($name, $url);
+            $session = Yii::$app->session;
+            $session["__remember"] = [$name => $url];
         }
     }
 
@@ -318,7 +319,8 @@ class BaseUrl
         if ($name === null) {
             return Yii::$app->getUser()->getReturnUrl();
         } else {
-            return Yii::$app->getSession()->get($name);
+            $session = Yii::$app->session;
+            return $session["__remember"][$name];
         }
     }
 


### PR DESCRIPTION
To make previous() und remember() work better i would suggest to save the vars in an "protected" session array. otherwise it will interferr with your session (if you don't think about how these little helper will work). 

It's a small improvement.

| Q             | A
| ------------- | ---
| Is bugfix?    | maybe
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
