### PR TITLE
Fix translations of `DataFilter::$_errorMessages`

### DIFF
--- a/framework/messages/de/yii-rest.php
+++ b/framework/messages/de/yii-rest.php
@@ -25,7 +25,7 @@
 return [
     '\'{attribute}\' does not support operator \'{operator}\'.' => '\'{attribute}\' unterstützt den Operator \'{operator}\' nicht.',
     'Condition for \'{attribute}\' should be either a value or valid operator specification.' => 'Die Bedingung für \'{attribute}\' muss entweder ein Wert oder ein Operatorvergleich sein.',
-    'Operator \'{operator}\' must be used with search attribute.' => 'Der Operator \'{operator}\' muss zusammen mit einem Such-Attribut verwendet werden.',
+    'Operator \'{operator}\' must be used with a search attribute.' => 'Der Operator \'{operator}\' muss zusammen mit einem Such-Attribut verwendet werden.',
     'Operator \'{operator}\' requires multiple operands.' => 'Der Operator \'{operator}\' erwartet mehrere Operanden.',
     'The format of {filter} is invalid.' => 'Das Format von {filter} ist ungültig.',
     'Unknown filter attribute \'{attribute}\'' => 'Unbekanntes Filter-Attribut \'{attribute}\'',

--- a/framework/messages/hy/yii-rest.php
+++ b/framework/messages/hy/yii-rest.php
@@ -26,7 +26,7 @@
 return [
     '\'{attribute}\' does not support operator \'{operator}\'.' => '«{attribute}»-ը չի սպասարկում «{operator}» օպերատորը։',
     'Condition for \'{attribute}\' should be either a value or valid operator specification.' => '«{attribute}»-ի համար պետք է լինի արժեք կամ գործող օպերատորի հստակեցում:',
-    'Operator \'{operator}\' must be used with search attribute.' => '«{operator}» օպերատորը պետք է օգտագործվի որոնման ատրիբուտի հետ միասին:',
+    'Operator \'{operator}\' must be used with a search attribute.' => '«{operator}» օպերատորը պետք է օգտագործվի որոնման ատրիբուտի հետ միասին:',
     'Operator \'{operator}\' requires multiple operands.' => '«{operator}» օպերատորը պահանջում բազմակի օպերանդներ։',
     'The format of {filter} is invalid.' => '{filter}-ի ֆորմատը անվավեր է։',
     'Unknown filter attribute \'{attribute}\'' => 'Անհայտ ֆիլտրի ատրիբուտ՝ «{attribute}»։',

--- a/framework/rest/DataFilter.php
+++ b/framework/rest/DataFilter.php
@@ -236,14 +236,7 @@ class DataFilter extends Model
     /**
      * @var array|\Closure list of error messages responding to invalid filter structure, in format: `[errorKey => message]`.
      */
-    private $_errorMessages = [
-        'invalidFilter' => 'The format of {filter} is invalid.',
-        'operatorRequireMultipleOperands' => "Operator '{operator}' requires multiple operands.",
-        'unknownAttribute' => "Unknown filter attribute '{attribute}'",
-        'invalidAttributeValueFormat' => "Condition for '{attribute}' should be either a value or a valid operator specification.",
-        'operatorRequireAttribute' => "Operator '{operator}' must be used with a search attribute.",
-        'unsupportedOperatorType' => "'{attribute}' does not support '{operator}' operator.",
-    ];
+    private $_errorMessages;
     /**
      * @var mixed raw filter specification.
      */

--- a/framework/rest/DataFilter.php
+++ b/framework/rest/DataFilter.php
@@ -392,7 +392,7 @@ class DataFilter extends Model
             'operatorRequireMultipleOperands' => Yii::t('yii-rest', "Operator '{operator}' requires multiple operands."),
             'unknownAttribute' => Yii::t('yii-rest', "Unknown filter attribute '{attribute}'"),
             'invalidAttributeValueFormat' => Yii::t('yii-rest', "Condition for '{attribute}' should be either a value or valid operator specification."),
-            'operatorRequireAttribute' => Yii::t('yii-rest', "Operator '{operator}' must be used with search attribute."),
+            'operatorRequireAttribute' => Yii::t('yii-rest', "Operator '{operator}' must be used with a search attribute."),
             'unsupportedOperatorType' => Yii::t('yii-rest', "'{attribute}' does not support operator '{operator}'."),
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

`DataFilter::$_errorMessages` should be `null` by default in order to use messages from `DataFilter::defaultErrorMessages()`.

/cc @klimov-paul 
