### PR TITLE
Fixes #7823: Added possibility to limit request by ajax in yii\filters\AccessRule

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -41,7 +41,7 @@ Yii Framework 2 Change Log
 - Chg #7936: Deprecate `yii\base\Object` in favor of `yii\base\BaseObject` for compatibility with PHP 7.2 (rob006, cebe, klimov-paul)
 - Bug #14492: Fixed error handler not escaping error info debug mode (samdark)
 - Chg #14487: Changed i18n message error to warning (dmirogin)
-- Enh #7823: Added possibility to limit request by ajax in `yii\filters\AccessRule` (dmirogin)
+- Enh #7823: Added `yii\filters\AjaxFilter` filter (dmirogin)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -41,6 +41,7 @@ Yii Framework 2 Change Log
 - Chg #7936: Deprecate `yii\base\Object` in favor of `yii\base\BaseObject` for compatibility with PHP 7.2 (rob006, cebe, klimov-paul)
 - Bug #14492: Fixed error handler not escaping error info debug mode (samdark)
 - Chg #14487: Changed i18n message error to warning (dmirogin)
+- Enh #7823: Added possibility to limit request by ajax in `yii\filters\AccessRule` (dmirogin)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/filters/AccessRule.php
+++ b/framework/filters/AccessRule.php
@@ -110,10 +110,6 @@ class AccessRule extends Component
      */
     public $verbs;
     /**
-     * @var bool If true then this rule applies only in case that request is ajax
-     */
-    public $ajax = false;
-    /**
      * @var callable a callback that will be called to determine if the rule should be applied.
      * The signature of the callback should be as follows:
      *
@@ -156,7 +152,6 @@ class AccessRule extends Component
             && $this->matchVerb($request->getMethod())
             && $this->matchController($action->controller)
             && $this->matchCustom($action)
-            && $this->matchAjax($request->getIsAjax())
         ) {
             return $this->allow ? true : false;
         }
@@ -269,14 +264,5 @@ class AccessRule extends Component
     protected function matchCustom($action)
     {
         return empty($this->matchCallback) || call_user_func($this->matchCallback, $this, $action);
-    }
-
-    /**
-     * @param boolean $isAjax whether the request is ajax
-     * @return bool whether the rule should be applied
-     */
-    protected function matchAjax($isAjax)
-    {
-        return empty($this->ajax) || $isAjax;
     }
 }

--- a/framework/filters/AccessRule.php
+++ b/framework/filters/AccessRule.php
@@ -110,6 +110,10 @@ class AccessRule extends Component
      */
     public $verbs;
     /**
+     * @var bool If true then this rule applies only in case that request is ajax
+     */
+    public $ajax = false;
+    /**
      * @var callable a callback that will be called to determine if the rule should be applied.
      * The signature of the callback should be as follows:
      *
@@ -152,6 +156,7 @@ class AccessRule extends Component
             && $this->matchVerb($request->getMethod())
             && $this->matchController($action->controller)
             && $this->matchCustom($action)
+            && $this->matchAjax($request->getIsAjax())
         ) {
             return $this->allow ? true : false;
         }
@@ -264,5 +269,14 @@ class AccessRule extends Component
     protected function matchCustom($action)
     {
         return empty($this->matchCallback) || call_user_func($this->matchCallback, $this, $action);
+    }
+
+    /**
+     * @param boolean $isAjax whether the request is ajax
+     * @return bool whether the rule should be applied
+     */
+    protected function matchAjax($isAjax)
+    {
+        return empty($this->ajax) || $isAjax;
     }
 }

--- a/framework/filters/AjaxFilter.php
+++ b/framework/filters/AjaxFilter.php
@@ -35,7 +35,7 @@ class AjaxFilter extends ActionFilter
     /**
      * @var string the message to be displayed when request isn't ajax
      */
-    public $errorMessage = 'Request must be XMLHttpRequest only.';
+    public $errorMessage = 'Request must be XMLHttpRequest.';
     /**
      * @var Request the current request. If not set, the `request` application component will be used.
      */

