### PR TITLE
Fixes #13885: Deprecated APC support in ApcCache. APCu works as before

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -20,6 +20,7 @@ Yii Framework 2 Change Log
 - Enh #2990: `yii\widgets\ActiveField::hiddenInput()` no longer renders label by default (lennartvdd)
 - Chg: Moved masked input field widget into separate extension https://github.com/yiisoft/yii2-maskedinput (samdark)
 - Chg #12089: Behavior of `yii\grid\DataColumn::$filterInputOptions` changed when default value is overwritten (bvanleeuwen, cebe)
+- Chg #13885: Deprecated APC support in ApcCache. APCu works as before (samdark) 
 
 2.0.13 under development
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -20,7 +20,7 @@ Yii Framework 2 Change Log
 - Enh #2990: `yii\widgets\ActiveField::hiddenInput()` no longer renders label by default (lennartvdd)
 - Chg: Moved masked input field widget into separate extension https://github.com/yiisoft/yii2-maskedinput (samdark)
 - Chg #12089: Behavior of `yii\grid\DataColumn::$filterInputOptions` changed when default value is overwritten (bvanleeuwen, cebe)
-- Chg #13885: Deprecated APC support in ApcCache. APCu works as before (samdark) 
+- Chg #13885: Removed APC support in ApcCache. APCu works as before (samdark) 
 - Chg #14178: Removed HHVM-specific code (samdark)
 
 2.0.13 under development

--- a/framework/caching/ApcCache.php
+++ b/framework/caching/ApcCache.php
@@ -10,11 +10,10 @@ namespace yii\caching;
 use yii\base\InvalidConfigException;
 
 /**
- * ApcCache provides APC caching in terms of an application component.
+ * ApcCache provides APCu caching in terms of an application component.
  *
- * To use this application component, the [APC PHP extension](http://www.php.net/apc) must be loaded.
- * Alternatively [APCu PHP extension](http://www.php.net/apcu) could be used via setting `useApcu` to `true`.
- * In order to enable APC or APCu for CLI you should add "apc.enable_cli = 1" to your php.ini.
+ * To use this application component, the [APCu PHP extension](http://www.php.net/apcu) must be loaded.
+ * In order to enable APCu for CLI you should add "apc.enable_cli = 1" to your php.ini.
  *
  * See [[Cache]] for common cache operations that ApcCache supports.
  *
@@ -26,25 +25,15 @@ use yii\base\InvalidConfigException;
 class ApcCache extends Cache
 {
     /**
-     * @var bool whether to use apcu or apc as the underlying caching extension.
-     * If true, [apcu](http://pecl.php.net/package/apcu) will be used.
-     * If false, [apc](http://pecl.php.net/package/apc) will be used.
-     * Defaults to false.
-     * @since 2.0.7
-     */
-    public $useApcu = false;
-
-
-    /**
      * Initializes this application component.
      * It checks if extension required is loaded.
+     * @throws \yii\base\InvalidConfigException
      */
     public function init()
     {
         parent::init();
-        $extension = $this->useApcu ? 'apcu' : 'apc';
-        if (!extension_loaded($extension)) {
-            throw new InvalidConfigException("ApcCache requires PHP $extension extension to be loaded.");
+        if (!extension_loaded('apcu')) {
+            throw new InvalidConfigException('ApcCache requires PHP apcu extension to be loaded.');
         }
     }
 
@@ -62,7 +51,7 @@ class ApcCache extends Cache
     {
         $key = $this->buildKey($key);
 
-        return $this->useApcu ? apcu_exists($key) : apc_exists($key);
+        return apcu_exists($key);
     }
 
     /**
@@ -73,7 +62,7 @@ class ApcCache extends Cache
      */
     protected function getValue($key)
     {
-        return $this->useApcu ? apcu_fetch($key) : apc_fetch($key);
+        return apcu_fetch($key);
     }
 
     /**
@@ -83,7 +72,7 @@ class ApcCache extends Cache
      */
     protected function getValues($keys)
     {
-        $values = $this->useApcu ? apcu_fetch($keys) : apc_fetch($keys);
+        $values = apcu_fetch($keys);
         return is_array($values) ? $values : [];
     }
 
@@ -99,7 +88,7 @@ class ApcCache extends Cache
      */
     protected function setValue($key, $value, $duration)
     {
-        return $this->useApcu ? apcu_store($key, $value, $duration) : apc_store($key, $value, $duration);
+        return apcu_store($key, $value, $duration);
     }
 
     /**
@@ -110,7 +99,7 @@ class ApcCache extends Cache
      */
     protected function setValues($data, $duration)
     {
-        $result = $this->useApcu ? apcu_store($data, null, $duration) : apc_store($data, null, $duration);
+        $result = apcu_store($data, null, $duration);
         return is_array($result) ? array_keys($result) : [];
     }
 
@@ -125,7 +114,7 @@ class ApcCache extends Cache
      */
     protected function addValue($key, $value, $duration)
     {
-        return $this->useApcu ? apcu_add($key, $value, $duration) : apc_add($key, $value, $duration);
+        return apcu_add($key, $value, $duration);
     }
 
     /**
@@ -136,7 +125,7 @@ class ApcCache extends Cache
      */
     protected function addValues($data, $duration)
     {
-        $result = $this->useApcu ? apcu_add($data, null, $duration) : apc_add($data, null, $duration);
+        $result = apcu_add($data, null, $duration);
         return is_array($result) ? array_keys($result) : [];
     }
 
@@ -148,7 +137,7 @@ class ApcCache extends Cache
      */
     protected function deleteValue($key)
     {
-        return $this->useApcu ? apcu_delete($key) : apc_delete($key);
+        return apcu_delete($key);
     }
 
     /**
@@ -158,6 +147,6 @@ class ApcCache extends Cache
      */
     protected function flushValues()
     {
-        return $this->useApcu ? apcu_clear_cache() : apc_clear_cache('user');
+        return apcu_clear_cache();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | ?
| Fixed issues  | #13885 
