### PR TITLE
Enh: comment wording in BaseActiveRecord::init()

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -889,7 +889,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * Initializes the object.
      * This method is called at the end of the constructor.
      * The default implementation will trigger an [[EVENT_INIT]] event.
-     * If you override this method, make sure you call the parent implementation at the end
+     * If you override this method, make sure you call the parent implementation at the beginning
      * to ensure triggering of the event.
      */
     public function init()

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -889,8 +889,6 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * Initializes the object.
      * This method is called at the end of the constructor.
      * The default implementation will trigger an [[EVENT_INIT]] event.
-     * If you override this method, make sure you call the parent implementation at the beginning
-     * to ensure triggering of the event.
      */
     public function init()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Based on the 3rd convention of extending Component/Object:

> If you override the [[yii\base\Object::init()]] method, make sure you call the parent implementation of init() **at the beginning of** your init() method.
>
> https://github.com/yiisoft/yii2/blob/master/docs/guide/concept-components.md

Suppose I created an AR class named `Customer`, and attached some events by overriding the `init()` method, I think

```php
public function init()
{
    parent::init();
    $this->on(self::EVENT_AFTER_INSERT, [$this, 'doSomething']);
}
```

is better than

```php
public function init()
{
    $this->on(self::EVENT_AFTER_INSERT, [$this, 'doSomething']);
    parent::init();
}
```
