### PR TITLE
Fix phpdoc for $_master and $_slave properties in yii\db\Connection

### DIFF
--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -403,11 +403,11 @@ class Connection extends Component
      */
     private $_driverName;
     /**
-     * @var Connection the currently active master connection
+     * @var Connection|false the currently active master connection
      */
     private $_master = false;
     /**
-     * @var Connection the currently active slave connection
+     * @var Connection|false the currently active slave connection
      */
     private $_slave = false;
     /**


### PR DESCRIPTION
This fixes issues reported by [Scrutinizer](https://scrutinizer-ci.com/g/yiisoft/yii2/inspections/45e312ad-cd29-42b7-8314-78a9930394d3/issues/files/framework/db/Connection.php?status=new&orderField=path&order=asc&honorSelectedPaths=0).
