### PR TITLE
Change pjax binding on links.

### DIFF
--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -204,7 +204,7 @@ class Pjax extends Widget
         $js = '';
         if ($this->linkSelector !== false) {
             $linkSelector = Json::htmlEncode($this->linkSelector !== null ? $this->linkSelector : '#' . $id . ' a');
-            $js .= "jQuery(document).pjax($linkSelector, $options);";
+            $js .= "jQuery(document).on('click', $linkSelector, function(event){jQuery.pjax.click(event, $options)});";
         }
         if ($this->formSelector !== false) {
             $formSelector = Json::htmlEncode($this->formSelector !== null ? $this->formSelector : '#' . $id . ' form[data-pjax]');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

Very useful fix that bind pjax handler on all links, including links come via pjax.