### PR TITLE
Added support for hint index for mysql DB driver

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.12 under development
 --------------------------
 
+- Enh #10869: Hint index support for mysql DB (fdezmc)
 - Enh #13523: Plural rule for pasta (developeruz)
 - Bug #13538: Fixed `yii\db\BaseActiveRecord::deleteAll()` changes method signature declared by `yii\db\ActiveRecordInterface::deleteAll()` (klimov-paul)
 - Enh #13278: `yii\caching\DbQueryDependency` created allowing specification of the cache dependency via `yii\db\QueryInterface` (klimov-paul)

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -70,6 +70,24 @@ class Query extends Component implements QueryInterface
      */
     public $from;
     /**
+     * @var array which hint index to use for the query, if supported. Each array element represents the specification
+     * of one hint index which has the following structure:
+     *
+     * ```php
+     * [$tableName, $hintType, $indexList, $for]
+     * ```
+     *
+     * For example,
+     *
+     * ```php
+     * [
+     *     ['user', 'useIndex', ['primary', 'user.name'], 'groupBy'],
+     *     ['user', 'ignoreIndex', 'profile_id'],
+     * ]
+     * ```
+     */
+    public $hintIndex = [];
+    /**
      * @var array how to group the query results. For example, `['company', 'department']`.
      * This is used to construct the GROUP BY clause in a SQL statement.
      */
@@ -991,6 +1009,28 @@ class Query extends Component implements QueryInterface
     }
 
     /**
+     * Sets the $hintIndex property in order to hint indexes if available.
+     * @param array $hints the hint(s) to be applied. See [[hintIndex]] for more
+     * details about the format of this parameter.
+     * The method will automatically quote the table and column names unless it contains some parenthesis
+     * (which means the table is given as a sub-query or DB expression).
+     *
+     * @return $this the query object itself
+     */
+    public function hintIndex($hints)
+    {
+        if (!is_array($hints[0])) {
+            $hints = [$hints];
+        }
+
+        foreach($hints as $hint) {
+            $this->hintIndex[] = $hint;
+        }
+
+        return $this;
+    }
+
+    /**
      * Adds additional parameters to be bound to the query.
      * @param array $params list of query parameter values indexed by parameter placeholders.
      * For example, `[':name' => 'Dan', ':age' => 31]`.
@@ -1038,6 +1078,7 @@ class Query extends Component implements QueryInterface
             'having' => $from->having,
             'union' => $from->union,
             'params' => $from->params,
+            'hintIndex' => $from->hintIndex,
         ]);
     }
 }

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -95,8 +95,8 @@ class QueryBuilder extends \yii\base\Object
 
         $clauses = [
             $this->buildSelect($query->select, $params, $query->distinct, $query->selectOption),
-            $this->buildFrom($query->from, $params),
-            $this->buildJoin($query->join, $params),
+            $this->buildFrom($query, $params),
+            $this->buildJoin($query, $params),
             $this->buildWhere($query->where, $params),
             $this->buildGroupBy($query->groupBy),
             $this->buildHaving($query->having, $params),
@@ -775,12 +775,14 @@ class QueryBuilder extends \yii\base\Object
     }
 
     /**
-     * @param array $tables
+     * @param Query $query the [[Query]] object from which the SQL statement will be generated.
      * @param array $params the binding parameters to be populated
      * @return string the FROM clause built from [[Query::$from]].
      */
-    public function buildFrom($tables, &$params)
+    public function buildFrom($query, &$params)
     {
+        $tables = $query->from;
+
         if (empty($tables)) {
             return '';
         }
@@ -791,13 +793,15 @@ class QueryBuilder extends \yii\base\Object
     }
 
     /**
-     * @param array $joins
+     * @param Query $query the [[Query]] object from which the SQL statement will be generated.
      * @param array $params the binding parameters to be populated
      * @return string the JOIN clause built from [[Query::$join]].
      * @throws Exception if the $joins parameter is not in proper format
      */
