### PR TITLE
Allows customize `yii\data\ActiveDataProvider` in `yii\rest\IndexAction`

### DIFF
--- a/framework/rest/IndexAction.php
+++ b/framework/rest/IndexAction.php
@@ -61,7 +61,8 @@ class IndexAction extends Action
         /* @var $modelClass \yii\db\BaseActiveRecord */
         $modelClass = $this->modelClass;
 
-        return new ActiveDataProvider([
+        return Yii::createObject([
+            'class' => ActiveDataProvider::className(),
             'query' => $modelClass::find(),
         ]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Allows customize `yii\data\ActiveDataProvider` properties by Dependency Injection

Example:
```php
//config/web.php
Yii::$container->set('yii\data\ActiveDataProvider', [
    'pagination' => false,
]);
```
