### PR TITLE
`yii\test\ActiveFixture::resetTable()` should use `yii\db\QueryBuilder::truncateTable()` instead of manual delete/reset

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,7 +9,7 @@ Yii Framework 2 Change Log
 - Enh #13278: `yii\caching\DbQueryDependency` created allowing specification of the cache dependency via `yii\db\QueryInterface` (klimov-paul)
 - Bug #11230: Include `defaultRoles` in `yii\rbac\DbManager->getRolesByUser()` results (developeruz)
 - Bug #11404: `yii\base\Model::loadMultiple()` returns true even if `yii\base\Model::load()` returns false (zvook)
-- Enh #13577: `yii\test\ActiveFixture::resetTable()` should use `yii\db\QueryBuilder::truncateTable()` in stead of manual delete and reset (boboldehampsink)
+- Enh #13577: `yii\test\ActiveFixture::resetTable()` should use `yii\db\QueryBuilder::truncateTable()` instead of manual delete and reset (boboldehampsink)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Enh #13278: `yii\caching\DbQueryDependency` created allowing specification of the cache dependency via `yii\db\QueryInterface` (klimov-paul)
 - Bug #11230: Include `defaultRoles` in `yii\rbac\DbManager->getRolesByUser()` results (developeruz)
 - Bug #11404: `yii\base\Model::loadMultiple()` returns true even if `yii\base\Model::load()` returns false (zvook)
+- Enh #13577: `yii\test\ActiveFixture::resetTable()` should use `yii\db\QueryBuilder::truncateTable()` in stead of manual delete and reset (boboldehampsink)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/test/ActiveFixture.php
+++ b/framework/test/ActiveFixture.php
@@ -113,10 +113,7 @@ class ActiveFixture extends BaseActiveFixture
     protected function resetTable()
     {
         $table = $this->getTableSchema();
-        $this->db->createCommand()->delete($table->fullName)->execute();
-        if ($table->sequenceName !== null) {
-            $this->db->createCommand()->resetSequence($table->fullName, 1)->execute();
-        }
+        $this->db->createCommand()->truncateTable($table->fullName)->execute();
     }
 
     /**


### PR DESCRIPTION
Because `yii\db\QueryBuilder::resetSequence()` is not implemented for all drivers, using `yii\db\QueryBuilder::truncateTable()` will yield better results over all drivers. For example, it enables the use of ActiveFixture for MSSQL, where it couldn't be used before.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13577
