### PR TITLE
Added tests for all `yii\db\QueryBuilder::resetSequence` implementations

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -20,7 +20,7 @@ Yii Framework 2 Change Log
 - Bug #13594: Fixes insufficient quoting in `yii\db\QueryBuilder::prepareInsertSelectSubQuery()` (sergeymakinen)
 - Enh #13576: Added support of `srcset` to `yii\helpers\Html::img()` (Kolyunya)
 - Enh #13467: `yii\data\ActiveDataProvider` no longer queries models if models count is zero (kLkA, Kolyunya)
-- Enh #13582: Added tests for all `yii\db\QueryBuilder::resetSequence` implementations (boboldehampsink)
+- Enh #13582: Added tests for all `yii\db\QueryBuilder::resetSequence` implementations, fixed SQLite implementation (boboldehampsink)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,11 +15,12 @@ Yii Framework 2 Change Log
 - Enh #13577: Implemented `yii\db\mssql\QueryBuilder::resetSequence()` (boboldehampsink)
 - Bug #13513: Fixed RBAC migration to work correctly on Oracle DBMS (silverfire)
 - Enh #13550: Refactored unset call order in `yii\di\ServiceLocator::set()` (Lanrik)
-- Bug #13582: PK column in `yii\db\pgsql\resetSequence()` was not quoted properly (boboldehampsink)
+- Bug #13582: PK column in `yii\db\pgsql\QueryBuilder::resetSequence()` was not quoted properly (boboldehampsink)
 - Bug #13592: Fixes Oracle’s `yii\db\oci\Schema::setTransactionIsolationLevel()` (sergeymakinen)
 - Bug #13594: Fixes insufficient quoting in `yii\db\QueryBuilder::prepareInsertSelectSubQuery()` (sergeymakinen)
 - Enh #13576: Added support of `srcset` to `yii\helpers\Html::img()` (Kolyunya)
 - Enh #13467: `yii\data\ActiveDataProvider` no longer queries models if models count is zero (kLkA, Kolyunya)
+- Enh #13582: Added tests for all `yii\db\QueryBuilder::resetSequence` implementations (boboldehampsink)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -134,13 +134,13 @@ class QueryBuilder extends \yii\db\QueryBuilder
                 $key = reset($table->primaryKey);
                 $tableName = $db->quoteTableName($tableName);
                 $value = $this->db->useMaster(function (Connection $db) use ($key, $tableName) {
-                    return $db->createCommand("SELECT MAX('$key') FROM $tableName")->queryScalar();
+                    return $db->createCommand("SELECT MAX($key) FROM $tableName")->queryScalar();
                 });
             } else {
                 $value = (int) $value - 1;
             }
             try {
-                $db->createCommand("UPDATE sqlite_sequence SET seq='$value' WHERE name='{$table->name}'")->execute();
+                return "UPDATE sqlite_sequence SET seq='$value' WHERE name='{$table->name}'";
             } catch (Exception $e) {
                 // it's possible that sqlite_sequence does not exist
             }

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -28,9 +28,9 @@ abstract class QueryBuilderTest extends DatabaseTestCase
      * @throws \Exception
      * @return QueryBuilder
      */
-    protected function getQueryBuilder()
+    protected function getQueryBuilder($reset = true, $open = false)
     {
-        $connection = $this->getConnection(true, false);
+        $connection = $this->getConnection($reset, $open);
 
         \Yii::$container->set('db', $connection);
 

--- a/tests/framework/db/cubrid/QueryBuilderTest.php
+++ b/tests/framework/db/cubrid/QueryBuilderTest.php
@@ -20,4 +20,17 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
     {
         return array_merge(parent::columnTypes(), []);
     }
+
+    public function testResetSequence()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = 'ALTER TABLE "item" AUTO_INCREMENT=6;';
+        $sql = $qb->resetSequence('item');
+        $this->assertEquals($expected, $sql);
+
+        $expected = 'ALTER TABLE "item" AUTO_INCREMENT=4;';
+        $sql = $qb->resetSequence('item', 4);
+        $this->assertEquals($expected, $sql);
+    }
 }

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -56,4 +56,17 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
             ],
         ]);
     }
