### PR TITLE
Allow limiting the length of the sql string that will be printed

### DIFF
--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -63,7 +63,8 @@ class Migration extends Component implements MigrationInterface
     public $db = 'db';
 
     /**
-     * @var int length of the string that will be printed on the screen.
+     * @var int length of the printed SQL. Useful for reduction of long statements and making console output more 
+     * compact and readable.
      */
     public $printedSqlLength;
 

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -191,7 +191,6 @@ class Migration extends Component implements MigrationInterface
     public function execute($sql, $params = [])
     {
         $printedSql = $sql;
-
         if ($this->printedSqlLength !== null) {
             $printedSql = StringHelper::truncate($sql, $this->printedSqlLength, '[... hidden]');
         }

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -61,6 +61,11 @@ class Migration extends Component implements MigrationInterface
      */
     public $db = 'db';
 
+    /**
+     * @var int length of the string that will be printed on the screen.
+     */
+    public $printSqlLength = 0;
+
 
     /**
      * Initializes the migration.
@@ -180,12 +185,11 @@ class Migration extends Component implements MigrationInterface
      * This method executes the specified SQL statement using [[db]].
      * @param string $sql the SQL statement to be executed
      * @param array $params input parameters (name => value) for the SQL execution.
-     * @param int $printSqlLength length of the string that will be printed on the screen.
      * See [[Command::execute()]] for more details.
      */
-    public function execute($sql, $params = [], $printSqlLength = 0)
+    public function execute($sql, $params = [])
     {
-        $sqlPrint = ($printSqlLength === 0 || strlen($sql) <= $printSqlLength) ? $sql : substr($sql, 0, $printSqlLength) . "(...hidden)";
+        $sqlPrint = ($this->printSqlLength === 0 || strlen($sql) <= $this->printSqlLength) ? $sql : substr($sql, 0, $this->printSqlLength) . "[...hidden]";
         echo "    > execute SQL: $sqlPrint ...";
         $time = microtime(true);
         $this->db->createCommand($sql)->bindValues($params)->execute();

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -180,11 +180,13 @@ class Migration extends Component implements MigrationInterface
      * This method executes the specified SQL statement using [[db]].
      * @param string $sql the SQL statement to be executed
      * @param array $params input parameters (name => value) for the SQL execution.
+     * @param int $printSqlLength length of the string that will be printed on the screen.
      * See [[Command::execute()]] for more details.
      */
-    public function execute($sql, $params = [])
+    public function execute($sql, $params = [], $printSqlLength = 0)
     {
-        echo "    > execute SQL: $sql ...";
+        $sqlPrint = ($printSqlLength === 0 || strlen($sql) <= $printSqlLength) ? $sql : substr($sql, 0, $printSqlLength) . "(...hidden)";
+        echo "    > execute SQL: $sqlPrint ...";
         $time = microtime(true);
         $this->db->createCommand($sql)->bindValues($params)->execute();
         echo ' done (time: ' . sprintf('%.3f', microtime(true) - $time) . "s)\n";

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -65,7 +65,7 @@ class Migration extends Component implements MigrationInterface
     /**
      * @var int length of the string that will be printed on the screen.
      */
-    public $printSqlLength;
+    public $printedSqlLength;
 
     /**
      * Initializes the migration.
@@ -189,13 +189,13 @@ class Migration extends Component implements MigrationInterface
      */
     public function execute($sql, $params = [])
     {
-        $sqlPrint = $sql;
+        $printedSql = $sql;
 
-        if ($this->printSqlLength !== null) {
-            $sqlPrint = StringHelper::truncate($sql, $this->printSqlLength, '[...hidden]');
+        if ($this->printedSqlLength !== null) {
+            $printedSql = StringHelper::truncate($sql, $this->printedSqlLength, '[... hidden]');
         }
 
-        echo "    > execute SQL: $sqlPrint ...";
+        echo "    > execute SQL: $printedSql ...";
         $time = microtime(true);
         $this->db->createCommand($sql)->bindValues($params)->execute();
         echo ' done (time: ' . sprintf('%.3f', microtime(true) - $time) . "s)\n";

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -9,6 +9,7 @@ namespace yii\db;
 
 use yii\base\Component;
 use yii\di\Instance;
+use yii\helpers\StringHelper;
 
 /**
  * Migration is the base class for representing a database migration.
@@ -64,8 +65,7 @@ class Migration extends Component implements MigrationInterface
     /**
      * @var int length of the string that will be printed on the screen.
      */
-    public $printSqlLength = 0;
-
+    public $printSqlLength;
 
     /**
      * Initializes the migration.
@@ -191,8 +191,8 @@ class Migration extends Component implements MigrationInterface
     {
         $sqlPrint = $sql;
 
-        if ($this->printSqlLength !== 0 && mb_strlen($sql) > $this->printSqlLength) {
-            $sqlPrint = mb_substr($sql, 0, $this->printSqlLength) . "[...hidden]";
+        if ($this->printSqlLength !== null) {
+            $sqlPrint = StringHelper::truncate($sql, $this->printSqlLength, '[...hidden]');
         }
 
         echo "    > execute SQL: $sqlPrint ...";

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -189,7 +189,12 @@ class Migration extends Component implements MigrationInterface
      */
     public function execute($sql, $params = [])
     {
-        $sqlPrint = ($this->printSqlLength === 0 || strlen($sql) <= $this->printSqlLength) ? $sql : substr($sql, 0, $this->printSqlLength) . "[...hidden]";
+        $sqlPrint = $sql;
+
+        if ($this->printSqlLength !== 0 && mb_strlen($sql) > $this->printSqlLength) {
+            $sqlPrint = mb_substr($sql, 0, $this->printSqlLength) . "[...hidden]";
+        }
+
         echo "    > execute SQL: $sqlPrint ...";
         $time = microtime(true);
         $this->db->createCommand($sql)->bindValues($params)->execute();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

When we run a migration with a very large view, for example, it is bad to follow the migration progress on the screen.