### PR TITLE
Bug #14296 log targets failure capturing [not fully completed]

### DIFF
--- a/framework/log/DbTarget.php
+++ b/framework/log/DbTarget.php
@@ -9,7 +9,6 @@ namespace yii\log;
 
 use Yii;
 use yii\base\InvalidConfigException;
-use yii\base\InvalidValueException;
 use yii\db\Connection;
 use yii\db\Exception;
 use yii\di\Instance;
@@ -59,8 +58,9 @@ class DbTarget extends Target
 
     /**
      * Stores log messages to DB.
+     * Starting from version 2.0.14, this method throws LogRuntimeException in case the log can not be exported.
      * @throws Exception
-     * @throws InvalidValueException
+     * @throws LogRuntimeException
      */
     public function export()
     {
@@ -93,7 +93,7 @@ class DbTarget extends Target
                 ])->execute() > 0) {
                 continue;
             }
-            throw new InvalidValueException('Unable to export log through database!');
+            throw new LogRuntimeException('Unable to export log through database!');
         }
     }
 }

--- a/framework/log/EmailTarget.php
+++ b/framework/log/EmailTarget.php
@@ -9,6 +9,7 @@ namespace yii\log;
 
 use Yii;
 use yii\base\InvalidConfigException;
+use yii\base\InvalidValueException;
 use yii\di\Instance;
 use yii\mail\MailerInterface;
 
@@ -72,6 +73,7 @@ class EmailTarget extends Target
 
     /**
      * Sends log messages to specified email addresses.
+     * @throws InvalidValueException
      */
     public function export()
     {
@@ -82,7 +84,10 @@ class EmailTarget extends Target
         }
         $messages = array_map([$this, 'formatMessage'], $this->messages);
         $body = wordwrap(implode("\n", $messages), 70);
-        $this->composeMessage($body)->send($this->mailer);
+        $message = $this->composeMessage($body);
+        if (!$message->send($this->mailer)) {
+            throw new InvalidValueException('Unable to export log through email!');
+        }
     }
 
     /**

--- a/framework/log/EmailTarget.php
+++ b/framework/log/EmailTarget.php
@@ -73,7 +73,8 @@ class EmailTarget extends Target
 
     /**
      * Sends log messages to specified email addresses.
-     * @throws InvalidValueException
+     * Starting from version 2.0.14, this method throws LogRuntimeException in case the log can not be exported.
+     * @throws LogRuntimeException
      */
     public function export()
     {
@@ -86,7 +87,7 @@ class EmailTarget extends Target
         $body = wordwrap(implode("\n", $messages), 70);
         $message = $this->composeMessage($body);
         if (!$message->send($this->mailer)) {
-            throw new InvalidValueException('Unable to export log through email!');
+            throw new LogRuntimeException('Unable to export log through email!');
         }
     }
 

