### PR TITLE
Add handleOptions to Cors filter so OPTIONS requests are handled for the preflight check.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - New #14151: Added `AttributesBehavior` that assigns values specified to one or multiple attributes of an AR object when certain events happen (bscheshirwork)
 - Bug #6526: Fixed `yii\db\Command::batchInsert()` casting of double values correctly independent of the locale (cebe, leammas)
+- Chg #14618: Handle OPTIONS request in `yii\filter\Cors` so the preflight check isn't passed trough Authentication filters. (michaelarnauts)
 - Bug #14542: Ensured only ASCII characters are in CSRF cookie value since binary data causes issues with ModSecurity and some browsers (samdark)
 - Enh #14022: `yii\web\UrlManager::setBaseUrl()` now supports aliases (dmirogin)
 - Bug #14471: `ContentNegotiator` will always set one of the configured server response formats even if the client does not accept any of them (PowerGamer1)

--- a/framework/filters/Cors.php
+++ b/framework/filters/Cors.php
@@ -106,6 +106,12 @@ class Cors extends ActionFilter
         $responseCorsHeaders = $this->prepareHeaders($requestCorsHeaders);
         $this->addCorsHeaders($this->response, $responseCorsHeaders);
 
+        if ($this->request->isOptions && $this->request->headers->has('Access-Control-Request-Method')) {
+            // it is CORS preflight request, respond with 200 OK without further processing
+            $this->response->setStatusCode(200);
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
The handling of the CORS preflight check in yii2 is broken at the moment and workarounds are being applied all the time.

Most posts or comments handle the case of the `yii\rest\ActiveRestController` where you have to add a `'except' => ['options']` to the Authentication filter, because an OPTIONS call will be routed to the `actionOptions` function. If you don't add this, the request will succeed trough the Cors filter, and arrive at the Authentication filter, where it will be rejected since the preflight check has no Authentication.

This recommendation is potentially dangerous, since code in the `actionOptions` can be executed without authentication. Also, when you extend from a `yii\rest\Controller`, the routing isn't done to `actionOptions`, and you can't use `'except' => ['options']` to force the request to go trough. A better approach is needed. 

This MR adds a `handleOptions` to the `Cors` filter. If you add this filter in your behaviour, you obviously expect those requests to arrive at your controller so you want the preflight check to pass. This change makes sure that the preflight checks are handled correctly by accepting them with a 200 OK, but not executing the code of the actual request (since the beforeAction returns `false`).

Since CORS requests don't have authentication, you still need to have the Cors filter before the Authentication filter. By returning false in the CORS filter, the handling is stopped and the Authentication filter isn't executed, so the request isn't rejected with an 401 Unauthorised.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | #14032, but a lot more. See also https://github.com/yiisoft/yii2/issues?q=cors%20OPTIONS

