### PR TITLE
Bug #14192 postgresql wrong default null value for timestamp

### DIFF
--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -441,11 +441,11 @@ SQL;
                     $column->defaultValue = bindec(trim($column->defaultValue, 'B\''));
                 } elseif (preg_match("/^'(.*?)'::/", $column->defaultValue, $matches)) {
                     $column->defaultValue = $matches[1];
-                } elseif (preg_match('/^(?:\()?(.*?)(?(1)\))(?:::.+)?$/', $column->defaultValue, $matches)) {
-                    if ($matches[1] === 'NULL') {
+                } elseif (preg_match('/^(\()?(.*?)(?(1)\))(?:::.+)?$/', $column->defaultValue, $matches)) {
+                    if ($matches[2] === 'NULL') {
                         $column->defaultValue = null;
                     } else {
-                        $column->defaultValue = $column->phpTypecast($matches[1]);
+                        $column->defaultValue = $column->phpTypecast($matches[2]);
                     }
                 } else {
                     $column->defaultValue = $column->phpTypecast($column->defaultValue);

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -195,6 +195,9 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         $this->assertEquals(0, $column->defaultValue);
     }
 
+    /**
+     * https://github.com/yiisoft/yii2/issues/14192
+     */
     public function testTimestampNullDefaultValue()
     {
         $db = $this->getConnection(false);

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -194,4 +194,21 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         $this->assertEquals('numeric', $column->dbType);
         $this->assertEquals(0, $column->defaultValue);
     }
+
+    public function testTimestampNullDefaultValue()
+    {
+        $db = $this->getConnection(false);
+        if ($db->schema->getTableSchema('test_timestamp_default_null') !== null) {
+            $db->createCommand()->dropTable('test_timestamp_default_null')->execute();
+        }
+
+        $db->createCommand()->createTable('test_timestamp_default_null', [
+            'id' => 'pk',
+            'timestamp' => 'timestamp DEFAULT NULL',
+        ])->execute();
+
+        $db->schema->refreshTableSchema('test_timestamp_default_null');
+        $tableSchema = $db->schema->getTableSchema('test_timestamp_default_null');
+        $this->assertNull($tableSchema->getColumn('timestamp')->defaultValue);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14192
