### PR TITLE
Fix a bug in `yii\web\User::loginRequired()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -54,6 +54,7 @@ Yii Framework 2 Change Log
 - Bug #13776: Fixed setting precision and scale for decimal columns in MSSQL (arturf)
 - Bug #13704: Fixed `yii\validators\UniqueValidator` to prefix attribute name with model's database table name (vladis84)
 - Enh #13823: Refactored migrations template (Kolyunya)
+- Bug #13822: Fixed `yii\web\User::loginRequired()` to throw an `UnauthorizedHttpException` instead of a `ForbiddenHttpException` (Kolyunya)
 
 2.0.11.2 February 08, 2017
 --------------------------

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -404,7 +404,7 @@ class User extends Component
      * the request does not accept HTML responses the current URL will not be SET as the return URL. Also instead of
      * redirecting the user an ForbiddenHttpException is thrown. This parameter is available since version 2.0.8.
      * @return Response the redirection response if [[loginUrl]] is set
-     * @throws ForbiddenHttpException the "Access Denied" HTTP exception if [[loginUrl]] is not set or a redirect is
+     * @throws UnauthorizedHttpException the "Unauthorized" HTTP exception if [[loginUrl]] is not set or a redirect is
      * not applicable.
      */
     public function loginRequired($checkAjax = true, $checkAcceptHeader = true)
@@ -424,7 +424,7 @@ class User extends Component
                 return Yii::$app->getResponse()->redirect($this->loginUrl);
             }
         }
-        throw new ForbiddenHttpException(Yii::t('yii', 'Login Required'));
+        throw new UnauthorizedHttpException(Yii::t('yii', 'Login Required'));
     }
 
     /**

--- a/tests/framework/web/UserTest.php
+++ b/tests/framework/web/UserTest.php
@@ -17,7 +17,7 @@ namespace yiiunit\framework\web;
 use yii\base\NotSupportedException;
 use yii\base\Component;
 use yii\rbac\PhpManager;
-use yii\web\ForbiddenHttpException;
+use yii\web\UnauthorizedHttpException;
 use yii\web\Cookie;
 use yii\web\CookieCollection;
 use yii\web\IdentityInterface;
@@ -226,7 +226,7 @@ class UserTest extends TestCase
         $_SERVER['HTTP_ACCEPT'] = 'text/json, */*; q=0.1';
         try {
             $user->loginRequired();
-        } catch (ForbiddenHttpException $e) {}
+        } catch (UnauthorizedHttpException $e) {}
         $this->assertFalse(Yii::$app->response->getIsRedirection());
 
         $this->reset();
@@ -263,12 +263,12 @@ class UserTest extends TestCase
         $_SERVER['HTTP_ACCEPT'] = 'text/json;q=0.1';
         try {
             $user->loginRequired();
-        } catch (ForbiddenHttpException $e) {}
+        } catch (UnauthorizedHttpException $e) {}
         $this->assertNotEquals('json-only', $user->getReturnUrl());
 
         $this->reset();
         $_SERVER['HTTP_ACCEPT'] = 'text/json;q=0.1';
-        $this->setExpectedException('yii\\web\\ForbiddenHttpException');
+        $this->setExpectedException('yii\\web\\UnauthorizedHttpException');
         $user->loginRequired();
     }
 
@@ -291,7 +291,7 @@ class UserTest extends TestCase
         $this->mockWebApplication($appConfig);
         $this->reset();
         $_SERVER['HTTP_ACCEPT'] = 'text/json,q=0.1';
-        $this->setExpectedException('yii\\web\\ForbiddenHttpException');
+        $this->setExpectedException('yii\\web\\UnauthorizedHttpException');
         Yii::$app->user->loginRequired();
     }
 


### PR DESCRIPTION
Throw Unauthorized HTTP exception instead of the Forbidden HTTP
exception when `loginUrl` is not set or a redirect is not applicable.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | #13822 
