### PR TITLE
Fix duplicated columns in Query::addSelect

### DIFF
--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -590,7 +590,20 @@ PATTERN;
         if ($this->select === null) {
             $this->select = $columns;
         } else {
-            $this->select = array_unique(array_merge($this->select, $columns), SORT_STRING);
+            foreach ($columns as $columnName => $columnDefinition) {
+                if (($columnDefinition instanceof Query) || !in_array($columnDefinition, $this->select, true)) {
+                    if (is_string($columnName))
+                        $this->select[$columnName] = $columnDefinition;
+                    else
+                        $this->select[] = $columnDefinition;
+                } else {
+                    $column_alias = array_search($columnDefinition, $this->select, true);
+                    if (is_string($columnName) && $column_alias != $columnName)
+                        $this->select[$columnName] = $columnDefinition;
+                    else if (is_string($column_alias) && !is_string($columnName))
+                        $this->select[] = $columnDefinition;
+                }
+            }
         }
 
         return $this;

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -605,15 +605,13 @@ PATTERN;
      */
     protected function removeDuplicatedColumns($columns)
     {
-        // delete simple columns duplicates
-        $simpleColumns = array_filter($this->select, 'is_integer', ARRAY_FILTER_USE_KEY);
 
         foreach ($columns as $columnName => $columnDefinition) {
             if ($columnDefinition instanceof Query)
                 continue;
 
             if ((is_string($columnName) && isset($this->select[$columnName]) && $this->select[$columnName] === $columnDefinition) ||
-                (is_integer($columnName) && in_array($columnDefinition, $simpleColumns)))
+                (is_integer($columnName) && in_array($columnDefinition, array_filter($this->select, 'is_integer', ARRAY_FILTER_USE_KEY))))
                 unset($columns[$columnName]);
         }
         return $columns;

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -590,7 +590,7 @@ PATTERN;
         if ($this->select === null) {
             $this->select = $columns;
         } else {
-            $this->select = array_unique(array_merge($this->select, $columns), SORT_REGULAR);
+            $this->select = array_unique(array_merge($this->select, $columns), SORT_STRING);
         }
 
         return $this;

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -590,7 +590,7 @@ PATTERN;
         if ($this->select === null) {
             $this->select = $columns;
         } else {
-            $this->select = array_unique(array_merge($this->select, $columns));
+            $this->select = array_unique(array_merge($this->select, $columns), SORT_REGULAR);
         }
 
         return $this;

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -597,11 +597,16 @@ PATTERN;
                     else
                         $this->select[] = $columnDefinition;
                 } else {
-                    $column_alias = array_search($columnDefinition, $this->select, true);
-                    if (is_string($columnName) && $column_alias != $columnName)
+                    if (is_string($columnName) && (!isset($this->select[$columnName]) || $this->select[$columnName] !== $columnDefinition))
                         $this->select[$columnName] = $columnDefinition;
-                    else if (is_string($column_alias) && !is_string($columnName))
+                    else if (!is_string($columnName)) {
+                        foreach ($this->select as $selectAlias => $selectDefinition) {
+                            if ($selectDefinition === $columnDefinition && !is_string($selectAlias))
+                                continue(2);
+                        }
                         $this->select[] = $columnDefinition;
+                    }
+
                 }
             }
         }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -590,28 +590,38 @@ PATTERN;
         if ($this->select === null) {
             $this->select = $columns;
         } else {
-            foreach ($columns as $columnName => $columnDefinition) {
-                if (($columnDefinition instanceof Query) || !in_array($columnDefinition, $this->select, true)) {
-                    if (is_string($columnName))
-                        $this->select[$columnName] = $columnDefinition;
-                    else
-                        $this->select[] = $columnDefinition;
-                } else {
-                    if (is_string($columnName) && (!isset($this->select[$columnName]) || $this->select[$columnName] !== $columnDefinition))
-                        $this->select[$columnName] = $columnDefinition;
-                    else if (!is_string($columnName)) {
-                        foreach ($this->select as $selectAlias => $selectDefinition) {
-                            if ($selectDefinition === $columnDefinition && !is_string($selectAlias))
-                                continue(2);
-                        }
-                        $this->select[] = $columnDefinition;
-                    }
-
-                }
-            }
+            $this->mergeSelect($columns);
         }
 
         return $this;
