### PR TITLE
Removed non-default call of `$app-get()` in favor of using `$app->has()`

### DIFF
--- a/framework/behaviors/BlameableBehavior.php
+++ b/framework/behaviors/BlameableBehavior.php
@@ -97,8 +97,7 @@ class BlameableBehavior extends AttributeBehavior
     protected function getValue($event)
     {
         if ($this->value === null && Yii::$app->has('user')) {
-            $user = Yii::$app->get('user');
-            return !$user->isGuest ? $user->id : null;
+            return Yii::$app->get('user')->id;
         }
 
         return parent::getValue($event);

--- a/framework/behaviors/BlameableBehavior.php
+++ b/framework/behaviors/BlameableBehavior.php
@@ -96,9 +96,9 @@ class BlameableBehavior extends AttributeBehavior
      */
     protected function getValue($event)
     {
-        if ($this->value === null) {
-            $user = Yii::$app->get('user', false);
-            return $user && !$user->isGuest ? $user->id : null;
+        if ($this->value === null && Yii::$app->has('user')) {
+            $user = Yii::$app->get('user');
+            return !$user->isGuest ? $user->id : null;
         }
 
         return parent::getValue($event);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

This is a small code quality improvement. Related to #14184
