### PR TITLE
Reduce `Segmentation fault` errors for PHP 5.4 tests on travis

### DIFF
--- a/tests/framework/db/mysql/connection/DeadLockTest.php
+++ b/tests/framework/db/mysql/connection/DeadLockTest.php
@@ -26,12 +26,8 @@ class DeadLockTest extends \yiiunit\framework\db\mysql\ConnectionTest
      */
     public function testDeadlockException()
     {
-        if (
-            getenv('TRAVIS')
-            && version_compare(PHP_VERSION, '5.5.0', '>=')
-            && version_compare(PHP_VERSION, '7.0.0', '<')
-        ) {
-            $this->markTestSkipped('Skipping PHP 5.5 and 5.6 on Travis since it segfaults with pcntl');
+        if (getenv('TRAVIS') && version_compare(PHP_VERSION, '7.0.0', '<')) {
+            $this->markTestSkipped('Skipping PHP 5 on Travis since it segfaults with pcntl');
         }
 
         if (!function_exists('pcntl_fork')) {


### PR DESCRIPTION
I think that we should not run this test on PHP 5.4, because it breaks almost every build - test for PHP 5.4 practically does not work.

Last 5 builds on master, all failed because of segmentation fault:
https://travis-ci.org/yiisoft/yii2/jobs/226541976
https://travis-ci.org/yiisoft/yii2/jobs/226548569
https://travis-ci.org/yiisoft/yii2/jobs/226732220
https://travis-ci.org/yiisoft/yii2/jobs/226964193
https://travis-ci.org/yiisoft/yii2/jobs/227550868

refs #13346