### PR TITLE
How to use service locator as shortcut

### DIFF
--- a/docs/guide-ru/concept-service-locator.md
+++ b/docs/guide-ru/concept-service-locator.md
@@ -62,7 +62,7 @@ $cache = $locator->cache;
 Поскольку Service Locator часто используется с [конфигурациями](concept-configurations.md), в нём имеется доступное
 для записи свойство [[yii\di\ServiceLocator::setComponents()|components]]. Это позволяет настроить и зарегистрировать
 сразу несколько компонентов. Следующий код демонстрирует конфигурационный массив, который может использоваться
-для регистрации компонентов `db`, `cache` и `search` в Service Locator (то есть в [приложении](structure-applications.md)):
+для регистрации компонентов `db`, `cache`, `tz` и `search` в Service Locator (то есть в [приложении](structure-applications.md)):
 
 ```php
 return [
@@ -75,6 +75,9 @@ return [
             'password' => '',
         ],
         'cache' => 'yii\caching\ApcCache',
+        'tz' => function() {
+            return new \DateTimeZone(Yii::$app->formatter->defaultTimeZone);
+        },
         'search' => function () {
             $solr = new app\components\SolrService('127.0.0.1');
             // ... дополнительная инициализация ...

--- a/docs/guide/concept-service-locator.md
+++ b/docs/guide/concept-service-locator.md
@@ -64,7 +64,7 @@ Because service locators are often being created with [configurations](concept-c
 a writable property named [[yii\di\ServiceLocator::setComponents()|components]] is provided. This allows you 
 to configure and register multiple components at once. The following code shows a configuration array
 that can be used to configure a service locator (e.g. an [application](structure-applications.md)) with 
-the `db`, `cache` and `search` components:
+the `db`, `cache`, `tz` and `search` components:
 
 ```php
 return [
@@ -77,6 +77,9 @@ return [
             'password' => '',
         ],
         'cache' => 'yii\caching\ApcCache',
+        'tz' => function() {
+            return new \DateTimeZone(Yii::$app->formatter->defaultTimeZone);
+        },
         'search' => function () {
             $solr = new app\components\SolrService('127.0.0.1');
             // ... other initializations ...


### PR DESCRIPTION
Little example
`\Yii::$app->tz` represent a `defaultTimeZone` and can be used in `\DateTime()` constructor

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no