### PR TITLE
Fix php notice in MultipartFormDataParser

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.13 under development
 ------------------------
 
+- Bug #14902: Fixed PHP notice in `yii\web\MultipartFormDataParser` (olimsaidov)
 - Bug #14129: Fixed console help to properly work with tricky camelcased controller names (samdark, silverfire)
 - Enh #14126: Added variadic parameters support to DI container (SamMousa)
 - Enh #14087: Added `yii\web\View::registerCsrfMetaTags()` method that registers CSRF tags dynamically ensuring that caching doesn't interfere (RobinKamps)

--- a/framework/web/MultipartFormDataParser.php
+++ b/framework/web/MultipartFormDataParser.php
@@ -262,7 +262,8 @@ class MultipartFormDataParser extends BaseObject implements RequestParserInterfa
             $namePart = trim($namePart, ']');
             if ($namePart === '') {
                 $current[] = [];
-                $lastKey = array_pop(array_keys($current));
+                $keys = array_keys($current);
+                $lastKey = array_pop($keys);
                 $current = &$current[$lastKey];
             } else {
                 if (!isset($current[$namePart])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

This patch fixes php notice "Only variables should be passed by reference" at web/MultipartFormDataParser.php:250
