### PR TITLE
Fixed Oracle SQL queries with `IN` condition and more than 1000 params

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -84,6 +84,7 @@ Yii Framework 2 Change Log
 - Enh #13981: `yii\caching\Cache::getOrSet()` now supports both `Closure` and `callable` (silverfire)
 - Enh #13911: Significantly enhanced MSSQL schema reading performance (paulzi, WebdevMerlion)
 - Enh #14059: Removed unused AR instantiating for calling of static methods (ElisDN)
+- Bug #10305: Oracle SQL queries with `IN` condition and more than 1000 parameters are working now (silverfire)
 
 2.0.11.2 February 08, 2017
 --------------------------

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -332,6 +332,9 @@ EOD;
         return parent::buildLikeCondition($operator, $operands, $params);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function buildInCondition($operator, $operands, &$params)
     {
         $splitCondition = $this->splitInCondition($operator, $operands, $params);

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -331,4 +331,56 @@ EOD;
         }
         return parent::buildLikeCondition($operator, $operands, $params);
     }
+
+    public function buildInCondition($operator, $operands, &$params)
+    {
+        $splitCondition = $this->splitInCondition($operator, $operands, $params);
+        if ($splitCondition !== null) {
+            return $splitCondition;
+        }
+
+        return parent::buildInCondition($operator, $operands, $params);
+    }
+
+    /**
+     * Oracle DBMS does not support more than 1000 parameters in `IN` condition.
+     * This method splits long `IN` condition into series of smaller ones.
+     *
+     * @param string $operator
+     * @param array $operands
+     * @param array $params
+     * @return null|string null when split is not required. Otherwise - built SQL condition.
+     * @throws Exception
+     * @since 2.0.12
+     */
+    protected function splitInCondition($operator, $operands, &$params)
+    {
+        if (!isset($operands[0], $operands[1])) {
+            throw new Exception("Operator '$operator' requires two operands.");
+        }
+
+        list($column, $values) = $operands;
+
+        if ($values instanceof \Traversable) {
+            $values = iterator_to_array($values);
+        }
+
+        if (!is_array($values)) {
+            return null;
+        }
+
+        $maxParameters = 1000;
+        $count = count($values);
+        if ($count <= $maxParameters) {
+            return null;
+        }
+
+        $condition = [($operator === 'IN') ? 'OR' : 'AND'];
+        for ($i = 0; $i < $count; $i += $maxParameters) {
+            $condition[] = [$operator, $column, array_slice($values, $i, $maxParameters)];
+        }
+
+        return $this->buildCondition(['AND', $condition], $params);
+    }
+
 }

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -2,8 +2,6 @@
 
 namespace yiiunit\framework\db\mssql;
 
-use yii\db\Expression;
-use yii\db\mssql\Schema;
 use yii\db\Query;
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #10305, #14062 

<s>@samdark could you check whether this fix is applicable to #10371, or MSSQL limits parameters count per query?</s> - checked. MSSQL problem is about bound parameters, not about number of params in `in`