### PR TITLE
Fixes #9438: yii\web\DbSession now relies on error handler to display errors

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.13 under development
 ------------------------
 
+- Enh #9438: `yii\web\DbSession` now relies on error handler to display errors (samdark)
 - Bug #14129: Fixed console help to properly work with tricky camelcased controller names (samdark, silverfire)
 - Enh #14126: Added variadic parameters support to DI container (SamMousa)
 - Enh #14087: Added `yii\web\View::registerCsrfMetaTags()` method that registers CSRF tags dynamically ensuring that caching doesn't interfere (RobinKamps)

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -183,13 +183,7 @@ class DbSession extends MultiFieldSession
                     ->execute();
             }
         } catch (\Exception $e) {
-            $exception = ErrorHandler::convertExceptionToString($e);
-            // its too late to use Yii logging here
-            error_log($exception);
-            if (YII_DEBUG) {
-                echo $exception;
-            }
-
+            Yii::$app->errorHandler->handleException($e);
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | -
| Fixed issues  | #9438
