### PR TITLE
Change access type of method

### DIFF
--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -641,7 +641,7 @@ abstract class BaseMigrateController extends Controller
      * @return array list of 2 elements: 'namespace' and 'class base name'
      * @since 2.0.10
      */
-    private function generateClassName($name)
+    protected function generateClassName($name)
     {
         $namespace = null;
         $name = trim($name, '\\');


### PR DESCRIPTION
BaseMigrateController::generateClassName() as protected.
If there is no impediment, I suggest changing the method of visibility to allow us to overwrite it.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
