### PR TITLE
Removed ability to define a hostname as trusted because of possible security issues

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -38,7 +38,7 @@ Yii Framework 2 Change Log
 - Enh #13824: Support extracting concatenated strings in `yii message` (developeruz)
 - Enh #14089: Added tests for `yii\base\Theme` (vladis84)
 - Enh #13586: Added `$preserveNonEmptyValues` property to the `yii\behaviors\AttributeBehavior` (Kolyunya)
-- Enh #13780: Added support for trusted proxies in `yii\web\Request` (sammousa, cebe)
+- Enh #13780: Added support for trusted proxies in `yii\web\Request` (sammousa, cebe, silverfire)
 - Bug #14192: Fixed wrong default null value for TIMESTAMP when using PostgreSQL (Tigrov)
 - Enh #14081: Added `yii\caching\CacheInterface` to make custom cache extensions adoption easier (silverfire)
 - Enh #11415: Added `yii\console\widgets\Table` to draw tables in console apps (pana1990, rob006, samdark, tonykor)

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -195,9 +195,9 @@ class Request extends \yii\base\Request
      * Default is to trust all headers except those listed in [[secureHeaders]] from all hosts.
      * Matches are tried in order and searching is stopped when IP matches.
      * 
-     * > Info: Matching is performed using [[yii\validators\IpValidator|IpValidator]]. 
-     *   See [[yii\validators\IpValidator::networks|IpValidator::setRanges()]] 
-     *   and [[yii\validators\IpValidator::networks|IpValidator::networks]] for advanced matching.
+     * > Info: Matching is performed using [[IpValidator]].
+     *   See [[IpValidator::::setRanges()|IpValidator::setRanges()]]
+     *   and [[IpValidator::networks]] for advanced matching.
      * 
      * @see $secureHeaders
      * @since 2.0.13
@@ -310,7 +310,7 @@ class Request extends \yii\base\Request
     }
 
     /**
-     * Creates instance of [[yii\validators\IpValidator]].
+     * Creates instance of [[IpValidator]].
      * You can override this method to adjust validator or implement different matching strategy.
      *
      * @return IpValidator

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -202,13 +202,13 @@ class Request extends \yii\base\Request
      * @see $secureHeaders
      * @since 2.0.13
      */
-    public $trustHeadersFrom = [];
+    public $trustedHosts = [];
     /**
      * @var array lists of headers that are, by default, subject to the trusted host configuration.
-     * These headers will be filtered unless explicitly allowed in [[$trustHeadersFrom]].
+     * These headers will be filtered unless explicitly allowed in [[trustedHosts]].
      * The match of header names is case-insensitive.
      * @see https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
-     * @see $trustHeadersFrom
+     * @see $trustedHosts
      * @since 2.0.13
      */
     public $secureHeaders = [
@@ -222,7 +222,7 @@ class Request extends \yii\base\Request
      * @var string[] List of headers where proxies store the real client IP.
      * It's not advisable to put insecure headers here.
      * The match of header names is case-insensitive.
-     * @see $trustHeadersFrom
+     * @see $trustedHosts
      * @see $secureHeaders
      * @since 2.0.13
      */
@@ -234,7 +234,7 @@ class Request extends \yii\base\Request
      * The array keys are header names and the array value is a list of header values that indicate a secure connection.
      * The match of header names and values is case-insensitive.
      * It's not advisable to put insecure headers here.
-     * @see $trustHeadersFrom
+     * @see $trustedHosts
      * @see $secureHeaders
      * @since 2.0.13
      */
@@ -275,7 +275,7 @@ class Request extends \yii\base\Request
     }
 
     /**
-     * Filters headers according to the [[trustHeadersFrom]].
+     * Filters headers according to the [[trustedHosts]].
      * @param HeaderCollection $headerCollection
      * @since 2.0.13
      */
@@ -285,10 +285,10 @@ class Request extends \yii\base\Request
         $trustedHeaders = [];
 
         // check if the client is a trusted host
-        if (!empty($this->trustHeadersFrom)) {
+        if (!empty($this->trustedHosts)) {
             $validator = $this->getIpValidator();
             $ip = $this->getRemoteIP();
-            foreach ($this->trustHeadersFrom as $cidr => $headers) {
+            foreach ($this->trustedHosts as $cidr => $headers) {
                 if (!is_array($headers)) {
                     $cidr = $headers;
                     $headers = $this->secureHeaders;

--- a/tests/framework/web/RequestTest.php
+++ b/tests/framework/web/RequestTest.php
@@ -320,7 +320,7 @@ class RequestTest extends TestCase
             [[
                 'HTTP_X_FORWARDED_PROTO' => 'https',
                 'REMOTE_HOST' => 'test.com',
-            ], true],
+            ], false],
             [[
                 'HTTP_X_FORWARDED_PROTO' => 'https',
                 'REMOTE_HOST' => 'othertest.com',
@@ -338,7 +338,7 @@ class RequestTest extends TestCase
             [[
                 'HTTP_FRONT_END_HTTPS' => 'on',
                 'REMOTE_HOST' => 'test.com',
-            ], true],
+            ], false],
             [[
                 'HTTP_FRONT_END_HTTPS' => 'on',
                 'REMOTE_HOST' => 'othertest.com',
@@ -363,9 +363,8 @@ class RequestTest extends TestCase
     {
         $original = $_SERVER;
         $request = new Request([
-            'trustedHosts' => [
-                '/^test.com$/',
-                '/^192\.168/',
+            'trustHeadersFrom' => [
+                '192.168.0.0/24',
             ],
         ]);
         $_SERVER = $server;
@@ -397,10 +396,10 @@ class RequestTest extends TestCase
                 [
                     'HTTP_X_FORWARDED_PROTO' => 'https',
                     'HTTP_X_FORWARDED_FOR' => '123.123.123.123',
-                    'REMOTE_HOST' => 'trusted.com',
+                    'REMOTE_HOST' => 'untrusted.com',
                     'REMOTE_ADDR' => '192.169.1.1',
                 ],
-                '123.123.123.123',
+                '192.169.1.1',
             ],
             [
                 [
@@ -424,9 +423,8 @@ class RequestTest extends TestCase
         $original = $_SERVER;
         $_SERVER = $server;
         $request = new Request([
-            'trustedHosts' => [
-                '/^192\.168/',
-                '/^trusted.com$/',
+            'trustHeadersFrom' => [
+                '192.168.0.0/24',
             ],
         ]);
 

--- a/tests/framework/web/RequestTest.php
+++ b/tests/framework/web/RequestTest.php
@@ -363,7 +363,7 @@ class RequestTest extends TestCase
     {
         $original = $_SERVER;
         $request = new Request([
-            'trustHeadersFrom' => [
+            'trustedHosts' => [
                 '192.168.0.0/24',
             ],
         ]);
@@ -423,7 +423,7 @@ class RequestTest extends TestCase
         $original = $_SERVER;
         $_SERVER = $server;
         $request = new Request([
-            'trustHeadersFrom' => [
+            'trustedHosts' => [
                 '192.168.0.0/24',
             ],
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | probably
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Closes #14691
