### PR TITLE
User primary inputmask alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "ezyang/htmlpurifier": "~4.6",
         "cebe/markdown": "~1.0.0 | ~1.1.0",
         "bower-asset/jquery": "2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
-        "bower-asset/jquery.inputmask": "~3.2.2 | ~3.3.5",
+        "bower-asset/inputmask": "~3.2.2 | ~3.3.5",
         "bower-asset/punycode": "1.3.*",
         "bower-asset/yii2-pjax": "~2.0.1"
     },

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Enh #13586: Added `$preserveNonEmptyValues` property to the `yii\behaviors\AttributeBehavior` (Kolyunya)
 - Bug #14192: Fixed wrong default null value for TIMESTAMP when using PostgreSQL (Tigrov)
 - Enh #14081: Added `yii\caching\CacheInterface` to make custom cache extensions adoption easier (silverfire)
+- Chg #14286: Used primary inputmask package name instead of an alias (samdark)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -35,7 +35,7 @@ upgrade might fail when the Yii version you chose has slightly different depende
 Another way to upgrade is to change the `composer.json` file to require the new Yii version and then
 run `composer update` by specifying all packages that are allowed to be updated.
 
-    composer update yiisoft/yii2 yiisoft/yii2-composer bower-asset/jquery.inputmask
+    composer update yiisoft/yii2 yiisoft/yii2-composer bower-asset/inputmask
 
 The above command will only update the specified packages and leave the versions of all other dependencies intact.
 This helps to update packages step by step without causing a lot of package version changes that might break in some way.

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -72,6 +72,9 @@ Upgrade from Yii 2.0.11
 * `yii\filters\AccessControl` now can be used without `user` component.  
   In this case `yii\filters\AccessControl::denyAccess()` throws `yii\web\ForbiddenHttpException` and using `AccessRule` 
   matching a role throws `yii\base\InvalidConfigException`.
+  
+* Inputmask package name was changed from `jquery.inputmask` to `inputmask`. If you've configured path to
+  assets manually, please adjust it. 
 
 Upgrade from Yii 2.0.10
 -----------------------

--- a/framework/composer.json
+++ b/framework/composer.json
@@ -71,7 +71,7 @@
         "ezyang/htmlpurifier": "~4.6",
         "cebe/markdown": "~1.0.0 | ~1.1.0",
         "bower-asset/jquery": "2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
-        "bower-asset/jquery.inputmask": "~3.2.2 | ~3.3.5",
+        "bower-asset/inputmask": "~3.2.2 | ~3.3.5",
         "bower-asset/punycode": "1.3.*",
         "bower-asset/yii2-pjax": "~2.0.1"
     },

--- a/framework/widgets/MaskedInput.php
+++ b/framework/widgets/MaskedInput.php
@@ -39,7 +39,7 @@ use yii\web\View;
  * ```
  *
  * The masked text field is implemented based on the
- * [jQuery input masked plugin](https://github.com/RobinHerbots/jquery.inputmask).
+ * [jQuery input masked plugin](https://github.com/RobinHerbots/Inputmask).
  *
  * @author Kartik Visweswaran <kartikv2@gmail.com>
  * @since 2.0
@@ -84,7 +84,7 @@ class MaskedInput extends InputWidget
     public $aliases;
     /**
      * @var array the JQuery plugin options for the input mask plugin.
-     * @see https://github.com/RobinHerbots/jquery.inputmask
+     * @see https://github.com/RobinHerbots/Inputmask
      */
     public $clientOptions = [];
     /**
@@ -94,7 +94,7 @@ class MaskedInput extends InputWidget
     public $options = ['class' => 'form-control'];
     /**
      * @var string the type of the input tag. Currently only 'text' and 'tel' are supported.
-     * @see https://github.com/RobinHerbots/jquery.inputmask
+     * @see https://github.com/RobinHerbots/Inputmask
      * @since 2.0.6
      */
     public $type = 'text';

--- a/framework/widgets/MaskedInputAsset.php
+++ b/framework/widgets/MaskedInputAsset.php
@@ -12,14 +12,14 @@ use yii\web\AssetBundle;
 /**
  * The asset bundle for the [[MaskedInput]] widget.
  *
- * Includes client assets of [jQuery input mask plugin](https://github.com/RobinHerbots/jquery.inputmask).
+ * Includes client assets of [jQuery input mask plugin](https://github.com/RobinHerbots/Inputmask).
  *
  * @author Kartik Visweswaran <kartikv2@gmail.com>
  * @since 2.0
  */
 class MaskedInputAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/jquery.inputmask/dist';
+    public $sourcePath = '@bower/inputmask/dist';
     public $js = [
         'jquery.inputmask.bundle.js'
     ];


### PR DESCRIPTION
Since jquery.inputmask was renamed to just inputmask, this change is necessary in order to keep dependencies more stable. There's an alias to old name but it failed recently.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | ?
| Fixed issues  | -
