### PR TITLE
Fix \yii\filters\RateLimiter

### DIFF
--- a/framework/filters/RateLimiter.php
+++ b/framework/filters/RateLimiter.php
@@ -106,10 +106,10 @@ class RateLimiter extends ActionFilter
      */
     public function checkRateLimit($user, $request, $response, $action)
     {
-        $current = time();
-
         list($limit, $window) = $user->getRateLimit($request, $action);
         list($allowance, $timestamp) = $user->loadAllowance($request, $action);
+
+        $current = time();
 
         $allowance += (int) (($current - $timestamp) * $limit / $window);
         if ($allowance > $limit) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

If `loadAllowance` returns current time, e.g.:
```
function() {
    sleep(10);
    return [100, time()];
}
```
Calculation `($current - $timestamp)` is always < 0, resulting in adding negative number to `$allowance`.