### PR TITLE
fixed #14334 \yii\db\QueryBuilder::buildNotCondition loses params when operand is \yii\db\Expression

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -18,6 +18,7 @@ Yii Framework 2 Change Log
 - Chg #14286: Used primary inputmask package name instead of an alias (samdark)
 - Enh #14298: The default response formatter configs defined by `yii\web\Response::defaultFormatters()` now use the array syntax (brandonkelly)
 - Bug #14304: Fixed `yii\validators\UniqueValidator` and `yii\validators\ExistValidator` to skip prefixes in case expressions are used (samdark)
+- Bug #14334: Fixed `\yii\db\QueryBuilder::buildNotCondition` loses params when operand is `\yii\db\Expression` (Ni-san)
 - Bug #14341: Fixed regression in error handling introduced by fixing #14264 (samdark)
 
 2.0.12 June 05, 2017

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -1160,7 +1160,7 @@ class QueryBuilder extends \yii\base\Object
         }
 
         $operand = reset($operands);
-        if (is_array($operand)) {
+        if (is_array($operand) || $operand instanceof Expression) {
             $operand = $this->buildCondition($operand, $params);
         }
         if ($operand === '') {

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -1125,6 +1125,10 @@ abstract class QueryBuilderTest extends DatabaseTestCase
             // direct conditions
             ['a = CONCAT(col1, col2)', 'a = CONCAT(col1, col2)', []],
             [new Expression('a = CONCAT(col1, :param1)', ['param1' => 'value1']), 'a = CONCAT(col1, :param1)', ['param1' => 'value1']],
+
+            // Expression with params as operand of 'not'
+            [['not', new Expression('any_expression(:a)', [':a' => 1])], 'NOT (any_expression(:a))', [':a' => 1]],
+            [new Expression('NOT (any_expression(:a))', [':a' => 1]), 'NOT (any_expression(:a))', [':a' => 1]],
         ];
         switch ($this->driverName) {
             case 'sqlsrv':


### PR DESCRIPTION
Fix method buildNotCondition: call `$this->buildCondition` if `$operand instanceof Expression`.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | fixed #14334, closed #14335 
