### PR TITLE
Resolve Instances on configuration of objects

### DIFF
--- a/framework/BaseYii.php
+++ b/framework/BaseYii.php
@@ -11,6 +11,7 @@ use yii\base\InvalidConfigException;
 use yii\base\InvalidParamException;
 use yii\base\UnknownClassException;
 use yii\di\Container;
+use yii\di\Instance;
 use yii\log\Logger;
 
 /**
@@ -529,6 +530,10 @@ class BaseYii
     public static function configure($object, $properties)
     {
         foreach ($properties as $name => $value) {
+            if ($value instanceof Instance) {
+                $value = $value->get();
+            }
+
             $object->$name = $value;
         }
 

--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -382,11 +382,8 @@ class Container extends Component
         }
 
         $object = $reflection->newInstanceArgs($dependencies);
-        foreach ($config as $name => $value) {
-            $object->$name = $value;
-        }
 
-        return $object;
+        return Yii::configure($object, $config);
     }
 
     /**

--- a/tests/framework/BaseYiiTest.php
+++ b/tests/framework/BaseYiiTest.php
@@ -8,8 +8,10 @@
 namespace yiiunit\framework;
 
 use Yii;
+use yii\base\BaseObject;
 use yii\BaseYii;
 use yii\di\Container;
+use yii\di\Instance;
 use yii\log\Logger;
 use yiiunit\data\base\Singer;
 use yiiunit\TestCase;
@@ -63,7 +65,7 @@ class BaseYiiTest extends TestCase
 
     public function testGetVersion()
     {
-        $this->assertTrue((bool) preg_match('~\d+\.\d+(?:\.\d+)?(?:-\w+)?~', \Yii::getVersion()));
+        $this->assertTrue((bool)preg_match('~\d+\.\d+(?:\.\d+)?(?:-\w+)?~', \Yii::getVersion()));
     }
 
     public function testPowered()
@@ -80,13 +82,11 @@ class BaseYiiTest extends TestCase
             return $a === 'a';
         }, ['a']));
 
-
         $singer = new Singer();
         $singer->firstName = 'Bob';
         $this->assertTrue(Yii::createObject(function (Singer $singer, $a) {
             return $singer->firstName === 'Bob';
         }, [$singer, 'a']));
-
 
         $this->assertTrue(Yii::createObject(function (Singer $singer, $a = 3) {
             return true;
@@ -155,5 +155,22 @@ class BaseYiiTest extends TestCase
         BaseYii::endProfile('endProfile message', 'endProfile category');
 
         BaseYii::setLogger(null);
+    }
+
+    public function testConfigure()
+    {
+        $stub = new \stdClass();
+
+        $stub = BaseYii::configure($stub, [
+            'a' => 'foo',
+            'b' => 'bar',
+            'c' => Instance::of(Logger::className()),
+            'd' => Instance::of(BaseObject::className()),
+        ]);
+
+        $this->assertSame('foo', $stub->a);
+        $this->assertSame('bar', $stub->b);
+        $this->assertInstanceOf(Logger::className(), $stub->c);
+        $this->assertInstanceOf(BaseObject::className(), $stub->d);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

Example:
```php
[
    'class' => SomeService::class,
    'logger' => Instance::of('logger'),
    'transactionManager'  => Instance::of(TransactionManager::class),
],
```

It allows resolve dependencies by key using existing `\yii\di\Instance` class.

It is what I really need in my project.