### PR TITLE
Refactor fragment cache widget

### DIFF
--- a/framework/widgets/FragmentCache.php
+++ b/framework/widgets/FragmentCache.php
@@ -134,25 +134,33 @@ class FragmentCache extends Widget
      */
     public function getCachedContent()
     {
-        if ($this->_content === null) {
-            $this->_content = false;
-            if ($this->cache instanceof Cache) {
-                $key = $this->calculateKey();
-                $data = $this->cache->get($key);
-                if (is_array($data) && count($data) === 2) {
-                    list ($content, $placeholders) = $data;
-                    if (is_array($placeholders) && count($placeholders) > 0) {
-                        if (empty($this->getView()->cacheStack)) {
-                            // outermost cache: replace placeholder with dynamic content
-                            $content = $this->updateDynamicContent($content, $placeholders);
-                        }
-                        foreach ($placeholders as $name => $statements) {
-                            $this->getView()->addDynamicPlaceholder($name, $statements);
-                        }
-                    }
-                    $this->_content = $content;
-                }
-            }
+        if ($this->_content !== null) {
+            return $this->_content;
+        }
+
+        $this->_content = false;
+
+        if (!($this->cache instanceof Cache)) {
+            return $this->_content;
+        }
+
+        $key = $this->calculateKey();
+        $data = $this->cache->get($key);
+        if (!is_array($data) || count($data) !== 2) {
+            return $this->_content;
+        }
+
+        list ($this->_content, $placeholders) = $data;
+        if (!is_array($placeholders) || count($placeholders) === 0) {
+            return $this->_content;
+        }
+
+        if (empty($this->getView()->cacheStack)) {
+            // outermost cache: replace placeholder with dynamic content
+            $this->_content = $this->updateDynamicContent($this->_content, $placeholders);
+        }
+        foreach ($placeholders as $name => $statements) {
+            $this->getView()->addDynamicPlaceholder($name, $statements);
         }
 
         return $this->_content;

--- a/tests/framework/widgets/FragmentCacheTest.php
+++ b/tests/framework/widgets/FragmentCacheTest.php
@@ -86,6 +86,109 @@ class FragmentCacheTest extends \yiiunit\TestCase
         $this->assertEquals($expectedLevel, ob_get_level(), 'Output buffer not closed correctly.');
     }
 
+    public function testSingleDynamicFragment()
+    {
+        Yii::$app->params['counter'] = 0;
+
+        $view = new View();
+
+        for ($counter = 0; $counter < 42; $counter++) {
+            ob_start();
+            ob_implicit_flush(false);
+
+            $cacheUnavailable = $view->beginCache('test');
+
+            if ($counter === 0) {
+                $this->assertTrue($cacheUnavailable);
+            } else {
+                $this->assertFalse($cacheUnavailable);
+            }
+
+            if ($cacheUnavailable) {
+                echo 'single dynamic cached fragment: ';
+                echo $view->renderDynamic('return \Yii::$app->params["counter"]++;');
+                $view->endCache();
+            }
+
+            $expectedContent = vsprintf('single dynamic cached fragment: %d', [
+                $counter,
+            ]);
+            $this->assertEquals($expectedContent, ob_get_clean());
+        }
+    }
+
+    public function testMultipleDynamicFragments()
+    {
+        Yii::$app->params['counter'] = 0;
+
+        $view = new View();
+
+        for ($counter = 0; $counter < 42; $counter++) {
+            ob_start();
+            ob_implicit_flush(false);
+
+            $cacheUnavailable = $view->beginCache('test');
+
+            if ($counter === 0) {
+                $this->assertTrue($cacheUnavailable);
+            } else {
+                $this->assertFalse($cacheUnavailable);
+            }
+
+            if ($cacheUnavailable) {
+                echo 'multiple dynamic cached fragments: ';
+                echo $view->renderDynamic('return md5(\Yii::$app->params["counter"]);');
+                echo $view->renderDynamic('return \Yii::$app->params["counter"]++;');
+                $view->endCache();
+            }
+
+            $expectedContent = vsprintf('multiple dynamic cached fragments: %s%d', [
+                md5($counter),
+                $counter,
+            ]);
+            $this->assertEquals($expectedContent, ob_get_clean());
+        }
+    }
+
+    public function testNestedDynamicFragments()
+    {
+        Yii::$app->params['counter'] = 0;
+
+        $view = new View();
+
+        for ($counter = 0; $counter < 42; $counter++) {
+            ob_start();
+            ob_implicit_flush(false);
+
+            $cacheUnavailable = $view->beginCache('test');
+
+            if ($counter === 0) {
+                $this->assertTrue($cacheUnavailable);
+            } else {
+                $this->assertFalse($cacheUnavailable);
+            }
+
+            if ($cacheUnavailable) {
+                echo 'nested dynamic cached fragments: ';
+                echo $view->renderDynamic('return md5(\Yii::$app->params["counter"]);');
+
+                if ($view->beginCache('test-nested')) {
+                    echo $view->renderDynamic('return sha1(\Yii::$app->params["counter"]);');
+                    $view->endCache();
+                }
+
+                echo $view->renderDynamic('return \Yii::$app->params["counter"]++;');
+                $view->endCache();
+            }
+
+            $expectedContent = vsprintf('nested dynamic cached fragments: %s%s%d', [
+                md5($counter),
+                sha1($counter),
+                $counter,
+            ]);
+            $this->assertEquals($expectedContent, ob_get_clean());
+        }
+    }
 
     // TODO test dynamic replacements
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | none

Five levels of indentation vs one. One `return` statement vs five.
It's highly arguable but I still believe that one level of indentation is more readable.

[Code Complete](http://www.cc2e.com/) - 17.1 return

> Use a return when it enhances readability. In certain routines, once you know the answer, you want to return it to the calling routine immediately. If the routine is defined in such a way that it doesn't require any cleanup, not returning immediately means that you have to write more code.