### PR TITLE
Fix PHP warning when UnknownCommandException is thrown for empty command

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #14248: `yii\console\controllers\MessageController` no longer outputs colorized filenames when console does not support text colorization (PowerGamer1)
 - Bug #14264: Fixed a bug where `yii\log\Logger::calculateTimings()` was not accepting messages with array tokens (bizley)
+- Bug #14307: Fixed PHP warning when `yii\console\UnknownCommandException` is thrown for empty command (rob006)
 - Chg #14201: `yii\console\controllers\MessageController::extractMessagesFromTokens()` is now protected (faenir)
 - Enh #13787: Added `yii\db\Migration::$maxSqlOutputLength` that allows limiting number of characters for outputting SQL (thiagotalma)
 - Enh #14089: Added tests for `yii\base\Theme` (vladis84)

--- a/framework/console/UnknownCommandException.php
+++ b/framework/console/UnknownCommandException.php
@@ -67,7 +67,7 @@ class UnknownCommandException extends Exception
     public function getSuggestedAlternatives()
     {
         $help = $this->application->createController('help');
-        if ($help === false) {
+        if ($help === false || $this->command === '') {
             return [];
         }
         /** @var $helpController HelpController */

--- a/tests/framework/console/UnknownCommandExceptionTest.php
+++ b/tests/framework/console/UnknownCommandExceptionTest.php
@@ -14,7 +14,7 @@ use yiiunit\TestCase;
 /**
  * @group console
  */
-class UnkownCommandExceptionTest extends TestCase
+class UnknownCommandExceptionTest extends TestCase
 {
     public function setUp()
     {
@@ -42,6 +42,7 @@ class UnkownCommandExceptionTest extends TestCase
             ['cach/fush', ['cache/flush']],
             ['cach/fushall', ['cache/flush-all']],
             ['what?', []],
+            ['', []],
             // test UTF 8 chars
             ['ёлка', []],
             // this crashes levenshtein because string is longer than 255 chars


### PR DESCRIPTION
### What steps will reproduce the problem?

Configure non-existing command as `defaultRoute` in console application. Run `./yii`.

### What is the expected result?

```
Unknown command: 
```

### What do you get instead?

```
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
PHP Warning:  strpos(): Empty needle in /path/to/app/vendor/yiisoft/yii2/console/UnknownCommandException.php on line 122
Unknown command: 

Did you mean "gii"?
```

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
