### PR TITLE
Refactor migration controller

### DIFF
--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -557,7 +557,7 @@ abstract class BaseMigrateController extends Controller
      */
     public function actionCreate($name)
     {
-        if (!preg_match('/^[\w\\\\]+$/', $name)) {
+        if (!preg_match('/^[\w\\]+$/', $name)) {
             throw new Exception('The migration name should contain letters, digits, underscore and/or backslash characters only.');
         }
 


### PR DESCRIPTION
Remove an excessive token from allowed migration names regular expression.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | none
