### PR TITLE
Use low-level query in UniqueValidator

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -114,6 +114,7 @@ Yii Framework 2 Change Log
 - Enh #11464: Populate foreign key names from schema (joaoppereira)
 - Bug #13401: Fixed lack of escaping of request dump at exception screens (samdark)
 - Enh #13417: Allow customizing `yii\data\ActiveDataProvider` in `yii\rest\IndexAction` (leandrogehlen)
+- Enh #13453: Select only primary key when counting records in UniqueValidator (developeruz)
 - Bug #12599: Fixed MSSQL fail to work with `nvarbinary`. Enhanced SQL scripts compatibility with older versions (samdark)
 - Enh #7435: Added `EVENT_BEFORE_RUN`, `EVENT_AFTER_RUN` and corresponding methods to `yii\base\Widget` (petrabarus)
 

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -160,8 +160,7 @@ class UniqueValidator extends Validator
             $exists = $query->exists();
         } else {
             // if current $model is in the database already we can't use exists()
-            /** @var $models ActiveRecordInterface[] */
-            $models = $query->limit(2)->all();
+            $models = $query->select($targetClass::primaryKey())->limit(2)->createCommand()->queryAll();
             $n = count($models);
             if ($n === 1) {
                 $keys = array_keys($conditions);
@@ -173,7 +172,7 @@ class UniqueValidator extends Validator
                     $exists = $model->getOldPrimaryKey() != $model->getPrimaryKey();
                 } else {
                     // non-primary key, need to exclude the current record based on PK
-                    $exists = reset($models)->getPrimaryKey() != $model->getOldPrimaryKey();
+                    $exists = $models[0] != $model->getOldPrimaryKey(true);
                 }
             } else {
                 $exists = $n > 1;


### PR DESCRIPTION
Fixes #13453, relates to #13098

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Fixes #13453, relates to #13098

Use low-level query in UniqueValidator to avoid triggering `afterFind` and other events.