### PR TITLE
Fix #13979 `Validator::$attributeNames` made dynamic

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,7 +8,7 @@ Yii Framework 2 Change Log
 - Bug #13671: Fixed error handler trace to work correctly with XDebug (samdark)
 - Bug #13657: Fixed `yii\helpers\StringHelper::truncateHtml()` skip extra tags at the end (sam002)
 - Bug #7946: Fixed a bug when the `form` attribute was not propagated to the hidden input of the checkbox (Kolyunya)
-- Bug #13087: Fixed getting active validators for safe attribute (developeruz)
+- Bug #13087: Fixed getting active validators for safe attribute (developeruz, klimov-paul)
 - Bug #13571: Fix `yii\db\mssql\QueryBuilder::checkIntegrity` for all tables (boboldehampsink)
 - Bug #11230: Include `defaultRoles` in `yii\rbac\DbManager->getRolesByUser()` results (developeruz)
 - Enh #13243: Added support for unicode attribute names in `yii\widgets\DetailView` (arogachev)

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -47,6 +47,8 @@ use yii\base\NotSupportedException;
  * - `ip`: [[IpValidator]]
  *
  * For more details and usage information on Validator, see the [guide article on validators](guide:input-validation).
+ * 
+ * @property array $attributeNames cleaned attribute names without the `!` character at the beginning. This property is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -101,11 +103,6 @@ class Validator extends Component
      * please specify them as an array; for single attribute, you may use either a string or an array.
      */
     public $attributes = [];
-    /**
-     * @var array cleaned attribute names. Contains attribute names without `!` character at the beginning
-     * @since 2.0.12
-     */
-    private $_attributeNames = [];
     /**
      * @var string the user-defined error message. It may contain the following placeholders which
      * will be replaced accordingly by the validator:
@@ -238,7 +235,6 @@ class Validator extends Component
         $this->attributes = (array) $this->attributes;
         $this->on = (array) $this->on;
         $this->except = (array) $this->except;
-        $this->setAttributeNames((array)$this->attributes);
     }
 
     /**
@@ -459,23 +455,13 @@ class Validator extends Component
 
     /**
      * Returns cleaned attribute names without the `!` character at the beginning
-     * @return array
+     * @return array attribute names.
      * @since 2.0.12
      */
     public function getAttributeNames()
     {
-        return $this->_attributeNames;
-    }
-
-    /**
-     * Saves attribute names without `!` character at the beginning
-     * @param array $attributeNames
-     * @since 2.0.12
-     */
-    private function setAttributeNames($attributeNames)
-    {
-        $this->_attributeNames = array_map(function($attribute) {
+        return array_map(function($attribute) {
             return ltrim($attribute, '!');
-        }, $attributeNames);
+        }, $this->attributes);
     }
 }

--- a/tests/framework/validators/ValidatorTest.php
+++ b/tests/framework/validators/ValidatorTest.php
@@ -242,17 +242,27 @@ class ValidatorTest extends TestCase
         $this->assertEquals('attr_msg_val::abc::param_value', $errors[0]);
     }
 
+    public function testGetAttributeNames()
+    {
+        $validator = new TestValidator();
+        $validator->attributes = ['id', 'name', '!email'];
+        $this->assertEquals(['id', 'name', 'email'], $validator->getAttributeNames());
+    }
+
+    /**
+     * @depends  testGetAttributeNames
+     */
     public function testGetActiveValidatorsForSafeAttributes()
     {
         $model = $this->getTestModel();
         $validators = $model->getActiveValidators('safe_attr');
-        $is_found = false;
+        $isFound = false;
         foreach ($validators as $v) {
             if ($v instanceof NumberValidator) {
-                $is_found = true;
+                $isFound = true;
                 break;
             }
         }
-        $this->assertTrue($is_found);
+        $this->assertTrue($isFound);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13979
