### PR TITLE
Update AttributeBehavior.php

### DIFF
--- a/framework/behaviors/AttributeBehavior.php
+++ b/framework/behaviors/AttributeBehavior.php
@@ -95,6 +95,10 @@ class AttributeBehavior extends Behavior
      */
     public $values = [];
     /**
+     * @var string current processed attribute name. Can be use inside callable item of [[values]].
+     */
+    public $currentAttribute;
+    /**
      * @var bool whether to skip this behavior when the `$owner` has not been
      * modified
      * @since 2.0.8
@@ -170,6 +174,7 @@ class AttributeBehavior extends Behavior
         if (array_key_exists($attribute, $this->values)) {
             $value = $this->value;
             $this->value = $this->values[$attribute];
+            $this->currentAttribute = $attribute;
             $result = $this->getValue($event);
             $this->value = $value;
             return $result;

--- a/framework/behaviors/AttributeBehavior.php
+++ b/framework/behaviors/AttributeBehavior.php
@@ -85,10 +85,12 @@ class AttributeBehavior extends Behavior
      * key - attribute name
      * value - corresponding value
      * Example:
+     * ```php
      * 'values' => [
      *   'number' => [$this, 'getNextNumber'],
      *   'status' => 'updated'
      * ]
+     * ```
      * @see value for possible values
      */
     public $values = [];

--- a/framework/behaviors/AttributeBehavior.php
+++ b/framework/behaviors/AttributeBehavior.php
@@ -81,8 +81,15 @@ class AttributeBehavior extends Behavior
     public $value;
     /**
      * @var array an array of the values indexed by attribute name that will be assigned to the current attributes respectively by attribute name.
-     * Will be assigned if $this->value is NULL
-     * The single value same at @see $value
+     * This property will be used only when [[value]] is `null`
+     * key - attribute name
+     * value - corresponding value
+     * Example:
+     * 'values' => [
+     *   'number' => [$this, 'getNextNumber'],
+     *   'status' => 'updated'
+     * ]
+     * @see value for possible values
      */
     public $values = [];
     /**


### PR DESCRIPTION
Add `$values` feature

Provide difference assigned values by attributes is user friendly.
Array of behaviors:
```php
            [
                'class' => AttributeBehavior::className(),
                'attributes' => [
                    ActiveRecord::EVENT_BEFORE_INSERT => ['number', 'name'],
                ],
                'values' => [
                    'number' => [$this, 'getNextNumber'],
                    'name' => [$this, 'getNewName']
                ]
            ],
```
instead of 
```php
            [
                'class' => AttributeBehavior::className(),
                'attributes' => [
                    ActiveRecord::EVENT_BEFORE_INSERT => 'number',
                ],
                'value' => [$this, 'getNextNumber']
            ],
           [
                'class' => AttributeBehavior::className(),
                'attributes' => [
                    ActiveRecord::EVENT_BEFORE_INSERT => 'name',
                ],
                'value' => [$this, 'getNewName']
            ],
```

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
