### PR TITLE
Fixes #14363: Added 'yii\widgets\LinkPager::$linkWrapOptions' and possibility to override tag in 'yii\widgets\LinkPager::$options'

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -45,7 +45,7 @@ Yii Framework 2 Change Log
 - Bug #14492: Fixed error handler not escaping error info debug mode (samdark)
 - Chg #14487: Changed i18n message error to warning (dmirogin)
 - Enh #7823: Added `yii\filters\AjaxFilter` filter (dmirogin)
-- Enh #14363: Added `yii\widgets\LinkPager::$linkWrapOptions` and possibility to override tag in `yii\widgets\LinkPager::$options` (dmirogin)
+- Enh #14363: Added `yii\widgets\LinkPager::$linkContainerOptions` and possibility to override tag in `yii\widgets\LinkPager::$options` (dmirogin)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -45,6 +45,7 @@ Yii Framework 2 Change Log
 - Bug #14492: Fixed error handler not escaping error info debug mode (samdark)
 - Chg #14487: Changed i18n message error to warning (dmirogin)
 - Enh #7823: Added `yii\filters\AjaxFilter` filter (dmirogin)
+- Enh #14363: Added `yii\widgets\LinkPager::$linkWrapOptions` and possibility to override tag in `yii\widgets\LinkPager::$options` (dmirogin)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -43,6 +43,7 @@ class LinkPager extends Widget
     public $options = ['class' => 'pagination'];
     /**
      * @var array HTML attributes which will be applied to all link wrappers
+     * @since 2.0.13
      */
     public $linkWrapOptions = [];
     /**

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -42,10 +42,10 @@ class LinkPager extends Widget
      */
     public $options = ['class' => 'pagination'];
     /**
-     * @var array HTML attributes which will be applied to all link wrappers
+     * @var array HTML attributes which will be applied to all link containers
      * @since 2.0.13
      */
-    public $linkWrapOptions = [];
+    public $linkContainerOptions = [];
     /**
      * @var array HTML attributes for the link in a pager container tag.
      * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
@@ -234,7 +234,7 @@ class LinkPager extends Widget
      */
     protected function renderPageButton($label, $page, $class, $disabled, $active)
     {
-        $options = $this->linkWrapOptions;
+        $options = $this->linkContainerOptions;
         $linkWrapTag = ArrayHelper::remove($options, 'tag', 'li');
         Html::addCssClass($options, empty($class) ? $this->pageCssClass : $class);
 

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -42,6 +42,10 @@ class LinkPager extends Widget
      */
     public $options = ['class' => 'pagination'];
     /**
+     * @var array HTML attributes which will be applied to all link wrappers
+     */
+    public $linkWrapOptions = [];
+    /**
      * @var array HTML attributes for the link in a pager container tag.
      * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
      */
@@ -212,7 +216,9 @@ class LinkPager extends Widget
             $buttons[] = $this->renderPageButton($lastPageLabel, $pageCount - 1, $this->lastPageCssClass, $currentPage >= $pageCount - 1, false);
         }
 
-        return Html::tag('ul', implode("\n", $buttons), $this->options);
+        $options = $this->options;
+        $tag = ArrayHelper::remove($options, 'tag', 'ul');
+        return Html::tag($tag, implode("\n", $buttons), $options);
     }
 
     /**
@@ -227,7 +233,10 @@ class LinkPager extends Widget
      */
     protected function renderPageButton($label, $page, $class, $disabled, $active)
     {
-        $options = ['class' => empty($class) ? $this->pageCssClass : $class];
+        $options = $this->linkWrapOptions;
+        $linkWrapTag = ArrayHelper::remove($options, 'tag', 'li');
+        Html::addCssClass($options, empty($class) ? $this->pageCssClass : $class);
+
         if ($active) {
             Html::addCssClass($options, $this->activePageCssClass);
         }
@@ -235,12 +244,12 @@ class LinkPager extends Widget
             Html::addCssClass($options, $this->disabledPageCssClass);
             $tag = ArrayHelper::remove($this->disabledListItemSubTagOptions, 'tag', 'span');
 
-            return Html::tag('li', Html::tag($tag, $label, $this->disabledListItemSubTagOptions), $options);
+            return Html::tag($linkWrapTag, Html::tag($tag, $label, $this->disabledListItemSubTagOptions), $options);
         }
         $linkOptions = $this->linkOptions;
         $linkOptions['data-page'] = $page;
 
