### PR TITLE
Fixes #14542: Ensured only ASCII characters are in CSRF cookie value

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.13 under development
 ------------------------
 
+- Bug #14542: Ensured only ASCII characters are in CSRF cookie value since binary data causes issues with ModSecurity and some browsers (samdark)
 - Enh #14022: `yii\web\UrlManager::setBaseUrl()` now supports aliases (dmirogin)
 - Bug #14471: `ContentNegotiator` will always set one of the configured server response formats even if the client does not accept any of them (PowerGamer1)
 - Bug #14525: Fixed 2.0.12 regression of loading of global fixtures trough `yii fixture/load` (michaelarnauts)

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -1385,7 +1385,7 @@ class Request extends \yii\base\Request
      */
     protected function generateCsrfToken()
     {
-        $token = Yii::$app->getSecurity()->generateRandomKey();
+        $token = Yii::$app->getSecurity()->generateRandomString();
         if ($this->enableCsrfCookie) {
             $cookie = $this->createCsrfCookie($token);
             Yii::$app->getResponse()->getCookies()->add($cookie);

--- a/tests/framework/web/RequestTest.php
+++ b/tests/framework/web/RequestTest.php
@@ -79,6 +79,20 @@ class RequestTest extends TestCase
         $this->assertEquals('pl', $request->getPreferredLanguage(['pl', 'ru-ru']));
     }
 
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/14542
+     */
+    public function testCsrfTokenContainsASCIIOnly()
+    {
+        $this->mockWebApplication();
+
+        $request = new Request();
+        $request->enableCsrfCookie = false;
+
+        $token = $request->getCsrfToken();
+        $this->assertRegExp('~[a-z0-9]~i', $token);
+    }
+
     public function testCsrfTokenValidation()
     {
         $this->mockWebApplication();

--- a/tests/framework/web/RequestTest.php
+++ b/tests/framework/web/RequestTest.php
@@ -90,7 +90,7 @@ class RequestTest extends TestCase
         $request->enableCsrfCookie = false;
 
         $token = $request->getCsrfToken();
-        $this->assertRegExp('~[a-z0-9]~i', $token);
+        $this->assertRegExp('~[-_=a-z0-9]~i', $token);
     }
 
     public function testCsrfTokenValidation()


### PR DESCRIPTION
Since binary data causes issues with ModSecurity and some browsers...

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14542
