### PR TITLE
Test case. Validator test. Changes in test case naming. Changes in class who called create.

### DIFF
--- a/tests/framework/validators/ValidatorTest.php
+++ b/tests/framework/validators/ValidatorTest.php
@@ -12,6 +12,7 @@ use yii\validators\BooleanValidator;
 use yii\validators\InlineValidator;
 use yii\validators\NumberValidator;
 use yii\validators\RequiredValidator;
+use yii\validators\Validator;
 use yiiunit\data\validators\models\FakedValidationModel;
 use yiiunit\data\validators\models\ValidatorTestFunctionModel;
 use yiiunit\data\validators\TestValidator;
@@ -85,7 +86,7 @@ class ValidatorTest extends TestCase
         $this->assertInstanceOf(RequiredValidator::className(), $validator);
     }
 
-    public function testValidate()
+    public function testValidateAttributes()
     {
         $val = new TestValidator(['attributes' => ['attr_runMe1', 'attr_runMe2']]);
         $model = $this->getTestModel();
@@ -201,7 +202,7 @@ class ValidatorTest extends TestCase
         // Access to validator in inline validation (https://github.com/yiisoft/yii2/issues/6242)
 
         $model = new FakedValidationModel();
-        $val = TestValidator::createValidator('inlineVal', $model, ['val_attr_a'], ['params' => ['foo' => 'bar']]);
+        $val = Validator::createValidator('inlineVal', $model, ['val_attr_a'], ['params' => ['foo' => 'bar']]);
         $val->validateAttribute($model, 'val_attr_a');
         $args = $model->getInlineValArgs();
 
@@ -221,7 +222,7 @@ class ValidatorTest extends TestCase
         // Access to validator in inline validation (https://github.com/yiisoft/yii2/issues/6242)
 
         $model = new FakedValidationModel();
-        $val = TestValidator::createValidator('inlineVal', $model, ['val_attr_a'], ['params' => ['foo' => 'bar']]);
+        $val = Validator::createValidator('inlineVal', $model, ['val_attr_a'], ['params' => ['foo' => 'bar']]);
         $val->clientValidate = 'clientInlineVal';
         $args = $val->clientValidateAttribute($model, 'val_attr_a', null);
 


### PR DESCRIPTION
`testValidateAttributes` instead `testValidate` because `validate` method not to be tested here.  
Called:
`public function validateAttributes($model, $attributes = null)`,  
`public function validateAttribute($model, $attribute)`,  
`protected function validateValue($value)`

`Validator` instead `TestValidator` 
because functional of  `TestValidator` is not used in this case. 

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes