### PR TITLE
Fix `\yii\db\QueryInterface` type hints

### DIFF
--- a/framework/db/QueryInterface.php
+++ b/framework/db/QueryInterface.php
@@ -241,14 +241,14 @@ interface QueryInterface
 
     /**
      * Sets the LIMIT part of the query.
-     * @param int $limit the limit. Use null or negative value to disable limit.
+     * @param int|null $limit the limit. Use null or negative value to disable limit.
      * @return $this the query object itself
      */
     public function limit($limit);
 
     /**
      * Sets the OFFSET part of the query.
-     * @param int $offset the offset. Use null or negative value to disable offset.
+     * @param int|null $offset the offset. Use null or negative value to disable offset.
      * @return $this the query object itself
      */
     public function offset($offset);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Not sure if we should specify `Expression` as one of the acceptable types. `\yii\db\QueryTrait` accepts it too. I will adjust the PR if needed.