### PR TITLE
fix: module version bug

### DIFF
--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -141,7 +141,7 @@ class Module extends ServiceLocator
      *
      * @since 2.0.11
      */
-    private $_version;
+    protected $_version;
 
 
     /**


### PR DESCRIPTION
Couldn't reassign version of module by setting $_version property.
defaultVerison was called anyway.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
