### PR TITLE
Fix for #11401, concurrency when inserting new session ID

### DIFF
--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -166,12 +166,11 @@ class DbSession extends MultiFieldSession
         // http://us.php.net/manual/en/function.session-set-save-handler.php#refsect1-function.session-set-save-handler-notes
         try {
             // Fix for #11401, concurrency when inserting new session ID            
-            $exists = $this->db->useMaster(function($db) use ($id) {
+            $exists = $this->db->useMaster(function() use ($id) {
                 return (new Query())->select(['id'])
                     ->from($this->sessionTable)
                     ->where(['id' => $id])
-                    ->createCommand($db)
-                    ->queryScalar();
+                    ->exists($this->db);
             });
             
             $fields = $this->composeFields($id, $data);

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -165,19 +165,14 @@ class DbSession extends MultiFieldSession
         // exception must be caught in session write handler
         // http://us.php.net/manual/en/function.session-set-save-handler.php#refsect1-function.session-set-save-handler-notes
         try {
-            
             // Fix for #11401, concurrency when inserting new session ID            
-            $exists = false;
-            $_self = $this;
-            $this->db->useMaster(function($db) use ($_self, $exists) {
-                $query = new Query();
-                $exists = $query->select(['id'])
-                    ->from($_self->sessionTable)
+            $exists = $this->db->useMaster(function($db) use ($id) {
+                return (new Query())->select(['id'])
+                    ->from($this->sessionTable)
                     ->where(['id' => $id])
                     ->createCommand($db)
                     ->queryScalar();
             });
-            // END Fix for #11401        
             
             $fields = $this->composeFields($id, $data);
             if ($exists === false) {


### PR DESCRIPTION
Fix for #11401, concurrency when inserting new session ID

Using master db connection when checking if session exists