### PR TITLE
Docs: example for concrete file alias

### DIFF
--- a/docs/guide-ru/concept-aliases.md
+++ b/docs/guide-ru/concept-aliases.md
@@ -18,6 +18,9 @@ Yii::setAlias('@foo', '/path/to/foo');
 
 // псевдоним URL
 Yii::setAlias('@bar', 'http://www.example.com');
+
+// псевдоним конкретного файла, содержащего класс \foo\Bar
+Yii::setAlias('@foo/Bar.php', '/definitely/not/foo/Bar.php');
 ```
 
 > Note: псевдоним пути к файлу или URL *не* обязательно указывает на существующий файл или ресурс.

--- a/docs/guide/concept-aliases.md
+++ b/docs/guide/concept-aliases.md
@@ -20,7 +20,7 @@ Yii::setAlias('@foo', '/path/to/foo');
 // an alias of a URL
 Yii::setAlias('@bar', 'http://www.example.com');
 
-// an alias of a concrete file that contain class \foo\Bar
+// an alias of a concrete file that contains a \foo\Bar class
 Yii::setAlias('@foo/Bar.php', '/definitely/not/foo/Bar.php');
 ```
 

--- a/docs/guide/concept-aliases.md
+++ b/docs/guide/concept-aliases.md
@@ -19,6 +19,9 @@ Yii::setAlias('@foo', '/path/to/foo');
 
 // an alias of a URL
 Yii::setAlias('@bar', 'http://www.example.com');
+
+// an alias of a concrete file that contain class \foo\Bar
+Yii::setAlias('@foo/Bar.php', '/definitely/not/foo/Bar.php');
 ```
 
 > Note: The file path or URL being aliased may *not* necessarily refer to an existing file or resource.


### PR DESCRIPTION
Add little bit concrete example to define non-simple (but root) alias, who resolve path to concrete file.

This will be helpful to redefine autoload path of non-package class or something else :angel: 
