### PR TITLE
Update db-migrations.md

### DIFF
--- a/docs/guide/db-migrations.md
+++ b/docs/guide/db-migrations.md
@@ -951,18 +951,21 @@ return [
             'class' => 'yii\console\controllers\MigrateController',
             'migrationNamespaces' => ['app\migrations'],
             'migrationTable' => 'migration_app',
+            'migrationPath' => null,
         ],
         // Migrations for the specific project's module
         'migrate-module' => [
             'class' => 'yii\console\controllers\MigrateController',
             'migrationNamespaces' => ['module\migrations'],
             'migrationTable' => 'migration_module',
+            'migrationPath' => null,
         ],
         // Migrations for the specific extension
         'migrate-rbac' => [
             'class' => 'yii\console\controllers\MigrateController',
             'migrationPath' => '@yii/rbac/migrations',
             'migrationTable' => 'migration_rbac',
+            'migrationPath' => null,
         ],
     ],
 ];


### PR DESCRIPTION
By default, the class BaseMigrateController property migrationPath is assigned the value '@app/migrations'. In the method getNewMigrations() is the conversion migrationNamescpaces in the path to the file and merges it all into a single array along with the path migrationPath. If the project for migration module is a separate table in the database, all migration came from migrationPath are not initialized and therefore try to migrate. Therefore, it is necessary to specify the property 'migrationPath' => null.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
