### PR TITLE
Update phpdoc, added @property-read for read-only property and @property-write for write-only property

### DIFF
--- a/framework/base/Action.php
+++ b/framework/base/Action.php
@@ -30,7 +30,7 @@ use Yii;
  *
  * For more details and usage information on Action, see the [guide article on actions](guide:structure-controllers).
  *
- * @property string $uniqueId The unique ID of this action among the whole application. This property is
+ * @property-read string $uniqueId The unique ID of this action among the whole application. This property is
  * read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -14,33 +14,33 @@ use Yii;
  *
  * For more details and usage information on Application, see the [guide article on applications](guide:structure-applications).
  *
- * @property \yii\web\AssetManager $assetManager The asset manager application component. This property is
+ * @property-read \yii\web\AssetManager $assetManager The asset manager application component. This property is
  * read-only.
- * @property \yii\rbac\ManagerInterface $authManager The auth manager application component. Null is returned
+ * @property-read \yii\rbac\ManagerInterface $authManager The auth manager application component. Null is returned
  * if auth manager is not configured. This property is read-only.
  * @property string $basePath The root directory of the application.
- * @property \yii\caching\Cache $cache The cache application component. Null if the component is not enabled.
+ * @property-read \yii\caching\Cache $cache The cache application component. Null if the component is not enabled.
  * This property is read-only.
- * @property array $container Values given in terms of name-value pairs. This property is write-only.
- * @property \yii\db\Connection $db The database connection. This property is read-only.
- * @property \yii\web\ErrorHandler|\yii\console\ErrorHandler $errorHandler The error handler application
+ * @property-write array $container Values given in terms of name-value pairs. This property is write-only.
+ * @property-read \yii\db\Connection $db The database connection. This property is read-only.
+ * @property-read \yii\web\ErrorHandler|\yii\console\ErrorHandler $errorHandler The error handler application
  * component. This property is read-only.
- * @property \yii\i18n\Formatter $formatter The formatter application component. This property is read-only.
- * @property \yii\i18n\I18N $i18n The internationalization application component. This property is read-only.
- * @property \yii\log\Dispatcher $log The log dispatcher application component. This property is read-only.
- * @property \yii\mail\MailerInterface $mailer The mailer application component. This property is read-only.
- * @property \yii\web\Request|\yii\console\Request $request The request component. This property is read-only.
- * @property \yii\web\Response|\yii\console\Response $response The response component. This property is
+ * @property-read \yii\i18n\Formatter $formatter The formatter application component. This property is read-only.
+ * @property-read \yii\i18n\I18N $i18n The internationalization application component. This property is read-only.
+ * @property-read \yii\log\Dispatcher $log The log dispatcher application component. This property is read-only.
+ * @property-read \yii\mail\MailerInterface $mailer The mailer application component. This property is read-only.
+ * @property-read \yii\web\Request|\yii\console\Request $request The request component. This property is read-only.
+ * @property-read \yii\web\Response|\yii\console\Response $response The response component. This property is
  * read-only.
  * @property string $runtimePath The directory that stores runtime files. Defaults to the "runtime"
  * subdirectory under [[basePath]].
- * @property \yii\base\Security $security The security application component. This property is read-only.
+ * @property-read \yii\base\Security $security The security application component. This property is read-only.
  * @property string $timeZone The time zone used by this application.
- * @property string $uniqueId The unique ID of the module. This property is read-only.
- * @property \yii\web\UrlManager $urlManager The URL manager for this application. This property is read-only.
+ * @property-read string $uniqueId The unique ID of the module. This property is read-only.
+ * @property-read \yii\web\UrlManager $urlManager The URL manager for this application. This property is read-only.
  * @property string $vendorPath The directory that stores vendor files. Defaults to "vendor" directory under
  * [[basePath]].
- * @property View|\yii\web\View $view The view application component that is used to render various view
+ * @property-read View|\yii\web\View $view The view application component that is used to render various view
  * files. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -92,7 +92,7 @@ use Yii;
  *
  * For more details and usage information on Component, see the [guide article on components](guide:concept-components).
  *
- * @property Behavior[] $behaviors List of behaviors attached to this component. This property is read-only.
+ * @property-read Behavior[] $behaviors List of behaviors attached to this component. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -14,11 +14,11 @@ use Yii;
  *
  * For more details and usage information on Controller, see the [guide article on controllers](guide:structure-controllers).
  *
- * @property Module[] $modules All ancestor modules that this controller is located within. This property is
+ * @property-read Module[] $modules All ancestor modules that this controller is located within. This property is
  * read-only.
- * @property string $route The route (module ID, controller ID and action ID) of the current request. This
+ * @property-read string $route The route (module ID, controller ID and action ID) of the current request. This
  * property is read-only.
- * @property string $uniqueId The controller ID that is prefixed with the module ID (if any). This property is
+ * @property-read string $uniqueId The controller ID that is prefixed with the module ID (if any). This property is
  * read-only.
  * @property View|\yii\web\View $view The view object that can be used to render views or view files.
  * @property string $viewPath The directory containing the view files for this controller.

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -37,18 +37,18 @@ use yii\validators\Validator;
  *
  * For more details and usage information on Model, see the [guide article on models](guide:structure-models).
  *
