### PR TITLE
Add OR relation for targetAttribute in UniqueValidator

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -50,6 +50,7 @@ Yii Framework 2 Change Log
 - Enh #6809: Added `yii\caching\Cache::$defaultDuration` property, allowing to set custom default cache duration (sdkiller)
 - Enh #7333: Improved error message for `yii\di\Instance::ensure()` when a component does not exist (cebe)
 - Enh #7420: Attributes for prompt generated with `renderSelectOptions` of `\yii\helpers\Html` helper (arogachev)
+- Enh #7820: Add `or` relation for `targetAttribute` in `yii\validators\UniqueValidator` (developeruz)
 - Enh #9053: Added`yii\grid\RadioButtonColumn` (darwinisgod)
 - Enh #9162: Added support of closures in `value` for attributes in `yii\widgets\DetailView` (arogachev)
 - Enh #10896: Select only primary key when counting records in UniqueValidator (developeruz)

--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -51,7 +51,6 @@ class ExistValidator extends Validator
      * of the attribute currently being validated. You may use an array to validate the existence
      * of multiple columns at the same time. The array values are the attributes that will be
      * used to validate the existence, while the array keys are the attributes whose values are to be validated.
-     * If the key and the value are the same, you can just specify the value.
      */
     public $targetAttribute;
     /**
@@ -66,6 +65,11 @@ class ExistValidator extends Validator
      */
     public $allowArray = false;
 
+    /**
+     * @var string and|or define how target attributes are related
+     * @since 2.0.11
+     */
+    public $targetAttributeJunction = 'and';
 
     /**
      * @inheritdoc
@@ -84,31 +88,24 @@ class ExistValidator extends Validator
     public function validateAttribute($model, $attribute)
     {
         $targetAttribute = $this->targetAttribute === null ? $attribute : $this->targetAttribute;
-
-        if (is_array($targetAttribute)) {
-            if ($this->allowArray) {
-                throw new InvalidConfigException('The "targetAttribute" property must be configured as a string.');
-            }
-            $params = [];
-            foreach ($targetAttribute as $k => $v) {
-                $params[$v] = is_int($k) ? $model->$v : $model->$k;
-            }
-        } else {
-            $params = [$targetAttribute => $model->$attribute];
-        }
+        $params = $this->prepareConditions($targetAttribute, $model, $attribute);
+        $conditions[] = $this->targetAttributeJunction == 'or' ? 'or' : 'and';
 
         if (!$this->allowArray) {
-            foreach ($params as $value) {
+            foreach ($params as $key => $value) {
                 if (is_array($value)) {
                     $this->addError($model, $attribute, Yii::t('yii', '{attribute} is invalid.'));
 
                     return;
                 }
+                $conditions[] = [$key => $value];
             }
+        } else {
+            $conditions[] = $params;
         }
 
         $targetClass = $this->targetClass === null ? get_class($model) : $this->targetClass;
-        $query = $this->createQuery($targetClass, $params);
+        $query = $this->createQuery($targetClass, $conditions);
 
         if (is_array($model->$attribute)) {
             if ($query->count("DISTINCT [[$targetAttribute]]") != count($model->$attribute)) {
@@ -117,6 +114,36 @@ class ExistValidator extends Validator
         } elseif (!$query->exists()) {
             $this->addError($model, $attribute, $this->message);
         }
+    }
+
+    /**
+     * Processes attributes' relations described in $targetAttribute parameter into conditions, compatible with
+     * [[\yii\db\Query::where()|Query::where()]] key-value format.
+     *
+     * @var string|array the name of the ActiveRecord attribute that should be used to
+     * validate the existence of the current attribute value. If not set, it will use the name
+     * of the attribute currently being validated. You may use an array to validate the existence
+     * of multiple columns at the same time. The array values are the attributes that will be
+     * used to validate the existence, while the array keys are the attributes whose values are to be validated.
+     * @param Model $model the data model to be validated
+     * @param string $attribute the name of the attribute to be validated in the $model
+
+     * @return array conditions, compatible with [[\yii\db\Query::where()|Query::where()]] key-value format.
+     */
+    private function prepareConditions($targetAttribute, $model, $attribute)
+    {
+        if (is_array($targetAttribute)) {
+            if ($this->allowArray) {
+                throw new InvalidConfigException('The "targetAttribute" property must be configured as a string.');
+            }
+            $params = [];
+            foreach ($targetAttribute as $k => $v) {
+                $params[$v] = is_int($k) ? $model->$attribute : $model->$k;
+            }
+        } else {
+            $params = [$targetAttribute => $model->$attribute];
+        }
+        return $params;
     }
 
     /**

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -196,7 +196,7 @@ class UniqueValidator extends Validator
     private function prepareQuery($targetClass, $conditions)
     {
         $query = $targetClass::find();
-        if($this->combineType == 'or') {
+        if ($this->combineType === 'or') {
             $query->orWhere($conditions);
         } else {
             $query->andWhere($conditions);

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -85,6 +85,12 @@ class UniqueValidator extends Validator
      */
     public $comboNotUnique;
 
