### PR TITLE
Fixed #13212 - DbSession failure when trying to regenerate session id

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -41,6 +41,7 @@ Yii Framework 2 Change Log
 - Bug #13159: Fixed `destroy` method in `yii.captcha.js` which did not work as expected (arogachev)
 - Bug #13198: Fixed order of checks in `yii\validators\IpValidator` that sometimes caused wrong error message (silverfire)
 - Bug #13200: Creating URLs for routes specified in `yii\rest\UrlRule::$extraPatterns` did not work if no HTTP verb was specified (cebe)
+- Bug #13212: Fixed `DbSession::regenerateID()` failure when `session_regenerate_id()` fails (andrewnester)
 - Bug #13229: Fix fetching schema information for `pgsql` when `PDO::ATTR_CASE` is set (klimov-paul)
 - Bug #13231: Fixed `destroy` method in `yii.gridView.js` which did not work as expected (arogachev)
 - Bug #13232: Event handlers were not detached with changed selector in `yii.gridView.js` (arogachev)

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -102,6 +102,11 @@ class DbSession extends MultiFieldSession
 
         parent::regenerateID(false);
         $newID = session_id();
+        // if session id regeneration failed, no need to create/update it.
+        if (empty($newID)) {
+            Yii::warning('Failed to generate new session ID', __METHOD__);
+            return;
+        }
 
         $query = new Query();
         $row = $query->from($this->sessionTable)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13212