- * @property \yii\validators\Validator[] $activeValidators The validators applicable to the current
+ * @property-read \yii\validators\Validator[] $activeValidators The validators applicable to the current
  * [[scenario]]. This property is read-only.
  * @property array $attributes Attribute values (name => value).
- * @property array $errors An array of errors for all attributes. Empty array is returned if no error. The
+ * @property-read array $errors An array of errors for all attributes. Empty array is returned if no error. The
  * result is a two-dimensional array. See [[getErrors()]] for detailed description. This property is read-only.
- * @property array $firstErrors The first errors. The array keys are the attribute names, and the array values
+ * @property-read array $firstErrors The first errors. The array keys are the attribute names, and the array values
  * are the corresponding error messages. An empty array will be returned if there is no error. This property is
  * read-only.
- * @property ArrayIterator $iterator An iterator for traversing the items in the list. This property is
+ * @property-read ArrayIterator $iterator An iterator for traversing the items in the list. This property is
  * read-only.
  * @property string $scenario The scenario that this model is in. Defaults to [[SCENARIO_DEFAULT]].
- * @property ArrayObject|\yii\validators\Validator[] $validators All the validators declared in the model.
+ * @property-read ArrayObject|\yii\validators\Validator[] $validators All the validators declared in the model.
  * This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -23,15 +23,15 @@ use yii\di\ServiceLocator;
  *
  * For more details and usage information on Module, see the [guide article on modules](guide:structure-modules).
  *
