### PR TITLE
Add support of `srcset` to `yii\helpers\Html::img()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Bug #11404: `yii\base\Model::loadMultiple()` returns true even if `yii\base\Model::load()` returns false (zvook)
 - Bug #13513: Fixed RBAC migration to work correctly on Oracle DBMS (silverfire)
 - Enh #13550: Refactored unset call order in `yii\di\ServiceLocator::set()` (Lanrik)
+- Enh #13576: Added support of `srcset` to `yii\helpers\Html::img()` (Kolyunya)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -435,6 +435,15 @@ class BaseHtml
     public static function img($src, $options = [])
     {
         $options['src'] = Url::to($src);
+
+        if (isset($options['srcset']) && is_array($options['srcset'])) {
+            $srcset = [];
+            foreach ($options['srcset'] as $descriptor => $url) {
+                $srcset[] = Url::to($url) . ' ' . $descriptor;
+            }
+            $options['srcset'] = implode(',', $srcset);
+        }
+
         if (!isset($options['alt'])) {
             $options['alt'] = '';
         }

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -430,6 +430,8 @@ class BaseHtml
      * the attributes of the resulting tag. The values will be HTML-encoded using [[encode()]].
      * If a value is null, the corresponding attribute will not be rendered.
      * See [[renderTagAttributes()]] for details on how attributes are being rendered.
+     * @since 2.0.12 It is possible to pass the "srcset" option as an array which keys are
+     * descriptors and values are URLs. All URLs will be processed by [[Url::to()]].
      * @return string the generated image tag
      */
     public static function img($src, $options = [])

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -132,35 +132,98 @@ class HtmlTest extends TestCase
         $this->assertEquals('<a href="mailto:test&gt;">test<></a>', Html::mailto('test<>', 'test>'));
     }
 
-    public function testImg()
+    /**
+     * @return array
+     */
+    public function imgDataProvider()
     {
-        $this->assertEquals('<img src="/example" alt="">', Html::img('/example'));
-        $this->assertEquals('<img src="/test" alt="">', Html::img(''));
-        $this->assertEquals('<img src="/example" width="10" alt="something">', Html::img('/example', ['alt' => 'something', 'width' => 10]));
-        $this->assertEquals('<img src="/base-url" alt="" srcset="/example-100w 100w,/example-500w 500w,/example-1500w 1500w">', Html::img('/base-url', [
-            'srcset' => [
-                '100w' => '/example-100w',
-                '500w' => '/example-500w',
-                '1500w' => '/example-1500w',
+        return [
+            [
+                '<img src="/example" alt="">',
+                '/example',
+                [],
             ],
-        ]));
-        $this->assertEquals('<img src="/base-url" alt="" srcset="/example-1x 1x,/example-2x 2x,/example-3x 3x">', Html::img('/base-url', [
-            'srcset' => [
-                '1x' => '/example-1x',
-                '2x' => '/example-2x',
-                '3x' => '/example-3x',
+            [
+                '<img src="/test" alt="">',
+                '',
+                [],
             ],
-        ]));
-        $this->assertEquals('<img src="/base-url" alt="" srcset="/example-1.42x 1.42x,/example-2.0x 2.0x,/example-3.999x 3.999x">', Html::img('/base-url', [
-            'srcset' => [
-                '1.42x' => '/example-1.42x',
-                '2.0x' => '/example-2.0x',
-                '3.999x' => '/example-3.999x',
+            [
+                '<img src="/example" width="10" alt="something">',
+                '/example',
+                [
+                    'alt' => 'something',
+                    'width' => 10,
+                ],
             ],
-        ]));
-        $this->assertEquals('<img src="/base-url" alt="" srcset="/example-1x 1x,/example-2x 2x,/example-3x 3x">', Html::img('/base-url', [
-            'srcset' => '/example-1x 1x,/example-2x 2x,/example-3x 3x',
-        ]));
+            [
+                '<img src="/base-url" alt="" srcset="">',
+                '/base-url',
+                [
+                    'srcset' => [
+                    ],
+                ],
+            ],
+            [
+                '<img src="/base-url" alt="" srcset="/example-9001w 9001w">',
+                '/base-url',
+                [
+                    'srcset' => [
+                        '9001w' => '/example-9001w',
+                    ],
+                ],
+            ],
+            [
+                '<img src="/base-url" alt="" srcset="/example-100w 100w,/example-500w 500w,/example-1500w 1500w">',
+                '/base-url',
+                [
+                    'srcset' => [
+                        '100w' => '/example-100w',
+                        '500w' => '/example-500w',
+                        '1500w' => '/example-1500w',
+                    ],
+                ],
+            ],
+            [
+                '<img src="/base-url" alt="" srcset="/example-1x 1x,/example-2x 2x,/example-3x 3x,/example-4x 4x,/example-5x 5x">',
+                '/base-url',
+                [
+                    'srcset' => [
+                        '1x' => '/example-1x',
+                        '2x' => '/example-2x',
+                        '3x' => '/example-3x',
+                        '4x' => '/example-4x',
+                        '5x' => '/example-5x',
+                    ],
+                ],
+            ],
+            [
+                '<img src="/base-url" alt="" srcset="/example-1.42x 1.42x,/example-2.0x 2.0x,/example-3.99999x 3.99999x">',
+                '/base-url',
+                [
+                    'srcset' => [
+                        '1.42x' => '/example-1.42x',
+                        '2.0x' => '/example-2.0x',
+                        '3.99999x' => '/example-3.99999x',
+                    ],
+                ],
+            ],
+            [
+                '<img src="/base-url" alt="" srcset="/example-1x 1x,/example-2x 2x,/example-3x 3x">',
+                '/base-url',
+                [
+                    'srcset' => '/example-1x 1x,/example-2x 2x,/example-3x 3x',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider imgDataProvider
+     */
+    public function testImg($expected, $src, $options)
+    {
+        $this->assertEquals($expected, Html::img($src, $options));
     }
 
     public function testLabel()

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -137,6 +137,30 @@ class HtmlTest extends TestCase
         $this->assertEquals('<img src="/example" alt="">', Html::img('/example'));
         $this->assertEquals('<img src="/test" alt="">', Html::img(''));
         $this->assertEquals('<img src="/example" width="10" alt="something">', Html::img('/example', ['alt' => 'something', 'width' => 10]));
+        $this->assertEquals('<img src="/base-url" alt="" srcset="/example-100w 100w,/example-500w 500w,/example-1500w 1500w">', Html::img('/base-url', [
+            'srcset' => [
+                '100w' => '/example-100w',
+                '500w' => '/example-500w',
+                '1500w' => '/example-1500w',
+            ],
+        ]));
+        $this->assertEquals('<img src="/base-url" alt="" srcset="/example-1x 1x,/example-2x 2x,/example-3x 3x">', Html::img('/base-url', [
+            'srcset' => [
+                '1x' => '/example-1x',
+                '2x' => '/example-2x',
+                '3x' => '/example-3x',
+            ],
+        ]));
+        $this->assertEquals('<img src="/base-url" alt="" srcset="/example-1.42x 1.42x,/example-2.0x 2.0x,/example-3.999x 3.999x">', Html::img('/base-url', [
+            'srcset' => [
+                '1.42x' => '/example-1.42x',
+                '2.0x' => '/example-2.0x',
+                '3.999x' => '/example-3.999x',
+            ],
+        ]));
+        $this->assertEquals('<img src="/base-url" alt="" srcset="/example-1x 1x,/example-2x 2x,/example-3x 3x">', Html::img('/base-url', [
+            'srcset' => '/example-1x 1x,/example-2x 2x,/example-3x 3x',
+        ]));
     }
 
     public function testLabel()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #10834 

Not sure if we should distinguish between `src` and `srcset` passed as the first argument using `yii\helpers\ArrayHelper::isAssociative()` or just pass `srcset` in `options` while passing `null` to `$src`.

If we choose the former it will hit the performance of each and every call to `Html::img()` in all existing and future applications. We also won't be able to support non-assiciative `srcsets` like following. Missing descriptor defaults to `1x` according to the [docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). Not sure if we should support this though.
```php
$srcset = [
    'base-url',
    '2x' => 'other-url',
];
```

If we choose the latter the method invocation will look somewhat _weird_ but I think we can live with it:
```php
<?= Html::img(null, ['srcset' => [
    '1x' => 'foo',
    '2x' => 'bar',
]]); ?>
```