### PR TITLE
Fixes #14929: Semicolon insertion with avoiding line comment

### DIFF
--- a/framework/console/controllers/AssetController.php
+++ b/framework/console/controllers/AssetController.php
@@ -568,9 +568,11 @@ EOD;
     {
         $content = '';
         foreach ($inputFiles as $file) {
+            // Add a semicolon to source code if trailing semicolon missing.
+            // Notice: It needs a new line before `;` to avoid affection of line comment. (// ...;)
             $fileContent = rtrim(file_get_contents($file));
             if (substr($fileContent, -1) !== ';') {
-                $fileContent .= ';';
+                $fileContent .= "\n;";
             }
             $content .= "/*** BEGIN FILE: $file ***/\n"
                 . $fileContent . "\n"


### PR DESCRIPTION
`"\n"` was added before additional `";"`. 
I also add comments why this process needs `"\n;"`.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14929