### PR TITLE
WIP: added basic support for database views

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -406,6 +406,7 @@ Yii Framework 2 Change Log
 - Enh #12580: Make `yii.js` comply with strict and non-strict javascript mode to allow concatenation with external code (mikehaertl)
 - Enh #12664: Added support for wildcards for `optional` at `yii\filters\auth\AuthMethod` (mg-code)
 - Enh #12744: Added `afterInit` event to `yii.activeForm.js` (werew01f)
+- Enh #8347: Added basic support for working with database views (igravity)
 - Enh: Method `yii\console\controllers\AssetController::getAssetManager()` automatically enables `yii\web\AssetManager::forceCopy` in case it is not explicitly specified (pana1990, klimov-paul)
 
 

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -940,6 +940,34 @@ class Command extends Component
     }
 
     /**
+     * Creates an SQL View.
+     *
+     * @param string $viewName the name of the view to be created.
+     * @param string|Query $subquery the select statement which defines the view.
+     * This can be either a string or a [[Query]] object.
+     * @return $this the command object itself.
+     * @since 2.0.13
+     */
+    public function createView($viewName, $subquery)
+    {
+        $sql = $this->db->getQueryBuilder()->createView($viewName, $subquery);
+        return $this->setSql($sql)->requireTableSchemaRefresh($viewName);
+    }
+
+    /**
+     * Drops an SQL View.
+     *
+     * @param string $viewName the name of the view to be dropped.
+     * @return $this the command object itself.
+     * @since 2.0.13
+     */
+    public function dropView($viewName)
+    {
+        $sql = $this->db->getQueryBuilder()->dropView($viewName);
+        return $this->setSql($sql)->requireTableSchemaRefresh($viewName);
+    }
+
+    /**
      * Executes the SQL statement.
      * This method should only be used for executing non-query SQL statement, such as `INSERT`, `DELETE`, `UPDATE` SQLs.
      * No result set will be returned.

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -802,6 +802,34 @@ class QueryBuilder extends \yii\base\BaseObject
     }
 
     /**
+     * Creates an SQL View.
+     *
+     * @param string $viewName the name of the view to be created.
+     * @param string|Query $subquery the select statement which defines the view.
+     * This can be either a string or a [[Query]] object.
+     * @return string the `CREATE VIEW` SQL statement.
+     */
+    public function createView($viewName, $subquery)
+    {
+        if ($subquery instanceof Query) {
+            list($subquery, $params) = $this->build($subquery);
+            // TODO how to deal with params here?
+        }
+        return 'CREATE VIEW ' . $this->db->quoteTableName($viewName) . ' AS ' . $subquery;
+    }
+
+    /**
+     * Drops an SQL View.
+     *
+     * @param string $viewName the name of the view to be dropped.
+     * @return string the `DROP VIEW` SQL statement.
+     */
+    public function dropView($viewName)
+    {
+        return 'DROP VIEW ' . $this->db->quoteTableName($viewName);
+    }
+
+    /**
      * Converts an abstract column type into a physical column type.
      *
      * The conversion is done using the type map specified in [[typeMap]].

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -1085,4 +1085,47 @@ SQL;
         $db->createCommand()->dropTable($tableName)->execute();
         $this->assertNull($db->getSchema()->getTableSchema($tableName));
     }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/8347
+     */
+    public function testCreateView()
+    {
+        $db = $this->getConnection();
+        $subquery = (new \yii\db\Query())
+            ->select('bar')
+            ->from('testCreateViewTable')
+            ->where(['>', 'bar', 5]);
+
+        if ($db->getSchema()->getTableSchema('testCreateViewTable') !== null) {
+            $db->createCommand()->dropTable('testCreateViewTable')->execute();
+        }
+        if ($db->getSchema()->getTableSchema('testCreateView') !== null) {
+          $db->createCommand()->dropView('testCreateView')->execute();
+        }
+
+        $db->createCommand()->createTable('testCreateViewTable', [
+            'id' => Schema::TYPE_PK,
+            'bar' => Schema::TYPE_INTEGER,
+        ])->execute();
+        $db->createCommand()->insert('testCreateViewTable', ['bar' => 1])->execute();
+        $db->createCommand()->insert('testCreateViewTable', ['bar' => 6])->execute();
+
+        $db->createCommand()->createView('testCreateView', $subquery)->execute();
+        $records = $db->createCommand('SELECT [[bar]] FROM {{testCreateView}};')->queryAll();
+        $this->assertEquals([['bar' => 1]], $records);
+    }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/8347
+     */
+    public function testDropView()
+    {
+        $db = $this->getConnection();
+
+        $viewName = 'animal_view'; // since it already exists in the fixtures
+        $this->assertNotNull($db->getSchema()->getTableSchema($viewName));
+        $db->createCommand()->dropView($viewName)->execute();
+        $this->assertNull($db->getSchema()->getTableSchema($viewName));
+    }
 }


### PR DESCRIPTION
This PR is a cleanup of #12101, tests are failing because params are not bound to the CREATE VIEW query. This was missing in the original PR too. Needs to addressed.

----

This support only handles creating the basic view and dropping the
view.

An enhancement to this may be to create views with specific keywords
for specific databases.

Syntax:

  - create: `$command->createView(string $name, \yii\db\Query $subquery)`
  - drop: `$command->dropView(string $name)`

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | **no**
| Fixed issues  | fixes #8347