### PR TITLE
Attempt to fix tests for HHVM

### DIFF
--- a/tests/framework/console/controllers/BaseMessageControllerTest.php
+++ b/tests/framework/console/controllers/BaseMessageControllerTest.php
@@ -484,7 +484,7 @@ abstract class BaseMessageControllerTest extends TestCase
      */
     public function testShouldNotMarkUnused()
     {
-        $category = 'my';
+        $category = 'testShouldNotMarkUnused';
 
         $key1 = 'key1';
         $key2 = 'key2';
@@ -497,7 +497,7 @@ abstract class BaseMessageControllerTest extends TestCase
             $category
         );
 
-        $sourceFileContent = 'Yii::t("my", "test");';
+        $sourceFileContent = 'Yii::t("testShouldNotMarkUnused", "test");';
         $this->createSourceFile($sourceFileContent);
 
         $this->saveConfigFile($this->getConfig(['markUnused' => false]));


### PR DESCRIPTION
See https://github.com/yiisoft/yii2/commit/f5591bb70eb9f4622ffa8b435e7d88543bcdb44a#commitcomment-24827510

This is probably only caching issue. Each test should use unique category in order to bypass HHVM cache from previous tests.

/cc @samdark 
