### PR TITLE
Remove label for hidden active field

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -96,6 +96,7 @@ Yii Framework 2 Change Log
   - Added `getMaster()` getter and `master` property for getting currently active master connection.
   - Extracted `openFromPoolSequentially()` protected method from `openFromPool()` protected method.
 
+- Enh #13319: Remove label for hidden active field (developeruz)
 
 2.0.10 October 20, 2016
 -----------------------

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -417,6 +417,7 @@ class ActiveField extends Component
         $options = array_merge($this->inputOptions, $options);
         $this->adjustLabelFor($options);
         $this->parts['{input}'] = Html::activeHiddenInput($this->model, $this->attribute, $options);
+        $this->parts['{label}'] = '';
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

I think it is ridiculous to have a label for a hidden input field. Let's remove them.