### PR TITLE
function clear() -- Set populated arrays to empty arrays

### DIFF
--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -103,32 +103,32 @@ class View extends \yii\base\View
      * @var array the registered meta tags.
      * @see registerMetaTag()
      */
-    public $metaTags;
+    public $metaTags = [];
     /**
      * @var array the registered link tags.
      * @see registerLinkTag()
      */
-    public $linkTags;
+    public $linkTags = [];
     /**
      * @var array the registered CSS code blocks.
      * @see registerCss()
      */
-    public $css;
+    public $css = [];
     /**
      * @var array the registered CSS files.
      * @see registerCssFile()
      */
-    public $cssFiles;
+    public $cssFiles = [];
     /**
      * @var array the registered JS code blocks
      * @see registerJs()
      */
-    public $js;
+    public $js = [];
     /**
      * @var array the registered JS files.
      * @see registerJsFile()
      */
-    public $jsFiles;
+    public $jsFiles = [];
 
     private $_assetManager;
 

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -236,15 +236,16 @@ class View extends \yii\base\View
 
     /**
      * Clears up the registered meta tags, link tags, css/js scripts and files.
+     * @return void
      */
     public function clear()
     {
-        $this->metaTags = null;
-        $this->linkTags = null;
-        $this->css = null;
-        $this->cssFiles = null;
-        $this->js = null;
-        $this->jsFiles = null;
+        $this->metaTags = [];
+        $this->linkTags = [];
+        $this->css = [];
+        $this->cssFiles = [];
+        $this->js = [];
+        $this->jsFiles = [];
         $this->assetBundles = [];
     }
 

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -236,7 +236,6 @@ class View extends \yii\base\View
 
     /**
      * Clears up the registered meta tags, link tags, css/js scripts and files.
-     * @return void
      */
     public function clear()
     {


### PR DESCRIPTION
Fix for issues found by Scrutinizer CI
https://scrutinizer-ci.com/g/yiisoft/yii2/issues/master/files/framework/web/View.php?selectedLabels%5B0%5D=9&orderField=issueCount&order=desc&honorSelectedPaths=0

`It seems like null of type null is incompatible with the declared type array of property $metaTags.`
`It seems like null of type null is incompatible with the declared type array of property $linkTags.`
`It seems like null of type null is incompatible with the declared type array of property $css.`
`It seems like null of type null is incompatible with the declared type array of property $cssFiles.`
`It seems like null of type null is incompatible with the declared type array of property $js.`
`It seems like null of type null is incompatible with the declared type array of property $jsFiles.`
