### PR TITLE
DbCache,  getValues now behaves the same as getValue with regards to streams

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -21,6 +21,7 @@ Yii Framework 2 Change Log
 - Enh #15221: Added support for the `--<option> <value>` console option syntax (brandonkelly)
 - Enh #15221: Improved the `help/list-action-options` console command output for command options without a description (brandonkelly)
 - Bug #15270: Resolved potential race conditions when writing generated php-files (kalessil)
+- Bug #15302: Fixed `yii\caching\DbCache` so that `getValues` now behaves the same as `getValue` with regards to streams (edwards-sj)
 
 2.0.13.1 November 14, 2017
 --------------------------

--- a/framework/caching/DbCache.php
+++ b/framework/caching/DbCache.php
@@ -170,7 +170,11 @@ class DbCache extends Cache
             $results[$key] = false;
         }
         foreach ($rows as $row) {
-            $results[$row['id']] = $row['data'];
+            if (is_resource($row['data']) && get_resource_type($row['data']) === 'stream') {
+                $results[$row['id']] = stream_get_contents($row['data']);
+            } else {
+                $results[$row['id']] = $row['data'];
+            }
         }
 
         return $results;

--- a/tests/framework/caching/PgSQLCacheTest.php
+++ b/tests/framework/caching/PgSQLCacheTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @link      http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license   http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\caching;
+
+use yii\db\Connection;
+
+/**
+ * Class for testing file cache backend.
+ * @group db
+ * @group caching
+ * @group pgsql
+ */
+class PgSQLCacheTest extends DbCacheTest
+{
+    protected static $driverName = 'pgsql';
+    private $_connection;
+
+    protected function setUp()
+    {
+        if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) {
+            $this->markTestSkipped('pdo and pdo_pgsql extensions are required.');
+        }
+
+        $this->getConnection()->createCommand('
+CREATE TABLE IF NOT EXISTS "cache"
+(
+    "id"  varchar(128) not null,
+    "expire" integer,
+    "data"   bytea,
+    primary key ("id")
+);
+        ')->execute();
+    }
+
+    /**
+     * @param  bool            $reset whether to clean up the test database
+     * @return Connection
+     */
+    public function getConnection($reset = true)
+    {
+        if ($this->_connection === null) {
+            $databases = self::getParam('databases');
+            $params = $databases[static::$driverName];
+            $db = new Connection();
+            $db->dsn = $params['dsn'];
+            $db->username = $params['username'];
+            $db->password = $params['password'];
+            if ($reset) {
+                $db->open();
+                $lines = explode(';', file_get_contents($params['fixture']));
+                foreach ($lines as $line) {
+                    if (trim($line) !== '') {
+                        $db->pdo->exec($line);
+                    }
+                }
+            }
+            $this->_connection = $db;
+        }
+
+        return $this->_connection;
+    }
+}


### PR DESCRIPTION
Changed yii\caching\DbCache so that getValues now behaves the same as getValue with regards to streams

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15302
