### PR TITLE
Fixes #14318: Trigger yiiActiveForm.events.afterValidateAttribute after updating attribute

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -39,7 +39,7 @@ Yii Framework 2 Change Log
 - Bug #14423: Fixed `ArrayHelper::merge` behavior with null values for integer-keyed elements (dmirogin)
 - Bug #14406: Fixed caching rules in `yii\web\UrlManager` with different ruleConfig configuration (dmirogin)
 - Chg #7936: Deprecate `yii\base\Object` in favor of `yii\base\BaseObject` for compatibility with PHP 7.2 (rob006, cebe, klimov-paul)
-
+- Bug #14318: Trigger `yiiActiveForm.events.afterValidateAttribute` after updating attribute  (dmirogin)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -702,7 +702,6 @@
         if (!$.isArray(messages[attribute.id])) {
             messages[attribute.id] = [];
         }
-        $form.trigger(events.afterValidateAttribute, [attribute, messages[attribute.id]]);
 
         attribute.status = 1;
         if ($input.length) {
@@ -725,6 +724,9 @@
             }
             attribute.value = getValue($form, attribute);
         }
+
+        $form.trigger(events.afterValidateAttribute, [attribute, messages[attribute.id]]);
+
         return hasError;
     };
 

--- a/tests/js/data/yii.activeForm.html
+++ b/tests/js/data/yii.activeForm.html
@@ -1,0 +1,3 @@
+<form id="main">
+    <input id="nameInput" type="text" name="name" value="value" />
+</form>

--- a/tests/js/tests/yii.activeForm.test.js
+++ b/tests/js/tests/yii.activeForm.test.js
@@ -54,9 +54,12 @@ describe('yii.activeForm', function () {
     describe('events', function () {
         describe('afterValidateAttribute', function () {
             var afterValidateAttributeEventSpy;
+            var dataForAssert;
 
             before(function () {
-                afterValidateAttributeEventSpy = sinon.spy();
+                afterValidateAttributeEventSpy = sinon.spy(function (event, data) {
+                    dataForAssert = data.value;
+                });
             });
 
             after(function () {
@@ -77,7 +80,7 @@ describe('yii.activeForm', function () {
                 $input.val('newValue');
                 $mainForm.yiiActiveForm('updateAttribute', inputId);
 
-                assert.equal('newValue', afterValidateAttributeEventSpy.getCall(0).args[1].value);
+                assert.equal('newValue', dataForAssert);
             });
         });
     });

--- a/tests/js/tests/yii.activeForm.test.js
+++ b/tests/js/tests/yii.activeForm.test.js
@@ -1,0 +1,84 @@
+var assert = require('chai').assert;
+var sinon;
+var jsdom = require('mocha-jsdom');
+
+var fs = require('fs');
+var vm = require('vm');
+
+describe('yii.activeForm', function () {
+    var yiiActiveFormPath = 'framework/assets/yii.activeForm.js';
+    var yiiPath = 'framework/assets/yii.js';
+    var jQueryPath = 'vendor/bower-asset/jquery/dist/jquery.js';
+    var $;
+    var $mainForm;
+
+    function registerYii() {
+        var code = fs.readFileSync(yiiPath);
+        var script = new vm.Script(code);
+        var sandbox = {window: window, jQuery: $};
+        var context = new vm.createContext(sandbox);
+        script.runInContext(context);
+        return sandbox.window.yii;
+    }
+
+    function registerTestableCode() {
+        var yii = registerYii();
+        var code = fs.readFileSync(yiiActiveFormPath);
+        var script = new vm.Script(code);
+        var context = new vm.createContext({
+            window: window,
+            document: window.document,
+            yii: yii
+        });
+        script.runInContext(context);
+    }
+
+    var activeFormHtml = fs.readFileSync('tests/js/data/yii.activeForm.html', 'utf-8');
+    var html = '<!doctype html><html><head><meta charset="utf-8"></head><body>' + activeFormHtml + '</body></html>';
+
+    jsdom({
+        html: html,
+        src: fs.readFileSync(jQueryPath, 'utf-8')
+    });
+
+    before(function () {
+        $ = window.$;
+        registerTestableCode();
+        sinon = require('sinon');
+    });
+
+    beforeEach(function () {
+        $mainForm = $('#main');
+    });
+
+    describe('events', function () {
+        describe('afterValidateAttribute', function () {
+            var afterValidateAttributeEventSpy;
+
+            before(function () {
+                afterValidateAttributeEventSpy = sinon.spy();
+            });
+
+            after(function () {
+                afterValidateAttributeEventSpy.reset();
+            });
+
+            it('should update attribute value', function () {
+                var inputId = 'nameInput',
+                    $input = $('#' + inputId);
+                $mainForm.yiiActiveForm([
+                    {
+                        id : inputId,
+                        input: '#' + inputId
+                    }
+                ]).on('afterValidateAttribute', afterValidateAttributeEventSpy);
+
+                // Set new value, update attribute
+                $input.val('newValue');
+                $mainForm.yiiActiveForm('updateAttribute', inputId);
+
+                assert.equal('newValue', afterValidateAttributeEventSpy.getCall(0).args[1].value);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Trigger yiiActiveForm.events.afterValidateAttribute after updating attribute

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14318 
