### PR TITLE
Tests: testSchema. MySQL over 8.1 (add versioned data set)

### DIFF
--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -50,7 +50,7 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         $result['3: check'][2] = false;
 
         // https://github.com/yiisoft/yii2/issues/15248
-        if (version_compare($this->getServerVersion(), '8.0.0', '>=') === true) {
+        if (version_compare($this->getServerVersion(), '8.0.1', '>=') === true) {
             $result['3: foreign key'][2][0]->foreignColumnNames = ['c_id_1', 'c_id_2'];
         }
 

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -7,6 +7,7 @@
 
 namespace yiiunit\framework\db\mysql;
 
+use PDO;
 use yiiunit\framework\db\AnyCaseValue;
 
 /**
@@ -16,6 +17,20 @@ use yiiunit\framework\db\AnyCaseValue;
 class SchemaTest extends \yiiunit\framework\db\SchemaTest
 {
     public $driverName = 'mysql';
+
+    protected $_serverVersion;
+
+    protected function getServerVersion($refresh = false)
+    {
+        if ($refresh || !isset($this->_serverVersion)) {
+            $databases = self::getParam('databases');
+            $this->database = $databases[$this->driverName];
+            $connection = $this->getConnection();
+            $this->_serverVersion = $connection->getSlavePdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+        }
+
+        return $this->_serverVersion;
+    }
 
     public function testGetSchemaNames()
     {
@@ -34,7 +49,13 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         $result['3: foreign key'][2][0]->foreignTableName = new AnyCaseValue('T_constraints_2');
         $result['3: check'][2] = false;
 
+        // https://github.com/yiisoft/yii2/issues/15248
+        if (version_compare($this->getServerVersion(), '8.0.0', '>=') === true) {
+            $result['3: foreign key'][2][0]->foreignColumnNames = ['c_id_1', 'c_id_2'];
+        }
+
         $result['4: check'][2] = false;
+
         return $result;
     }
 }


### PR DESCRIPTION
I run test with `MySQL=^8`

I can see lower case in foreign key names. 

```sh
There were 5 failures:

1) yiiunit\framework\db\mysql\SchemaTest::testTableSchemaConstraints with data set "3: foreign key" ('T_constraints_3', 'foreignKeys', array(yii\db\ForeignKeyConstraint Object (...)))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    '{"columnNames":["C_fk_id_1","C_fk_id_2"],"foreignColumnNames":["C_id_1","C_id_2"],"foreignTableName":"t_constraints_2","onDelete":"CASCADE","onUpdate":"CASCADE"}' => yii\db\ForeignKeyConstraint Object (...)
+    '{"columnNames":["C_fk_id_1","C_fk_id_2"],"foreignColumnNames":["c_id_1","c_id_2"],"foreignTableName":"t_constraints_2","onDelete":"CASCADE","onUpdate":"CASCADE"}' => yii\db\ForeignKeyConstraint Object (...)
 )

/var/www/html/tests/framework/db/SchemaTest.php:732
/var/www/html/tests/framework/db/SchemaTest.php:681
/var/www/html/vendor/phpunit/phpunit/phpunit:52

2) yiiunit\framework\db\mysql\SchemaTest::testTableSchemaConstraintsWithPdoUppercase with data set "3: foreign key" ('T_constraints_3', 'foreignKeys', array(yii\db\ForeignKeyConstraint Object (...)))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    '{"columnNames":["C_fk_id_1","C_fk_id_2"],"foreignColumnNames":["C_id_1","C_id_2"],"foreignTableName":"t_constraints_2","onDelete":"CASCADE","onUpdate":"CASCADE"}' => yii\db\ForeignKeyConstraint Object (...)
+    '{"columnNames":["C_fk_id_1","C_fk_id_2"],"foreignColumnNames":["c_id_1","c_id_2"],"foreignTableName":"t_constraints_2","onDelete":"CASCADE","onUpdate":"CASCADE"}' => yii\db\ForeignKeyConstraint Object (...)
 )

/var/www/html/tests/framework/db/SchemaTest.php:732
/var/www/html/tests/framework/db/SchemaTest.php:699
/var/www/html/vendor/phpunit/phpunit/phpunit:52

3) yiiunit\framework\db\mysql\SchemaTest::testTableSchemaConstraintsWithPdoLowercase with data set "3: foreign key" ('T_constraints_3', 'foreignKeys', array(yii\db\ForeignKeyConstraint Object (...)))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    '{"columnNames":["C_fk_id_1","C_fk_id_2"],"foreignColumnNames":["C_id_1","C_id_2"],"foreignTableName":"t_constraints_2","onDelete":"CASCADE","onUpdate":"CASCADE"}' => yii\db\ForeignKeyConstraint Object (...)
+    '{"columnNames":["C_fk_id_1","C_fk_id_2"],"foreignColumnNames":["c_id_1","c_id_2"],"foreignTableName":"t_constraints_2","onDelete":"CASCADE","onUpdate":"CASCADE"}' => yii\db\ForeignKeyConstraint Object (...)
 )

/var/www/html/tests/framework/db/SchemaTest.php:732
/var/www/html/tests/framework/db/SchemaTest.php:717
/var/www/html/vendor/phpunit/phpunit/phpunit:52

```

I can see 
```php
        $connection->getSlavePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
```
and 
```php
        $connection->getSlavePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
```
provide lower case in constrain too.

**this attribute is not attribute about case of foreign key name? Only for column name?**

**May be this is a Error in PDO driver? Or MySQL error?** 

I can't find any info about set this behavior throw settings.

Also I can't find... So... I can find someone like. May be this is source of problem.

https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html
> referenced_table_schema and referenced_table_name field values in the mysql.foreign_keys data dictionary table were not stored in lowercase when lower_case_table_names was enabled. (Bug #25495714)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  |no
| Breaks BC?    | no
| Tests pass?   | yes
```sh
 docker-compose -f ../yii2-phpunit-docker-composition.yml run --rm --entrypoint bash php
root@2d371b5fa9dd:/var/www/html# vendor/bin/phpunit --filter testTableSchemaConstraints tests/framework/db/mysql/SchemaTest.php
PHPUnit 4.8.34 by Sebastian Bergmann and contributors.

............................................................

Time: 3.63 minutes, Memory: 6.00MB

OK (60 tests, 96 assertions)
root@2d371b5fa9dd:/var/www/html# 
```

| Fixed issues  | #15248