### PR TITLE
lowered default version for PgSQL to match TravisCI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ services:
 
 variables:
   DOCKER_MYSQL_IMAGE: percona:5.7
-  DOCKER_POSTGRES_IMAGE: postgres:10.1
+  DOCKER_POSTGRES_IMAGE: postgres:9.3
 
 before_script:
   - apk add --no-cache python py2-pip git


### PR DESCRIPTION
in addition to https://github.com/yiisoft/yii2/pull/15251 - would be better to have a default for which tests pass, see also https://github.com/yiisoft/yii2/issues/15254

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

