### PR TITLE
Removed call to deleteAll from deleteInternal

### DIFF
--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -607,7 +607,7 @@ class ActiveRecord extends BaseActiveRecord
         if ($lock !== null) {
             $condition[$lock] = $this->$lock;
         }
-        $result = static::deleteAll($condition);
+        $result = static::getDb()->createCommand()->delete(static::tableName(), $condition)->execute();
         if ($lock !== null && !$result) {
             throw new StaleObjectException('The object being deleted is outdated.');
         }


### PR DESCRIPTION
in this manner we removed the hidden relation between delete and deleteAll. Example: if we have to override deleteAll and call delete for single model (and trigger delete event)