### PR TITLE
Implementing Migration::change() [WIP]

### DIFF
--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -468,7 +468,7 @@ class ActiveRecord extends BaseActiveRecord
     public function insert($runValidation = true, $attributes = null)
     {
         if ($runValidation && !$this->validate($attributes)) {
-            Yii::info('Model not inserted due to validation error.', __METHOD__);
+            $this->db->getLogger()->log('Model not inserted due to validation error.', __METHOD__);
             return false;
         }
 
@@ -577,7 +577,7 @@ class ActiveRecord extends BaseActiveRecord
     public function update($runValidation = true, $attributeNames = null)
     {
         if ($runValidation && !$this->validate($attributeNames)) {
-            Yii::info('Model not updated due to validation error.', __METHOD__);
+            $this->db->getLogger()->log('Model not updated due to validation error.', __METHOD__);
             return false;
         }
 

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -981,7 +981,7 @@ class Command extends Component
     {
         if ($this->db->enableLogging) {
             $rawSql = $this->getRawSql();
-            Yii::info($rawSql, $category);
+            $this->db->getLogger()->log($rawSql, $category);
         }
         if (!$this->db->enableProfiling) {
             return [false, isset($rawSql) ? $rawSql : null];
@@ -1018,7 +1018,7 @@ class Command extends Component
                 ];
                 $result = $cache->get($cacheKey);
                 if (is_array($result) && isset($result[0])) {
-                    Yii::trace('Query result served from cache', 'yii\db\Command::query');
+                    $this->db->getLogger()->trace('Query result served from cache', 'yii\db\Command::query');
                     return $result[0];
                 }
             }
@@ -1049,7 +1049,7 @@ class Command extends Component
 
         if (isset($cache, $cacheKey, $info)) {
             $cache->set($cacheKey, [$result], $info[1], $info[2]);
-            Yii::trace('Saved query result in cache', 'yii\db\Command::query');
+            $this->db->getLogger()->trace('Saved query result in cache', 'yii\db\Command::query');
         }
 
         return $result;

--- a/framework/db/ConnectionLoggerInterface.php
+++ b/framework/db/ConnectionLoggerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace yii\db;
+
+/**
+ * Interface ConnectionLoggerInterface
+ *
+ * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
+ * @since 2.0.13
+ */
+interface ConnectionLoggerInterface
+{
+    public function log($message, $category);
+
+    public function error($message, $category);
+
+    public function trace($message, $category);
+
+    public function warning($message, $category);
+}

--- a/framework/db/IrreversibleCommandException.php
+++ b/framework/db/IrreversibleCommandException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace yii\db;
+
+class IrreversibleCommandException extends \yii\base\Exception
+{
+    public function getName()
+    {
+        return 'Migration step can not be reverted automatically';
+    }
+}

--- a/framework/db/MigrationReverser.php
+++ b/framework/db/MigrationReverser.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace yii\db;
+
+use yii\db\fake\FakeConnection;
+
+/**
+ * Class MigrationReverser
+ *
+ * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
+ * @since 2.0.13
+ */
+class MigrationReverser
+{
+    /**
+     * @var ReversibleMigrationInterface|Migration
+     */
+    protected $migration;
+
+    /**
+     * MigrationReverser constructor.
+     *
+     * @param ReversibleMigrationInterface $migration
+     */
+    function __construct(ReversibleMigrationInterface $migration)
+    {
+        $this->migration = $migration;
+    }
+
+    /**
+     * Applies migration using `change()` method without reversing
+     */
+    public function apply()
+    {
+        $this->checkCommands($this->collectCommands());
+        $this->migration->change();
+    }
+
+    /**
+     * Apply reverse migration using `change()` method
+     */
+    public function revert()
+    {
+        $commands = $this->collectCommands();
+        $this->checkCommands($commands);
+
+        $reversedCommands = $this->reverse($commands);
+
+        foreach ($reversedCommands as $command) {
+            call_user_func_array([$this->migration, $command[0]], $command[1]);
+        }
+    }
+
+    protected function collectCommands()
+    {
+        $connection = $this->migration->db;
+        $fakeConnection = new FakeConnection($connection);
+
+        $this->migration->db = $fakeConnection;
+        $this->migration->change();
+        $commands = $fakeConnection->getLogger()->getExecutedCommands();
+        $this->migration->db = $connection;
+
+        return $commands;
+    }
+
+    protected function checkCommands($commands)
+    {
+        foreach ($commands as $command) {
+            if (!$this->canReverse($command[0])) {
+                throw new IrreversibleCommandException('Command "' . $command[0] . '" can not be reversed automatically. It should be located either in "up" or "down" methods');
+            }
+        }
+
+        return $commands;
+    }
+
+    /**
+     * Checks whether $commandName can be revered automatically
+     *
+     * @param string $commandName
+     * @return bool
+     */
+    public function canReverse($commandName)
+    {
+        return method_exists($this, 'reverse' . $commandName);
+    }
+
+    protected function reverseCreateTable($arguments)
+    {
+        return ['dropTable', [$arguments[0]]];
+    }
+
+    // TODO: other methods that can be reversed
+
+    /**
+     * Reverses $commands TODO: enhance docs
+     *
+     * @param string $commands
+     * @return array
+     */
+    protected function reverse($commands)
+    {
+        $result = [];
+        foreach ($commands as $command) {
+            $result[] = call_user_func([$this, 'reverse' . $command[0]], $command[1]);
+        }
+
+        return $result;
+    }
+}

--- a/framework/db/ReversibleMigrationInterface.php
+++ b/framework/db/ReversibleMigrationInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace yii\db;
+
+/**
+ * Interface ReversibleMigrationInterface
+ *
+ * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
+ * @since 2.0.13
+ */
+interface ReversibleMigrationInterface
+{
+    public function change();
+}

--- a/framework/db/Transaction.php
+++ b/framework/db/Transaction.php
@@ -122,7 +122,7 @@ class Transaction extends \yii\base\BaseObject
             if ($isolationLevel !== null) {
                 $this->db->getSchema()->setTransactionIsolationLevel($isolationLevel);
             }
-            Yii::trace('Begin transaction' . ($isolationLevel ? ' with isolation level ' . $isolationLevel : ''), __METHOD__);
+            $this->db->getLogger()->trace('Begin transaction' . ($isolationLevel ? ' with isolation level ' . $isolationLevel : ''), __METHOD__);
 
             $this->db->trigger(Connection::EVENT_BEGIN_TRANSACTION);
             $this->db->pdo->beginTransaction();
@@ -133,10 +133,10 @@ class Transaction extends \yii\base\BaseObject
 
         $schema = $this->db->getSchema();
         if ($schema->supportsSavepoint()) {
-            Yii::trace('Set savepoint ' . $this->_level, __METHOD__);
+            $this->db->getLogger()->trace('Set savepoint ' . $this->_level, __METHOD__);
             $schema->createSavepoint('LEVEL' . $this->_level);
         } else {
-            Yii::info('Transaction not started: nested transaction not supported', __METHOD__);
+            $this->db->getLogger()->log('Transaction not started: nested transaction not supported', __METHOD__);
         }
         $this->_level++;
     }
@@ -153,7 +153,7 @@ class Transaction extends \yii\base\BaseObject
 
         $this->_level--;
         if ($this->_level === 0) {
-            Yii::trace('Commit transaction', __METHOD__);
+            $this->db->getLogger()->trace('Commit transaction', __METHOD__);
             $this->db->pdo->commit();
             $this->db->trigger(Connection::EVENT_COMMIT_TRANSACTION);
             return;
@@ -161,10 +161,10 @@ class Transaction extends \yii\base\BaseObject
 
         $schema = $this->db->getSchema();
         if ($schema->supportsSavepoint()) {
-            Yii::trace('Release savepoint ' . $this->_level, __METHOD__);
+            $this->db->getLogger()->trace('Release savepoint ' . $this->_level, __METHOD__);
             $schema->releaseSavepoint('LEVEL' . $this->_level);
         } else {
-            Yii::info('Transaction not committed: nested transaction not supported', __METHOD__);
+            $this->db->getLogger()->log('Transaction not committed: nested transaction not supported', __METHOD__);
         }
     }
 
@@ -182,7 +182,7 @@ class Transaction extends \yii\base\BaseObject
 
         $this->_level--;
         if ($this->_level === 0) {
-            Yii::trace('Roll back transaction', __METHOD__);
+            $this->db->getLogger()->trace('Roll back transaction', __METHOD__);
             $this->db->pdo->rollBack();
             $this->db->trigger(Connection::EVENT_ROLLBACK_TRANSACTION);
             return;
@@ -190,10 +190,10 @@ class Transaction extends \yii\base\BaseObject
 
         $schema = $this->db->getSchema();
         if ($schema->supportsSavepoint()) {
-            Yii::trace('Roll back to savepoint ' . $this->_level, __METHOD__);
+            $this->db->getLogger()->trace('Roll back to savepoint ' . $this->_level, __METHOD__);
             $schema->rollBackSavepoint('LEVEL' . $this->_level);
         } else {
-            Yii::info('Transaction not rolled back: nested transaction not supported', __METHOD__);
+            $this->db->getLogger()->log('Transaction not rolled back: nested transaction not supported', __METHOD__);
             // throw an exception to fail the outer transaction
             throw new Exception('Roll back failed: nested transaction not supported.');
         }
@@ -216,7 +216,7 @@ class Transaction extends \yii\base\BaseObject
         if (!$this->getIsActive()) {
             throw new Exception('Failed to set isolation level: transaction was inactive.');
         }
-        Yii::trace('Setting transaction isolation level to ' . $level, __METHOD__);
+        $this->db->getLogger()->trace('Setting transaction isolation level to ' . $level, __METHOD__);
         $this->db->getSchema()->setTransactionIsolationLevel($level);
     }
 

--- a/framework/db/YiiConnectionLogger.php
+++ b/framework/db/YiiConnectionLogger.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace yii\db;
+
+use Yii;
+
+/**
+ * Class YiiConnectionLogger
+ *
+ * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
+ * @since 2.0.13
+ */
+class YiiConnectionLogger implements ConnectionLoggerInterface
+{
+    public function log($message, $category)
+    {
+        Yii::info($message, $category);
+    }
+
+    public function error($message, $category)
+    {
+        Yii::error($message, $category);
+    }
+
+    public function trace($message, $category)
+    {
+        Yii::trace($message, $category);
+    }
+
+    public function warning($message, $category)
+    {
+        Yii::warning($message, $category);
+    }
+}

--- a/framework/db/fake/FakeCommand.php
+++ b/framework/db/fake/FakeCommand.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace yii\db\proxy;
+
+/**
+ * Class FakeCommand logs commands to be executed and prevents real execution
+ *
+ * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
+ * @since 2.0.12
+ */
+class FakeCommand extends \yii\db\Command
+{
+    const EXECUTED_COMMAND_LOG = 'executed_command';
+
+    protected function recordCommand($name, $params)
+    {
+        $this->db->getLogger()->log([$name, $params], self::EXECUTED_COMMAND_LOG);
+
+        return $this;
+    }
+
+    public function createTable($table, $columns, $options = null)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function dropTable($table)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function createIndex($name, $table, $columns, $unique = false)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function dropIndex($name, $table)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function addForeignKey($name, $table, $columns, $refTable, $refColumns, $delete = null, $update = null)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function dropForeignKey($name, $table)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function addDefaultValue($name, $table, $column, $value)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function addUnique($name, $table, $columns)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function dropUnique($name, $table)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function addPrimaryKey($name, $table, $columns)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function dropPrimaryKey($name, $table)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function dropDefaultValue($name, $table)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function alterColumn($table, $column, $type)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function delete($table, $condition = '', $params = [])
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function addCheck($name, $table, $expression)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function dropCheck($name, $table)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function addColumn($table, $column, $type)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function dropColumn($table, $column)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function addCommentOnColumn($table, $column, $comment)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function dropCommentFromColumn($table, $column)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function addCommentOnTable($table, $comment)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function dropCommentFromTable($table)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function renameColumn($table, $oldName, $newName)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function renameTable($table, $newName)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function truncateTable($table)
+    {
+        return $this->recordCommand(__FUNCTION__, func_get_args());
+    }
+
+    public function execute()
+    {
+        return true;
+    }
+}

--- a/framework/db/fake/FakeConnection.php
+++ b/framework/db/fake/FakeConnection.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace yii\db\fake;
+
+use yii\db\Connection;
+
+class FakeConnection extends \yii\db\Connection
+{
+    protected $proxyConnection;
+
+    /**
+     * FakeConnection constructor.
+     *
+     * @param Connection $connection
+     * @param array $config
+     */
+    public function __construct($connection, array $config = [])
+    {
+        $this->proxyConnection = $connection;
+
+        parent::__construct($config);
+    }
+
+    public $commandClass = 'yii\db\fake\FakeCommand';
+    public $loggerClass = 'yii\db\fake\FakeConnectionLogger';
+
+    public function getSchema()
+    {
+        return $this->proxyConnection->getSchema();
+    }
+
+    /**
+     * @return \yii\db\ConnectionLoggerInterface|FakeConnectionLoggerInterface
+     */
+    public function getLogger()
+    {
+        return parent::getLogger();
+    }
+
+    public function open()
+    {
+        return true;
+    }
+
+    public function close()
+    {
+        return true;
+    }
+}

--- a/framework/db/fake/FakeConnectionLogger.php
+++ b/framework/db/fake/FakeConnectionLogger.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace yii\db\fake;
+
+use yii\db\ConnectionLoggerInterface;
+
+/**
+ * Class FakeConnectionLogger is designed to log events from fake connection
+ * // TODO better docs
+ *
+ * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
+ * @since 2.0.13
+ */
+class FakeConnectionLogger implements ConnectionLoggerInterface, FakeConnectionLoggerInterface
+{
+    protected $items = [];
+
+    /**
+     * @return array commands description that where executed
+     */
+    public function getExecutedCommands()
+    {
+        $result = [];
+        foreach ($this->items as list($command, $category)) {
+            if ($category === FakeCommand::EXECUTED_COMMAND_LOG) {
+                $result[] = $command;
+            }
+        }
+
+        return $result;
+    }
+
+    public function log($message, $category)
+    {
+        $this->items['log'][] = [$message, $category];
+    }
+
+    public function error($message, $category)
+    {
+        $this->items['error'][] = [$message, $category];
+    }
+
+    public function trace($message, $category)
+    {
+        $this->items['trace'][] = [$message, $category];
+    }
+
+    public function warning($message, $category)
+    {
+        $this->items['warning'][] = [$message, $category];
+    }
+}

--- a/framework/db/fake/FakeConnectionLoggerInterface.php
+++ b/framework/db/fake/FakeConnectionLoggerInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace yii\db\fake;
+
+interface FakeConnectionLoggerInterface
+{
+    public function getExecutedCommands();
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #7928, #593

This is the first scratch implementation of Migration::change().
The PR contains changes in Connection logging in order to reduce direct dependencies on `Yii::info()`, `Yii::error()` etc in support of #13103

TODO:
 - [x] Basic implementation for `createTable`
 - [ ] Review and adjustments
 - [ ] Tests
 - [ ] Docs