### PR TITLE
docs/guide fix [ci skip]

### DIFF
--- a/docs/guide/runtime-sessions-cookies.md
+++ b/docs/guide/runtime-sessions-cookies.md
@@ -200,7 +200,7 @@ $session->setFlash('postDeleted', 'You have successfully deleted your post.');
 echo $session->getFlash('postDeleted');
 
 // Request #3
-// $result will be `false` since the flash message was automatically deleted
+// $result will be false since the flash message was automatically deleted
 $result = $session->hasFlash('postDeleted');
 ```
 

--- a/docs/guide/tutorial-core-validators.md
+++ b/docs/guide/tutorial-core-validators.md
@@ -26,7 +26,7 @@ In the following, we will describe the main usage and properties of every core v
     // checks if "selected" is either 0 or 1, regardless of data type
     ['selected', 'boolean'],
 
-    // checks if "deleted" is of boolean type, either `true` or `false`
+    // checks if "deleted" is of boolean type, either true or false
     ['deleted', 'boolean', 'trueValue' => true, 'falseValue' => false, 'strict' => true],
 ]
 ```
@@ -175,7 +175,7 @@ or `1970-01-01` in the input field of a date picker.
 
 ```php
 [
-    // set "age" to be `null` if it is empty
+    // set "age" to be null if it is empty
     ['age', 'default', 'value' => null],
 
     // set "country" to be "USA" if it is empty


### PR DESCRIPTION
docs/guide typo fix

"true", "false" and "nul"` in code blocks should not be quoted with backquotes.