--- a/framework/filters/AjaxFilter.php
+++ b/framework/filters/AjaxFilter.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\filters;
+
+use Yii;
+use yii\base\ActionFilter;
+use yii\web\BadRequestHttpException;
+use yii\web\Request;
+
+/**
+ * AjaxFilter allow to limit access only for ajax requests.
+ *
+ * ```php
+ * public function behaviors()
+ * {
+ *     return [
+ *         [
+ *             'class' => 'yii\filters\AjaxFilter',
+ *             'only' => ['index']
+ *         ],
+ *     ];
+ * }
+ * ```
+ *
+ * @author Dmitry Dorogin <dmirogin@ya.ru>
+ * @since 2.0.13
+ */
+class AjaxFilter extends ActionFilter
+{
+    /**
+     * @var string the message to be displayed when request isn't ajax
+     */
+    public $errorMessage = 'Request must be XMLHttpRequest only.';
+    /**
+     * @var Request the current request. If not set, the `request` application component will be used.
+     */
+    public $request;
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        if ($this->request === null) {
+            $this->request = Yii::$app->getRequest();
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function beforeAction($action)
+    {
+        if ($this->request->getIsAjax()) {
+            return true;
+        }
+
+        throw new BadRequestHttpException($this->errorMessage);
+    }
+}

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -35,17 +35,15 @@ class AccessRuleTest extends \yiiunit\TestCase
 
     /**
      * @param string $method
-     * @param boolean $isAjax
      * @return Request
      */
-    protected function mockRequest($method = 'GET', $isAjax = false)
+    protected function mockRequest($method = 'GET')
     {
         /** @var Request $request */
         $request = $this->getMockBuilder('\yii\web\Request')
-            ->setMethods(['getMethod', 'getIsAjax'])
+            ->setMethods(['getMethod'])
             ->getMock();
         $request->method('getMethod')->willReturn($method);
-        $request->method('getIsAjax')->willReturn($isAjax);
 
         return $request;
     }
@@ -457,29 +455,6 @@ class AccessRuleTest extends \yiiunit\TestCase
         // no match, IPv6
         $_SERVER['REMOTE_ADDR'] = '::1';
         $rule->ips = ['2a01:4f8:120:*'];
-        $rule->allow = true;
-        $this->assertNull($rule->allows($action, $user, $request));
-        $rule->allow = false;
-        $this->assertNull($rule->allows($action, $user, $request));
-    }
-
-    public function testMatchAjax()
-    {
-        $user = false;
-        $action = $this->mockAction();
-
-        $rule = new AccessRule([
-            'allow' => true,
-            'ajax' => true,
-        ]);
-
-        $request = $this->mockRequest('GET', true);
-        $rule->allow = true;
-        $this->assertTrue($rule->allows($action, $user, $request));
-        $rule->allow = false;
-        $this->assertFalse($rule->allows($action, $user, $request));
-
-        $request = $this->mockRequest('GET', false);
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
         $rule->allow = false;

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -35,15 +35,18 @@ class AccessRuleTest extends \yiiunit\TestCase
 
     /**
      * @param string $method
+     * @param boolean $isAjax
      * @return Request
      */
-    protected function mockRequest($method = 'GET')
+    protected function mockRequest($method = 'GET', $isAjax = false)
     {
         /** @var Request $request */
         $request = $this->getMockBuilder('\yii\web\Request')
-            ->setMethods(['getMethod'])
+            ->setMethods(['getMethod', 'getIsAjax'])
             ->getMock();
         $request->method('getMethod')->willReturn($method);
+        $request->method('getIsAjax')->willReturn($isAjax);
+
         return $request;
     }
 
@@ -454,6 +457,29 @@ class AccessRuleTest extends \yiiunit\TestCase
         // no match, IPv6
         $_SERVER['REMOTE_ADDR'] = '::1';
         $rule->ips = ['2a01:4f8:120:*'];
+        $rule->allow = true;
+        $this->assertNull($rule->allows($action, $user, $request));
+        $rule->allow = false;
+        $this->assertNull($rule->allows($action, $user, $request));
+    }
+
+    public function testMatchAjax()
+    {
+        $user = false;
+        $action = $this->mockAction();
+
+        $rule = new AccessRule([
+            'allow' => true,
+            'ajax' => true,
+        ]);
+
+        $request = $this->mockRequest('GET', true);
+        $rule->allow = true;
+        $this->assertTrue($rule->allows($action, $user, $request));
+        $rule->allow = false;
+        $this->assertFalse($rule->allows($action, $user, $request));
+
+        $request = $this->mockRequest('GET', false);
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
         $rule->allow = false;

--- a/tests/framework/filters/AjaxFilterTest.php
+++ b/tests/framework/filters/AjaxFilterTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\filters;
+
+use Yii;
+use yii\base\Action;
+use yii\filters\AjaxFilter;
+use yii\web\BadRequestHttpException;
+use yii\web\Controller;
+use yii\web\Request;
+use yiiunit\TestCase;
+
+/**
+ * @group filters
+ */
+class AjaxFilterTest extends TestCase
+{
+    /**
+     * @param boolean $isAjax
+     * @return Request
+     */
+    protected function mockRequest($isAjax)
+    {
+        /** @var Request $request */
+        $request = $this->getMockBuilder('\yii\web\Request')
+            ->setMethods(['getIsAjax'])
+            ->getMock();
+        $request->method('getIsAjax')->willReturn($isAjax);
+
+        return $request;
+    }
+
+    public function testFilter()
+    {
+        $this->mockWebApplication();
+        $controller = new Controller('id', Yii::$app);
+        $action = new Action('test', $controller);
+        $filter = new AjaxFilter();
+
+        $filter->request = $this->mockRequest(true);
+        $this->assertTrue($filter->beforeAction($action));
+
+        $filter->request = $this->mockRequest(false);
+        $this->expectException('yii\web\BadRequestHttpException');
+        $filter->beforeAction($action);
+    }
+}


### PR DESCRIPTION
Added possibility to limit request by ajax in yii\filters\AccessRule

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #7823
