### PR TITLE
Fix #14770: Correct `Html::addCssClass` array to string conversion bug

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.13 under development
 ------------------------
 
+- Bug #14770: Avoid `Html::addCssClass` array to string conversion error (kartik-v)
 - Enh #14273: `yii\log\Target::$enabled` now supports callable value (dmirogin)
 - Bug #14723: Fixed serialization of `yii\db\Connection` instance closes database connection (klimov-paul)
 - Bug #14697: Fixed `console\widgets\Table` rendering when there's no data supplied (bscheshirwork)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1904,7 +1904,7 @@ class BaseHtml
                 $options['class'] = implode(' ', self::mergeCssClasses($classes, (array) $class));
             }
         } else {
-            $options['class'] = $class;
+            $options['class'] = is_array($options['class']) ? implode(' ', $options['class']) : $class;
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14770
