### PR TITLE
Added copyEmptyDirectories option to FileHelper

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #4408: Add support for unicode word characters and `+` character in attribute names (sammousa, kmindi)
 - Bug #7946: Fixed a bug when the `form` attribute was not propagated to the hidden input of the checkbox (Kolyunya)
 - Bug #8120: Fixes LIKE special characters escaping for Cubrid/MSSQL/Oracle/SQLite in `yii\db\QueryBuilder` (sergeymakinen)
+- Bug #9669: AssetManager and `FileHelper::copyDirectory()` were copying empty directories when using `only` or `except` options. Added an option to disable this (cebe)
 - Bug #10346: Fixed "DOMException: Invalid Character Error" in `yii\web\XmlResponseFormatter::buildXml()` (sasha-ch)
 - Bug #10372: Fixed console controller including complex typed arguments in help (sammousa)
 - Bug #11230: Include `defaultRoles` in `yii\rbac\DbManager->getRolesByUser()` results (developeruz)

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -527,6 +527,7 @@ class AssetManager extends Component
                 [
                     'dirMode' => $this->dirMode,
                     'fileMode' => $this->fileMode,
+                    'copyEmptyDirectories' => false,
                 ]
             );
             if (!isset($opts['beforeCopy'])) {

--- a/tests/framework/helpers/FileHelperTest.php
+++ b/tests/framework/helpers/FileHelperTest.php
@@ -791,13 +791,7 @@ class FileHelperTest extends TestCase
         }
     }
 
-    /**
-     * @see https://github.com/yiisoft/yii2/issues/9669
-     *
-     * @depends testCopyDirectory
-     * @depends testFindFiles
-     */
-    public function testCopyDirectoryEmptyDirectories()
+    private function setupCopyEmptyDirectoriesTest()
     {
         $srcDirName = 'test_empty_src_dir';
         $this->createFileStructure([
@@ -814,8 +808,21 @@ class FileHelperTest extends TestCase
             ],
         ]);
 
-        $basePath = $this->testFilePath;
-        $srcDirName = $basePath . DIRECTORY_SEPARATOR . $srcDirName;
+        return [
+            $this->testFilePath, // basePath
+            $this->testFilePath . DIRECTORY_SEPARATOR . $srcDirName,
+        ];
+    }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/9669
+     *
+     * @depends testCopyDirectory
+     * @depends testFindFiles
+     */
+    public function testCopyDirectoryEmptyDirectories()
+    {
+        list($basePath, $srcDirName) = $this->setupCopyEmptyDirectoriesTest();
 
         // copy with empty directories
         $dstDirName = $basePath . DIRECTORY_SEPARATOR . 'test_empty_dst_dir';
@@ -830,6 +837,17 @@ class FileHelperTest extends TestCase
         $this->assertFileExists($dstDirName . DIRECTORY_SEPARATOR . 'dir1' . DIRECTORY_SEPARATOR . 'file2.txt');
         $this->assertFileExists($dstDirName . DIRECTORY_SEPARATOR . 'dir2');
         $this->assertFileExists($dstDirName . DIRECTORY_SEPARATOR . 'dir3');
+    }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/9669
+     *
+     * @depends testCopyDirectory
+     * @depends testFindFiles
+     */
+    public function testCopyDirectoryNoEmptyDirectories()
+    {
+        list($basePath, $srcDirName) = $this->setupCopyEmptyDirectoriesTest();
 
         // copy without empty directories
         $dstDirName = $basePath . DIRECTORY_SEPARATOR . 'test_empty_dst_dir2';

--- a/tests/framework/helpers/FileHelperTest.php
+++ b/tests/framework/helpers/FileHelperTest.php
@@ -790,4 +790,59 @@ class FileHelperTest extends TestCase
             $this->assertStringEqualsFile($fileName, $content, 'Incorrect file content!');
         }
     }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/9669
+     *
+     * @depends testCopyDirectory
+     * @depends testFindFiles
+     */
+    public function testCopyDirectoryEmptyDirectories()
+    {
+        $srcDirName = 'test_empty_src_dir';
+        $this->createFileStructure([
+            $srcDirName => [
+                'dir1' => [
+                    'file1.txt' => 'file1',
+                    'file2.txt' => 'file2',
+                ],
+                'dir2' => [
+                    'file1.log' => 'file1',
+                    'file2.log' => 'file2',
+                ],
+                'dir3' => [],
+            ],
+        ]);
+
+        $basePath = $this->testFilePath;
+        $srcDirName = $basePath . DIRECTORY_SEPARATOR . $srcDirName;
+
+        // copy with empty directories
+        $dstDirName = $basePath . DIRECTORY_SEPARATOR . 'test_empty_dst_dir';
+        FileHelper::copyDirectory($srcDirName, $dstDirName, ['only' => ['*.txt'], 'copyEmptyDirectories' => true]);
+
+        $this->assertFileExists($dstDirName, 'Destination directory does not exist!');
+        $copiedFiles = FileHelper::findFiles($dstDirName);
+        $this->assertCount(2, $copiedFiles, 'wrong files count copied');
+
+        $this->assertFileExists($dstDirName . DIRECTORY_SEPARATOR . 'dir1');
+        $this->assertFileExists($dstDirName . DIRECTORY_SEPARATOR . 'dir1' . DIRECTORY_SEPARATOR . 'file1.txt');
+        $this->assertFileExists($dstDirName . DIRECTORY_SEPARATOR . 'dir1' . DIRECTORY_SEPARATOR . 'file2.txt');
+        $this->assertFileExists($dstDirName . DIRECTORY_SEPARATOR . 'dir2');
+        $this->assertFileExists($dstDirName . DIRECTORY_SEPARATOR . 'dir3');
+
+        // copy without empty directories
+        $dstDirName = $basePath . DIRECTORY_SEPARATOR . 'test_empty_dst_dir2';
+        FileHelper::copyDirectory($srcDirName, $dstDirName, ['only' => ['*.txt'], 'copyEmptyDirectories' => false]);
+
+        $this->assertFileExists($dstDirName, 'Destination directory does not exist!');
+        $copiedFiles = FileHelper::findFiles($dstDirName);
+        $this->assertCount(2, $copiedFiles, 'wrong files count copied');
+
+        $this->assertFileExists($dstDirName . DIRECTORY_SEPARATOR . 'dir1');
+        $this->assertFileExists($dstDirName . DIRECTORY_SEPARATOR . 'dir1' . DIRECTORY_SEPARATOR . 'file1.txt');
+        $this->assertFileExists($dstDirName . DIRECTORY_SEPARATOR . 'dir1' . DIRECTORY_SEPARATOR . 'file2.txt');
+        $this->assertFileNotExists($dstDirName . DIRECTORY_SEPARATOR . 'dir2');
+        $this->assertFileNotExists($dstDirName . DIRECTORY_SEPARATOR . 'dir3');
+    }
 }

