### PR TITLE
Adjusted implementation of migration name length limit

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.13 under development
 ------------------------
 
-- Bug #14543: Throw exception when trying to create migration longer than 180 symbols (dmirogin)
+- Bug #14543: Throw exception when trying to create migration longer than 180 symbols (dmirogin, cebe)
 - Enh #14877: Disabled profiling on connection opening when profiling is disabled (njasm)
 - Enh #14967: Added Armenian Translations (gevorgmansuryan)
 - Enh #4479: Implemented REST filters (klimov-paul)

--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -31,10 +31,6 @@ abstract class BaseMigrateController extends Controller
      */
     const BASE_MIGRATION = 'm000000_000000_base';
 
-    /**
-     * Maximum length of migration name
-     */
-    const MAX_NAME_LENGTH = 180;
 
     /**
      * @var string the default command action.
@@ -189,6 +185,10 @@ abstract class BaseMigrateController extends Controller
         }
 
         foreach ($migrations as $migration) {
+            if (strlen($migration) > $this->getMigrationNameLimit()) {
+                $this->stdout("\nThe migration name '$migration' is too long. Its not possible to apply this migration.\n", Console::FG_RED);
+                return ExitCode::UNSPECIFIED_ERROR;
+            }
             $this->stdout("\t$migration\n");
         }
         $this->stdout("\n");
@@ -196,11 +196,6 @@ abstract class BaseMigrateController extends Controller
         $applied = 0;
         if ($this->confirm('Apply the above ' . ($n === 1 ? 'migration' : 'migrations') . '?')) {
             foreach ($migrations as $migration) {
-                if (strlen($migration) > static::MAX_NAME_LENGTH) {
-                    $this->stdout("\nThe migration name is too long. The rest of the migrations are canceled.\n", Console::FG_RED);
-                    return ExitCode::UNSPECIFIED_ERROR;
-                }
-
                 if (!$this->migrateUp($migration)) {
                     $this->stdout("\n$applied from $n " . ($applied === 1 ? 'migration was' : 'migrations were') . " applied.\n", Console::FG_RED);
                     $this->stdout("\nMigration failed. The rest of the migrations are canceled.\n", Console::FG_RED);
@@ -633,7 +628,7 @@ abstract class BaseMigrateController extends Controller
 
         list($namespace, $className) = $this->generateClassName($name);
         // Abort if name is too long
-        if (strlen($className) > static::MAX_NAME_LENGTH) {
+        if (strlen($className) > $this->getMigrationNameLimit()) {
             throw new Exception('The migration name is too long.');
         }
 
@@ -947,6 +942,18 @@ abstract class BaseMigrateController extends Controller
     protected function truncateDatabase()
     {
         throw new NotSupportedException('This command is not implemented in ' . get_class($this));
+    }
+
+    /**
+     * Return the maximum name length for a migration.
+     *
+     * Subclasses may override this method to define a limit.
+     * @return int|null the maximum name length for a migration or `null` if no limit applies.
+     * @since 2.0.13
+     */
+    protected function getMigrationNameLimit()
+    {
+        return null;
     }
 
     /**

--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -185,7 +185,8 @@ abstract class BaseMigrateController extends Controller
         }
 
         foreach ($migrations as $migration) {
-            if (strlen($migration) > $this->getMigrationNameLimit()) {
+            $nameLimit = $this->getMigrationNameLimit();
+            if ($nameLimit !== null && strlen($migration) > $nameLimit) {
                 $this->stdout("\nThe migration name '$migration' is too long. Its not possible to apply this migration.\n", Console::FG_RED);
                 return ExitCode::UNSPECIFIED_ERROR;
             }
@@ -628,7 +629,8 @@ abstract class BaseMigrateController extends Controller
 
         list($namespace, $className) = $this->generateClassName($name);
         // Abort if name is too long
-        if (strlen($className) > $this->getMigrationNameLimit()) {
+        $nameLimit = $this->getMigrationNameLimit();
+        if ($nameLimit !== null && strlen($className) > $nameLimit) {
             throw new Exception('The migration name is too long.');
         }
 

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -74,6 +74,13 @@ use yii\helpers\Console;
 class MigrateController extends BaseMigrateController
 {
     /**
+     * Maximum length of a migration name.
+     * @since 2.0.13
+     */
+    const MAX_NAME_LENGTH = 180;
+
+
+    /**
      * @var string the name of the table for keeping applied migration information.
      */
     public $migrationTable = '{{%migration}}';
