### PR TITLE
added StringHelper::floatToString() as locale independent cast

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -97,6 +97,7 @@ Yii Framework 2 Change Log
 - Chg #14487: Changed i18n message error to warning (dmirogin)
 - Enh #14864: Ability to use dependencies in constructor of migrations (vtvz)
 - Enh #14913: Assset hashing now takes asset linking into account to improve cache busting (schmunk42)
+- Enh #15015: Added `StringHelper::floatToString()` to savely cast float values independent of the locale, also fixes some places in the framework that use it now (cebe)
 
 2.0.12 June 05, 2017
 --------------------

--- a/framework/behaviors/AttributeTypecastBehavior.php
+++ b/framework/behaviors/AttributeTypecastBehavior.php
@@ -11,6 +11,7 @@ use yii\base\Behavior;
 use yii\base\InvalidParamException;
 use yii\base\Model;
 use yii\db\BaseActiveRecord;
+use yii\helpers\StringHelper;
 use yii\validators\BooleanValidator;
 use yii\validators\NumberValidator;
 use yii\validators\StringValidator;
@@ -253,6 +254,9 @@ class AttributeTypecastBehavior extends Behavior
                 case self::TYPE_BOOLEAN:
                     return (bool) $value;
                 case self::TYPE_STRING:
+                    if (is_float($value)) {
+                        return StringHelper::floatToString($value);
+                    }
                     return (string) $value;
                 default:
                     throw new InvalidParamException("Unsupported type '{$type}'");

--- a/framework/db/ColumnSchema.php
+++ b/framework/db/ColumnSchema.php
@@ -8,6 +8,7 @@
 namespace yii\db;
 
 use yii\base\BaseObject;
