### PR TITLE
Restored part of original Yii::trace documentation

### DIFF
--- a/framework/BaseYii.php
+++ b/framework/BaseYii.php
@@ -381,7 +381,8 @@ class BaseYii
     /**
      * Logs a trace message.
      * Trace messages are logged mainly for development purpose to see
-     * the execution work flow of some code.
+     * the execution work flow of some code. This method will only log
+     * a message when the application is in debug mode.
      * @param string|array $message the message to be logged. This can be a simple string or a more
      * complex data structure, such as array.
      * @param string $category the category of the message.


### PR DESCRIPTION
Restored original warning in the Yii::trace documentation that this method will only log a message when the application is in debug mode.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
