### PR TITLE
Fix redirect error cause by getHostInfo

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -561,7 +561,9 @@ class Request extends \yii\base\Request
         if ($this->_hostInfo === null) {
             $secure = $this->getIsSecureConnection();
             $http = $secure ? 'https' : 'http';
-            if (isset($_SERVER['HTTP_HOST'])) {
+            if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+                $this->_hostInfo = $http . '://' . $_SERVER['HTTP_X_FORWARDED_HOST'];
+            } elseif (isset($_SERVER['HTTP_HOST'])) {
                 $this->_hostInfo = $http . '://' . $_SERVER['HTTP_HOST'];
             } elseif (isset($_SERVER['SERVER_NAME'])) {
                 $this->_hostInfo = $http . '://' . $_SERVER['SERVER_NAME'];


### PR DESCRIPTION
Yii Application run in intranet server and expose to internet using apache http proxy that run in server with public IP. Open Yii home page work fine, but after login it show error redirect.

This will fix redirect error cause by getHostInfo when Yii Application run behind apache http proxy.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | ... 
| Fixed issues  | ...
