### PR TITLE
Implement rendering of PHP strings

### DIFF
--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -349,6 +349,29 @@ class View extends Component
     }
 
     /**
+     * Renders a view string as a PHP script.
+     *
+     * This method treats the view string as a PHP script and evaluates it.
+     * It extracts the given parameters and makes them available in the view string.
+     * The method captures the output of the view string and returns it as a rendered string.
+     *
+     * @param string $string the view string.
+     * @param array $params the parameters (name-value pairs) that will be extracted and made available in the view string.
+     * @return string the rendering result
+     */
+    public function renderPhpString($string, $params = [])
+    {
+        $tempFile = tmpfile();
+        $metaData = stream_get_meta_data($tempFile);
+        $tempFilename = $metaData['uri'];
+        fwrite($tempFile, $string);
+        $result = $this->renderPhpFile($tempFilename, $params);
+        fclose($tempFile);
+
+        return $result;
+    }
+
+    /**
      * Renders dynamic content returned by the given PHP statements.
      * This method is mainly used together with content caching (fragment caching and page caching)
      * when some portions of the content (called *dynamic content*) should not be cached.


### PR DESCRIPTION
Stores string in temporary file, renders and returns result using existing renderPhpFile function.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #6252,#7309

- [x] Code
- [ ] Tests
- [x] Documentation (PHPDoc)
- [ ] Documentation (Guide)
- [ ] Example of use case

The purpose of this feature is to create a way to utilize Yii framework View class to work with string-based PHP view code that are stored in data base or generated dynamically.

This can be used for CMS editable PHP templates for widgets, templated e-mail messages and templated PDF documents (generated from HTML code).

This implementation should be tested how it performs in console environment, where `Yii::$app->view` is a bit different than in web environment.