### PR TITLE
Fixed PHP 7.2 compatibility of FileHelper::getExtensionsByMimeType() by introducing mime aliases

### DIFF
--- a/build/controllers/MimeTypeController.php
+++ b/build/controllers/MimeTypeController.php
@@ -27,34 +27,60 @@ use yii\helpers\VarDumper;
 class MimeTypeController extends Controller
 {
     /**
-     * @param string $outFile the file to update. Defaults to @yii/helpers/mimeTypes.php
+     * @var array MIME type aliases
      */
-    public function actionIndex($outFile = null)
+    private $aliases = [
+        'text/xml' => 'application/xml',
+    ];
+
+    /**
+     * @param string $outFile the mime file to update. Defaults to @yii/helpers/mimeTypes.php
+     * @param string $aliasesOutFile the aliases file to update. Defaults to @yii/helpers/mimeAliases.php
+     */
+    public function actionIndex($outFile = null, $aliasesOutFile = null)
     {
         if ($outFile === null) {
             $outFile = Yii::getAlias('@yii/helpers/mimeTypes.php');
         }
+
+        if ($aliasesOutFile === null) {
+            $aliasesOutFile = Yii::getAlias('@yii/helpers/mimeAliases.php');
+        }
+
         $this->stdout('downloading mime-type file from apache httpd repository...');
-        if ($content = file_get_contents('http://svn.apache.org/viewvc/httpd/httpd/trunk/docs/conf/mime.types?view=co')) {
+        if ($apacheMimeTypesFileContent = file_get_contents('http://svn.apache.org/viewvc/httpd/httpd/trunk/docs/conf/mime.types?view=co')) {
             $this->stdout("done.\n", Console::FG_GREEN);
-            $this->stdout("generating file $outFile...");
-            $mimeMap = [];
-            foreach (explode("\n", $content) as $line) {
-                $line = trim($line);
-                if (empty($line) || $line[0] == '#') { // skip comments and empty lines
-                    continue;
-                }
-                $parts = preg_split('/\s+/', $line);
-                $mime = array_shift($parts);
-                foreach ($parts as $ext) {
-                    if (!empty($ext)) {
-                        $mimeMap[$ext] = $mime;
-                    }
+            $this->generateMimeTypesFile($outFile, $apacheMimeTypesFileContent);
+            $this->generateMimeAliasesFile($aliasesOutFile);
+        } else {
+            $this->stderr("Failed to download mime.types file from apache SVN.\n");
+        }
+    }
+
+    /**
+     * @param string $outFile
+     * @param string $content
+     */
+    private function generateMimeTypesFile($outFile, $content)
+    {
+        $this->stdout("generating file $outFile...");
+        $mimeMap = [];
+        foreach (explode("\n", $content) as $line) {
+            $line = trim($line);
+            if (empty($line) || $line[0] === '#') { // skip comments and empty lines
+                continue;
+            }
+            $parts = preg_split('/\s+/', $line);
+            $mime = array_shift($parts);
+            foreach ($parts as $ext) {
+                if (!empty($ext)) {
+                    $mimeMap[$ext] = $mime;
                 }
             }
-            ksort($mimeMap);
-            $array = VarDumper::export($mimeMap);
-            $content = <<<EOD
+        }
+        ksort($mimeMap);
+        $array = VarDumper::export($mimeMap);
+        $content = <<<EOD
 <?php
 /**
  * MIME types.
@@ -68,10 +94,28 @@ class MimeTypeController extends Controller
 return $array;
 
 EOD;
-            file_put_contents($outFile, $content);
-            $this->stdout("done.\n", Console::FG_GREEN);
-        } else {
-            $this->stderr("Failed to download mime.types file from apache SVN.\n");
-        }
+        file_put_contents($outFile, $content);
+        $this->stdout("done.\n", Console::FG_GREEN);
+    }
+
+    /**
+     * @param string $outFile
+     */
+    private function generateMimeAliasesFile($outFile)
+    {
+        $this->stdout("generating file $outFile...");
+        $array = VarDumper::export($this->aliases);
+        $content = <<<EOD
+<?php
+/**
+ * MIME aliases.
+ *
+ * This file contains aliases for MIME types.
+ */
+return $array;
+
+EOD;
+        file_put_contents($outFile, $content);
+        $this->stdout("done.\n", Console::FG_GREEN);
     }
 }

--- a/build/controllers/ReleaseController.php
+++ b/build/controllers/ReleaseController.php
@@ -433,8 +433,8 @@ class ReleaseController extends Controller
         $this->dryRun || Yii::$app->runAction('classmap', [$frameworkPath]);
         $this->stdout("done.\n", Console::FG_GREEN, Console::BOLD);
 
-        $this->stdout('updating mimetype magic file...', Console::BOLD);
-        $this->dryRun || Yii::$app->runAction('mime-type', ["$frameworkPath/helpers/mimeTypes.php"]);
+        $this->stdout('updating mimetype magic file and mime aliases...', Console::BOLD);
+        $this->dryRun || Yii::$app->runAction('mime-type', ["$frameworkPath/helpers/mimeTypes.php"], ["$frameworkPath/helpers/mimeAliases.php"]);
         $this->stdout("done.\n", Console::FG_GREEN, Console::BOLD);
 
         $this->stdout("fixing various PHPDoc style issues...\n", Console::BOLD);

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -24,6 +24,7 @@ Yii Framework 2 Change Log
 - Bug #15270: Resolved potential race conditions when writing generated php-files (kalessil)
 - Bug #15302: Fixed `yii\caching\DbCache` so that `getValues` now behaves the same as `getValue` with regards to streams (edwards-sj)
 - Bug #15301: Fixed `ArrayHelper::filter()` to work properly with `0` in values (hhniao)
+- Bug #15322: Fixed PHP 7.2 compatibility of `FileHelper::getExtensionsByMimeType()` (samdark)
 
 2.0.13.1 November 14, 2017
 --------------------------

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -34,6 +34,12 @@ class BaseFileHelper
      */
     public static $mimeMagicFile = '@yii/helpers/mimeTypes.php';
 
+    /**
+     * @var string the path (or alias) of a PHP file containing MIME aliases.
+     * @since 2.0.14
+     */
+    public static $mimeAliasesFile = '@yii/helpers/mimeAliases.php';
+
 
     /**
      * Normalizes a file/directory path.
@@ -189,6 +195,11 @@ class BaseFileHelper
      */
     public static function getExtensionsByMimeType($mimeType, $magicFile = null)
     {
+        $aliases = static::loadMimeAliases(static::$mimeAliasesFile);
+        if (isset($aliases[$mimeType])) {
+            $mimeType = $aliases[$mimeType];
+        }
+
         $mimeTypes = static::loadMimeTypes($magicFile);
         return array_keys($mimeTypes, mb_strtolower($mimeType, 'UTF-8'), true);
     }
@@ -212,6 +223,28 @@ class BaseFileHelper
         }
 
         return self::$_mimeTypes[$magicFile];
+    }
+
+    private static $_mimeAliases = [];
+
+    /**
+     * Loads MIME aliases from the specified file.
+     * @param string $aliasesFile the path (or alias) of the file that contains MIME type aliases.
+     * If this is not set, the file specified by [[mimeAliasesFile]] will be used.
+     * @return array the mapping from file extensions to MIME types
+     * @since 2.0.14
+     */
+    protected static function loadMimeAliases($aliasesFile)
+    {
+        if ($aliasesFile === null) {
+            $aliasesFile = static::$mimeAliasesFile;
+        }
+        $aliasesFile = Yii::getAlias($aliasesFile);
+        if (!isset(self::$_mimeAliases[$aliasesFile])) {
+            self::$_mimeAliases[$aliasesFile] = require $aliasesFile;
+        }
+
+        return self::$_mimeAliases[$aliasesFile];
     }
 
     /**

--- a/framework/helpers/mimeAliases.php
+++ b/framework/helpers/mimeAliases.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * MIME aliases.
+ *
+ * This file contains aliases for MIME types.
+ */
+return [
+    'text/xml' => 'application/xml',
+];

--- a/tests/framework/validators/FileValidatorTest.php
+++ b/tests/framework/validators/FileValidatorTest.php
@@ -415,11 +415,7 @@ class FileValidatorTest extends TestCase
             ['test.png', 'image/*', 'png'],
             ['test.png', 'IMAGE/*', 'png'],
             ['test.txt', 'text/*', 'txt'],
-            // Disabled for PHP 7.2 RC because of regression:
-            // https://bugs.php.net/bug.php?id=75380
-            version_compare(PHP_VERSION, '7.2.0.RC.1', '>=') && version_compare(PHP_VERSION, '7.2.0.RC.6', '<=')
-                ? null
-                : ['test.xml', '*/xml', 'xml'],
+            ['test.xml', '*/xml', 'xml'],
             ['test.odt', 'application/vnd*', 'odt'],
         ]);
     }
@@ -445,7 +441,8 @@ class FileValidatorTest extends TestCase
     {
         $validator = new FileValidator(['extensions' => (array) $allowedExtensions]);
         $file = $this->getRealTestFile($fileName);
-        $this->assertTrue($validator->validate($file));
+        $detectedMimeType = FileHelper::getMimeType($file->tempName, null, false);
+        $this->assertTrue($validator->validate($file), "Mime type detected was \"$detectedMimeType\". Consider adding it to MimeTypeController::\$aliases.");
     }
 
     /**


### PR DESCRIPTION
Proper fix for mime type detection incompatibility in PHP 7.2. It fixes it for `text/xml` but it's easy to add more types if we'll find out these were changed.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
