### PR TITLE
setStatusCode method of Response should return $this

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -41,7 +41,7 @@ Yii Framework 2 Change Log
 - Bug #13379: Fixed `applyFilter` function in `yii.gridView.js` to work correctly when params in `filterUrl` are indexed (SilverFire) 
 - Bug #13670: Fixed alias option from console when it includes `-` or `_` in option name (pana1990)
 - Enh: Added `yii\di\Instance::__set_state()` method to restore object after serialization using `var_export()` function (silvefire)
-- Enh: `setStatusCode` in `\yii\web\Response` returns `$this`
+- Enh: `setStatusCode` in `\yii\web\Response` returns `$this` (kyle-mccarthy)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -41,7 +41,7 @@ Yii Framework 2 Change Log
 - Bug #13379: Fixed `applyFilter` function in `yii.gridView.js` to work correctly when params in `filterUrl` are indexed (SilverFire) 
 - Bug #13670: Fixed alias option from console when it includes `-` or `_` in option name (pana1990)
 - Enh: Added `yii\di\Instance::__set_state()` method to restore object after serialization using `var_export()` function (silvefire)
-- Enh: `setStatusCode` in `\yii\web\Response` returns `$this` (kyle-mccarthy)
+- Enh #13695: `\yii\web\Response::setStatusCode()` method now returns the Response object itself (kyle-mccarthy)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -41,6 +41,7 @@ Yii Framework 2 Change Log
 - Bug #13379: Fixed `applyFilter` function in `yii.gridView.js` to work correctly when params in `filterUrl` are indexed (SilverFire) 
 - Bug #13670: Fixed alias option from console when it includes `-` or `_` in option name (pana1990)
 - Enh: Added `yii\di\Instance::__set_state()` method to restore object after serialization using `var_export()` function (silvefire)
+- Enh: `setStatusCode` in `\yii\web\Response` returns `$this`
 
 
 2.0.11.2 February 08, 2017

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -271,6 +271,7 @@ class Response extends \yii\base\Response
      * @param int $value the status code
      * @param string $text the status text. If not set, it will be set automatically based on the status code.
      * @throws InvalidParamException if the status code is invalid.
+     * @return $this
      */
     public function setStatusCode($value, $text = null)
     {
@@ -286,6 +287,7 @@ class Response extends \yii\base\Response
         } else {
             $this->statusText = $text;
         }
+        return $this;
     }
 
     /**

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -271,7 +271,7 @@ class Response extends \yii\base\Response
      * @param int $value the status code
      * @param string $text the status text. If not set, it will be set automatically based on the status code.
      * @throws InvalidParamException if the status code is invalid.
-     * @return $this
+     * @return $this the response object itself
      */
     public function setStatusCode($value, $text = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

The `setStatusCode` method of `yii\web\Response` should return the Response instance.  This will allow for returning a response in a controller without having issues related to returning void.

```
/**
 * @return \yii\web\Response 
 */
public function actionExample()
{
    $model = new Example();
    if ($model->load(Yii::$app->request->post() && $model->save()) {
        return $this->asJson(['message' => 'Example saved']);
    }
    return $this->asJson(['message' => 'Could not save example', 'errors' => $model->getErrors()])->setResponseCode(400);
}
```