### PR TITLE
Enable `phpdoc_add_missing_param_annotation` rule in php-cs-fixer config

### DIFF
--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -356,6 +356,8 @@ class PhpDocController extends Controller
 
     /**
      * Fixes line spacing code style for properties and constants
+     * @param string[] $lines
+     * @return string[]
      */
     protected function fixLineSpacing($lines)
     {

--- a/build/controllers/ReleaseController.php
+++ b/build/controllers/ReleaseController.php
@@ -367,6 +367,7 @@ class ReleaseController extends Controller
     /**
      * @param array $what list of items
      * @param array $limit list of things to allow, or empty to allow any, can be `app`, `framework`, `extension`
+     * @param bool $ensureGitClean
      * @throws \yii\base\Exception
      */
     protected function validateWhat(array $what, $limit = [], $ensureGitClean = true)
@@ -847,6 +848,9 @@ class ReleaseController extends Controller
 
     /**
      * Extract changelog content for a specific version
+     * @param string $file
+     * @param string $version
+     * @return array
      */
     protected function splitChangelog($file, $version)
     {
@@ -880,6 +884,8 @@ class ReleaseController extends Controller
 
     /**
      * Ensure sorting of the changelog lines
+     * @param string[] $changelog
+     * @return string[]
      */
     protected function resortChangelog($changelog)
     {

--- a/cs/src/YiiConfig.php
+++ b/cs/src/YiiConfig.php
@@ -124,9 +124,7 @@ class YiiConfig extends Config
             'php_unit_dedicate_assert' => true,
             'php_unit_fqcn_annotation' => true,
 //            'php_unit_strict' => true, // needs more attention
-//            'phpdoc_add_missing_param_annotation' => [ // needs more attention
-//                'only_untyped' => false,
-//            ],
+            'phpdoc_add_missing_param_annotation' => true,
             'phpdoc_indent' => true,
 //            'phpdoc_inline_tag' => true, // see https://github.com/yiisoft/yii2/issues/11635
             'phpdoc_no_access' => true,

--- a/framework/caching/Dependency.php
+++ b/framework/caching/Dependency.php
@@ -60,6 +60,8 @@ abstract class Dependency extends \yii\base\BaseObject
     /**
      * Returns a value indicating whether the dependency has changed.
      * @deprecated since version 2.0.11. Will be removed in version 2.1. Use [[isChanged()]] instead.
+     * @param CacheInterface $cache the cache component that is currently evaluating this dependency
+     * @return bool whether the dependency has changed.
      */
     public function getHasChanged($cache)
     {

--- a/tests/framework/base/ActionFilterTest.php
+++ b/tests/framework/base/ActionFilterTest.php
@@ -101,6 +101,7 @@ class ActionFilterTest extends TestCase
 
     /**
      * @dataProvider actionFilterProvider
+     * @param string|array $filterClass
      */
     public function testActive($filterClass)
     {

--- a/tests/framework/base/SecurityTest.php
+++ b/tests/framework/base/SecurityTest.php
@@ -12,6 +12,7 @@ namespace yii\base {
      * where different execution paths are chosen based on calling function_exists.
      *
      * This function overrides function_exists from the root namespace in yii\base.
+     * @param string $name
      */
     function function_exists($name)
     {
@@ -25,6 +26,8 @@ namespace yii\base {
      * where different execution paths are chosen based on the return value of fopen/fread
      *
      * This function overrides fopen and fread from the root namespace in yii\base.
+     * @param string $filename
+     * @param mixed $mode
      */
     function fopen($filename, $mode)
     {
@@ -875,6 +878,7 @@ TEXT;
     /**
      * @dataProvider randomKeyInvalidInputs
      * @expectedException \yii\base\InvalidParamException
+     * @param mixed $input
      */
     public function testRandomKeyInvalidInput($input)
     {
@@ -926,6 +930,7 @@ TEXT;
 
     /**
      * @dataProvider randomKeyVariants
+     * @param array $functions
      */
     public function testGenerateRandomKey($functions)
     {
@@ -1258,6 +1263,7 @@ TEXT;
 
     /**
      * @dataProvider maskProvider
+     * @param mixed $unmaskedToken
      */
     public function testMasking($unmaskedToken)
     {

--- a/tests/framework/behaviors/AttributeBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeBehaviorTest.php
@@ -95,6 +95,10 @@ class AttributeBehaviorTest extends TestCase
 
     /**
      * @dataProvider preserveNonEmptyValuesDataProvider
+     * @param string $aliasExpected
+     * @param bool $preserveNonEmptyValues
+     * @param string $name
+     * @param string|null $alias
      */
     public function testPreserveNonEmptyValues(
         $aliasExpected,

--- a/tests/framework/behaviors/AttributesBehaviorTest.php
+++ b/tests/framework/behaviors/AttributesBehaviorTest.php
@@ -95,6 +95,10 @@ class AttributesBehaviorTest extends TestCase
 
     /**
      * @dataProvider preserveNonEmptyValuesDataProvider
+     * @param string $aliasExpected
+     * @param bool $preserveNonEmptyValues
+     * @param string $name
+     * @param string|null $alias
      */
     public function testPreserveNonEmptyValues(
         $aliasExpected,
@@ -136,6 +140,10 @@ class AttributesBehaviorTest extends TestCase
 
     /**
      * @dataProvider orderProvider
+     * @param string $aliasExpected
+     * @param array $order
+     * @param string $name
+     * @param string $alias
      */
     public function testOrder(
         $aliasExpected,

--- a/tests/framework/behaviors/TimestampBehaviorTest.php
+++ b/tests/framework/behaviors/TimestampBehaviorTest.php
@@ -141,6 +141,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * @dataProvider expressionProvider
+     * @param mixed $expression
+     * @param mixed $expected
      */
     public function testNewRecordExpression($expression, $expected)
     {

--- a/tests/framework/caching/CacheTestCase.php
+++ b/tests/framework/caching/CacheTestCase.php
@@ -114,6 +114,7 @@ abstract class CacheTestCase extends TestCase
 
     /**
      * @dataProvider multiSetExpiry
+     * @param int $expiry
      */
     public function testMultiset($expiry)
     {

--- a/tests/framework/console/RequestTest.php
+++ b/tests/framework/console/RequestTest.php
@@ -141,6 +141,9 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider provider
+     * @param array $params
+     * @param array $expected
+     * @param array|null $expectedException
      */
     public function testResolve($params, $expected, $expectedException = null)
     {

--- a/tests/framework/console/UnknownCommandExceptionTest.php
+++ b/tests/framework/console/UnknownCommandExceptionTest.php
@@ -54,6 +54,8 @@ class UnknownCommandExceptionTest extends TestCase
 
     /**
      * @dataProvider suggestedCommandsProvider
+     * @param string $command
+     * @param array $expectedSuggestion
      */
     public function testSuggestCommand($command, $expectedSuggestion)
     {

--- a/tests/framework/console/controllers/HelpControllerTest.php
+++ b/tests/framework/console/controllers/HelpControllerTest.php
@@ -41,8 +41,8 @@ class HelpControllerTest extends TestCase
 
     /**
      * Emulates running controller action.
-     * @param  string $actionID id of action to be run.
-     * @param  array $args action arguments.
+     * @param string $actionID id of action to be run.
+     * @param array $actionParams action arguments.
      * @return string command output.
      */
     protected function runControllerAction($actionID, $actionParams = [])

--- a/tests/framework/console/controllers/MigrateControllerTest.php
+++ b/tests/framework/console/controllers/MigrateControllerTest.php
@@ -238,13 +238,13 @@ class MigrateControllerTest extends TestCase
      */
     public function testRefreshMigration()
     {
-      Yii::$app->db->createCommand(
-        "create table hall_of_fame(id int, string varchar(255))")->execute();
+        Yii::$app->db->createCommand('create table hall_of_fame(id int, string varchar(255))')
+            ->execute();
 
-      Yii::$app->db->createCommand(
-        "insert into hall_of_fame values(1, 'Qiang Xue');")->execute();
-      Yii::$app->db->createCommand(
-        "insert into hall_of_fame values(2, 'Alexander Makarov');")->execute();
+        Yii::$app->db->createCommand("insert into hall_of_fame values(1, 'Qiang Xue');")
+            ->execute();
+        Yii::$app->db->createCommand("insert into hall_of_fame values(2, 'Alexander Makarov');")
+            ->execute();
 
         $result = $this->runMigrateControllerAction('fresh');
 

--- a/tests/framework/console/controllers/MigrateControllerTestTrait.php
+++ b/tests/framework/console/controllers/MigrateControllerTestTrait.php
@@ -98,6 +98,7 @@ trait MigrateControllerTestTrait
     /**
      * @param string $name
      * @param string|null $date
+     * @param string|null $path
      * @return string generated class name
      */
     protected function createMigration($name, $date = null, $path = null)

--- a/tests/framework/data/PaginationTest.php
+++ b/tests/framework/data/PaginationTest.php
@@ -67,6 +67,7 @@ class PaginationTest extends TestCase
      * @param int $page
      * @param int $pageSize
      * @param string $expectedUrl
+     * @param array $params
      */
     public function testCreateUrl($page, $pageSize, $expectedUrl, $params)
     {

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -931,6 +931,8 @@ abstract class ActiveRecordTest extends DatabaseTestCase
      * Test whether conditions are quoted correctly in conditions where joinWith is used.
      * @see https://github.com/yiisoft/yii2/issues/11088
      * @dataProvider tableNameProvider
+     * @param string $orderTableName
+     * @param string $orderItemTableName
      */
     public function testRelationWhereParams($orderTableName, $orderItemTableName)
     {

--- a/tests/framework/db/ColumnSchemaBuilderTest.php
+++ b/tests/framework/db/ColumnSchemaBuilderTest.php
@@ -49,6 +49,10 @@ abstract class ColumnSchemaBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider typesProvider
+     * @param string $expected
+     * @param string $type
+     * @param int|null $length
+     * @param mixed $calls
      */
     public function testCustomTypes($expected, $type, $length, $calls)
     {
@@ -58,7 +62,7 @@ abstract class ColumnSchemaBuilderTest extends DatabaseTestCase
     /**
      * @param string $expected
      * @param string $type
-     * @param int $length
+     * @param int|null $length
      * @param array $calls
      */
     public function checkBuildString($expected, $type, $length, $calls)

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -241,6 +241,7 @@ SQL;
     /**
      * Test whether param binding works in other places than WHERE
      * @dataProvider paramsNonWhereProvider
+     * @param string $sql
      */
     public function testBindParamsNonWhere($sql)
     {
@@ -550,6 +551,7 @@ SQL;
      * @dataProvider invalidSelectColumns
      * @expectedException \yii\base\InvalidParamException
      * @expectedExceptionMessage Expected select query object with enumerated (named) parameters
+     * @param mixed $invalidSelectColumns
      */
     public function testInsertSelectFailed($invalidSelectColumns)
     {

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -41,6 +41,8 @@ abstract class QueryBuilderTest extends DatabaseTestCase
     /**
      * @throws \Exception
      * @return QueryBuilder
+     * @param bool $reset
+     * @param bool $open
      */
     protected function getQueryBuilder($reset = true, $open = false)
     {
@@ -1207,6 +1209,9 @@ abstract class QueryBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider conditionProvider
+     * @param array $condition
+     * @param string $expected
+     * @param array $expectedParams
      */
     public function testBuildCondition($condition, $expected, $expectedParams)
     {
@@ -1218,6 +1223,9 @@ abstract class QueryBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider filterConditionProvider
+     * @param array $condition
+     * @param string $expected
+     * @param array $expectedParams
      */
     public function testBuildFilterCondition($condition, $expected, $expectedParams)
     {
@@ -1255,6 +1263,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider primaryKeysProvider
+     * @param string $sql
      */
     public function testAddDropPrimaryKey($sql, \Closure $builder)
     {
@@ -1290,6 +1299,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider foreignKeysProvider
+     * @param string $sql
      */
     public function testAddDropForeignKey($sql, \Closure $builder)
     {
@@ -1337,6 +1347,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider indexesProvider
+     * @param string $sql
      */
     public function testCreateDropIndex($sql, \Closure $builder)
     {
@@ -1373,6 +1384,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider uniquesProvider
+     * @param string $sql
      */
     public function testAddDropUnique($sql, \Closure $builder)
     {
@@ -1401,6 +1413,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider checksProvider
+     * @param string $sql
      */
     public function testAddDropCheck($sql, \Closure $builder)
     {
@@ -1429,6 +1442,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider defaultValuesProvider
+     * @param string $sql
      */
     public function testAddDropDefaultValue($sql, \Closure $builder)
     {
@@ -1445,6 +1459,8 @@ abstract class QueryBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider existsParamsProvider
+     * @param string $cond
+     * @param string $expectedQuerySql
      */
     public function testBuildWhereExists($cond, $expectedQuerySql)
     {
@@ -1803,6 +1819,10 @@ abstract class QueryBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider batchInsertProvider
+     * @param string $table
+     * @param array $columns
+     * @param array $value
+     * @param string $expected
      */
     public function testBatchInsert($table, $columns, $value, $expected)
     {
@@ -1897,6 +1917,9 @@ abstract class QueryBuilderTest extends DatabaseTestCase
 
     /**
      * @dataProvider likeConditionProvider
+     * @param array $condition
+     * @param string $expected
+     * @param array $expectedParams
      */
     public function testBuildLikeCondition($condition, $expected, $expectedParams)
     {

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -29,6 +29,7 @@ abstract class SchemaTest extends DatabaseTestCase
 
     /**
      * @dataProvider pdoAttributesProvider
+     * @param array $pdoAttributes
      */
     public function testGetTableNames($pdoAttributes)
     {
@@ -52,6 +53,7 @@ abstract class SchemaTest extends DatabaseTestCase
 
     /**
      * @dataProvider pdoAttributesProvider
+     * @param array $pdoAttributes
      */
     public function testGetTableSchemas($pdoAttributes)
     {
@@ -570,6 +572,9 @@ abstract class SchemaTest extends DatabaseTestCase
 
     /**
      * @dataProvider constraintsProvider
+     * @param string $tableName
+     * @param string $type
+     * @param mixed $expected
      */
     public function testTableSchemaConstraints($tableName, $type, $expected)
     {
@@ -583,6 +588,9 @@ abstract class SchemaTest extends DatabaseTestCase
 
     /**
      * @dataProvider uppercaseConstraintsProvider
+     * @param string $tableName
+     * @param string $type
+     * @param mixed $expected
      */
     public function testTableSchemaConstraintsWithPdoUppercase($tableName, $type, $expected)
     {
@@ -598,6 +606,9 @@ abstract class SchemaTest extends DatabaseTestCase
 
     /**
      * @dataProvider lowercaseConstraintsProvider
+     * @param string $tableName
+     * @param string $type
+     * @param mixed $expected
      */
     public function testTableSchemaConstraintsWithPdoLowercase($tableName, $type, $expected)
     {

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -151,6 +151,7 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
 
     /**
      * @dataProvider bigintValueProvider
+     * @param int $bigint
      */
     public function testBigintValue($bigint)
     {

--- a/tests/framework/db/sqlite/SqlTokenizerTest.php
+++ b/tests/framework/db/sqlite/SqlTokenizerTest.php
@@ -1119,6 +1119,7 @@ SELECT*from/*foo*/`T_constraints_1`WHERE not`C_check`=\'foo\'\'bar\'--bar
 
     /**
      * @dataProvider sqlProvider
+     * @param string $sql
      */
     public function testTokenizer($sql, SqlToken $expectedToken)
     {

--- a/tests/framework/filters/PageCacheTest.php
+++ b/tests/framework/filters/PageCacheTest.php
@@ -138,6 +138,7 @@ class PageCacheTest extends TestCase
 
     /**
      * @dataProvider cacheTestCaseProvider
+     * @param array $testCase
      */
     public function testCache($testCase)
     {

--- a/tests/framework/filters/auth/AuthTest.php
+++ b/tests/framework/filters/auth/AuthTest.php
@@ -92,6 +92,8 @@ class AuthTest extends \yiiunit\TestCase
 
     /**
      * @dataProvider tokenProvider
+     * @param string|null $token
+     * @param string|null $login
      */
     public function testQueryParamAuth($token, $login)
     {
@@ -104,6 +106,8 @@ class AuthTest extends \yiiunit\TestCase
 
     /**
      * @dataProvider tokenProvider
+     * @param string|null $token
+     * @param string|null $login
      */
     public function testHttpBasicAuth($token, $login)
     {
@@ -117,6 +121,8 @@ class AuthTest extends \yiiunit\TestCase
 
     /**
      * @dataProvider tokenProvider
+     * @param string|null $token
+     * @param string|null $login
      */
     public function testHttpBasicAuthCustom($token, $login)
     {
@@ -139,6 +145,8 @@ class AuthTest extends \yiiunit\TestCase
 
     /**
      * @dataProvider tokenProvider
+     * @param string|null $token
+     * @param string|null $login
      */
     public function testHttpBearerAuth($token, $login)
     {
@@ -161,6 +169,7 @@ class AuthTest extends \yiiunit\TestCase
 
     /**
      * @dataProvider authMethodProvider
+     * @param string $authClass
      */
     public function testActive($authClass)
     {

--- a/tests/framework/helpers/ConsoleTest.php
+++ b/tests/framework/helpers/ConsoleTest.php
@@ -137,6 +137,8 @@ class ConsoleTest extends TestCase
 
     /**
      * @dataProvider ansiFormats
+     * @param string $ansi
+     * @param string $html
      */
     public function testAnsi2Html($ansi, $html)
     {

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -299,6 +299,9 @@ class HtmlTest extends TestCase
 
     /**
      * @dataProvider imgDataProvider
+     * @param string $expected
+     * @param string $src
+     * @param array $options
      */
     public function testImg($expected, $src, $options)
     {
@@ -414,6 +417,10 @@ class HtmlTest extends TestCase
 
     /**
      * @dataProvider textareaDataProvider
+     * @param string $expected
+     * @param string $name
+     * @param string $value
+     * @param array $options
      */
     public function testTextarea($expected, $name, $value, $options)
     {

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -149,6 +149,9 @@ class StringHelperTest extends TestCase
 
     /**
      * @dataProvider providerStartsWith
+     * @param bool $result
+     * @param string $string
+     * @param string|null $with
      */
     public function testStartsWith($result, $string, $with)
     {
@@ -202,6 +205,9 @@ class StringHelperTest extends TestCase
 
     /**
      * @dataProvider providerEndsWith
+     * @param bool $result
+     * @param string $string
+     * @param string|null $with
      */
     public function testEndsWith($result, $string, $with)
     {

--- a/tests/framework/i18n/FallbackMessageFormatterTest.php
+++ b/tests/framework/i18n/FallbackMessageFormatterTest.php
@@ -178,6 +178,9 @@ _MSG_
 
     /**
      * @dataProvider patterns
+     * @param string $pattern
+     * @param string $expected
+     * @param array $args
      */
     public function testNamedArguments($pattern, $expected, $args)
     {

--- a/tests/framework/i18n/FormatterDateTest.php
+++ b/tests/framework/i18n/FormatterDateTest.php
@@ -520,6 +520,9 @@ class FormatterDateTest extends TestCase
 
     /**
      * @dataProvider dateInputs
+     * @param mixed $expected
+     * @param mixed $value
+     * @param mixed|null $expectedException
      */
     public function testIntlDateInput($expected, $value, $expectedException = null)
     {
@@ -528,6 +531,9 @@ class FormatterDateTest extends TestCase
 
     /**
      * @dataProvider dateInputs
+     * @param mixed $expected
+     * @param mixed $value
+     * @param mixed|null $expectedException
      */
     public function testDateInput($expected, $value, $expectedException = null)
     {
@@ -584,6 +590,9 @@ class FormatterDateTest extends TestCase
     /**
      * Test timezones with input date and time in other timezones
      * @dataProvider provideTimesAndTz
+     * @param string $defaultTz
+     * @param mixed $inputTimeDst
+     * @param mixed $inputTimeNonDst
      */
     public function testIntlTimezoneInput($defaultTz, $inputTimeDst, $inputTimeNonDst)
     {
@@ -593,6 +602,9 @@ class FormatterDateTest extends TestCase
     /**
      * Test timezones with input date and time in other timezones
      * @dataProvider provideTimesAndTz
+     * @param string $defaultTz
+     * @param mixed $inputTimeDst
+     * @param mixed $inputTimeNonDst
      */
     public function testTimezoneInput($defaultTz, $inputTimeDst, $inputTimeNonDst)
     {
@@ -743,6 +755,7 @@ class FormatterDateTest extends TestCase
      * Fixed in PHP >5.4.26 and >5.5.10. http://3v4l.org/mlZX7
      *
      * @dataProvider provideTimezones
+     * @param string $dtz
      */
     public function testIssue6263($dtz)
     {

--- a/tests/framework/i18n/FormatterNumberTest.php
+++ b/tests/framework/i18n/FormatterNumberTest.php
@@ -80,6 +80,7 @@ class FormatterNumberTest extends TestCase
 
     /**
      * @dataProvider differentConfigProvider
+     * @param array $config
      */
     public function testIntlAsInteger($config)
     {

--- a/tests/framework/i18n/FormatterTest.php
+++ b/tests/framework/i18n/FormatterTest.php
@@ -243,8 +243,8 @@ class FormatterTest extends TestCase
     }
 
     /**
-     * @param $value
-     * @param $expected
+     * @param mixed $value
+     * @param string $expected
      *
      * @dataProvider lengthDataProvider
      */
@@ -255,8 +255,9 @@ class FormatterTest extends TestCase
     }
 
     /**
-     * @param $value
-     * @param $expected
+     * @param mixed $value
+     * @param string $expected
+     * @param string $_
      *
      * @dataProvider lengthDataProvider
      */
@@ -283,8 +284,8 @@ class FormatterTest extends TestCase
     }
 
     /**
-     * @param $value
-     * @param $expected
+     * @param mixed $value
+     * @param string $expected
      *
      * @dataProvider weightDataProvider
      */
@@ -295,8 +296,9 @@ class FormatterTest extends TestCase
     }
 
     /**
-     * @param $value
-     * @param $expected
+     * @param mixed $value
+     * @param string $_
+     * @param string $expected
      *
      * @dataProvider weightDataProvider
      */

--- a/tests/framework/i18n/MessageFormatterTest.php
+++ b/tests/framework/i18n/MessageFormatterTest.php
@@ -337,6 +337,11 @@ _MSG_
 
     /**
      * @dataProvider patterns
+     * @param string $pattern
+     * @param string $expected
+     * @param array $args
+     * @param bool $skip
+     * @param string $skipMessage
      */
     public function testNamedArguments($pattern, $expected, $args, $skip = false, $skipMessage = '')
     {
@@ -350,6 +355,10 @@ _MSG_
 
     /**
      * @dataProvider parsePatterns
+     * @param string $pattern
+     * @param string $expected
+     * @param array $args
+     * @param string $locale
      */
     public function testParseNamedArguments($pattern, $expected, $args, $locale = 'en-US')
     {

--- a/tests/framework/log/FileTargetTest.php
+++ b/tests/framework/log/FileTargetTest.php
@@ -34,6 +34,7 @@ class FileTargetTest extends TestCase
 
     /**
      * @dataProvider booleanDataProvider
+     * @param bool $rotateByCopy
      */
     public function testRotate($rotateByCopy)
     {

--- a/tests/framework/log/TargetTest.php
+++ b/tests/framework/log/TargetTest.php
@@ -51,6 +51,8 @@ class TargetTest extends TestCase
 
     /**
      * @dataProvider filters
+     * @param array $filter
+     * @param array $expected
      */
     public function testFilter($filter, $expected)
     {

--- a/tests/framework/mail/BaseMailerTest.php
+++ b/tests/framework/mail/BaseMailerTest.php
@@ -253,6 +253,9 @@ TEXT
 
     /**
      * @dataProvider htmlAndPlainProvider
+     * @param int $i
+     * @param string $htmlViewFileContent
+     * @param string $expectedTextRendering
      */
     public function testComposePlainTextFallback($i, $htmlViewFileContent, $expectedTextRendering)
     {

--- a/tests/framework/rbac/DbManagerTestCase.php
+++ b/tests/framework/rbac/DbManagerTestCase.php
@@ -167,6 +167,9 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
     /**
      * @dataProvider emptyValuesProvider
+     * @param mixed $userId
+     * @param mixed $searchUserId
+     * @param mixed $isValid
      */
     public function testGetPermissionsByUserWithEmptyValue($userId, $searchUserId, $isValid)
     {
@@ -184,6 +187,9 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
     /**
      * @dataProvider emptyValuesProvider
+     * @param mixed $userId
+     * @param mixed $searchUserId
+     * @param mixed $isValid
      */
     public function testGetRolesByUserWithEmptyValue($userId, $searchUserId, $isValid)
     {
@@ -201,6 +207,9 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
     /**
      * @dataProvider emptyValuesProvider
+     * @param mixed $userId
+     * @param mixed $searchUserId
+     * @param mixed $isValid
      */
     public function testGetAssignmentWithEmptyValue($userId, $searchUserId, $isValid)
     {
@@ -218,6 +227,9 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
     /**
      * @dataProvider emptyValuesProvider
+     * @param mixed $userId
+     * @param mixed $searchUserId
+     * @param mixed $isValid
      */
     public function testGetAssignmentsWithEmptyValue($userId, $searchUserId, $isValid)
     {
@@ -236,6 +248,9 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
     /**
      * @dataProvider emptyValuesProvider
+     * @param mixed $userId
+     * @param mixed $searchUserId
+     * @param mixed $isValid
      */
     public function testRevokeWithEmptyValue($userId, $searchUserId, $isValid)
     {
@@ -253,6 +268,9 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
     /**
      * @dataProvider emptyValuesProvider
+     * @param mixed $userId
+     * @param mixed $searchUserId
+     * @param mixed $isValid
      */
     public function testRevokeAllWithEmptyValue($userId, $searchUserId, $isValid)
     {

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -464,6 +464,7 @@ abstract class ManagerTestCase extends TestCase
 
     /**
      * @dataProvider RBACItemsProvider
+     * @param mixed $RBACItemType
      */
     public function testAssignRule($RBACItemType)
     {
@@ -531,6 +532,7 @@ abstract class ManagerTestCase extends TestCase
 
     /**
      * @dataProvider RBACItemsProvider
+     * @param mixed $RBACItemType
      */
     public function testRevokeRule($RBACItemType)
     {

--- a/tests/framework/rbac/PhpManagerTest.php
+++ b/tests/framework/rbac/PhpManagerTest.php
@@ -9,6 +9,7 @@ namespace yii\rbac;
 
 /**
  * Mock for the filemtime() function for rbac classes. Avoid random test fails.
+ * @param string $file
  * @return int
  */
 function filemtime($file)

--- a/tests/framework/validators/DateValidatorTest.php
+++ b/tests/framework/validators/DateValidatorTest.php
@@ -44,6 +44,7 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider provideTimezones
+     * @param string $timezone
      */
     public function testIntlValidateValue($timezone)
     {
@@ -83,6 +84,7 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider provideTimezones
+     * @param string $timezone
      */
     public function testValidateValue($timezone)
     {
@@ -125,6 +127,7 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider provideTimezones
+     * @param string $timezone
      */
     public function testIntlValidateAttributePHPFormat($timezone)
     {
@@ -133,6 +136,7 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider provideTimezones
+     * @param string $timezone
      */
     public function testValidateAttributePHPFormat($timezone)
     {
@@ -169,6 +173,7 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider provideTimezones
+     * @param string $timezone
      */
     public function testIntlValidateAttributeICUFormat($timezone)
     {
@@ -177,6 +182,7 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider provideTimezones
+     * @param string $timezone
      */
     public function testValidateAttributeICUFormat($timezone)
     {
@@ -257,6 +263,11 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider timestampFormatProvider
+     * @param string|null $format
+     * @param string $date
+     * @param string|int $expectedDate
+     * @param string $timezone
+     * @param string $appTimezone
      */
     public function testIntlTimestampAttributeFormat($format, $date, $expectedDate, $timezone, $appTimezone)
     {
@@ -265,6 +276,11 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider timestampFormatProvider
+     * @param string|null $format
+     * @param string $date
+     * @param string|int $expectedDate
+     * @param string $timezone
+     * @param string $appTimezone
      */
     public function testTimestampAttributeFormat($format, $date, $expectedDate, $timezone, $appTimezone)
     {
@@ -282,6 +298,7 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider provideTimezones
+     * @param string $timezone
      */
     public function testIntlValidationWithTime($timezone)
     {
@@ -321,6 +338,7 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider provideTimezones
+     * @param string $timezone
      */
     public function testValidationWithTime($timezone)
     {
@@ -383,6 +401,7 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider provideTimezones
+     * @param string $timezone
      */
     public function testIntlValidationWithTimeAndOutputTimeZone($timezone)
     {
@@ -391,6 +410,7 @@ class DateValidatorTest extends TestCase
 
     /**
      * @dataProvider provideTimezones
+     * @param string $timezone
      */
     public function testValidationWithTimeAndOutputTimeZone($timezone)
     {

--- a/tests/framework/validators/EmailValidatorTest.php
+++ b/tests/framework/validators/EmailValidatorTest.php
@@ -168,6 +168,7 @@ class EmailValidatorTest extends TestCase
      * https://legalhackers.com/advisories/SwiftMailer-Exploit-Remote-Code-Exec-CVE-2016-10074-Vuln.html
      *
      * @dataProvider malformedAddressesProvider
+     * @param string $value
      */
     public function testMalformedAddresses($value)
     {

--- a/tests/framework/validators/IpValidatorTest.php
+++ b/tests/framework/validators/IpValidatorTest.php
@@ -42,6 +42,8 @@ class IpValidatorTest extends TestCase
 
     /**
      * @dataProvider provideRangesForSubstitution
+     * @param array $range
+     * @param array $expectedRange
      */
     public function testRangesSubstitution($range, $expectedRange)
     {
@@ -70,6 +72,7 @@ class IpValidatorTest extends TestCase
 
     /**
      * @dataProvider provideBadIps
+     * @param mixed $badIp
      */
     public function testValidateValueNotAnIP($badIp)
     {
@@ -80,6 +83,7 @@ class IpValidatorTest extends TestCase
 
     /**
      * @dataProvider provideBadIps
+     * @param mixed $badIp
      */
     public function testValidateModelAttributeNotAnIP($badIp)
     {

--- a/tests/framework/web/AssetBundleTest.php
+++ b/tests/framework/web/AssetBundleTest.php
@@ -249,6 +249,8 @@ EOF;
 
     /**
      * @dataProvider positionProvider
+     * @param int $pos
+     * @param bool $jqAlreadyRegistered
      */
     public function testPositionDependency($pos, $jqAlreadyRegistered)
     {
@@ -318,6 +320,8 @@ EOF;
 
     /**
      * @dataProvider positionProvider
+     * @param int $pos
+     * @param bool $jqAlreadyRegistered
      */
     public function testPositionDependencyConflict($pos, $jqAlreadyRegistered)
     {
@@ -489,8 +493,9 @@ EOF;
      * @dataProvider registerFileDataProvider
      * @param string $type either `js` or `css`
      * @param string $path
-     * @param string bool $appendTimestamp
+     * @param string|bool $appendTimestamp
      * @param string $expected
+     * @param string|null $webAlias
      */
     public function testRegisterFileAppendTimestamp($type, $path, $appendTimestamp, $expected, $webAlias = null)
     {

--- a/tests/framework/web/RequestTest.php
+++ b/tests/framework/web/RequestTest.php
@@ -356,6 +356,8 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider isSecureServerDataProvider
+     * @param array $server
+     * @param bool $expected
      */
     public function testGetIsSecureConnection($server, $expected)
     {
@@ -414,6 +416,8 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider getUserIPDataProvider
+     * @param array $server
+     * @param string $expected
      */
     public function testGetUserIP($server, $expected)
     {
@@ -451,6 +455,8 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider getMethodDataProvider
+     * @param array $server
+     * @param string $expected
      */
     public function testGetMethod($server, $expected)
     {
@@ -481,6 +487,8 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider getIsAjaxDataProvider
+     * @param array $server
+     * @param bool $expected
      */
     public function testGetIsAjax($server, $expected)
     {
@@ -512,6 +520,8 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider getIsPjaxDataProvider
+     * @param array $server
+     * @param bool $expected
      */
     public function testGetIsPjax($server, $expected)
     {

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -43,6 +43,10 @@ class ResponseTest extends \yiiunit\TestCase
 
     /**
      * @dataProvider rightRanges
+     * @param string $rangeHeader
+     * @param string $expectedHeader
+     * @param int $length
+     * @param string $expectedContent
      */
     public function testSendFileRanges($rangeHeader, $expectedHeader, $length, $expectedContent)
     {
@@ -76,6 +80,7 @@ class ResponseTest extends \yiiunit\TestCase
 
     /**
      * @dataProvider wrongRanges
+     * @param string $rangeHeader
      */
     public function testSendFileWrongRanges($rangeHeader)
     {
@@ -129,6 +134,8 @@ class ResponseTest extends \yiiunit\TestCase
 
     /**
      * @dataProvider dataProviderSetStatusCodeByException
+     * @param \Exception $exception
+     * @param int $statusCode
      */
     public function testSetStatusCodeByException($exception, $statusCode)
     {

--- a/tests/framework/web/UrlManagerCreateUrlTest.php
+++ b/tests/framework/web/UrlManagerCreateUrlTest.php
@@ -97,6 +97,10 @@ class UrlManagerCreateUrlTest extends TestCase
      * without rules.
      *
      * @dataProvider variationsProvider
+     * @param string $method
+     * @param bool $showScriptName
+     * @param string $prefix
+     * @param array $config
      */
     public function testWithoutRules($method, $showScriptName, $prefix, $config)
     {
@@ -128,6 +132,10 @@ class UrlManagerCreateUrlTest extends TestCase
      * With UrlManager::$suffix
      *
      * @dataProvider variationsProvider
+     * @param string $method
+     * @param bool $showScriptName
+     * @param string $prefix
+     * @param array $config
      */
     public function testWithoutRulesWithSuffix($method, $showScriptName, $prefix, $config)
     {
@@ -182,6 +190,10 @@ class UrlManagerCreateUrlTest extends TestCase
      * with simple rules.
      *
      * @dataProvider variationsProvider
+     * @param string $method
+     * @param bool $showScriptName
+     * @param string $prefix
+     * @param array $config
      */
     public function testSimpleRules($method, $showScriptName, $prefix, $config)
     {
@@ -231,6 +243,10 @@ class UrlManagerCreateUrlTest extends TestCase
      * With UrlManager::$suffix
      *
      * @dataProvider variationsProvider
+     * @param string $method
+     * @param bool $showScriptName
+     * @param string $prefix
+     * @param array $config
      */
     public function testSimpleRulesWithSuffix($method, $showScriptName, $prefix, $config)
     {
@@ -280,6 +296,10 @@ class UrlManagerCreateUrlTest extends TestCase
      * with rules that have varadic controller/actions.
      *
      * @dataProvider variationsProvider
+     * @param string $method
+     * @param bool $showScriptName
+     * @param string $prefix
+     * @param array $config
      */
     public function testControllerActionParams($method, $showScriptName, $prefix, $config)
     {
@@ -327,6 +347,10 @@ class UrlManagerCreateUrlTest extends TestCase
      * with rules that have default values for parameters.
      *
      * @dataProvider variationsProvider
+     * @param string $method
+     * @param bool $showScriptName
+     * @param string $prefix
+     * @param array $config
      */
     public function testRulesWithDefaultParams($method, $showScriptName, $prefix, $config)
     {
@@ -401,6 +425,10 @@ class UrlManagerCreateUrlTest extends TestCase
      *
      * @dataProvider variationsProvider
      * @see https://github.com/yiisoft/yii2/issues/10935
+     * @param string $method
+     * @param bool $showScriptName
+     * @param string $prefix
+     * @param array $config
      */
     public function testWithNullParams($method, $showScriptName, $prefix, $config)
     {
@@ -437,6 +465,10 @@ class UrlManagerCreateUrlTest extends TestCase
      *
      * @dataProvider variationsProvider
      * @see https://github.com/yiisoft/yii2/issues/6717
+     * @param string $method
+     * @param bool $showScriptName
+     * @param string $prefix
+     * @param array $config
      */
     public function testWithEmptyPattern($method, $showScriptName, $prefix, $config)
     {
@@ -505,6 +537,9 @@ class UrlManagerCreateUrlTest extends TestCase
     /**
      * Test rules that have host info in the patterns.
      * @dataProvider absolutePatternsVariations
+     * @param bool $showScriptName
+     * @param string $prefix
+     * @param array $config
      */
     public function testAbsolutePatterns($showScriptName, $prefix, $config)
     {
@@ -563,6 +598,9 @@ class UrlManagerCreateUrlTest extends TestCase
      * Test rules that have host info in the patterns, that are protocol relative.
      * @dataProvider absolutePatternsVariations
      * @see https://github.com/yiisoft/yii2/issues/12691
+     * @param bool $showScriptName
+     * @param string $prefix
+     * @param array $config
      */
     public function testProtocolRelativeAbsolutePattern($showScriptName, $prefix, $config)
     {
@@ -654,6 +692,7 @@ class UrlManagerCreateUrlTest extends TestCase
      *
      * @dataProvider multipleHostsRulesDataProvider
      * @see https://github.com/yiisoft/yii2/issues/7948
+     * @param string $host
      */
     public function testMultipleHostsRules($host)
     {

--- a/tests/framework/web/UrlManagerParseUrlTest.php
+++ b/tests/framework/web/UrlManagerParseUrlTest.php
@@ -112,6 +112,7 @@ class UrlManagerParseUrlTest extends TestCase
 
     /**
      * @dataProvider suffixProvider
+     * @param string $suffix
      */
     public function testWithoutRulesWithSuffix($suffix)
     {
@@ -198,6 +199,7 @@ class UrlManagerParseUrlTest extends TestCase
 
     /**
      * @dataProvider suffixProvider
+     * @param string $suffix
      */
     public function testSimpleRulesWithSuffix($suffix)
     {
@@ -242,6 +244,7 @@ class UrlManagerParseUrlTest extends TestCase
 
     /**
      * @dataProvider suffixProvider
+     * @param string $suffix
      */
     public function testSimpleRulesWithSuffixStrict($suffix)
     {

--- a/tests/framework/web/UrlManagerTest.php
+++ b/tests/framework/web/UrlManagerTest.php
@@ -73,6 +73,8 @@ class UrlManagerTest extends TestCase
 
     /**
      * @dataProvider ignoredOptionsProvider
+     * @param bool $showScriptName
+     * @param bool $enableStrictParsing
      */
     public function testCreateUrlSimple($showScriptName, $enableStrictParsing)
     {
@@ -96,6 +98,8 @@ class UrlManagerTest extends TestCase
 
     /**
      * @dataProvider ignoredOptionsProvider
+     * @param bool $showScriptName
+     * @param bool $enableStrictParsing
      */
     public function testCreateUrlWithParams($showScriptName, $enableStrictParsing)
     {
@@ -117,6 +121,8 @@ class UrlManagerTest extends TestCase
      * @dataProvider ignoredOptionsProvider
      *
      * @see https://github.com/yiisoft/yii2/pull/9596
+     * @param bool $showScriptName
+     * @param bool $enableStrictParsing
      */
     public function testCreateUrlWithAnchor($showScriptName, $enableStrictParsing)
     {
@@ -140,6 +146,8 @@ class UrlManagerTest extends TestCase
 
     /**
      * @dataProvider ignoredOptionsProvider
+     * @param bool $showScriptName
+     * @param bool $enableStrictParsing
      */
     public function testCreateAbsoluteUrl($showScriptName, $enableStrictParsing)
     {
@@ -186,6 +194,8 @@ class UrlManagerTest extends TestCase
     /**
      * Test normalisation of different routes.
      * @dataProvider ignoredOptionsProvider
+     * @param bool $showScriptName
+     * @param bool $enableStrictParsing
      */
     public function testCreateUrlRouteVariants($showScriptName, $enableStrictParsing)
     {
@@ -216,6 +226,7 @@ class UrlManagerTest extends TestCase
 
     /**
      * @dataProvider routeParamProvider
+     * @param string $routeParam
      */
     public function testParseRequest($routeParam)
     {

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -258,6 +258,8 @@ EOT;
 
     /**
      * @dataProvider hintDataProvider
+     * @param mixed $hint
+     * @param string $expectedHtml
      */
     public function testHint($hint, $expectedHtml)
     {

--- a/tests/framework/widgets/BreadcrumbsTest.php
+++ b/tests/framework/widgets/BreadcrumbsTest.php
@@ -189,6 +189,8 @@ class BreadcrumbsTest extends \yiiunit\TestCase
 
     /**
      * Helper methods
+     * @param string $class
+     * @param string $method
      */
     protected function reflectMethod($class = '\yii\widgets\Breadcrumbs', $method = 'renderItem')
     {

--- a/tests/framework/widgets/ListViewTest.php
+++ b/tests/framework/widgets/ListViewTest.php
@@ -154,6 +154,8 @@ HTML
 
     /**
      * @dataProvider itemViewOptions
+     * @param mixed $itemView
+     * @param string $expected
      */
     public function testItemViewOptions($itemView, $expected)
     {
@@ -198,6 +200,8 @@ HTML
 
     /**
      * @dataProvider itemOptions
+     * @param mixed $itemOptions
+     * @param string $expected
      */
     public function testItemOptions($itemOptions, $expected)
     {


### PR DESCRIPTION
https://github.com/FriendsOfPHP/PHP-CS-Fixer

> **phpdoc_add_missing_param_annotation**
> Phpdoc should contain `@param` for all params.