### PR TITLE
Improved description of format of $controllers

### DIFF
--- a/framework/filters/AccessRule.php
+++ b/framework/filters/AccessRule.php
@@ -32,6 +32,7 @@ class AccessRule extends Component
     public $actions;
     /**
      * @var array list of the controller IDs that this rule applies to. Each controller ID is prefixed with the module ID (if any).
+     * The comparison uses [[Controller::uniqueId]], so the items in $controller look like ['shop/product'].
      * The comparison is case-sensitive. If not set or empty, it means this rule applies to all controllers.
      */
     public $controllers;


### PR DESCRIPTION
Improved explanation of the format of the $controllers property. This explains what is meant by "prefixed with the module ID"

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
