### PR TITLE
Add a failing test to the `yii\web\UrlRule`

### DIFF
--- a/tests/framework/web/UrlRuleTest.php
+++ b/tests/framework/web/UrlRuleTest.php
@@ -884,6 +884,18 @@ class UrlRuleTest extends TestCase
                 ],
             ],
             [
+                'optional param at the begining',
+                [
+                    'pattern' => '<language>/<category>',
+                    'route' => 'site/category',
+                    'defaults' => ['language' => 'en'],
+                ],
+                [
+                    ['books', ['site/category', ['language' => 'en', 'category' => 'books']]],
+                    ['en/books', ['site/category', ['language' => 'en', 'category' => 'books']]],
+                ],
+            ],
+            [
                 'optional param at the end',
                 [
                     'pattern' => 'post/<tag>/<page:\d+>',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | none

Added a failing test to reproduce and verify the #13086.
Not sure if the test should pass or not by design. Two options are possible:
* If it should not pass we will change the first test to return `false` and it would serve as a documentation.
* If it indeed should we will need to fix the `UrlRule`.