### PR TITLE
Add routePrefix AND add yii\rest\GroupUrlRule

### DIFF
--- a/framework/rest/GroupUrlRule.php
+++ b/framework/rest/GroupUrlRule.php
@@ -48,7 +48,7 @@ use yii\web\UrlRuleInterface;
  * The above example assumes the prefix for patterns and routes are the same. They can be made different
  * by configuring [[prefix]] and [[routePrefix]] separately.
  * Note: [[prefix]] can not be resolved to [[yii\rest\UrlRule::prefix]];
- * [[routePrefix]] can be resolved to [[yii\rest\UrlRule::controllerPrefix]]
+ * [[routePrefix]] can be resolved to [[yii\rest\UrlRule::routePrefix]]
  *
  * Using a GroupUrlRule is more efficient than directly declaring the individual rules it contains.
  * This is because GroupUrlRule can quickly determine if it should process a URL parsing or creation request
@@ -72,7 +72,7 @@ class GroupUrlRule extends CompositeUrlRule
      * automatically when it is put in the patterns of the generated rules.
      *
      * @see prefix
-     * @see controllerPrefix
+     * @see routePrefix
      * @see \yii\rest\UrlRule::controller
      */
     public $rules = [];
@@ -85,9 +85,9 @@ class GroupUrlRule extends CompositeUrlRule
      * @var string the prefix for the controller part of every rule declared in [[rules]].
      * The prefix and the route will be separated with a slash.
      * If this property is not set, it will take the value of [[prefix]].
-     * @see \yii\rest\UrlRule::controllerPrefix
+     * @see \yii\rest\UrlRule::routePrefix
      */
