### PR TITLE
Store regex for attribute names in one place. Allow '+' character.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -46,8 +46,7 @@ Yii Framework 2 Change Log
 - Enh #13695: `\yii\web\Response::setStatusCode()` method now returns the Response object itself (kyle-mccarthy)
 - Enh #13698: `yii\grid\DataColumn` filter is automatically generated as dropdown list in case of `format` set to `boolean` (bizley)
 - Enh #13254: Core validators no longer require Yii::$app to be set (sammousa)
-- Bug #4408: Add support for unicode word characters in attribute names (sammousa, kmindi)
-- Enh #13765: Allow non-word character '+' in attribute names (sammousa)
+- Bug #4408: Add support for unicode word characters and `+` character in attribute names (sammousa, kmindi)
 
 2.0.11.2 February 08, 2017
 --------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -45,7 +45,8 @@ Yii Framework 2 Change Log
 - Enh: Added `yii\di\Instance::__set_state()` method to restore object after serialization using `var_export()` function (silvefire)
 - Enh #13695: `\yii\web\Response::setStatusCode()` method now returns the Response object itself (kyle-mccarthy)
 - Enh #13698: `yii\grid\DataColumn` filter is automatically generated as dropdown list in case of `format` set to `boolean` (bizley)
-
+- Bug #4408: Add support for unicode word characters in attribute names. (sammousa, kmindi)
+- Enh #13765: Allow non-word character '+' in attribute names. (sammousa)
 
 2.0.11.2 February 08, 2017
 --------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -45,8 +45,8 @@ Yii Framework 2 Change Log
 - Enh: Added `yii\di\Instance::__set_state()` method to restore object after serialization using `var_export()` function (silvefire)
 - Enh #13695: `\yii\web\Response::setStatusCode()` method now returns the Response object itself (kyle-mccarthy)
 - Enh #13698: `yii\grid\DataColumn` filter is automatically generated as dropdown list in case of `format` set to `boolean` (bizley)
