### PR TITLE
Update BaseHtml.php

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1298,8 +1298,8 @@ class BaseHtml
             unset($options['maxlength']);
             $attrName = static::getAttributeName($attribute);
             foreach ($model->getActiveValidators($attrName) as $validator) {
-                if ($validator instanceof StringValidator && $validator->max !== null) {
-                    $options['maxlength'] = $validator->max;
+                if ($validator instanceof yii\Validators\StringValidator && ($validator->max !== null || $validator->length !== null)) {
+                    $options['maxlength'] = ($validator->length !== null ? $validator->length : $validator->max);
                     break;
                 }
             }


### PR DESCRIPTION
For test for instances when using namespaces, neeed use fully qualified class name: http://php.net/manual/en/language.operators.type.php#106882

The maximum length of a string is limited both by the "max" parameter of the validator and by the "length" parameter: http://www.yiiframework.com/doc-2.0/yii-validators-stringvalidator.html#$length-detail

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
