### PR TITLE
PHP Warning: "unserialize() expects parameter 1 to be string, resource given"

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -63,6 +63,7 @@ Yii Framework 2 Change Log
 - Enh #13560: Refactored `\yii\widgets\FragmentCache::getCachedContent()`, added tests (Kolyunya)
 - Bug #13901: Fixed passing unused parameter to `formatMessage()` call in `\yii\validators\IpValidator` (Kolyunya)
 - Enh #13945: Removed Courier New from error page fonts list since it looks bad on Linux (samdark)
+- Bug #13961: RBAC Rules: PostgreSQL: PHP Warning "unserialize() expects parameter 1 to be string, resource given" was fixed (vsguts)
 
 2.0.11.2 February 08, 2017
 --------------------------

--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -987,7 +987,11 @@ class DbManager extends BaseManager
         $query = (new Query)->from($this->ruleTable);
         $this->rules = [];
         foreach ($query->all($this->db) as $row) {
-            $this->rules[$row['name']] = unserialize($row['data']);
+            $data = $row['data'];
+            if (is_resource($data)) {
+                $data = stream_get_contents($data);
+            }
+            $this->rules[$row['name']] = unserialize($data);
         }
 
         $query = (new Query)->from($this->itemChildTable);


### PR DESCRIPTION
RBAC: PostgreSQL: Rules: PHP Warning: "unserialize() expects parameter 1 to be string, resource given" was fixed.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
