### PR TITLE
Fix console cache controller

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -53,6 +53,7 @@ Yii Framework 2 Change Log
 - Enh #7823: Added `yii\filters\AjaxFilter` filter (dmirogin)
 - Enh #14363: Added `yii\widgets\LinkPager::$linkContainerOptions` and possibility to override tag in `yii\widgets\LinkPager::$options` (dmirogin)
 - Bug #14202: Fixed current time in (UTC) `\Yii::$app->formatter` if time not set (bscheshirwork)
+- Bug #13969: Fixed a bug in a `yii\console\controllers\CacheController` when caches defined via a closure were not detected (Kolyunya)
 
 
 2.0.12 June 05, 2017

--- a/framework/console/controllers/CacheController.php
+++ b/framework/console/controllers/CacheController.php
@@ -270,6 +270,12 @@ class CacheController extends Controller
                 $caches[$name] = $component['class'];
             } elseif (is_string($component) && $this->isCacheClass($component)) {
                 $caches[$name] = $component;
+            } elseif ($component instanceof \Closure) {
+                $cache = Yii::$app->get($name);
+                if ($this->isCacheClass($cache)) {
+                    $cacheClass = get_class($cache);
+                    $caches[$name] = $cacheClass;
+                }
             }
         }
 

--- a/tests/framework/console/controllers/CacheControllerTest.php
+++ b/tests/framework/console/controllers/CacheControllerTest.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\console\controllers;
 
 use Yii;
+use yii\caching\ArrayCache;
 use yii\console\controllers\CacheController;
 use yiiunit\TestCase;
 
@@ -49,7 +50,9 @@ class CacheControllerTest extends TestCase
         $this->mockApplication([
             'components' => [
                 'firstCache' => 'yii\caching\ArrayCache',
-                'secondCache' => 'yii\caching\ArrayCache',
+                'secondCache' => function () {
+                    return new ArrayCache();
+                },
                 'session' => 'yii\web\CacheSession', // should be ignored at `actionFlushAll()`
                 'db' => [
                     'class' => isset($config['class']) ? $config['class'] : 'yii\db\Connection',


### PR DESCRIPTION
Fixed a bug in a `yii\console\controllers\CacheController` when caches
defined via a closure were not detected.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #13969 
