### PR TITLE
`MySqlMutex`, `PgsqlMutex` and `OracleMutex` now use `useMaster()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #7890: Allow `migrate/mark` to mark history at the point of the base migration (cebe)
+- Bug #14206: `MySqlMutex`, `PgsqlMutex` and `OracleMutex` now use `useMaster()` to ensure lock is aquired on the same DB server (cebe)
 - Chg #14321: `yii\widgets\MaskedInput` is now registering its JavaScript `clientOptions` initialization code in head section (DaveFerger)
 - Bug #13757: Fixed ambiguous column error in `BaseActiveRecord::refresh()` when the query adds a JOIN by default (cebe, ivankff)
 - Bug #13859: Fixed ambiguous column error in `Query::column()` when `$indexBy` is used with a JOIN (cebe)

--- a/framework/mutex/MysqlMutex.php
+++ b/framework/mutex/MysqlMutex.php
@@ -56,9 +56,13 @@ class MysqlMutex extends DbMutex
      */
     protected function acquireLock($name, $timeout = 0)
     {
-        return (bool) $this->db
-            ->createCommand('SELECT GET_LOCK(:name, :timeout)', [':name' => $name, ':timeout' => $timeout])
-            ->queryScalar();
+        return $this->db->useMaster(function($db) use ($name, $timeout) {
+            /** @var \yii\db\Connection $db */
+            return (bool) $db->createCommand(
+                'SELECT GET_LOCK(:name, :timeout)',
+                [':name' => $name, ':timeout' => $timeout]
+            )->queryScalar();
+        });
     }
 
     /**
@@ -69,8 +73,12 @@ class MysqlMutex extends DbMutex
      */
     protected function releaseLock($name)
     {
-        return (bool) $this->db
-            ->createCommand('SELECT RELEASE_LOCK(:name)', [':name' => $name])
-            ->queryScalar();
+        return $this->db->useMaster(function ($db) use ($name) {
+            /** @var \yii\db\Connection $db */
+            return (bool)$db->createCommand(
+                'SELECT RELEASE_LOCK(:name)',
+                [':name' => $name]
+            )->queryScalar();
+        });
     }
 }

--- a/framework/mutex/OracleMutex.php
+++ b/framework/mutex/OracleMutex.php
@@ -83,12 +83,14 @@ class OracleMutex extends DbMutex
     {
         $lockStatus = null;
 
-        /** clean vars before using */
+        // clean vars before using
         $releaseOnCommit = $this->releaseOnCommit ? 'TRUE' : 'FALSE';
         $timeout = abs((int) $timeout);
 
         // inside pl/sql scopes pdo binding not working correctly :(
-        $this->db->createCommand(
+        $this->db->useMaster(function($db) use ($name, $timeout, $releaseOnCommit, &$lockStatus) {
+            /** @var \yii\db\Connection $db */
+            $db->createCommand(
                 'DECLARE
     handle VARCHAR2(128);
 BEGIN
@@ -99,6 +101,7 @@ END;',
             )
             ->bindParam(':lockStatus', $lockStatus, PDO::PARAM_INT, 1)
             ->execute();
+        });
 
         return $lockStatus === 0 || $lockStatus === '0';
     }
@@ -112,7 +115,9 @@ END;',
     protected function releaseLock($name)
     {
         $releaseStatus = null;
-        $this->db->createCommand(
+        $this->db->useMaster(function($db) use ($name, &$releaseStatus) {
+            /** @var \yii\db\Connection $db */
+            $db->createCommand(
                 'DECLARE
     handle VARCHAR2(128);
 BEGIN
@@ -123,6 +128,7 @@ END;',
             )
             ->bindParam(':result', $releaseStatus, PDO::PARAM_INT, 1)
             ->execute();
+        });
 
         return $releaseStatus === 0 || $releaseStatus === '0';
     }

--- a/framework/mutex/PgsqlMutex.php
+++ b/framework/mutex/PgsqlMutex.php
@@ -71,9 +71,13 @@ class PgsqlMutex extends DbMutex
             throw new InvalidParamException('PgsqlMutex does not support timeout.');
         }
         list($key1, $key2) = $this->getKeysFromName($name);
-        return (bool) $this->db
-            ->createCommand('SELECT pg_try_advisory_lock(:key1, :key2)', [':key1' => $key1, ':key2' => $key2])
-            ->queryScalar();
+        return $this->db->useMaster(function($db) use ($key1, $key2) {
+            /** @var \yii\db\Connection $db */
+            return (bool)$db->createCommand(
+                'SELECT pg_try_advisory_lock(:key1, :key2)',
+                [':key1' => $key1, ':key2' => $key2]
+            )->queryScalar();
+        });
     }
 
     /**
@@ -85,8 +89,12 @@ class PgsqlMutex extends DbMutex
     protected function releaseLock($name)
     {
         list($key1, $key2) = $this->getKeysFromName($name);
-        return (bool) $this->db
-            ->createCommand('SELECT pg_advisory_unlock(:key1, :key2)', [':key1' => $key1, ':key2' => $key2])
-            ->queryScalar();
+        return $this->db->useMaster(function($db) use ($key1, $key2) {
+            /** @var \yii\db\Connection $db */
+            return (bool)$db->createCommand(
+                'SELECT pg_advisory_unlock(:key1, :key2)',
+                [':key1' => $key1, ':key2' => $key2]
+            )->queryScalar();
+        });
     }
 }


### PR DESCRIPTION
to ensure lock is aquired on the same DB server.

fixes #14206

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14206
