### PR TITLE
Fixed ignored params when using count in `SqlDataProvider`

### DIFF
--- a/framework/data/SqlDataProvider.php
+++ b/framework/data/SqlDataProvider.php
@@ -163,6 +163,9 @@ class SqlDataProvider extends BaseDataProvider
      */
     protected function prepareTotalCount()
     {
-        return (new Query())->from(['sub' => "({$this->sql})"])->count('*', $this->db);
+        return (new Query([
+            'from' => ['sub' => "({$this->sql})"],
+            'params' => $this->params
+        ]))->count('*', $this->db);
     }
 }

--- a/tests/framework/data/SqlDataProviderTest.php
+++ b/tests/framework/data/SqlDataProviderTest.php
@@ -32,4 +32,16 @@ class SqlDataProviderTest extends DatabaseTestCase
         ]);
         $this->assertEquals(3, $dataProvider->getTotalCount());
     }
+
+    public function testTotalCountWithParams()
+    {
+        $dataProvider = new SqlDataProvider([
+            'sql' => 'select * from `customer` where id > :minimum',
+            'params' => [
+                ':minimum' => -1
+            ],
+            'db' => $this->getConnection(),
+        ]);
+        $this->assertEquals(3, $dataProvider->getTotalCount());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14046 
