### PR TITLE
Remove unnecessary parentheses

### DIFF
--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -1258,7 +1258,7 @@ class QueryBuilder extends \yii\base\BaseObject
             }
         }
         if (!empty($parts)) {
-            return '(' . implode(") $operator (", $parts) . ')';
+            return '(' . implode(" $operator ", $parts) . ')';
         }
 
         return '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no

The generated sql queries have an excess of parentheses that bothers us when we need to debug.

What do you think about reducing the excess of unnecessary parentheses in sql queries a bit?

This PR is just a suggestion, other parentheses can also be removed.
