### PR TITLE
Update Query.php

### DIFF
--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -446,7 +446,7 @@ class Query extends Component implements QueryInterface
             return $command->queryScalar();
         }
 
-        return (new self())
+        return (new static())
             ->select([$selectExpression])
             ->from(['c' => $this])
             ->createCommand($db)


### PR DESCRIPTION
Its need to return static object in queryScalar() method last return statement because inherited createCommand() invoke QueryBuilder::build() method, which may be reloaded in inherited QueryBuilder class.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | 
