### PR TITLE
Closes #13352: Do not render empty row in `yii\grid\GridView` when data is empty and `emptyText` set to `false`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -99,6 +99,7 @@ Yii Framework 2 Change Log
 - Enh #13264: Added `yii\widgets\InputWidget::$field` field, allowing access to the related `yii\widget\ActiveField` instance (klimov-paul)
 - Enh #13266: Added `yii\validators\EachValidator::$stopOnFirstError` allowing addition of more than one error (klimov-paul)
 - Enh #13268: Added logging of memory usage (bashkarev)
+- Enh #13352: Do not render empty row in `yii\grid\GridView` when data is empty and `emptyText` set to `false` (arogachev)
 - Enh: Added constants for specifying `yii\validators\CompareValidator::$type` (cebe)
 - Enh: Refactored `yii\web\ErrorAction` to make it reusable (silverfire)
 - Enh: Added support for field `yii\console\controllers\BaseMigrateController::$migrationNamespaces` setup from CLI (schmunk42)

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -483,7 +483,7 @@ class GridView extends BaseListView
             }
         }
 
-        if (empty($rows)) {
+        if (empty($rows) && $this->emptyText !== false) {
             $colspan = count($this->columns);
 
             return "<tbody>\n<tr><td colspan=\"$colspan\">" . $this->renderEmpty() . "</td></tr>\n</tbody>";

--- a/framework/widgets/BaseListView.php
+++ b/framework/widgets/BaseListView.php
@@ -77,7 +77,8 @@ abstract class BaseListView extends Widget
      */
     public $showOnEmpty = false;
     /**
-     * @var string the HTML content to be displayed when [[dataProvider]] does not have any data.
+     * @var string|bool the HTML content to be displayed when [[dataProvider]] does not have any data. When `false`,
+     * row with empty text will not be displayed.
      */
     public $emptyText;
     /**

--- a/tests/data/grid/TestGridView.php
+++ b/tests/data/grid/TestGridView.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace yiiunit\data\grid;
+
+use yii\widgets\BaseListView;
+
+class TestGridView extends \yii\grid\GridView
+{
+    public $options = [];
+    public $tableOptions = [];
+
+    public function getId($autoGenerate = true)
+    {
+        return parent::getId(false);
+    }
+
+    public function run()
+    {
+        BaseListView::run();
+    }
+}

--- a/tests/framework/grid/GridViewTest.php
+++ b/tests/framework/grid/GridViewTest.php
@@ -5,7 +5,7 @@ namespace yiiunit\framework\grid;
 
 use yii\data\ArrayDataProvider;
 use yii\grid\DataColumn;
-use yii\grid\GridView;
+use yiiunit\data\grid\TestGridView;
 
 /**
  * @author Evgeniy Tkachenko <et.coder@gmail.com>
@@ -13,12 +13,49 @@ use yii\grid\GridView;
  */
 class GridViewTest extends \yiiunit\TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mockApplication();
+    }
+
+    /**
+     * @return array
+     */
+    public function emptyDataProvider()
+    {
+        return [
+            [null, 'No results found.'],
+            ['Empty', 'Empty'],
+            // https://github.com/yiisoft/yii2/issues/13352
+            [false, ''],
+        ];
+    }
+
+    /**
+     * @dataProvider emptyDataProvider
+     * @param mixed $emptyText
+     * @param string $expectedText
+     * @throws \Exception
+     */
+    public function testEmpty($emptyText, $expectedText)
+    {
+        $html = TestGridView::widget([
+            'dataProvider' => new ArrayDataProvider(['allModels' => []]),
+            'showHeader' => false,
+            'emptyText' => $emptyText,
+        ]);
+        $emptyRowHtml = "<tr><td colspan=\"0\"><div class=\"empty\">{$expectedText}</div></td></tr>";
+        $expectedHtml = "<div><table><tbody>{$emptyRowHtml}</tbody></table></div>";
+        $html = preg_replace("/\r|\n/", '', $html);
+        $this->assertEquals($expectedHtml, $html);
+    }
+
     public function testGuessColumns()
     {
-        $this->mockApplication();
         $row = ['id' => 1, 'name' => 'Name1', 'value' => 'Value1', 'description' => 'Description1',];
 
-        $grid = new GridView([
+        $grid = new TestGridView([
             'dataProvider' => new ArrayDataProvider(
                 [
                     'allModels' => [
@@ -39,7 +76,7 @@ class GridViewTest extends \yiiunit\TestCase
         $row = array_merge($row, ['relation' => ['id' => 1, 'name' => 'RelationName',],]);
         $row = array_merge($row, ['otherRelation' => (object)$row['relation']]);
 
-        $grid = new GridView([
+        $grid = new TestGridView([
             'dataProvider' => new ArrayDataProvider(
                 [
                     'allModels' => [

--- a/tests/framework/grid/GridViewTest.php
+++ b/tests/framework/grid/GridViewTest.php
@@ -45,9 +45,9 @@ class GridViewTest extends \yiiunit\TestCase
             'showHeader' => false,
             'emptyText' => $emptyText,
         ]);
+        $html = preg_replace("/\r|\n/", '', $html);
         $emptyRowHtml = "<tr><td colspan=\"0\"><div class=\"empty\">{$expectedText}</div></td></tr>";
         $expectedHtml = "<div><table><tbody>{$emptyRowHtml}</tbody></table></div>";
-        $html = preg_replace("/\r|\n/", '', $html);
         $this->assertEquals($expectedHtml, $html);
     }
 

--- a/tests/framework/grid/GridViewTest.php
+++ b/tests/framework/grid/GridViewTest.php
@@ -46,8 +46,14 @@ class GridViewTest extends \yiiunit\TestCase
             'emptyText' => $emptyText,
         ]);
         $html = preg_replace("/\r|\n/", '', $html);
-        $emptyRowHtml = "<tr><td colspan=\"0\"><div class=\"empty\">{$expectedText}</div></td></tr>";
+
+        if ($expectedText) {
+            $emptyRowHtml = "<tr><td colspan=\"0\"><div class=\"empty\">{$expectedText}</div></td></tr>";
+        } else {
+            $emptyRowHtml = '';
+        }
         $expectedHtml = "<div><table><tbody>{$emptyRowHtml}</tbody></table></div>";
+
         $this->assertEquals($expectedHtml, $html);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13352 

Closes #13352 🔒 :shipit:
