### PR TITLE
Add `mergeType`, `beforeKeys` and `afterKeys` to `registerJs()` method to solve issues dealing with order of inline JS includes.

### DIFF
--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -659,7 +659,7 @@ class View extends \yii\base\View
         if (empty($this->_jsAfter[$scriptKey])) {
             return false;
         }
-        foreach ($this->_jsAfter[$scriptKey] as $beforeKey => $null) {
+        foreach ($this->_jsAfter[$scriptKey] as $beforeKey => $isAfter) {
             if (array_key_exists($beforeKey, $this->_jsAfter) && array_key_exists($scriptKey, $this->_jsAfter[$beforeKey])) {
                 throw new \Exception("Circular dependency detected with keys: $beforeKey <-> $scriptKey");
             } else if (array_key_exists($beforeKey, $array) && !array_key_exists($beforeKey, $this->_jsHandled)) {

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -669,12 +669,11 @@ class View extends \yii\base\View
         return $this->add($this->_jsAfter, $afterKeys, $scriptKey, $pos);
     }
     
-    
-    public function jsLines($pos)
+    private function mergeAfter($pos, &$array)
     {
-        $array = $this->js[$pos];
-        $lines = '';
-        $this->_jsHandled[$pos] = [];
+        if (!isset($this->_jsBefore[$pos])) {
+            return;
+        }
         foreach ($this->_jsBefore[$pos] as $beforeKey => $afterKeys) {
             foreach ($afterKeys as $afterKey) {
                 if (isset($array[$afterKey])) {
@@ -682,6 +681,15 @@ class View extends \yii\base\View
                 }
             }
         }
+        unset($this->_jsBefore);
+    }
+    
+    public function jsLines($pos)
+    {
+        $array = $this->js[$pos];
+        $lines = '';
+        $this->_jsHandled[$pos] = [];
+        $this->mergeAfter($pos, $array);
         while (count($this->_jsHandled[$pos]) < count($array)) {
             foreach ($array as $scriptKey => $script) {
                 if (array_key_exists($scriptKey, $this->_jsHandled[$pos]) || $this->isLineDeferred($scriptKey, $array, $pos)) {

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -494,6 +494,7 @@ class View extends \yii\base\View
         } else {
             $this->js[$position][$key] = $js;
         }
+        return $this;
     }
 
     /**
@@ -645,6 +646,7 @@ class View extends \yii\base\View
         } else {
             $this->_jsBefore[$pos][$scriptKey][$beforeKeys] = true;
         }
+        return $this;
     }
     
     public function addAfter($afterKeys, $scriptKey = null, $pos = null)
@@ -659,6 +661,7 @@ class View extends \yii\base\View
         } else {
             $this->_jsAfter[$pos][$scriptKey][$afterKeys] = true;
         }
+        return $this;
     }
     
     

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -152,6 +152,7 @@ class View extends \yii\base\View
 
     private $_assetManager;
     private $_jsHandled;
+    private $_jsBefore;
     private $_jsAfter;
     private $_currentKey;
     private $_currentPos;
@@ -476,11 +477,11 @@ class View extends \yii\base\View
         }
         $this->_currentKey = $key;
         $this->_currentPos = $position;
-        if ($afterKeys) {
-            $this->addAfter($afterKeys, $key, $position);
-        }
         if ($beforeKeys) {
             $this->addBefore($beforeKeys, $key, $position);
+        }
+        if ($afterKeys) {
+            $this->addAfter($afterKeys, $key, $position);
         }
         if (isset($this->js[$position][$key]) && $mergeType !== self::MERGE_REPLACE) {
             if ($mergeType === self::MERGE_SKIP) {
@@ -634,34 +635,29 @@ class View extends \yii\base\View
         return empty($lines) ? '' : implode("\n", $lines);
     }
     
-    public function addBefore($beforeKeys, $scriptKey = null, $pos = null)
+    private function add(&$where, $beforeKeys, $scriptKey = null, $pos = null)
     {
         if (!isset($scriptKey)) {
             $scriptKey = $this->_currentKey;
         }
         if (is_array($beforeKeys)) {
             foreach($beforeKeys as $key) {
-                $this->_jsBefore[$pos][$scriptKey][$key] = true;
+                $where[$pos][$scriptKey][$key] = true;
             }
         } else {
-            $this->_jsBefore[$pos][$scriptKey][$beforeKeys] = true;
+            $where[$pos][$scriptKey][$beforeKeys] = true;
         }
         return $this;
     }
     
+    public function addBefore($beforeKeys, $scriptKey = null, $pos = null)
+    {
+       return $this->add($this->_jsBefore, $beforeKeys, $scriptKey, $pos);
+    }
+    
     public function addAfter($afterKeys, $scriptKey = null, $pos = null)
     {
-        if (!isset($scriptKey)) {
-            $scriptKey = $this->_currentKey;
-        }
-        if (is_array($afterKeys)) {
-            foreach($afterKeys as $afterKey) {
-                $this->_jsAfter[$pos][$scriptKey][$afterKey] = true;
-            }
-        } else {
-            $this->_jsAfter[$pos][$scriptKey][$afterKeys] = true;
-        }
-        return $this;
+       return $this->add($this->_jsAfter, $afterKeys, $scriptKey, $pos);
     }
     
     

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -475,27 +475,33 @@ class View extends \yii\base\View
         if ($position === self::POS_READY || $position === self::POS_LOAD) {
             JqueryAsset::register($this);
         }
-        $this->_currentKey = $key;
-        $this->_currentPos = $position;
-        if ($beforeKeys) {
-            $this->addBefore($beforeKeys, $key, $position);
-        }
-        if ($afterKeys) {
-            $this->addAfter($afterKeys, $key, $position);
-        }
-        if (isset($this->js[$position][$key]) && $mergeType !== self::MERGE_REPLACE) {
-            if ($mergeType === self::MERGE_SKIP) {
-                return;
-            }
-            if ($mergeType === self::MERGE_PREPEND) {
-                $this->js[$position][$key] = $js ."\n". $this->js[$position][$key];
-            } else if ($mergeType === self::MERGE_APPEND) {
-                $this->js[$position][$key] .= $js;
-            }
-        } else {
+        $this->setCurrent($key, $position);
+        $this->addBefore($beforeKeys, $key, $position);
+        $this->addAfter($afterKeys, $key, $position);
+        
+        if (!isset($this->js[$position][$key])) {
             $this->js[$position][$key] = $js;
+            return;
+        }
+        
+        switch ($mergeType) {
+            case self::MERGE_REPLACE:
+                $this->js[$position][$key] = $js;
+                break;
+            case self::MERGE_PREPEND:
+                $this->js[$position][$key] = $js ."\n". $this->js[$position][$key];
+                break;
+            case self::MERGE_APPEND:
+                $this->js[$position][$key] .= $js;
+                break;
         }
         return $this;
+    }
+    
+    public function setCurrent($key, $position)
+    {
+        $this->_currentKey = $key;
+        $this->_currentPos = $position;
     }
 
     /**
@@ -637,6 +643,9 @@ class View extends \yii\base\View
     
     private function add(&$where, $beforeKeys, $scriptKey = null, $pos = null)
     {
+        if (!isset($where)) {
+            return $this;
+        }
         if (!isset($scriptKey)) {
             $scriptKey = $this->_currentKey;
         }
@@ -650,14 +659,14 @@ class View extends \yii\base\View
         return $this;
     }
     
-    public function addBefore($beforeKeys, $scriptKey = null, $pos = null)
+    public function addBefore($beforeKeys = null, $scriptKey = null, $pos = null)
     {
-       return $this->add($this->_jsBefore, $beforeKeys, $scriptKey, $pos);
+        return $this->add($this->_jsBefore, $beforeKeys, $scriptKey, $pos);
     }
     
-    public function addAfter($afterKeys, $scriptKey = null, $pos = null)
+    public function addAfter($afterKeys = null, $scriptKey = null, $pos = null)
     {
-       return $this->add($this->_jsAfter, $afterKeys, $scriptKey, $pos);
+        return $this->add($this->_jsAfter, $afterKeys, $scriptKey, $pos);
     }
     
     

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -458,7 +458,7 @@ class View extends \yii\base\View
      * @param string $key the key that identifies the JS code block. If null, it will use
      * $js as the key. If two JS code blocks are registered with the same key, the latter
      * will overwrite the former.
-     * @param int $merger the type of merge that should be applied if a code block exists with the same key:
+     * @param int $mergeType the type of merge that should be applied if a code block exists with the same key:
      *
      * - [[MERGE_REPLACE]]: the existing code block will be replaced (default)
      * - [[MERGE_PREPEND]]: the JS code will be prepended to the existing JS code block.
@@ -467,7 +467,7 @@ class View extends \yii\base\View
      *
      * @param string|array $afterKeys key or array of keys that should be rendered before the current script if they exist. 
      */
-    public function registerJs($js, $position = self::POS_READY, $key = null, $merger = self::MERGE_REPLACE, $beforeKeys = null, $afterKeys = null)
+    public function registerJs($js, $position = self::POS_READY, $key = null, $mergeType = self::MERGE_REPLACE, $beforeKeys = null, $afterKeys = null)
     {
         $key = $key ?: md5($js);
         if ($position === self::POS_READY || $position === self::POS_LOAD) {
@@ -481,13 +481,13 @@ class View extends \yii\base\View
         if ($afterKeys) {
             $this->addBefore($afterKeys, $key, $position);
         }
-        if (isset($this->js[$position][$key]) && $merger !== self::MERGE_REPLACE) {
-            if ($merger === self::MERGE_SKIP) {
+        if (isset($this->js[$position][$key]) && $mergeType !== self::MERGE_REPLACE) {
+            if ($mergeType === self::MERGE_SKIP) {
                 return;
             }
-            if ($merger === self::MERGE_PREPEND) {
+            if ($mergeType === self::MERGE_PREPEND) {
                 $this->js[$position][$key] = $js ."\n". $this->js[$position][$key];
-            } else if ($merger === self::MERGE_APPEND) {
+            } else if ($mergeType === self::MERGE_APPEND) {
                 $this->js[$position][$key] .= $js;
             }
         } else {

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -88,6 +88,26 @@ class View extends \yii\base\View
      * This is internally used as the placeholder for receiving the content registered for the end of the body section.
      */
     const PH_BODY_END = '<![CDATA[YII-BLOCK-BODY-END]]>';
+    /**
+     * How the registered JavaScript code block should be included in the JavaScript section.
+     * This means the JavaScript code block will be skipped if the code block exists.
+     */
+    const MERGE_SKIP = 0;
+    /**
+     * How the registered JavaScript code block should be included in the JavaScript section.
+     * This means the JavaScript code block will replace the current code block if the code block exists.
+     */
+    const MERGE_REPLACE = 1;
+    /**
+     * How the registered JavaScript code block should be included in the JavaScript section.
+     * This means the JavaScript code block will be prepended to the current code block if the code block exists.
+     */
+    const MERGE_PREPEND = 2;
+    /**
+     * How the registered JavaScript code block should be included in the JavaScript section.
+     * This means the JavaScript code block will be appended to the current code block if the code block exists.
+     */
+    const MERGE_APPEND = 3;
 
     /**
      * @var AssetBundle[] list of the registered asset bundles. The keys are the bundle names, and the values
@@ -131,6 +151,8 @@ class View extends \yii\base\View
     public $jsFiles;
 
     private $_assetManager;
+    private $_jsHandled;
+    private $_jsAfter;
 
 
     /**
@@ -419,7 +441,7 @@ class View extends \yii\base\View
 
     /**
      * Registers a JS code block.
-     * @param string $js the JS code block to be registered
+     * @param string|callable|\Closure $js the JS code block to be registered or a callable method that returns a JS string.
      * @param int $position the position at which the JS script tag should be inserted
      * in a page. The possible values are:
      *
@@ -434,13 +456,35 @@ class View extends \yii\base\View
      * @param string $key the key that identifies the JS code block. If null, it will use
      * $js as the key. If two JS code blocks are registered with the same key, the latter
      * will overwrite the former.
+     * @param int $merger the type of merge that should be applied if a code block exists with the same key:
+     *
+     * - [[MERGE_REPLACE]]: the existing code block will be replaced (default)
+     * - [[MERGE_PREPEND]]: the JS code will be prepended to the existing JS code block.
+     * - [[MERGE_APPEND]]: the JS code will be appended to the existing JS code block.
+     * - [[MERGE_SKIP]]: keep the current value of the JS code block.
+     *
+     * @param string|array $afterKeys key or array of keys that should be rendered before the current script if they exist. 
      */
-    public function registerJs($js, $position = self::POS_READY, $key = null)
+    public function registerJs($js, $position = self::POS_READY, $key = null, $merger = self::MERGE_REPLACE, $afterKeys = null)
     {
         $key = $key ?: md5($js);
-        $this->js[$position][$key] = $js;
         if ($position === self::POS_READY || $position === self::POS_LOAD) {
             JqueryAsset::register($this);
+        }
+        if ($afterKeys) {
+            $this->addAfter($afterKeys, $key);
+        }
+        if (isset($this->js[$position][$key]) && $merger !== self::MERGE_REPLACE) {
+            if ($merger === self::MERGE_SKIP) {
+                return;
+            }
+            if ($merger === self::MERGE_PREPEND) {
+                $this->js[$position][$key] = $js ."\n". $this->js[$position][$key];
+            } else if ($merger === self::MERGE_APPEND) {
+                $this->js[$position][$key] .= $js;
+            }
+        } else {
+            $this->js[$position][$key] = $js;
         }
     }
 
@@ -510,7 +554,7 @@ class View extends \yii\base\View
             $lines[] = implode("\n", $this->jsFiles[self::POS_HEAD]);
         }
         if (!empty($this->js[self::POS_HEAD])) {
-            $lines[] = Html::script(implode("\n", $this->js[self::POS_HEAD]), ['type' => 'text/javascript']);
+            $lines[] = Html::script($this->jsLines(self::POS_HEAD), ['type' => 'text/javascript']);
         }
 
         return empty($lines) ? '' : implode("\n", $lines);
@@ -528,7 +572,7 @@ class View extends \yii\base\View
             $lines[] = implode("\n", $this->jsFiles[self::POS_BEGIN]);
         }
         if (!empty($this->js[self::POS_BEGIN])) {
-            $lines[] = Html::script(implode("\n", $this->js[self::POS_BEGIN]), ['type' => 'text/javascript']);
+            $lines[] = Html::script($this->jsLines(self::POS_BEGIN), ['type' => 'text/javascript']);
         }
 
         return empty($lines) ? '' : implode("\n", $lines);
@@ -553,31 +597,75 @@ class View extends \yii\base\View
         if ($ajaxMode) {
             $scripts = [];
             if (!empty($this->js[self::POS_END])) {
-                $scripts[] = implode("\n", $this->js[self::POS_END]);
+                $scripts[] = $this->jsLines(self::POS_END);
             }
             if (!empty($this->js[self::POS_READY])) {
-                $scripts[] = implode("\n", $this->js[self::POS_READY]);
+                $scripts[] = $this->jsLines(self::POS_READY);
             }
             if (!empty($this->js[self::POS_LOAD])) {
-                $scripts[] = implode("\n", $this->js[self::POS_LOAD]);
+                $scripts[] = $this->jsLines(self::POS_LOAD);
             }
             if (!empty($scripts)) {
                 $lines[] = Html::script(implode("\n", $scripts), ['type' => 'text/javascript']);
             }
         } else {
             if (!empty($this->js[self::POS_END])) {
-                $lines[] = Html::script(implode("\n", $this->js[self::POS_END]), ['type' => 'text/javascript']);
+                $lines[] = Html::script($this->jsLines(self::POS_END), ['type' => 'text/javascript']);
             }
             if (!empty($this->js[self::POS_READY])) {
-                $js = "jQuery(document).ready(function () {\n" . implode("\n", $this->js[self::POS_READY]) . "\n});";
+                $js = "jQuery(document).ready(function () {\n" . $this->jsLines(self::POS_READY) . "\n});";
                 $lines[] = Html::script($js, ['type' => 'text/javascript']);
             }
             if (!empty($this->js[self::POS_LOAD])) {
-                $js = "jQuery(window).on('load', function () {\n" . implode("\n", $this->js[self::POS_LOAD]) . "\n});";
+                $js = "jQuery(window).on('load', function () {\n" . $this->jsLines(self::POS_LOAD) . "\n});";
                 $lines[] = Html::script($js, ['type' => 'text/javascript']);
             }
         }
 
         return empty($lines) ? '' : implode("\n", $lines);
+    }
+    
+    public function addAfter($afterKeys, $sciptKey)
+    {
+        if (is_array($afterKeys)) {
+            foreach($afterKeys as $afterKey) {
+                $this->_jsAfter[$sciptKey][$afterKey] = true;
+            }
+        } else {
+            $this->_jsAfter[$sciptKey][$afterKeys] = true;
+        }
+    }
+    
+    
+    public function jsLines($pos)
+    {
+        $array = $this->js[$pos];
+        $lines = '';
+        $this->_jsHandled = [];
+        while (count($this->_jsHandled) < count($array)) {
+            foreach ($array as $scriptKey => $script) {
+                if (array_key_exists($scriptKey, $this->_jsHandled) || $this->isLineDeferred($scriptKey, $array)) {
+                    continue;
+                }
+                $lines .= $script."\n";
+                $this->_jsHandled[$scriptKey] = true;
+            }
+        }
+        return $lines;
+    }
+    
+    public function isLineDeferred(&$scriptKey, &$array)
+    {
+        if (empty($this->_jsAfter[$scriptKey])) {
+            return false;
+        }
+        foreach ($this->_jsAfter[$scriptKey] as $beforeKey => $null) {
+            if (array_key_exists($beforeKey, $this->_jsAfter) && array_key_exists($scriptKey, $this->_jsAfter[$beforeKey])) {
+                throw new \Exception("Circular dependency detected with keys: $beforeKey <-> $scriptKey");
+            } else if (array_key_exists($beforeKey, $array) && !array_key_exists($beforeKey, $this->_jsHandled)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -684,6 +684,16 @@ class View extends \yii\base\View
         unset($this->_jsBefore);
     }
     
+    public function jsLine($script)
+    {
+        if (is_array($script)) {
+            return call_user_func($script, $this);
+        } else if ($script instanceof Closure) {
+            return $script($this);
+        }
+        return $script."\n";
+    }
+    
     public function jsLines($pos)
     {
         $array = $this->js[$pos];
@@ -695,7 +705,7 @@ class View extends \yii\base\View
                 if (array_key_exists($scriptKey, $this->_jsHandled[$pos]) || $this->isLineDeferred($scriptKey, $array, $pos)) {
                     continue;
                 }
-                $lines .= $script."\n";
+                $lines .= $this->getJsLine($script)."\n";
                 $this->_jsHandled[$pos][$scriptKey] = true;
             }
         }

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -465,7 +465,8 @@ class View extends \yii\base\View
      * - [[MERGE_APPEND]]: the JS code will be appended to the existing JS code block.
      * - [[MERGE_SKIP]]: keep the current value of the JS code block.
      *
-     * @param string|array $afterKeys key or array of keys that should be rendered before the current script if they exist. 
+     * @param string|array $beforeKeys key or array of keys that should be rendered before the current script if they exist. 
+     * @param string|array $afterKeys key or array of keys that should be rendered after the current script if they exist. 
      */
     public function registerJs($js, $position = self::POS_READY, $key = null, $mergeType = self::MERGE_REPLACE, $beforeKeys = null, $afterKeys = null)
     {
@@ -475,11 +476,11 @@ class View extends \yii\base\View
         }
         $this->_currentKey = $key;
         $this->_currentPos = $position;
-        if ($beforeKeys) {
-            $this->addAfter($beforeKeys, $key, $position);
-        }
         if ($afterKeys) {
-            $this->addBefore($afterKeys, $key, $position);
+            $this->addAfter($afterKeys, $key, $position);
+        }
+        if ($beforeKeys) {
+            $this->addBefore($beforeKeys, $key, $position);
         }
         if (isset($this->js[$position][$key]) && $mergeType !== self::MERGE_REPLACE) {
             if ($mergeType === self::MERGE_SKIP) {

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -7,14 +7,16 @@
 
 namespace yii\widgets;
 
+use Closure;
 use Yii;
 use yii\base\InvalidCallException;
-use yii\base\Widget;
 use yii\base\Model;
+use yii\base\Widget;
 use yii\helpers\ArrayHelper;
-use yii\helpers\Url;
 use yii\helpers\Html;
 use yii\helpers\Json;
+use yii\helpers\Url;
+use yii\web\View;
 
 /**
  * ActiveForm is a widget that builds an interactive HTML form for one or multiple data models.
@@ -49,7 +51,7 @@ class ActiveForm extends Widget
     public $method = 'post';
     /**
      * @var array the HTML attributes (name-value pairs) for the form tag.
-     * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
+     * @see Html::renderTagAttributes() for details on how attributes are being rendered.
      */
     public $options = [];
     /**
@@ -58,7 +60,7 @@ class ActiveForm extends Widget
      */
     public $fieldClass = 'yii\widgets\ActiveField';
     /**
-     * @var array|\Closure the default configuration used by [[field()]] when creating a new field object.
+     * @var array|Closure the default configuration used by [[field()]] when creating a new field object.
      * This can be either a configuration array or an anonymous function returning a configuration array.
      * If the latter, the signature should be as follows:
      *
@@ -210,7 +212,7 @@ class ActiveForm extends Widget
             $attributes = Json::htmlEncode($this->attributes);
             $view = $this->getView();
             ActiveFormAsset::register($view);
-            $view->registerJs("jQuery('#$id').yiiActiveForm($attributes, $options);");
+            $view->registerJs("jQuery('#$id').yiiActiveForm($attributes, $options);", View::POS_READY, 'activeform', View::MERGE_APPEND);
         }
 
         echo Html::endForm();
@@ -289,7 +291,7 @@ class ActiveForm extends Widget
     public function field($model, $attribute, $options = [])
     {
         $config = $this->fieldConfig;
-        if ($config instanceof \Closure) {
+        if ($config instanceof Closure) {
             $config = call_user_func($config, $model, $attribute);
         }
         if (!isset($config['class'])) {


### PR DESCRIPTION
Add method `jsLines()` and replace implode statements with `jsLines()` method.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | needs testing
| Fixed issues  | Helps fix issues related to the order in which JS scripts get included. 

**`mergeType`** parameter to define how existing inline JS with the same keys should be merged together.

 For example the Pjax widget would require inner pjax containers to be appended so that the events get binded in the correct order. In this case you would use `View::MERGE_PREPEND` since the `registerJs()` method is in the `run()` method the inner widgets are called first and thus the order is reversed. An alternative would be to use `registerJs()` in the `begin()` method but this would break if nesting widgets between the layout and action views since the layout is rendered after the action's view.  Thus the only way to correctly order the widgets inline scripts when nested in both the layout and action is to use `View::MERGE_PREPEND` in the `run()` method of the widget. 

**`afterKeys`** which enables JS code to be deferred and included after another widgets code if needed. For example with the Pjax widget you want to make sure the ActiveForm events are attached first to prevent the Pjax request from happening before Ajax validation.

**`beforeKeys`** that works the same as `afterKeys` except the JS code get's included before.


**Example usage:**

```php
$view->registerJs($js, View::POS_READY, 'pjax', View::MERGE_PREPEND,null,'activeform');
```

Or could use separate methods to make code cleaner:

```php
$view->registerJs($js, View::POS_READY, 'pjax', View::MERGE_PREPEND)
      ->addAfter('activeform');

$view->registerJs($js, View::POS_READY, 'some-widget', View::MERGE_PREPEND)
     ->addBefore(['activeform','other-widget', '..']);
```

Added support for callables and closures to the `js` paramter of `registerJs()` method so that widgets can handle their own lines.

 ```php

class MyWidget extends \yii\base\Widget
{
    /**
     * @inheritdoc
     */
    public function run()
    {
         // ... 
         $this->registerClientScript();
    }

    /**
     * Registers the needed JavaScript.
     */
    public function registerClientScript()
    {
            self::$js .= ".fadeIn().fadeOut()";
            $view = $this->getView();
            // merge skip makes sure the callback is added once
            $view->registerJs([self::className()], View::POS_READY, 'my-custom-widget', View::MERGE_SKIP);
    }
  public static $js = "";
    
    public static function initJs($view)
    {
        // can use the callback to customize the output 
        return "jQuery(document)".implode("\n", self::$js).";\n";
    }
}

```
