### PR TITLE
Fix message formatting in the IP validator

### DIFF
--- a/framework/validators/IpValidator.php
+++ b/framework/validators/IpValidator.php
@@ -608,7 +608,7 @@ class IpValidator extends Validator
         foreach ($messages as &$message) {
             $message = $this->formatMessage($message, [
                 'attribute' => $model->getAttributeLabel($attribute),
-            ], Yii::$app->language);
+            ]);
         }
 
         $options = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

`yii\validators\Validator::formatMessage()` accepts two parameters. Three were provided.