### PR TITLE
Allow to use custom AR constructors

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Enh #4495:  Added closure support in `yii\i18n\Formatter` (developeruz)
 - Enh #13787: Added `yii\db\Migration::$maxSqlOutputLength` that allows limiting number of characters for outputting SQL (thiagotalma)
 - Enh #13824: Support extracting concatenated strings in `yii message` (developeruz)
+- Enh #14078: Allowed to use custom constructors in ActiveRecord-based classes (ElisDN)
 - Enh #14089: Added tests for `yii\base\Theme` (vladis84)
 - Enh #13586: Added `$preserveNonEmptyValues` property to the `yii\behaviors\AttributeBehavior` (Kolyunya)
 - Bug #14192: Fixed wrong default null value for TIMESTAMP when using PostgreSQL (Tigrov)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -76,6 +76,9 @@ Upgrade from Yii 2.0.11
 * Inputmask package name was changed from `jquery.inputmask` to `inputmask`. If you've configured path to
   assets manually, please adjust it. 
 
+* The usage of `yii\db\BaseActiveRecord::instantiate()` was changed to more general `instantiate($row = [])`. The method is called
+  everywhere in framework internal code instead of `new $modelClass()` and can receive empty `$row` array in this cases.
+
 Upgrade from Yii 2.0.10
 -----------------------
 

--- a/framework/data/ActiveDataProvider.php
+++ b/framework/data/ActiveDataProvider.php
@@ -177,7 +177,12 @@ class ActiveDataProvider extends BaseDataProvider
         parent::setSort($value);
         if (($sort = $this->getSort()) !== false && $this->query instanceof ActiveQueryInterface) {
             /* @var $model Model */
-            $model = new $this->query->modelClass();
+            if (is_subclass_of($this->query->modelClass, 'yii\db\ActiveRecordInterface')) {
+                $modelClass = $this->query->modelClass;
+                $model = $modelClass::instantiate();
+            } else {
+                $model = new $this->query->modelClass();
+            }
             if (empty($sort->attributes)) {
                 foreach ($model->attributes() as $attribute) {
                     $sort->attributes[$attribute] = [

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -435,7 +435,9 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         $join = $this->join;
         $this->join = [];
 
-        $model = new $this->modelClass();
+        $modelClass = $this->modelClass;
+        $model = $modelClass::instantiate();
+
         foreach ($this->joinWith as $config) {
             list($with, $eagerLoading, $joinType) = $config;
             $this->joinWithRelations($model, $with, $joinType);
@@ -515,7 +517,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 } else {
                     $relation = $relations[$fullName];
                 }
-                $primaryModel = new $relation->modelClass();
+                $modelClass = $relation->modelClass;
+                $primaryModel = $modelClass::instantiate();
                 $parent = $relation;
                 $prefix = $fullName;
                 $name = $childName;

--- a/framework/db/ActiveRecordInterface.php
+++ b/framework/db/ActiveRecordInterface.php
@@ -427,4 +427,19 @@ interface ActiveRecordInterface
      * @return mixed the database connection used by this AR class.
      */
     public static function getDb();
+
+    /**
+     * Creates an active record instance.
+     *
+     * This method is called internally by framework for instantiating new record object.
+     * It is not meant to be used for creating new records directly.
+     *
+     * You may override this method if the instance being created
+     * depends on the row data to be populated into the record.
+     * For example, by creating a record based on the value of a column,
+     * you may implement the so-called single-table inheritance mapping.
+     * @param array $row row data to be populated into the record (can be empty).
+     * @return ActiveRecordInterface the newly created active record
+     */
+    public static function instantiate($row = []);
 }

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -177,7 +177,8 @@ trait ActiveRelationTrait
                 $relatedModel->populateRelation($this->inverseOf, $inverseRelation->multiple ? [$this->primaryModel] : $this->primaryModel);
             } else {
                 if (!isset($inverseRelation)) {
-                    $inverseRelation = (new $this->modelClass())->getRelation($this->inverseOf);
+                    $modelClass = $this->modelClass;
+                    $inverseRelation = $modelClass::instantiate()->getRelation($this->inverseOf);
                 }
                 $result[$i][$this->inverseOf] = $inverseRelation->multiple ? [$this->primaryModel] : $this->primaryModel;
             }
@@ -298,7 +299,12 @@ trait ActiveRelationTrait
         }
         $model = reset($models);
         /* @var $relation ActiveQueryInterface|ActiveQuery */
-        $relation = $model instanceof ActiveRecordInterface ? $model->getRelation($name) : (new $this->modelClass())->getRelation($name);
+        if ($model instanceof ActiveRecordInterface) {
+            $relation = $model->getRelation($name);
+        } else {
+            $modelClass = $this->modelClass;
+            $relation = $modelClass::instantiate()->getRelation($name);
+        }
 
         if ($relation->multiple) {
             $buckets = $this->buildBuckets($primaryModels, $relation->link, null, null, false);

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1148,17 +1148,17 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
     /**
      * Creates an active record instance.
      *
-     * This method is called together with [[populateRecord()]] by [[ActiveQuery]].
+     * This method is called internally by framework for instantiating new record object.
      * It is not meant to be used for creating new records directly.
      *
      * You may override this method if the instance being created
      * depends on the row data to be populated into the record.
      * For example, by creating a record based on the value of a column,
      * you may implement the so-called single-table inheritance mapping.
-     * @param array $row row data to be populated into the record.
+     * @param array $row row data to be populated into the record (can be empty).
      * @return static the newly created active record
      */
-    public static function instantiate($row)
+    public static function instantiate($row = [])
     {
         return new static();
     }
@@ -1271,7 +1271,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
             if (is_array($relation->via)) {
                 /* @var $viaClass ActiveRecordInterface */
                 /* @var $record ActiveRecordInterface */
-                $record = new $viaClass();
+                $record = $viaClass::instantiate();
                 foreach ($columns as $column => $value) {
                     $record->$column = $value;
                 }
@@ -1570,7 +1570,8 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
                     } catch (InvalidParamException $e) {
                         return $this->generateAttributeLabel($attribute);
                     }
-                    $relatedModel = new $relation->modelClass();
+                    $modelClass = $relation->modelClass;
+                    $relatedModel = $modelClass::instantiate();
                 }
             }
 
