### PR TITLE
allow multiple sql queries in DbDependency

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -87,6 +87,7 @@ Yii Framework 2 Change Log
 - Enh #12988: Changed `textarea` method within the `yii\helpers\BaseHtml` class to allow users to control whether HTML entities found within `$value` will be double-encoded or not (cyphix333)
 - Enh #13020: Added `disabledListItemSubTagOptions` attribute for `yii\widgets\LinkPager` in order to customize the disabled list item sub tag element (nadar)
 - Enh #13035: Use ArrayHelper::getValue() in SluggableBehavior::getValue() (thyseus)
+- Enh #13402: Allow multiple SQL queries in DbDependency (thyseus)
 - Enh #13036: Added shortcut methods `asJson()` and `asXml()` for returning JSON and XML data in web controller actions (cebe)
 - Enh #13050: Added `yii\filters\HostControl` allowing protection against 'host header' attacks (klimov-paul, rob006)
 - Enh #13074: Improved `yii\log\SyslogTarget` with `$options` to be able to change the default `openlog` options (timbeks)

--- a/framework/caching/DbDependency.php
+++ b/framework/caching/DbDependency.php
@@ -55,14 +55,21 @@ class DbDependency extends Dependency
             throw new InvalidConfigException('DbDependency::sql must be set.');
         }
 
+        // temporarily disable and re-enable query caching later
+        $reenable_query_cache = false;
         if ($db->enableQueryCache) {
-            // temporarily disable and re-enable query caching
             $db->enableQueryCache = false;
-            $result = $db->createCommand($this->sql, $this->params)->queryOne();
-            $db->enableQueryCache = true;
-        } else {
-            $result = $db->createCommand($this->sql, $this->params)->queryOne();
+            $reenable_query_cache = true;
         }
+
+        if (is_array($this->sql)) {
+            foreach ($this->sql as $sql)
+                $result[] = $db->createCommand($sql, $this->params)->queryOne();
+        } else
+            $result = $db->createCommand($this->sql, $this->params)->queryOne();
+
+        if ($reenable_query_cache)
+            $db->enableQueryCache = true;
 
         return $result;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes - PHP5.5 wrongly configured on travis

And also a little bit of refactoring.

I know that \yii\caching\ChainedDependency exists, but this way is much more convinient:

```php
 'dependency' => [
        'class' => 'yii\caching\DbDependency',
        'sql' => [
           'SELECT updated_at from agency where user_id = ' . Yii::$app->user->id,
           'SELECT max(updated_at) from offer_has_agency where agency_id = ' . Yii::$app->user->identity->agency->id,
           'select count(*) from message where message.status = 1 and message.to = ' . Yii::$app->user->id,
        ],
    ],
```