### PR TITLE
fix file upload bug if used with dynamic forms and elements are zero

### DIFF
--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -367,6 +367,8 @@ yii.validation = (function ($) {
             return [];
         }
 
+        // Continue validation if file input does not exist
+        // (in case file inputs are added dynamically and no file input has been added to the form)
         if (typeof $(attribute.input, attribute.$form).get(0) === "undefined") {
             return [];
         }

--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -367,6 +367,10 @@ yii.validation = (function ($) {
             return [];
         }
 
+        if (typeof $(attribute.input, attribute.$form).get(0) === "undefined") {
+            return [];
+        }
+
         var files = $(attribute.input, attribute.$form).get(0).files;
         if (!files) {
             messages.push(options.message);

--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -59,14 +59,17 @@ yii.validation = (function ($) {
                 return;
             }
 
-            if (options.is !== undefined && value.length != options.is) {
+            //line breaks will be counted as 2 characters (\r\n) in php/mb_strlen
+            var mb_strlen = value.replace(/\r(?!\n)|\n(?!\r)/g, "\r\n").length;
+
+            if (options.is !== undefined && mb_strlen !== options.is) {
                 pub.addMessage(messages, options.notEqual, value);
                 return;
             }
-            if (options.min !== undefined && value.length < options.min) {
+            if (options.min !== undefined && mb_strlen < options.min) {
                 pub.addMessage(messages, options.tooShort, value);
             }
-            if (options.max !== undefined && value.length > options.max) {
+            if (options.max !== undefined && mb_strlen > options.max) {
                 pub.addMessage(messages, options.tooLong, value);
             }
         },

--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -59,17 +59,14 @@ yii.validation = (function ($) {
                 return;
             }
 
-            //line breaks will be counted as 2 characters (\r\n) in php/mb_strlen
-            var mb_strlen = value.replace(/\r(?!\n)|\n(?!\r)/g, "\r\n").length;
-
-            if (options.is !== undefined && mb_strlen !== options.is) {
+            if (options.is !== undefined && value.length != options.is) {
                 pub.addMessage(messages, options.notEqual, value);
                 return;
             }
-            if (options.min !== undefined && mb_strlen < options.min) {
+            if (options.min !== undefined && value.length < options.min) {
                 pub.addMessage(messages, options.tooShort, value);
             }
-            if (options.max !== undefined && mb_strlen > options.max) {
+            if (options.max !== undefined && value.length > options.max) {
                 pub.addMessage(messages, options.tooLong, value);
             }
         },

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -342,26 +342,6 @@ class View extends \yii\base\View
     }
 
     /**
-     * Registers csrf meta tags.
-     *
-     * For example, csrf meta tags can be added like the following:
-     *
-     * ```php
-     * $view->registerCsrfMetaTags();
-     * ```
-     *
-     * will result in the meta tags `<meta name="csrf-param" content="_csrf-frontend">`
-     * and `<meta name="csrf-token" content="tTNpWKpdy-bx8ZmIq9R1N72G3dJdNefxXI3KGlSTLIixHzttlXskzoeHsjognf7Oa3jvOjQzpK1y8IP3XGkzZA==">`
-     *
-     * @param bool $dynamic determines if the csrf tags should be rendered dynamically.
-     * If used in conjunction with cache this should be set to be true, to retrieve a new csrf token for each request.
-     */
-    public function registerCsrfMetaTags($dynamic = false)
-    {
-        $this->metaTags['csrf_meta_tags'] = ($dynamic === false) ? Html::csrfMetaTags() : $this->renderDynamic('return yii\helpers\Html::csrfMetaTags();');
-    }
-
-    /**
      * Registers a link tag.
      *
      * For example, a link tag for a custom [favicon](http://www.w3.org/2005/10/howto-favicon)

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -342,6 +342,26 @@ class View extends \yii\base\View
     }
 
     /**
+     * Registers csrf meta tags.
+     *
+     * For example, csrf meta tags can be added like the following:
+     *
+     * ```php
+     * $view->registerCsrfMetaTags();
+     * ```
+     *
+     * will result in the meta tags `<meta name="csrf-param" content="_csrf-frontend">`
+     * and `<meta name="csrf-token" content="tTNpWKpdy-bx8ZmIq9R1N72G3dJdNefxXI3KGlSTLIixHzttlXskzoeHsjognf7Oa3jvOjQzpK1y8IP3XGkzZA==">`
+     *
+     * @param bool $dynamic determines if the csrf tags should be rendered dynamically.
+     * If used in conjunction with cache this should be set to be true, to retrieve a new csrf token for each request.
+     */
+    public function registerCsrfMetaTags($dynamic = false)
+    {
+        $this->metaTags['csrf_meta_tags'] = ($dynamic === false) ? Html::csrfMetaTags() : $this->renderDynamic('return yii\helpers\Html::csrfMetaTags();');
+    }
+
+    /**
      * Registers a link tag.
      *
      * For example, a link tag for a custom [favicon](http://www.w3.org/2005/10/howto-favicon)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

If used with dynamic forms and fileInput it comes to typeError if there are no file-inputs (min elements = 0). Due to this error the whole form will not be validated at the client side.
I tested other input validations (url, string etc) on a similar setting (dynamic forms with zero elements) and all worked fine, only the file-input-validation did not work.
This little addition fixes the issue.

The error was:
[Error] TypeError: undefined is not an object (evaluating '$(attribute.input, attribute.$form).get(0).files')
	getUploadedFiles (yii.validation.js:371)
	file (yii.validation.js:75)
	validate (create:1090:2956)
	(anonyme Funktion) (yii.activeForm.js:338)
	each (jquery.js:365)
	validate (yii.activeForm.js:323)
	submitForm (yii.activeForm.js:427)
	dispatch (jquery.js:4737)
	handle (jquery.js:4549)