### PR TITLE
Fixed DB schema cache did not honor table prefixes (fixes #15117)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #15081: Fixed "Undefined offset: 1" in log Target (ischenko)
 - Bug #15086: Fixed jQuery onLoad event handling (alexantr)
 - Bug #15108: Fixed `yii\db\Schema::getSchemaNames()` for MSSQL and added tests for all DBMSes (sergeymakinen)
+- Bug #15117: Fixed DB schema cache did not honor table prefixes (sergeymakinen)
 
 
 2.0.13 November 03, 2017

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -277,12 +277,13 @@ abstract class Schema extends BaseObject
      */
     public function refreshTableSchema($name)
     {
-        unset($this->_tableMetadata[$name]);
+        $rawName = $this->getRawTableName($name);
+        unset($this->_tableMetadata[$rawName]);
         $this->_tableNames = [];
         /* @var $cache CacheInterface */
         $cache = is_string($this->db->schemaCache) ? Yii::$app->get($this->db->schemaCache, false) : $this->db->schemaCache;
         if ($this->db->enableSchemaCache && $cache instanceof CacheInterface) {
-            $cache->delete($this->getCacheKey($name));
+            $cache->delete($this->getCacheKey($rawName));
         }
     }
 
@@ -607,8 +608,8 @@ abstract class Schema extends BaseObject
 
     /**
      * Returns the cache key for the specified table name.
-     * @param string $name the table name
-     * @return mixed the cache key
+     * @param string $name the table name.
+     * @return mixed the cache key.
      */
     protected function getCacheKey($name)
     {
@@ -616,7 +617,7 @@ abstract class Schema extends BaseObject
             __CLASS__,
             $this->db->dsn,
             $this->db->username,
-            $name,
+            $this->getRawTableName($name),
         ];
     }
 
@@ -653,15 +654,16 @@ abstract class Schema extends BaseObject
                 $cache = $schemaCache;
             }
         }
-        if ($refresh || !isset($this->_tableMetadata[$name])) {
-            $this->loadTableMetadataFromCache($cache, $name);
+        $rawName = $this->getRawTableName($name);
+        if ($refresh || !isset($this->_tableMetadata[$rawName])) {
+            $this->loadTableMetadataFromCache($cache, $rawName);
         }
-        if (!array_key_exists($type, $this->_tableMetadata[$name])) {
-            $this->_tableMetadata[$name][$type] = $this->{'loadTable' . ucfirst($type)}($this->getRawTableName($name));
-            $this->saveTableMetadataToCache($cache, $name);
+        if (!array_key_exists($type, $this->_tableMetadata[$rawName])) {
+            $this->_tableMetadata[$rawName][$type] = $this->{'loadTable' . ucfirst($type)}($rawName);
+            $this->saveTableMetadataToCache($cache, $rawName);
         }
 
-        return $this->_tableMetadata[$name][$type];
+        return $this->_tableMetadata[$rawName][$type];
     }
 
     /**
@@ -701,7 +703,7 @@ abstract class Schema extends BaseObject
      */
     protected function setTableMetadata($name, $type, $data)
     {
-        $this->_tableMetadata[$name][$type] = $data;
+        $this->_tableMetadata[$this->getRawTableName($name)][$type] = $data;
     }
 
     /**

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -176,7 +176,6 @@ abstract class SchemaTest extends DatabaseTestCase
     }
 
     /**
-     * @group iss
      * @dataProvider tableSchemaCachePrefixesProvider
      * @depends testSchemaCache
      */

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\db;
 
 use PDO;
+use yii\caching\ArrayCache;
 use yii\caching\FileCache;
 use yii\db\CheckConstraint;
 use yii\db\ColumnSchema;
@@ -16,6 +17,7 @@ use yii\db\Expression;
 use yii\db\ForeignKeyConstraint;
 use yii\db\IndexConstraint;
 use yii\db\Schema;
+use yii\db\TableSchema;
 
 abstract class SchemaTest extends DatabaseTestCase
 {
@@ -130,6 +132,83 @@ abstract class SchemaTest extends DatabaseTestCase
         $schema->refreshTableSchema('type');
         $refreshedTable = $schema->getTableSchema('type', false);
         $this->assertNotSame($noCacheTable, $refreshedTable);
+    }
+
+    public function tableSchemaCachePrefixesProvider()
+    {
+        $configs = [
+            [
+                'prefix' => '',
+                'name' => 'type',
+            ],
+            [
+                'prefix' => '',
+                'name' => '{{%type}}',
+            ],
+            [
+                'prefix' => 'ty',
+                'name' => '{{%pe}}',
+            ],
+        ];
+        $data = [];
+        foreach ($configs as $config) {
+            foreach ($configs as $testConfig) {
+                if ($config === $testConfig) {
+                    continue;
+                }
+
+                $description = sprintf(
+                    "%s (with '%s' prefix) against %s (with '%s' prefix)",
+                    $config['name'],
+                    $config['prefix'],
+                    $testConfig['name'],
+                    $testConfig['prefix']
+                );
+                $data[$description] = [
+                    $config['prefix'],
+                    $config['name'],
+                    $testConfig['prefix'],
+                    $testConfig['name'],
+                ];
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * @group iss
+     * @dataProvider tableSchemaCachePrefixesProvider
+     * @depends testSchemaCache
+     */
+    public function testTableSchemaCacheWithTablePrefixes($tablePrefix, $tableName, $testTablePrefix, $testTableName)
+    {
+        /* @var $schema Schema */
+        $schema = $this->getConnection()->schema;
+        $schema->db->enableSchemaCache = true;
+
+        $schema->db->tablePrefix = $tablePrefix;
+        $schema->db->schemaCache = new ArrayCache();
+        $noCacheTable = $schema->getTableSchema($tableName, true);
+        $this->assertInstanceOf(TableSchema::className(), $noCacheTable);
+
+        // Compare
+        $schema->db->tablePrefix = $testTablePrefix;
+        $testNoCacheTable = $schema->getTableSchema($testTableName);
+        $this->assertSame($noCacheTable, $testNoCacheTable);
+
+        $schema->db->tablePrefix = $tablePrefix;
+        $schema->refreshTableSchema($tableName);
+        $refreshedTable = $schema->getTableSchema($tableName, false);
+        $this->assertInstanceOf(TableSchema::className(), $refreshedTable);
+        $this->assertNotSame($noCacheTable, $refreshedTable);
+
+        // Compare
+        $schema->db->tablePrefix = $testTablePrefix;
+        $schema->refreshTableSchema($testTablePrefix);
+        $testRefreshedTable = $schema->getTableSchema($testTableName, false);
+        $this->assertInstanceOf(TableSchema::className(), $testRefreshedTable);
+        $this->assertEquals($refreshedTable, $testRefreshedTable);
+        $this->assertNotSame($testNoCacheTable, $testRefreshedTable);
     }
 
     public function testCompositeFk()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15117 

> `MigrateController::truncateDatabase()` gets table names from `Schema::getTableSchemas()`, where the `TableSchema::$name` for the migrations table is plain **`migration`** (or `{prefix}migration` if current `Connection::$tablePrefix` is `{prefix}`). The metadata for **this** table name is discarded.
> 
 > But `MigrateController::getMigrationHistory()`, which is called when migrating up, gets the metadata for `MigrateController::$migrationTable`, defined as **`{{%migration}}`** by default. If the metadata for **this** table name is cached, `Schema::getTableMetadata()` will return that regardless of the value of `$refresh` (and the actual schema state). That's what this issue is all about.
> 
> I suppose a solution would involve tuning table prefix resolution for schema caching and/or migrations.
> 
> @U-D13
