### PR TITLE
Fixes #13704: Unique validator doesn't prefix attribute name with model's database table name

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -48,6 +48,7 @@ Yii Framework 2 Change Log
 - Enh #13254: Core validators no longer require Yii::$app to be set (sammousa)
 - Bug #4408: Add support for unicode word characters and `+` character in attribute names (sammousa, kmindi)
 - Bug #10372: Fixed console controller including complex typed arguments in help (sammousa)
+- Bug #13704: Fixed `yii\validators\UniqueValidator` was not prefixing attribute name with model's database table name (vladis84)
 
 2.0.11.2 February 08, 2017
 --------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -48,7 +48,7 @@ Yii Framework 2 Change Log
 - Enh #13254: Core validators no longer require Yii::$app to be set (sammousa)
 - Bug #4408: Add support for unicode word characters and `+` character in attribute names (sammousa, kmindi)
 - Bug #10372: Fixed console controller including complex typed arguments in help (sammousa)
-- Bug #13704: Fixed `yii\validators\UniqueValidator` was not prefixing attribute name with model's database table name (vladis84)
+- Bug #13704: Fixed `yii\validators\UniqueValidator` to prefix attribute name with model's database table name (vladis84)
 
 2.0.11.2 February 08, 2017
 --------------------------

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -148,7 +148,7 @@ class UniqueValidator extends Validator
      */
     private function getTargetClass($model)
     {
-        return is_null($this->targetClass) ? get_class($model) : $this->targetClass;
+        return $this->targetClass === null ? get_class($model) : $this->targetClass;
     }
 
     /**

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -144,7 +144,7 @@ class UniqueValidator extends Validator
 
     /**
      * @param Model $model the data model to be validated
-     * @return string Target class name.
+     * @return string Target class name
      */
     private function getTargetClass($model)
     {
@@ -248,7 +248,7 @@ class UniqueValidator extends Validator
             return $conditions;
         }
 
-        // Add table prefix for column.
+        // Add table prefix for column
         $targetClass = $this->getTargetClass($model);
         $tableName = $targetClass::tableName();
         $conditionsWithTableName = [];

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -10,6 +10,7 @@ namespace yii\validators;
 use Yii;
 use yii\base\Model;
 use yii\db\ActiveQuery;
+use yii\db\ActiveRecord;
 use yii\db\ActiveQueryInterface;
 use yii\db\ActiveRecordInterface;
 use yii\db\Query;
@@ -119,7 +120,7 @@ class UniqueValidator extends Validator
     public function validateAttribute($model, $attribute)
     {
         /* @var $targetClass ActiveRecordInterface */
-        $targetClass = $this->targetClass === null ? get_class($model) : $this->targetClass;
+        $targetClass = $this->getTargetClass($model);
         $targetAttribute = $this->targetAttribute === null ? $attribute : $this->targetAttribute;
         $rawConditions = $this->prepareConditions($targetAttribute, $model, $attribute);
         $conditions[] = $this->targetAttributeJunction === 'or' ? 'or' : 'and';
@@ -139,6 +140,15 @@ class UniqueValidator extends Validator
                 $this->addError($model, $attribute, $this->message);
             }
         }