+    /**
+     * @var string and|or define how target attributes are related
+     * @since 2.0.11
+     */
+    public $combineType = 'and';
+
 
     /**
      * @inheritdoc
@@ -190,8 +196,11 @@ class UniqueValidator extends Validator
     private function prepareQuery($targetClass, $conditions)
     {
         $query = $targetClass::find();
-        $query->andWhere($conditions);
-
+        if($this->combineType == 'or') {
+            $query->orWhere($conditions);
+        } else {
+            $query->andWhere($conditions);
+        }
         if ($this->filter instanceof \Closure) {
             call_user_func($this->filter, $query);
         } elseif ($this->filter !== null) {
@@ -220,7 +229,7 @@ class UniqueValidator extends Validator
         if (is_array($targetAttribute)) {
             $conditions = [];
             foreach ($targetAttribute as $k => $v) {
-                $conditions[$v] = is_int($k) ? $model->$v : $model->$k;
+                $conditions[$v] = is_int($k) ? $model->$attribute : $model->$k;
             }
         } else {
             $conditions = [$targetAttribute => $model->$attribute];

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -53,7 +53,6 @@ class UniqueValidator extends Validator
      * of the attribute currently being validated. You may use an array to validate the uniqueness
      * of multiple columns at the same time. The array values are the attributes that will be
      * used to validate the uniqueness, while the array keys are the attributes whose values are to be validated.
-     * If the key and the value are the same, you can just specify the value.
      */
     public $targetAttribute;
     /**
@@ -215,7 +214,6 @@ class UniqueValidator extends Validator
      * should be used to validate the uniqueness of the current attribute value. You may use an array to validate
      * the uniqueness of multiple columns at the same time. The array values are the attributes that will be
      * used to validate the uniqueness, while the array keys are the attributes whose values are to be validated.
-     * If the key and the value are the same, you can just specify the value.
      * @param Model $model the data model to be validated
      * @param string $attribute the name of the attribute to be validated in the $model
 

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -149,7 +149,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
     {
         $val = new UniqueValidator([
             'targetClass' => OrderItem::className(),
-            'targetAttribute' => ['order_id', 'item_id'],
+            'targetAttribute' => ['order_id', 'item_id' => 'item_id'],
         ]);
         // validate old record
         /** @var OrderItem $m */

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -80,7 +80,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
 
         $customerModel->name = 'test data';
         $customerModel->email = ['email@mail.com', 'email2@mail.com',];
-        $validator->targetAttribute = ['email', 'name'];
+        $validator->targetAttribute = ['email' => 'email', 'name' => 'name'];
         $validator->validateAttribute($customerModel, 'name');
         $this->assertEquals($messageError, $customerModel->getFirstError('name'));
     }
@@ -319,7 +319,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
 
         $targetAttribute = ['val_attr_b', 'val_attr_c'];
         $result = $this->invokeMethod(new UniqueValidator(), 'prepareConditions', [$targetAttribute, $model, $attribute]);
-        $expected = ['val_attr_b' => 'test value b', 'val_attr_c' => 'test value c'];
+        $expected = ['val_attr_b' => 'test value a', 'val_attr_c' => 'test value a'];
         $this->assertEquals($expected, $result);
 
         $targetAttribute = ['val_attr_a' => 'val_attr_b'];
@@ -327,10 +327,9 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $expected = ['val_attr_b' => 'test value a'];
         $this->assertEquals($expected, $result);
 
-
         $targetAttribute = ['val_attr_b', 'val_attr_a' => 'val_attr_c'];
         $result = $this->invokeMethod(new UniqueValidator(), 'prepareConditions', [$targetAttribute, $model, $attribute]);
-        $expected = ['val_attr_b' => 'test value b', 'val_attr_c' => 'test value a'];
+        $expected = ['val_attr_b' => 'test value a', 'val_attr_c' => 'test value a'];
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #7820

1) Bug fix:
`['name', 'unique', 'targetClass' => User::className(), 'targetAttribute' => 'realname']`,
compares that in DB doesn't exist row with `realname=$model->name`
`['name', 'unique', 'targetClass' => User::className(), 'targetAttribute' => [‘realname’]]`,
used to compare that in DB doesn’t exist row with `realname=$model->realname` and $model->name doesn’t affect the validation at all. 
After my fix, if a key is not specified in targetAttributes, validator compares with validated attribute values.
`['name', 'unique', 'targetClass' => User::className(), 'targetAttribute' => [‘realname’]]`,
means `realname=$model->name`
`['name', 'unique', 'targetClass' => User::className(), 'targetAttribute' => [‘realname’ => ‘realname’]]`,
means `realname=$model->realname`

2) New feature: 
All targetAttribute values were combined with AND condition
`['name', 'unique', 'targetClass' => User::className(), 'targetAttribute' => ['realname', 'nick', 'altname']]`
checks that in DB exist row where `realname=name AND nick=name AND altname=name`
$combineType allows user to change condition type
`['name', 'unique', 'targetClass' => User::className(), 'targetAttribute' => ['realname', 'nick', 'altname’], ‘combineType’ => ‘or’]`
checks that in DB row exists where `realname=name OR nick=name OR altname=name`