### PR TITLE
Enable `non_printable_character` rule in php-cs-fixer config

### DIFF
--- a/cs/src/YiiConfig.php
+++ b/cs/src/YiiConfig.php
@@ -95,7 +95,7 @@ class YiiConfig extends Config
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-//            'non_printable_character' => true, // breaks Formatter::asCurrency() tests
+            'non_printable_character' => true,
             'normalize_index_brace' => true,
             'object_operator_without_whitespace' => true,
 //            'ordered_class_elements' => [ // needs more discussion

--- a/framework/messages/pt-BR/yii.php
+++ b/framework/messages/pt-BR/yii.php
@@ -127,7 +127,7 @@ return [
     'The verification code is incorrect.' => 'O código de verificação está incorreto.',
     'Total <b>{count, number}</b> {count, plural, one{item} other{items}}.' => 'Total <b>{count, number}</b> {count, plural, one{item} other{itens}}.',
     'Unable to verify your data submission.' => 'Não foi possível verificar o seu envio de dados.',
-    'Unknown alias: -{name}' => 'Alias ​​desconhecido: -{name}',
+    'Unknown alias: -{name}' => 'Alias desconhecido: -{name}',
     'Unknown option: --{name}' => 'Opção desconhecida : --{name}',
     'Update' => 'Alterar',
     'View' => 'Exibir',

--- a/tests/framework/i18n/FormatterNumberTest.php
+++ b/tests/framework/i18n/FormatterNumberTest.php
@@ -247,51 +247,52 @@ class FormatterNumberTest extends TestCase
         //$value = '-123456.123';
         //$this->assertSame("($123,456.12)", $this->formatter->asCurrency($value));
 
+        // "\u{00a0}" is used as non-breaking space explicitly
         $this->formatter->locale = 'de-DE';
         $this->formatter->currencyCode = null;
-        $this->assertSame('123,00 €', $this->formatter->asCurrency('123'));
+        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123'));
         $this->formatter->currencyCode = 'USD';
-        $this->assertSame('123,00 $', $this->formatter->asCurrency('123'));
+        $this->assertSame("123,00\u{00a0}$", $this->formatter->asCurrency('123'));
         $this->formatter->currencyCode = 'EUR';
-        $this->assertSame('123,00 €', $this->formatter->asCurrency('123'));
+        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123'));
 
         $this->formatter->locale = 'de-DE';
         $this->formatter->currencyCode = null;
-        $this->assertSame('123,00 €', $this->formatter->asCurrency('123', 'EUR'));
-        $this->assertSame('123,00 $', $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123,00\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
         $this->formatter->currencyCode = 'USD';
-        $this->assertSame('123,00 €', $this->formatter->asCurrency('123', 'EUR'));
-        $this->assertSame('123,00 $', $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123,00\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
         $this->formatter->currencyCode = 'EUR';
-        $this->assertSame('123,00 €', $this->formatter->asCurrency('123', 'EUR'));
-        $this->assertSame('123,00 $', $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123,00\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
 
         // default russian currency symbol
         $this->formatter->locale = 'ru-RU';
         $this->formatter->currencyCode = null;
-        $this->assertIsOneOf($this->formatter->asCurrency('123'), ['123,00 ₽', '123,00 руб.']);
+        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123,00\u{00a0}₽", "123,00\u{00a0}руб."]);
         $this->formatter->currencyCode = 'RUB';
-        $this->assertIsOneOf($this->formatter->asCurrency('123'), ['123,00 ₽', '123,00 руб.']);
+        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123,00\u{00a0}₽", "123,00\u{00a0}руб."]);
 
         // custom currency symbol
         $this->formatter->currencyCode = null;
         $this->formatter->numberFormatterSymbols = [
             NumberFormatter::CURRENCY_SYMBOL => '₽',
         ];
-        $this->assertSame('123,00 ₽', $this->formatter->asCurrency('123'));
+        $this->assertSame("123,00\u{00a0}₽", $this->formatter->asCurrency('123'));
         $this->formatter->numberFormatterSymbols = [
             NumberFormatter::CURRENCY_SYMBOL => 'RUR',
         ];
-        $this->assertSame('123,00 RUR', $this->formatter->asCurrency('123'));
+        $this->assertSame("123,00\u{00a0}RUR", $this->formatter->asCurrency('123'));
 
         /* See https://github.com/yiisoft/yii2/issues/13629
         // setting the currency code overrides the symbol
         $this->formatter->currencyCode = 'RUB';
-        $this->assertIsOneOf($this->formatter->asCurrency('123'), ['123,00 ₽', '123,00 руб.']);
+        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123,00\u{00a0}₽", "123,00\u{00a0}руб."]);
         $this->formatter->numberFormatterSymbols = [NumberFormatter::CURRENCY_SYMBOL => '₽'];
-        $this->assertSame('123,00 $', $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123,00\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
         $this->formatter->numberFormatterSymbols = [NumberFormatter::CURRENCY_SYMBOL => '₽'];
-        $this->assertSame('123,00 €', $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
         */
 
         // custom separators
@@ -299,22 +300,22 @@ class FormatterNumberTest extends TestCase
         $this->formatter->currencyCode = null;
         $this->formatter->numberFormatterSymbols = [];
         $this->formatter->thousandSeparator = ' ';
-        $this->assertSame('123 456,00 €', $this->formatter->asCurrency('123456', 'EUR'));
+        $this->assertSame("123 456,00\u{00a0}€", $this->formatter->asCurrency('123456', 'EUR'));
 
         // empty input
         $this->formatter->locale = 'de-DE';
         $this->formatter->currencyCode = null;
         $this->formatter->numberFormatterSymbols = [];
         $this->formatter->thousandSeparator = null;
-        $this->assertSame('0,00 €', $this->formatter->asCurrency(false));
-        $this->assertSame('0,00 €', $this->formatter->asCurrency(''));
+        $this->assertSame("0,00\u{00a0}€", $this->formatter->asCurrency(false));
+        $this->assertSame("0,00\u{00a0}€", $this->formatter->asCurrency(''));
 
         // decimal formatting
         $this->formatter->locale = 'de-DE';
-        $this->assertSame('100 $', \Yii::$app->formatter->asCurrency(100, 'USD', [
+        $this->assertSame("100\u{00a0}$", \Yii::$app->formatter->asCurrency(100, 'USD', [
             NumberFormatter::MAX_FRACTION_DIGITS => 0,
         ]));
-        $this->assertSame('100,00 $', $this->formatter->asCurrency(100, 'USD', [
+        $this->assertSame("100,00\u{00a0}$", $this->formatter->asCurrency(100, 'USD', [
             NumberFormatter::MAX_FRACTION_DIGITS => 2,
         ]));
 
@@ -333,29 +334,29 @@ class FormatterNumberTest extends TestCase
         ];
         $this->formatter->locale = 'de-DE';
         $this->formatter->currencyCode = null;
-        $this->assertSame('123 €', $this->formatter->asCurrency('123'));
-        $this->assertSame('123 €', $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123\u{00a0}€", $this->formatter->asCurrency('123'));
+        $this->assertSame("123\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
         $this->formatter->currencyCode = 'USD';
-        $this->assertSame('123 $', $this->formatter->asCurrency('123'));
-        $this->assertSame('123 $', $this->formatter->asCurrency('123', 'USD'));
-        $this->assertSame('123 €', $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123\u{00a0}$", $this->formatter->asCurrency('123'));
+        $this->assertSame("123\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
         $this->formatter->currencyCode = 'EUR';
-        $this->assertSame('123 €', $this->formatter->asCurrency('123'));
-        $this->assertSame('123 $', $this->formatter->asCurrency('123', 'USD'));
-        $this->assertSame('123 €', $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123\u{00a0}€", $this->formatter->asCurrency('123'));
+        $this->assertSame("123\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
 
         $this->formatter->locale = 'ru-RU';
         $this->formatter->currencyCode = null;
-        $this->assertIsOneOf($this->formatter->asCurrency('123'), ['123 ₽', '123 руб.']);
+        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123\u{00a0}₽", "123\u{00a0}руб."]);
 
         $this->formatter->numberFormatterSymbols = [
             NumberFormatter::CURRENCY_SYMBOL => '&#8381;',
         ];
-        $this->assertSame('123 &#8381;', $this->formatter->asCurrency('123'));
+        $this->assertSame("123\u{00a0}&#8381;", $this->formatter->asCurrency('123'));
 
         $this->formatter->numberFormatterSymbols = [];
         $this->formatter->currencyCode = 'RUB';
-        $this->assertIsOneOf($this->formatter->asCurrency('123'), ['123 ₽', '123 руб.']);
+        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123\u{00a0}₽", "123\u{00a0}руб."]);
     }
 
     /**

--- a/tests/framework/i18n/FormatterNumberTest.php
+++ b/tests/framework/i18n/FormatterNumberTest.php
@@ -247,52 +247,52 @@ class FormatterNumberTest extends TestCase
         //$value = '-123456.123';
         //$this->assertSame("($123,456.12)", $this->formatter->asCurrency($value));
 
-        // "\u{00a0}" is used as non-breaking space explicitly
+        // "\xc2\xa0" is used as non-breaking space explicitly
         $this->formatter->locale = 'de-DE';
         $this->formatter->currencyCode = null;
-        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123'));
+        $this->assertSame("123,00\xc2\xa0€", $this->formatter->asCurrency('123'));
         $this->formatter->currencyCode = 'USD';
-        $this->assertSame("123,00\u{00a0}$", $this->formatter->asCurrency('123'));
+        $this->assertSame("123,00\xc2\xa0$", $this->formatter->asCurrency('123'));
         $this->formatter->currencyCode = 'EUR';
-        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123'));
+        $this->assertSame("123,00\xc2\xa0€", $this->formatter->asCurrency('123'));
 
         $this->formatter->locale = 'de-DE';
         $this->formatter->currencyCode = null;
-        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
-        $this->assertSame("123,00\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123,00\xc2\xa0€", $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123,00\xc2\xa0$", $this->formatter->asCurrency('123', 'USD'));
         $this->formatter->currencyCode = 'USD';
-        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
-        $this->assertSame("123,00\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123,00\xc2\xa0€", $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123,00\xc2\xa0$", $this->formatter->asCurrency('123', 'USD'));
         $this->formatter->currencyCode = 'EUR';
-        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
-        $this->assertSame("123,00\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123,00\xc2\xa0€", $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123,00\xc2\xa0$", $this->formatter->asCurrency('123', 'USD'));
 
         // default russian currency symbol
         $this->formatter->locale = 'ru-RU';
         $this->formatter->currencyCode = null;
-        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123,00\u{00a0}₽", "123,00\u{00a0}руб."]);
+        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123,00\xc2\xa0₽", "123,00\xc2\xa0руб."]);
         $this->formatter->currencyCode = 'RUB';
-        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123,00\u{00a0}₽", "123,00\u{00a0}руб."]);
+        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123,00\xc2\xa0₽", "123,00\xc2\xa0руб."]);
 
         // custom currency symbol
         $this->formatter->currencyCode = null;
         $this->formatter->numberFormatterSymbols = [
             NumberFormatter::CURRENCY_SYMBOL => '₽',
         ];
-        $this->assertSame("123,00\u{00a0}₽", $this->formatter->asCurrency('123'));
+        $this->assertSame("123,00\xc2\xa0₽", $this->formatter->asCurrency('123'));
         $this->formatter->numberFormatterSymbols = [
             NumberFormatter::CURRENCY_SYMBOL => 'RUR',
         ];
-        $this->assertSame("123,00\u{00a0}RUR", $this->formatter->asCurrency('123'));
+        $this->assertSame("123,00\xc2\xa0RUR", $this->formatter->asCurrency('123'));
 
         /* See https://github.com/yiisoft/yii2/issues/13629
         // setting the currency code overrides the symbol
         $this->formatter->currencyCode = 'RUB';
-        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123,00\u{00a0}₽", "123,00\u{00a0}руб."]);
+        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123,00\xc2\xa0₽", "123,00\xc2\xa0руб."]);
         $this->formatter->numberFormatterSymbols = [NumberFormatter::CURRENCY_SYMBOL => '₽'];
-        $this->assertSame("123,00\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123,00\xc2\xa0$", $this->formatter->asCurrency('123', 'USD'));
         $this->formatter->numberFormatterSymbols = [NumberFormatter::CURRENCY_SYMBOL => '₽'];
-        $this->assertSame("123,00\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123,00\xc2\xa0€", $this->formatter->asCurrency('123', 'EUR'));
         */
 
         // custom separators
@@ -300,22 +300,22 @@ class FormatterNumberTest extends TestCase
         $this->formatter->currencyCode = null;
         $this->formatter->numberFormatterSymbols = [];
         $this->formatter->thousandSeparator = ' ';
-        $this->assertSame("123 456,00\u{00a0}€", $this->formatter->asCurrency('123456', 'EUR'));
+        $this->assertSame("123 456,00\xc2\xa0€", $this->formatter->asCurrency('123456', 'EUR'));
 
         // empty input
         $this->formatter->locale = 'de-DE';
         $this->formatter->currencyCode = null;
         $this->formatter->numberFormatterSymbols = [];
         $this->formatter->thousandSeparator = null;
-        $this->assertSame("0,00\u{00a0}€", $this->formatter->asCurrency(false));
-        $this->assertSame("0,00\u{00a0}€", $this->formatter->asCurrency(''));
+        $this->assertSame("0,00\xc2\xa0€", $this->formatter->asCurrency(false));
+        $this->assertSame("0,00\xc2\xa0€", $this->formatter->asCurrency(''));
 
         // decimal formatting
         $this->formatter->locale = 'de-DE';
-        $this->assertSame("100\u{00a0}$", \Yii::$app->formatter->asCurrency(100, 'USD', [
+        $this->assertSame("100\xc2\xa0$", \Yii::$app->formatter->asCurrency(100, 'USD', [
             NumberFormatter::MAX_FRACTION_DIGITS => 0,
         ]));
-        $this->assertSame("100,00\u{00a0}$", $this->formatter->asCurrency(100, 'USD', [
+        $this->assertSame("100,00\xc2\xa0$", $this->formatter->asCurrency(100, 'USD', [
             NumberFormatter::MAX_FRACTION_DIGITS => 2,
         ]));
 
@@ -334,29 +334,29 @@ class FormatterNumberTest extends TestCase
         ];
         $this->formatter->locale = 'de-DE';
         $this->formatter->currencyCode = null;
-        $this->assertSame("123\u{00a0}€", $this->formatter->asCurrency('123'));
-        $this->assertSame("123\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123\xc2\xa0€", $this->formatter->asCurrency('123'));
+        $this->assertSame("123\xc2\xa0€", $this->formatter->asCurrency('123', 'EUR'));
         $this->formatter->currencyCode = 'USD';
-        $this->assertSame("123\u{00a0}$", $this->formatter->asCurrency('123'));
-        $this->assertSame("123\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
-        $this->assertSame("123\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123\xc2\xa0$", $this->formatter->asCurrency('123'));
+        $this->assertSame("123\xc2\xa0$", $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123\xc2\xa0€", $this->formatter->asCurrency('123', 'EUR'));
         $this->formatter->currencyCode = 'EUR';
-        $this->assertSame("123\u{00a0}€", $this->formatter->asCurrency('123'));
-        $this->assertSame("123\u{00a0}$", $this->formatter->asCurrency('123', 'USD'));
-        $this->assertSame("123\u{00a0}€", $this->formatter->asCurrency('123', 'EUR'));
+        $this->assertSame("123\xc2\xa0€", $this->formatter->asCurrency('123'));
+        $this->assertSame("123\xc2\xa0$", $this->formatter->asCurrency('123', 'USD'));
+        $this->assertSame("123\xc2\xa0€", $this->formatter->asCurrency('123', 'EUR'));
 
         $this->formatter->locale = 'ru-RU';
         $this->formatter->currencyCode = null;
-        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123\u{00a0}₽", "123\u{00a0}руб."]);
+        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123\xc2\xa0₽", "123\xc2\xa0руб."]);
 
         $this->formatter->numberFormatterSymbols = [
             NumberFormatter::CURRENCY_SYMBOL => '&#8381;',
         ];
-        $this->assertSame("123\u{00a0}&#8381;", $this->formatter->asCurrency('123'));
+        $this->assertSame("123\xc2\xa0&#8381;", $this->formatter->asCurrency('123'));
 
         $this->formatter->numberFormatterSymbols = [];
         $this->formatter->currencyCode = 'RUB';
-        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123\u{00a0}₽", "123\u{00a0}руб."]);
+        $this->assertIsOneOf($this->formatter->asCurrency('123'), ["123\xc2\xa0₽", "123\xc2\xa0руб."]);
     }
 
     /**


### PR DESCRIPTION
https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.2

> **non_printable_character**
> Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible unicode symbols.