### PR TITLE
Fix for invalid example in Request.php

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -393,7 +393,7 @@ class Request extends \yii\base\Request
 
             $rawContentType = $this->getContentType();
             if (($pos = strpos($rawContentType, ';')) !== false) {
-                // e.g. application/json; charset=UTF-8
+                // e.g. text/html; charset=UTF-8
                 $contentType = substr($rawContentType, 0, $pos);
             } else {
                 $contentType = $rawContentType;


### PR DESCRIPTION
"application/json" media type does not have any parameters (including "charset"):
https://tools.ietf.org/html/rfc7159#section-11
https://www.iana.org/assignments/media-types/application/json

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
