### PR TITLE
Add migration file example for DbSession

### DIFF
--- a/docs/guide/runtime-sessions-cookies.md
+++ b/docs/guide/runtime-sessions-cookies.md
@@ -178,6 +178,31 @@ where 'BLOB' refers to the BLOB-type of your preferred DBMS. Below are the BLOB 
   the length of the `id` column. For example, if `session.hash_function=sha256`, you should use a
   length 64 instead of 40.
 
+Alternatively, this can be accomplished with the following migration:
+
+```php
+<?php
+
+use yii\db\Migration;
+
+class m170529_050554_create_table_session extends Migration
+{
+    public function up()
+    {
+        $this->createTable('{{%session}}', [
+            'id' => $this->char(64)->notNull(),
+            'expire' => $this->integer(),
+            'data' => $this->binary()
+        ]);
+        $this->addPrimaryKey('pk-id', '{{%session}}', 'id');
+    }
+
+    public function down()
+    {
+        $this->dropTable('{{%session}}');
+    }
+}
+```
 
 ### Flash Data <span id="flash-data"></span>
 


### PR DESCRIPTION
Creating a `char` primaryKey in a migration is non-obvious. Used solution from this [issue comment](https://github.com/yiisoft/yii2/issues/10889#issuecomment-302995086).

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | none - documentation issue
