### PR TITLE
Fixed yii.activeForm.js

### DIFF
--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -306,7 +306,7 @@
                 needAjaxValidation = false,
                 messages = {},
                 deferreds = deferredArray(),
-                submitting = data.submitting && !forceValidate;
+                submitting = data.submitting;
 
             if (data.submitting) {
                 var event = $.Event(events.beforeValidate);


### PR DESCRIPTION
In function validate, when force validation is set to true, it actually set's data.submitting to true.
Few rows later, variable submitting was set to data.submitting && !forceValidate, which will always be false in case forceValidation is true.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | #13940
