### PR TITLE
Fixed Formatter::normalizeDatetimeValue() docs

### DIFF
--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -656,7 +656,7 @@ class Formatter extends Component
      * whether the timestamp has date information.
      * This parameter is available since version 2.0.1.
      * @return DateTime|array the normalized datetime value.
-     * Since version 2.0.1 this may also return an array if `$checkTimeInfo` is true.
+     * Since version 2.0.1 this may also return an array if `$checkDateTimeInfo` is true.
      * The first element of the array is the normalized timestamp and the second is a boolean indicating whether
      * the timestamp has time information or it is just a date value.
      * Since version 2.0.12 the array has third boolean element indicating whether the timestamp has date information


### PR DESCRIPTION
There was a reference to `$checkTimeInfo` that was leftover from 54278fc84262fc45e696ccccfd2258a6028bd9e3

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