-        return Html::tag('li', Html::a($label, $this->pagination->createUrl($page), $linkOptions), $options);
+        return Html::tag($linkWrapTag, Html::a($label, $this->pagination->createUrl($page), $linkOptions), $options);
     }
 
     /**

--- a/tests/framework/widgets/LinkPagerTest.php
+++ b/tests/framework/widgets/LinkPagerTest.php
@@ -129,7 +129,7 @@ class LinkPagerTest extends \yiiunit\TestCase
     {
         $output = LinkPager::widget([
             'pagination' => $this->getPagination(1),
-            'linkWrapOptions' => [
+            'linkContainerOptions' => [
                 'tag' => 'div',
                 'class' => 'my-class'
             ]

--- a/tests/framework/widgets/LinkPagerTest.php
+++ b/tests/framework/widgets/LinkPagerTest.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\widgets;
 
 use yii\data\Pagination;
+use yii\helpers\StringHelper;
 use yii\widgets\LinkPager;
 
 /**
@@ -27,13 +28,24 @@ class LinkPagerTest extends \yiiunit\TestCase
         ]);
     }
 
-    public function testFirstLastPageLabels()
+    /**
+     * Get pagination
+     * @param int $page
+     * @return Pagination
+     */
+    private function getPagination($page)
     {
         $pagination = new Pagination();
-        $pagination->setPage(5);
+        $pagination->setPage($page);
         $pagination->totalCount = 500;
         $pagination->route = 'test';
 
+        return $pagination;
+    }
+
+    public function testFirstLastPageLabels()
+    {
+        $pagination = $this->getPagination(5);
         $output = LinkPager::widget([
             'pagination' => $pagination,
             'firstPageLabel' => true,
@@ -64,13 +76,8 @@ class LinkPagerTest extends \yiiunit\TestCase
 
     public function testDisabledPageElementOptions()
     {
-        $pagination = new Pagination();
-        $pagination->setPage(0);
-        $pagination->totalCount = 50;
-        $pagination->route = 'test';
-
         $output = LinkPager::widget([
-            'pagination' => $pagination,
+            'pagination' => $this->getPagination(0),
             'disabledListItemSubTagOptions' => ['class' => 'foo-bar'],
         ]);
 
@@ -79,13 +86,8 @@ class LinkPagerTest extends \yiiunit\TestCase
 
     public function testDisabledPageElementOptionsWithTagOption()
     {
-        $pagination = new Pagination();
-        $pagination->setPage(0);
-        $pagination->totalCount = 50;
-        $pagination->route = 'test';
-
         $output = LinkPager::widget([
-            'pagination' => $pagination,
+            'pagination' => $this->getPagination(0),
             'disabledListItemSubTagOptions' => ['class' => 'foo-bar', 'tag' => 'div'],
         ]);
 
@@ -94,11 +96,7 @@ class LinkPagerTest extends \yiiunit\TestCase
 
     public function testDisableCurrentPageButton()
     {
-        $pagination = new Pagination();
-        $pagination->setPage(5);
-        $pagination->totalCount = 500;
-        $pagination->route = 'test';
-
+        $pagination = $this->getPagination(5);
         $output = LinkPager::widget([
             'pagination' => $pagination,
             'disableCurrentPageButton' => false,
@@ -112,5 +110,38 @@ class LinkPagerTest extends \yiiunit\TestCase
         ]);
 
         static::assertContains('<li class="active disabled"><span>6</span></li>', $output);
+    }
+    
+    public function testOptionsWithTagOption()
+    {
+        $output = LinkPager::widget([
+            'pagination' => $this->getPagination(5),
+            'options' => [
+                'tag' => 'div',
+            ]
+        ]);
+
+        $this->assertTrue(StringHelper::startsWith($output, '<div>'));
+        $this->assertTrue(StringHelper::endsWith($output, '</div>'));
+    }
+
+    public function testLinkWrapOptions()
+    {
+        $output = LinkPager::widget([
+            'pagination' => $this->getPagination(1),
+            'linkWrapOptions' => [
+                'tag' => 'div',
+                'class' => 'my-class'
+            ]
+        ]);
+
+        $this->assertContains(
+            '<div class="my-class"><a href="/?r=test&amp;page=3" data-page="2">3</a></div>',
+            $output
+        );
+        $this->assertContains(
+            '<div class="my-class active"><a href="/?r=test&amp;page=2" data-page="1">2</a></div>',
+            $output
+        );
     }
 }


### PR DESCRIPTION
Fixes #14363: Added 'yii\widgets\LinkPager::$linkWrapOptions' and possibility to override tag in 'yii\widgets\LinkPager::$options'

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14363 

Now, if you have been wondering how to make your own list pager structure, you can just use this way
```
LinkPager::widget([
     'pagination' => $pagination,
     'options' => [
           'tag' => 'div',
           'class' => 'container'
     ],
     'linkWrapOptions' => [
          'tag' => 'div',
     ]
])
```
And you will get similar result

```
<div class="container">
    <div class="prev"><a href="/?r=test&amp;page=1" data-page="0">&laquo;</a></div>
    ...
    <div class="active"><a href="/?r=test&amp;page=2" data-page="1">2</a></div>
    ...
    <div class="next"><a href="/?r=test&amp;page=3" data-page="2">&raquo;</a></div>
</div>
```

