### PR TITLE
Named params is DI container

### DIFF
--- a/tests/framework/di/ContainerTest.php
+++ b/tests/framework/di/ContainerTest.php
@@ -310,4 +310,20 @@ class ContainerTest extends TestCase
 
         require __DIR__ . '/testContainerWithVariadicCallable.php';
     }
+
+    /**
+     * @requires PHP 5.6
+     */
+    public function testNamedParams()
+    {
+        $container = new Container();
+        $container->set(Qux::className(), [], [
+            'a' => 'value_one'
+        ]);
+
+        $object = $container->get(Qux::className());
+
+        $this->assertInstanceOf(Qux::className(), $object);
+        $this->assertSame($object->a, 'value_one');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | tests of DI group is pass

Example:

```php
class Foo
{
    public $bar;
    public $bar2;

    public function __construct($bar, $bar2)
    {
        $this->bar = $bar;
        $this->bar2 = $bar2;
    }
}

//.....

$container->set(Foo::class, [], [
    'bar2' => 'value_two',
    'bar' => 'value_one',
]);

//.....

$container->get(Foo::class);
// which is equivalent to:
new Foo('value_one', 'value_two');
```

Tests:
```bash
docker-compose build; docker-compose run --rm php vendor/bin/phpunit -v --group di
PHPUnit 4.8.34 by Sebastian Bergmann and contributors.

Runtime:        PHP 7.0.14
Configuration:  /project/phpunit.xml.dist

.............................

Time: 839 ms, Memory: 36.00MB

OK (29 tests, 98 assertions)
```