### PR TITLE
Add new HTTP status code 451

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.12 under development
 --------------------------
-
+- Enh #13820: Add new HTTP status code 451 (yyxx9988)
 - Bug #13671: Fixed error handler trace to work correctly with XDebug (samdark)
 - Bug #13657: Fixed `yii\helpers\StringHelper::truncateHtml()` skip extra tags at the end (sam002)
 - Bug #7946: Fixed a bug when the `form` attribute was not propagated to the hidden input of the checkbox (Kolyunya)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,6 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.12 under development
 --------------------------
+
 - Enh #13820: Add new HTTP status code 451 (yyxx9988)
 - Bug #13671: Fixed error handler trace to work correctly with XDebug (samdark)
 - Bug #13657: Fixed `yii\helpers\StringHelper::truncateHtml()` skip extra tags at the end (sam002)

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -216,6 +216,7 @@ class Response extends \yii\base\Response
         431 => 'Request Header Fields Too Large',
         449 => 'Retry With',
         450 => 'Blocked by Windows Parental Controls',
+        451 => 'Unavailable For Legal Reasons',
         500 => 'Internal Server Error',
         501 => 'Not Implemented',
         502 => 'Bad Gateway or Proxy Error',


### PR DESCRIPTION
> Unavailable For Legal Reasons (RFC 7725)
> A server operator has received a legal demand to deny access to a resource or to a set of resources that includes the requested resource. The code 451 was chosen as a reference to the novel Fahrenheit 451.

See https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_errors for more info.