### PR TITLE
Don't add Fixture to the Class if it exists. Fixes #14525

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.13 under development
 ------------------------
 
+- Bug #14525: Fixed 2.0.12 regression of loading of global fixtures trough `yii fixture/load` (michaelarnauts)
 - Bug #14523: Added `yii\web\MultipartFormDataParser::$force` option allowing to enforce parsing even on 'POST' request (klimov-paul)
 - Bug #14533: Fixed `yii\validators\ExistValidator` and `yii\validators\UniqueValidator` throw exception in case they are set for `yii\db\ActiveRecord` with `$targetClass` pointing to NOSQL ActiveRecord (klimov-paul)
 - Bug #14449: Fix PHP 7.2 compatibility bugs and add explicit closure support in `yii\base\Application` (dynasource)

--- a/framework/console/controllers/FixtureController.php
+++ b/framework/console/controllers/FixtureController.php
@@ -453,10 +453,12 @@ class FixtureController extends Controller
             $isNamespaced = (strpos($fixture, '\\') !== false);
             // replace linux' path slashes to namespace backslashes, in case if $fixture is non-namespaced relative path
             $fixture = str_replace('/', '\\', $fixture);
-            $fullClassName = $isNamespaced ? $fixture . 'Fixture' : $this->namespace . '\\' . $fixture . 'Fixture';
+            $fullClassName = $isNamespaced ? $fixture : $this->namespace . '\\' . $fixture;
 
             if (class_exists($fullClassName)) {
                 $config[] = $fullClassName;
+            } elseif (class_exists($fullClassName . 'Fixture')) {
+                $config[] = $fullClassName . 'Fixture';
             }
         }
 

--- a/tests/framework/console/controllers/FixtureControllerTest.php
+++ b/tests/framework/console/controllers/FixtureControllerTest.php
@@ -49,6 +49,7 @@ class FixtureControllerTest extends TestCase
     {
         $this->_fixtureController->globalFixtures = [
             '\yiiunit\data\console\controllers\fixtures\Global',
+            '\yiiunit\data\console\controllers\fixtures\GlobalFixture',
         ];
 
         $this->_fixtureController->actionLoad(['First']);
@@ -61,6 +62,7 @@ class FixtureControllerTest extends TestCase
     {
         $this->_fixtureController->globalFixtures = [
             '\yiiunit\data\console\controllers\fixtures\Global',
+            '\yiiunit\data\console\controllers\fixtures\GlobalFixture',
         ];
 
         FixtureStorage::$globalFixturesData[] = 'some seeded global fixture data';

--- a/tests/framework/console/controllers/FixtureControllerTest.php
+++ b/tests/framework/console/controllers/FixtureControllerTest.php
@@ -49,6 +49,17 @@ class FixtureControllerTest extends TestCase
     {
         $this->_fixtureController->globalFixtures = [
             '\yiiunit\data\console\controllers\fixtures\Global',
+        ];
+
+        $this->_fixtureController->actionLoad(['First']);
+
+        $this->assertCount(1, FixtureStorage::$globalFixturesData, 'global fixture data should be loaded');
+        $this->assertCount(1, FixtureStorage::$firstFixtureData, 'first fixture data should be loaded');
+    }
+
+    public function testLoadGlobalFixtureWithFixture()
+    {
+        $this->_fixtureController->globalFixtures = [
             '\yiiunit\data\console\controllers\fixtures\GlobalFixture',
         ];
 
@@ -62,7 +73,6 @@ class FixtureControllerTest extends TestCase
     {
         $this->_fixtureController->globalFixtures = [
             '\yiiunit\data\console\controllers\fixtures\Global',
-            '\yiiunit\data\console\controllers\fixtures\GlobalFixture',
         ];
 
         FixtureStorage::$globalFixturesData[] = 'some seeded global fixture data';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no, it fixes it
| Tests pass?   | yes
| Fixed issues  | #14525

Since 96dae1cebc1835a712be572fff47505085d035ea, the `$globalFixtures` was changed to `yii\test\InitDbFixture`, causing it to become `yii\test\InitDbFixtureFixture` inside `getFixturesConfig()`.

This change checks if the original Fixture name exists before trying to add Fixture.