### PR TITLE
Added support for specifying aliases for migrationNamespaces

### DIFF
--- a/docs/guide/db-migrations.md
+++ b/docs/guide/db-migrations.md
@@ -933,8 +933,8 @@ yii migrate/create 'app\\migrations\\createUserTable'
   contain a namespace, namespaced migration can be applied only via [[yii\console\controllers\MigrateController::migrationNamespaces]]
   property.
 
-Since version 2.0.12 the [[yii\console\controllers\MigrateController::migrationNamespaces|migrationNamespaces]] property
-also accepts [aliases](concept-aliases.md) for specifying directories that contain migrations without a namespace.
+Since version 2.0.12 the [[yii\console\controllers\MigrateController::migrationPath|migrationPath]] property
+also accepts an array for specifying multiple directories that contain migrations without a namespace.
 This is mainly added to be used in existing projects which use migrations from different locations. These migrations mainly come
 from external sources, like Yii extensions developed by other developers,
 which can not be changed to use namespaces easily when starting to use the new approach.

--- a/docs/guide/db-migrations.md
+++ b/docs/guide/db-migrations.md
@@ -933,6 +933,11 @@ yii migrate/create 'app\\migrations\\createUserTable'
   contain a namespace, namespaced migration can be applied only via [[yii\console\controllers\MigrateController::migrationNamespaces]]
   property.
 
+Since version 2.0.12 the [[yii\console\controllers\MigrateController::migrationNamespaces|migrationNamespaces]] property
+also accepts [aliases](concept-aliases.md) for specifying directories that contain migrations without a namespace.
+This is mainly added to be used in existing projects which use migrations from different locations. These migrations mainly come
+from external sources, like Yii extensions developed by other developers,
+which can not be changed to use namespaces easily when starting to use the new approach.
 
 ### Separated Migrations <span id="separated-migrations"></span>
 

--- a/docs/guide/db-migrations.md
+++ b/docs/guide/db-migrations.md
@@ -835,9 +835,10 @@ The migration command comes with a few command-line options that can be used to 
   When this is `true`, the user will be prompted before the command performs certain actions.
   You may want to set this to `false` if the command is being used in a background process.
 
-* `migrationPath`: string (defaults to `@app/migrations`), specifies the directory storing all migration
+* `migrationPath`: string|array (defaults to `@app/migrations`), specifies the directory storing all migration
   class files. This can be specified as either a directory path or a path [alias](concept-aliases.md).
-  Note that the directory must exist, or the command may trigger an error.
+  Note that the directory must exist, or the command may trigger an error. Since version 2.0.12 an array can be
+  specified for loading migrations from multiple sources.
 
 * `migrationTable`: string (defaults to `migration`), specifies the name of the database table for storing
   migration history information. The table will be automatically created by the command if it does not exist.

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -73,6 +73,7 @@ Yii Framework 2 Change Log
 - Enh #13254: Core validators no longer require `Yii::$app` to be set (sammousa)
 - Enh #13260: Added support for sorting by expression to `\yii\data\Sort` (LAV45, klimov-paul)
 - Enh #13278: `yii\caching\DbQueryDependency` created allowing specification of the cache dependency via `yii\db\QueryInterface` (klimov-paul)
+- Enh #13356: Support aliases in `MigrateController::$migrationNamespaces` to load non-namespaced migrations for BC with existing applications and extensions (schmunk42, cebe)
 - Enh #13360: Added Dockerized test setup for the framework tests (schmunk42)
 - Enh #13369: Added ability to render current `yii\widgets\LinkPager` page disabled (aquy)
 - Enh #13376: Data provider now automatically sets an ID so there is no need to set it manually in case multiple data providers are used with pagination (SamMousa)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -73,7 +73,7 @@ Yii Framework 2 Change Log
 - Enh #13254: Core validators no longer require `Yii::$app` to be set (sammousa)
 - Enh #13260: Added support for sorting by expression to `\yii\data\Sort` (LAV45, klimov-paul)
 - Enh #13278: `yii\caching\DbQueryDependency` created allowing specification of the cache dependency via `yii\db\QueryInterface` (klimov-paul)
-- Enh #13356: Support aliases in `MigrateController::$migrationNamespaces` to load non-namespaced migrations for BC with existing applications and extensions (schmunk42, cebe)
+- Enh #13356: Support multiple paths in `MigrateController::$migrationPath` to load non-namespaced migrations for BC with existing applications and extensions (schmunk42, cebe)
 - Enh #13360: Added Dockerized test setup for the framework tests (schmunk42)
 - Enh #13369: Added ability to render current `yii\widgets\LinkPager` page disabled (aquy)
 - Enh #13376: Data provider now automatically sets an ID so there is no need to set it manually in case multiple data providers are used with pagination (SamMousa)

