### PR TITLE
QueryBuilder::insert() doesn't preserve passed params when building a INSERT INTO … SELECT query

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #14276: Fixed I18N format with dotted parameters (developeruz)
 - Bug #14604: Fixed `yii\validators\CompareValidator` `compareAttribute` does not work if `compareAttribute` form ID has been changed (mikk150) 
+- Bug #15194: Fixed `yii\db\QueryBuilder::insert()` to preserve passed params when building a `INSERT INTO ... SELECT` query for MSSQL, PostgreSQL and SQLite (sergeymakinen)
 - Enh #15135: Automatic completion for help in bash and zsh (Valkeru)
 - Enh #14662: Added support for custom `Content-Type` specification to `yii\web\JsonResponseFormatter` (Kolyunya)
 - Enh #14568: Refactored migration templates to use `safeUp()` and `safeDown()` methods (Kolyunya)

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -179,7 +179,7 @@ class QueryBuilder extends \yii\base\BaseObject
         $placeholders = [];
         $values = ' DEFAULT VALUES';
         if ($columns instanceof \yii\db\Query) {
-            list($names, $values, $params) = $this->prepareInsertSelectSubQuery($columns, $schema);
+            list($names, $values, $params) = $this->prepareInsertSelectSubQuery($columns, $schema, $params);
         } else {
             foreach ($columns as $name => $value) {
                 $names[] = $schema->quoteColumnName($name);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15194 
