### PR TITLE
Improved method

### DIFF
--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -9,7 +9,6 @@ namespace yii\web;
 
 use Yii;
 use yii\base\InlineAction;
-use yii\helpers\Url;
 
 /**
  * Controller is the base class of web controllers.

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -199,7 +199,7 @@ class Controller extends \yii\base\Controller
      */
     public function redirect($url, $statusCode = 302)
     {
-        return Yii::$app->getResponse()->redirect(Url::to($url), $statusCode);
+        return Yii::$app->getResponse()->redirect($url, $statusCode);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

I removed `Url::to()` from `yii\web\Controller::redirect()` because it calls in `yii\web\Response::redirect()`
