### PR TITLE
Helper independent

### DIFF
--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -44,7 +44,9 @@ class ArrayHelperTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Helper must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testToArray()
@@ -267,6 +269,7 @@ class ArrayHelperTest extends TestCase
         $sort = new Sort([
             'attributes' => ['name', 'age'],
             'defaultOrder' => ['name' => SORT_ASC],
+            'params' => [],
         ]);
         $orders = $sort->getOrders();
 
@@ -284,6 +287,7 @@ class ArrayHelperTest extends TestCase
         $sort = new Sort([
             'attributes' => ['name', 'age'],
             'defaultOrder' => ['name' => SORT_ASC, 'age' => SORT_DESC],
+            'params' => [],
         ]);
         $orders = $sort->getOrders();
 

--- a/tests/framework/helpers/ConsoleTest.php
+++ b/tests/framework/helpers/ConsoleTest.php
@@ -12,6 +12,14 @@ use yiiunit\TestCase;
  */
 class ConsoleTest extends TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // destroy application, Helper must work without Yii::$app
+        $this->destroyApplication();
+    }
+
     public function testStripAnsiFormat()
     {
         ob_start();

--- a/tests/framework/helpers/FileHelperTest.php
+++ b/tests/framework/helpers/FileHelperTest.php
@@ -33,7 +33,13 @@ class FileHelperTest extends TestCase
              */
             $this->markTestInComplete('Unit tests runtime directory should be local!');
         }
+
+        parent::setUp();
+
+        // destroy application, Helper must work without Yii::$app
+        $this->destroyApplication();
     }
+
 
     public function tearDown()
     {

--- a/tests/framework/helpers/InflectorTest.php
+++ b/tests/framework/helpers/InflectorTest.php
@@ -10,6 +10,14 @@ use yiiunit\TestCase;
  */
 class InflectorTest extends TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // destroy application, Helper must work without Yii::$app
+        $this->destroyApplication();
+    }
+
     public function testPluralize()
     {
         $testData = [

--- a/tests/framework/helpers/JsonTest.php
+++ b/tests/framework/helpers/JsonTest.php
@@ -14,6 +14,14 @@ use yiiunit\framework\web\Post;
  */
 class JsonTest extends TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // destroy application, Helper must work without Yii::$app
+        $this->destroyApplication();
+    }
+
     public function testEncode()
     {
         // basic data encoding

--- a/tests/framework/helpers/MarkdownTest.php
+++ b/tests/framework/helpers/MarkdownTest.php
@@ -12,6 +12,14 @@ use yii\helpers\Markdown;
  */
 class MarkdownTest extends TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // destroy application, Helper must work without Yii::$app
+        $this->destroyApplication();
+    }
+
     public function testOriginalFlavor()
     {
         $text = <<<TEXT

--- a/tests/framework/helpers/VarDumperTest.php
+++ b/tests/framework/helpers/VarDumperTest.php
@@ -10,6 +10,14 @@ use yiiunit\TestCase;
  */
 class VarDumperTest extends TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // destroy application, Helper must work without Yii::$app
+        $this->destroyApplication();
+    }
+
     public function testDumpIncompleteObject()
     {
         $serializedObj = 'O:16:"nonExistingClass":0:{}';

--- a/tests/framework/validators/BooleanValidatorTest.php
+++ b/tests/framework/validators/BooleanValidatorTest.php
@@ -14,7 +14,9 @@ class BooleanValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testValidateValue()

--- a/tests/framework/validators/CompareValidatorTest.php
+++ b/tests/framework/validators/CompareValidatorTest.php
@@ -14,7 +14,9 @@ class CompareValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testValidateValueException()

--- a/tests/framework/validators/DefaultValueValidatorTest.php
+++ b/tests/framework/validators/DefaultValueValidatorTest.php
@@ -13,7 +13,9 @@ class DefaultValueValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testValidateAttribute()

--- a/tests/framework/validators/EachValidatorTest.php
+++ b/tests/framework/validators/EachValidatorTest.php
@@ -14,7 +14,9 @@ class EachValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testArrayFormat()

--- a/tests/framework/validators/EmailValidatorTest.php
+++ b/tests/framework/validators/EmailValidatorTest.php
@@ -13,7 +13,9 @@ class EmailValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testValidateValue()

--- a/tests/framework/validators/ExistValidatorTest.php
+++ b/tests/framework/validators/ExistValidatorTest.php
@@ -14,10 +14,12 @@ use yiiunit\framework\db\DatabaseTestCase;
 
 abstract class ExistValidatorTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
         ActiveRecord::$db = $this->getConnection();
     }
 

--- a/tests/framework/validators/FileValidatorTest.php
+++ b/tests/framework/validators/FileValidatorTest.php
@@ -14,8 +14,9 @@ use yiiunit\TestCase;
  */
 class FileValidatorTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
+        parent::setUp();
         $this->mockApplication();
     }
 

--- a/tests/framework/validators/FilterValidatorTest.php
+++ b/tests/framework/validators/FilterValidatorTest.php
@@ -14,7 +14,8 @@ class FilterValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testAssureExceptionOnInit()

--- a/tests/framework/validators/IpValidatorTest.php
+++ b/tests/framework/validators/IpValidatorTest.php
@@ -14,7 +14,8 @@ class IpValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testInitException()

--- a/tests/framework/validators/NumberValidatorTest.php
+++ b/tests/framework/validators/NumberValidatorTest.php
@@ -46,8 +46,11 @@ class NumberValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
         $this->oldLocale = setlocale(LC_NUMERIC, 0);
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testEnsureMessageOnInit()

--- a/tests/framework/validators/RangeValidatorTest.php
+++ b/tests/framework/validators/RangeValidatorTest.php
@@ -14,7 +14,9 @@ class RangeValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testInitException()

--- a/tests/framework/validators/RegularExpressionValidatorTest.php
+++ b/tests/framework/validators/RegularExpressionValidatorTest.php
@@ -14,7 +14,9 @@ class RegularExpressionValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testValidateValue()

--- a/tests/framework/validators/RequiredValidatorTest.php
+++ b/tests/framework/validators/RequiredValidatorTest.php
@@ -13,7 +13,9 @@ class RequiredValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testValidateValueWithDefaults()

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -16,11 +16,13 @@ use yiiunit\framework\db\DatabaseTestCase;
 
 abstract class UniqueValidatorTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
         ActiveRecord::$db = $this->getConnection();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testAssureMessageSetOnInit()

--- a/tests/framework/validators/UrlValidatorTest.php
+++ b/tests/framework/validators/UrlValidatorTest.php
@@ -14,7 +14,9 @@ class UrlValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     public function testValidateValue()

--- a/tests/framework/validators/ValidatorTest.php
+++ b/tests/framework/validators/ValidatorTest.php
@@ -17,7 +17,9 @@ class ValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->mockApplication();
+
+        // destroy application, Validator must work without Yii::$app
+        $this->destroyApplication();
     }
 
     protected function getTestModel($additionalAttributes = [])


### PR DESCRIPTION
Follow up to #13263 makeing sure most helpers and validators are independent of Yii::$app.
Some depend on it and its not easy or useful to change that right now.