### PR TITLE
Fix truncateHtml. Resolve duplicates tags from tree.

### DIFF
--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -118,7 +118,7 @@ class StringHelperTest extends TestCase
 
         $this->assertEquals('<p>This is a test</p><ul><li>bullet1</li><li>b</li></ul>...', StringHelper::truncate('<p>This is a test</p><ul><li>bullet1</li><li>bullet2</li><li>bullet3</li><li>bullet4</li></ul>', 22, '...', null, true));
 
-        $this->assertEquals('<div><ul><li>bullet1</li><li>b</li></ul></div>...', StringHelper::truncate('<div><ul><li>bullet1</li><li>bullet2</li><li>bullet3</li></ul><br></div>', 8, '...', null, true));
+        $this->assertEquals('<div><ul><li>bullet1</li><li><div>b</div></li></ul></div>...', StringHelper::truncate('<div><ul><li>bullet1</li><li><div>bullet2</div></li></ul><br></div>', 8, '...', null, true));
     }
 
     public function testTruncateWords()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  |  #13657

Sorry me, plz! I found broken case:
Fixes when nested tags with same names.
```php
StringHelper::truncate('<div><ul><li>bullet1</li><li><div>bullet2</div></li></ul><br></div>', 8, '...', null, true)
```

Old:
```html
<div><ul><li>bullet1</li><li><div>b</li></ul></div></div>...
```
New:
```html
<div><ul><li>bullet1</li><li><div>b</div></li></ul></div>...
```

_It is better performance implementation: checking the open/close tag on each level of nesting._