### PR TITLE
Bug #14165: Fix slave usage disabled after Connection::close, set _sl…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.12 under development
 --------------------------
-- Bug #14165: Set `_slave` of `Connection` to `false` instead of `null` in `close` method
+- Bug #14165: Set `_slave` of `Connection` to `false` instead of `null` in `close` method (rossoneri)
 - Bug #13842: Fixed ambiguous table SQL error while using `yii\validators\ExistValidator` and `yii\validators\UniqueValidator` (vladis84, samdark)
 - Bug #5442: Fixed problem on load fixture dependencies with database related tests (leandrogehlen)
 - Bug #4408: Add support for unicode word characters and `+` character in attribute names (sammousa, kmindi)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.12 under development
 --------------------------
-
+- Bug #14165: Set `_slave` of `Connection` to `false` instead of `null` in `close` method
 - Bug #13842: Fixed ambiguous table SQL error while using `yii\validators\ExistValidator` and `yii\validators\UniqueValidator` (vladis84, samdark)
 - Bug #5442: Fixed problem on load fixture dependencies with database related tests (leandrogehlen)
 - Bug #4408: Add support for unicode word characters and `+` character in attribute names (sammousa, kmindi)

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -608,7 +608,7 @@ class Connection extends Component
 
         if ($this->_slave) {
             $this->_slave->close();
-            $this->_slave = null;
+            $this->_slave = false;
         }
     }
 

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -596,7 +596,7 @@ class Connection extends Component
             }
 
             $this->_master->close();
-            $this->_master = null;
+            $this->_master = false;
         }
 
         if ($this->pdo !== null) {

--- a/tests/framework/db/mysql/ConnectionTest.php
+++ b/tests/framework/db/mysql/ConnectionTest.php
@@ -9,4 +9,29 @@ namespace yiiunit\framework\db\mysql;
 class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
 {
     protected $driverName = 'mysql';
+
+
+    /**
+     * Test whether slave connection is recovered when call getSlavePdo() after close()
+     *
+     * @see https://github.com/yiisoft/yii2/issues/14165
+     */
+    public function testGetPdoAfterClose(){
+        $connection = $this->getConnection();
+        if(!empty($connection->slaves)){
+            $connection->getSlavePdo(false);
+        }
+        $connection->close();
+
+        $masterPdo = $connection->getMasterPdo();
+        $this->assertNotFalse($masterPdo);
+        $this->assertNotNull($masterPdo);
+
+        if(!empty($connection->slaves)){
+            $slavePdo = $connection->getSlavePdo(false);
+            $this->assertNotFalse($slavePdo);
+            $this->assertNotNull($slavePdo);
+            $this->assertNotSame($masterPdo,$slavePdo);
+        }
+    }
 }

--- a/tests/framework/db/mysql/ConnectionTest.php
+++ b/tests/framework/db/mysql/ConnectionTest.php
@@ -16,9 +16,10 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
      *
      * @see https://github.com/yiisoft/yii2/issues/14165
      */
-    public function testGetPdoAfterClose(){
+    public function testGetPdoAfterClose()
+    {
         $connection = $this->getConnection();
-        if(!empty($connection->slaves)){
+        if (!empty($connection->slaves)){
             $connection->getSlavePdo(false);
         }
         $connection->close();
@@ -27,7 +28,7 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
         $this->assertNotFalse($masterPdo);
         $this->assertNotNull($masterPdo);
 
-        if(!empty($connection->slaves)){
+        if (!empty($connection->slaves)){
             $slavePdo = $connection->getSlavePdo(false);
             $this->assertNotFalse($slavePdo);
             $this->assertNotNull($slavePdo);


### PR DESCRIPTION
…ave to false instead of nulll

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14165 
