### PR TITLE
13598 access filter rule support

### DIFF
--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -9,6 +9,7 @@ use yii\filters\HttpCache;
 use yii\web\Controller;
 use yii\web\Request;
 use yii\web\User;
+use yiiunit\framework\filters\stubs\MockAuthManager;
 use yiiunit\framework\filters\stubs\UserIdentity;
 
 /**
@@ -39,14 +40,19 @@ class AccessRuleTest extends \yiiunit\TestCase
     }
 
     /**
+     * @param string optional user id
      * @return User
      */
-    protected function mockUser()
+    protected function mockUser($userid = null)
     {
-        return new User([
+        $user = new User([
             'identityClass' => UserIdentity::className(),
             'enableAutoLogin' => false,
         ]);
+        if ($userid !== null) {
+            $user->setIdentity(UserIdentity::findIdentity($userid));
+        }
+        return $user;
     }
 
     /**
@@ -56,6 +62,41 @@ class AccessRuleTest extends \yiiunit\TestCase
     {
         $controller = new Controller('site', Yii::$app);
         return new Action('test', $controller);
+    }
+
+    /**
+     * @return BaseManager
+     */
+    protected function mockAuthManager() {
+        $auth = new MockAuthManager();
+        // add "createPost" permission
+        $createPost = $auth->createPermission('createPost');
+        $createPost->description = 'Create a post';
+        $auth->add($createPost);
+
+        // add "updatePost" permission
+        $updatePost = $auth->createPermission('updatePost');
+        $updatePost->description = 'Update post';
+        $auth->add($updatePost);
+
+        // add "author" role and give this role the "createPost" permission
+        $author = $auth->createRole('author');
+        $auth->add($author);
+        $auth->addChild($author, $createPost);
+
+        // add "admin" role and give this role the "updatePost" permission
+        // as well as the permissions of the "author" role
+        $admin = $auth->createRole('admin');
+        $auth->add($admin);
+        $auth->addChild($admin, $updatePost);
+        $auth->addChild($admin, $author);
+
+        // Assign roles to users. 1 and 2 are IDs returned by IdentityInterface::getId()
+        // usually implemented in your User model.
+        $auth->assign($author, 'user2');
+        $auth->assign($admin, 'user1');
+
+        return $auth;
     }
 
     public function testMatchAction()
@@ -88,7 +129,55 @@ class AccessRuleTest extends \yiiunit\TestCase
 
     // TODO test match controller
 
-    // TODO test match roles
+    public function testMatchRole()
+    {
+        $action = $this->mockAction();
+        $auth = $this->mockAuthManager();
+        $request = $this->mockRequest();
+
+        $rule = new AccessRule([
+            'allow' => true,
+            'roles' => ['createPost'],
+            'actions' => ['create'],
+        ]);
+
+        $action->id = 'create';
+
+        $user = $this->mockUser('user1');
+        $user->accessChecker = $auth;
+        $this->assertTrue($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('user2');
+        $user->accessChecker = $auth;
+        $this->assertTrue($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('user3');
+        $user->accessChecker = $auth;
+        $this->assertNull($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('unknown');
+        $user->accessChecker = $auth;
+        $this->assertNull($rule->allows($action, $user, $request));
+
+        $rule->allow = false;
+
+        $user = $this->mockUser('user1');
+        $user->accessChecker = $auth;
+        $this->assertFalse($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('user2');
+        $user->accessChecker = $auth;
+        $this->assertFalse($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('user3');
+        $user->accessChecker = $auth;
+        $this->assertNull($rule->allows($action, $user, $request));
+
+        $user = $this->mockUser('unknown');
+        $user->accessChecker = $auth;
+        $this->assertNull($rule->allows($action, $user, $request));
+    }
+
 
     public function testMatchVerb()
     {

--- a/tests/framework/filters/stubs/AuthorRule.php
+++ b/tests/framework/filters/stubs/AuthorRule.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace yiiunit\framework\filters\stubs;
+
+use yii\rbac\Rule;
+
+/**
+ * Checks if authorId matcher user passwd via params
+ */
+class AuthorRule extends Rule
+{
+    public $name = 'isAuthor';
+
+    /**
+     * @param string|int $user the user ID.
+     * @param Item $item the role or permission that this rule is associated with
+     * @param array $params parameters passed to ManagerInterface::checkAccess().
+     * @return bool a value indicating whether the rule permits the role or permission it is associated with.
+     */
+    public function execute($user, $item, $params)
+    {
+        return isset($params['authorId']) ? $params['authorId'] == $user : false;
+    }
+}

--- a/tests/framework/filters/stubs/MockAuthManager.php
+++ b/tests/framework/filters/stubs/MockAuthManager.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace yiiunit\framework\filters\stubs;
+
+use yii\rbac\PhpManager;
+
+class MockAuthManager extends PhpManager {
+
+    /**
+     * This mock does not persist
+     * @inheritdoc
+     */
+    protected function saveToFile($data, $file) {
+    }
+
+}


### PR DESCRIPTION

Proposed solution to Issue #13598 

I've added the rulesParamCallabck, wich is checked and called before the $user->can is called. Any parameters returned are passed the the $user->can() call.

I think it would be very useful to know about the current action in the callback, because mostly you would look from incoming parameters that are dependent on the action. But because of this I had to change the signature of the 'matchRole' method. I admit this is not 100% safe when there are dependent implementations, so I can accept if you rather ignore the 'action' parameter to ensure backward compatibility.

Unit tests were added to demonstrate the usage of the new feature. The tests mimic the example from the [definitive guide](http://www.yiiframework.com/doc-2.0/guide-security-authorization.html#using-rules)

Please let me know your toughts on this change.


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | somewhat on a protected call
| Tests pass?   | yes
| Fixed issues  | 13598
