### PR TITLE
Fixed #13296: Removed UTF-8 BOM in az messages

### DIFF
--- a/framework/messages/az/yii.php
+++ b/framework/messages/az/yii.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Message translations.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13296 

I guess CHANGELOG line is not needed here. Nice find, @abra7134!
