### PR TITLE
Fixes all issues related to nested pjax. 

### DIFF
--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -464,8 +464,6 @@ class View extends \yii\base\View
                 $this->js[$position][$key] = $js ."\n". $this->js[$position][$key];
             } else if ($merger === self::MERGE_APPEND) {
                 $this->js[$position][$key] .= $js;
-            } else {
-                $this->js[$position][$key] = $js;
             }
         } else {
             $this->js[$position][$key] = $js;

--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -99,6 +99,11 @@ class Pjax extends Widget
      */
     public $clientOptions;
     /**
+     * @var bool clear the resources. If set to `true` any resources registered outside the pjax widget's scope will be removed.
+     * This should be set to `false` if your pjax widget is inside the layout view since the layout is rendered after the content.
+     */
+    public $clear = true;
+    /**
      * @inheritdoc
      * @internal
      */
@@ -121,7 +126,9 @@ class Pjax extends Widget
             ob_start();
             ob_implicit_flush(false);
             $view = $this->getView();
-            $view->clear();
+            if ($this->clear) {
+                $view->clear();
+            }
             $view->beginPage();
             $view->head();
             $view->beginBody();

--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -13,6 +13,7 @@ use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
 use yii\helpers\Json;
 use yii\web\Response;
+use yii\web\View;
 
 /**
  * Pjax is a widget integrating the [pjax](https://github.com/yiisoft/jquery-pjax) jQuery plugin.
@@ -147,11 +148,13 @@ class Pjax extends Widget
     public function run()
     {
         if (!$this->requiresPjax()) {
+            $this->registerClientScript();
             echo Html::endTag(ArrayHelper::remove($this->options, 'tag', 'div'));
             $this->registerClientScript();
 
             return;
         }
+        $this->registerClientScript(false);
 
         $view = $this->getView();
         $view->endBody();
@@ -189,7 +192,7 @@ class Pjax extends Widget
     /**
      * Registers the needed JavaScript.
      */
-    public function registerClientScript()
+    public function registerClientScript($registerAssets = true)
     {
         $id = $this->options['id'];
         $this->clientOptions['push'] = $this->enablePushState;
@@ -211,10 +214,13 @@ class Pjax extends Widget
             $js .= "\njQuery(document).on($submitEvent, $formSelector, function (event) {jQuery.pjax.submit(event, $options);});";
         }
         $view = $this->getView();
-        PjaxAsset::register($view);
+        
+        if ($registerAssets) {
+            PjaxAsset::register($view);
+        }
 
         if ($js !== '') {
-            $view->registerJs($js);
+            $view->registerJs($js, View::POS_READY, 'pjax-init', View::MERGE_PREPEND);
         }
     }
 }

--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -190,7 +190,7 @@ class Pjax extends Widget
     /**
      * Registers the needed JavaScript.
      */
-    public function registerClientScript($jsMerge = View::MERGE_APPEND)
+    public function registerClientScript()
     {
         $id = $this->options['id'];
         $this->clientOptions['push'] = $this->enablePushState;

--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -149,11 +149,10 @@ class Pjax extends Widget
         $view = $this->getView();
         $this->registerClientScript();
         if (!$this->requiresPjax()) {
+            PjaxAsset::register($view);
             echo Html::endTag(ArrayHelper::remove($this->options, 'tag', 'div'));
             return;
         }
-
-        PjaxAsset::register($view);
         
         $view->endBody();
         $view->endPage(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13493

Requires pull request yiisoft/jquery-pjax/pull/48

This fix will make sure the `$(document).pjax(...)` calls are made in the right order which allows for nested pjax widgets.