### PR TITLE
Added new HTTP status code 103

### DIFF
--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -165,6 +165,7 @@ class Response extends \yii\base\Response
         100 => 'Continue',
         101 => 'Switching Protocols',
         102 => 'Processing',
+        103 => 'Early Hints',
         118 => 'Connection timed out',
         200 => 'OK',
         201 => 'Created',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | 
| Fixed issues  | none

IETF introduced new HTTP status code `103`:  `Early Hints`.

more info at https://datatracker.ietf.org/doc/draft-ietf-httpbis-early-hints/