### PR TITLE
Made ActionColumn Yii::t() tags static again

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #11502: Fixed `yii\console\controllers\MessageController` to properly populate missing languages in case of extraction with "db" format (bizley)
+- Bug #13489: Fixed button names in ActionColumn to contain proper `Yii::t()` tags and restored missing translations for `ja` and `ru` (cebe, softark)
 
 
 2.0.11 February 01, 2017

--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -161,7 +161,7 @@ class ActionColumn extends Column
     {
         if (!isset($this->buttons[$name]) && strpos($this->template, '{' . $name . '}') !== false) {
             $this->buttons[$name] = function ($url, $model, $key) use ($name, $iconName, $additionalOptions) {
-                switch($name) {
+                switch ($name) {
                     case 'view':
                         $title = Yii::t('yii', 'View');
                         break;

--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -161,7 +161,19 @@ class ActionColumn extends Column
     {
         if (!isset($this->buttons[$name]) && strpos($this->template, '{' . $name . '}') !== false) {
             $this->buttons[$name] = function ($url, $model, $key) use ($name, $iconName, $additionalOptions) {
-                $title = Yii::t('yii', ucfirst($name));
+                switch($name) {
+                    case 'view':
+                        $title = Yii::t('yii', 'View');
+                        break;
+                    case 'update':
+                        $title = Yii::t('yii', 'Update');
+                        break;
+                    case 'delete':
+                        $title = Yii::t('yii', 'Delete');
+                        break;
+                    default:
+                        $title = ucfirst($name);
+                }
                 $options = array_merge([
                     'title' => $title,
                     'aria-label' => $title,


### PR DESCRIPTION
this was changed in 2.0.11 and cause the messages translation command to not
recognize them anymore.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | n/a
