### PR TITLE
Replace (isset) with (!empty) beacuse isset('') always means true, 'on' condition default to empty string.

### DIFF
--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -771,7 +771,7 @@ class QueryBuilder extends \yii\base\Object
             $tables = $this->quoteTableNames((array) $table, $params);
             $table = reset($tables);
             $joins[$i] = "$joinType $table";
-            if (isset($join[2])) {
+            if (!empty($join[2])) {
                 $condition = $this->buildCondition($join[2], $params);
                 if ($condition !== '') {
                     $joins[$i] .= ' ON ' . $condition;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | join condition $on default to '', isset('') always means true, so I replace 'isset()' with '!empty()'
| note | I'm sorry, my english is poor.
