### PR TITLE
Improve SQL LIKE condition handling and testing (fixes #13745)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -45,6 +45,7 @@ Yii Framework 2 Change Log
 - Enh: Added `yii\di\Instance::__set_state()` method to restore object after serialization using `var_export()` function (silvefire)
 - Enh #13695: `\yii\web\Response::setStatusCode()` method now returns the Response object itself (kyle-mccarthy)
 - Enh #13698: `yii\grid\DataColumn` filter is automatically generated as dropdown list in case of `format` set to `boolean` (bizley)
+- Bug #13745: `SQLSTATE[HY093]: Invalid parameter number: parameter was not defined` in MSSQL and bug fixes in `yii\db\QueryBuilder::buildLikeCondition()` (sergeymakinen)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -45,7 +45,6 @@ Yii Framework 2 Change Log
 - Enh: Added `yii\di\Instance::__set_state()` method to restore object after serialization using `var_export()` function (silvefire)
 - Enh #13695: `\yii\web\Response::setStatusCode()` method now returns the Response object itself (kyle-mccarthy)
 - Enh #13698: `yii\grid\DataColumn` filter is automatically generated as dropdown list in case of `format` set to `boolean` (bizley)
-- Bug #13745: `SQLSTATE[HY093]: Invalid parameter number: parameter was not defined` in MSSQL and bug fixes in `yii\db\QueryBuilder::buildLikeCondition()` (sergeymakinen)
 
 
 2.0.11.2 February 08, 2017

--- a/framework/db/cubrid/QueryBuilder.php
+++ b/framework/db/cubrid/QueryBuilder.php
@@ -47,7 +47,15 @@ class QueryBuilder extends \yii\db\QueryBuilder
     /**
      * @inheritdoc
      */
-    protected $likeEscapeCharacter = '\\';
+    protected $likeEscapeCharacter = '!';
+    /**
+     * @inheritdoc
+     */
+    protected $likeEscapingReplacements = [
+        '%' => '!%',
+        '_' => '!_',
+        '!' => '!!',
+    ];
 
     /**
      * Creates a SQL statement for resetting the sequence value of a table's primary key.

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -49,16 +49,12 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * @inheritdoc
      */
     protected $likeEscapingReplacements = [
-        '%' => '\%',
-        '_' => '\_',
-        '[' => '\[',
-        ']' => '\]',
-        '\\' => '\\\\',
+        '%' => '[%]',
+        '_' => '[_]',
+        '[' => '[[]',
+        ']' => '[]]',
+        '\\' => '[\\]',
     ];
-    /**
-     * @inheritdoc
-     */
-    protected $likeEscapeCharacter = '\\';
 
     /**
      * @inheritdoc

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -49,7 +49,29 @@ class QueryBuilder extends \yii\db\QueryBuilder
     /**
      * @inheritdoc
      */
-    protected $likeEscapeCharacter = '\\';
+    protected $likeEscapeCharacter = '!';
+    /**
+     * @inheritdoc
+     */
+    protected $likeEscapingReplacements = [
+        '%' => '!%',
+        '_' => '!_',
+        '!' => '!!',
+        // \ will be checked later Because yii\db\Schema::quoteValue may quote it
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function init()
+    {
+        parent::init();
+        /*
+         * Different pdo_oci8 version may or may not implement PDO::quote(), so
+         * it may or may not fallback to yii\db\Schema::quoteValue() which quotes \.
+         */
+        $this->likeEscapingReplacements['\\'] = substr($this->db->quoteValue('\\'), 1, -1);
+    }
 
     /**
      * @inheritdoc

--- a/tests/framework/db/cubrid/QueryBuilderTest.php
+++ b/tests/framework/db/cubrid/QueryBuilderTest.php
@@ -12,7 +12,13 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
 {
     public $driverName = 'cubrid';
 
-    protected $likeEscapeCharSql = " ESCAPE '\\'";
+    protected $likeEscapeCharSql = " ESCAPE '!'";
+    protected $likeParameterReplacements = [
+        '\%' => '!%',
+        '\_' => '!_',
+        '\!' => '!!',
+        '\\\\' => '\\',
+    ];
 
     /**
      * this is not used as a dataprovider for testGetColumnType to speed up the test

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -14,9 +14,12 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
 {
     public $driverName = 'sqlsrv';
 
-    protected $likeEscapeCharSql = " ESCAPE '\\'";
     protected $likeParameterReplacements = [
-        '[abc]' => '\[abc\]',
+        '\%' => '[%]',
+        '\_' => '[_]',
+        '[' => '[[]',
+        ']' => '[]]',
+        '\\\\' => '[\\]',
     ];
 
     public function testOffsetLimit()

--- a/tests/framework/db/oci/QueryBuilderTest.php
+++ b/tests/framework/db/oci/QueryBuilderTest.php
@@ -76,18 +76,14 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
         $this->assertEquals($expected, $sql);
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function testBuildLikeCondition($condition, $expected, $expectedParams)
+    public function likeConditionProvider()
     {
         /*
-         * Different pdo_oci8 version may or may not implement PDO::quote(), so
-         * it may or may not fallback to yii\db\Schema::quoteValue() which quotes \.
+         * Different pdo_oci8 versions may or may not implement PDO::quote(), so
+         * yii\db\Schema::quoteValue() may or may not quote \.
          */
         $encodedBackslash = substr($this->getDb()->quoteValue('\\'), 1, -1);
         $this->likeParameterReplacements[$encodedBackslash] = '\\';
-        parent::testBuildLikeCondition($condition, $expected, $expectedParams);
+        return parent::likeConditionProvider();
     }
-
 }

--- a/tests/framework/db/oci/QueryBuilderTest.php
+++ b/tests/framework/db/oci/QueryBuilderTest.php
@@ -12,7 +12,12 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
 {
     public $driverName = 'oci';
 
-    protected $likeEscapeCharSql = " ESCAPE '\\'";
+    protected $likeEscapeCharSql = " ESCAPE '!'";
+    protected $likeParameterReplacements = [
+        '\%' => '!%',
+        '\_' => '!_',
+        '!' => '!!',
+    ];
 
     /**
      * this is not used as a dataprovider for testGetColumnType to speed up the test
@@ -70,4 +75,19 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
         $sql = $qb->resetSequence('item', 4);
         $this->assertEquals($expected, $sql);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function testBuildLikeCondition($condition, $expected, $expectedParams)
+    {
+        /*
+         * Different pdo_oci8 version may or may not implement PDO::quote(), so
+         * it may or may not fallback to yii\db\Schema::quoteValue() which quotes \.
+         */
+        $encodedBackslash = substr($this->getDb()->quoteValue('\\'), 1, -1);
+        $this->likeParameterReplacements[$encodedBackslash] = '\\';
+        parent::testBuildLikeCondition($condition, $expected, $expectedParams);
+    }
+
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13745 

This PR adds real db tests of QueryBuilder’s `LIKE` handling and fixes all bugs I found for now:

- Cubrid doesn’t like `\`, it’s okay with `!`
- Oracle doesn’t have a quote char by default at all, moreover later pro_oci versions (in PHP 7.x) handle quoting so they won’t quote `\` while in PHP 5.x Yii will do it by itself (which leads to another bug, that inserts `\\` instead of `\` but it’s another issue…)
- sqlsrv driver doesn’t like preparing (it keeps telling about placeholders/params count mismatch) when using `ESCAPE`
