### PR TITLE
fix mb_strlen \r\n bug

### DIFF
--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -59,14 +59,17 @@ yii.validation = (function ($) {
                 return;
             }
 
-            if (options.is !== undefined && value.length != options.is) {
+            //line breaks will be counted as 2 characters (\r\n) in php/mb_strlen
+            var mb_strlen = value.replace(/\r(?!\n)|\n(?!\r)/g, "\r\n").length;
+
+            if (options.is !== undefined && mb_strlen !== options.is) {
                 pub.addMessage(messages, options.notEqual, value);
                 return;
             }
-            if (options.min !== undefined && value.length < options.min) {
+            if (options.min !== undefined && mb_strlen < options.min) {
                 pub.addMessage(messages, options.tooShort, value);
             }
-            if (options.max !== undefined && value.length > options.max) {
+            if (options.max !== undefined && mb_strlen > options.max) {
                 pub.addMessage(messages, options.tooLong, value);
             }
         },

--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -59,17 +59,14 @@ yii.validation = (function ($) {
                 return;
             }
 
-            //line breaks will be counted as 2 characters (\r\n) in php/mb_strlen
-            var mb_strlen = value.replace(/\r(?!\n)|\n(?!\r)/g, "\r\n").length;
-
-            if (options.is !== undefined && mb_strlen !== options.is) {
+            if (options.is !== undefined && value.length != options.is) {
                 pub.addMessage(messages, options.notEqual, value);
                 return;
             }
-            if (options.min !== undefined && mb_strlen < options.min) {
+            if (options.min !== undefined && value.length < options.min) {
                 pub.addMessage(messages, options.tooShort, value);
             }
-            if (options.max !== undefined && mb_strlen > options.max) {
+            if (options.max !== undefined && value.length > options.max) {
                 pub.addMessage(messages, options.tooLong, value);
             }
         },

--- a/framework/validators/StringValidator.php
+++ b/framework/validators/StringValidator.php
@@ -111,6 +111,8 @@ class StringValidator extends Validator
             return;
         }
 
+		$value = str_replace(["\r\n", "\r"], "\n", $value);
+
         $length = mb_strlen($value, $this->encoding);
 
         if ($this->min !== null && $length < $this->min) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no (server side)- may affect count characters left scripts (client side)
| Tests pass?   | yes
| Fixed issues  | #14086

This PR solves the issue by counting line breaks in texareas, etc. the same way as mb_strlen in php will do - so this does not break BC server side.
However it could have some side effects to client side scripts:
Client side scripts wich count the characters left may show a different count.
(Users may also wonder if they actually count their typed in characters.)