### PR TITLE
suggest add target of validation to call handler

### DIFF
--- a/framework/validators/InlineValidator.php
+++ b/framework/validators/InlineValidator.php
@@ -69,7 +69,7 @@ class InlineValidator extends Validator
         if (is_string($method)) {
             $method = [$model, $method];
         }
-        call_user_func($method, $attribute, $this->params, $this);
+        call_user_func($method, $model, $attribute, $this->params, $this);
     }
 
     /**
@@ -83,7 +83,7 @@ class InlineValidator extends Validator
                 $method = [$model, $method];
             }
 
-            return call_user_func($method, $attribute, $this->params, $this);
+            return call_user_func($method, $model, $attribute, $this->params, $this);
         } else {
             return null;
         }


### PR DESCRIPTION
default it can solve via:
```php
['var', [$this->validator, 'validateVar'], 'params' => $this],
```
example handler now
```php
class MyValidator {
    public function validateVar($attribute, $params, $inlineValidator) {
        $model = $params;
    }
}
```

this issue allow write
```php
    public function validateVar($model, $attribute, $params, $inlineValidator)
```

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | not tested
