### PR TITLE
add events before and after BaseActiveRecord::updateAttributes()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -83,6 +83,7 @@ Yii Framework 2 Change Log
 - Enh #12988: Changed `textarea` method within the `yii\helpers\BaseHtml` class to allow users to control whether HTML entities found within `$value` will be double-encoded or not (cyphix333)
 - Enh #13020: Added `disabledListItemSubTagOptions` attribute for `yii\widgets\LinkPager` in order to customize the disabled list item sub tag element (nadar)
 - Enh #13035: Use ArrayHelper::getValue() in SluggableBehavior::getValue() (thyseus)
+- Enh #13375: introduce EVENT_BEFORE_UPDATE_ATTRIBUTES and EVENT_AFTER_UPDATE_ATTRIBUTES in BaseActiveRecord (thyseus)
 - Enh #13036: Added shortcut methods `asJson()` and `asXml()` for returning JSON and XML data in web controller actions (cebe)
 - Enh #13050: Added `yii\filters\HostControl` allowing protection against 'host header' attacks (klimov-paul, rob006)
 - Enh #13074: Improved `yii\log\SyslogTarget` with `$options` to be able to change the default `openlog` options (timbeks)

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -69,6 +69,14 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     const EVENT_AFTER_UPDATE = 'afterUpdate';
     /**
+     * @event BeforeUpdateAttributes is an event that is triggered before updateAttributes() is called.
+     */
+    const EVENT_BEFORE_UPDATE_ATTRIBUTES = 'beforeUpdateAttributes';
+    /**
+     * @event AfterUpdateAttributes is an event that is triggered after updateAttributes() has been called.
+     */
+    const EVENT_AFTER_UPDATE_ATTRIBUTES = 'afterUpdateAttributes';
+    /**
      * @event ModelEvent an event that is triggered before deleting a record.
      * You may set [[ModelEvent::isValid]] to be `false` to stop the deletion.
      */
@@ -715,6 +723,8 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function updateAttributes($attributes)
     {
+        $this->trigger(self::EVENT_BEFORE_UPDATE_ATTRIBUTES);
+
         $attrs = [];
         foreach ($attributes as $name => $value) {
             if (is_int($name)) {
@@ -735,6 +745,8 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
         foreach ($values as $name => $value) {
             $this->_oldAttributes[$name] = $this->_attributes[$name];
         }
+
+        $this->trigger(self::EVENT_AFTER_UPDATE_ATTRIBUTES);
 
         return $rows;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    |no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | n/a

Add events before and after BaseActiveRecord::updateAttributes(). This will probably be necessary for https://github.com/bedezign/yii2-audit/issues/183 - or are there any other ideas?
