### PR TITLE
Cache user assignments to avoid unnecessary DB queries

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -66,6 +66,7 @@ Yii Framework 2 Change Log
 - Bug #14202: Fixed current time in (UTC) `\Yii::$app->formatter` if time not set (bscheshirwork)
 - Bug #11825: User can login by cookie only once when `autoRenewCookie` is set to false (shirase, silverfire)
 - Bug #13969: Fixed a bug in a `yii\console\controllers\CacheController` when caches defined via a closure were not detected (Kolyunya)
+- Enh #14061: Added request scope assignments cache to `yii\rbac\DbManager::checkAccess()` to avoid duplicate queries for user assignments (leandrogehlen, cebe, nineinchnick, ryusoft)
 
 
 2.0.12 June 05, 2017

--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -122,11 +122,11 @@ class DbManager extends BaseManager
      */
     public function checkAccess($userId, $permissionName, $params = [])
     {
-        if (isset($this->_checkAccessAssignments[$userId])) {
-            $assignments = $this->_checkAccessAssignments[$userId];
+        if (isset($this->_checkAccessAssignments[(string) $userId])) {
+            $assignments = $this->_checkAccessAssignments[(string) $userId];
         } else {
             $assignments = $this->getAssignments($userId);
-            $this->_checkAccessAssignments[$userId] = $assignments;
+            $this->_checkAccessAssignments[(string) $userId] = $assignments;
         }
 
         if ($this->hasNoAssignments($assignments)) {
@@ -857,7 +857,7 @@ class DbManager extends BaseManager
                 'created_at' => $assignment->createdAt,
             ])->execute();
 
-        unset($this->_checkAccessAssignments[$userId]);
+        unset($this->_checkAccessAssignments[(string) $userId]);
         return $assignment;
     }
 
@@ -870,7 +870,7 @@ class DbManager extends BaseManager
             return false;
         }
 
-        unset($this->_checkAccessAssignments[$userId]);
+        unset($this->_checkAccessAssignments[(string) $userId]);
         return $this->db->createCommand()
             ->delete($this->assignmentTable, ['user_id' => (string) $userId, 'item_name' => $role->name])
             ->execute() > 0;
@@ -885,7 +885,7 @@ class DbManager extends BaseManager
             return false;
         }
 
-        unset($this->_checkAccessAssignments[$userId]);
+        unset($this->_checkAccessAssignments[(string) $userId]);
         return $this->db->createCommand()
             ->delete($this->assignmentTable, ['user_id' => (string) $userId])
             ->execute() > 0;

--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -115,12 +115,19 @@ class DbManager extends BaseManager
         }
     }
 
+    private $_checkAccessAssignments = [];
+
     /**
      * @inheritdoc
      */
     public function checkAccess($userId, $permissionName, $params = [])
     {
-        $assignments = $this->getAssignments($userId);
+        if (isset($this->_checkAccessAssignments[$userId])) {
+            $assignments = $this->_checkAccessAssignments[$userId];
+        } else {
+            $assignments = $this->getAssignments($userId);
+            $this->_checkAccessAssignments[$userId] = $assignments;
+        }
 
         if ($this->hasNoAssignments($assignments)) {
             return false;
@@ -850,6 +857,7 @@ class DbManager extends BaseManager
                 'created_at' => $assignment->createdAt,
             ])->execute();
 
+        unset($this->_checkAccessAssignments[$userId]);
         return $assignment;
     }
 
@@ -862,6 +870,7 @@ class DbManager extends BaseManager
             return false;
         }
 
+        unset($this->_checkAccessAssignments[$userId]);
         return $this->db->createCommand()
             ->delete($this->assignmentTable, ['user_id' => (string) $userId, 'item_name' => $role->name])
             ->execute() > 0;
@@ -876,6 +885,7 @@ class DbManager extends BaseManager
             return false;
         }
 
+        unset($this->_checkAccessAssignments[$userId]);
         return $this->db->createCommand()
             ->delete($this->assignmentTable, ['user_id' => (string) $userId])
             ->execute() > 0;
@@ -960,6 +970,7 @@ class DbManager extends BaseManager
      */
     public function removeAllAssignments()
     {
+        $this->_checkAccessAssignments = [];
         $this->db->createCommand()->delete($this->assignmentTable)->execute();
     }
 
@@ -971,6 +982,7 @@ class DbManager extends BaseManager
             $this->rules = null;
             $this->parents = null;
         }
+        $this->_checkAccessAssignments = [];
     }
 
     public function loadFromCache()

