### PR TITLE
Console improvements

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,9 @@ Yii Framework 2 Change Log
 - Enh #15135: Automatic completion for help in bash and zsh (Valkeru)
 - Enh #14662: Added support for custom `Content-Type` specification to `yii\web\JsonResponseFormatter` (Kolyunya)
 - Enh #14568: Refactored migration templates to use `safeUp()` and `safeDown()` methods (Kolyunya)
+- Enh #15221: Added support for specifying `--camelCase` console options in `--kebab-case` (brandonkelly)
+- Enh #15221: Added support for the `--<option> <value>` console option syntax (brandonkelly)
+- Enh #15221: Improved the `help/list-action-options` console command output for command options without a description (brandonkelly)
 
 2.0.13.1 November 14, 2017
 --------------------------

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -12,6 +12,7 @@ use yii\base\Action;
 use yii\base\InlineAction;
 use yii\base\InvalidRouteException;
 use yii\helpers\Console;
+use yii\helpers\Inflector;
 
 /**
  * Controller is the base class of console command classes.
@@ -110,6 +111,14 @@ class Controller extends \yii\base\Controller
                 unset($params['_aliases']);
             }
             foreach ($params as $name => $value) {
+                // Allow camelCase options to be entered in kebab-case
+                if (!in_array($name, $options, true) && strpos($name, '-') !== false) {
+                    $altName = lcfirst(Inflector::id2camel($name));
+                    if (in_array($altName, $options, true)) {
+                        $name = $altName;
+                    }
+                }
+
                 if (in_array($name, $options, true)) {
                     $default = $this->$name;
                     if (is_array($default)) {
@@ -544,6 +553,10 @@ class Controller extends \yii\base\Controller
             }
             $defaultValue = $property->getValue($this);
             $tags = $this->parseDocCommentTags($property);
+
+            // Display camelCase options in kebab-case
+            $name = Inflector::camel2id($name, '-', true);
+
             if (isset($tags['var']) || isset($tags['property'])) {
                 $doc = isset($tags['var']) ? $tags['var'] : $tags['property'];
                 if (is_array($doc)) {

--- a/framework/console/Request.php
+++ b/framework/console/Request.php
@@ -71,6 +71,7 @@ class Request extends \yii\base\Request
         }
 
         $params = [];
+        $prevOption = null;
         foreach ($rawParams as $param) {
             if ($endOfOptionsFound) {
                 $params[] = $param;
@@ -84,6 +85,7 @@ class Request extends \yii\base\Request
 
                 if ($name !== Application::OPTION_APPCONFIG) {
                     $params[$name] = isset($matches[2]) ? $matches[2] : true;
+                    $prevOption = &$params[$name];
                 }
             } elseif (preg_match('/^-([\w-]+)(?:=(.*))?$/', $param, $matches)) {
                 $name = $matches[1];
@@ -91,7 +93,11 @@ class Request extends \yii\base\Request
                     $params[] = $param;
                 } else {
                     $params['_aliases'][$name] = isset($matches[2]) ? $matches[2] : true;
+                    $prevOption = &$params['_aliases'][$name];
                 }
+            } elseif ($prevOption === true) {
+                // `--option value` syntax
+                $prevOption = $param;
             } else {
                 $params[] = $param;
             }

--- a/framework/console/controllers/HelpController.php
+++ b/framework/console/controllers/HelpController.php
@@ -125,8 +125,8 @@ class HelpController extends Controller
         $this->stdout("\n");
         $options = $controller->getActionOptionsHelp($action);
         foreach ($options as $argument => $help) {
-            $description = str_replace("\n", '', addcslashes($help['comment'], ':')) ?: $argument;
-            $this->stdout('--' . $argument . ':' . $description . "\n");
+            $description = str_replace("\n", '', addcslashes($help['comment'], ':'));
+            $this->stdout('--' . $argument . ($description ? ':' . $description : '') . "\n");
         }
     }
 

--- a/tests/framework/console/ControllerTest.php
+++ b/tests/framework/console/ControllerTest.php
@@ -58,6 +58,11 @@ class ControllerTest extends TestCase
         $this->assertEquals('from params', $fromParam);
         $this->assertEquals('notdefault', $other);
 
+        $params = ['test-array' => 'from params,notdefault'];
+        list($fromParam, $other) = $controller->runAction('aksi6', $params);
+        $this->assertEquals('from params', $fromParam);
+        $this->assertEquals('notdefault', $other);
+
         $params = ['avaliable'];
         $message = Yii::t('yii', 'Missing required arguments: {params}', ['params' => implode(', ', ['missing'])]);
         $this->expectException('yii\console\Exception');

--- a/tests/framework/console/RequestTest.php
+++ b/tests/framework/console/RequestTest.php
@@ -122,6 +122,45 @@ class RequestTest extends TestCase
                     ],
                 ],
             ],
+            // Case: `--<option> <value>` and `-<alias> <value>` syntax
+            [
+                'params' => [
+                    'controller/route',
+                    'param1',
+                    '-12345',
+                    '--option1',
+                    '--option2',
+                    'testValue1',
+                    '--option-3',
+                    'testValue2',
+                    '--option_4',
+                    'testValue3',
+                    '-alias1',
+                    '-alias2',
+                    'testValue1',
+                    '-alias-3',
+                    'testValue2',
+                    '-alias_4',
+                    'testValue3',
+                ],
+                'expected' => [
+                    'route' => 'controller/route',
+                    'params' => [
+                        'param1',
+                        '-12345',
+                        'option1' => true,
+                        'option2' => 'testValue1',
+                        'option-3' => 'testValue2',
+                        'option_4' => 'testValue3',
+                        '_aliases' => [
+                            'alias1' => true,
+                            'alias2' => 'testValue1',
+                            'alias-3' => 'testValue2',
+                            'alias_4' => 'testValue3',
+                        ],
+                    ],
+                ],
+            ],
             [
                 // PHP does not allow variable name, starting with digit.
                 // InvalidParamException must be thrown during request resolving:


### PR DESCRIPTION
Made a few improvements to Yii's CLI support:

1. camelCased console command options can now optionally be specified in kebab-case. So for example if you have an option called `dumpJson`, now either `--dumpJson` or `--dump-json` will work.

   It was technically already possible for console commands to support kebab-cased options, as the option regex has always allowed `-`s. (For example we made it possible by overriding a command’s `__get()` and `__set()` methods [in a recent project](https://github.com/pixelandtonic/craftcom/blob/c801526a6efe1a185b32930b255fc13b6506127f/src/console/controllers/PackagesController.php#L23-L42).) So to ensure we don’t break BC, the code makes sure that the kebab-cased option wasn’t already in `$options` before converting it to camelCase.

   In addition, any camelCase option names are now converted to kebab-case in the `help` command outputs, e.g. `help command/path` and `help/list-action-options command/path`.

2. Added support for `--<option> <value>` and `-<alias> <value>` syntax, as an alternative to `--<option>=<value>` and `-<alias>=<value>`. Basically when looping through the `$params` in yii\console\Request::resolve(), if it gets to a raw param value that didn't have an option name, it will check whether the last param was missing a value, and if so, it overrides its assumed value (`true`) with the current value.

   Technically this is a change in behavior for yii\console\Request::resolve(), which given the options `--foo bar` would have previously returned the params `['foo' => true, 0 => 'bar']`, however that would have resulted in an `Unknown option` error in yii\console\Controller::runAction(), so I don’t think anyone will consider this a breaking change :)

3. Improved the `help/list-action-options` command output, for options without a description. Previously they would have been output as `--<option>:<option>`, which was confusing; now they will output as just `--<option>`.


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
