### PR TITLE
Enhance `yii\behaviors\AttributeBehavior`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Bug #11404: `yii\base\Model::loadMultiple()` returns true even if `yii\base\Model::load()` returns false (zvook)
 - Bug #13513: Fixed RBAC migration to work correctly on Oracle DBMS (silverfire)
 - Enh #13550: Refactored unset call order in `yii\di\ServiceLocator::set()` (Lanrik)
+- Enh #13586: Added `$preserveNonEmptyValues` property to the `yii\behaviors\AttributeBehavior` (Kolyunya)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/behaviors/AttributeBehavior.php
+++ b/framework/behaviors/AttributeBehavior.php
@@ -85,6 +85,11 @@ class AttributeBehavior extends Behavior
      * @since 2.0.8
      */
     public $skipUpdateOnClean = true;
+    /**
+     * @var bool whether to preserve non-empty attribute values.
+     * @since 2.0.12
+     */
+    public $preserveNonEmptyValues = false;
 
 
     /**
@@ -117,6 +122,9 @@ class AttributeBehavior extends Behavior
             foreach ($attributes as $attribute) {
                 // ignore attribute names which are not string (e.g. when set by TimestampBehavior::updatedAtAttribute)
                 if (is_string($attribute)) {
+                    if ($this->preserveNonEmptyValues && !empty($this->owner->$attribute)) {
+                        continue;
+                    }
                     $this->owner->$attribute = $value;
                 }
             }

--- a/tests/framework/behaviors/AttributeBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeBehaviorTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace yiiunit\framework\behaviors;
+
+use Yii;
+use yiiunit\TestCase;
+use yii\db\Connection;
+use yii\db\ActiveRecord;
+use yii\behaviors\AttributeBehavior;
+
+/**
+ * Unit test for [[\yii\behaviors\AttributeBehavior]].
+ * @see AttributeBehavior
+ *
+ * @group behaviors
+ */
+class AttributeBehaviorTest extends TestCase
+{
+    /**
+     * @var Connection test db connection
+     */
+    protected $dbConnection;
+
+    public static function setUpBeforeClass()
+    {
+        if (!extension_loaded('pdo') || !extension_loaded('pdo_sqlite')) {
+            static::markTestSkipped('PDO and SQLite extensions are required.');
+        }
+    }
+
+    public function setUp()
+    {
+        $this->mockApplication([
+            'components' => [
+                'db' => [
+                    'class' => '\yii\db\Connection',
+                    'dsn' => 'sqlite::memory:',
+                ]
+            ]
+        ]);
+
+        $columns = [
+            'id' => 'pk',
+            'name' => 'string',
+            'alias' => 'string',
+        ];
+        Yii::$app->getDb()->createCommand()->createTable('test_attribute', $columns)->execute();
+    }
+
+    public function tearDown()
+    {
+        Yii::$app->getDb()->close();
+        parent::tearDown();
+    }
+
+    // Tests :
+
+    /**
+     * @return array
+     */
+    public function preserveNonEmptyValuesDataProvider()
+    {
+        return [
+            [
+                'John Doe',
+                false,
+                'John Doe',
+                null,
+            ],
+            [
+                'John Doe',
+                false,
+                'John Doe',
+                'Johnny',
+            ],
+            [
+                'John Doe',
+                true,
+                'John Doe',
+                null,
+            ],
+            [
+                'Johnny',
+                true,
+                'John Doe',
+                'Johnny',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider preserveNonEmptyValuesDataProvider
+     */
+    public function testPreserveNonEmptyValues(
+        $aliasExpected,
+        $preserveNonEmptyValues,
+        $name,
+        $alias
+    )
+    {
+        $model = new ActiveRecordWithAttributeBehavior();
+        $model->attributeBehavior->preserveNonEmptyValues = $preserveNonEmptyValues;
+        $model->name = $name;
+        $model->alias = $alias;
+        $model->validate();
+
+        $this->assertEquals($aliasExpected, $model->alias);
+    }
+}
+
+/**
+ * Test Active Record class with [[AttributeBehavior]] behavior attached.
+ *
+ * @property integer $id
+ * @property string $name
+ * @property string $alias
+ *
+ * @property AttributeBehavior $attributeBehavior
+ */
+class ActiveRecordWithAttributeBehavior extends ActiveRecord
+{
+    public function behaviors()
+    {
+        return [
+            'attribute' => [
+                'class' => AttributeBehavior::className(),
+                'attributes' => [
+                    self::EVENT_BEFORE_VALIDATE => 'alias',
+                ],
+                'value' => function ($event) {
+                    return $event->sender->name;
+                },
+            ],
+        ];
+    }
+
+    public static function tableName()
+    {
+        return 'test_attribute';
+    }
+
+    /**
+     * @return AttributeBehavior
+     */
+    public function getAttributeBehavior()
+    {
+        return $this->getBehavior('attribute');
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Tests pass? | yes |
| Fixed issues | #11923 |

`AttributeBehavior` can preserve current attribute values now.
Basic tests coverage is included.
