### PR TITLE
Fix number attributes comparison

### DIFF
--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -277,8 +277,8 @@ yii.validation = (function ($) {
             }
 
             if (options.type === 'number') {
-                value = parseFloat(value);
-                compareValue = parseFloat(compareValue);
+                value = value ? parseFloat(value) : 0;
+                compareValue = compareValue ? parseFloat(compareValue) : 0;
             }
             switch (options.operator) {
                 case '==':


### PR DESCRIPTION
Assume we have 2 attributes: `min` and `max`. Also we have a rule that `max` is equal or greater than `min` and they both are optional.
Than in case `min` is empty and `max` is set we got a validation error. The reason is that `parseFloat()` function converts empty string of `min` to `NaN`.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

