### PR TITLE
Support DI container constructor injection

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1179,7 +1179,9 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public static function instantiate($row)
     {
-        return new static();
+        /** @var static $instance */
+        $instance = Instance::ensure(static::className());
+        return $instance;
     }
 
     /**


### PR DESCRIPTION
Object create directly, without DI injection resolving. I propose resolve this by "Instance::ensure" object creating.
The same bug i find in (but I'm not sure that there is this problem now exist in follow files, since in the new version you use the model::instance() method) :
yiisoft/yii2/grid/DataColumn.php - function getHeaderCellLabel
yiisoft/yii2/data/ActiveDataProvider.php - function setSort

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Tests pass?   | no
