### PR TITLE
Both offset and limit can set with a Pagination instance or an array …

### DIFF
--- a/docs/guide/db-query-builder.md
+++ b/docs/guide/db-query-builder.md
@@ -473,6 +473,23 @@ If you specify an invalid limit or offset (e.g. a negative value), it will be ig
   statement that emulates the `LIMIT`/`OFFSET` behavior.
 
 
+### [[yii\db\Query::page()|page()]] <span id="page"></span>
+
+The [[yii\db\Query::page()|page()]] method specify both the `LIMIT` and `OFFSET` fragments of a SQL query at one time.
+For example,
+
+```php
+// ... LIMIT 10 OFFSET 20
+// use an array
+$query->page([20, 10]); // equals to $query->offset(20)->limit(10);
+// OR use pagination
+$pagination = new \yii\data\Pagination(['totalCount'=>$query->count()]);
+$query->page($pagination); // equals to $query->offset($pagination->getOffset())->limit($pagination->getLimit());
+```
+This method use [limit() and offset()](#limit-offset) to specify `LIMIT` and `OFFSET` fragments.
+Please refer to the documentation for [limit() and offset()](#limit-offset) for more details.
+
+
 ### [[yii\db\Query::join()|join()]] <span id="join"></span>
 
 The [[yii\db\Query::join()|join()]] method specifies the `JOIN` fragment of a SQL query. For example,

--- a/framework/db/QueryTrait.php
+++ b/framework/db/QueryTrait.php
@@ -8,6 +8,7 @@
 namespace yii\db;
 
 use yii\base\NotSupportedException;
+use yii\data\Pagination;
 
 /**
  * The BaseQuery trait represents the minimum method set of a database Query.
@@ -393,6 +394,25 @@ trait QueryTrait
     public function offset($offset)
     {
         $this->offset = $offset;
+        return $this;
+    }
+
+    /**
+     * Sets both OFFSET and LIMIT part of the query with Pagination or an array.
+     * @param $page Pagination|array Offset and limit values.
+     * Page info can be specified in either a Pagination instance or an array
+     * (e.g. `[offset, limit]`).
+     * @return $this the query object itself
+     */
+    public function page($page)
+    {
+        if ($page instanceof Pagination) {
+            $this->offset($page->offset);
+            $this->limit($page->limit);
+        } elseif (is_array($page)) {
+            $this->offset($page[0]);
+            $this->limit($page[1]);
+        }
         return $this;
     }
 

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -7,6 +7,7 @@
 
 namespace yiiunit\framework\db;
 
+use yii\data\Pagination;
 use yii\db\Connection;
 use yii\db\Expression;
 use yii\db\Query;
@@ -255,6 +256,26 @@ abstract class QueryTest extends DatabaseTestCase
         $this->assertNotContains(1, $result);
         $this->assertContains(2, $result);
         $this->assertContains(3, $result);
+    }
+
+    public function testLimitOffsetWithPagination()
+    {
+        $query = new Query();
+        $pagination = new Pagination(['totalCount' => 100, 'defaultPageSize' => 10]);
+        $pagination->setPage(2);
+        $query->page($pagination);
+
+        $this->assertEquals(20, $query->offset);
+        $this->assertEquals(10, $query->limit);
+    }
+
+    public function testLimitOffsetWithArray()
+    {
+        $query = new Query();
+        $query->page([20, 10]);
+
+        $this->assertEquals(20, $query->offset);
+        $this->assertEquals(10, $query->limit);
     }
 
     public function testUnion()


### PR DESCRIPTION
Before:
`$query->offset($pagination->getOffset())->limit($pagination->getLimit());`
After:
`$query->page($pagination);`
Or:
`$query->page([123, 20]);`
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
