### PR TITLE
Fixed processing parse errors on PHP 7 since these are instances of \ParseError

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.12 under development
 --------------------------
 
+- Bug #14052: Fixed processing parse errors on PHP 7 since these are instances of `\ParseError` (samdark)
 - Bug #14033: Fixed `yii\filters\AccessRule::matchIp()` erroring in case IP is not defined under HHVM (Kolyunya)
 - Bug #13848: `yii\di\Instance::ensure()` wasn't throwing an exception when `$type` is specified and `$reference` object isn't instance of `$type` (c-jonua)
 - Enh #13226: `yii cache` command now warns about the fact that it's not able to flush APC cache from console (samdark)

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -306,11 +306,11 @@ class ErrorHandler extends \yii\base\ErrorHandler
 
     /**
      * Renders call stack.
-     * @param \Exception $exception exception to get call stack from
+     * @param \Exception|\ParseError $exception exception to get call stack from
      * @return string HTML content of the rendered call stack.
      * @since 2.0.12
      */
-    public function renderCallStack(\Exception $exception)
+    public function renderCallStack($exception)
     {
         $out = '<ul>';
         $out .= $this->renderCallStackItem($exception->getFile(), $exception->getLine(), null, null, [], 1);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes but not critical
| Tests pass?   | yes
| Fixed issues  | 
