### PR TITLE
Changed return value in MemCache::setValues()

### DIFF
--- a/framework/caching/MemCache.php
+++ b/framework/caching/MemCache.php
@@ -304,7 +304,7 @@ class MemCache extends Cache
      * Stores multiple key-value pairs in cache.
      * @param array $data array where key corresponds to cache key while value is the value stored
      * @param int $duration the number of seconds in which the cached values will expire. 0 means never expire.
-     * @return array array of failed keys. Always empty in case of using memcached.
+     * @return array array of failed keys.
      */
     protected function setValues($data, $duration)
     {
@@ -313,9 +313,10 @@ class MemCache extends Cache
             // @see http://php.net/manual/en/memcache.set.php
             // @see http://php.net/manual/en/memcached.expiration.php
             $expire = $duration > 0 ? $duration + time() : 0;
-            $this->_cache->setMulti($data, $expire);
 
-            return [];
+            // Memcached::setMulti() returns boolean
+            // @see http://php.net/manual/ru/memcached.setmulti.php
+            return $this->_cache->setMulti($data, $expire) ? [] : array_keys($data);
         } else {
             return parent::setValues($data, $duration);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

`Memcached::setMulti()` doesn't return an array of failed keys....ok! But it returns a boolean value, not a void value. So we can and must check success of this operation. For example: if it returns `false` then mark all of the keys as failed. What do you think about it?