### PR TITLE
Container type for pjax must be string

### DIFF
--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -165,7 +165,7 @@ window.yii = (function ($) {
             if (usePjax) {
                 pjaxContainer = $e.data('pjax-container') || $e.closest('[data-pjax-container]');
                 if (!pjaxContainer.length) {
-                    pjaxContainer = $('body');
+                    pjaxContainer = 'body';
                 }
                 pjaxOptions = {
                     container: pjaxContainer,

--- a/tests/js/tests/yii.test.js
+++ b/tests/js/tests/yii.test.js
@@ -328,7 +328,7 @@ describe('yii', function () {
             // container needs to be checked separately
 
             if (typeof pjaxOptions.container === 'string') {
-                assert.equal(pjaxOptions.container, ('#' + pjaxContainerId) || 'body');
+                assert.equal(pjaxOptions.container, pjaxContainerId ? ('#' + pjaxContainerId) : 'body');
             } else {
                 assert.instanceOf(pjaxOptions.container, $);
                 assert.equal(pjaxOptions.container.attr('id'), pjaxContainerId || 'body');
@@ -380,9 +380,13 @@ describe('yii', function () {
             var pjaxOptions = pjaxSubmitStub.getCall(0).args[1];
 
             // container needs to be checked separately
+            if (typeof pjaxOptions.container === 'string') {
+                assert.equal(pjaxOptions.container, 'body');
+            } else {
+                assert.instanceOf(pjaxOptions.container, $);
+                assert.equal(pjaxOptions.container.attr('id'), 'body');
+            }
 
-            assert.instanceOf(pjaxOptions.container, $);
-            assert.equal(pjaxOptions.container.attr('id'), 'body');
             delete pjaxOptions.container;
 
             assert.deepEqual(pjaxOptions, {

--- a/tests/js/tests/yii.test.js
+++ b/tests/js/tests/yii.test.js
@@ -328,7 +328,7 @@ describe('yii', function () {
             // container needs to be checked separately
 
             if (typeof pjaxOptions.container === 'string') {
-                assert.equal(pjaxOptions.container, '#' + pjaxContainerId || 'body');
+                assert.equal(pjaxOptions.container, ('#' + pjaxContainerId) || 'body');
             } else {
                 assert.instanceOf(pjaxOptions.container, $);
                 assert.equal(pjaxOptions.container.attr('id'), pjaxContainerId || 'body');

--- a/tests/js/tests/yii.test.js
+++ b/tests/js/tests/yii.test.js
@@ -328,7 +328,7 @@ describe('yii', function () {
             // container needs to be checked separately
 
             if (typeof pjaxOptions.container === 'string') {
-                assert.equal(pjaxOptions.container, pjaxContainerId ? ('#' + pjaxContainerId) : 'body');
+                assert.equal(pjaxOptions.container, pjaxContainerId || 'body');
             } else {
                 assert.instanceOf(pjaxOptions.container, $);
                 assert.equal(pjaxOptions.container.attr('id'), pjaxContainerId || 'body');
@@ -494,11 +494,11 @@ describe('yii', function () {
                     });
 
                     withData({
-                        'link, data-pjax': ['.link-pjax', '#body'],
-                        'link, data-pjax="1"': ['.link-pjax-1', '#body'],
-                        'link, data-pjax="true"': ['.link-pjax-true', '#body'],
+                        'link, data-pjax': ['.link-pjax', 'body'],
+                        'link, data-pjax="1"': ['.link-pjax-1', 'body'],
+                        'link, data-pjax="true"': ['.link-pjax-true', 'body'],
                         'link, data-pjax, outside a container': [
-                            '.link-pjax-outside-container', 'pjax-separate-container'
+                            '.link-pjax-outside-container', '#pjax-separate-container'
                         ],
                         'link href, data-pjax, inside a container': ['.link-pjax-inside-container', 'pjax-container-2']
                     }, function (elementSelector, expectedPjaxContainerId) {

--- a/tests/js/tests/yii.test.js
+++ b/tests/js/tests/yii.test.js
@@ -494,9 +494,9 @@ describe('yii', function () {
                     });
 
                     withData({
-                        'link, data-pjax': ['.link-pjax', 'body'],
-                        'link, data-pjax="1"': ['.link-pjax-1', 'body'],
-                        'link, data-pjax="true"': ['.link-pjax-true', 'body'],
+                        'link, data-pjax': ['.link-pjax', '#body'],
+                        'link, data-pjax="1"': ['.link-pjax-1', '#body'],
+                        'link, data-pjax="true"': ['.link-pjax-true', '#body'],
                         'link, data-pjax, outside a container': [
                             '.link-pjax-outside-container', 'pjax-separate-container'
                         ],


### PR DESCRIPTION
Here in pjax is checking this https://github.com/defunkt/jquery-pjax/blob/master/jquery.pjax.js#L176
For this reason, I received an error after the click on delete action in ActionColumn:

![2017-10-03-161049_1920x1080_scrot](https://user-images.githubusercontent.com/2357407/31126822-8e3b43de-a855-11e7-959c-3f430d72ebc6.png)


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