--- a/framework/log/FileTarget.php
+++ b/framework/log/FileTarget.php
@@ -122,7 +122,8 @@ class FileTarget extends Target
             @fclose($fp);
             $writeResult = @file_put_contents($this->logFile, $text, FILE_APPEND | LOCK_EX);
             if ($writeResult === false) {
-                throw new LogRuntimeException('Unable to export log through file!');
+                $error = error_get_last();
+                throw new LogRuntimeException("Unable to export log through file!: {$error['message']}");
             }
             if ($writeResult < strlen($text)) {
                 throw new LogRuntimeException("Unable to export whole log through file! Wrote $writeResult out of " . strlen($text) . ' bytes.');
@@ -130,7 +131,8 @@ class FileTarget extends Target
         } else {
             $writeResult = @fwrite($fp, $text);
             if ($writeResult === false) {
-                throw new LogRuntimeException('Unable to export log through file!');
+                $error = error_get_last();
+                throw new LogRuntimeException("Unable to export log through file!: {$error['message']}");
             }
             if ($writeResult < strlen($text)) {
                 throw new LogRuntimeException("Unable to export whole log through file! Wrote $writeResult out of " . strlen($text) . ' bytes.');

--- a/framework/log/FileTarget.php
+++ b/framework/log/FileTarget.php
@@ -100,8 +100,9 @@ class FileTarget extends Target
 
     /**
      * Writes log messages to a file.
+     * Starting from version 2.0.14, this method throws LogRuntimeException in case the log can not be exported.
      * @throws InvalidConfigException if unable to open the log file for writing
-     * @throws InvalidValueException if unable to write the log file
+     * @throws LogRuntimeException if unable to write complete log to file
      */
     public function export()
     {
@@ -121,18 +122,18 @@ class FileTarget extends Target
             @fclose($fp);
             $writeResult = @file_put_contents($this->logFile, $text, FILE_APPEND | LOCK_EX);
             if ($writeResult === false) {
-                throw new InvalidValueException('Unable to export log through file!');
+                throw new LogRuntimeException('Unable to export log through file!');
             }
             if ($writeResult < strlen($text)) {
-                throw new InvalidValueException("Unable to export whole log through file! Wrote $writeResult out of " . strlen($text) . ' bytes.');
+                throw new LogRuntimeException("Unable to export whole log through file! Wrote $writeResult out of " . strlen($text) . ' bytes.');
             }
         } else {
             $writeResult = @fwrite($fp, $text);
             if ($writeResult === false) {
-                throw new InvalidValueException('Unable to export log through file!');
+                throw new LogRuntimeException('Unable to export log through file!');
             }
             if ($writeResult < strlen($text)) {
-                throw new InvalidValueException("Unable to export whole log through file! Wrote $writeResult out of " . strlen($text) . ' bytes.');
+                throw new LogRuntimeException("Unable to export whole log through file! Wrote $writeResult out of " . strlen($text) . ' bytes.');
             }
             @flock($fp, LOCK_UN);
             @fclose($fp);

--- a/framework/log/LogRuntimeException.php
+++ b/framework/log/LogRuntimeException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\log;
+
+/**
+ * LogRuntimeException represents an exception caused by problems with log delivery.
+ *
+ * @author Bizley <pawel@positive.codes>
+ * @since 2.0.14
+ */
+class LogRuntimeException extends \yii\base\Exception
+{
+    /**
+     * @return string the user-friendly name of this exception
+     */
+    public function getName()
+    {
+        return 'Log Runtime';
+    }
+}

--- a/framework/log/SyslogTarget.php
+++ b/framework/log/SyslogTarget.php
@@ -61,15 +61,16 @@ class SyslogTarget extends Target
     }
 
     /**
-     * Writes log messages to syslog
-     * @throws InvalidValueException
+     * Writes log messages to syslog.
+     * Starting from version 2.0.14, this method throws LogRuntimeException in case the log can not be exported.
+     * @throws LogRuntimeException
      */
     public function export()
     {
         openlog($this->identity, $this->options, $this->facility);
         foreach ($this->messages as $message) {
             if (syslog($this->_syslogLevels[$message[1]], $this->formatMessage($message)) === false) {
-                throw new InvalidValueException('Unable to export log through system log!');
+                throw new LogRuntimeException('Unable to export log through system log!');
             }
         }
         closelog();

--- a/framework/log/SyslogTarget.php
+++ b/framework/log/SyslogTarget.php
@@ -8,6 +8,7 @@
 namespace yii\log;
 
 use Yii;
+use yii\base\InvalidValueException;
 use yii\helpers\VarDumper;
 
 /**
@@ -61,12 +62,15 @@ class SyslogTarget extends Target
 
     /**
      * Writes log messages to syslog
+     * @throws InvalidValueException
      */
     public function export()
     {
         openlog($this->identity, $this->options, $this->facility);
         foreach ($this->messages as $message) {
-            syslog($this->_syslogLevels[$message[1]], $this->formatMessage($message));
+            if (syslog($this->_syslogLevels[$message[1]], $this->formatMessage($message)) === false) {
+                throw new InvalidValueException('Unable to export log through system log!');
+            }
         }
         closelog();
     }

--- a/tests/framework/log/EmailTargetTest.php
+++ b/tests/framework/log/EmailTargetTest.php
@@ -65,6 +65,7 @@ class EmailTargetTest extends TestCase
         $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
             ->setMethods(['setTextBody', 'send', 'setSubject'])
             ->getMockForAbstractClass();
+        $message->method('send')->willReturn(true);
 
         $this->mailer->expects($this->once())->method('compose')->willReturn($message);
 
@@ -109,6 +110,7 @@ class EmailTargetTest extends TestCase
         $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
             ->setMethods(['setTextBody', 'send', 'setSubject'])
             ->getMockForAbstractClass();
+        $message->method('send')->willReturn(true);
 
         $this->mailer->expects($this->once())->method('compose')->willReturn($message);
 
@@ -135,6 +137,36 @@ class EmailTargetTest extends TestCase
                 [$message2, $message2[0]],
             ]
         );
+        $mailTarget->export();
+    }
+
+    /**
+     * @covers \yii\log\EmailTarget::export()
+     *
+     * See https://github.com/yiisoft/yii2/issues/14296
+     */
+    public function testExportWithSendFailure()
+    {
+        $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
+            ->setMethods(['send'])
+            ->getMockForAbstractClass();
+        $message->method('send')->willReturn(false);
+
+        $this->mailer->expects($this->once())->method('compose')->willReturn($message);
+
+        $mailTarget = $this->getMockBuilder('yii\\log\\EmailTarget')
+            ->setMethods(['formatMessage'])
+            ->setConstructorArgs([
+                [
+                    'mailer' => $this->mailer,
+                    'message' => [
+                        'to' => 'developer@example.com',
+                    ],
+                ],
+            ])
+            ->getMock();
+
+        $this->expectException('yii\base\InvalidValueException');
         $mailTarget->export();
     }
 }

--- a/tests/framework/log/EmailTargetTest.php
+++ b/tests/framework/log/EmailTargetTest.php
@@ -166,7 +166,7 @@ class EmailTargetTest extends TestCase
             ])
             ->getMock();
 
