### PR TITLE
ActiveDataProvider should avoid query data when data count is zero

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -1,6 +1,11 @@
 Yii Framework 2 Change Log
 ==========================
 
+2.0.12 under development
+------------------------
+
+- Enh #12752: ActiveDataProvider should avoid query data when data count is zero
+
 2.0.11 under development
 ------------------------
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.12 under development
 ------------------------
 
-- Enh #12752: ActiveDataProvider should avoid query data when data count is zero
+- Enh #12752: ActiveDataProvider should avoid query data when data count is zero (kLkA)
 
 2.0.11 under development
 ------------------------

--- a/framework/data/ActiveDataProvider.php
+++ b/framework/data/ActiveDataProvider.php
@@ -103,7 +103,8 @@ class ActiveDataProvider extends BaseDataProvider
         }
         $query = clone $this->query;
         if (($pagination = $this->getPagination()) !== false) {
-            if (($pagination->totalCount = $this->getTotalCount()) === 0) {
+            $pagination->totalCount = $this->getTotalCount();
+            if ($pagination->totalCount === 0) {
                 return [];
             }
             $query->limit($pagination->getLimit())->offset($pagination->getOffset());

--- a/framework/data/ActiveDataProvider.php
+++ b/framework/data/ActiveDataProvider.php
@@ -103,7 +103,9 @@ class ActiveDataProvider extends BaseDataProvider
         }
         $query = clone $this->query;
         if (($pagination = $this->getPagination()) !== false) {
-            $pagination->totalCount = $this->getTotalCount();
+            if (($pagination->totalCount = $this->getTotalCount()) === 0) {
+                return [];
+            }
             $query->limit($pagination->getLimit())->offset($pagination->getOffset());
         }
         if (($sort = $this->getSort()) !== false) {

--- a/tests/framework/data/ActiveDataProviderTest.php
+++ b/tests/framework/data/ActiveDataProviderTest.php
@@ -177,4 +177,18 @@ abstract class ActiveDataProviderTest extends DatabaseTestCase
         $provider->refresh();
         $this->assertEquals(2, count($provider->getModels()));
     }
+
+    public function testZeroTotalCount()
+    {
+        $query = new Query;
+        $provider = new ActiveDataProvider([
+            'db' => $this->getConnection(),
+            'query' => $query->from('item')->where([
+                'name' => 'Should not exist'
+            ]),
+        ]);
+        $this->assertTrue(($pagination = $provider->getPagination()) !== false);
+        $this->assertTrue(($pagination->totalCount = $provider->getTotalCount()) === 0);
+        $this->assertCount(0, $provider->getModels());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #12752 
