### PR TITLE
Additional check for updateInternal() with optimisticLock

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -770,6 +770,9 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
         $condition = $this->getOldPrimaryKey(true);
         $lock = $this->optimisticLock();
         if ($lock !== null) {
+            if (isset($values[$lock])) {
+                throw new StaleObjectException('The object being updated is outdated.');
+            }
             $values[$lock] = $this->$lock + 1;
             $condition[$lock] = $this->$lock;
         }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

There is no need to excute the sql if the column for optimistic lock has been changed.
