### PR TITLE
Allow get non-exists attributes of DynamicModel

### DIFF
--- a/framework/base/DynamicModel.php
+++ b/framework/base/DynamicModel.php
@@ -84,7 +84,7 @@ class DynamicModel extends Model
             return $this->_attributes[$name];
         }
 
-        return parent::__get($name);
+        return null;
     }
 
     /**


### PR DESCRIPTION
Currently I have an issue when used DynamicModel in case of ad-hoc validation, when creating request-based «virtual» model: if I passed request data which must be validated but request does not contains some required attributes, my application will throws an exception because validator tried to validate non-existent attributes.
Use case:
```php
    public function actionIndex()
    {
        $rules = [
            [['id', 'email'], 'required'],
            ['id', 'integer'],
            ['name', 'string'],
            ['email', 'email'],
        ];

        $preModel = DynamicModel::validateData(\Yii::$app->request->bodyParams, $rules);

        /*
         * some code 
         */
    }
```

If HTTP form wouldn't contain any of attributes, which enumerated in rules this cause fatal exception in application instead of fills of "errors" of dynamic model.

I think this is not right behavior of this class. Dynamic model is a «virtual» model, therefore its logic could have some differs from basic model. For example, primary purpose of dynamic model — ad-hoc data validation. But actually we can't correctly verify source object, if this object hasn't some attributes, if even "required" validators were created.

I offer following solution of this issue: DynamicModel must always "correctly" handling a getting of *any* attributes. If getting of non-exsting attribute called, it just return an empty null-value. If we would need, we could check this attribute by relevant validator — e.g., "required".

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