+
+    public function testResetSequence()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = 'ALTER TABLE `item` AUTO_INCREMENT=6';
+        $sql = $qb->resetSequence('item');
+        $this->assertEquals($expected, $sql);
+
+        $expected = 'ALTER TABLE `item` AUTO_INCREMENT=4';
+        $sql = $qb->resetSequence('item', 4);
+        $this->assertEquals($expected, $sql);
+    }
 }

--- a/tests/framework/db/oci/QueryBuilderTest.php
+++ b/tests/framework/db/oci/QueryBuilderTest.php
@@ -53,4 +53,19 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
         $sql = $qb->dropCommentFromTable('comment');
         $this->assertEquals($this->replaceQuotes($expected), $sql);
     }
+
+    public function testResetSequence()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = 'DROP SEQUENCE "item_SEQ";'
+            .'CREATE SEQUENCE "item_SEQ" START WITH 6 INCREMENT BY 1 NOMAXVALUE NOCACHE';
+        $sql = $qb->resetSequence('item');
+        $this->assertEquals($expected, $sql);
+
+        $expected = 'DROP SEQUENCE "item_SEQ";'
+            .'CREATE SEQUENCE "item_SEQ" START WITH 4 INCREMENT BY 1 NOMAXVALUE NOCACHE';
+        $sql = $qb->resetSequence('item', 4);
+        $this->assertEquals($expected, $sql);
+    }
 }

--- a/tests/framework/db/pgsql/QueryBuilderTest.php
+++ b/tests/framework/db/pgsql/QueryBuilderTest.php
@@ -131,4 +131,17 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
 
         return $data;
     }
+
+    public function testResetSequence()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = "SELECT SETVAL('\"item_id_seq\"',(SELECT COALESCE(MAX(\"id\"),0) FROM \"item\")+1,false)";
+        $sql = $qb->resetSequence('item');
+        $this->assertEquals($expected, $sql);
+
+        $expected = "SELECT SETVAL('\"item_id_seq\"',4,false)";
+        $sql = $qb->resetSequence('item', 4);
+        $this->assertEquals($expected, $sql);
+    }
 }

--- a/tests/framework/db/sqlite/QueryBuilderTest.php
+++ b/tests/framework/db/sqlite/QueryBuilderTest.php
@@ -113,11 +113,11 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
     {
         $qb = $this->getQueryBuilder();
 
-        $expected = "UPDATE sqlite_sequence SET seq='6' WHERE name='item'";
+        $expected = "UPDATE sqlite_sequence SET seq='5' WHERE name='item'";
         $sql = $qb->resetSequence('item');
         $this->assertEquals($expected, $sql);
 
-        $expected = "UPDATE sqlite_sequence SET seq='4' WHERE name='item'";
+        $expected = "UPDATE sqlite_sequence SET seq='3' WHERE name='item'";
         $sql = $qb->resetSequence('item', 4);
         $this->assertEquals($expected, $sql);
     }

--- a/tests/framework/db/sqlite/QueryBuilderTest.php
+++ b/tests/framework/db/sqlite/QueryBuilderTest.php
@@ -108,4 +108,17 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
         $this->assertEquals($expectedQuerySql, $actualQuerySql);
         $this->assertEquals([], $queryParams);
     }
+
+    public function testResetSequence()
+    {
+        $qb = $this->getQueryBuilder();
+
+        $expected = "UPDATE sqlite_sequence SET seq='6' WHERE name='item'";
+        $sql = $qb->resetSequence('item');
+        $this->assertEquals($expected, $sql);
+
+        $expected = "UPDATE sqlite_sequence SET seq='4' WHERE name='item'";
+        $sql = $qb->resetSequence('item', 4);
+        $this->assertEquals($expected, $sql);
+    }
 }

--- a/tests/framework/db/sqlite/QueryBuilderTest.php
+++ b/tests/framework/db/sqlite/QueryBuilderTest.php
@@ -111,7 +111,7 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
 
     public function testResetSequence()
     {
-        $qb = $this->getQueryBuilder();
+        $qb = $this->getQueryBuilder(true, true);
 
         $expected = "UPDATE sqlite_sequence SET seq='5' WHERE name='item'";
         $sql = $qb->resetSequence('item');


### PR DESCRIPTION
In #13582 we added this to the MSSQL driver, and agreed to add these for all drivers.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13582
