### PR TITLE
Fixes #13945: Removed Courier New from error page fonts list since it looks bad on Linux

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -62,6 +62,7 @@ Yii Framework 2 Change Log
 - Enh #13837: Refactored masking of CSRF tokens (sammousa)
 - Enh #13560: Refactored `\yii\widgets\FragmentCache::getCachedContent()`, added tests (Kolyunya)
 - Bug #13901: Fixed passing unused parameter to `formatMessage()` call in `\yii\validators\IpValidator` (Kolyunya)
+- Enh #13945: Removed Courier New from error page fonts list since it looks bad on Linux (samdark)
 
 2.0.11.2 February 08, 2017
 --------------------------

--- a/framework/views/errorHandler/exception.php
+++ b/framework/views/errorHandler/exception.php
@@ -239,7 +239,7 @@ h1,h2,h3,p,img,ul li{
     line-height: 20px;
     font-size: 12px;
     margin-top: 1px;
-    font-family: Consolas, Courier New, monospace;
+    font-family: Consolas, monospace;
 }
 .call-stack ul li .code pre{
     position: relative;
@@ -247,7 +247,7 @@ h1,h2,h3,p,img,ul li{
     left: 50px;
     line-height: 20px;
     font-size: 12px;
-    font-family: Consolas, Courier New, monospace;
+    font-family: Consolas, monospace;
     display: inline;
 }
 @-moz-document url-prefix() {
@@ -272,7 +272,7 @@ h1,h2,h3,p,img,ul li{
 .request .code pre{
     font-size: 14px;
     line-height: 18px;
-    font-family: Consolas, Courier New, monospace;
+    font-family: Consolas, monospace;
     display: inline;
     word-wrap: break-word;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    |  no
| Tests pass?   | yes
| Fixed issues  | #13945
