### PR TITLE
Fix an invalid phpDocumentor annotation

### DIFF
--- a/framework/data/DataProviderInterface.php
+++ b/framework/data/DataProviderInterface.php
@@ -66,7 +66,7 @@ interface DataProviderInterface
     public function getSort();
 
     /**
-     * @return Pagination the pagination object. If this is false, it means the pagination is disabled.
+     * @return Pagination|false the pagination object. If this is false, it means the pagination is disabled.
      */
     public function getPagination();
 }


### PR DESCRIPTION
Fixed an invalid phpDocumentor annotation of `yii\data\DataProviderInterface::getPagination()`.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
