### PR TITLE
Add DBMS name and DBMS version properties to the DB connection

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Enh #13523: Plural rule for pasta (developeruz)
 - Bug #13538: Fixed `yii\db\BaseActiveRecord::deleteAll()` changes method signature declared by `yii\db\ActiveRecordInterface::deleteAll()` (klimov-paul)
 - Enh #13278: `yii\caching\DbQueryDependency` created allowing specification of the cache dependency via `yii\db\QueryInterface` (klimov-paul)
+- Enh #13570: Added `$dbmsName` and `$dbmsVersion` properties to the `yii\db\Connection` (Kolyunya)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -373,6 +373,18 @@ class Connection extends Component
      * @see masters
      */
     public $shuffleMasters = true;
+    /**
+     * @var string DBMS name.
+     * Can be checked against particular DBMS names to use DBMS-specific features.
+     * @since 2.0.12
+     */
+    public $dbmsName;
+    /**
+     * @var string DBMS version.
+     * Can be checked against particular DBMS versions to use DBMS-specific features.
+     * @since 2.0.12
+     */
+    public $dbmsVersion;
 
     /**
      * @var Transaction the currently active transaction


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #9592

https://github.com/yiisoft/yii2/issues/9592#issuecomment-243462861
> Note, that there is already \yii\db\Connection::driverName.

The driver name is not the DBMS name. E.g. `PDO_DBLIB` driver [supports](http://php.net/manual/en/pdo.drivers.php) the following DBMSs: FreeTDS, Microsoft SQL Server, Sybase.