### PR TITLE
BaseHtml updates for ActiveRadio and ActiveChecbox

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.12 under development
 --------------------------
-- Bug #13649: Fixes issue where `['uncheck' => false]` and `['label' => false]` options for `ActiveRadio` and `ActiveCheckbox` were ignored (Alex-Code)
+
 - Bug #13087: Fixed getting active validators for safe attribute (developeruz)
 - Bug #13571: Fix `yii\db\mssql\QueryBuilder::checkIntegrity` for all tables (boboldehampsink)
 - Bug #11230: Include `defaultRoles` in `yii\rbac\DbManager->getRolesByUser()` results (developeruz)
@@ -28,6 +28,7 @@ Yii Framework 2 Change Log
 - Enh #13577: Implemented `yii\db\mssql\QueryBuilder::resetSequence()` (boboldehampsink)
 - Enh #13582: Added tests for all `yii\db\QueryBuilder::resetSequence` implementations, fixed SQLite implementation (boboldehampsink)
 - Enh #13407: Added URL-safe base64 encode/decode methods to `StringHelper` (andrewnester)
+- Bug #13649: Fixes issue where `['uncheck' => false]` and `['label' => false]` options for `ActiveRadio` and `ActiveCheckbox` were ignored (Alex-Code)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.12 under development
 --------------------------
-
+- Bug #13649: Fixes issue where `['uncheck' => false]` and `['label' => false]` options for `ActiveRadio` and `ActiveCheckbox` were ignored (Alex-Code)
 - Bug #13087: Fixed getting active validators for safe attribute (developeruz)
 - Bug #13571: Fix `yii\db\mssql\QueryBuilder::checkIntegrity` for all tables (boboldehampsink)
 - Bug #11230: Include `defaultRoles` in `yii\rbac\DbManager->getRolesByUser()` results (developeruz)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1476,12 +1476,12 @@ class BaseHtml
         }
         if (!array_key_exists('uncheck', $options)) {
             $options['uncheck'] = '0';
-        } else if ($options['uncheck'] === false) {
+        } elseif ($options['uncheck'] === false) {
             unset($options['uncheck']);
         }
         if (!array_key_exists('label', $options)) {
             $options['label'] = static::encode($model->getAttributeLabel(static::getAttributeName($attribute)));
-        } else if ($options['label'] === false) {
+        } elseif ($options['label'] === false) {
             unset($options['label']);
         }
 

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1476,9 +1476,13 @@ class BaseHtml
         }
         if (!array_key_exists('uncheck', $options)) {
             $options['uncheck'] = '0';
+        } else if ($options['uncheck'] === false) {
+            unset($options['uncheck']);
         }
         if (!array_key_exists('label', $options)) {
             $options['label'] = static::encode($model->getAttributeLabel(static::getAttributeName($attribute)));
+        } else if ($options['label'] === false) {
+            unset($options['label']);
         }
 
         $checked = "$value" === "{$options['value']}";

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1165,6 +1165,94 @@ EOD;
         $noCsrfForm = Html::beginForm('/index.php', 'post', ['csrf' => false, 'id' => 'myform']);
         $this->assertEquals('<form id="myform" action="/index.php" method="post">', $noCsrfForm);
     }
+    
+    /**
+     * Data provider for [[testActiveRadio()]]
+     * @return array test data
+     */
+    public function dataProviderActiveRadio()
+    {
+        return [
+            [
+                true,
+                [],
+                '<input type="hidden" name="HtmlTestModel[radio]" value="0"><label><input type="radio" id="htmltestmodel-radio" name="HtmlTestModel[radio]" value="1" checked> Radio</label>'
+            ],
+            [
+                true,
+                ['uncheck' => false],
+                '<label><input type="radio" id="htmltestmodel-radio" name="HtmlTestModel[radio]" value="1" checked> Radio</label>'
+            ],
+            [
+                true,
+                ['label' => false],
+                '<input type="hidden" name="HtmlTestModel[radio]" value="0"><input type="radio" id="htmltestmodel-radio" name="HtmlTestModel[radio]" value="1" checked>'
+            ],
+            [
+                true,
+                ['uncheck' => false, 'label' => false],
+                '<input type="radio" id="htmltestmodel-radio" name="HtmlTestModel[radio]" value="1" checked>'
+            ],
+        ];
+    }
+    
+    /**
+     * @dataProvider dataProviderActiveRadio
+     *
+     * @param string $value
+     * @param array $options
+     * @param string $expectedHtml
+     */
+    public function testActiveRadio($value, array $options, $expectedHtml)
+    {
+        $model = new HtmlTestModel();
+        $model->radio = $value;
+        $this->assertEquals($expectedHtml, Html::activeRadio($model, 'radio', $options));
+    }
+        
+    /**
+     * Data provider for [[testActiveCheckbox()]]
+     * @return array test data
+     */
+    public function dataProviderActiveCheckbox()
+    {
+        return [
+            [
+                true,
+                [],
+                '<input type="hidden" name="HtmlTestModel[checkbox]" value="0"><label><input type="checkbox" id="htmltestmodel-checkbox" name="HtmlTestModel[checkbox]" value="1" checked> Checkbox</label>'
+            ],
+            [
+                true,
+                ['uncheck' => false],
+                '<label><input type="checkbox" id="htmltestmodel-checkbox" name="HtmlTestModel[checkbox]" value="1" checked> Checkbox</label>'
+            ],
+            [
+                true,
+                ['label' => false],
+                '<input type="hidden" name="HtmlTestModel[checkbox]" value="0"><input type="checkbox" id="htmltestmodel-checkbox" name="HtmlTestModel[checkbox]" value="1" checked>'
+            ],
+            [
+                true,
+                ['uncheck' => false, 'label' => false],
+                '<input type="checkbox" id="htmltestmodel-checkbox" name="HtmlTestModel[checkbox]" value="1" checked>'
+            ],
+        ];
+    }
+    
+    /**
+     * @dataProvider dataProviderActiveCheckbox
+     *
+     * @param string $value
+     * @param array $options
+     * @param string $expectedHtml
+     */
+    public function testActiveCheckbox($value, array $options, $expectedHtml)
+    {
+        $model = new HtmlTestModel();
+        $model->checkbox = $value;
+        $this->assertEquals($expectedHtml, Html::activeCheckbox($model, 'checkbox', $options));
+    }
 }
 
 /**
@@ -1176,7 +1264,7 @@ class HtmlTestModel extends DynamicModel
 {
     public function init()
     {
-        foreach (['name', 'types', 'description'] as $attribute) {
+        foreach (['name', 'types', 'description', 'radio', 'checkbox'] as $attribute) {
             $this->defineAttribute($attribute);
         }
     }
@@ -1187,6 +1275,7 @@ class HtmlTestModel extends DynamicModel
             ['name', 'required'],
             ['name', 'string', 'max' => 100],
             ['description', 'string', 'max' => 500],
+            [['radio', 'checkbox'], 'boolean'],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| Breaks BC?    | no
| Tests pass?   | yes

This fixes an issue where if `['uncheck' => false]` was used with `ActiveRadio` or `ActiveCheckbox` it would produce a hidden input with an empty value.

`['label' => false]` was also the same.