+use yii\helpers\StringHelper;
 
 /**
  * ColumnSchema class describes the metadata of a column in a database table.
@@ -127,9 +128,8 @@ class ColumnSchema extends BaseObject
                 }
                 if (is_float($value)) {
                     // ensure type cast always has . as decimal separator in all locales
-                    return str_replace(',', '.', (string) $value);
+                    return StringHelper::floatToString($value);
                 }
-
                 return (string) $value;
             case 'integer':
                 return (int) $value;

--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -9,6 +9,7 @@ namespace yii\db;
 
 use Yii;
 use yii\base\BaseObject;
+use yii\helpers\StringHelper;
 
 /**
  * ColumnSchemaBuilder helps to define database schema types using a PHP interface.
@@ -345,7 +346,7 @@ class ColumnSchemaBuilder extends BaseObject
                 break;
             case 'double':
                 // ensure type cast always has . as decimal separator in all locales
-                $string .= str_replace(',', '.', (string) $this->default);
+                $string .= StringHelper::floatToString($this->default);
                 break;
             case 'boolean':
                 $string .= $this->default ? 'TRUE' : 'FALSE';

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -10,6 +10,7 @@ namespace yii\db;
 use yii\base\InvalidParamException;
 use yii\base\NotSupportedException;
 use yii\helpers\ArrayHelper;
+use yii\helpers\StringHelper;
 
 /**
  * QueryBuilder builds a SELECT SQL statement based on the specification given as a [[Query]] object.
@@ -282,7 +283,7 @@ class QueryBuilder extends \yii\base\BaseObject
                     $value = $schema->quoteValue($value);
                 } elseif (is_float($value)) {
                     // ensure type cast always has . as decimal separator in all locales
-                    $value = str_replace(',', '.', (string) $value);
+                    $value = StringHelper::floatToString($value);
                 } elseif ($value === false) {
                     $value = 0;
                 } elseif ($value === null) {

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -11,6 +11,7 @@ use yii\base\InvalidParamException;
 use yii\db\Connection;
 use yii\db\Exception;
 use yii\db\Expression;
+use yii\helpers\StringHelper;
 
 /**
  * QueryBuilder is the query builder for Oracle databases.
@@ -271,7 +272,7 @@ EOD;
                     $value = $schema->quoteValue($value);
                 } elseif (is_float($value)) {
                     // ensure type cast always has . as decimal separator in all locales
-                    $value = str_replace(',', '.', (string) $value);
+                    $value = StringHelper::floatToString($value);
                 } elseif ($value === false) {
                     $value = 0;
                 } elseif ($value === null) {

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -8,6 +8,7 @@
 namespace yii\db\pgsql;
 
 use yii\base\InvalidParamException;
+use yii\helpers\StringHelper;
 
 /**
  * QueryBuilder is the query builder for PostgreSQL databases.
@@ -308,7 +309,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
                     $value = $schema->quoteValue($value);
                 } elseif (is_float($value)) {
                     // ensure type cast always has . as decimal separator in all locales
-                    $value = str_replace(',', '.', (string) $value);
+                    $value = StringHelper::floatToString($value);
                 } elseif ($value === true) {
                     $value = 'TRUE';
                 } elseif ($value === false) {

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -12,6 +12,7 @@ use yii\base\NotSupportedException;
 use yii\db\Connection;
 use yii\db\Expression;
 use yii\db\Query;
+use yii\helpers\StringHelper;
 
 /**
  * QueryBuilder is the query builder for SQLite databases.
@@ -104,7 +105,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
                     $value = $schema->quoteValue($value);
                 } elseif (is_float($value)) {
                     // ensure type cast always has . as decimal separator in all locales
-                    $value = str_replace(',', '.', (string) $value);
+                    $value = StringHelper::floatToString($value);
                 } elseif ($value === false) {
                     $value = 0;
                 } elseif ($value === null) {

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -478,7 +478,7 @@ class BaseArrayHelper
                 $value = static::getValue($element, $key);
                 if ($value !== null) {
                     if (is_float($value)) {
-                        $value = (string) $value;
+                        $value = StringHelper::floatToString($value);
                     }
                     $lastArray[$value] = $element;
                 }

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -352,7 +352,7 @@ class BaseStringHelper
     }
 
     /**
-     * Savely casts a float to string independent of the current locale.
+     * Safely casts a float to string independent of the current locale.
      *
      * The decimal separator will always be `.`.
      * @param float|int $number a floating point number or integer.

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -350,4 +350,19 @@ class BaseStringHelper
     {
         return base64_decode(strtr($input, '-_', '+/'));
     }
+
+    /**
+     * Savely casts a float to string independent of the current locale.
+     *
+     * The decimal separator will always be `.`.
+     * @param float|int $number a floating point number or integer.
+     * @return string the string representation of the number.
+     * @since 2.0.13
+     */
+    public static function floatToString($number)
+    {
+        // . and , are the only decimal separators known in ICU data,
+        // so its save to call str_replace here
+        return str_replace(',', '.', (string) $number);
+    }
 }

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -362,7 +362,7 @@ class BaseStringHelper
     public static function floatToString($number)
     {
         // . and , are the only decimal separators known in ICU data,
-        // so its save to call str_replace here
+        // so its safe to call str_replace here
         return str_replace(',', '.', (string) $number);
     }
 }

--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -11,6 +11,7 @@ use Yii;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
+use yii\helpers\StringHelper;
 use yii\helpers\VarDumper;
 use yii\web\Request;
 
@@ -359,7 +360,7 @@ abstract class Target extends Component
      */
     protected function getTime($timestamp)
     {
-        list ($timestamp, $usec) = explode('.', (string)$timestamp);
+        list ($timestamp, $usec) = explode('.', StringHelper::floatToString($timestamp));
 
         return date('Y-m-d H:i:s', $timestamp) . ($this->microtime ? ('.' . $usec) : '');
     }

--- a/framework/web/XmlResponseFormatter.php
+++ b/framework/web/XmlResponseFormatter.php
@@ -128,8 +128,8 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
     /**
      * Formats scalar value to use in XML text node.
      *
-     * @param int|string|bool $value
-     * @return string
+     * @param int|string|bool|float $value a scalar value.
+     * @return string string representation of the value.
      * @since 2.0.11
      */
     protected function formatScalarValue($value)
@@ -137,11 +137,12 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
         if ($value === true) {
             return 'true';
         }
-
         if ($value === false) {
             return 'false';
         }
-
+        if (is_float($value)) {
+            return StringHelper::floatToString($value);
+        }
         return (string) $value;
     }
 


### PR DESCRIPTION
This problem popped up in a lot of places when casting a float to
string and the locale sets a decimal separator as `,` unexpected
results occur. This adds a helper which is now called in various places
where this problem exists.

fixes #15015

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15015
