### PR TITLE
Add example for yii\validators\Validator::addError() [skip ci]

### DIFF
--- a/docs/guide-ru/input-validation.md
+++ b/docs/guide-ru/input-validation.md
@@ -384,7 +384,9 @@ class MyForm extends Model
 Вы можете реализовать свою логику проверки путем переопределения метода
 [[yii\validators\Validator::validateAttribute()]]. Если атрибут не прошел проверку, вызвать
 [[yii\base\Model::addError()]],
-чтобы сохранить сообщение об ошибке в модели, как это делают [встроенные валидаторы](#inline-validators). Например:
+чтобы сохранить сообщение об ошибке в модели, как это делают [встроенные валидаторы](#inline-validators).
+Также можно использовать одноимённый метод валидатора [[yii\validators\Validator::addError()]] для дополнительной обработки
+сообщения о ошибке перед сохранением сообщения об ошибке в модели, например:
 
 ```php
 namespace app\components;
@@ -396,7 +398,7 @@ class CountryValidator extends Validator
     public function validateAttribute($model, $attribute)
     {
         if (!in_array($model->$attribute, ['USA', 'Web'])) {
-            $this->addError($model, $attribute, 'Страна должна быть либо "USA" или "Web".');
+            $this->addError($model, $attribute, 'Страна должна быть либо "{country1}" либо "{country2}".', ['country1' => 'USA', 'country2' => 'Web']);
         }
     }
 }

--- a/docs/guide-ru/input-validation.md
+++ b/docs/guide-ru/input-validation.md
@@ -358,8 +358,8 @@ class MyForm extends Model
 
     public function validateCountry($attribute, $params)
     {
-        if (!in_array($this->$attribute, ['USA', 'Web'])) {
-            $this->addError($attribute, 'Страна должна быть либо "USA" или "Web".');
+        if (!in_array($this->$attribute, ['USA', 'Indonesia'])) {
+            $this->addError($attribute, 'Страна должна быть либо "USA" или "Indonesia".');
         }
     }
 }
@@ -385,8 +385,8 @@ class MyForm extends Model
 [[yii\validators\Validator::validateAttribute()]]. Если атрибут не прошел проверку, вызвать
 [[yii\base\Model::addError()]],
 чтобы сохранить сообщение об ошибке в модели, как это делают [встроенные валидаторы](#inline-validators).
-Также можно использовать одноимённый метод валидатора [[yii\validators\Validator::addError()]] для дополнительной обработки
-сообщения о ошибке перед сохранением сообщения об ошибке в модели, например:
+
+Валидация может быть помещена в отдельный класс [[components/validators/CountryValidator]]. В этом случае можно использовать метод  [[yii\validators\Validator::addError()]] для того, чтобы добавить своё сообщение об ошибке в модель:
 
 ```php
 namespace app\components;
@@ -397,8 +397,8 @@ class CountryValidator extends Validator
 {
     public function validateAttribute($model, $attribute)
     {
-        if (!in_array($model->$attribute, ['USA', 'Web'])) {
-            $this->addError($model, $attribute, 'Страна должна быть либо "{country1}" либо "{country2}".', ['country1' => 'USA', 'country2' => 'Web']);
+        if (!in_array($model->$attribute, ['USA', 'Indonesia'])) {
+            $this->addError($model, $attribute, 'Страна должна быть либо "{country1}" либо "{country2}".', ['country1' => 'USA', 'country2' => 'Indonesia']);
         }
     }
 }

--- a/docs/guide/input-validation.md
+++ b/docs/guide/input-validation.md
@@ -423,7 +423,7 @@ with [inline validators](#inline-validators).
 
 
 For example, the inline validator above could be moved into new [[components/validators/CountryValidator]] class.
-In this case we can use [[yii\validators\Validator::addError()]] to set customized for the model.
+In this case we can use [[yii\validators\Validator::addError()]] to set customized message for the model.
 
 ```php
 namespace app\components;

--- a/docs/guide/input-validation.md
+++ b/docs/guide/input-validation.md
@@ -423,6 +423,8 @@ with [inline validators](#inline-validators).
 
 
 For example the inline validator above could be moved into new [[components/validators/CountryValidator]] class.
+In this case we can use [[yii\validators\Validator::addError()]] for customize the error message before 
+save the error message in the model.
 
 ```php
 namespace app\components;
@@ -434,7 +436,7 @@ class CountryValidator extends Validator
     public function validateAttribute($model, $attribute)
     {
         if (!in_array($model->$attribute, ['USA', 'Web'])) {
-            $this->addError($model, $attribute, 'The country must be either "USA" or "Web".');
+            $this->addError($model, $attribute, 'The country must be either "{country1}" or "{country2}".', ['country1' => 'USA', 'country2' => 'Web']);
         }
     }
 }

--- a/docs/guide/input-validation.md
+++ b/docs/guide/input-validation.md
@@ -387,8 +387,8 @@ class MyForm extends Model
 
     public function validateCountry($attribute, $params, $validator)
     {
-        if (!in_array($this->$attribute, ['USA', 'Web'])) {
-            $this->addError($attribute, 'The country must be either "USA" or "Web".');
+        if (!in_array($this->$attribute, ['USA', 'Indonesia'])) {
+            $this->addError($attribute, 'The country must be either "USA" or "Indonesia".');
         }
     }
 }
@@ -434,7 +434,7 @@ class CountryValidator extends Validator
 {
     public function validateAttribute($model, $attribute)
     {
-        if (!in_array($model->$attribute, ['USA', 'Web'])) {
+        if (!in_array($model->$attribute, ['USA', 'Indonesia'])) {
             $this->addError($model, $attribute, 'The country must be either "{country1}" or "{country2}".', ['country1' => 'USA', 'country2' => 'Indonesia']);
         }
     }

--- a/docs/guide/input-validation.md
+++ b/docs/guide/input-validation.md
@@ -422,9 +422,8 @@ fails the validation, call [[yii\base\Model::addError()]] to save the error mess
 with [inline validators](#inline-validators).
 
 
-For example the inline validator above could be moved into new [[components/validators/CountryValidator]] class.
-In this case we can use [[yii\validators\Validator::addError()]] for customize the error message before 
-save the error message in the model.
+For example, the inline validator above could be moved into new [[components/validators/CountryValidator]] class.
+In this case we can use [[yii\validators\Validator::addError()]] to set customized for the model.
 
 ```php
 namespace app\components;

--- a/docs/guide/input-validation.md
+++ b/docs/guide/input-validation.md
@@ -435,7 +435,7 @@ class CountryValidator extends Validator
     public function validateAttribute($model, $attribute)
     {
         if (!in_array($model->$attribute, ['USA', 'Web'])) {
-            $this->addError($model, $attribute, 'The country must be either "{country1}" or "{country2}".', ['country1' => 'USA', 'country2' => 'Web']);
+            $this->addError($model, $attribute, 'The country must be either "{country1}" or "{country2}".', ['country1' => 'USA', 'country2' => 'Indonesia']);
         }
     }
 }


### PR DESCRIPTION
Show differences between 
` [[yii\base\Model::addError()]]`
and
`[[yii\validators\Validator::addError()]]`


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
