### PR TITLE
Fixed changing array keys after validation of multiple files in yii\validators\FileValidator

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #6226: Fix fatal symlink error durint assets publishing in multi threaded environment (dynasource)
 - Bug #6526: Fixed `yii\db\Command::batchInsert()` casting of double values correctly independent of the locale (cebe, leammas)
+- Bug #6588: Fixed changing array keys after validation of multiple files in `yii\validators\FileValidator` (developeruz)
 - Bug #7890: Allow `migrate/mark` to mark history at the point of the base migration (cebe)
 - Bug #11242: Fixed excess escaping in `yii\db\Command::batchInsert()` (silverfire)
 - Bug #11825: User can login by cookie only once when `autoRenewCookie` is set to false (shirase, silverfire)

--- a/framework/validators/FileValidator.php
+++ b/framework/validators/FileValidator.php
@@ -197,7 +197,7 @@ class FileValidator extends Validator
                     unset($files[$i]);
                 }
             }
-            $model->$attribute = array_values($files);
+            $model->$attribute = $files;
             if (empty($files)) {
                 $this->addError($model, $attribute, $this->uploadRequired);
             }

--- a/tests/framework/validators/FileValidatorTest.php
+++ b/tests/framework/validators/FileValidatorTest.php
@@ -145,6 +145,27 @@ class FileValidatorTest extends TestCase
         $this->assertTrue($m->hasErrors());
         $this->assertNotFalse(stripos(current($m->getErrors('attr_files')), 'you can upload at most'));
 
+        $files = [
+            'file_1' => [
+                'name' => 'test_up_1.txt',
+                'size' => 1024,
+            ],
+            'file_2' => [
+                'name' => 'test_up_2.txt',
+                'size' => 1024,
+            ]
+        ];
+        $m = FakedValidationModel::createWithAttributes(
+            [
+                'attr_files' => $this->createTestFiles(
+                    $files
+                ),
+            ]
+        );
+        $val->validateAttribute($m, 'attr_files');
+        $this->assertFalse($m->hasErrors());
+        $this->assertEquals(array_keys($m->attr_files), array_keys($files));
+
         $val->maxFiles = 0;
         $m->clearErrors();
         $val->validateAttribute($m, 'attr_files');
@@ -230,9 +251,9 @@ class FileValidatorTest extends TestCase
             return $randomString;
         };
         $files = [];
-        foreach ($params as $param) {
+        foreach ($params as $key => $param) {
             if (empty($param) && count($params) != 1) {
-                $files[] = ['no instance of UploadedFile'];
+                $files[$key] = ['no instance of UploadedFile'];
                 continue;
             }
             $name = isset($param['name']) ? $param['name'] : $rndString();
@@ -258,7 +279,7 @@ class FileValidatorTest extends TestCase
                     'error' => $error,
                 ]);
             }
-            $files[] = new UploadedFile([
+            $files[$key] = new UploadedFile([
                 'name' => $name,
                 'tempName' => $tempName,
                 'type' => $type,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #6588
