### PR TITLE
Update AttributeTypecastBehavior.php

### DIFF
--- a/framework/behaviors/AttributeTypecastBehavior.php
+++ b/framework/behaviors/AttributeTypecastBehavior.php
@@ -161,6 +161,14 @@ class AttributeTypecastBehavior extends Behavior
      */
     public $typecastBeforeSave = false;
     /**
+     * @var bool whether to perform typecasting after saving owner model (insert or update).
+     * This option may be disabled in order to achieve better performance.
+     * For example, in case of [[\yii\db\ActiveRecord]] usage, typecasting after save
+     * will grant no benefit an thus can be disabled.
+     * Note that changing this option value will have no effect after this behavior has been attached to the model.
+     */
+    public $typecastAfterSave = false;
+    /**
      * @var bool whether to perform typecasting after retrieving owner model data from
      * the database (after find or refresh).
      * This option may be disabled in order to achieve better performance.
@@ -302,6 +310,10 @@ class AttributeTypecastBehavior extends Behavior
             $events[BaseActiveRecord::EVENT_BEFORE_INSERT] = 'beforeSave';
             $events[BaseActiveRecord::EVENT_BEFORE_UPDATE] = 'beforeSave';
         }
+        if ($this->typecastAfterSave) {
+            $events[BaseActiveRecord::EVENT_AFTER_INSERT] = 'afterSave';
+            $events[BaseActiveRecord::EVENT_AFTER_UPDATE] = 'afterSave';
+        }
         if ($this->typecastAfterFind) {
             $events[BaseActiveRecord::EVENT_AFTER_FIND] = 'afterFind';
         }
@@ -321,10 +333,19 @@ class AttributeTypecastBehavior extends Behavior
     }
 
     /**
-     * Handles owner 'afterInsert' and 'afterUpdate' events, ensuring attribute typecasting.
+     * Handles owner 'beforeInsert' and 'beforeUpdate' events, ensuring attribute typecasting.
      * @param \yii\base\Event $event event instance.
      */
     public function beforeSave($event)
+    {
+        $this->typecastAttributes();
+    }
+    
+    /**
+     * Handles owner 'afterInsert' and 'afterUpdate' events, ensuring attribute typecasting.
+     * @param \yii\base\Event $event event instance.
+     */
+    public function afterSave($event)
     {
         $this->typecastAttributes();
     }


### PR DESCRIPTION
Line `Handles owner 'beforeInsert' and 'beforeUpdate' events, ensuring attribute typecasting.` required for change (hotfix php docs.)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
