### PR TITLE
Better fix for #13305: Disable timeout completely for JS tests

### DIFF
--- a/docs/internals/git-workflow.md
+++ b/docs/internals/git-workflow.md
@@ -76,10 +76,6 @@ You may limit the tests to a group of tests you are working on e.g. to run only 
 
 You can execute JavaScript unit tests by running `npm test` in the repo root directory.
 
-> Note: If you get timeout errors like `Error: timeout of 2000ms exceeded. Ensure the done() callback is being called
-in this test.`, you can increase timeout: `npm test -- --timeout 30000` (don't miss `--`, it's needed for passing
-additional arguments).
-
 ### Extensions
 
 To work on extensions you have to clone the extension repository. We have created a command that can do this for you:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "sinon": "^1.17.6"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha tests/js/tests/*.test.js --timeout 30000"
+    "test": "./node_modules/mocha/bin/mocha tests/js/tests/*.test.js --timeout 0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13305
