### PR TITLE
Fixes #4999: Added support for wildcards at `yii\filters\AccessRule::$controllers`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -103,6 +103,7 @@ Yii Framework 2 Change Log
 - Enh #14059: Removed unused AR instantiating for calling of static methods (ElisDN)
 - Enh #14067: `yii\web\View::clear()` sets populated arrays to empty arrays instead of null, also changed default values to empty array (craiglondon)
 - Enh #4793: `yii\filters\AccessControl` now can be used without `user` component (bizley)
+- Enh #4999: Added support for wildcards at `yii\filters\AccessRule::$controllers` (klimov-paul)
 - Enh: Added `yii\di\Instance::__set_state()` method to restore object after serialization using `var_export()` function (silvefire)
 - Bug #14072: Fixed a bug where `\yii\db\Command::createTable()`, `addForeignKey()`, `dropForeignKey()`, `addCommentOnColumn()`, and `dropCommentFromColumn()` weren't refreshing the table cache on `yii\db\Schema` (brandonkelly) 
 - Bug #10305: Oracle SQL queries with `IN` condition and more than 1000 parameters are working now (silverfire)

--- a/framework/filters/AccessRule.php
+++ b/framework/filters/AccessRule.php
@@ -43,6 +43,8 @@ class AccessRule extends Component
      * The comparison is case-sensitive.
      *
      * If not set or empty, it means this rule applies to all controllers.
+     *
+     * Since version 2.0.12 controller IDs can be specified as wildcards, e.g. `module/*`.
      */
     public $controllers;
     /**
@@ -172,7 +174,18 @@ class AccessRule extends Component
      */
     protected function matchController($controller)
     {
-        return empty($this->controllers) || in_array($controller->uniqueId, $this->controllers, true);
+        if (empty($this->controllers)) {
+            return true;
+        }
+
+        $id = $controller->getUniqueId();
+        foreach ($this->controllers as $pattern) {
+            if (fnmatch($pattern, $id)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -141,7 +141,65 @@ class AccessRuleTest extends \yiiunit\TestCase
         $this->assertNull($rule->allows($action, $user, $request));
     }
 
-    // TODO test match controller
+    public function testMatchController()
+    {
+        $action = $this->mockAction();
+        $user = false;
+        $request = $this->mockRequest();
+
+        $rule = new AccessRule([
+            'allow' => true,
+            'controllers' => ['test', 'other'],
+        ]);
+
+        $action->controller->id = 'test';
+        $this->assertTrue($rule->allows($action, $user, $request));
+
+        $action->controller->id = 'other';
+        $this->assertTrue($rule->allows($action, $user, $request));
+        $action->controller->id = 'foreign';
+        $this->assertNull($rule->allows($action, $user, $request));
+
+        $rule->allow = false;
+
+        $action->controller->id = 'test';
+        $this->assertFalse($rule->allows($action, $user, $request));
+        $action->controller->id = 'other';
+        $this->assertFalse($rule->allows($action, $user, $request));
+        $action->controller->id = 'foreign';
+        $this->assertNull($rule->allows($action, $user, $request));
+    }
+
+    /**
+     * @depends testMatchController
+     */
+    public function testMatchControllerWildcard()
+    {
+        $action = $this->mockAction();
+        $user = false;
+        $request = $this->mockRequest();
+
+        $rule = new AccessRule([
+            'allow' => true,
+            'controllers' => ['module/*', '*/controller'],
+        ]);
+
+        $action->controller->id = 'module/test';
+        $this->assertTrue($rule->allows($action, $user, $request));
+        $action->controller->id = 'any-module/controller';
+        $this->assertTrue($rule->allows($action, $user, $request));
+        $action->controller->id = 'other/other';
+        $this->assertNull($rule->allows($action, $user, $request));
+
+        $rule->allow = false;
+
+        $action->controller->id = 'module/test';
+        $this->assertFalse($rule->allows($action, $user, $request));
+        $action->controller->id = 'any-module/controller';
+        $this->assertFalse($rule->allows($action, $user, $request));
+        $action->controller->id = 'other/other';
+        $this->assertNull($rule->allows($action, $user, $request));
+    }
 
     /**
      * Data provider for testMatchRole


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #4999