+    }
+
+    /**
+     * Merges given columns definitions into current query.
+     *
+     * @param array $columns the columns to be merged to the select.
+     */
+    protected function mergeSelect($columns)
+    {
+        foreach ($columns as $columnName => $columnDefinition) {
+            if (($columnDefinition instanceof Query) || !in_array($columnDefinition, $this->select, true)) {
+                if (is_string($columnName))
+                    $this->select[$columnName] = $columnDefinition;
+                else
+                    $this->select[] = $columnDefinition;
+            } else {
+                if (is_string($columnName) && (!isset($this->select[$columnName]) || $this->select[$columnName] !== $columnDefinition))
+                    $this->select[$columnName] = $columnDefinition;
+                else if (!is_string($columnName)) {
+                    foreach ($this->select as $selectAlias => $selectDefinition) {
+                        if ($selectDefinition === $columnDefinition && !is_string($selectAlias))
+                            continue(2);
+                    }
+                    $this->select[] = $columnDefinition;
+                }
+
+            }
+        }
     }
 
     /**

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -606,15 +606,24 @@ PATTERN;
     protected function removeDuplicatedColumns($columns)
     {
         foreach ($columns as $columnName => $columnDefinition) {
-            if ($columnDefinition instanceof Query)
+            if ($columnDefinition instanceof Query) {
                 continue;
+            }
 
-            if (is_string($columnName) && isset($this->select[$columnName]) && $this->select[$columnName] == $columnDefinition)
+            if (is_string($columnName) && isset($this->select[$columnName]) && $this->select[$columnName] === $columnDefinition) {
                 unset($columns[$columnName]);
+            }
 
             // check if column is already present with numeric key
-            if (is_integer($columnName) && in_array($columnDefinition, array_filter($this->select, function ($def, $key) { return is_integer($key); }, ARRAY_FILTER_USE_BOTH)))
+            if (is_integer($columnName) && in_array($columnDefinition, array_filter(
+                $this->select,
+                function ($def, $key) {
+                    return is_integer($key);
+                },
+                ARRAY_FILTER_USE_BOTH
+            ))) {
                 unset($columns[$columnName]);
+            }
         }
         return $columns;
     }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -590,7 +590,7 @@ PATTERN;
         if ($this->select === null) {
             $this->select = $columns;
         } else {
-            $this->select = array_merge($this->select, $columns);
+            $this->select = array_unique(array_merge($this->select, $columns));
         }
 
         return $this;

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -605,13 +605,18 @@ PATTERN;
      */
     protected function removeDuplicatedColumns($columns)
     {
+        $numeric_values = [];
+        foreach ($this->select as $columnName => $columnDefinition) {
+            if (is_integer($columnName))
+                $numeric_values[] = $columnDefinition;
+        }
 
         foreach ($columns as $columnName => $columnDefinition) {
             if ($columnDefinition instanceof Query)
                 continue;
 
             if ((is_string($columnName) && isset($this->select[$columnName]) && $this->select[$columnName] === $columnDefinition) ||
-                (is_integer($columnName) && in_array($columnDefinition, array_filter($this->select, 'is_integer', ARRAY_FILTER_USE_KEY))))
+                (is_integer($columnName) && in_array($columnDefinition, $numeric_values)))
                 unset($columns[$columnName]);
         }
         return $columns;

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -1194,6 +1194,6 @@ PATTERN;
      */
     public function __toString()
     {
-        return $this->createCommand()->getSql();
+        return serialize($this);
     }
 }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -605,21 +605,30 @@ PATTERN;
      */
     protected function removeDuplicatedColumns($columns)
     {
-        $numeric_values = [];
-        foreach ($this->select as $columnName => $columnDefinition) {
-            if (is_integer($columnName))
-                $numeric_values[] = $columnDefinition;
-        }
+        $simple_columns = $this->filterSimpleColumnsFromSelect();
 
         foreach ($columns as $columnName => $columnDefinition) {
             if ($columnDefinition instanceof Query)
                 continue;
 
             if ((is_string($columnName) && isset($this->select[$columnName]) && $this->select[$columnName] === $columnDefinition) ||
-                (is_integer($columnName) && in_array($columnDefinition, $numeric_values)))
+                (is_integer($columnName) && in_array($columnDefinition, $simple_columns)))
                 unset($columns[$columnName]);
         }
         return $columns;
