### PR TITLE
Fixes #13707: Fixed `\yii\web\ErrorHandler` not setting correct respo…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -42,7 +42,7 @@ Yii Framework 2 Change Log
 - Bug #13670: Fixed alias option from console when it includes `-` or `_` in option name (pana1990)
 - Enh: Added `yii\di\Instance::__set_state()` method to restore object after serialization using `var_export()` function (silvefire)
 - Enh #13695: `\yii\web\Response::setStatusCode()` method now returns the Response object itself (kyle-mccarthy)
-- Bug #13707: Fixed `\yii\web\ErrorHandler` not setting correct response code to response object before rendering error view (samdark)
+- Bug #13707: Fixed `\yii\web\ErrorHandler` and `\yii\web\ErrorAction` not setting correct response code to response object before rendering error view (samdark)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -42,6 +42,7 @@ Yii Framework 2 Change Log
 - Bug #13670: Fixed alias option from console when it includes `-` or `_` in option name (pana1990)
 - Enh: Added `yii\di\Instance::__set_state()` method to restore object after serialization using `var_export()` function (silvefire)
 - Enh #13695: `\yii\web\Response::setStatusCode()` method now returns the Response object itself (kyle-mccarthy)
+- Bug #13707: Fixed `\yii\web\ErrorHandler` not setting correct response code to response object before rendering error view (samdark)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/web/ErrorAction.php
+++ b/framework/web/ErrorAction.php
@@ -98,12 +98,7 @@ class ErrorAction extends Action
      */
     public function run()
     {
-        $response = Yii::$app->getResponse();
-        if ($this->exception instanceof HttpException) {
-            $response->setStatusCode($this->exception->statusCode);
-        } else {
-            $response->setStatusCode(500);
-        }
+        Yii::$app->getResponse()->setStatusCodeByException($this->exception);
 
         if (Yii::$app->getRequest()->getIsAjax()) {
             return $this->renderAjaxResponse();

--- a/framework/web/ErrorAction.php
+++ b/framework/web/ErrorAction.php
@@ -98,6 +98,13 @@ class ErrorAction extends Action
      */
     public function run()
     {
+        $response = Yii::$app->getResponse();
+        if ($this->exception instanceof HttpException) {
+            $response->setStatusCode($this->exception->statusCode);
+        } else {
+            $response->setStatusCode(500);
+        }
+
         if (Yii::$app->getRequest()->getIsAjax()) {
             return $this->renderAjaxResponse();
         }

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -89,11 +89,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
             $response = new Response();
         }
 
-        if ($exception instanceof HttpException) {
-            $response->setStatusCode($exception->statusCode);
-        } else {
-            $response->setStatusCode(500);
-        }
+        $response->setStatusCodeByException($exception);
 
         $useErrorView = $response->format === Response::FORMAT_HTML && (!YII_DEBUG || $exception instanceof UserException);
 

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -474,6 +474,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
 
     /**
      * @return bool if simple HTML should be rendered
+     * @since 2.0.12
      */
     protected function shouldRenderSimpleHtml()
     {

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -89,6 +89,12 @@ class ErrorHandler extends \yii\base\ErrorHandler
             $response = new Response();
         }
 
+        if ($exception instanceof HttpException) {
+            $response->setStatusCode($exception->statusCode);
+        } else {
+            $response->setStatusCode(500);
+        }
+
         $useErrorView = $response->format === Response::FORMAT_HTML && (!YII_DEBUG || $exception instanceof UserException);
 
         if ($useErrorView && $this->errorAction !== null) {
@@ -117,12 +123,6 @@ class ErrorHandler extends \yii\base\ErrorHandler
             $response->data = static::convertExceptionToString($exception);
         } else {
             $response->data = $this->convertExceptionToArray($exception);
-        }
-
-        if ($exception instanceof HttpException) {
-            $response->setStatusCode($exception->statusCode);
-        } else {
-            $response->setStatusCode(500);
         }
 
         $response->send();

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -105,7 +105,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
                 $response->data = $result;
             }
         } elseif ($response->format === Response::FORMAT_HTML) {
-            if (YII_ENV_TEST || isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest') {
+            if ($this->shouldRenderSimpleHtml()) {
                 // AJAX request
                 $response->data = '<pre>' . $this->htmlEncode(static::convertExceptionToString($exception)) . '</pre>';
             } else {
@@ -450,5 +450,13 @@ class ErrorHandler extends \yii\base\ErrorHandler
             return $exception->getName();
         }
         return null;
+    }
+
+    /**
+     * @return bool if simple HTML should be rendered
+     */
+    protected function shouldRenderSimpleHtml()
+    {
+        return YII_ENV_TEST || isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest';
     }
 }

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -291,6 +291,24 @@ class Response extends \yii\base\Response
     }
 
     /**
+     * Sets the response status code based on the exception.
+     * @param \Exception $e
+     * @throws InvalidParamException if the status code is invalid.
+     * @return $this the response object itself
+     *
+     * @since 2.0.12
+     */
+    public function setStatusCodeByException(\Exception $e)
+    {
+        if ($e instanceof HttpException) {
+            $this->setStatusCode($e->statusCode);
+        } else {
+            $this->setStatusCode(500);
+        }
+        return $this;
+    }
+
+    /**
      * Returns the header collection.
      * The header collection contains the currently registered HTTP headers.
      * @return HeaderCollection the header collection

--- a/tests/data/views/error.php
+++ b/tests/data/views/error.php
@@ -9,6 +9,8 @@
 ?>
 Name: <?= $name ?>
 
+Code: <?= Yii::$app->response->statusCode ?>
+
 Message: <?= $message ?>
 
 Exception: <?= get_class($exception) ?>

--- a/tests/data/views/errorHandler.php
+++ b/tests/data/views/errorHandler.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @var Exception $exception
+ */
+
+?>
+Code: <?= Yii::$app->response->statusCode ?>
+
+Message: <?= $exception->getMessage() ?>
+
+Exception: <?= get_class($exception) ?>

