### PR TITLE
Send Pjax Header with response to fix redirect

### DIFF
--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -171,6 +171,11 @@ class Pjax extends Widget
         $response->setStatusCode(200);
         $response->format = Response::FORMAT_HTML;
         $response->content = $content;
+        
+        if (!isset($response->headers['X-Pjax-Url'])) {
+			$response->headers->set('X-Pjax-Url', Yii::$app->request->url);
+		}
+        
         $response->send();
 
         Yii::$app->end();


### PR DESCRIPTION
Based on this issue: https://github.com/yiisoft/jquery-pjax/issues/44.
Note that $checkAjax must be set to false when calling Response::redirect()
Seemed to work for me.