--- a/tests/framework/log/ArrayTarget.php
+++ b/tests/framework/log/ArrayTarget.php
@@ -6,7 +6,7 @@ use yii\base\Exception;
 use yii\log\Target;
 
 /**
- * A log target used to track logged data
+ * ArrayTarget logs messages into an array, useful for tracking data in tests.
  */
 class ArrayTarget extends Target
 {

--- a/tests/framework/log/ArrayTarget.php
+++ b/tests/framework/log/ArrayTarget.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace yiiunit\framework\log;
+
+use yii\base\Exception;
+use yii\log\Target;
+
+/**
+ * A log target used to track logged data
+ */
+class ArrayTarget extends Target
+{
+    public $exportInterval = 1000000;
+
+    /**
+     * Exports log [[messages]] to a specific destination.
+     */
+    public function export()
+    {
+        // throw exception if message limit is reached
+        throw new Exception('More than 1000000 messages logged.');
+    }
+}

--- a/tests/framework/rbac/DbManagerTestCase.php
+++ b/tests/framework/rbac/DbManagerTestCase.php
@@ -315,45 +315,45 @@ abstract class DbManagerTestCase extends ManagerTestCase
         foreach (['readPost' => true, 'createPost' => false] as $permission => $result) {
             $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
         }
-        $this->assertLogTargetMessage($logTarget);
+        $this->assertSingleQueryToAssignmentsTable($logTarget);
 
         // verify cache is flushed on assign (createPost is now true)
         $this->auth->assign($this->auth->getRole('admin'), 'reader A');
         foreach (['readPost' => true, 'createPost' => true] as $permission => $result) {
             $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
         }
-        $this->assertLogTargetMessage($logTarget);
+        $this->assertSingleQueryToAssignmentsTable($logTarget);
 
         // verify cache is flushed on unassign (createPost is now false again)
         $this->auth->revoke($this->auth->getRole('admin'), 'reader A');
         foreach (['readPost' => true, 'createPost' => false] as $permission => $result) {
             $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
         }
-        $this->assertLogTargetMessage($logTarget);
+        $this->assertSingleQueryToAssignmentsTable($logTarget);
 
         // verify cache is flushed on revokeall
         $this->auth->revokeAll('reader A');
         foreach (['readPost' => false, 'createPost' => false] as $permission => $result) {
             $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
         }
-        $this->assertLogTargetMessage($logTarget);
+        $this->assertSingleQueryToAssignmentsTable($logTarget);
 
         // verify cache is flushed on removeAllAssignments
         $this->auth->assign($this->auth->getRole('admin'), 'reader A');
         foreach (['readPost' => true, 'createPost' => true] as $permission => $result) {
             $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
         }
-        $this->assertLogTargetMessage($logTarget);
+        $this->assertSingleQueryToAssignmentsTable($logTarget);
         $this->auth->removeAllAssignments();
         foreach (['readPost' => false, 'createPost' => false] as $permission => $result) {
             $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
         }
-        $this->assertLogTargetMessage($logTarget);
+        $this->assertSingleQueryToAssignmentsTable($logTarget);
     }
 
-    private function assertLogTargetMessage($logTarget)
+    private function assertSingleQueryToAssignmentsTable($logTarget)
     {
-        $this->assertCount(1, $logTarget->messages, print_r($logTarget->messages, true));
+        $this->assertCount(1, $logTarget->messages, 'Only one query should have been performed, but there are the following logs: ' . print_r($logTarget->messages, true));
         $this->assertContains('auth_assignment', $logTarget->messages[0][0], 'Log message should be a query to auth_assignment table');
         $logTarget->messages = [];
     }

--- a/tests/framework/rbac/DbManagerTestCase.php
+++ b/tests/framework/rbac/DbManagerTestCase.php
@@ -7,6 +7,7 @@
 
 namespace yiiunit\framework\rbac;
 
+use app\models\User;
 use Yii;
 use yii\caching\ArrayCache;
 use yii\console\Application;
@@ -301,7 +302,7 @@ abstract class DbManagerTestCase extends ManagerTestCase
         // warm up item cache, so only assignment queries are sent to DB
         $this->auth->cache = new ArrayCache();
         $this->auth->checkAccess('author B', 'readPost');
-        $this->auth->checkAccess('author B', 'createPost');
+        $this->auth->checkAccess(new UserID('author B'), 'createPost');
 
         // track db queries
         Yii::$app->log->flushInterval = 1;

