### PR TITLE
updated base-image for dockerized tests, examples, GitLab config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,22 +1,13 @@
-before_script:
-  # set stack isolation
-  - export ISOLATION=buildpipeline${CI_PIPELINE_ID}${CI_BUILD_NAME}
-  - export COMPOSE_PROJECT_NAME=${ISOLATION}
-  - export TUPLE_C=$(expr ${CI_BUILD_ID} % 99)
-  - echo ${TUPLE_C}
-  # run docker-compose commands from tests environment
-  - cd tests
-  - cp .env-dist .env
-  - docker-compose config
+image: docker:latest
 
-after_script:
-  - export ISOLATION=buildpipeline${CI_PIPELINE_ID}${CI_BUILD_NAME}
-  - export COMPOSE_PROJECT_NAME=${ISOLATION}
-  # run docker-compose commands from tests environment
+services:
+  - docker:dind
+
+before_script:
+  - apk add --no-cache python py2-pip git
+  - pip install --no-cache-dir docker-compose==1.16.0
+  - docker info
   - cd tests
-  - cp .env-dist .env
-  - docker-compose down -v --remove-orphans
-  - docker ps -f name=${ISOLATION}
 
 stages:
   - travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dmstr/php-yii2:7.0-fpm-1.9-beta2-alpine-nginx
+FROM yiisoftware/yii2-php:7.1-apache
 
 # Project source-code
 WORKDIR /project

--- a/tests/.env-dist
+++ b/tests/.env-dist
@@ -3,7 +3,7 @@
 # Choose a flavour
 #COMPOSE_FILE=docker-compose.yml:docker-compose.caching.yml
 #COMPOSE_FILE=docker-compose.yml:docker-compose.mysql.yml
-#COMPOSE_FILE=docker-compose.yml:docker-compose.postgres.yml
+#COMPOSE_FILE=docker-compose.yml:docker-compose.pgsql.yml
 
 # Choose a version
 DOCKER_MYSQL_IMAGE=percona:5.7

--- a/tests/README.md
+++ b/tests/README.md
@@ -75,6 +75,7 @@ Run phpunit directly
     cd tests    
     docker-compose run --rm php vendor/bin/phpunit -v --group caching,db   
     docker-compose run --rm php vendor/bin/phpunit -v --exclude base,caching,db,i18n,log,mutex,rbac,validators,web
+    docker-compose run --rm php vendor/bin/phpunit -v --exclude mssql,oci,wincache,xcache,zenddata,cubrid
 
 ### Cubrid
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

GitLab config for dockerized tests has been updated to use default GitLab.com runners.
Also updated to use the latest Docker image from yiisoftware/yii2-php

Example build & test: https://gitlab.com/yiisoft/yii2/-/jobs/40844211