- * @property array $aliases List of path aliases to be defined. The array keys are alias names (must start
+ * @property-write array $aliases List of path aliases to be defined. The array keys are alias names (must start
  * with `@`) and the array values are the corresponding paths or aliases. See [[setAliases()]] for an example.
  * This property is write-only.
  * @property string $basePath The root directory of the module.
- * @property string $controllerPath The directory that contains the controller classes. This property is
+ * @property-read string $controllerPath The directory that contains the controller classes. This property is
  * read-only.
  * @property string $layoutPath The root directory of layout files. Defaults to "[[viewPath]]/layouts".
  * @property array $modules The modules (indexed by their IDs).
- * @property string $uniqueId The unique ID of the module. This property is read-only.
+ * @property-read string $uniqueId The unique ID of the module. This property is read-only.
  * @property string $version The version of this module. Note that the type of this property differs in getter
  * and setter. See [[getVersion()]] and [[setVersion()]] for details.
  * @property string $viewPath The root directory of view files. Defaults to "[[basePath]]/views".

--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -20,7 +20,7 @@ use yii\widgets\FragmentCache;
  *
  * For more details and usage information on View, see the [guide article on views](guide:structure-views).
  *
- * @property string|bool $viewFile The view file currently being rendered. False if no view file is being
+ * @property-read string|bool $viewFile The view file currently being rendered. False if no view file is being
  * rendered. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/base/Widget.php
+++ b/framework/base/Widget.php
@@ -18,7 +18,7 @@ use ReflectionClass;
  * @property string $id ID of the widget.
  * @property \yii\web\View $view The view object that can be used to render views or view files. Note that the
  * type of this property differs in getter and setter. See [[getView()]] and [[setView()]] for details.
- * @property string $viewPath The directory containing the view files for this widget. This property is
+ * @property-read string $viewPath The directory containing the view files for this widget. This property is
  * read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/caching/MemCache.php
+++ b/framework/caching/MemCache.php
@@ -55,7 +55,7 @@ use yii\base\InvalidConfigException;
  *
  * For more details and usage information on Cache, see the [guide article on caching](guide:caching-overview).
  *
- * @property \Memcache|\Memcached $memcache The memcache (or memcached) object used by this cache component.
+ * @property-read \Memcache|\Memcached $memcache The memcache (or memcached) object used by this cache component.
  * This property is read-only.
  * @property MemCacheServer[] $servers List of memcache server configurations. Note that the type of this
  * property differs in getter and setter. See [[getServers()]] and [[setServers()]] for details.

--- a/framework/captcha/CaptchaAction.php
+++ b/framework/captcha/CaptchaAction.php
@@ -31,7 +31,7 @@ use yii\web\Response;
  *    to be validated by the 'captcha' validator.
  * 3. In the controller view, insert a [[Captcha]] widget in the form.
  *
- * @property string $verifyCode The verification code. This property is read-only.
+ * @property-read string $verifyCode The verification code. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/console/Application.php
+++ b/framework/console/Application.php
@@ -50,9 +50,9 @@ defined('STDERR') or define('STDERR', fopen('php://stderr', 'w'));
  * yii help
  * ```
  *
- * @property ErrorHandler $errorHandler The error handler application component. This property is read-only.
- * @property Request $request The request component. This property is read-only.
- * @property Response $response The response component. This property is read-only.
+ * @property-read ErrorHandler $errorHandler The error handler application component. This property is read-only.
+ * @property-read Request $request The request component. This property is read-only.
+ * @property-read Response $response The response component. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -27,11 +27,11 @@ use yii\helpers\Console;
  * where `<route>` is a route to a controller action and the params will be populated as properties of a command.
  * See [[options()]] for details.
  *
- * @property string $help This property is read-only.
- * @property string $helpSummary This property is read-only.
- * @property array $passedOptionValues The properties corresponding to the passed options. This property is
+ * @property-read string $help This property is read-only.
+ * @property-read string $helpSummary This property is read-only.
+ * @property-read array $passedOptionValues The properties corresponding to the passed options. This property is
  * read-only.
- * @property array $passedOptions The names of the options passed during execution. This property is
+ * @property-read array $passedOptions The names of the options passed during execution. This property is
  * read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/console/controllers/HelpController.php
+++ b/framework/console/controllers/HelpController.php
@@ -30,7 +30,7 @@ use yii\helpers\Inflector;
  * In the above, if the command name is not provided, all
  * available commands will be displayed.
  *
- * @property array $commands All available command names. This property is read-only.
+ * @property-read array $commands All available command names. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/data/BaseDataProvider.php
+++ b/framework/data/BaseDataProvider.php
@@ -16,7 +16,7 @@ use yii\base\InvalidParamException;
  *
  * For more details and usage information on BaseDataProvider, see the [guide article on data providers](guide:output-data-providers).
  *
- * @property int $count The number of data models in the current page. This property is read-only.
+ * @property-read int $count The number of data models in the current page. This property is read-only.
  * @property array $keys The list of key values corresponding to [[models]]. Each data model in [[models]] is
  * uniquely identified by the corresponding key value in this array.
  * @property array $models The list of data models in the current page.

--- a/framework/data/Pagination.php
+++ b/framework/data/Pagination.php
@@ -58,15 +58,15 @@ use yii\web\Request;
  *
  * For more details and usage information on Pagination, see the [guide article on pagination](guide:output-pagination).
  *
- * @property int $limit The limit of the data. This may be used to set the LIMIT value for a SQL statement for
+ * @property-read int $limit The limit of the data. This may be used to set the LIMIT value for a SQL statement for
  * fetching the current page of data. Note that if the page size is infinite, a value -1 will be returned. This
  * property is read-only.
- * @property array $links The links for navigational purpose. The array keys specify the purpose of the links
+ * @property-read array $links The links for navigational purpose. The array keys specify the purpose of the links
  * (e.g. [[LINK_FIRST]]), and the array values are the corresponding URLs. This property is read-only.
- * @property int $offset The offset of the data. This may be used to set the OFFSET value for a SQL statement
+ * @property-read int $offset The offset of the data. This may be used to set the OFFSET value for a SQL statement
  * for fetching the current page of data. This property is read-only.
  * @property int $page The zero-based current page number.
- * @property int $pageCount Number of pages. This property is read-only.
+ * @property-read int $pageCount Number of pages. This property is read-only.
  * @property int $pageSize The number of items per page. If it is less than 1, it means the page size is
  * infinite, and thus a single page contains all items.
  *

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -71,7 +71,7 @@ use yii\web\Request;
  * @property array $attributeOrders Sort directions indexed by attribute names. Sort direction can be either
  * `SORT_ASC` for ascending order or `SORT_DESC` for descending order. Note that the type of this property
  * differs in getter and setter. See [[getAttributeOrders()]] and [[setAttributeOrders()]] for details.
- * @property array $orders The columns (keys) and their corresponding sort directions (values). This can be
+ * @property-read array $orders The columns (keys) and their corresponding sort directions (values). This can be
  * passed to [[\yii\db\Query::orderBy()]] to construct a DB query. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -22,18 +22,18 @@ use yii\helpers\ArrayHelper;
  *
  * See [[\yii\db\ActiveRecord]] for a concrete implementation.
  *
- * @property array $dirtyAttributes The changed attribute values (name-value pairs). This property is
+ * @property-read array $dirtyAttributes The changed attribute values (name-value pairs). This property is
  * read-only.
  * @property bool $isNewRecord Whether the record is new and should be inserted when calling [[save()]].
  * @property array $oldAttributes The old attribute values (name-value pairs). Note that the type of this
  * property differs in getter and setter. See [[getOldAttributes()]] and [[setOldAttributes()]] for details.
- * @property mixed $oldPrimaryKey The old primary key value. An array (column name => column value) is
+ * @property-read mixed $oldPrimaryKey The old primary key value. An array (column name => column value) is
  * returned if the primary key is composite. A string is returned otherwise (null will be returned if the key
  * value is null). This property is read-only.
- * @property mixed $primaryKey The primary key value. An array (column name => column value) is returned if
+ * @property-read mixed $primaryKey The primary key value. An array (column name => column value) is returned if
  * the primary key is composite. A string is returned otherwise (null will be returned if the key value is null).
  * This property is read-only.
- * @property array $relatedRecords An array of related records indexed by relation names. This property is
+ * @property-read array $relatedRecords An array of related records indexed by relation names. This property is
  * read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -47,7 +47,7 @@ use yii\base\NotSupportedException;
  *
  * For more details and usage information on Command, see the [guide article on Database Access Objects](guide:db-dao).
  *
- * @property string $rawSql The raw SQL with parameter values inserted into the corresponding placeholders in
+ * @property-read string $rawSql The raw SQL with parameter values inserted into the corresponding placeholders in
  * [[sql]]. This property is read-only.
  * @property string $sql The SQL statement to be executed.
  *

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -111,22 +111,22 @@ use yii\caching\Cache;
  * ```
  *
  * @property string $driverName Name of the DB driver.
- * @property bool $isActive Whether the DB connection is established. This property is read-only.
- * @property string $lastInsertID The row ID of the last row inserted, or the last value retrieved from the
+ * @property-read bool $isActive Whether the DB connection is established. This property is read-only.
+ * @property-read string $lastInsertID The row ID of the last row inserted, or the last value retrieved from the
  * sequence object. This property is read-only.
- * @property Connection $master The currently active master connection. `null` is returned if there is no
+ * @property-read Connection $master The currently active master connection. `null` is returned if there is no
  * master available. This property is read-only.
- * @property PDO $masterPdo The PDO instance for the currently active master connection. This property is
+ * @property-read PDO $masterPdo The PDO instance for the currently active master connection. This property is
  * read-only.
- * @property QueryBuilder $queryBuilder The query builder for the current DB connection. This property is
+ * @property-read QueryBuilder $queryBuilder The query builder for the current DB connection. This property is
  * read-only.
- * @property Schema $schema The schema information for the database opened by this connection. This property
+ * @property-read Schema $schema The schema information for the database opened by this connection. This property
  * is read-only.
- * @property Connection $slave The currently active slave connection. `null` is returned if there is no slave
+ * @property-read Connection $slave The currently active slave connection. `null` is returned if there is no slave
  * available and `$fallbackToMaster` is false. This property is read-only.
- * @property PDO $slavePdo The PDO instance for the currently active slave connection. `null` is returned if
+ * @property-read PDO $slavePdo The PDO instance for the currently active slave connection. `null` is returned if
  * no slave connection is available and `$fallbackToMaster` is false. This property is read-only.
- * @property Transaction $transaction The currently active transaction. Null if no active transaction. This
+ * @property-read Transaction $transaction The currently active transaction. Null if no active transaction. This
  * property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/db/DataReader.php
+++ b/framework/db/DataReader.php
@@ -40,10 +40,10 @@ use yii\base\InvalidCallException;
  * [[fetchMode]]. See the [PHP manual](http://www.php.net/manual/en/function.PDOStatement-setFetchMode.php)
  * for more details about possible fetch mode.
  *
- * @property int $columnCount The number of columns in the result set. This property is read-only.
- * @property int $fetchMode Fetch mode. This property is write-only.
- * @property bool $isClosed Whether the reader is closed or not. This property is read-only.
- * @property int $rowCount Number of rows contained in the result. This property is read-only.
+ * @property-read int $columnCount The number of columns in the result set. This property is read-only.
+ * @property-write int $fetchMode Fetch mode. This property is write-only.
+ * @property-read bool $isClosed Whether the reader is closed or not. This property is read-only.
+ * @property-read int $rowCount Number of rows contained in the result. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -19,15 +19,15 @@ use yii\caching\TagDependency;
  *
  * Schema represents the database schema information that is DBMS specific.
  *
- * @property string $lastInsertID The row ID of the last row inserted, or the last value retrieved from the
+ * @property-read string $lastInsertID The row ID of the last row inserted, or the last value retrieved from the
  * sequence object. This property is read-only.
- * @property QueryBuilder $queryBuilder The query builder for this connection. This property is read-only.
- * @property string[] $schemaNames All schema names in the database, except system schemas. This property is
+ * @property-read QueryBuilder $queryBuilder The query builder for this connection. This property is read-only.
+ * @property-read string[] $schemaNames All schema names in the database, except system schemas. This property is
  * read-only.
- * @property string[] $tableNames All table names in the database. This property is read-only.
- * @property TableSchema[] $tableSchemas The metadata for all tables in the database. Each array element is an
+ * @property-read string[] $tableNames All table names in the database. This property is read-only.
+ * @property-read TableSchema[] $tableSchemas The metadata for all tables in the database. Each array element is an
  * instance of [[TableSchema]] or its child class. This property is read-only.
- * @property string $transactionIsolationLevel The transaction isolation level to use for this transaction.
+ * @property-write string $transactionIsolationLevel The transaction isolation level to use for this transaction.
  * This can be one of [[Transaction::READ_UNCOMMITTED]], [[Transaction::READ_COMMITTED]],
  * [[Transaction::REPEATABLE_READ]] and [[Transaction::SERIALIZABLE]] but also a string containing DBMS specific
  * syntax to be used after `SET TRANSACTION ISOLATION LEVEL`. This property is write-only.

--- a/framework/db/TableSchema.php
+++ b/framework/db/TableSchema.php
@@ -13,7 +13,7 @@ use yii\base\InvalidParamException;
 /**
  * TableSchema represents the metadata of a database table.
  *
- * @property array $columnNames List of column names. This property is read-only.
+ * @property-read array $columnNames List of column names. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/db/Transaction.php
+++ b/framework/db/Transaction.php
@@ -38,13 +38,13 @@ use yii\base\InvalidConfigException;
  * > with PHP 5.x and PHP 7.x. `\Exception` implements the [`\Throwable` interface](http://php.net/manual/en/class.throwable.php)
  * > since PHP 7.0, so you can skip the part with `\Exception` if your app uses only PHP 7.0 and higher.
  *
- * @property bool $isActive Whether this transaction is active. Only an active transaction can [[commit()]] or
+ * @property-read bool $isActive Whether this transaction is active. Only an active transaction can [[commit()]] or
  * [[rollBack()]]. This property is read-only.
- * @property string $isolationLevel The transaction isolation level to use for this transaction. This can be
+ * @property-write string $isolationLevel The transaction isolation level to use for this transaction. This can be
  * one of [[READ_UNCOMMITTED]], [[READ_COMMITTED]], [[REPEATABLE_READ]] and [[SERIALIZABLE]] but also a string
  * containing DBMS specific syntax to be used after `SET TRANSACTION ISOLATION LEVEL`. This property is
  * write-only.
- * @property int $level The current nesting level of the transaction. This property is read-only.
+ * @property-read int $level The current nesting level of the transaction. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -16,7 +16,7 @@ use yii\db\TableSchema;
 /**
  * Schema is the class for retrieving metadata from an Oracle database
  *
- * @property string $lastInsertID The row ID of the last row inserted, or the last value retrieved from the
+ * @property-read string $lastInsertID The row ID of the last row inserted, or the last value retrieved from the
  * sequence object. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -16,7 +16,7 @@ use yii\db\ViewFinderTrait;
  * Schema is the class for retrieving metadata from a PostgreSQL database
  * (version 9.x and above).
  *
- * @property string[] $viewNames All view names in the database. This property is read-only.
+ * @property-read string[] $viewNames All view names in the database. This property is read-only.
  *
  * @author Gevik Babakhani <gevikb@gmail.com>
  * @since 2.0

--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -91,7 +91,7 @@ use yii\helpers\ArrayHelper;
  *
  * For more details and usage information on Container, see the [guide article on di-containers](guide:concept-di-container).
  *
- * @property array $definitions The list of the object definitions or the loaded shared objects (type or ID =>
+ * @property-read array $definitions The list of the object definitions or the loaded shared objects (type or ID =>
  * definition or instance). This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/i18n/MessageFormatter.php
+++ b/framework/i18n/MessageFormatter.php
@@ -36,8 +36,8 @@ use yii\base\NotSupportedException;
  *   Also messages that are working with the fallback implementation are not necessarily compatible with the
  *   PHP intl MessageFormatter so do not rely on the fallback if you are able to install intl extension somehow.
  *
- * @property string $errorCode Code of the last error. This property is read-only.
- * @property string $errorMessage Description of the last error. This property is read-only.
+ * @property-read string $errorCode Code of the last error. This property is read-only.
+ * @property-read string $errorMessage Description of the last error. This property is read-only.
  *
  * @author Alexander Makarov <sam@rmcreative.ru>
  * @author Carsten Brandt <mail@cebe.cc>

--- a/framework/log/Logger.php
+++ b/framework/log/Logger.php
@@ -30,11 +30,11 @@ use yii\base\Component;
  * to send logged messages to different log targets, such as [[FileTarget|file]], [[EmailTarget|email]],
  * or [[DbTarget|database]], with the help of the [[dispatcher]].
  *
- * @property array $dbProfiling The first element indicates the number of SQL statements executed, and the
+ * @property-read array $dbProfiling The first element indicates the number of SQL statements executed, and the
  * second element the total time spent in SQL execution. This property is read-only.
- * @property float $elapsedTime The total elapsed time in seconds for current request. This property is
+ * @property-read float $elapsedTime The total elapsed time in seconds for current request. This property is
  * read-only.
- * @property array $profiling The profiling results. Each element is an array consisting of these elements:
+ * @property-read array $profiling The profiling results. Each element is an array consisting of these elements:
  * `info`, `category`, `timestamp`, `trace`, `level`, `duration`, `memory`, `memoryDiff`. The `memory` and
  * `memoryDiff` values are available since version 2.0.11. This property is read-only.
  *

--- a/framework/test/ActiveFixture.php
+++ b/framework/test/ActiveFixture.php
@@ -25,7 +25,7 @@ use yii\db\TableSchema;
  *
  * For more details and usage information on ActiveFixture, see the [guide article on fixtures](guide:test-fixtures).
  *
- * @property TableSchema $tableSchema The schema information of the database table associated with this
+ * @property-read TableSchema $tableSchema The schema information of the database table associated with this
  * fixture. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/validators/FileValidator.php
+++ b/framework/validators/FileValidator.php
@@ -19,7 +19,7 @@ use yii\helpers\FileHelper;
  *
  * Note that you should enable `fileinfo` PHP extension.
  *
- * @property int $sizeLimit The size limit for uploaded files. This property is read-only.
+ * @property-read int $sizeLimit The size limit for uploaded files. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/web/Application.php
+++ b/framework/web/Application.php
@@ -16,12 +16,12 @@ use yii\base\InvalidRouteException;
  *
  * For more details and usage information on Application, see the [guide article on applications](guide:structure-applications).
  *
- * @property ErrorHandler $errorHandler The error handler application component. This property is read-only.
+ * @property-read ErrorHandler $errorHandler The error handler application component. This property is read-only.
  * @property string $homeUrl The homepage URL.
- * @property Request $request The request component. This property is read-only.
- * @property Response $response The response component. This property is read-only.
- * @property Session $session The session component. This property is read-only.
- * @property User $user The user component. This property is read-only.
+ * @property-read Request $request The request component. This property is read-only.
+ * @property-read Response $response The response component. This property is read-only.
+ * @property-read Session $session The session component. This property is read-only.
+ * @property-read User $user The user component. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/web/CacheSession.php
+++ b/framework/web/CacheSession.php
@@ -31,7 +31,7 @@ use yii\di\Instance;
  * ]
  * ```
  *
- * @property bool $useCustomStorage Whether to use custom storage. This property is read-only.
+ * @property-read bool $useCustomStorage Whether to use custom storage. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/web/CookieCollection.php
+++ b/framework/web/CookieCollection.php
@@ -17,8 +17,8 @@ use yii\base\Object;
  *
  * For more details and usage information on CookieCollection, see the [guide article on handling cookies](guide:runtime-sessions-cookies).
  *
- * @property int $count The number of cookies in the collection. This property is read-only.
- * @property ArrayIterator $iterator An iterator for traversing the cookies in the collection. This property
+ * @property-read int $count The number of cookies in the collection. This property is read-only.
+ * @property-read ArrayIterator $iterator An iterator for traversing the cookies in the collection. This property
  * is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/web/HeaderCollection.php
+++ b/framework/web/HeaderCollection.php
@@ -14,8 +14,8 @@ use ArrayIterator;
 /**
  * HeaderCollection is used by [[Response]] to maintain the currently registered HTTP headers.
  *
- * @property int $count The number of headers in the collection. This property is read-only.
- * @property ArrayIterator $iterator An iterator for traversing the headers in the collection. This property
+ * @property-read int $count The number of headers in the collection. This property is read-only.
+ * @property-read ArrayIterator $iterator An iterator for traversing the headers in the collection. This property
  * is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/web/MultiFieldSession.php
+++ b/framework/web/MultiFieldSession.php
@@ -22,7 +22,7 @@ namespace yii\web;
  * While extending this class you should use [[composeFields()]] method - while writing the session data into the storage and
  * [[extractData()]] - while reading session data from the storage.
  *
- * @property bool $useCustomStorage Whether to use custom storage. This property is read-only.
+ * @property-read bool $useCustomStorage Whether to use custom storage. This property is read-only.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0.6

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -23,62 +23,62 @@ use yii\helpers\StringHelper;
  *
  * For more details and usage information on Request, see the [guide article on requests](guide:runtime-requests).
  *
- * @property string $absoluteUrl The currently requested absolute URL. This property is read-only.
+ * @property-read string $absoluteUrl The currently requested absolute URL. This property is read-only.
  * @property array $acceptableContentTypes The content types ordered by the quality score. Types with the
  * highest scores will be returned first. The array keys are the content types, while the array values are the
  * corresponding quality score and other parameters as given in the header.
  * @property array $acceptableLanguages The languages ordered by the preference level. The first element
  * represents the most preferred language.
- * @property string|null $authPassword The password sent via HTTP authentication, null if the password is not
+ * @property-read string|null $authPassword The password sent via HTTP authentication, null if the password is not
  * given. This property is read-only.
- * @property string|null $authUser The username sent via HTTP authentication, null if the username is not
+ * @property-read string|null $authUser The username sent via HTTP authentication, null if the username is not
  * given. This property is read-only.
  * @property string $baseUrl The relative URL for the application.
  * @property array $bodyParams The request parameters given in the request body.
- * @property string $contentType Request content-type. Null is returned if this information is not available.
+ * @property-read string $contentType Request content-type. Null is returned if this information is not available.
  * This property is read-only.
- * @property CookieCollection $cookies The cookie collection. This property is read-only.
- * @property string $csrfToken The token used to perform CSRF validation. This property is read-only.
- * @property string $csrfTokenFromHeader The CSRF token sent via [[CSRF_HEADER]] by browser. Null is returned
+ * @property-read CookieCollection $cookies The cookie collection. This property is read-only.
+ * @property-read string $csrfToken The token used to perform CSRF validation. This property is read-only.
+ * @property-read string $csrfTokenFromHeader The CSRF token sent via [[CSRF_HEADER]] by browser. Null is returned
  * if no such header is sent. This property is read-only.
- * @property array $eTags The entity tags. This property is read-only.
- * @property HeaderCollection $headers The header collection. This property is read-only.
+ * @property-read array $eTags The entity tags. This property is read-only.
+ * @property-read HeaderCollection $headers The header collection. This property is read-only.
  * @property string|null $hostInfo Schema and hostname part (with port number if needed) of the request URL
  * (e.g. `http://www.yiiframework.com`), null if can't be obtained from `$_SERVER` and wasn't set. See
  * [[getHostInfo()]] for security related notes on this property.
- * @property string|null $hostName Hostname part of the request URL (e.g. `www.yiiframework.com`). This
+ * @property-read string|null $hostName Hostname part of the request URL (e.g. `www.yiiframework.com`). This
  * property is read-only.
- * @property bool $isAjax Whether this is an AJAX (XMLHttpRequest) request. This property is read-only.
- * @property bool $isDelete Whether this is a DELETE request. This property is read-only.
- * @property bool $isFlash Whether this is an Adobe Flash or Adobe Flex request. This property is read-only.
- * @property bool $isGet Whether this is a GET request. This property is read-only.
- * @property bool $isHead Whether this is a HEAD request. This property is read-only.
- * @property bool $isOptions Whether this is a OPTIONS request. This property is read-only.
- * @property bool $isPatch Whether this is a PATCH request. This property is read-only.
- * @property bool $isPjax Whether this is a PJAX request. This property is read-only.
- * @property bool $isPost Whether this is a POST request. This property is read-only.
- * @property bool $isPut Whether this is a PUT request. This property is read-only.
- * @property bool $isSecureConnection If the request is sent via secure channel (https). This property is
+ * @property-read bool $isAjax Whether this is an AJAX (XMLHttpRequest) request. This property is read-only.
+ * @property-read bool $isDelete Whether this is a DELETE request. This property is read-only.
+ * @property-read bool $isFlash Whether this is an Adobe Flash or Adobe Flex request. This property is read-only.
+ * @property-read bool $isGet Whether this is a GET request. This property is read-only.
+ * @property-read bool $isHead Whether this is a HEAD request. This property is read-only.
+ * @property-read bool $isOptions Whether this is a OPTIONS request. This property is read-only.
+ * @property-read bool $isPatch Whether this is a PATCH request. This property is read-only.
+ * @property-read bool $isPjax Whether this is a PJAX request. This property is read-only.
+ * @property-read bool $isPost Whether this is a POST request. This property is read-only.
+ * @property-read bool $isPut Whether this is a PUT request. This property is read-only.
+ * @property-read bool $isSecureConnection If the request is sent via secure channel (https). This property is
  * read-only.
- * @property string $method Request method, such as GET, POST, HEAD, PUT, PATCH, DELETE. The value returned is
+ * @property-read string $method Request method, such as GET, POST, HEAD, PUT, PATCH, DELETE. The value returned is
  * turned into upper case. This property is read-only.
  * @property string $pathInfo Part of the request URL that is after the entry script and before the question
  * mark. Note, the returned path info is already URL-decoded.
  * @property int $port Port number for insecure requests.
  * @property array $queryParams The request GET parameter values.
- * @property string $queryString Part of the request URL that is after the question mark. This property is
+ * @property-read string $queryString Part of the request URL that is after the question mark. This property is
  * read-only.
  * @property string $rawBody The request body.
- * @property string|null $referrer URL referrer, null if not available. This property is read-only.
+ * @property-read string|null $referrer URL referrer, null if not available. This property is read-only.
  * @property string $scriptFile The entry script file path.
  * @property string $scriptUrl The relative URL of the entry script.
  * @property int $securePort Port number for secure requests.
- * @property string $serverName Server name, null if not available. This property is read-only.
- * @property int|null $serverPort Server port number, null if not available. This property is read-only.
+ * @property-read string $serverName Server name, null if not available. This property is read-only.
+ * @property-read int|null $serverPort Server port number, null if not available. This property is read-only.
  * @property string $url The currently requested relative URL. Note that the URI returned is URL-encoded.
- * @property string|null $userAgent User agent, null if not available. This property is read-only.
- * @property string|null $userHost User host name, null if not available. This property is read-only.
- * @property string|null $userIP User IP address, null if not available. This property is read-only.
+ * @property-read string|null $userAgent User agent, null if not available. This property is read-only.
+ * @property-read string|null $userHost User host name, null if not available. This property is read-only.
+ * @property-read string|null $userIP User IP address, null if not available. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -37,21 +37,21 @@ use yii\helpers\StringHelper;
  *
  * For more details and usage information on Response, see the [guide article on responses](guide:runtime-responses).
  *
- * @property CookieCollection $cookies The cookie collection. This property is read-only.
- * @property string $downloadHeaders The attachment file name. This property is write-only.
- * @property HeaderCollection $headers The header collection. This property is read-only.
- * @property bool $isClientError Whether this response indicates a client error. This property is read-only.
- * @property bool $isEmpty Whether this response is empty. This property is read-only.
- * @property bool $isForbidden Whether this response indicates the current request is forbidden. This property
+ * @property-read CookieCollection $cookies The cookie collection. This property is read-only.
+ * @property-write string $downloadHeaders The attachment file name. This property is write-only.
+ * @property-read HeaderCollection $headers The header collection. This property is read-only.
+ * @property-read bool $isClientError Whether this response indicates a client error. This property is read-only.
+ * @property-read bool $isEmpty Whether this response is empty. This property is read-only.
+ * @property-read bool $isForbidden Whether this response indicates the current request is forbidden. This property
  * is read-only.
- * @property bool $isInformational Whether this response is informational. This property is read-only.
- * @property bool $isInvalid Whether this response has a valid [[statusCode]]. This property is read-only.
- * @property bool $isNotFound Whether this response indicates the currently requested resource is not found.
+ * @property-read bool $isInformational Whether this response is informational. This property is read-only.
+ * @property-read bool $isInvalid Whether this response has a valid [[statusCode]]. This property is read-only.
+ * @property-read bool $isNotFound Whether this response indicates the currently requested resource is not found.
  * This property is read-only.
- * @property bool $isOk Whether this response is OK. This property is read-only.
- * @property bool $isRedirection Whether this response is a redirection. This property is read-only.
- * @property bool $isServerError Whether this response indicates a server error. This property is read-only.
- * @property bool $isSuccessful Whether this response is successful. This property is read-only.
+ * @property-read bool $isOk Whether this response is OK. This property is read-only.
+ * @property-read bool $isRedirection Whether this response is a redirection. This property is read-only.
+ * @property-read bool $isServerError Whether this response indicates a server error. This property is read-only.
+ * @property-read bool $isSuccessful Whether this response is successful. This property is read-only.
  * @property int $statusCode The HTTP status code to send with the response.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -45,26 +45,26 @@ use yii\base\InvalidParamException;
  *
  * For more details and usage information on Session, see the [guide article on sessions](guide:runtime-sessions-cookies).
  *
- * @property array $allFlashes Flash messages (key => message or key => [message1, message2]). This property
+ * @property-read array $allFlashes Flash messages (key => message or key => [message1, message2]). This property
  * is read-only.
- * @property array $cookieParams The session cookie parameters. This property is read-only.
- * @property int $count The number of session variables. This property is read-only.
- * @property string $flash The key identifying the flash message. Note that flash messages and normal session
+ * @property-read array $cookieParams The session cookie parameters. This property is read-only.
+ * @property-read int $count The number of session variables. This property is read-only.
+ * @property-write string $flash The key identifying the flash message. Note that flash messages and normal session
  * variables share the same name space. If you have a normal session variable using the same name, its value will
  * be overwritten by this method. This property is write-only.
  * @property float $gCProbability The probability (percentage) that the GC (garbage collection) process is
  * started on every session initialization, defaults to 1 meaning 1% chance.
  * @property bool $hasSessionId Whether the current request has sent the session ID.
  * @property string $id The current session ID.
- * @property bool $isActive Whether the session has started. This property is read-only.
- * @property SessionIterator $iterator An iterator for traversing the session variables. This property is
+ * @property-read bool $isActive Whether the session has started. This property is read-only.
+ * @property-read SessionIterator $iterator An iterator for traversing the session variables. This property is
  * read-only.
  * @property string $name The current session name.
  * @property string $savePath The current session save path, defaults to '/tmp'.
  * @property int $timeout The number of seconds after which data will be seen as 'garbage' and cleaned up. The
  * default value is 1440 seconds (or the value of "session.gc_maxlifetime" set in php.ini).
  * @property bool|null $useCookies The value indicating whether cookies should be used to store session IDs.
- * @property bool $useCustomStorage Whether to use custom storage. This property is read-only.
+ * @property-read bool $useCustomStorage Whether to use custom storage. This property is read-only.
  * @property bool $useTransparentSessionID Whether transparent sid support is enabled or not, defaults to
  * false.
  *

--- a/framework/web/UploadedFile.php
+++ b/framework/web/UploadedFile.php
@@ -20,9 +20,9 @@ use yii\helpers\Html;
  *
  * For more details and usage information on UploadedFile, see the [guide article on handling uploads](guide:input-file-upload).
  *
- * @property string $baseName Original file base name. This property is read-only.
- * @property string $extension File extension. This property is read-only.
- * @property bool $hasError Whether there is an error with the uploaded file. Check [[error]] for detailed
+ * @property-read string $baseName Original file base name. This property is read-only.
+ * @property-read string $extension File extension. This property is read-only.
+ * @property-read bool $hasError Whether there is an error with the uploaded file. Check [[error]] for detailed
  * error code information. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -46,11 +46,11 @@ use yii\rbac\CheckAccessInterface;
  * ]
  * ```
  *
- * @property string|int $id The unique identifier for the user. If `null`, it means the user is a guest. This
+ * @property-read string|int $id The unique identifier for the user. If `null`, it means the user is a guest. This
  * property is read-only.
  * @property IdentityInterface|null $identity The identity object associated with the currently logged-in
  * user. `null` is returned if the user is not logged in (not authenticated).
- * @property bool $isGuest Whether the current user is a guest. This property is read-only.
+ * @property-read bool $isGuest Whether the current user is a guest. This property is read-only.
  * @property string $returnUrl The URL that the user should be redirected to after login. Note that the type
  * of this property differs in getter and setter. See [[getReturnUrl()]] and [[setReturnUrl()]] for details.
  *

--- a/framework/widgets/FragmentCache.php
+++ b/framework/widgets/FragmentCache.php
@@ -16,7 +16,7 @@ use yii\di\Instance;
 /**
  * FragmentCache is used by [[\yii\base\View]] to provide caching of page fragments.
  *
- * @property string|false $cachedContent The cached content. False is returned if valid content is not found
+ * @property-read string|false $cachedContent The cached content. False is returned if valid content is not found
  * in the cache. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>


### PR DESCRIPTION
The @property-read tag allows a class to know which ‘magic’ properties are present that are read-only.
https://phpdoc.org/docs/latest/references/phpdoc/tags/property-read.html

The @property-write tag allows a class to know which ‘magic’ properties are present that are write-only.
https://phpdoc.org/docs/latest/references/phpdoc/tags/property-write.html