--- a/tests/framework/rbac/DbManagerTestCase.php
+++ b/tests/framework/rbac/DbManagerTestCase.php
@@ -295,6 +295,7 @@ abstract class DbManagerTestCase extends ManagerTestCase
      */
     public function testCheckAccessCache()
     {
+        $this->mockApplication();
         $this->prepareData();
 
         // warm up item cache, so only assignment queries are sent to DB

--- a/tests/framework/rbac/DbManagerTestCase.php
+++ b/tests/framework/rbac/DbManagerTestCase.php
@@ -8,15 +8,18 @@
 namespace yiiunit\framework\rbac;
 
 use Yii;
+use yii\caching\ArrayCache;
 use yii\console\Application;
 use yii\console\ExitCode;
 use yii\db\Connection;
+use yii\log\Logger;
 use yii\rbac\Assignment;
 use yii\rbac\DbManager;
 use yii\rbac\Permission;
 use yii\rbac\Role;
 use yiiunit\data\rbac\UserID;
 use yiiunit\framework\console\controllers\EchoMigrateController;
+use yiiunit\framework\log\ArrayTarget;
 
 /**
  * DbManagerTestCase.
@@ -285,5 +288,73 @@ abstract class DbManagerTestCase extends ManagerTestCase
         } else {
             $this->assertFalse($result);
         }
+    }
+
+    /**
+     * Ensure assignments are read from DB only once on subsequent tests.
+     */
+    public function testCheckAccessCache()
+    {
+        $this->prepareData();
+
+        // warm up item cache, so only assignment queries are sent to DB
+        $this->auth->cache = new ArrayCache();
+        $this->auth->checkAccess('author B', 'readPost');
+        $this->auth->checkAccess('author B', 'createPost');
+
+        // track db queries
+        Yii::$app->log->flushInterval = 1;
+        Yii::$app->log->getLogger()->messages = [];
+        Yii::$app->log->targets['rbacqueries'] = $logTarget = new ArrayTarget([
+            'categories' => ['yii\\db\\Command::query'],
+            'levels' => Logger::LEVEL_INFO,
+        ]);
+        $this->assertCount(0, $logTarget->messages);
+
+        // testing access on two different permissons for the same user should only result in one DB query for user assignments
+        foreach (['readPost' => true, 'createPost' => false] as $permission => $result) {
+            $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
+        }
+        $this->assertLogTargetMessage($logTarget);
+
+        // verify cache is flushed on assign (createPost is now true)
+        $this->auth->assign($this->auth->getRole('admin'), 'reader A');
+        foreach (['readPost' => true, 'createPost' => true] as $permission => $result) {
+            $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
+        }
+        $this->assertLogTargetMessage($logTarget);
+
+        // verify cache is flushed on unassign (createPost is now false again)
+        $this->auth->revoke($this->auth->getRole('admin'), 'reader A');
+        foreach (['readPost' => true, 'createPost' => false] as $permission => $result) {
+            $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
+        }
+        $this->assertLogTargetMessage($logTarget);
+
+        // verify cache is flushed on revokeall
+        $this->auth->revokeAll('reader A');
+        foreach (['readPost' => false, 'createPost' => false] as $permission => $result) {
+            $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
+        }
+        $this->assertLogTargetMessage($logTarget);
+
+        // verify cache is flushed on removeAllAssignments
+        $this->auth->assign($this->auth->getRole('admin'), 'reader A');
+        foreach (['readPost' => true, 'createPost' => true] as $permission => $result) {
+            $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
+        }
+        $this->assertLogTargetMessage($logTarget);
+        $this->auth->removeAllAssignments();
+        foreach (['readPost' => false, 'createPost' => false] as $permission => $result) {
+            $this->assertEquals($result, $this->auth->checkAccess('reader A', $permission), "Checking $permission");
+        }
+        $this->assertLogTargetMessage($logTarget);
+    }
+
+    private function assertLogTargetMessage($logTarget)
+    {
+        $this->assertCount(1, $logTarget->messages, print_r($logTarget->messages, true));
+        $this->assertContains('auth_assignment', $logTarget->messages[0][0], 'Log message should be a query to auth_assignment table');
+        $logTarget->messages = [];
     }
 }


### PR DESCRIPTION
alternative to #9138 and #10981, only cache on `checkAccess` call which is usually
called on every request. Cache is not necessary in RBAC management.

Similar to #14061 but includes proper cache invalidation and test.

`getAssignments()` always queries the DB. The cache is only applied on
`checkAccess` calls, and invalidated as soon as the RBAC structure is
modified through the manager component (verified by the test case).

Regarding [concerns of memory usage](https://github.com/yiisoft/yii2/pull/14061#issuecomment-297982502)
if used in batch mode on multiple users, you can call
`invalidateCache()` method if this really causes a problem.

fixes #7743
close #9138
close #14061
close #10981

See also
- https://github.com/yiisoft/yii2/issues/7626#issuecomment-77745166
- https://github.com/yiisoft/yii2/pull/14061#issuecomment-319645488

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
