### PR TITLE
[IpValidator] disable ipv6 checks

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -64,6 +64,7 @@ Yii Framework 2 Change Log
 - Bug #13901: Fixed passing unused parameter to `formatMessage()` call in `\yii\validators\IpValidator` (Kolyunya)
 - Enh #13945: Removed Courier New from error page fonts list since it looks bad on Linux (samdark)
 - Bug #13961: RBAC Rules: PostgreSQL: PHP Warning "unserialize() expects parameter 1 to be string, resource given" was fixed (vsguts)
+- Enh #13976: Disabled IPv6 check on `\yii\validators\IpValidator` as it turns out it is not needed for inet_* methods to work (mikk150)
 
 2.0.11.2 February 08, 2017
 --------------------------

--- a/framework/validators/IpValidator.php
+++ b/framework/validators/IpValidator.php
@@ -221,7 +221,6 @@ class IpValidator extends Validator
         if (!$this->ipv4 && !$this->ipv6) {
             throw new InvalidConfigException('Both IPv4 and IPv6 checks can not be disabled at the same time');
         }
-        
         if ($this->message === null) {
             $this->message = Yii::t('yii', '{attribute} must be a valid IP address.');
         }

--- a/framework/validators/IpValidator.php
+++ b/framework/validators/IpValidator.php
@@ -221,11 +221,7 @@ class IpValidator extends Validator
         if (!$this->ipv4 && !$this->ipv6) {
             throw new InvalidConfigException('Both IPv4 and IPv6 checks can not be disabled at the same time');
         }
-
-        if (!defined('AF_INET6') && $this->ipv6) {
-            throw new InvalidConfigException('IPv6 validation can not be used. PHP is compiled without IPv6');
-        }
-
+        
         if ($this->message === null) {
             $this->message = Yii::t('yii', '{attribute} must be a valid IP address.');
         }

--- a/tests/framework/validators/IpValidatorTest.php
+++ b/tests/framework/validators/IpValidatorTest.php
@@ -13,10 +13,6 @@ class IpValidatorTest extends TestCase
 {
     protected function setUp()
     {
-        if (!defined('AF_INET6')) {
-            $this->markTestSkipped('The environment does not support IPv6.');
-        }
-
         parent::setUp();
         $this->mockApplication();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes (at least IpValidatorTest did)
| Fixed issues  | #13976 