@@ -258,7 +265,7 @@ class MigrateController extends BaseMigrateController
         $tableName = $this->db->schema->getRawTableName($this->migrationTable);
         $this->stdout("Creating migration history table \"$tableName\"...", Console::FG_YELLOW);
         $this->db->createCommand()->createTable($this->migrationTable, [
-            'version' => 'varchar(180) NOT NULL PRIMARY KEY',
+            'version' => 'varchar(' . static::MAX_NAME_LENGTH . ') NOT NULL PRIMARY KEY',
             'apply_time' => 'integer',
         ])->execute();
         $this->db->createCommand()->insert($this->migrationTable, [
@@ -315,6 +322,15 @@ class MigrateController extends BaseMigrateController
         $command->delete($this->migrationTable, [
             'version' => $version,
         ])->execute();
+    }
+
+    /**
+     * @inheritdoc
+     * @since 2.0.13
+     */
+    protected function getMigrationNameLimit()
+    {
+        return static::MAX_NAME_LENGTH;
     }
 
     /**

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -174,10 +174,7 @@ class MigrateController extends BaseMigrateController
     public function beforeAction($action)
     {
         if (parent::beforeAction($action)) {
-            if ($action->id !== 'create') {
-                $this->db = Instance::ensure($this->db, Connection::className());
-            }
-
+            $this->db = Instance::ensure($this->db, Connection::className());
             return true;
         }
 
@@ -324,12 +321,22 @@ class MigrateController extends BaseMigrateController
         ])->execute();
     }
 
+    private $_migrationNameLimit;
+
     /**
      * @inheritdoc
      * @since 2.0.13
      */
     protected function getMigrationNameLimit()
     {
+        if ($this->_migrationNameLimit !== null) {
+            return $this->_migrationNameLimit;
+        }
+        $tableSchema = $this->db->schema ? $this->db->schema->getTableSchema($this->migrationTable, true) : null;
+        if ($tableSchema !== null) {
+            return $this->_migrationNameLimit = $tableSchema->columns['version']->size;
+        }
+
         return static::MAX_NAME_LENGTH;
     }
 

--- a/tests/framework/console/controllers/MigrateControllerTest.php
+++ b/tests/framework/console/controllers/MigrateControllerTest.php
@@ -150,7 +150,8 @@ class MigrateControllerTest extends TestCase
 
         $result = $this->runMigrateControllerAction('up');
 
-        $this->assertContains('The migration name is too long. The rest of the migrations are canceled.', $result);
+        $this->assertContains('The migration name', $result);
+        $this->assertContains('is too long. Its not possible to apply this migration.', $result);
     }
 
     public function testCreateLongNamedMigration()

--- a/tests/framework/console/controllers/MigrateControllerTest.php
+++ b/tests/framework/console/controllers/MigrateControllerTest.php
@@ -154,6 +154,21 @@ class MigrateControllerTest extends TestCase
         $this->assertContains('is too long. Its not possible to apply this migration.', $result);
     }
 
+    public function testNamedMigrationWithCustomLimit()
+    {
+        Yii::$app->db->createCommand()->createTable('migration', [
+            'version' => 'varchar(255) NOT NULL PRIMARY KEY', // varchar(255) is longer than the default of 180
+            'apply_time' => 'integer',
+        ])->execute();
+
+        $this->createMigration(str_repeat('a', 180));
+
+        $result = $this->runMigrateControllerAction('up');
+
+        $this->assertContains('1 migration was applied.', $result);
+        $this->assertContains('Migrated up successfully.', $result);
+    }
+
     public function testCreateLongNamedMigration()
     {
         $migrationName = str_repeat('a', 180);


### PR DESCRIPTION
- warn about the problem before applying migrations
- make it specific to SQL dbms because other implementations do not have a limit

see also:
- commit 614fb52c45b06077682114f2ba246399af0e9a9c
- issue #14543
- PR #15002