--- a/tests/framework/web/ErrorActionTest.php
+++ b/tests/framework/web/ErrorActionTest.php
@@ -7,7 +7,6 @@ use yii\base\InvalidConfigException;
 use yii\base\UserException;
 use yii\web\Controller;
 use yii\web\ErrorAction;
-use yii\web\Request;
 use yiiunit\TestCase;
 
 /**
@@ -18,16 +17,15 @@ class ErrorActionTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-
-        $this->mockApplication([
-            'components' => [
-                'request' => [
-                    'class' => Request::className(),
-                ],
-            ],
-        ]);
+        $this->mockWebApplication();
     }
 
+    /**
+     * Creates a controller instance
+     *
+     * @param array $actionConfig
+     * @return TestController
+     */
     public function getController($actionConfig = [])
     {
         return new TestController('test', Yii::$app, ['layout' => false, 'actionConfig' => $actionConfig]);
@@ -38,6 +36,7 @@ class ErrorActionTest extends TestCase
         Yii::$app->getErrorHandler()->exception = new InvalidConfigException('This message will not be shown to the user');
 
         $this->assertEquals('Name: Invalid Configuration
+Code: 500
 Message: An internal server error occurred.
 Exception: yii\base\InvalidConfigException', $this->getController()->runAction('error'));
     }
@@ -47,6 +46,7 @@ Exception: yii\base\InvalidConfigException', $this->getController()->runAction('
         Yii::$app->getErrorHandler()->exception = new UserException('User can see this error message');
 
         $this->assertEquals('Name: Exception
+Code: 500
 Message: User can see this error message
 Exception: yii\base\UserException', $this->getController()->runAction('error'));
     }
@@ -63,6 +63,7 @@ Exception: yii\base\UserException', $this->getController()->runAction('error'));
         Yii::$app->getErrorHandler()->exception = new \InvalidArgumentException('This message will not be shown to the user');
 
         $this->assertEquals('Name: Error
+Code: 500
 Message: An internal server error occurred.
 Exception: InvalidArgumentException', $this->getController()->runAction('error'));
     }
@@ -77,6 +78,7 @@ Exception: InvalidArgumentException', $this->getController()->runAction('error')
         ]);
 
         $this->assertEquals('Name: Oops...
+Code: 500
 Message: The system is drunk
 Exception: InvalidArgumentException', $controller->runAction('error'));
     }
@@ -84,6 +86,7 @@ Exception: InvalidArgumentException', $controller->runAction('error'));
     public function testNoExceptionInHandler()
     {
         $this->assertEquals('Name: Not Found (#404)
+Code: 404
 Message: Page not found.
 Exception: yii\web\NotFoundHttpException', $this->getController()->runAction('error'));
     }
@@ -95,7 +98,8 @@ Exception: yii\web\NotFoundHttpException', $this->getController()->runAction('er
 
         // Unset view name. Class should try to load view that matches action name by default
         $action->view = null;
-        $this->setExpectedExceptionRegExp('yii\base\ViewNotFoundException', '#The view file does not exist: .*?views/test/error.php#');
+        $ds = preg_quote(DIRECTORY_SEPARATOR, '\\');
+        $this->setExpectedExceptionRegExp('yii\base\ViewNotFoundException', '#The view file does not exist: .*?views' . $ds . 'test' . $ds . 'error.php#');
         $this->invokeMethod($action, 'renderHtmlResponse');
     }
 

--- a/tests/framework/web/ErrorHandlerTest.php
+++ b/tests/framework/web/ErrorHandlerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace yiiunit\framework\web;
+
+use Yii;
+use yii\web\NotFoundHttpException;
+use yiiunit\TestCase;
+
+class ErrorHandlerTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mockWebApplication([
+            'components' => [
+                'errorHandler' => [
+                    'class' => 'yiiunit\framework\web\ErrorHandler',
+                    'errorView' => '@yiiunit/data/views/errorHandler.php',
+                ],
+            ],
+        ]);
+    }
+
+    public function testCorrectResponseCodeInErrorView()
+       {
+           /** @var ErrorHandler $handler */
+           $handler = Yii::$app->getErrorHandler();
+           $this->invokeMethod($handler, 'renderException', [new NotFoundHttpException('This message is displayed to end user')]);
+           $out = Yii::$app->response->data;
+           $this->assertEquals('Code: 404
+Message: This message is displayed to end user
+Exception: yii\web\NotFoundHttpException', $out);
+       }
+}
+
+class ErrorHandler extends \yii\web\ErrorHandler
+{
+    /**
+     * @return bool if simple HTML should be rendered
+     */
+    protected function shouldRenderSimpleHtml()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
…nse code to response object before rendering error view

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | #13707
