### PR TITLE
Add testcase demonstrating UniqueValidator bug

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #8983: Only truncate the original log file for rotation (matthewyang, developeruz)
 - Bug #14276: Fixed I18N format with dotted parameters (developeruz)
+- Bug #14484: Fixed `yii\validators\UniqueValidator` for target classes with a default scope (laszlovl)
 - Bug #14604: Fixed `yii\validators\CompareValidator` `compareAttribute` does not work if `compareAttribute` form ID has been changed (mikk150)
 - Bug #15142: Fixed array params replacing in `yii\helpers\BaseUrl::current()` (IceJOKER)
 - Bug #15194: Fixed `yii\db\QueryBuilder::insert()` to preserve passed params when building a `INSERT INTO ... SELECT` query for MSSQL, PostgreSQL and SQLite (sergeymakinen)
@@ -150,12 +151,6 @@ Yii Framework 2 Change Log
 - Chg #14286: Used primary inputmask package name instead of an alias (samdark)
 - Chg #14321: `yii\widgets\MaskedInput` is now registering its JavaScript `clientOptions` initialization code in head section (DaveFerger)
 - Chg #14487: Changed i18n message error to warning (dmirogin)
-
-- Enh #13835: Added `yii\web\Request::getOrigin()` method that returns HTTP_ORIGIN of current CORS request (yyxx9988)
-- Enh #14188: Add constants and function for sysexits(3) to `ConsoleHelper` (tom--, samdark, cebe)
-- Bug #14165: Set `_slave` of `Connection` to `false` instead of `null` in `close` method (rossoneri)
-- Bug #14423: Fixed `ArrayHelper::merge` behavior with null values for integer-keyed elements (dmirogin)
-- Bug #14484: Fixed `yii\validators\UniqueValidator` for target classes with a default scope (laszlovl)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -151,6 +151,11 @@ Yii Framework 2 Change Log
 - Chg #14321: `yii\widgets\MaskedInput` is now registering its JavaScript `clientOptions` initialization code in head section (DaveFerger)
 - Chg #14487: Changed i18n message error to warning (dmirogin)
 
+- Enh #13835: Added `yii\web\Request::getOrigin()` method that returns HTTP_ORIGIN of current CORS request (yyxx9988)
+- Enh #14188: Add constants and function for sysexits(3) to `ConsoleHelper` (tom--, samdark, cebe)
+- Bug #14165: Set `_slave` of `Connection` to `false` instead of `null` in `close` method (rossoneri)
+- Bug #14423: Fixed `ArrayHelper::merge` behavior with null values for integer-keyed elements (dmirogin)
+- Bug #14484: Fixed `yii\validators\UniqueValidator` for target classes with a default scope (laszlovl)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,7 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #8983: Only truncate the original log file for rotation (matthewyang, developeruz)
 - Bug #14276: Fixed I18N format with dotted parameters (developeruz)
-- Bug #14484: Fixed `yii\validators\UniqueValidator` for target classes with a default scope (laszlovl)
+- Bug #14484: Fixed `yii\validators\UniqueValidator` for target classes with a default scope (laszlovl, developeruz)
 - Bug #14604: Fixed `yii\validators\CompareValidator` `compareAttribute` does not work if `compareAttribute` form ID has been changed (mikk150)
 - Bug #15142: Fixed array params replacing in `yii\helpers\BaseUrl::current()` (IceJOKER)
 - Bug #15194: Fixed `yii\db\QueryBuilder::insert()` to preserve passed params when building a `INSERT INTO ... SELECT` query for MSSQL, PostgreSQL and SQLite (sergeymakinen)
@@ -36,6 +36,7 @@ Yii Framework 2 Change Log
 - Enh #15335: Added `FileHelper::unlink()` that works well under all OSes (samdark)
 - Enh #15340: Test CHANGELOG.md for valid format (sammousa)
 - Bug #15317: Regenerate CSRF token if an empty value is given (sammousa)
+
 
 
 2.0.13.1 November 14, 2017

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -174,6 +174,9 @@ class UniqueValidator extends Validator
                 // only select primary key to optimize query
                 $columnsCondition = array_flip($targetClass::primaryKey());
                 $query->select(array_flip($this->applyTableAlias($query, $columnsCondition)));
+                
+                // since we only select() the primary key, a potential default scope can't be loaded
+                $query->with = null;
             }
             $models = $query->limit(2)->asArray()->all();
             $n = count($models);

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -175,7 +175,7 @@ class UniqueValidator extends Validator
                 $columnsCondition = array_flip($targetClass::primaryKey());
                 $query->select(array_flip($this->applyTableAlias($query, $columnsCondition)));
                 
-                // since we only select() the primary key, a potential default scope can't be loaded
+                // any with relation can't be loaded because related fields are not selected
                 $query->with = null;
             }
             $models = $query->limit(2)->asArray()->all();

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -434,4 +434,25 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $validator->validateAttribute($model, 'title');
         $this->assertFalse($model->hasErrors(), 'There were errors: ' . json_encode($model->getErrors()));
     }
+
+    public function testFindModelWith()
+    {
+        $validator = new UniqueValidator([
+            'targetAttribute' => ['status', 'profile_id']
+        ]);
+
+        $withCustomer = new class extends Customer {
+            public static function find() {
+                $res = parent::find();
+
+                $res->with('profile');
+
+                return $res;
+            }
+        };
+        
+        $model = $withCustomer::find()->one();
+
+        $validator->validateAttribute($model, 'dummy');
+    }
 }

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -444,11 +444,14 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $validator = new UniqueValidator([
             'targetAttribute' => ['status', 'profile_id']
         ]);
-
-       
         $model = WithCustomer::find()->one();
+        try {
+            $validator->validateAttribute($model, 'email');
+        } catch (\Exception $exception) {
+            $this->fail('Query is crashed because "with" relation cannot be loaded');
+        }
 
-        $validator->validateAttribute($model, 'dummy');
+
     }
 }
 

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -435,24 +435,29 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $this->assertFalse($model->hasErrors(), 'There were errors: ' . json_encode($model->getErrors()));
     }
 
+    /**
+     * Test validating a class with default scope
+     * @see https://github.com/yiisoft/yii2/issues/14484
+    */
     public function testFindModelWith()
     {
         $validator = new UniqueValidator([
             'targetAttribute' => ['status', 'profile_id']
         ]);
 
-        $withCustomer = new class extends Customer {
-            public static function find() {
-                $res = parent::find();
-
-                $res->with('profile');
-
-                return $res;
-            }
-        };
-        
-        $model = $withCustomer::find()->one();
+       
+        $model = WithCustomer::find()->one();
 
         $validator->validateAttribute($model, 'dummy');
+    }
+}
+
+class WithCustomer extends Customer {
+    public static function find() {
+        $res = parent::find();
+
+        $res->with('profile');
+
+        return $res;
     }
 }


### PR DESCRIPTION
Commit 0df8020dd0e2990a9bc39bd84056aa2c88d50df7 broke UniqueValidator for models with a "default scope".

What happens is that UniqueValidator queries the target class only `select()`'ing the primary key, while the default scoped relation's foreign key is necessary in `filterByModels`. Because of the `asArray()` in UniqueValidator, the missing column isn't handled gracefully by ActiveRecord but triggers a key error.

There are a few possible solutions, not sure which one is preferred.

1. Remove `asArray()` in https://github.com/yiisoft/yii2-framework/blob/master/validators/UniqueValidator.php#L178
2. Remove if block in https://github.com/yiisoft/yii2-framework/blob/master/validators/UniqueValidator.php#L174 so every column is selected
3. Gracefully handle non-existing keys in `filterByModels`