+    }
+
+    /**
+     * @return array List of simple columns from query SELECT
+     */
+    protected function filterSimpleColumnsFromSelect()
+    {
+        $result = [];
+        foreach ($this->select as $name => $value) {
+            if (is_integer($name) && !in_array($value, $result))
+                $result[] = $value;
+        }
+        return $result;
     }
 
     /**

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -560,7 +560,7 @@ PATTERN;
         } elseif (!is_array($columns)) {
             $columns = preg_split('/\s*,\s*/', trim($columns), -1, PREG_SPLIT_NO_EMPTY);
         }
-        $this->select = $columns;
+        $this->select = $this->getUniqueColumns($columns);
         $this->selectOption = $option;
         return $this;
     }
@@ -587,10 +587,11 @@ PATTERN;
         } elseif (!is_array($columns)) {
             $columns = preg_split('/\s*,\s*/', trim($columns), -1, PREG_SPLIT_NO_EMPTY);
         }
+        $columns = $this->getUniqueColumns($columns);
         if ($this->select === null) {
             $this->select = $columns;
         } else {
-            $this->select = array_merge($this->select, $this->getUniqueColumns($columns));
+            $this->select = array_merge($this->select, $columns);
         }
 
         return $this;
@@ -606,7 +607,7 @@ PATTERN;
      */
     protected function getUniqueColumns($columns)
     {
-        $simpleColumns = $this->getUnaliasedColumnsFromSelect();
+        $unaliasedColumns = $this->getUnaliasedColumnsFromSelect();
         $columns = array_unique($columns);
 
         foreach ($columns as $columnAlias => $columnDefinition) {
@@ -615,7 +616,7 @@ PATTERN;
             }
 
             if ((is_string($columnAlias) && isset($this->select[$columnAlias]) && $this->select[$columnAlias] === $columnDefinition) ||
-                (is_integer($columnAlias) && in_array($columnDefinition, $simpleColumns))) {
+                (is_integer($columnAlias) && in_array($columnDefinition, $unaliasedColumns))) {
                 unset($columns[$columnAlias]);
             }
         }