@@ -1610,7 +1611,8 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
                     } catch (InvalidParamException $e) {
                         return '';
                     }
-                    $relatedModel = new $relation->modelClass();
+                    $modelClass = $relation->modelClass;
+                    $relatedModel = $modelClass::instantiate();
                 }
             }
 

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -146,11 +146,21 @@ class DataColumn extends Column
         if ($this->label === null) {
             if ($provider instanceof ActiveDataProvider && $provider->query instanceof ActiveQueryInterface) {
                 /* @var $model Model */
-                $model = new $provider->query->modelClass();
+                if (is_subclass_of($provider->query->modelClass, 'yii\db\ActiveRecordInterface')) {
+                    $modelClass = $provider->query->modelClass;
+                    $model = $modelClass::instantiate();
+                } else {
+                    $model = new $provider->query->modelClass();
+                }
                 $label = $model->getAttributeLabel($this->attribute);
             } elseif ($provider instanceof ArrayDataProvider && $provider->modelClass !== null) {
                 /* @var $model Model */
-                $model = new $provider->modelClass();
+                if (is_subclass_of($provider->modelClass, 'yii\db\ActiveRecordInterface')) {
+                    $modelClass = $provider->modelClass;
+                    $model = $modelClass::instantiate();
+                } else {
+                    $model = new $provider->modelClass();
+                }
                 $label = $model->getAttributeLabel($this->attribute);
             } elseif ($this->grid->filterModel !== null && $this->grid->filterModel instanceof Model) {
                 $label = $this->grid->filterModel->getAttributeLabel($this->attribute);

--- a/tests/data/ar/Animal.php
+++ b/tests/data/ar/Animal.php
@@ -36,10 +36,11 @@ class Animal extends ActiveRecord
     }
 
     /**
-     * @param type $row
+     *
+     * @param array $row
      * @return \yiiunit\data\ar\Animal
      */
-    public static function instantiate($row)
+    public static function instantiate($row = [])
     {
         $class = $row['type'];
         return new $class();

--- a/tests/data/ar/CustomerWithConstructor.php
+++ b/tests/data/ar/CustomerWithConstructor.php
@@ -1,0 +1,51 @@
+<?php
+namespace yiiunit\data\ar;
+
+use yiiunit\framework\db\ActiveRecordTest;
+
+/**
+ * Class Customer
+ *
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property string $address
+ * @property int $status
+ *
+ * @property ProfileWithConstructor $profile
+ */
+class CustomerWithConstructor extends ActiveRecord
+{
+    const STATUS_ACTIVE = 1;
+    const STATUS_INACTIVE = 2;
+
+    public static function tableName()
+    {
+        return 'customer';
+    }
+
+    public function __construct($name, $email, $address)
+    {
+        $this->name = $name;
+        $this->email = $email;
+        $this->address = $address;
+        parent::__construct();
+    }
+
+    public static function instantiate($row = [])
+    {
+        return (new \ReflectionClass(static::className()))->newInstanceWithoutConstructor();
+    }
+
+    public function getProfile()
+    {
+        return $this->hasOne(ProfileWithConstructor::className(), ['id' => 'profile_id']);
+    }
+
+    public function afterSave($insert, $changedAttributes)
+    {
+        ActiveRecordTest::$afterSaveInsert = $insert;
+        ActiveRecordTest::$afterSaveNewRecord = $this->isNewRecord;
+        parent::afterSave($insert, $changedAttributes);
+    }
+}

--- a/tests/data/ar/OrderItemWithConstructor.php
+++ b/tests/data/ar/OrderItemWithConstructor.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace yiiunit\data\ar;
+
+/**
+ * Class OrderItem
+ *
+ * @property int $order_id
+ * @property int $item_id
+ * @property int $quantity
+ * @property string $subtotal
+ */
+class OrderItemWithConstructor extends ActiveRecord
+{
+    public static $tableName;
+
+    public static function tableName()
+    {
+        return static::$tableName ?: 'order_item';
+    }
+
+    public function __construct($item_id, $quantity)
+    {
+        $this->item_id = $item_id;
+        $this->quantity = $quantity;
+        parent::__construct();
+    }
+
+    public static function instantiate($row = [])
+    {
+        return (new \ReflectionClass(static::className()))->newInstanceWithoutConstructor();
+    }
+
+    public function getOrder()
+    {
+        return $this->hasOne(OrderWithConstructor::className(), ['id' => 'order_id']);
+    }
+}

--- a/tests/data/ar/OrderWithConstructor.php
+++ b/tests/data/ar/OrderWithConstructor.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace yiiunit\data\ar;
+
+/**
+ * Class Order
+ *
+ * @property int $id
+ * @property int $customer_id
+ * @property int $created_at
+ * @property string $total
+ *
+ * @property OrderItemWithConstructor $orderItems
+ * @property CustomerWithConstructor $customer
+ * @property CustomerWithConstructor $customerJoinedWithProfile
+ */
+class OrderWithConstructor extends ActiveRecord
+{
+    public static $tableName;
+
+    public static function tableName()
+    {
+        return static::$tableName ?: 'order';
+    }
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+        $this->created_at = time();
+        parent::__construct();
+    }
+
+    public static function instantiate($row = [])
+    {
+        return (new \ReflectionClass(static::className()))->newInstanceWithoutConstructor();
+    }
+
+    public function getCustomer()
+    {
+        return $this->hasOne(CustomerWithConstructor::className(), ['id' => 'customer_id']);
+    }
+
+    public function getCustomerJoinedWithProfile()
+    {
+        return $this->hasOne(CustomerWithConstructor::className(), ['id' => 'customer_id'])
+            ->joinWith('profile');
+    }
+
+    public function getOrderItems()
+    {
+        return $this->hasMany(OrderItemWithConstructor::className(), ['order_id' => 'id'])->inverseOf('order');
+    }
+}

--- a/tests/data/ar/ProfileWithConstructor.php
+++ b/tests/data/ar/ProfileWithConstructor.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace yiiunit\data\ar;
+
+/**
+ * Class Profile
+ *
+ * @property int $id
+ * @property string $description
+ *
+ */
+class ProfileWithConstructor extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'profile';
+    }
+
+    public function __construct($description)
+    {
+        $this->description = $description;
+        parent::__construct();
+    }
+
+    public static function instantiate($row = [])
+    {
+        return (new \ReflectionClass(static::className()))->newInstanceWithoutConstructor();
+    }
+}

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -14,15 +14,19 @@ use yiiunit\data\ar\BitValues;
 use yiiunit\data\ar\Cat;
 use yiiunit\data\ar\Category;
 use yiiunit\data\ar\Customer;
