### PR TITLE
Fixed error handler not escaping error info in debug mode

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -38,7 +38,7 @@ Yii Framework 2 Change Log
 - Bug #14165: Set `_slave` of `Connection` to `false` instead of `null` in `close` method (rossoneri)
 - Bug #14423: Fixed `ArrayHelper::merge` behavior with null values for integer-keyed elements (dmirogin)
 - Chg #7936: Deprecate `yii\base\Object` in favor of `yii\base\BaseObject` for compatibility with PHP 7.2 (rob006, cebe, klimov-paul)
-
+- Bug #14492: Fixed error handler not displaying `yii\db\Exception` error info (samdark)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -38,7 +38,7 @@ Yii Framework 2 Change Log
 - Bug #14165: Set `_slave` of `Connection` to `false` instead of `null` in `close` method (rossoneri)
 - Bug #14423: Fixed `ArrayHelper::merge` behavior with null values for integer-keyed elements (dmirogin)
 - Chg #7936: Deprecate `yii\base\Object` in favor of `yii\base\BaseObject` for compatibility with PHP 7.2 (rob006, cebe, klimov-paul)
-- Bug #14492: Fixed error handler not escpaping error info debug mode (samdark)
+- Bug #14492: Fixed error handler not escaping error info debug mode (samdark)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -38,7 +38,7 @@ Yii Framework 2 Change Log
 - Bug #14165: Set `_slave` of `Connection` to `false` instead of `null` in `close` method (rossoneri)
 - Bug #14423: Fixed `ArrayHelper::merge` behavior with null values for integer-keyed elements (dmirogin)
 - Chg #7936: Deprecate `yii\base\Object` in favor of `yii\base\BaseObject` for compatibility with PHP 7.2 (rob006, cebe, klimov-paul)
-- Bug #14492: Fixed error handler not displaying `yii\db\Exception` error info (samdark)
+- Bug #14492: Fixed error handler not escpaping error info debug mode (samdark)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/views/errorHandler/exception.php
+++ b/framework/views/errorHandler/exception.php
@@ -373,7 +373,7 @@ body.mousedown pre {
         <h2><?= nl2br($handler->htmlEncode($exception->getMessage())) ?></h2>
 
         <?php if ($exception instanceof \yii\db\Exception && !empty($exception->errorInfo)): ?>
-            <pre>Error Info: <?php print_r($exception->errorInfo, true) ?></pre>
+            <pre>Error Info: <?= $handler->htmlEncode(print_r($exception->errorInfo, true)) ?></pre>
         <?php endif ?>
 
         <?= $handler->renderPreviousExceptions($exception) ?>

--- a/framework/views/errorHandler/previousException.php
+++ b/framework/views/errorHandler/previousException.php
@@ -17,7 +17,7 @@
     <h3><?= nl2br($handler->htmlEncode($exception->getMessage())) ?></h3>
     <p>in <span class="file"><?= $exception->getFile() ?></span> at line <span class="line"><?= $exception->getLine() ?></span></p>
     <?php if ($exception instanceof \yii\db\Exception && !empty($exception->errorInfo)): ?>
-        <pre>Error Info: <?php print_r($exception->errorInfo, true) ?></pre>
+        <pre>Error Info: <?= $handler->htmlEncode(print_r($exception->errorInfo, true)) ?></pre>
     <?php endif ?>
     <?= $handler->renderPreviousExceptions($exception) ?>
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | -
| Fixed issues  | -

Current code won't actually output any error info. `print_r()` with `true` passed as a second argument doesn't print itself but returns a string that we aren't printing afterwards.

Seems it's like that since 2014: https://github.com/yiisoft/yii2/commit/7511de6cab2f57a599638063c2823cf83828f0e8