### PR TITLE
Fix stylesheets so that they only get applied once unless specified o…

### DIFF
--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -98,6 +98,14 @@ class Pjax extends Widget
      */
     public $clientOptions;
     /**
+     * @var bool Reapply stylesheets if the stylesheet is already loaded. 
+     */
+    public $reapplyStyles = true;
+    /**
+     * @var bool Put stylesheets in the HTML head section so that they do not get removed on subsequent PJAX calls. 
+     */
+    public $stylesHead = true;
+    /**
      * @inheritdoc
      * @internal
      */
@@ -128,6 +136,9 @@ class Pjax extends Widget
             if ($view->title !== null) {
                 echo Html::tag('title', Html::encode($view->title));
             }
+            $headers = Yii::$app->response->headers;
+            $headers->set('X-PJAX-Stylesheets-Reapply', $this->reapplyStyles);
+            $headers->set('X-PJAX-Stylesheets-Head', $this->stylesHead);
         } else {
             $options = $this->options;
             $tag = ArrayHelper::remove($options, 'tag', 'div');
@@ -155,11 +166,6 @@ class Pjax extends Widget
 
         $view = $this->getView();
         $view->endBody();
-
-        // Do not re-send css files as it may override the css files that were loaded after them.
-        // This is a temporary fix for https://github.com/yiisoft/yii2/issues/2310
-        // It should be removed once pjax supports loading only missing css files
-        $view->cssFiles = null;
 
         $view->endPage(true);
 

--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -100,11 +100,11 @@ class Pjax extends Widget
     /**
      * @var bool Reapply stylesheets if the stylesheet is already loaded. 
      */
-    public $reapplyStyles = true;
+    public $reapplyStyles = false;
     /**
      * @var bool Put stylesheets in the HTML head section so that they do not get removed on subsequent PJAX calls. 
      */
-    public $stylesHead = true;
+    public $stylesHead = false;
     /**
      * @inheritdoc
      * @internal


### PR DESCRIPTION
…therwise.

Adds two new options:
 - **$reapplyStyles** Reapply existing stylesheets if set to true.
 - **$stylesHead** Moves stylesheets to the HTML head element so that they are not removed on subsequent PJAX calls.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #2310, #13155

Requires: yiisoft/jquery-pjax/pull/49