@@ -629,9 +630,11 @@ PATTERN;
     protected function getUnaliasedColumnsFromSelect()
     {
         $result = [];
-        foreach ($this->select as $name => $value) {
-            if (is_integer($name)) {
-                $result[] = $value;
+        if (is_array($this->select)) {
+            foreach ($this->select as $name => $value) {
+                if (is_integer($name)) {
+                    $result[] = $value;
+                }
             }
         }
         return array_unique($result);

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -605,6 +605,7 @@ PATTERN;
      */
     protected function removeDuplicatedColumns($columns)
     {
+        $simpleColumns = array_intersect_key($this->select, array_fill_keys(array_filter(array_keys($this->select), 'is_integer'), null));
         foreach ($columns as $columnName => $columnDefinition) {
             if ($columnDefinition instanceof Query) {
                 continue;
@@ -615,15 +616,8 @@ PATTERN;
             }
 
             // check if column is already present with numeric key
-            if (is_integer($columnName) && in_array($columnDefinition, array_filter(
-                $this->select,
-                function ($def, $key) {
-                    return is_integer($key);
-                },
-                ARRAY_FILTER_USE_BOTH
-            ))) {
+            if (is_integer($columnName) && in_array($columnDefinition, $simpleColumns))
                 unset($columns[$columnName]);
-            }
         }
         return $columns;
     }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -598,7 +598,9 @@ PATTERN;
 
     /**
      * Removes duplicated columns from given columns definitions.
-     *
+     * Columns to be removed:
+     * - if column definition already present in SELECT part with same alias
+     * - if column definition without alias already present in SELECT part without alias too
      * @param array $columns the columns to be merged to the select.
      */
     protected function removeDuplicatedColumns($columns)
@@ -610,15 +612,9 @@ PATTERN;
             if (is_string($columnName) && isset($this->select[$columnName]) && $this->select[$columnName] == $columnDefinition)
                 unset($columns[$columnName]);
 
-
-            if (!is_string($columnName) && in_array($columnDefinition, $this->select)) {
-                foreach ($this->select as $selectAlias => $selectDefinition) {
-                    if (!is_string($selectAlias) && $selectDefinition === $columnDefinition) {
-                        unset($columns[$columnName]);
-                        break;
-                    }
-                }
-            }
+            // check if column is already present with numeric key
+            if (is_integer($columnName) && in_array($columnDefinition, array_filter($this->select, function ($def, $key) { return is_integer($key); }, ARRAY_FILTER_USE_BOTH)))
+                unset($columns[$columnName]);
         }
         return $columns;
     }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -605,18 +605,15 @@ PATTERN;
      */
     protected function removeDuplicatedColumns($columns)
     {
+        // delete simple columns duplicates
         $simpleColumns = array_filter($this->select, 'is_integer', ARRAY_FILTER_USE_KEY);
+
         foreach ($columns as $columnName => $columnDefinition) {
-            if ($columnDefinition instanceof Query) {
+            if ($columnDefinition instanceof Query)
                 continue;
-            }
 
-            if (is_string($columnName) && isset($this->select[$columnName]) && $this->select[$columnName] === $columnDefinition) {
-                unset($columns[$columnName]);
-            }
-
-            // check if column is already present with numeric key
-            if (is_integer($columnName) && in_array($columnDefinition, $simpleColumns))
+            if ((is_string($columnName) && isset($this->select[$columnName]) && $this->select[$columnName] === $columnDefinition) ||
+                (is_integer($columnName) && in_array($columnDefinition, $simpleColumns)))
                 unset($columns[$columnName]);
         }
         return $columns;

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -615,8 +615,10 @@ PATTERN;
                 continue;
             }
 
-            if ((is_string($columnAlias) && isset($this->select[$columnAlias]) && $this->select[$columnAlias] === $columnDefinition) ||
-                (is_integer($columnAlias) && in_array($columnDefinition, $unaliasedColumns))) {
+            if (
+                (is_string($columnAlias) && isset($this->select[$columnAlias]) && $this->select[$columnAlias] === $columnDefinition)
+                || (is_integer($columnAlias) && in_array($columnDefinition, $unaliasedColumns))
+            ) {
                 unset($columns[$columnAlias]);
             }
         }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -605,7 +605,7 @@ PATTERN;
      */
     protected function removeDuplicatedColumns($columns)
     {
-        $simpleColumns = array_intersect_key($this->select, array_fill_keys(array_filter(array_keys($this->select), 'is_integer'), null));
+        $simpleColumns = array_filter($this->select, 'is_integer', ARRAY_FILTER_USE_KEY);
         foreach ($columns as $columnName => $columnDefinition) {
             if ($columnDefinition instanceof Query) {
                 continue;

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -607,8 +607,8 @@ PATTERN;
      */
     protected function getUniqueColumns($columns)
     {
-        $unaliasedColumns = $this->getUnaliasedColumnsFromSelect();
         $columns = array_unique($columns);
+        $unaliasedColumns = $this->getUnaliasedColumnsFromSelect();
 
         foreach ($columns as $columnAlias => $columnDefinition) {
             if ($columnDefinition instanceof Query) {
@@ -1186,5 +1186,14 @@ PATTERN;
             'union' => $from->union,
             'params' => $from->params,
         ]);
+    }
+
+    /**
+     * Returns the SQL representation of Query
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->createCommand()->getSql();
     }
 }

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -37,20 +37,26 @@ abstract class QueryTest extends DatabaseTestCase
         $query->select('id, name');
         $query->addSelect('email');
         $this->assertEquals(['id', 'name', 'email'], $query->select);
-        
+
         $query = new Query();
         $query->select('name, lastname');
         $query->addSelect('name');
         $this->assertEquals(['name', 'lastname'], $query->select);
-        
+
         $query = new Query();
         $query->addSelect(['*', 'abc']);
         $query->addSelect(['*', 'bca']);
-        $this->assertEquals(['*', 'abc', 'bca'], array_values($query->select));
-        
+        $this->assertEquals(['*', 'abc', 'bca'], $query->select);
+
         $query = new Query();
         $query->addSelect(['field1 as a', 'field 1 as b']);
         $this->assertEquals(['field1 as a', 'field 1 as b'], $query->select);
+
+        $query = new Query();
+        $query->select(['name' => 'firstname', 'lastname']);
+        $query->addSelect(['firstname', 'surname' => 'lastname']);
+        $query->addSelect(['firstname', 'lastname']);
+        $this->assertEquals(['name' => 'firstname', 'lastname', 'firstname', 'surname' => 'lastname'], $query->select);
     }
 
     public function testFrom()

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -47,6 +47,10 @@ abstract class QueryTest extends DatabaseTestCase
         $query->addSelect(['*', 'abc']);
         $query->addSelect(['*', 'bca']);
         $this->assertEquals(['*', 'abc', 'bca'], array_values($query->select));
+        
+        $query = new Query();
+        $query->addSelect(['field1 as a', 'field 1 as b']);
+        $this->assertEquals(['field1 as a', 'field 1 as b'], $query->select);
     }
 
     public function testFrom()

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -46,7 +46,7 @@ abstract class QueryTest extends DatabaseTestCase
         $query = new Query();
         $query->addSelect(['*', 'abc']);
         $query->addSelect(['*', 'bca']);
-        $this->assertEquals(['*', 'abc', 'bca'], $query->select);
+        $this->assertEquals(['*', 'abc', 'bca'], array_values($query->select));
     }
 
     public function testFrom()

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -42,6 +42,11 @@ abstract class QueryTest extends DatabaseTestCase
         $query->select('name, lastname');
         $query->addSelect('name');
         $this->assertEquals(['name', 'lastname'], $query->select);
+        
+        $query = new Query();
+        $query->addSelect(['*', 'abc']);
+        $query->addSelect(['*', 'bca']);
+        $this->assertEquals(['*', 'abc', 'bca'], $query->select);
     }
 
     public function testFrom()

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -37,6 +37,11 @@ abstract class QueryTest extends DatabaseTestCase
         $query->select('id, name');
         $query->addSelect('email');
         $this->assertEquals(['id', 'name', 'email'], $query->select);
+        
+        $query = new Query();
+        $query->select('name, lastname');
+        $query->addSelect('name');
+        $this->assertEquals(['name', 'lastname'], $query->select);
     }
 
     public function testFrom()

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -57,6 +57,10 @@ abstract class QueryTest extends DatabaseTestCase
         $query->addSelect(['firstname', 'surname' => 'lastname']);
         $query->addSelect(['firstname', 'lastname']);
         $this->assertEquals(['name' => 'firstname', 'lastname', 'firstname', 'surname' => 'lastname'], $query->select);
+
+        $query = new Query();
+        $query->select('name, name, name as X, name as X');
+        $this->assertEquals(['name', 'name as X'], array_values($query->select));
     }
 
     public function testFrom()


### PR DESCRIPTION
Fix for case when `addSelect` called few times in a chain like this and finally it looks like `SELECT *, abc, *, (INNER QUERY)` by this code:
```php
$this->addSelect(['*', new Expression('...')]);
// ...
$this->addSelect(['*', new Expression('...')]);
```

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | ---