--- a/tests/framework/web/AssetBundleTest.php
+++ b/tests/framework/web/AssetBundleTest.php
@@ -78,8 +78,6 @@ class AssetBundleTest extends \yiiunit\TestCase
         $this->assertTrue(is_dir($bundle->basePath));
         $this->sourcesPublish_VerifyFiles('css', $bundle);
         $this->sourcesPublish_VerifyFiles('js', $bundle);
-
-        $this->assertTrue(rmdir($bundle->basePath));
     }
 
     private function sourcesPublish_VerifyFiles($type, $bundle)
@@ -89,9 +87,8 @@ class AssetBundleTest extends \yiiunit\TestCase
             $sourceFile = $bundle->sourcePath . DIRECTORY_SEPARATOR . $filename;
             $this->assertFileExists($publishedFile);
             $this->assertFileEquals($publishedFile, $sourceFile);
-            $this->assertTrue(unlink($publishedFile));
         }
-        $this->assertTrue(rmdir($bundle->basePath . DIRECTORY_SEPARATOR . $type));
+        $this->assertTrue(is_dir($bundle->basePath . DIRECTORY_SEPARATOR . $type));
     }
 
     public function testSourcesPublishedBySymlink()
@@ -109,7 +106,7 @@ class AssetBundleTest extends \yiiunit\TestCase
             }
         ]);
         $bundle = $this->verifySourcesPublishedBySymlink($view);
-        $this->assertTrue(rmdir(dirname($bundle->basePath)));
+        $this->assertTrue(is_dir(dirname($bundle->basePath)));
     }
 
     public function testSourcesPublish_AssetManagerBeforeCopy()
@@ -165,15 +162,15 @@ class AssetBundleTest extends \yiiunit\TestCase
         ]);
         $bundle->publish($am);
 
-        $notNeededFilesDir = $bundle->basePath . DIRECTORY_SEPARATOR . 'css';
+        $notNeededFilesDir = dirname($bundle->basePath . DIRECTORY_SEPARATOR . $bundle->css[0]);
         $this->assertFileNotExists($notNeededFilesDir);
 
         foreach ($bundle->js as $filename) {
             $publishedFile = $bundle->basePath . DIRECTORY_SEPARATOR . $filename;
-            $this->assertTrue(unlink($publishedFile));
+            $this->assertFileExists($publishedFile);
         }
-        $this->assertTrue(rmdir($bundle->basePath . DIRECTORY_SEPARATOR . 'js'));
-        $this->assertTrue(rmdir($bundle->basePath));
+        $this->assertTrue(is_dir(dirname($bundle->basePath . DIRECTORY_SEPARATOR . $bundle->js[0])));
+        $this->assertTrue(is_dir($bundle->basePath));
     }
 
     /**

--- a/tests/framework/web/AssetBundleTest.php
+++ b/tests/framework/web/AssetBundleTest.php
@@ -134,6 +134,31 @@ class AssetBundleTest extends \yiiunit\TestCase
         $this->assertTrue(rmdir($bundle->basePath));
     }
 
+    public function testSourcesPublish_publishOptions_Only()
+    {
+        $view = $this->getView();
+        $am = $view->assetManager;
+
+        $bundle = new TestSourceAsset([
+            'publishOptions' => [
+                'only' => [
+                    'js/*'
+                ]
+            ],
+        ]);
+        $bundle->publish($am);
+
+        $notNeededFilesDir = $bundle->basePath . DIRECTORY_SEPARATOR . 'css';
+        $this->assertFileNotExists($notNeededFilesDir);
+
+        foreach ($bundle->js as $filename) {
+            $publishedFile = $bundle->basePath . DIRECTORY_SEPARATOR . $filename;
+            $this->assertTrue(unlink($publishedFile));
+        }
+        $this->assertTrue(rmdir($bundle->basePath . DIRECTORY_SEPARATOR . 'js'));
+        $this->assertTrue(rmdir($bundle->basePath));
+    }
+
     /**
      * @param View $view
      * @return AssetBundle


### PR DESCRIPTION
also set it to false in AssetManager to avoid creating a lot of empty
directories. fixes #9669


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #9669 