--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -52,7 +52,7 @@ abstract class BaseMigrateController extends Controller
      *
      * @see $migrationNamespaces
      */
-    public $migrationPath = '@app/migrations';
+    public $migrationPath = ['@app/migrations'];
     /**
      * @var array list of namespaces containing the migration classes.
      *

--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -717,6 +717,21 @@ abstract class BaseMigrateController extends Controller
      */
     protected function createMigration($class)
     {
+        $this->includeMigrationFile($class);
+        return new $class();
+    }
+
+    /**
+     * Includes the migration file for a given migration class name.
+     *
+     * This function will do nothing on namespaced migrations, which are loaded by
+     * autoloading automatically. It will include the migration file, by searching
+     * [[migrationPath]] for classes without namespace.
+     * @param string $class the migration class name.
+     * @since 2.0.12
+     */
+    protected function includeMigrationFile($class)
+    {
         $class = trim($class, '\\');
         if (strpos($class, '\\') === false) {
             if (is_array($this->migrationPath)) {
@@ -732,8 +747,6 @@ abstract class BaseMigrateController extends Controller
                 require_once($file);
             }
         }
-
-        return new $class();
     }
 
     /**

--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -13,6 +13,7 @@ use yii\console\Exception;
 use yii\console\Controller;
 use yii\helpers\Console;
 use yii\helpers\FileHelper;
+use yii\helpers\StringHelper;
 
 /**
  * BaseMigrateController is the base class for migrate controllers.
@@ -718,6 +719,9 @@ abstract class BaseMigrateController extends Controller
         if (strpos($class, '\\') === false) {
             $file = $this->migrationPath . DIRECTORY_SEPARATOR . $class . '.php';
             require_once($file);
+        } elseif (!class_exists($class, true)) {
+            // if the class with namespace does not exist, try to load it without namespace
+            $class = StringHelper::basename($class);
         }
 
         return new $class();

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -184,9 +184,20 @@ class MigrateController extends BaseMigrateController
     {
         $class = trim($class, '\\');
         if (strpos($class, '\\') === false) {
-            $file = $this->migrationPath . DIRECTORY_SEPARATOR . $class . '.php';
-            require_once($file);
+            if (is_array($this->migrationPath)) {
+                foreach($this->migrationPath as $path) {
+                    $file = $path . DIRECTORY_SEPARATOR . $class . '.php';
+                    if (is_file($file)) {
+                        require_once($file);
+                        break;
+                    }
+                }
+            } else {
+                $file = $this->migrationPath . DIRECTORY_SEPARATOR . $class . '.php';
+                require_once($file);
+            }
         }
+
 
         return new $class(['db' => $this->db]);
     }

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -182,23 +182,7 @@ class MigrateController extends BaseMigrateController
      */
     protected function createMigration($class)
     {
-        $class = trim($class, '\\');
-        if (strpos($class, '\\') === false) {
-            if (is_array($this->migrationPath)) {
-                foreach($this->migrationPath as $path) {
-                    $file = $path . DIRECTORY_SEPARATOR . $class . '.php';
-                    if (is_file($file)) {
-                        require_once($file);
-                        break;
-                    }
-                }
-            } else {
-                $file = $this->migrationPath . DIRECTORY_SEPARATOR . $class . '.php';
-                require_once($file);
-            }
-        }
-
-
+        $this->includeMigrationFile($class);
         return new $class(['db' => $this->db]);
     }
 


### PR DESCRIPTION
This is used to specify pathes to migrations that do not have
namespaces.

While not directly supported by the migration command provided by the
framework, these migrations exist in a lot of extensions because custom implementations
of migration controllers out of the framework were using this approach
to load multiple migrations from multiple paths.

Even the framework itself currently ships non-namespaced migrations:

- https://github.com/yiisoft/yii2/blob/17a1d91e4a517f4f15dce973bf3c50dd939dce63/framework/rbac/migrations/m140506_102106_rbac_init.php
- https://github.com/yiisoft/yii2/blob/17a1d91e4a517f4f15dce973bf3c50dd939dce63/framework/caching/migrations/m150909_153426_cache_init.php
- https://github.com/yiisoft/yii2/blob/17a1d91e4a517f4f15dce973bf3c50dd939dce63/framework/log/migrations/m141106_185632_log_init.php

This change allows existing applications to adopt the new namespace-based approach
while keeping existing migrations. While it would be possible to add
namespaces to migrations in the application itself, it is not easily possible
to add namespaces to migrations that come from external sources like
extensions.

related discussion in #13359 and #13356.

this replaces #13359

- [x] I will add some tests to verify behavior later.