### PR TITLE
Add pagination method

### DIFF
--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -840,7 +840,8 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         $query = $this;
         $countQuery = clone $query;
 
-        $paginator = \Yii::$container->get('yii\data\Pagination',['totalCount' => $countQuery->count()]);
+        $paginator = \Yii::$container->get('yii\data\Pagination');
+        $paginator->totalCount = $countQuery->count();
         $paginator->pageParam = $pageName;
 
         if($page){

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -816,6 +816,54 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     }
 
     /**
+     * Paginate the given query.
+     * ```php
+     * public function getItems()
+     * {
+     *     $result = Article::find()->where(['status' => 1])->paginate(15);
+     *     return $this->render('index', [
+     *                 'items' => $result['items'],
+     *                 'pages' => $result['pages'],
+     *            ]);
+     * }
+     * ```
+     * @param  int  $perPage
+     * @param  array  $columns
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function paginate($perPage = null, $columns = [], $pageName = 'page', $page = null)
+    {
+        $query = $this;
+        $countQuery = clone $query;
+
+        $paginator = \Yii::$container->get('yii\data\Pagination',['totalCount' => $countQuery->count()]);
+        $paginator->pageParam = $pageName;
+
+        if($page){
+            $paginator->setPage($page);
+        }
+
+        if($perPage){
+            $paginator->setPageSize($perPage);
+        }
+
+        if($columns){
+            $query = $query->addSelect($columns);
+        }
+
+        $query->offset($paginator->offset)->limit($paginator->limit);
+
+        return [
+            'items' => $query->all(),
+            'pages' => $paginator
+        ];
+    }
+
+    /**
      * @return string primary table name
      * @since 2.0.12
      */

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -837,32 +837,31 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     public function paginate($perPage = null, $columns = [], $pageName = 'page', $page = null)
     {
-        $query = $this;
-        $countQuery = clone $query;
-
-        $paginator = \Yii::$container->get('yii\data\Pagination');
-        $paginator->totalCount = $countQuery->count();
-        $paginator->pageParam = $pageName;
-
-        if($page){
-            $paginator->setPage($page);
-        }
-
-        if($perPage){
-            $paginator->setPageSize($perPage);
-        }
+        $paginator = $this->setPaginator($this, $perPage, $pageName, $page);
 
         if($columns){
-            $query = $query->addSelect($columns);
+            $this->addSelect($columns);
         }
 
-        $query->offset($paginator->offset)->limit($paginator->limit);
+        $this->offset($paginator->offset)->limit($paginator->limit)->count();
 
         return [
-            'items' => $query->all(),
+            'items' => $this->all(),
             'pages' => $paginator
         ];
     }
+
+    protected function setPaginator(Query $query, $perPage, $pageName = 'page', $page = null)
+    {
+        $paginator = \Yii::$container->get('yii\data\Pagination');
+        $paginator->totalCount = $query->count();
+        $paginator->pageParam = $pageName;
+        $paginator->setPage($page);
+        $paginator->setPageSize($perPage);
+
+        return $paginator;
+    }
+
 
     /**
      * @return string primary table name

--- a/tests/framework/db/ActiveQueryTest.php
+++ b/tests/framework/db/ActiveQueryTest.php
@@ -255,7 +255,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
         ], $tables);
     }
 
-    public function testPagination_true()
+    public function testPagination()
     {
         $query = new ActiveQuery(Profile::className());
         $result = $query->paginate(5);

--- a/tests/framework/db/ActiveQueryTest.php
+++ b/tests/framework/db/ActiveQueryTest.php
@@ -255,18 +255,18 @@ abstract class ActiveQueryTest extends DatabaseTestCase
         ], $tables);
     }
 
-    public function testPagination()
+    public function testPagination_true()
     {
         $query = new ActiveQuery(Profile::className());
         $result = $query->paginate(5);
 
         $query = new ActiveQuery(Profile::className());
         $countQuery = clone $query;
-        $pages = new Pagination(['totalCount' => $countQuery->count()]);
+        $pages = new Pagination(['totalCount' => $countQuery->count(), 'pageSize'=>5]);
         $models = $query->offset($pages->offset)
                         ->limit($pages->limit)
                         ->all();
 
-        $this->assertEquals($result, ['items'=>$models, 'pages'=>$pages]);
+        $this->assertEquals(['items'=>$models, 'pages'=>$pages], $result);
     }
 }

--- a/tests/framework/db/ActiveQueryTest.php
+++ b/tests/framework/db/ActiveQueryTest.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\db;
 
 use yii\base\Event;
+use yii\data\Pagination;
 use yii\db\ActiveQuery;
 use yii\db\Connection;
 use yii\db\QueryBuilder;
@@ -252,5 +253,20 @@ abstract class ActiveQueryTest extends DatabaseTestCase
         $this->assertEquals([
             '{{' . Profile::tableName() . '}}' => '{{' . Profile::tableName() . '}}',
         ], $tables);
+    }
+
+    public function testPagination()
+    {
+        $query = new ActiveQuery(Profile::className());
+        $result = $query->paginate(5);
+
+        $query = new ActiveQuery(Profile::className());
+        $countQuery = clone $query;
+        $pages = new Pagination(['totalCount' => $countQuery->count()]);
+        $models = $query->offset($pages->offset)
+                        ->limit($pages->limit)
+                        ->all();
+
+        $this->assertEquals($result, ['items'=>$models, 'pages'=>$pages]);
     }
 }


### PR DESCRIPTION
Added method paginate in ActiveQuery class for quick get pagination data

How to use:
```
$result = Article::find()->where(['status' => 1])->paginate(15);
return $this->render('index', [
                 'items' => $result['items'],
                 'pages' => $result['pages'],
           ]);
```

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

