### PR TITLE
\rest\DataFilter $searchModel in error message instead $model 

### DIFF
--- a/framework/rest/DataFilter.php
+++ b/framework/rest/DataFilter.php
@@ -276,7 +276,7 @@ class DataFilter extends Model
         if (!is_object($this->_searchModel) || $this->_searchModel instanceof \Closure) {
             $model = Yii::createObject($this->_searchModel);
             if (!$model instanceof Model) {
-                throw new InvalidConfigException('`' . get_class($this) . '::$model` should be an instance of `' . Model::className() . '` or its DI compatible configuration.');
+                throw new InvalidConfigException('`' . get_class($this) . '::$searchModel` should be an instance of `' . Model::className() . '` or its DI compatible configuration.');
             }
             $this->_searchModel = $model;
         }
@@ -290,7 +290,7 @@ class DataFilter extends Model
     public function setSearchModel($model)
     {
         if (is_object($model) && !$model instanceof Model && !$model instanceof \Closure) {
-            throw new InvalidConfigException('`' . get_class($this) . '::$model` should be an instance of `' . Model::className() . '` or its DI compatible configuration.');
+            throw new InvalidConfigException('`' . get_class($this) . '::$searchModel` should be an instance of `' . Model::className() . '` or its DI compatible configuration.');
         }
         $this->_searchModel = $model;
     }


### PR DESCRIPTION
I think we say about $searchModel property in setter/getter $_searchModel, not about `$model`

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    |  no
| Tests pass?   | yes/no
| Fixed issues  | related #15013 
