### PR TITLE
Fixes #13277: Invalid parsing of `--` in CLI

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -1,6 +1,11 @@
 Yii Framework 2 Change Log
 ==========================
 
+2.0.12
+------
+
+- Bug #13277: Fixed invalid parsing of `--` ("End of Options" special argument) in CLI (rugabarbo)
+
 2.0.11 under development
 ------------------------
 

--- a/framework/console/Request.php
+++ b/framework/console/Request.php
@@ -62,7 +62,7 @@ class Request extends \yii\base\Request
             $route = $rawParams[0];
             array_shift($rawParams);
 
-            if ($route == '--') {
+            if ($route === '--') {
                 $endOfOptionsFound = true;
                 $route = $rawParams[0];
                 array_shift($rawParams);
@@ -75,7 +75,7 @@ class Request extends \yii\base\Request
         foreach ($rawParams as $param) {
             if ($endOfOptionsFound) {
                 $params[] = $param;
-            } elseif ($param == '--') {
+            } elseif ($param === '--') {
                 $endOfOptionsFound = true;
             } elseif (preg_match('/^--(\w+)(?:=(.*))?$/', $param, $matches)) {
                 $name = $matches[1];

--- a/framework/console/Request.php
+++ b/framework/console/Request.php
@@ -57,16 +57,27 @@ class Request extends \yii\base\Request
     public function resolve()
     {
         $rawParams = $this->getParams();
+        $endOfOptionsFound = false;
         if (isset($rawParams[0])) {
             $route = $rawParams[0];
             array_shift($rawParams);
+
+            if ($route == '--') {
+                $endOfOptionsFound = true;
+                $route = $rawParams[0];
+                array_shift($rawParams);
+            }
         } else {
             $route = '';
         }
 
         $params = [];
         foreach ($rawParams as $param) {
-            if (preg_match('/^--(\w+)(?:=(.*))?$/', $param, $matches)) {
+            if ($endOfOptionsFound) {
+                $params[] = $param;
+            } elseif ($param == '--') {
+                $endOfOptionsFound = true;
+            } elseif (preg_match('/^--(\w+)(?:=(.*))?$/', $param, $matches)) {
                 $name = $matches[1];
                 if ($name !== Application::OPTION_APPCONFIG) {
                     $params[$name] = isset($matches[2]) ? $matches[2] : true;

--- a/tests/framework/console/RequestTest.php
+++ b/tests/framework/console/RequestTest.php
@@ -44,6 +44,70 @@ class RequestTest extends TestCase
                         ]
                     ]
                 ]
+            ],
+            [
+                // Case: Special argument "End of Options" used
+                'params' => [
+                    'controller/route',
+                    'param1',
+                    '-12345',
+                    '--option1',
+                    '--option2=testValue',
+                    '-alias1',
+                    '-alias2=testValue',
+                    '--', // Special argument "End of Options"
+                    'param2',
+                    '-54321',
+                    '--option3',
+                    '--', // Second `--` argument shouldn't be treated as special
+                    '--option4=testValue',
+                    '-alias3',
+                    '-alias4=testValue'
+                ],
+                'expected' => [
+                    'route' => 'controller/route',
+                    'params' => [
+                        'param1',
+                        '-12345',
+                        'option1' => '1',
+                        'option2' => 'testValue',
+                        '_aliases' => [
+                            'alias1' => true,
+                            'alias2' => 'testValue'
+                        ],
+                        'param2',
+                        '-54321',
+                        '--option3',
+                        '--',
+                        '--option4=testValue',
+                        '-alias3',
+                        '-alias4=testValue'
+                    ]
+                ]
+            ],
+            [
+                // Case: Special argument "End of Options" placed before route
+                'params' => [
+                    '--', // Special argument "End of Options"
+                    'controller/route',
+                    'param1',
+                    '-12345',
+                    '--option1',
+                    '--option2=testValue',
+                    '-alias1',
+                    '-alias2=testValue'
+                ],
+                'expected' => [
+                    'route' => 'controller/route',
+                    'params' => [
+                        'param1',
+                        '-12345',
+                        '--option1',
+                        '--option2=testValue',
+                        '-alias1',
+                        '-alias2=testValue'
+                    ]
+                ]
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13277 
