### PR TITLE
Make FileHelper::normalizeOptions() protected

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -89,6 +89,7 @@ Yii Framework 2 Change Log
 - Enh: Added `yii\di\Instance::__set_state()` method to restore object after serialization using `var_export()` function (silvefire)
 
 - Bug #10305: Oracle SQL queries with `IN` condition and more than 1000 parameters are working now (silverfire)
+- Enh #14098: `yii\helpers\BaseFileHelper::normalizeOptions()` is now protected (brandonkelly)
 
 2.0.11.2 February 08, 2017
 --------------------------

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -696,6 +696,7 @@ class BaseFileHelper
     /**
      * @param array $options raw options
      * @return array normalized options
+     * @since 2.0.12
      */
     protected static function normalizeOptions(array $options)
     {

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -270,7 +270,7 @@ class BaseFileHelper
         if (!isset($options['basePath'])) {
             // this should be done only once
             $options['basePath'] = realpath($src);
-            $options = self::normalizeOptions($options);
+            $options = static::normalizeOptions($options);
         }
         while (($file = readdir($handle)) !== false) {
             if ($file === '.' || $file === '..') {
@@ -396,7 +396,7 @@ class BaseFileHelper
         if (!isset($options['basePath'])) {
             // this should be done only once
             $options['basePath'] = realpath($dir);
-            $options = self::normalizeOptions($options);
+            $options = static::normalizeOptions($options);
         }
         $list = [];
         $handle = opendir($dir);

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -697,7 +697,7 @@ class BaseFileHelper
      * @param array $options raw options
      * @return array normalized options
      */
-    private static function normalizeOptions(array $options)
+    protected static function normalizeOptions(array $options)
     {
         if (!array_key_exists('caseSensitive', $options)) {
             $options['caseSensitive'] = true;


### PR DESCRIPTION
We have a need to call `normalizeOptions()` in an extension of FileHelper in Craft (preceding some calls to `filterPath()`). Assume there’s no harm in making it protected, so we don’t have to copy the function over to our class, just to work around the private visibility.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
