### PR TITLE
[Guide] Issue in retrieval list from the DB in Input form

### DIFF
--- a/docs/guide/input-forms.md
+++ b/docs/guide/input-forms.md
@@ -144,7 +144,7 @@ or by retrieval from the DB:
 
 ```php
 $items = Category::find()
-        ->select(['id', 'label'])
+        ->select(['label'])
         ->indexBy('id')
         ->column();
 ```


### PR DESCRIPTION
## When does the issue occur?

When I have generate `dropDownList` or `radioButtonList` from DB at time return same key and value like

```php
return [
    2 => 2,
    3 => 3
]
``` 

because `column` method is return first column in `select` statement. when i change position in select statement like set `label` field first at time return my expected results like.

## What was the expected result?

```php
return [
    2 => 'My label/title-1',
    3 => 'My label/title-2'
]
``` 


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
