### PR TITLE
Fixed autoloading inside BaseYii scope

### DIFF
--- a/framework/BaseYii.php
+++ b/framework/BaseYii.php
@@ -285,7 +285,7 @@ class BaseYii
             return;
         }
 
-        include($classFile);
+        cleanAutoload($classFile);
 
         if (YII_DEBUG && !class_exists($className, false) && !interface_exists($className, false) && !trait_exists($className, false)) {
             throw new UnknownClassException("Unable to find '$className' in file: $classFile. Namespace missing?");
@@ -540,4 +540,13 @@ class BaseYii
     {
         return get_object_vars($object);
     }
+}
+
+/**
+ * Prevents access to scope of BaseYii::autoload() from included file.
+ * @param string $classFile
+ */
+function cleanAutoload($classFile)
+{
+    include($classFile);
 }

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.12 under development
 --------------------------
 
+- Bug #13374: Fixed autoloading inside `yii\BaseYii::autoload()` scope (and800)
 - Enh #13523: Plural rule for pasta (developeruz)
 - Bug #13538: Fixed `yii\db\BaseActiveRecord::deleteAll()` changes method signature declared by `yii\db\ActiveRecordInterface::deleteAll()` (klimov-paul)
 - Enh #13278: `yii\caching\DbQueryDependency` created allowing specification of the cache dependency via `yii\db\QueryInterface` (klimov-paul)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Currently the autoloader includes files inside `yii\BaseYii::autoload()` method. That means that the included code shares the scope with that method, including `self` pointing to `BaseYii` and `static` pointing to `Yii`. I've added a workaround which Composer uses: execute `include` statement in separate function.