### PR TITLE
Fixes #13306: Wildcard in `reloadableScripts` in `yii.js` allows 0 characters

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.12 under development
 --------------------------
 
+- Bug #13306: Wildcard in `reloadableScripts` in `yii.js` allows 0 characters
 - Enh #13523: Plural rule for pasta (developeruz)
 - Bug #13538: Fixed `yii\db\BaseActiveRecord::deleteAll()` changes method signature declared by `yii\db\ActiveRecordInterface::deleteAll()` (klimov-paul)
 - Bug: Fixed `yii\db\Connection::useMaster()` - Exception within callback completely disables slaves (Vovan-VE)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.12 under development
 --------------------------
 
-- Bug #13306: Wildcard in `reloadableScripts` in `yii.js` allows 0 characters
+- Bug #13306: Wildcard in `reloadableScripts` in `yii.js` allows 0 characters (arogachev)
 - Enh #13523: Plural rule for pasta (developeruz)
 - Bug #13538: Fixed `yii\db\BaseActiveRecord::deleteAll()` changes method signature declared by `yii\db\ActiveRecordInterface::deleteAll()` (klimov-paul)
 - Bug: Fixed `yii\db\Connection::useMaster()` - Exception within callback completely disables slaves (Vovan-VE)

--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -483,7 +483,7 @@ window.yii = (function ($) {
     function isReloadableAsset(url) {
         for (var i = 0; i < pub.reloadableScripts.length; i++) {
             var rule = getAbsoluteUrl(pub.reloadableScripts[i]);
-            var match = new RegExp("^" + escapeRegExp(rule).split('\\*').join('.*') + "$").test(url);
+            var match = new RegExp("^" + escapeRegExp(rule).split('\\*').join('.+') + "$").test(url);
             if (match === true) {
                 return true;
             }

--- a/tests/js/tests/yii.test.js
+++ b/tests/js/tests/yii.test.js
@@ -1095,7 +1095,7 @@ describe('yii', function () {
                     yii.reloadableScripts = [
                         '/js/reloadable.js',
                         // https://github.com/yiisoft/yii2/issues/11494
-                        '/js/reloadable/script*.js'
+                        '/js/reloadable/script*.js?v=*'
                     ];
                 });
 
@@ -1106,9 +1106,9 @@ describe('yii', function () {
                 describe('with match', function () {
                     withData({
                         'relative url, exact': ['/js/reloadable.js'],
-                        'relative url, wildcard': ['http://foo.bar/js/reloadable/script1.js'],
+                        'relative url, wildcard': ['/js/reloadable/script1.js?v=1'],
                         'absolute url, exact': ['http://foo.bar/js/reloadable.js'],
-                        'absolute url, wildcard': ['http://foo.bar/js/reloadable/script2.js']
+                        'absolute url, wildcard': ['http://foo.bar/js/reloadable/script2.js?v=2']
                     }, function (url) {
                         it('should load it as many times as it was requested', function () {
                             $.getScript(url);
@@ -1127,7 +1127,9 @@ describe('yii', function () {
                 describe('with no match', function () {
                     withData({
                         'relative url': ['/js/not_reloadable.js'],
-                        'absolute url': ['http://foo.bar/js/reloadable/not_reloadable_script.js']
+                        'relative url, all wildcards are empty': ['/js/reloadable/script.js?v='],
+                        'absolute url': ['http://foo.bar/js/reloadable/not_reloadable_script.js'],
+                        'absolute url, 1 empty wildcard': ['http://foo.bar/js/reloadable/script1.js?v=']
                     }, function (url) {
                         it('should load it only once for both relative and absolute urls', function () {
                             $.getScript(url);
@@ -1144,14 +1146,14 @@ describe('yii', function () {
 
                 describe('with failed load after successful load and making it not reloadable', function () {
                     it('should allow to load it again', function () {
-                        $.getScript('/js/reloadable/script_fail.js');
+                        $.getScript('/js/reloadable/script_fail.js?v=1');
                         respondToRequestWithSuccess(0);
 
-                        $.getScript('/js/reloadable/script_fail.js');
+                        $.getScript('/js/reloadable/script_fail.js?v=1');
                         respondToRequestWithError(1);
                         yii.reloadableScripts = [];
 
-                        $.getScript('/js/reloadable/script_fail.js');
+                        $.getScript('/js/reloadable/script_fail.js?v=1');
                         respondToRequestWithError(2);
 
                         assert.lengthOf(server.requests, 3);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13306 

Fixes #13306 🐛 🔨 
