### PR TITLE
Fix input ID uniqueness

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -96,6 +96,17 @@ class BaseHtml
      */
     public static $dataAttributes = ['data', 'data-ng', 'ng'];
 
+    /**
+     * Counter to make each input with guaranteed unique ID
+     * @var int
+     */
+    protected static $inputIdCounter = 0;
+
+    /**
+     * Salt to guarantee uniqueness for input IDs in cross-ajax requests
+     * @var string
+     */
+    protected static $inputIdSalt;
 
     /**
      * Encodes special characters into HTML entities.
@@ -2180,7 +2191,12 @@ class BaseHtml
     public static function getInputId($model, $attribute)
     {
         $name = strtolower(static::getInputName($model, $attribute));
-        return str_replace(['[]', '][', '[', ']', ' ', '.'], ['', '-', '-', '', '-', '-'], $name);
+        $id = str_replace(['[]', '][', '[', ']', ' ', '.'], ['', '-', '-', '', '-', '-'], $name);
+        if (empty(static::$inputIdSalt)) {
+            static::$inputIdSalt = \yii::$app->security->generateRandomString();
+        }
+        static::$inputIdCounter++;
+        return "jsinput-$id-" . static::$inputIdSalt . '-' . static::$inputIdCounter;
     }
 
     /**


### PR DESCRIPTION
In case when on one page there are several forms for the same `ActiveRecord` model, than auto-generated by `ActiveForm` inputs have identical HTML attribute `id`, that obviously causes lots of problems.

I propose:
1. Add simple counter to guarantee uniqueness even for inputs of same attribute of same model
2. Add "salt" for a case of ajax requests, when counter will turn back to "0"

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | possibly, if developers used auto generated IDs in there JS quires
| Tests pass?   | yes