-- Bug #4408: Add support for unicode word characters in attribute names. (sammousa, kmindi)
-- Enh #13765: Allow non-word character '+' in attribute names. (sammousa)
+- Bug #4408: Add support for unicode word characters in attribute names (sammousa, kmindi)
+- Enh #13765: Allow non-word character '+' in attribute names (sammousa)
 
 2.0.11.2 February 08, 2017
 --------------------------

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -25,6 +25,10 @@ use yii\base\Model;
 class BaseHtml
 {
 
+    /**
+     * @var string Regular expression used for attribute name validation.
+     * @since 2.0.12
+     */
     public static $attributeRegex = '/(^|.*\])([\w\.\+]+)(\[.*|$)/u';
     /**
      * @var array list of void elements (element name => 1)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -24,6 +24,8 @@ use yii\base\Model;
  */
 class BaseHtml
 {
+
+    public static $attributeRegex = '/(^|.*\])([\w\.\+]+)(\[.*|$)/';
     /**
      * @var array list of void elements (element name => 1)
      * @see http://www.w3.org/TR/html-markup/syntax.html#void-element
@@ -2073,7 +2075,7 @@ class BaseHtml
      */
     public static function getAttributeName($attribute)
     {
-        if (preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/', $attribute, $matches)) {
+        if (preg_match(static::$attributeRegex, $attribute, $matches)) {
             return $matches[2];
         } else {
             throw new InvalidParamException('Attribute name must contain word characters only.');
@@ -2096,7 +2098,7 @@ class BaseHtml
      */
     public static function getAttributeValue($model, $attribute)
     {
-        if (!preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/', $attribute, $matches)) {
+        if (!preg_match(static::$attributeRegex, $attribute, $matches)) {
             throw new InvalidParamException('Attribute name must contain word characters only.');
         }
         $attribute = $matches[2];
@@ -2146,7 +2148,7 @@ class BaseHtml
     public static function getInputName($model, $attribute)
     {
         $formName = $model->formName();
-        if (!preg_match('/(^|.*\])([\w\.]+)(\[.*|$)/', $attribute, $matches)) {
+        if (!preg_match(static::$attributeRegex, $attribute, $matches)) {
             throw new InvalidParamException('Attribute name must contain word characters only.');
         }
         $prefix = $matches[1];

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -25,7 +25,7 @@ use yii\base\Model;
 class BaseHtml
 {
 
-    public static $attributeRegex = '/(^|.*\])([\w\.\+]+)(\[.*|$)/';
+    public static $attributeRegex = '/(^|.*\])([\w\.\+]+)(\[.*|$)/u';
     /**
      * @var array list of void elements (element name => 1)
      * @see http://www.w3.org/TR/html-markup/syntax.html#void-element

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1260,6 +1260,55 @@ EOD;
         $model->checkbox = $value;
         $this->assertEquals($expectedHtml, Html::activeCheckbox($model, 'checkbox', $options));
     }
+
+    /**
+     * Data provider for [[testAttributeNameValidation()]]
+     * @return array test data
+     */
+    public function dataProviderAttributeNames()
+    {
+        return [
+            ["asd]asdf.asdfa[asdfa", "asdf.asdfa"],
+            ["a", "a"],
+            ["[0]a", "a"],
+            ["a[0]", "a"],
+            ["[0]a[0]", "a"],
+            ["[0]a.[0]", "a."],
+
+            // Unicode checks.
+            ["ä", "ä"],
+            ["ä", "ä"],
+            ["asdf]öáöio..[asdfasdf", "öáöio.."],
+            ["öáöio", "öáöio"],
+            ["[0]test.ööößß.d", "test.ööößß.d"],
+            ["ИІК", "ИІК"],
+            ["]ИІК[", "ИІК"],
+            ["[0]ИІК[0]", "ИІК"],
+
+            // Exception checks
+            ['. ..', null],
+            ['a +b', null],
+            ['a,b', null]
+
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderAttributeNames
+     *
+     * @param string $name
+     * @param string|null $expected
+     */
+    public function testAttributeNameValidation($name, $expected)
+    {
+        if (!isset($expected)) {
+            $this->setExpectedException('yii\base\InvalidParamException');
+            Html::getAttributeName($name);
+        } else {
+            $this->assertEquals($expected, Html::getAttributeName($name));
+        }
+
+    }
 }
 
 /**

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1301,7 +1301,7 @@ EOD;
     }
 
     /**
-     * @dataProvider dataProviderAttributeNames
+     * @dataProvider dataProviderValidAttributeNames
      *
      * @param string $name
      * @param string $expected

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1265,7 +1265,7 @@ EOD;
      * Data provider for [[testAttributeNameValidation()]]
      * @return array test data
      */
-    public function dataProviderAttributeNames()
+    public function dataProviderValidAttributeNames()
     {
         return [
             ["asd]asdf.asdfa[asdfa", "asdf.asdfa"],
@@ -1283,12 +1283,20 @@ EOD;
             ["[0]test.ööößß.d", "test.ööößß.d"],
             ["ИІК", "ИІК"],
             ["]ИІК[", "ИІК"],
-            ["[0]ИІК[0]", "ИІК"],
+            ["[0]ИІК[0]", "ИІК"]
+        ];
+    }
 
-            // Exception checks
-            ['. ..', null],
-            ['a +b', null],
-            ['a,b', null]
+        /**
+     * Data provider for [[testAttributeNameValidation()]]
+     * @return array test data
+     */
+    public function dataProviderInvalidAttributeNames()
+    {
+        return [
+            '. ..',
+            'a +b',
+            'a,b',
 
         ];
     }
@@ -1308,6 +1316,18 @@ EOD;
             $this->assertEquals($expected, Html::getAttributeName($name));
         }
 
+    }
+    
+    /**
+     * @dataProvider dataProviderInvalidAttributeNames
+     *
+     * @param string $name
+     * @param string|null $expected
+     */
+    public function testAttributeNameException($name)
+    {
+        $this->setExpectedException('yii\base\InvalidParamException');
+        Html::getAttributeName($name);
     }
 }
 

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1265,7 +1265,7 @@ EOD;
      * Data provider for [[testAttributeNameValidation()]]
      * @return array test data
      */
-    public function dataProviderValidAttributeNames()
+    public function validAttributeNamesProvider()
     {
         return [
             ["asd]asdf.asdfa[asdfa", "asdf.asdfa"],
@@ -1291,17 +1291,17 @@ EOD;
      * Data provider for [[testAttributeNameValidation()]]
      * @return array test data
      */
-    public function dataProviderInvalidAttributeNames()
+    public function invalidAttributeNamesProvider()
     {
         return [
-            '. ..',
-            'a +b',
-            'a,b'
+            ['. ..'],
+            ['a +b'],
+            ['a,b']
         ];
     }
 
     /**
-     * @dataProvider dataProviderValidAttributeNames
+     * @dataProvider validAttributeNamesProvider
      *
      * @param string $name
      * @param string $expected
@@ -1317,7 +1317,7 @@ EOD;
     }
     
     /**
-     * @dataProvider dataProviderInvalidAttributeNames
+     * @dataProvider invalidAttributeNamesProvider
      *
      * @param string $name
      */

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1287,7 +1287,7 @@ EOD;
         ];
     }
 
-        /**
+    /**
      * Data provider for [[testAttributeNameValidation()]]
      * @return array test data
      */
@@ -1296,8 +1296,7 @@ EOD;
         return [
             '. ..',
             'a +b',
-            'a,b',
-
+            'a,b'
         ];
     }
 
@@ -1305,7 +1304,7 @@ EOD;
      * @dataProvider dataProviderAttributeNames
      *
      * @param string $name
-     * @param string|null $expected
+     * @param string $expected
      */
     public function testAttributeNameValidation($name, $expected)
     {
@@ -1315,14 +1314,12 @@ EOD;
         } else {
             $this->assertEquals($expected, Html::getAttributeName($name));
         }
-
     }
     
     /**
      * @dataProvider dataProviderInvalidAttributeNames
      *
      * @param string $name
-     * @param string|null $expected
      */
     public function testAttributeNameException($name)
     {


### PR DESCRIPTION
Partial fix. Moves the regex to one place and adds support for the `+` character.
Does not add support for other non-word characters as mentioned in #4408.


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #4408 