-    public $controllerPrefix;
+    public $routePrefix;
     /**
      * @var array the default configuration of URL rules. Individual rule configurations
      * specified via [[rules]] will take precedence when the same property of the rule is configured.
@@ -101,7 +101,7 @@ class GroupUrlRule extends CompositeUrlRule
     public function init()
     {
         $this->prefix = trim($this->prefix, '/');
-        $this->controllerPrefix = $this->controllerPrefix === null ? $this->prefix : trim($this->controllerPrefix, '/');
+        $this->routePrefix = $this->routePrefix === null ? $this->prefix : trim($this->routePrefix, '/');
         parent::init();
     }
 
@@ -121,9 +121,9 @@ class GroupUrlRule extends CompositeUrlRule
             $rule['prefix'] = isset($rule['prefix']) ?
                 ltrim($this->prefix . '/' . $rule['prefix'], '/') :
                 $this->prefix;
-            $rule['controllerPrefix'] = isset($rule['controllerPrefix']) ?
-                ltrim($this->controllerPrefix . '/' . $rule['controllerPrefix'], '/') :
-                $this->controllerPrefix;
+            $rule['routePrefix'] = isset($rule['routePrefix']) ?
+                ltrim($this->routePrefix . '/' . $rule['routePrefix'], '/') :
+                $this->routePrefix;
 
             $rule = Yii::createObject(array_merge($this->ruleConfig, $rule));
             if (!$rule instanceof UrlRuleInterface) {
@@ -153,7 +153,7 @@ class GroupUrlRule extends CompositeUrlRule
      */
     public function createUrl($manager, $route, $params)
     {
-        if ($this->controllerPrefix === '' || strpos($route, $this->controllerPrefix . '/') === 0) {
+        if ($this->routePrefix === '' || strpos($route, $this->routePrefix . '/') === 0) {
             return parent::createUrl($manager, $route, $params);
         }
 

--- a/framework/rest/GroupUrlRule.php
+++ b/framework/rest/GroupUrlRule.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\rest;
+
+use Yii;
+use yii\base\InvalidConfigException;
+use yii\web\CompositeUrlRule;
+use yii\web\UrlRule as WebUrlRule;
+use yii\web\UrlRuleInterface;
+
+/**
+ * GroupUrlRule represents a collection of URL rules sharing the same prefix in their patterns and routes.
+ *
+ * GroupUrlRule is best used by a module which often uses module ID as the prefix for the URL rules.
+ * For example, the following code creates a rule for the `admin` module:
+ *
+ * ```php
+ * new GroupUrlRule([
+ *     'prefix' => 'v1',
+ *     'rules' => [
+ *         'user',
+ *         [
+ *             'controller' => ['customer', 'post'],
+ *             'pluralize' => false,
+ *             'only' => ['view'],
+ *         ],
+ *     ],
+ * ]);
+ * ```
+ *
+ * The above code will create a whole set of URL rules supporting the following RESTful API endpoints:
+ *
+ * - `'PUT,PATCH v1/users/<id>' => 'v1/user/update'`: update a user
+ * - `'DELETE v1/users/<id>' => 'v1/user/delete'`: delete a user
+ * - `'GET,HEAD v1/users/<id>' => 'v1/user/view'`: return the details/overview/options of a user
+ * - `'POST v1/users' => 'v1/user/create'`: create a new user
+ * - `'GET,HEAD v1/users' => 'v1/user/index'`: return a list/overview/options of users
+ * - `'v1/users/<id>' => 'v1/user/options'`: process all unhandled verbs of a user
+ * - `'v1/users' => 'v1/user/options'`: process all unhandled verbs of user collection
+ * - `'GET,HEAD v1/customer/<id>' => 'v1/customer/view'`: return the details/overview/options of a customer
+ * - `'GET,HEAD v1/post/<id>' => 'v1/post/view'`: return the details/overview/options of a post
+ *
+ * The above example assumes the prefix for patterns and routes are the same. They can be made different
+ * by configuring [[prefix]] and [[routePrefix]] separately.
+ * Note: [[prefix]] can not be resolved to [[yii\rest\UrlRule::prefix]];
+ * [[routePrefix]] can be resolved to [[yii\rest\UrlRule::controllerPrefix]]
+ *
+ * Using a GroupUrlRule is more efficient than directly declaring the individual rules it contains.
+ * This is because GroupUrlRule can quickly determine if it should process a URL parsing or creation request
+ * by simply checking if the prefix matches.
+ *
+ * @author Qiang Xue <qiang.xue@gmail.com>
+ * @author BSCheshir <bscheshir.work@gmail.com>
+ * @since 2.0.13
+ */
+class GroupUrlRule extends CompositeUrlRule
+{
+    /**
+     * @var array the rules contained within this composite rule. Please refer to [[UrlManager::rules]]
+     * for the format of this property.
+     *
+     * A special shortcut format can be used if a rule only specifies [[\yii\rest\UrlRule::controller]]
+     * That is, instead of using a configuration array, one can use an array with the array key
+     * being as the controller ID in the pattern, and the array value the actual controller ID.
+     * For example, `'rules' => ['u' => 'user']`. You can omit the array key `'rules' => ['user']`
+     * To use [[\yii\rest\UrlRule::controller]] as default, the controller ID will be pluralized
+     * automatically when it is put in the patterns of the generated rules.
+     *
+     * @see prefix
+     * @see controllerPrefix
+     * @see \yii\rest\UrlRule::controller
+     */
+    public $rules = [];
+    /**
+     * @var string the prefix for the pattern part of every rule declared in [[rules]].
+     * The prefix and the pattern will be separated with a slash.
+     */
+    public $prefix;
+    /**
+     * @var string the prefix for the controller part of every rule declared in [[rules]].
+     * The prefix and the route will be separated with a slash.
+     * If this property is not set, it will take the value of [[prefix]].
+     * @see \yii\rest\UrlRule::controllerPrefix
+     */
+    public $controllerPrefix;
+    /**
+     * @var array the default configuration of URL rules. Individual rule configurations
+     * specified via [[rules]] will take precedence when the same property of the rule is configured.
+     */
+    public $ruleConfig = ['class' => 'yii\rest\UrlRule'];
+
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        $this->prefix = trim($this->prefix, '/');
+        $this->controllerPrefix = $this->controllerPrefix === null ? $this->prefix : trim($this->controllerPrefix, '/');
+        parent::init();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function createRules()
+    {
+        $rules = [];
+        foreach ($this->rules as $key => $rule) {
+            if (!is_array($rule)) {
+                if (!is_string($rule)) {
+                    throw new InvalidConfigException('Single rule of group REST URL rule must be a array or a string.');
+                }
+                $rule = ['controller' => [$key => $rule]];
+            }
+            $rule['prefix'] = isset($rule['prefix']) ?
+                ltrim($this->prefix . '/' . $rule['prefix'], '/') :
+                $this->prefix;
+            $rule['controllerPrefix'] = isset($rule['controllerPrefix']) ?
+                ltrim($this->controllerPrefix . '/' . $rule['controllerPrefix'], '/') :
+                $this->controllerPrefix;
+
+            $rule = Yii::createObject(array_merge($this->ruleConfig, $rule));
+            if (!$rule instanceof UrlRuleInterface) {
+                throw new InvalidConfigException('URL rule class must implement UrlRuleInterface.');
+            }
+            $rules[] = $rule;
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function parseRequest($manager, $request)
+    {
+        $pathInfo = $request->getPathInfo();
+        if ($this->prefix === '' || strpos($pathInfo . '/', $this->prefix . '/') === 0) {
+            return parent::parseRequest($manager, $request);
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createUrl($manager, $route, $params)
+    {
+        if ($this->controllerPrefix === '' || strpos($route, $this->controllerPrefix . '/') === 0) {
+            return parent::createUrl($manager, $route, $params);
+        }
+
+        $this->createStatus = WebUrlRule::CREATE_STATUS_ROUTE_MISMATCH;
+
+        return false;
+    }
+}

--- a/framework/rest/UrlRule.php
+++ b/framework/rest/UrlRule.php
@@ -63,6 +63,7 @@ class UrlRule extends CompositeUrlRule
 {
     /**
      * @var string the common prefix string shared by all patterns.
+     * The prefix and the pattern will be separated with a slash.
      */
     public $prefix;
     /**
@@ -82,6 +83,19 @@ class UrlRule extends CompositeUrlRule
      * generate applicable URL rules for EVERY specified controller. For example, `['user', 'post']`.
      */
     public $controller;
+    /**
+     * @var string the common prefix string shared by all controller (for example is a module ID).
+     * The controllerPrefix will not be a pluralize unlike of the composite controller property (e.g. `admin/user`).
+     * The controllerPrefix and the pattern will be separated with a slash.
+     * ```php
+     * [
+     *     'class' => 'yii\rest\UrlRule',
+     *     'controller' => ['user', 'post'],
+     *     'controllerPrefix' => 'v1',
+     * ]
+     * ```
+     */
+    public $controllerPrefix;
     /**
      * @var array list of acceptable actions. If not empty, only the actions within this array
      * will have the corresponding URL rules created.
@@ -151,6 +165,9 @@ class UrlRule extends CompositeUrlRule
 
         $controllers = [];
         foreach ((array) $this->controller as $urlName => $controller) {
+            if (!is_string($controller)) {
+                throw new InvalidConfigException('Controller property of REST URL rule must be a string or a array with strung values.');
+            }
             if (is_int($urlName)) {
                 $urlName = $this->pluralize ? Inflector::pluralize($controller) : $controller;
             }
@@ -159,6 +176,7 @@ class UrlRule extends CompositeUrlRule
         $this->controller = $controllers;
 
         $this->prefix = trim($this->prefix, '/');
+        $this->controllerPrefix = trim($this->controllerPrefix, '/');
 
         parent::init();
     }
@@ -174,6 +192,7 @@ class UrlRule extends CompositeUrlRule
         $rules = [];
         foreach ($this->controller as $urlName => $controller) {
             $prefix = trim($this->prefix . '/' . $urlName, '/');
+            $controller = ltrim($this->controllerPrefix . '/' . $controller, '/');
             foreach ($patterns as $pattern => $action) {
                 if (!isset($except[$action]) && (empty($only) || isset($only[$action]))) {
                     $rules[$urlName][] = $this->createRule($pattern, $prefix, $controller . '/' . $action);

--- a/framework/rest/UrlRule.php
+++ b/framework/rest/UrlRule.php
@@ -85,17 +85,17 @@ class UrlRule extends CompositeUrlRule
     public $controller;
     /**
      * @var string the common prefix string shared by all controller (for example is a module ID).
-     * The controllerPrefix will not be a pluralize unlike of the composite controller property (e.g. `admin/user`).
-     * The controllerPrefix and the pattern will be separated with a slash.
+     * The routePrefix will not be a pluralize unlike of the composite controller property (e.g. `admin/user`).
+     * The routePrefix and the pattern will be separated with a slash.
      * ```php
      * [
      *     'class' => 'yii\rest\UrlRule',
      *     'controller' => ['user', 'post'],
-     *     'controllerPrefix' => 'v1',
+     *     'routePrefix' => 'v1',
      * ]
      * ```
      */
-    public $controllerPrefix;
+    public $routePrefix;
     /**
      * @var array list of acceptable actions. If not empty, only the actions within this array
      * will have the corresponding URL rules created.
@@ -176,7 +176,7 @@ class UrlRule extends CompositeUrlRule
         $this->controller = $controllers;
 
         $this->prefix = trim($this->prefix, '/');
-        $this->controllerPrefix = trim($this->controllerPrefix, '/');
+        $this->routePrefix = trim($this->routePrefix, '/'); // @todo 2.1 BC broken //$this->routePrefix = $this->routePrefix === null ? $this->prefix : trim($this->routePrefix, '/');
 
         parent::init();
     }
@@ -192,7 +192,7 @@ class UrlRule extends CompositeUrlRule
         $rules = [];
         foreach ($this->controller as $urlName => $controller) {
             $prefix = trim($this->prefix . '/' . $urlName, '/');
-            $controller = ltrim($this->controllerPrefix . '/' . $controller, '/');
+            $controller = ltrim($this->routePrefix . '/' . $controller, '/');
             foreach ($patterns as $pattern => $action) {
                 if (!isset($except[$action]) && (empty($only) || isset($only[$action]))) {
                     $rules[$urlName][] = $this->createRule($pattern, $prefix, $controller . '/' . $action);

--- a/tests/framework/rest/GroupUrlRuleTest.php
+++ b/tests/framework/rest/GroupUrlRuleTest.php
@@ -82,6 +82,34 @@ class GroupUrlRuleTest extends TestCase
             ],
 
             [
+                'prefixed route prefixed group route',
+                [
+                    'prefix' => 'v1',
+                    'routePrefix' => 'moduleid',
+                    'rules' => [
+                        ['controller' => 'post', 'prefix' => 'admin'],
+                    ],
+                ],
+                [
+                    ['v1/admin/posts', 'moduleid/post/index'],
+                ],
+            ],
+
+            [
+                'prefixed route prefixed group route prefixed all',
+                [
+                    'prefix' => 'v1',
+                    'routePrefix' => 'moduleid',
+                    'rules' => [
+                        ['controller' => 'post', 'prefix' => 'admin', 'routePrefix' => 'controllersubfoder'],
+                    ],
+                ],
+                [
+                    ['v1/admin/posts', 'moduleid/controllersubfoder/post/index'],
+                ],
+            ],
+
+            [
                 'suffixed route',
                 [
                     'prefix' => 'v1',

--- a/tests/framework/rest/GroupUrlRuleTest.php
+++ b/tests/framework/rest/GroupUrlRuleTest.php
@@ -435,22 +435,20 @@ class GroupUrlRuleTest extends TestCase
 
     /**
      * @dataProvider createUrlDataProvider
-     * @param array $rule
+     * @param array $config
      * @param array $tests
      */
-    public function testCreateUrl($rule, $tests)
+    public function testCreateUrl($config, $tests)
     {
+        $this->mockWebApplication();
+        Yii::$app->set('request', new Request(['hostInfo' => 'http://api.example.com', 'scriptUrl' => '/index.php']));
+        $manager = new UrlManager(['cache' => null]);
+        $rule = new GroupUrlRule($config);
+
         foreach ($tests as $test) {
             list($params, $expected) = $test;
-
-            $this->mockWebApplication();
-            Yii::$app->set('request', new Request(['hostInfo' => 'http://api.example.com', 'scriptUrl' => '/index.php']));
             $route = array_shift($params);
-
-            $manager = new UrlManager([
-                'cache' => null,
-            ]);
-            $rule = new GroupUrlRule($rule);
+            
             $this->assertEquals($expected, $rule->createUrl($manager, $route, $params));
         }
     }
@@ -555,17 +553,16 @@ class GroupUrlRuleTest extends TestCase
      */
     public function testGetCreateUrlStatus($config, $tests)
     {
+        $this->mockWebApplication();
+        Yii::$app->set('request', new Request(['hostInfo' => 'http://api.example.com', 'scriptUrl' => '/index.php']));
+        $manager = new UrlManager(['cache' => null]);
+
+        $rule = new GroupUrlRule($config);
+
         foreach ($tests as $test) {
             list($params, $expected, $status) = $test;
-
-            $this->mockWebApplication();
-            Yii::$app->set('request', new Request(['hostInfo' => 'http://api.example.com', 'scriptUrl' => '/index.php']));
             $route = array_shift($params);
 
-            $manager = new UrlManager([
-                'cache' => null,
-            ]);
-            $rule = new GroupUrlRule($config);
             $errorMessage = 'Failed test: ' . VarDumper::dumpAsString($test);
             $this->assertSame($expected, $rule->createUrl($manager, $route, $params), $errorMessage);
             $this->assertNotNull($status, $errorMessage);

--- a/tests/framework/rest/GroupUrlRuleTest.php
+++ b/tests/framework/rest/GroupUrlRuleTest.php
@@ -1,0 +1,580 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\rest;
+
+use Yii;
+use yii\helpers\VarDumper;
+use yii\rest\GroupUrlRule;
+use yii\web\Request;
+use yii\web\UrlManager;
+use yii\web\UrlRule as WebUrlRule;
+use yiiunit\TestCase;
+
+/**
+ * @group rest
+ */
+class GroupUrlRuleTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mockApplication();
+    }
+
+
+    /**
+     * Provides test cases for testParseRequest() method.
+     *
+     * - first param are message for the test
+     * - second param is an config for the URL rule
+     * - thirds param is an array of test cases, containing four element arrays:
+     *   - first element is a pathInfo
+     *   - second element is a expected route, or false if the rule doesn't apply
+     *   - thirds element is a expected params
+     *   - fourth element is a method
+     */
+    public function parseRequestDataProvider(){
+        return [
+            [
+                'short syntax',
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        'post',
+                        'p' => 'post',
+                    ],
+                ],
+                [
+                    ['v1/posts', 'v1/post/index'],
+                    ['v1/p', 'v1/post/index'],
+                ],
+            ],
+
+            [
+                'pluralized name',
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        ['controller' => 'post'],
+                    ],
+                ],
+                [
+                    ['v1/posts', 'v1/post/index'],
+                ],
+            ],
+
+            [
+                'prefixed route',
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        ['controller' => 'post', 'prefix' => 'admin'],
+                    ],
+                ],
+                [
+                    ['v1/admin/posts', 'v1/post/index'],
+                ],
+            ],
+
+            [
+                'suffixed route',
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        ['controller' => 'post', 'suffix' => '.json'],
+                    ],
+                ],
+                [
+                    ['v1/posts.json', 'v1/post/index'],
+                    ['v1/posts.json', 'v1/post/create', [], 'POST'],
+                    ['v1/posts/123.json', 'v1/post/view', ['id' => 123], 'GET'],
+                ],
+            ],
+
+            [
+                'default routes according request method',
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        ['controller' => 'post'],
+                    ],
+                ],
+                [
+                    ['v1/posts', 'v1/post/index', [], 'GET'],
+                    ['v1/posts', 'v1/post/index', [], 'HEAD'],
+                    ['v1/posts', 'v1/post/create', [], 'POST'],
+                    ['v1/posts', 'v1/post/options', [], 'PATCH'],
+                    ['v1/posts', 'v1/post/options', [], 'PUT'],
+                    ['v1/posts', 'v1/post/options', [], 'DELETE'],
+
+                    ['v1/posts/123', 'v1/post/view', ['id' => 123], 'GET'],
+                    ['v1/posts/123', 'v1/post/view', ['id' => 123], 'HEAD'],
+                    ['v1/posts/123', 'v1/post/options', ['id' => 123], 'POST'],
+                    ['v1/posts/123', 'v1/post/update', ['id' => 123], 'PATCH'],
+                    ['v1/posts/123', 'v1/post/update', ['id' => 123], 'PUT'],
+                    ['v1/posts/123', 'v1/post/delete', ['id' => 123], 'DELETE'],
+
+                    ['v1/posts/new', false],
+                ],
+            ],
+
+            [
+                'only selected routes',
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        ['controller' => 'post', 'only' => ['index']],
+                    ],
+                ],
+                [
+                    ['v1/posts', 'v1/post/index'],
+                    ['v1/posts/123', false],
+                    ['v1/posts', false, [], 'POST'],
+                ],
+            ],
+
+            [
+                'except routes',
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        ['controller' => 'post', 'except' => ['delete', 'create']],
+                    ],
+                ],
+                [
+                    ['v1/posts', 'v1/post/index'],
+                    ['v1/posts/123', 'v1/post/view', ['id' => 123]],
+                    ['v1/posts/123', 'v1/post/options', ['id' => 123], 'DELETE'],
+                    ['v1/posts', 'v1/post/options', [], 'POST'],
+                ],
+            ],
+
+            [
+                'extra patterns',
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        ['controller' => 'post', 'extraPatterns' => ['POST new' => 'create']],
+                    ],
+                ],
+                [
+                    ['v1/posts/new', 'v1/post/create', [], 'POST'],
+                    ['v1/posts', 'v1/post/create', [], 'POST'],
+                ],
+            ],
+
+            [
+                'extra patterns overwrite patterns',
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        ['controller' => 'post', 'extraPatterns' => ['POST' => 'new']],
+                    ],
+                ],
+                [
+                    ['v1/posts', 'v1/post/new', [], 'POST'],
+                ],
+            ],
+
+            [
+                'extra patterns rule is higher priority than patterns',
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        ['controller' => 'post', 'extraPatterns' => ['GET 1337' => 'leet']],
+                    ],
+                ],
+                [
+                    ['v1/posts/1337', 'v1/post/leet'],
+                    ['v1/posts/1338', 'v1/post/view', ['id' => 1338]],
+                ],
+            ],
+        ];
+
+    }
+
+    /**
+     * @dataProvider parseRequestDataProvider
+     * @param $name
+     * @param $config
+     * @param $tests
+     */
+    public function testParseRequest($name, $config, $tests)
+    {
+        static $i;
+        $i++;
+        $manager = new UrlManager(['cache' => null]);
+        $request = new Request(['hostInfo' => 'http://en.example.com', 'methodParam' => '_METHOD']);
+        $rule = new GroupUrlRule($config);
+        foreach ($tests as $j => $test) {
+            $request->pathInfo = $test[0];
+            $route = $test[1];
+            $params = isset($test[2]) ? $test[2] : [];
+            $_POST['_METHOD'] = isset($test[3]) ? $test[3] : 'GET';
+            $result = $rule->parseRequest($manager, $request);
+            if ($route === false) {
+                $this->assertFalse($result, "Test#$i-$j: $name");
+            } else {
+                $this->assertEquals([$route, $params], $result, "Test#$i-$j: $name");
+            }
+        }
+    }
+
+
+
+    /**
+     * Provides test cases for createUrl() method.
+     *
+     * - first param are properties of the UrlRule
+     * - second param is an array of test cases, containing two element arrays:
+     *   - first element is the route to create
+     *   - second element is the expected URL
+     */
+    public function createUrlDataProvider()
+    {
+        return [
+            // with pluralize
+            // single controller, string
+            [
+                [ // Rule properties
+                    'prefix' => 'v1',
+                    'rules' => [
+                        [
+                            'controller' => 'channel',
+                            'pluralize' => true,
+                        ],
+                    ],
+                ],
+                [ // test cases: route, expected
+                    [['v1/channel/index'], 'v1/channels'],
+                    [['v1/channel/index', 'offset' => 1], 'v1/channels?offset=1'],
+                    [['v1/channel/view', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/options'], 'v1/channels'],
+                    [['v1/channel/options', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/delete'], false],
+                ],
+            ],
+            // with pluralize
+            // single controller, array
+            [
+                [ // Rule properties
+                    'prefix' => 'v1',
+                    'rules' => [
+                        [
+                            'controller' => ['channel'],
+                            'pluralize' => true,
+                        ],
+                    ],
+                ],
+                [ // test cases: route, expected
+                    [['v1/channel/index'], 'v1/channels'],
+                    [['v1/channel/index', 'offset' => 1], 'v1/channels?offset=1'],
+                    [['v1/channel/view', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/options'], 'v1/channels'],
+                    [['v1/channel/options', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/delete'], false],
+                ],
+            ],
+            // with pluralize
+            // multiple controller, key-value pair
+            [
+                [ // Rule properties
+                    'prefix' => 'v1',
+                    'rules' => [
+                        [
+                            'controller' => ['channel', 'u' => 'user'],
+                            'pluralize' => true,
+                        ],
+                    ],
+                ],
+                [ // test cases: route, expected
+                    [['v1/channel/index'], 'v1/channels'],
+                    [['v1/channel/view', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/options'], 'v1/channels'],
+                    [['v1/channel/options', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/delete'], false],
+                    [['v1/user/index'], 'v1/u'],
+                    [['v1/user/view', 'id' => 1], 'v1/u/1'],
+                    [['v1/channel/options'], 'v1/channels'],
+                    [['v1/channel/options', 'id' => 42], 'v1/channels/42'],
+                    [['v1/user/delete'], false],
+                ],
+            ],
+            // with pluralize
+            // short syntax array, key-value pair
+            [
+                [ // Rule properties
+                    'prefix' => 'v1',
+                    'rules' => [
+                        'channel',
+                        'u' => 'user',
+                    ],
+                ],
+                [ // test cases: route, expected
+                    [['v1/channel/index'], 'v1/channels'],
+                    [['v1/channel/view', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/options'], 'v1/channels'],
+                    [['v1/channel/options', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/delete'], false],
+                    [['v1/user/index'], 'v1/u'],
+                    [['v1/user/view', 'id' => 1], 'v1/u/1'],
+                    [['v1/channel/options'], 'v1/channels'],
+                    [['v1/channel/options', 'id' => 42], 'v1/channels/42'],
+                    [['v1/user/delete'], false],
+                ],
+            ],
+
+
+            // without pluralize
+            // single controller, string
+            [
+                [ // Rule properties
+                    'prefix' => 'v1',
+                    'rules' => [
+                        [
+                            'controller' => 'channel',
+                            'pluralize' => false,
+                        ],
+                    ],
+                ],
+                [ // test cases: route, expected
+                    [['v1/channel/index'], 'v1/channel'],
+                    [['v1/channel/index', 'offset' => 1], 'v1/channel?offset=1'],
+                    [['v1/channel/view', 'id' => 42], 'v1/channel/42'],
+                    [['v1/channel/options'], 'v1/channel'],
+                    [['v1/channel/options', 'id' => 42], 'v1/channel/42'],
+                    [['v1/channel/delete'], false],
+                ],
+            ],
+            // without pluralize
+            // single controller, array
+            [
+                [ // Rule properties
+                    'prefix' => 'v1',
+                    'rules' => [
+                        [
+                            'controller' => ['channel'],
+                            'pluralize' => false,
+                        ],
+                    ],
+                ],
+                [ // test cases: route, expected
+                    [['v1/channel/index'], 'v1/channel'],
+                    [['v1/channel/index', 'offset' => 1], 'v1/channel?offset=1'],
+                    [['v1/channel/view', 'id' => 42], 'v1/channel/42'],
+                    [['v1/channel/options'], 'v1/channel'],
+                    [['v1/channel/options', 'id' => 42], 'v1/channel/42'],
+                    [['v1/channel/delete'], false],
+                ],
+            ],
+            // without pluralize
+            // multiple controller, key-value pair
+            [
+                [ // Rule properties
+                    'prefix' => 'v1',
+                    'rules' => [
+                        [
+                            'controller' => ['channel', 'u' => 'user'],
+                            'pluralize' => false,
+                        ],
+                    ],
+                ],
+                [ // test cases: route, expected
+                    [['v1/channel/index'], 'v1/channel'],
+                    [['v1/channel/view', 'id' => 42], 'v1/channel/42'],
+                    [['v1/channel/options'], 'v1/channel'],
+                    [['v1/channel/options', 'id' => 42], 'v1/channel/42'],
+                    [['v1/channel/delete'], false],
+                    [['v1/user/index'], 'v1/u'],
+                    [['v1/user/view', 'id' => 1], 'v1/u/1'],
+                    [['v1/user/options'], 'v1/u'],
+                    [['v1/user/options', 'id' => 42], 'v1/u/42'],
+                    [['v1/user/delete'], false],
+                ],
+            ],
+
+            // using extra patterns
+            [
+                [ // Rule properties
+                    'prefix' => 'v1',
+                    'rules' => [
+                        [
+                            'controller' => 'channel',
+                            'pluralize' => true,
+                            'extraPatterns' => [
+                                '{id}/my' => 'my',
+                                'my' => 'my',
+                                // this should not create a URL, no GET definition
+                                'POST {id}/my2' => 'my2',
+                            ],
+                        ],
+                    ],
+                ],
+                [ // test cases: route, expected
+                    // normal actions should behave as before
+                    [['v1/channel/index'], 'v1/channels'],
+                    [['v1/channel/index', 'offset' => 1], 'v1/channels?offset=1'],
+                    [['v1/channel/view', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/options'], 'v1/channels'],
+                    [['v1/channel/options', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/delete'], false],
+
+                    [['v1/channel/my'], 'v1/channels/my'],
+                    [['v1/channel/my', 'id' => 42], 'v1/channels/42/my'],
+                    [['v1/channel/my2'], false],
+                    [['v1/channel/my2', 'id' => 42], false],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider createUrlDataProvider
+     * @param array $rule
+     * @param array $tests
+     */
+    public function testCreateUrl($rule, $tests)
+    {
+        foreach ($tests as $test) {
+            list($params, $expected) = $test;
+
+            $this->mockWebApplication();
+            Yii::$app->set('request', new Request(['hostInfo' => 'http://api.example.com', 'scriptUrl' => '/index.php']));
+            $route = array_shift($params);
+
+            $manager = new UrlManager([
+                'cache' => null,
+            ]);
+            $rule = new GroupUrlRule($rule);
+            $this->assertEquals($expected, $rule->createUrl($manager, $route, $params));
+        }
+    }
+
+
+    /**
+     * Provides test cases for getCreateUrlStatus() method.
+     *
+     * - first param are properties of the UrlRule
+     * - second param is an array of test cases, containing two element arrays:
+     *   - first element is the route to create
+     *   - second element is the expected URL
+     *   - third element is the expected result of getCreateUrlStatus() method
+     */
+    public function testGetCreateUrlStatusProvider()
+    {
+        return [
+            'single controller' => [
+                // rule properties
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        [
+                            'controller' => ['channel'],
+                            'pluralize' => true,
+                        ],
+                    ],
+                ],
+                // test cases: route, expected, createStatus
+                [
+                    [['v1/channel/index'], 'v1/channels', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/index', 'offset' => 1], 'v1/channels?offset=1', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/view', 'id' => 42], 'v1/channels/42', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/options'], 'v1/channels', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/options', 'id' => 42], 'v1/channels/42', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/delete'], false, WebUrlRule::CREATE_STATUS_PARSING_ONLY],
+                    [['v1/missing/view'], false, WebUrlRule::CREATE_STATUS_ROUTE_MISMATCH],
+                    [['v1/channel/view'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
+                ],
+            ],
+            'multiple controllers' => [
+                // rule properties
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        [
+                            'controller' => ['channel', 'u' => 'user'],
+                            'pluralize' => false,
+                        ],
+                    ],
+                ],
+                // test cases: route, expected, createStatus
+                [
+                    [['v1/channel/index'], 'v1/channel', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/view', 'id' => 42], 'v1/channel/42', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/options'], 'v1/channel', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/options', 'id' => 42], 'v1/channel/42', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/delete'], false, WebUrlRule::CREATE_STATUS_PARSING_ONLY],
+                    [['v1/user/index'], 'v1/u', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/view', 'id' => 1], 'v1/u/1', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/options'], 'v1/u', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/options', 'id' => 42], 'v1/u/42', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/delete'], false, WebUrlRule::CREATE_STATUS_PARSING_ONLY],
+                    [['v1/user/view'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
+                    [['v1/missing/view'], false, WebUrlRule::CREATE_STATUS_ROUTE_MISMATCH],
+                ],
+            ],
+            'short syntax' => [
+                // rule properties
+                [
+                    'prefix' => 'v1',
+                    'rules' => [
+                        'channel',
+                        'u' => 'user',
+                    ],
+                ],
+                // test cases: route, expected, createStatus
+                [
+                    [['v1/channel/index'], 'v1/channels', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/index', 'offset' => 1], 'v1/channels?offset=1', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/view', 'id' => 42], 'v1/channels/42', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/options'], 'v1/channels', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/options', 'id' => 42], 'v1/channels/42', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/delete'], false, WebUrlRule::CREATE_STATUS_PARSING_ONLY],
+                    [['v1/missing/view'], false, WebUrlRule::CREATE_STATUS_ROUTE_MISMATCH],
+                    [['v1/channel/view'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
+                    [['v1/user/index'], 'v1/u', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/view', 'id' => 1], 'v1/u/1', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/options'], 'v1/u', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/options', 'id' => 42], 'v1/u/42', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/delete'], false, WebUrlRule::CREATE_STATUS_PARSING_ONLY],
+                    [['v1/user/view'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider testGetCreateUrlStatusProvider
+     * @param array $config
+     * @param array $tests
+     */
+    public function testGetCreateUrlStatus($config, $tests)
+    {
+        foreach ($tests as $test) {
+            list($params, $expected, $status) = $test;
+
+            $this->mockWebApplication();
+            Yii::$app->set('request', new Request(['hostInfo' => 'http://api.example.com', 'scriptUrl' => '/index.php']));
+            $route = array_shift($params);
+
+            $manager = new UrlManager([
+                'cache' => null,
+            ]);
+            $rule = new GroupUrlRule($config);
+            $errorMessage = 'Failed test: ' . VarDumper::dumpAsString($test);
+            $this->assertSame($expected, $rule->createUrl($manager, $route, $params), $errorMessage);
+            $this->assertNotNull($status, $errorMessage);
+            if ($status > 0) {
+                $this->assertSame($status, $rule->getCreateUrlStatus() & $status, $errorMessage);
+            } else {
+                $this->assertSame($status, $rule->getCreateUrlStatus(), $errorMessage);
+            }
+        }
+    }
+
+}

--- a/tests/framework/rest/UrlRuleTest.php
+++ b/tests/framework/rest/UrlRuleTest.php
@@ -230,6 +230,7 @@ class UrlRuleTest extends TestCase
                 [ // Rule properties
                     'controller' => 'channel',
                     'controllerPrefix' => 'v1',
+                    'prefix' => 'v1',
                     'pluralize' => true,
                 ],
                 [ // test cases: route, expected

--- a/tests/framework/rest/UrlRuleTest.php
+++ b/tests/framework/rest/UrlRuleTest.php
@@ -89,6 +89,13 @@ class UrlRuleTest extends TestCase
                 ],
             ],
             [
+                'prefixed route and controller',
+                ['controller' => 'post', 'controllerPrefix' => 'v1', 'prefix' => 'admin'],
+                [
+                    ['admin/posts', 'v1/post/index'],
+                ],
+            ],
+            [
                 'suffixed route',
                 ['controller' => 'post', 'suffix' => '.json'],
                 [
@@ -218,6 +225,22 @@ class UrlRuleTest extends TestCase
     public function createUrlDataProvider()
     {
         return [
+            // with prefix
+            [
+                [ // Rule properties
+                    'controller' => 'channel',
+                    'controllerPrefix' => 'v1',
+                    'pluralize' => true,
+                ],
+                [ // test cases: route, expected
+                    [['v1/channel/index'], 'v1/channels'],
+                    [['v1/channel/index', 'offset' => 1], 'v1/channels?offset=1'],
+                    [['v1/channel/view', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/options'], 'v1/channels'],
+                    [['v1/channel/options', 'id' => 42], 'v1/channels/42'],
+                    [['v1/channel/delete'], false],
+                ],
+            ],
             // with pluralize
             [
                 [ // Rule properties

--- a/tests/framework/rest/UrlRuleTest.php
+++ b/tests/framework/rest/UrlRuleTest.php
@@ -90,7 +90,7 @@ class UrlRuleTest extends TestCase
             ],
             [
                 'prefixed route and controller',
-                ['controller' => 'post', 'controllerPrefix' => 'v1', 'prefix' => 'admin'],
+                ['controller' => 'post', 'routePrefix' => 'v1', 'prefix' => 'admin'],
                 [
                     ['admin/posts', 'v1/post/index'],
                 ],
@@ -229,7 +229,7 @@ class UrlRuleTest extends TestCase
             [
                 [ // Rule properties
                     'controller' => 'channel',
-                    'controllerPrefix' => 'v1',
+                    'routePrefix' => 'v1',
                     'prefix' => 'v1',
                     'pluralize' => true,
                 ],


### PR DESCRIPTION
This PR is part 2 of split. Same as #14996, applied #15042 changes

For more "versioned" of config of `RESTful` `api` application

All of rules of major version is one rest\GroupUrlRule;
In nested rules `module` prefix is omitted;

Current
```php
return [
    'modules' => [
        'v1' => [
            'class' => 'app\modules\v1\Module',
        ],
        'v2' => [
            'class' => 'app\modules\v2\Module',
        ],
    ],
    'components' => [
        'urlManager' => [
            'enablePrettyUrl' => true,
            'enableStrictParsing' => true,
            'showScriptName' => false,
            'rules' => [
                ['class' => 'yii\rest\UrlRule', 'controller' => ['v1/user', 'v1/post']],
                ['class' => 'yii\rest\UrlRule', 'controller' => ['v2/user', 'v2/post']],
            ],
        ],
    ],
];
```
propose
```php
return [
    'modules' => [
        'v1' => [
            'class' => 'app\modules\v1\Module',
        ],
        'v2' => [
            'class' => 'app\modules\v2\Module',
        ],
    ],
    'components' => [
        'urlManager' => [
            'enablePrettyUrl' => true,
            'enableStrictParsing' => true,
            'showScriptName' => false,
            'rules' => [
                // v1
                [
                    'class' => 'yii\rest\GroupUrlRule',
                    'prefix' => 'v1',
                    'rules' => [
                        [
                            'controller' => 'post',
                            'pluralize' => false,
                            'only' => ['index', 'view', 'options'],
                        ],
                       'user',
                        //another yii\rest\UrlRule of v1 module with differences in params
                    ],
                ],
                // v2
                [
                    'class' => 'yii\rest\GroupUrlRule',
                    'prefix' => 'v2',
                    'rules' => [
                        [
                            'controller' => 'post',
                            'pluralize' => false,
                            'only' => ['index', 'view', 'options'],
                        ],
                        'u' => 'user',
                        //another yii\rest\UrlRule of v2 module with differences in params
                    ],
                ],
                //...
            ],
        ],
    ],
];
```


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | related #14996 #15042