+use yiiunit\data\ar\CustomerWithConstructor;
 use yiiunit\data\ar\Document;
 use yiiunit\data\ar\Dog;
 use yiiunit\data\ar\Item;
 use yiiunit\data\ar\NullValues;
 use yiiunit\data\ar\Order;
 use yiiunit\data\ar\OrderItem;
+use yiiunit\data\ar\OrderItemWithConstructor;
 use yiiunit\data\ar\OrderItemWithNullFK;
+use yiiunit\data\ar\OrderWithConstructor;
 use yiiunit\data\ar\OrderWithNullFK;
 use yiiunit\data\ar\Profile;
+use yiiunit\data\ar\ProfileWithConstructor;
 use yiiunit\data\ar\Type;
 use yiiunit\framework\ar\ActiveRecordTestTrait;
 use yiiunit\framework\db\cubrid\ActiveRecordTest as CubridActiveRecordTest;
@@ -220,6 +224,39 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertCount(2, $order['books']);
         $this->assertEquals(1, $order['books'][0]['id']);
         $this->assertEquals(2, $order['books'][1]['id']);
+    }
+
+    public function testFindWithConstructors()
+    {
+        /** @var OrderWithConstructor[] $orders */
+        $orders = OrderWithConstructor::find()->with(['customer.profile', 'orderItems'])->orderBy('id')->all();
+        $this->assertCount(3, $orders);
+
+        $order = $orders[0];
+        $this->assertEquals(1, $order->id);
+
+        $this->assertNotNull($customer = $order->customer);
+        $this->assertInstanceOf(CustomerWithConstructor::className(), $customer);
+        $this->assertEquals(1, $customer->id);
+
+        $this->assertNotNull($profile = $customer->profile);
+        $this->assertInstanceOf(ProfileWithConstructor::className(), $profile);
+        $this->assertEquals(1, $profile->id);
+
+        $this->assertNotNull($customerWithProfile = $order->customerJoinedWithProfile);
+        $this->assertInstanceOf(CustomerWithConstructor::className(), $customerWithProfile);
+        $this->assertEquals(1, $customerWithProfile->id);
+
+        $this->assertNotNull($customerProfile = $customerWithProfile->profile);
+        $this->assertInstanceOf(ProfileWithConstructor::className(), $customerProfile);
+        $this->assertEquals(1, $customerProfile->id);
+
+        $this->assertCount(2, $order->orderItems);
+
+        $item = $order->orderItems[0];
+        $this->assertInstanceOf(OrderItemWithConstructor::className(), $item);
+
+        $this->assertEquals(1, $item->item_id);
     }
 
     // deeply nested table relation


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | potentially
| Tests pass?   | yes
| Fixed issues  | #5786, #8639, #13779, #5771

The PR replaces all `new $modelClass` internal calls to `$modelClass::instantiate()`. It allows to use custom constructors in ActiveRecord-based classes:

~~~php
class User extends ActiveRecord
{
    public static function instantiate($row = [])
    {
        $record = (new \ReflectionClass(static::className()))->newInstanceWithoutConstructor();
        $record->init();
        return $record;
    }
    
    public function __construct($name, $email)
    {
        $this->name = $name;
        $this->email = $email;
        $this->created_at = time();
        parent::__construct();
    }
}
~~~

without internal issues with all types of relations.

Backwards compatibility
------

The `$row` argument can be an empty array in new cases. It may break existing code. For example, for [STI](https://github.com/samdark/yii2-cookbook/blob/master/book/ar-single-table-inheritance.md) you must add `empty($row)` checking before `switch` sentence:

```php
public static function instantiate($row = [])
{
    if (empty($row)) {
        return new self();
    }

    switch ($row['type']) {
        ...
    }
}
```
or use safe `ArrayHelper::getValue($row, 'type')` instead of unsafe `$row['data']` calling.