### PR TITLE
Fix `yii\filters\AccessRule::matchIP()`

### DIFF
--- a/framework/filters/AccessRule.php
+++ b/framework/filters/AccessRule.php
@@ -165,7 +165,7 @@ class AccessRule extends Component
     }
 
     /**
-     * @param string $ip the IP address
+     * @param string|null $ip the IP address
      * @return bool whether the rule applies to the IP address
      */
     protected function matchIP($ip)
@@ -174,7 +174,14 @@ class AccessRule extends Component
             return true;
         }
         foreach ($this->ips as $rule) {
-            if ($rule === '*' || $rule === $ip || (($pos = strpos($rule, '*')) !== false && !strncmp($ip, $rule, $pos))) {
+            if ($rule === '*' ||
+                $rule === $ip ||
+                (
+                    $ip !== null &&
+                    ($pos = strpos($rule, '*')) !== false &&
+                    strncmp($ip, $rule, $pos) === 0
+                )
+            ) {
                 return true;
             }
         }

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -292,6 +292,14 @@ class AccessRuleTest extends \yiiunit\TestCase
         $this->assertNull($rule->allows($action, $user, $request));
         $rule->allow = false;
         $this->assertNull($rule->allows($action, $user, $request));
+
+        // undefined IP
+        $_SERVER['REMOTE_ADDR'] = null;
+        $rule->ips = ['192.168.*'];
+        $rule->allow = true;
+        $this->assertNull($rule->allows($action, $user, $request));
+        $rule->allow = false;
+        $this->assertNull($rule->allows($action, $user, $request));
     }
 
     public function testMatchIPWildcard()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

[Here](https://github.com/yiisoft/yii2/blob/master/framework/filters/AccessRule.php#L112) `matchIP()` may be passed a `null` which will be passed to `strncmp()` [here](https://github.com/yiisoft/yii2/blob/master/framework/filters/AccessRule.php#L177).
`strncmp()` expects to be receive a `string`, not `null` and it [seems to be triggering a warning](https://3v4l.org/sFe7o) on an `HHVM`..