### PR TITLE
Created unit tests for role based access filter

### DIFF
--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -136,7 +136,7 @@ class AccessRuleTest extends \yiiunit\TestCase
      *           the id of the action
      *           should the action allow (true) or disallow (false)
      *           test user id
-     *           excepted match result (true, false, null)
+     *           expected match result (true, false, null)
      */
     public function matchRoleProvider() {
         return [
@@ -156,11 +156,11 @@ class AccessRuleTest extends \yiiunit\TestCase
      *
      * @dataProvider matchRoleProvider
      * @param string the action id
-     * @param boolean wether the rule hould allow access
+     * @param boolean whether the rule should allow access
      * @param string the userid to check
-     * @param boolean the excepted result or null
+     * @param boolean the expected result or null
      */
-    public function testMatchRole($actionid, $allow, $userid, $excepted) {
+    public function testMatchRole($actionid, $allow, $userid, $expected) {
         $action = $this->mockAction();
         $auth = $this->mockAuthManager();
         $request = $this->mockRequest();
@@ -175,7 +175,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         $user = $this->mockUser($userid);
         $user->accessChecker = $auth;
-        $this->assertEquals($excepted, $rule->allows($action, $user, $request));
+        $this->assertEquals($expected, $rule->allows($action, $user, $request));
     }
 
 

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -129,53 +129,53 @@ class AccessRuleTest extends \yiiunit\TestCase
 
     // TODO test match controller
 
-    public function testMatchRole()
-    {
+    /**
+     * Data provider for testMatchRole
+     *
+     * @return array or arrays
+     *           the id of the action
+     *           should the action allow (true) or disallow (false)
+     *           test user id
+     *           excepted match result (true, false, null)
+     */
+    public function matchRoleProvider() {
+        return [
+            ['create', true, 'user1', true],
+            ['create', true, 'user2', true],
+            ['create', true, 'user3', null],
+            ['create', true, 'unknown', null],
+            ['create', false, 'user1', false],
+            ['create', false, 'user2', false],
+            ['create', false, 'user3', null],
+            ['create', false, 'unknown', null],
+        ];
+    }
+
+    /**
+     * Test that a user matches certain roles
+     *
+     * @dataProvider matchRoleProvider
+     * @param string the action id
+     * @param boolean wether the rule hould allow access
+     * @param string the userid to check
+     * @param boolean the excepted result or null
+     */
+    public function testMatchRole($actionid, $allow, $userid, $excepted) {
         $action = $this->mockAction();
         $auth = $this->mockAuthManager();
         $request = $this->mockRequest();
 
         $rule = new AccessRule([
-            'allow' => true,
+            'allow' => $allow,
             'roles' => ['createPost'],
             'actions' => ['create'],
         ]);
 
-        $action->id = 'create';
+        $action->id = $actionid;
 
-        $user = $this->mockUser('user1');
+        $user = $this->mockUser($userid);
         $user->accessChecker = $auth;
-        $this->assertTrue($rule->allows($action, $user, $request));
-
-        $user = $this->mockUser('user2');
-        $user->accessChecker = $auth;
-        $this->assertTrue($rule->allows($action, $user, $request));
-
-        $user = $this->mockUser('user3');
-        $user->accessChecker = $auth;
-        $this->assertNull($rule->allows($action, $user, $request));
-
-        $user = $this->mockUser('unknown');
-        $user->accessChecker = $auth;
-        $this->assertNull($rule->allows($action, $user, $request));
-
-        $rule->allow = false;
-
-        $user = $this->mockUser('user1');
-        $user->accessChecker = $auth;
-        $this->assertFalse($rule->allows($action, $user, $request));
-
-        $user = $this->mockUser('user2');
-        $user->accessChecker = $auth;
-        $this->assertFalse($rule->allows($action, $user, $request));
-
-        $user = $this->mockUser('user3');
-        $user->accessChecker = $auth;
-        $this->assertNull($rule->allows($action, $user, $request));
-
-        $user = $this->mockUser('unknown');
-        $user->accessChecker = $auth;
-        $this->assertNull($rule->allows($action, $user, $request));
+        $this->assertEquals($excepted, $rule->allows($action, $user, $request));
     }
 
 

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -9,6 +9,7 @@ use yii\filters\HttpCache;
 use yii\web\Controller;
 use yii\web\Request;
 use yii\web\User;
+use yiiunit\framework\filters\stubs\MockAuthManager;
 use yiiunit\framework\filters\stubs\UserIdentity;
 
 /**
@@ -39,14 +40,19 @@ class AccessRuleTest extends \yiiunit\TestCase
     }
 
     /**
+     * @param string optional user id
      * @return User
      */
-    protected function mockUser()
+    protected function mockUser($userid = null)
     {
-        return new User([
+        $user = new User([
             'identityClass' => UserIdentity::className(),
             'enableAutoLogin' => false,
         ]);
+        if ($userid !== null) {
+            $user->setIdentity(UserIdentity::findIdentity($userid));
+        }
+        return $user;
     }
 
     /**
@@ -56,6 +62,41 @@ class AccessRuleTest extends \yiiunit\TestCase
     {
         $controller = new Controller('site', Yii::$app);
         return new Action('test', $controller);
+    }
+
+    /**
+     * @return BaseManager
+     */
+    protected function mockAuthManager() {
+        $auth = new MockAuthManager();
+        // add "createPost" permission
+        $createPost = $auth->createPermission('createPost');
+        $createPost->description = 'Create a post';
+        $auth->add($createPost);
+
+        // add "updatePost" permission
+        $updatePost = $auth->createPermission('updatePost');
+        $updatePost->description = 'Update post';
+        $auth->add($updatePost);
+
+        // add "author" role and give this role the "createPost" permission
+        $author = $auth->createRole('author');
+        $auth->add($author);
+        $auth->addChild($author, $createPost);
+
+        // add "admin" role and give this role the "updatePost" permission
+        // as well as the permissions of the "author" role
+        $admin = $auth->createRole('admin');
+        $auth->add($admin);
+        $auth->addChild($admin, $updatePost);
+        $auth->addChild($admin, $author);
+
+        // Assign roles to users. 1 and 2 are IDs returned by IdentityInterface::getId()
+        // usually implemented in your User model.
+        $auth->assign($author, 'user2');
+        $auth->assign($admin, 'user1');
+
+        return $auth;
     }
 
     public function testMatchAction()
@@ -88,7 +129,55 @@ class AccessRuleTest extends \yiiunit\TestCase
 
     // TODO test match controller
 
-    // TODO test match roles
+    public function testMatchRole()
+    {
+        $action = $this->mockAction();
+        $auth = $this->mockAuthManager();
+        $request = $this->mockRequest();
+
+        $rule = new AccessRule([
+            'allow' => true,
+            'roles' => ['createPost'],
+            'actions' => ['create'],
+        ]);
+
+        $action->id = 'create';
+
+        $user = $this->mockUser('user1');
+        $user->accessChecker = $auth;
+        $this->assertTrue($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('user2');
+        $user->accessChecker = $auth;
+        $this->assertTrue($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('user3');
+        $user->accessChecker = $auth;
+        $this->assertNull($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('unknown');
+        $user->accessChecker = $auth;
+        $this->assertNull($rule->allows($action, $user, $request));
+
+        $rule->allow = false;
+
+        $user = $this->mockUser('user1');
+        $user->accessChecker = $auth;
+        $this->assertFalse($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('user2');
+        $user->accessChecker = $auth;
+        $this->assertFalse($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('user3');
+        $user->accessChecker = $auth;
+        $this->assertNull($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('unknown');
+        $user->accessChecker = $auth;
+        $this->assertNull($rule->allows($action, $user, $request));
+    }
+
 
     public function testMatchVerb()
     {

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -155,10 +155,10 @@ class AccessRuleTest extends \yiiunit\TestCase
      * Test that a user matches certain roles
      *
      * @dataProvider matchRoleProvider
-     * @param string the action id
-     * @param boolean whether the rule should allow access
-     * @param string the userid to check
-     * @param boolean the expected result or null
+     * @param string $actionid the action id
+     * @param boolean $allow whether the rule should allow access
+     * @param string $userid the userid to check
+     * @param boolean $expected the expected result or null
      */
     public function testMatchRole($actionid, $allow, $userid, $expected) {
         $action = $this->mockAction();

--- a/tests/framework/filters/stubs/MockAuthManager.php
+++ b/tests/framework/filters/stubs/MockAuthManager.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace yiiunit\framework\filters\stubs;
+
+use yii\rbac\PhpManager;
+
+class MockAuthManager extends PhpManager {
+
+    /**
+     * This mock does not persist
+     * @inheritdoc
+     */
+    protected function saveToFile($data, $file) {
+    }
+
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no - extra unit test coverage
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | none

I've noticed that there are no unit test for AccessControl filter that checks RBAC roles. I'm working on an access control enhancement, so to check the current behavior was a must.

This patch introduces a mock auth manager for the AccessRuleTest, than mimicks the auth schema from the [definitive guide](http://www.yiiframework.com/doc-2.0/guide-security-authorization.html), and also a test for role based authorization.
