### PR TITLE
Fix error during handling of closure errors

### DIFF
--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -191,7 +191,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
         $url = null;
 
         $shouldGenerateLink = true;
-        if ($method !== null) {
+        if ($method !== null  && substr_compare($method, '{closure}', -9) !== 0) {
             $reflection = new \ReflectionMethod($class, $method);
             $shouldGenerateLink = $reflection->isPublic() || $reflection->isProtected();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | -
| Fixed issues  | https://github.com/yiisoft/yii2/issues/13689

If an error occurs inside a closure method, the error handler will fail. For example:

```php
        $x = array_map(function ($r) {
            return $r->doesnotexist;
        }, [1, 2, 3]);
```

Will lead to:

> An Error occurred while handling another error:
ReflectionException: Method app\controllers\ClientController::app\controllers\{closure}() does not exist in /var/www/vendor/yiisoft/yii2/web/ErrorHandler.php:199

The fix is easy, but I was not sure how to properly test this.