### PR TITLE
Fixed translation in german when too many files are uploaded

### DIFF
--- a/framework/messages/de/yii.php
+++ b/framework/messages/de/yii.php
@@ -64,7 +64,7 @@ return [
     'Yes' => 'Ja',
     'Yii Framework' => 'Yii Framework',
     'You are not allowed to perform this action.' => 'Sie dürfen diese Aktion nicht durchführen.',
-    'You can upload at most {limit, number} {limit, plural, one{file} other{files}}.' => 'Sie können maximal {limit, number} {limit, plural, one{eine Datei} other{# Dateien}} hochladen.',
+    'You can upload at most {limit, number} {limit, plural, one{file} other{files}}.' => 'Sie können maximal {limit, number} {limit, plural, one{eine Datei} other{Dateien}} hochladen.',
     'in {delta, plural, =1{a day} other{# days}}' => 'in {delta, plural, =1{einem Tag} other{# Tagen}}',
     'in {delta, plural, =1{a minute} other{# minutes}}' => 'in {delta, plural, =1{einer Minute} other{# Minuten}}',
     'in {delta, plural, =1{a month} other{# months}}' => 'in {delta, plural, =1{einem Monat} other{# Monaten}}',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

Fixed issue with the german translation when too many files are uploaded.

**Before:**
Sie können maximal 7 7 Dateien hochladen.

**After:**
Sie können maximal 7 Dateien hochladen.
