### PR TITLE
Allow specify $attributeNames as a string for yii\base\Model validate()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -18,6 +18,7 @@ Yii Framework 2 Change Log
 - Bug #15320: Fixed special role checks in `yii\filters\AccessRule::matchRole()` (Izumi-kun)
 - Bug #15322: Fixed PHP 7.2 compatibility of `FileHelper::getExtensionsByMimeType()` (samdark)
 - Enh #5515: Added default value for `yii\behaviors\BlameableBehavior` for cases when the user is guest (dmirogin)
+- Enh #8752: Allow specify `$attributeNames` as a string for `yii\base\Model` `validate()` method (developeruz)
 - Enh #9137: Added `Access-Control-Allow-Method` header for the OPTIONS request (developeruz)
 - Enh #14043: Added `yii\helpers\IpHelper` (silverfire, cebe)
 - Enh #14568: Refactored migration templates to use `safeUp()` and `safeDown()` methods (Kolyunya)

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -329,7 +329,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      * Errors found during the validation can be retrieved via [[getErrors()]],
      * [[getFirstErrors()]] and [[getFirstError()]].
      *
-     * @param array $attributeNames list of attribute names that should be validated.
+     * @param string[]|string $attributeNames attribute name or list of attribute names that should be validated.
      * If this parameter is empty, it means any attribute listed in the applicable
      * validation rules should be validated.
      * @param bool $clearErrors whether to call [[clearErrors()]] before performing validation
@@ -355,6 +355,8 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
         if ($attributeNames === null) {
             $attributeNames = $this->activeAttributes();
         }
+
+        $attributeNames = (array)$attributeNames;
 
         foreach ($this->getActiveValidators() as $validator) {
             $validator->validateAttributes($this, $attributeNames);

--- a/tests/framework/base/ModelTest.php
+++ b/tests/framework/base/ModelTest.php
@@ -462,10 +462,24 @@ class ModelTest extends TestCase
 
         $this->assertTrue($model->validate());
     }
+
+    public function testValidateAttributeNames()
+    {
+        $model = new ComplexModel1();
+        $model->name = 'Some value';
+        $this->assertTrue($model->validate(['name']), 'Should validate only name attribute');
+        $this->assertTrue($model->validate('name'), 'Should validate only name attribute');
+        $this->assertFalse($model->validate(), 'Should validate all attributes');
+    }
 }
 
 class ComplexModel1 extends Model
 {
+    public $name;
+    public $description;
+    public $id;
+    public $is_disabled;
+
     public function rules()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | not sure
| Tests pass?   | yes
| Fixed issues  | #8752