### PR TITLE
Fix: Query::each() without `indexBy()` zero based keys

### DIFF
--- a/framework/db/BatchQueryResult.php
+++ b/framework/db/BatchQueryResult.php
@@ -118,7 +118,11 @@ class BatchQueryResult extends BaseObject implements \Iterator
             if ($this->query->indexBy !== null) {
                 $this->_key = key($this->_batch);
             } elseif (key($this->_batch) !== null) {
-                $this->_key++;
+                if (null === $this->_key) {
+                    $this->_key = 0;
+                } else {
+                    $this->_key++;
+                }
             } else {
                 $this->_key = null;
             }

--- a/framework/db/BatchQueryResult.php
+++ b/framework/db/BatchQueryResult.php
@@ -118,11 +118,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
             if ($this->query->indexBy !== null) {
                 $this->_key = key($this->_batch);
             } elseif (key($this->_batch) !== null) {
-                if (null === $this->_key) {
-                    $this->_key = 0;
-                } else {
-                    $this->_key++;
-                }
+                $this->_key = $this->_key === null ? 0 : $this->_key + 1;
             } else {
                 $this->_key = null;
             }

--- a/tests/framework/db/BatchQueryResultTest.php
+++ b/tests/framework/db/BatchQueryResultTest.php
@@ -80,13 +80,26 @@ abstract class BatchQueryResultTest extends DatabaseTestCase
         $query = new Query();
         $query->from('customer')->orderBy('id');
         $allRows = [];
-        foreach ($query->each(100, $db) as $rows) {
-            $allRows[] = $rows;
+        foreach ($query->each(100, $db) as $index => $rows) {
+            $allRows[$index] = $rows;
         }
         $this->assertCount(3, $allRows);
+        $this->assertArrayHasKey(0, $allRows);
+        $this->assertArrayHasKey(1, $allRows);
+        $this->assertArrayHasKey(2, $allRows);
         $this->assertEquals('user1', $allRows[0]['name']);
         $this->assertEquals('user2', $allRows[1]['name']);
         $this->assertEquals('user3', $allRows[2]['name']);
+
+        // each with default keys in multiple batches
+        $query = new Query();
+        $query->from('customer')->orderBy('id');
+        $allKeys = [];
+        foreach ($query->each(2, $db) as $index => $rows) {
+            $allKeys[] = $index;
+        }
+        $this->assertCount(3, $allKeys);
+        $this->assertSame([0, 1, 2], $allKeys);
 
         // each with key
         $query = new Query();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes?
| Tests pass?   | yes
| Fixed issues  | #14916

Existing tests did not cover subject case, so it passed before.

- [ ] Add info to CHANGELOG for appropriate dev version
- [ ] Add notes to UPGRADE