### PR TITLE
#14643 Easy change layout for error action

### DIFF
--- a/framework/web/ErrorAction.php
+++ b/framework/web/ErrorAction.php
@@ -66,6 +66,13 @@ class ErrorAction extends Action
      * Defaults to "An internal server error occurred.".
      */
     public $defaultMessage;
+    /**
+     * @var string|false|null the name of the layout to be applied to this error action view.
+     * If not set, the layout configured in the controller will be used.
+     * @see \yii\base\Controller::$layout
+     * @since 2.0.15
+     */
+    public $layout;
 
     /**
      * @var \Exception the exception object, normally is filled on [[init()]] method call.
@@ -73,13 +80,6 @@ class ErrorAction extends Action
      * @since 2.0.11
      */
     protected $exception;
-
-    /**
-     * @var string|false the name of the layout to be applied to this error action view
-     * @see [[yii\base\Controller::$layout]]
-     * @since 2.0.15
-     */
-    public $layout;
 
 
     /**
@@ -105,7 +105,7 @@ class ErrorAction extends Action
      */
     public function run()
     {
-        if ($this->layout) {
+        if ($this->layout !== null) {
             $this->controller->layout = $this->layout;
         }
 

--- a/framework/web/ErrorAction.php
+++ b/framework/web/ErrorAction.php
@@ -77,7 +77,7 @@ class ErrorAction extends Action
     /**
      * @var string|false the name of the layout to be applied to this error action view
      * @see [[yii\base\Component::$layout]]
-     * @since 2.0.~
+     * @since 2.0.15
      */
     public $layout;
 
@@ -105,7 +105,9 @@ class ErrorAction extends Action
      */
     public function run()
     {
-        if ($this->layout) $this->controller->layout = $this->layout;
+        if ($this->layout) {
+            $this->controller->layout = $this->layout;
+        }
 
         Yii::$app->getResponse()->setStatusCodeByException($this->exception);
 

--- a/framework/web/ErrorAction.php
+++ b/framework/web/ErrorAction.php
@@ -74,6 +74,13 @@ class ErrorAction extends Action
      */
     protected $exception;
 
+    /**
+     * @var string|false the name of the layout to be applied to this error action view
+     * @see [[yii\base\Component::$layout]]
+     * @since 2.0.~
+     */
+    public $layout;
+
 
     /**
      * {@inheritdoc}
@@ -98,6 +105,8 @@ class ErrorAction extends Action
      */
     public function run()
     {
+        if ($this->layout) $this->controller->layout = $this->layout;
+
         Yii::$app->getResponse()->setStatusCodeByException($this->exception);
 
         if (Yii::$app->getRequest()->getIsAjax()) {

--- a/framework/web/ErrorAction.php
+++ b/framework/web/ErrorAction.php
@@ -76,7 +76,7 @@ class ErrorAction extends Action
 
     /**
      * @var string|false the name of the layout to be applied to this error action view
-     * @see [[yii\base\Component::$layout]]
+     * @see [[yii\base\Controller::$layout]]
      * @since 2.0.15
      */
     public $layout;


### PR DESCRIPTION
Sometimes when we use ErrorAction, we need use different layout, but now it's little bit difficult to do it easily, so this small new feature help to solve problem

```
    public function actions()
    {
        return [
            'error' => [
                'class' => 'yii\web\ErrorAction',
                'layout' => 'error'
            ],
        ];
    }
```

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14643
