### PR TITLE
Incorrect use case of Datepicker widget

### DIFF
--- a/docs/guide/structure-widgets.md
+++ b/docs/guide/structure-widgets.md
@@ -34,9 +34,7 @@ use yii\jui\DatePicker;
     'model' => $model,
     'attribute' => 'from_date',
     'language' => 'ru',
-    'clientOptions' => [
-        'dateFormat' => 'yy-mm-dd',
-    ],
+    'dateFormat' => 'php:Y-m-d',
 ]) ?>
 ```
 


### PR DESCRIPTION
`dateFormat` property in the `clientOptions` always overridden by `dateFormat` property of the widget: https://github.com/yiisoft/yii2-jui/blob/master/DatePicker.php#L141