+    }
+
+    /**
+     * @param Model $model the data model to be validated
+     * @return string Target class name.
+     */
+    private function getTargetClass($model)
+    {
+        return is_null($this->targetClass) ? get_class($model) : $this->targetClass;
     }
 
     /**
@@ -234,7 +244,20 @@ class UniqueValidator extends Validator
             $conditions = [$targetAttribute => $model->$attribute];
         }
 
-        return $conditions;
+        if (!$model instanceof ActiveRecord) {
+            return $conditions;
+        }
+
+        // Add table prefix for column.
+        $targetClass = $this->getTargetClass($model);
+        $tableName = $targetClass::tableName();
+        $conditionsWithTableName = [];
+        foreach ($conditions as $columnName => $columnValue) {
+            $columnNameWithPrefix = "{$tableName}.$columnName";
+            $conditionsWithTableName[$columnNameWithPrefix] = $columnValue;
+        }
+
+        return $conditionsWithTableName;
     }
 
     /**

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -332,7 +332,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $expected = ['val_attr_b' => 'test value b', 'val_attr_c' => 'test value a'];
         $this->assertEquals($expected, $result);
 
-        // Add table prefix for column name.
+        // Add table prefix for column name
         $model = Profile::findOne(1);
         $attribute = 'id';
         $targetAttribute = 'id';
@@ -341,7 +341,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testGetTargetClassFilledPropertyTargetClass()
+    public function testGetTargetClassWithFilledTargetClassProperty()
     {
         $validator = new UniqueValidator(['targetClass' => Profile::className()]);
         $model = new FakedValidationModel();
@@ -350,7 +350,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $this->assertEquals(Profile::className(), $actualTargetClass);
     }
 
-    public function testGetTargetClassNotFilledPropertyTargetClass()
+    public function testGetTargetClassWithNotFilledTargetClassProperty()
     {
         $validator = new UniqueValidator();
         $model = new FakedValidationModel();

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -343,14 +343,14 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
 
     public function testGetTargetClass()
     {
-        // Filled validator target class.
+        // Filled property targetClass.
         $validator = new UniqueValidator();
         $validator->targetClass = 'target class';
         $model = new FakedValidationModel();
         $actualTargetClass = $this->invokeMethod($validator, 'getTargetClass', [$model]);
         $this->assertEquals('target class', $actualTargetClass);
 
-        // Not filled validator target class.
+        // Not filled property targetClass.
         $validator = new UniqueValidator();
         $model = new FakedValidationModel();
         $actualTargetClass = $this->invokeMethod($validator, 'getTargetClass', [$model]);

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -331,6 +331,31 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $result = $this->invokeMethod(new UniqueValidator(), 'prepareConditions', [$targetAttribute, $model, $attribute]);
         $expected = ['val_attr_b' => 'test value b', 'val_attr_c' => 'test value a'];
         $this->assertEquals($expected, $result);
+
+        // Add table prefix for column name.
+        $model = Profile::findOne(1);
+        $attribute = 'id';
+        $targetAttribute = 'id';
+        $result = $this->invokeMethod(new UniqueValidator(), 'prepareConditions', [$targetAttribute, $model, $attribute]);
+        $expected = [Profile::tableName() . '.' . $attribute => $model->id];
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetTargetClass()
+    {
+        // Filled validator target class.
+        $validator = new UniqueValidator();
+        $validator->targetClass = 'target class';
+        $model = new FakedValidationModel();
+        $actualTargetClass = $this->invokeMethod($validator, 'getTargetClass', [$model]);
+        $this->assertEquals('target class', $actualTargetClass);
+
+        // Not filled validator target class.
+        $validator = new UniqueValidator();
+        $model = new FakedValidationModel();
+        $actualTargetClass = $this->invokeMethod($validator, 'getTargetClass', [$model]);
+        $expectedTargetClass = FakedValidationModel::className();
+        $this->assertEquals($expectedTargetClass, $actualTargetClass);
     }
 
     public function testPrepareQuery()

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -341,21 +341,22 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testGetTargetClass()
+    public function testGetTargetClassFilledPropertyTargetClass()
     {
-        // Filled property targetClass.
-        $validator = new UniqueValidator();
-        $validator->targetClass = 'target class';
+        $validator = new UniqueValidator(['targetClass' => Profile::className()]);
         $model = new FakedValidationModel();
         $actualTargetClass = $this->invokeMethod($validator, 'getTargetClass', [$model]);
-        $this->assertEquals('target class', $actualTargetClass);
 
-        // Not filled property targetClass.
+        $this->assertEquals(Profile::className(), $actualTargetClass);
+    }
+
+    public function testGetTargetClassNotFilledPropertyTargetClass()
+    {
         $validator = new UniqueValidator();
         $model = new FakedValidationModel();
         $actualTargetClass = $this->invokeMethod($validator, 'getTargetClass', [$model]);
-        $expectedTargetClass = FakedValidationModel::className();
-        $this->assertEquals($expectedTargetClass, $actualTargetClass);
+        
+        $this->assertEquals(FakedValidationModel::className(), $actualTargetClass);
     }
 
     public function testPrepareQuery()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13704
