### PR TITLE
Change extractMessagesFromTokens to protected

### DIFF
--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -506,7 +506,7 @@ EOD;
      * @param array $ignoreCategories message categories to ignore.
      * @return array messages.
      */
-    private function extractMessagesFromTokens(array $tokens, array $translatorTokens, array $ignoreCategories)
+    protected function extractMessagesFromTokens(array $tokens, array $translatorTokens, array $ignoreCategories)
     {
         $messages = [];
         $translatorTokensCount = count($translatorTokens);


### PR DESCRIPTION
In my modules I use function like this:
```php
public static function t($message, $params = [], $language = null)
{
    return \Yii::t('category_name', $message, $params, $language);
}
```
Due to this there is no need to specify a category each time.
```php
Module::t('message')
```
But `message/extract` not working without category.
I wanted to extend the method `extractMessagesFromTokens `, but it `private`. Can we change it to `protected`?