### PR TITLE
Fix active fixture when used in second db connection

### DIFF
--- a/framework/test/ActiveFixture.php
+++ b/framework/test/ActiveFixture.php
@@ -62,6 +62,8 @@ class ActiveFixture extends BaseActiveFixture
         if ($this->modelClass === null && $this->tableName === null) {
             throw new InvalidConfigException('Either "modelClass" or "tableName" must be set.');
         }
+        $modelClass = $this->modelClass;
+        $this->db = $modelClass::getDb();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

I found that ActiveFixture don't set db connection for models that require to be created in not main db connection.
