### PR TITLE
avoid use common class like another code

### DIFF
--- a/framework/web/HeaderCollection.php
+++ b/framework/web/HeaderCollection.php
@@ -7,7 +7,6 @@
 
 namespace yii\web;
 
-use ArrayIterator;
 use Yii;
 use yii\base\BaseObject;
 
@@ -15,7 +14,7 @@ use yii\base\BaseObject;
  * HeaderCollection is used by [[Response]] to maintain the currently registered HTTP headers.
  *
  * @property int $count The number of headers in the collection. This property is read-only.
- * @property ArrayIterator $iterator An iterator for traversing the headers in the collection. This property
+ * @property \ArrayIterator $iterator An iterator for traversing the headers in the collection. This property
  * is read-only.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
@@ -33,11 +32,11 @@ class HeaderCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * Returns an iterator for traversing the headers in the collection.
      * This method is required by the SPL interface [[\IteratorAggregate]].
      * It will be implicitly called when you use `foreach` to traverse the collection.
-     * @return ArrayIterator an iterator for traversing the headers in the collection.
+     * @return \ArrayIterator an iterator for traversing the headers in the collection.
      */
     public function getIterator()
     {
-        return new ArrayIterator($this->_headers);
+        return new \ArrayIterator($this->_headers);
     }
 
     /**


### PR DESCRIPTION
Like 
https://github.com/yiisoft/yii2/blob/0ee17dcb7d763b00819ad764a60e8d582f62f662/framework/base/ArrayAccessTrait.php#L23-L32

Same style is better.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | 
