### PR TITLE
Fixtures named dependencies.

### DIFF
--- a/framework/test/FixtureTrait.php
+++ b/framework/test/FixtureTrait.php
@@ -195,9 +195,10 @@ trait FixtureTrait
                 if (!isset($instances[$name])) {
                     $instances[$name] = false;
                     $stack[] = $fixture = Yii::createObject($fixture);
-                    foreach ($fixture->depends as $dep) {
+                    foreach ($fixture->depends as $alias => $dep) {
                         // need to use the configuration provided in test case
                         $stack[] = isset($config[$dep]) ? $config[$dep] : ['class' => $dep];
+                        if (is_string($alias)) $aliases[$dep] = $alias;
                     }
                 } elseif ($instances[$name] === false) {
                     throw new InvalidConfigException("A circular dependency is detected for fixture '$class'.");


### PR DESCRIPTION
**Example**
In fixture class:
```
class FirstFixture extends ActiveFixture
{
    public $depends  = [
        // the old set dependent fixtures, and it remains if you 
        SecondFixture::class,

        // new set
        'second_fixture_alias' => SecondFixture::class
    ];
}
```

In test class:

```
class SomeCest
{
    public function _before(UnitTester $I)
    {
        $I->haveFixtures([
            'first_fixture_alias' => FirstFixture::class,
        ]);
    }

    public function checkFixtures(UnitTester $I)
    {
        // the old grab dependent fixtures behavior, and it remains if you 
        $data = $I->grabFixture(SecondFixture::class);

        // new behavior
        $data = $I->grabFixture('second_fixture_alias');
    }
}
```


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | don't check
