### PR TITLE
Update ActiveDataProvider.php

### DIFF
--- a/framework/data/ActiveDataProvider.php
+++ b/framework/data/ActiveDataProvider.php
@@ -11,6 +11,7 @@ use yii\base\InvalidConfigException;
 use yii\base\Model;
 use yii\db\ActiveQueryInterface;
 use yii\db\Connection;
+use yii\db\Query;
 use yii\db\QueryInterface;
 use yii\di\Instance;
 
@@ -166,7 +167,7 @@ class ActiveDataProvider extends BaseDataProvider
             throw new InvalidConfigException('The "query" property must be an instance of a class that implements the QueryInterface e.g. yii\db\Query or its subclasses.');
         }
         $query = clone $this->query;
-        return (int) $query->limit(-1)->offset(-1)->orderBy([])->count('*', $this->db);
+        return (int) (new Query())->from(['totalCount' => $query->limit(-1)->offset(-1)->orderBy([])])->count('*', $this->db);
     }
 
     /**


### PR DESCRIPTION
доработка для того чтобы count для такого запроса считался правильно
```
$query = Client::find()
     ->innerJoinWith([
         'ordersSum' => function (OrderQuery $query) use ($currency) {
             $query->onCondition(['currency' => $currency]);
         }
     ]);
```
вот фрагмент связей используемых в модели:
```
    /**
     * @return ActiveQuery|OrderQuery
     */
    public function getOrders()
    {
        return $this->hasMany(Order::className(), ['client_id' => 'id'])
            ->inverseOf('client');
    }


    /**
     * @return ActiveQuery|OrderQuery
     */
    public function getOrdersSum()
    {
        return $this->getOrders()
            ->select(['*'])
            ->addSelect(new Expression('SUM(price * quantity) as sumPrice'))
            ->groupBy(['currency', 'client_id']);
    }
```
проблема была в том что `COUNT()` вычислялся агрегируемый `GROUP BY`

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
