### PR TITLE
Updates @bower and @npm alias in Application::setVendorPath

### DIFF
--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -461,8 +461,8 @@ abstract class Application extends Module
     {
         $this->_vendorPath = Yii::getAlias($path);
         Yii::setAlias('@vendor', $this->_vendorPath);
-        Yii::setAlias('@bower', $this->_vendorPath . DIRECTORY_SEPARATOR . 'bower');
-        Yii::setAlias('@npm', $this->_vendorPath . DIRECTORY_SEPARATOR . 'npm');
+        Yii::setAlias('@bower', $this->_vendorPath . DIRECTORY_SEPARATOR . 'bower-asset');
+        Yii::setAlias('@npm', $this->_vendorPath . DIRECTORY_SEPARATOR . 'npm-asset');
     }
 
     /**


### PR DESCRIPTION
Since switched to asset-packagist.org, `yii\base\Application::setVendorPath()` bower and npm paths should be updated to `bower-asset` and `npm-asset`, respectively.

Fixes https://github.com/yiisoft/yii2-apidoc/issues/152 , #15088 .

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | 
| Tests pass?   | 
| Fixed issues  | https://github.com/yiisoft/yii2-apidoc/issues/152 , #15088