-        $this->expectException('yii\base\InvalidValueException');
+        $this->expectException('yii\log\LogRuntimeException');
         $mailTarget->export();
     }
 }

--- a/tests/framework/log/SyslogTargetTest.php
+++ b/tests/framework/log/SyslogTargetTest.php
@@ -9,17 +9,17 @@ namespace yii\log {
 
     function openlog()
     {
-        \yiiunit\framework\log\SyslogTargetTest::openlog(func_get_args());
+        return \yiiunit\framework\log\SyslogTargetTest::openlog(func_get_args());
     }
 
     function syslog()
     {
-        \yiiunit\framework\log\SyslogTargetTest::syslog(func_get_args());
+        return \yiiunit\framework\log\SyslogTargetTest::syslog(func_get_args());
     }
 
     function closelog()
     {
-        \yiiunit\framework\log\SyslogTargetTest::closelog(func_get_args());
+        return \yiiunit\framework\log\SyslogTargetTest::closelog(func_get_args());
     }
 }
 
@@ -130,20 +130,56 @@ namespace yiiunit\framework\log {
             static::$functions['openlog'] = function ($arguments) use ($syslogTarget) {
                 $this->assertCount(3, $arguments);
                 list($identity, $option, $facility) = $arguments;
-                $syslogTarget->openlog($identity, $option, $facility);
+                return $syslogTarget->openlog($identity, $option, $facility);
             };
-
             static::$functions['syslog'] = function ($arguments) use ($syslogTarget) {
                 $this->assertCount(2, $arguments);
                 list($priority, $message) = $arguments;
-                $syslogTarget->syslog($priority, $message);
+                return $syslogTarget->syslog($priority, $message);
             };
-
             static::$functions['closelog'] = function ($arguments) use ($syslogTarget) {
                 $this->assertCount(0, $arguments);
-                $syslogTarget->closelog();
+                return $syslogTarget->closelog();
             };
 
+            $syslogTarget->export();
+        }
+
+        /**
+         * @covers \yii\log\SyslogTarget::export()
+         *
+         * See https://github.com/yiisoft/yii2/issues/14296
+         */
+        public function testFailedExport()
+        {
+            $syslogTarget = $this->getMockBuilder('yii\\log\\SyslogTarget')
+                ->setMethods(['openlog', 'syslog', 'formatMessage', 'closelog'])
+                ->getMock();
+            $syslogTarget->method('syslog')->willReturn(false);
+
+            $syslogTarget->identity = 'identity string';
+            $syslogTarget->options = LOG_ODELAY | LOG_PID;
+            $syslogTarget->facility = 'facility string';
+            $syslogTarget->messages = [
+                ['test', Logger::LEVEL_INFO],
+            ];
+
+            static::$functions['openlog'] = function ($arguments) use ($syslogTarget) {
+                $this->assertCount(3, $arguments);
+                list($identity, $option, $facility) = $arguments;
+                return $syslogTarget->openlog($identity, $option, $facility);
+            };
+            static::$functions['syslog'] = function ($arguments) use ($syslogTarget) {
+                $this->assertCount(2, $arguments);
+                list($priority, $message) = $arguments;
+                return $syslogTarget->syslog($priority, $message);
+            };
+            static::$functions['closelog'] = function ($arguments) use ($syslogTarget) {
+                $this->assertCount(0, $arguments);
+                return $syslogTarget->closelog();
+            };
+
+            $this->expectException('yii\base\InvalidValueException');
             $syslogTarget->export();
         }
 

--- a/tests/framework/log/SyslogTargetTest.php
+++ b/tests/framework/log/SyslogTargetTest.php
@@ -179,7 +179,7 @@ namespace yiiunit\framework\log {
                 return $syslogTarget->closelog();
             };
 
-            $this->expectException('yii\base\InvalidValueException');
+            $this->expectException('yii\log\LogRuntimeException');
             $syslogTarget->export();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | isolated log tests - yes, not sure about the whole app
| Fixed issues  | #14296

This fix adds condition check for log targets exporting and in case of failure exception is thrown.
Exception is caught by dispatcher and the warning can be passed to the next log target if there are any left.

## Status of this PR:

### EmailTarget
- [x] condition check based on the result of `send()` method implemented through `\yii\mail\MessageInterface`
- [x] tests covered

### FileTarget
- [x] condition check based on the result of `fwrite()` and `file_put_contents()` methods - exception is thrown when methods return `false` or write less bytes than expected
- [ ] tests covered - not sure how to mock `fwrite()` error properly - possible solution is to do it like in the `/tests/framework/log/SyslogTargetTest.php` or to use `vfsStream` library but this is not included in the `composer.json` right now

### DbTarget
- [x] condition check based on whether the result of `execute()` method with `INSERT` statement returned more than 0 rows or not
- [ ] tests covered - not sure how to mock failed INSERT statement

### SyslogTarget
- [x] condition check based on the result of `syslog()` method
- [x] tests covered - overridden methods `openlog()`, `syslog()` and `closelog()` return boolean values now