-    public function buildJoin($joins, &$params)
+    public function buildJoin($query, &$params)
     {
+        $joins = $query->join;
+
         if (empty($joins)) {
             return '';
         }
@@ -829,7 +833,7 @@ class QueryBuilder extends \yii\base\Object
      * @param array $params
      * @return array
      */
-    private function quoteTableNames($tables, &$params)
+    protected function quoteTableNames($tables, &$params)
     {
         foreach ($tables as $i => $table) {
             if ($table instanceof Query) {

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -775,13 +775,16 @@ class QueryBuilder extends \yii\base\Object
     }
 
     /**
-     * @param Query $query the [[Query]] object from which the SQL statement will be generated.
+     * @param array|Query $tables the [[Query]] object from which the SQL statement will be generated or tables array
      * @param array $params the binding parameters to be populated
      * @return string the FROM clause built from [[Query::$from]].
      */
-    public function buildFrom($query, &$params)
+    public function buildFrom($tables, &$params)
     {
-        $tables = $query->from;
+        $query = $tables;
+        if ($query instanceof Query) {
+            $tables = $query->from;
+        }
 
         if (empty($tables)) {
             return '';
@@ -793,14 +796,17 @@ class QueryBuilder extends \yii\base\Object
     }
 
     /**
-     * @param Query $query the [[Query]] object from which the SQL statement will be generated.
+     * @param array|Query $joins the [[Query]] object from which the SQL statement will be generated or joins array
      * @param array $params the binding parameters to be populated
      * @return string the JOIN clause built from [[Query::$join]].
      * @throws Exception if the $joins parameter is not in proper format
      */
-    public function buildJoin($query, &$params)
+    public function buildJoin($joins, &$params)
     {
-        $joins = $query->join;
+        $query = $joins;
+        if ($query instanceof Query) {
+            $joins = $query->join;
+        }
 
         if (empty($joins)) {
             return '';

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -319,26 +319,30 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
-     * @param Query $query the [[Query]] object from which the SQL statement will be generated.
+     * @param array|Query $tables the [[Query]] object from which the SQL statement will be generated or tables array
      * @param array $params the binding parameters to be populated
      * @return string the FROM clause built from [[Query::$from]].
      */
-    public function buildFrom($query, &$params)
+    public function buildFrom($tables, &$params)
     {
-        $from = parent::buildFrom($query, $params);
+        $query = $tables;
+        $from = parent::buildFrom($tables, $params);
 
         return $this->buildHintIndex($from, $query->hintIndex);
     }
 
     /**
-     * @param Query $query the [[Query]] object from which the SQL statement will be generated.
+     * @param array|Query $joins the [[Query]] object from which the SQL statement will be generated or joins array
      * @param array $params the binding parameters to be populated
      * @return string the JOIN clause built from [[Query::$join]].
      * @throws Exception if the $joins parameter is not in proper format
      */
-    public function buildJoin($query, &$params)
+    public function buildJoin($joins, &$params)
     {
-        $joins = $query->join;
+        $query = $joins;
+        if ($query instanceof Query) {
+            $joins = $query->join;
+        }
 
         if (empty($joins)) {
             return '';

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -411,8 +411,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
         $clauses = [
             $this->buildSelect($query->select, $params, $query->distinct, $query->selectOption),
-            $this->buildFrom($query, $params),
-            $this->buildJoin($query, $params),
+            $this->buildFrom($query->from, $params),
+            $this->buildJoin($query->join, $params),
             $this->buildWhere($query->where, $params),
             $this->buildGroupBy($query->groupBy),
             $this->buildHaving($query->having, $params),

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -411,8 +411,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
         $clauses = [
             $this->buildSelect($query->select, $params, $query->distinct, $query->selectOption),
-            $this->buildFrom($query->from, $params),
-            $this->buildJoin($query->join, $params),
+            $this->buildFrom($query, $params),
+            $this->buildJoin($query, $params),
             $this->buildWhere($query->where, $params),
             $this->buildGroupBy($query->groupBy),
             $this->buildHaving($query->having, $params),

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1471,6 +1471,19 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         }
         $this->assertEquals($expected, $sql);
 
+        // join
+        $hintIndex = ['order', 'forceIndex', 'primary'];
+        $query = Order::find()->hintIndex($hintIndex)
+            ->leftJoin('customer', 'order.customer_id = customer.id')->hintIndex(['customer', 'forceIndex', 'primary']);
+        $sql = $query->createCommand()->getRawSql();
+        // Mysql support hintIndex
+        if ($this->driverName === 'mysql') {
+            $expected = $this->replaceQuotes('SELECT [[order]].* FROM [[order]] FORCE INDEX ([[primary]]) LEFT JOIN [[customer]] FORCE INDEX ([[primary]]) ON order.customer_id = customer.id');
+        } else {
+            $expected = $this->replaceQuotes('SELECT [[order]].* FROM [[order]] LEFT JOIN [[customer]] ON order.customer_id = customer.id');
+        }
+        $this->assertEquals($expected, $sql);
+
         // joinWith, primary and alias
         $hintIndex = ['order', 'forceIndex', 'primary'];
         $query = Order::find()->hintIndex($hintIndex)->joinWith('items');

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -1521,7 +1521,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
         if ($this->driverName === 'mysql') {
             $expected = $this->replaceQuotes('SELECT * FROM (SELECT * FROM [[customer]] FORCE INDEX ([[primary]]) WHERE status = 1) [[activecustomers]]');
         } else {
-            $expected = $this->replaceQuotes('SELECT * FROM (SELECT * FROM [[customer]]) WHERE status = 1) [[activecustomers]]');
+            $expected = $this->replaceQuotes('SELECT * FROM (SELECT * FROM [[customer]] WHERE status = 1) [[activecustomers]]');
         }
         $this->assertEquals($expected, $sql);
         $this->assertEmpty($params);


### PR DESCRIPTION
Allowing support for hint index in MySQL with ActiveQuery and ActiveRecord (#10869).

Currently hint index with Expression for ActiveQuery with joins fails: 
(_yiiunit\framework\db\mysql\ActiveQueryTest::testFromIndexHint is incorrect_)
```
$query = (new Query)
    ->from([new Expression('{{user}} {{t}} FORCE INDEX (primary) IGNORE INDEX FOR ORDER BY (i1)')])
    ->leftJoin(['p' => 'profile'], 'user.id = profile.user_id USE INDEX (i2)');

--- Expected
+++ Actual
@@ @@
-'SELECT * FROM {{user}} {{t}} FORCE INDEX (primary) IGNORE INDEX FOR ORDER BY (i1) LEFT JOIN `profile` `p` USE INDEX (i2) ON user.id = profile.user_id'
+'SELECT * FROM {{user}} {{t}} FORCE INDEX (primary) IGNORE INDEX FOR ORDER BY (i1) LEFT JOIN `profile` `p` ON user.id = profile.user_id USE INDEX (i2)'
```

and hint index with ActiveRecord is not currently supported.


***This pull request allow all functionality for hint index on mysql DB driver***

ActiveQuery with no joins:
```
$query = (new Query)
	->from(['o' => order])->hintIndex(['order', 'forceIndex', 'primary']);

+++ Actual
@@ @@
'SELECT `order`.* FROM `order` FORCE INDEX (primary)'
```

ActiveQuery with joins:
```
$query = (new Query)
    ->from('order')->hintIndex([['order', 'forceIndex', 'primary'], ['order', 'ignoreIndex', 'FK_order_customer_id', 'orderBy']])
    ->leftJoin('customer', 'order.customer_id = customer.id')->hintIndex(['customer', 'useIndex', 'primary']);

+++ Actual
@@ @@
'SELECT * FROM `order` FORCE INDEX (`primary`) IGNORE INDEX FOR ORDER BY (`FK_order_customer_id`) LEFT JOIN `customer` USE INDEX (`primary`) ON order.customer_id = customer.id
```

ActiveRecord with no joins:
```
$hintIndex = ['order', 'useIndex', ['primary', 'FK_order_customer_id']];
$query = Order::find()->hintIndex($hintIndex)->where(['id' => 1, 'customer_id' => 1]);
+++ Actual
@@ @@
'SELECT * FROM `order` USE INDEX (`primary`, `FK_order_customer_id`) WHERE (`id`=1) AND (`customer_id`=1)'
```

ActiveRecord with joins:
```
$hintIndex = ['order', 'forceIndex', 'primary'];
$query = Order::find()->hintIndex($hintIndex)
	->leftJoin('customer', 'order.customer_id = customer.id')->hintIndex(['customer', 'forceIndex', 'primary']);
+++ Actual
@@ @@
'SELECT `order`.* FROM `order` FORCE INDEX (`primary`) LEFT JOIN `customer` FORCE INDEX (`primary`) ON order.customer_id = customer.id'
```

Hinted columns as string:
```
$hintIndex = ['order', 'ignoreIndex', 'FK_order_customer_id'];
$query = Order::find()->hintIndex($hintIndex)->where(['id' => 1, 'customer_id' => 1]);
```

Multiple hints at once
```
$hintIndex = [['order', 'forceIndex', ['primary']], ['order', 'ignoreIndex', 'FK_order_customer_id', 'orderBy']];
$query = Order::find()->hintIndex($hintIndex)->orderBy('customer_id');
```

With alias
```
$hintIndex = ['order', 'ignoreIndex', 'customer_id'];
$query = Order::find()->from(['o' => 'order'])->hintIndex($hintIndex)->where(['id' => 1, 'customer_id' => 1]);
```

With joinWith, primary and alias
```
$hintIndex = ['order', 'forceIndex', 'primary'];
$query = Order::find()->hintIndex($hintIndex)->joinWith('items');
```

With relation by puntuation and hint on join table
```
$hintIndex = ['item', 'forceIndex', 'primary', 'orderBy'];
$query = Order::find()->joinWith('orderItems.item')->hintIndex($hintIndex)->orderBy('item.id');
```

All logic is in the specific DB driver class:
- _/yii2/framework/db/mysql/QueryBuilder.php_
- _/yii2/framework/db/sqlite/QueryBuilder.php_ (*)
- _/yii2/framework/db/cubrid/QueryBuilder.php_ (*)
- _/yii2/framework/db/mssql/QueryBuilder.php_ (*)
- _/yii2/framework/db/oci/QueryBuilder.php_ (*)
- _/yii2/framework/db/pgsql/QueryBuilder.php_ (*)

_(*) This DB drivers support for hint index is not implemente in this pull-request yet. Query::hintIndex property will be ignore_

I have no experience enought with other DB drivers than mysql, so just write functionality for mysql.
Support for the left DB drivers can be done following this approach.


