### PR TITLE
fix to validate when `$requiredValue` is `null` and validation is strict

### DIFF
--- a/framework/validators/RequiredValidator.php
+++ b/framework/validators/RequiredValidator.php
@@ -68,7 +68,7 @@ class RequiredValidator extends Validator
     protected function validateValue($value)
     {
         if ($this->requiredValue === null) {
-            if ($this->strict && $value !== null || !$this->strict && !$this->isEmpty(is_string($value) ? trim($value) : $value)) {
+            if ($this->strict && $value === null || !$this->strict && !$this->isEmpty(is_string($value) ? trim($value) : $value)) {
                 return null;
             }
         } elseif (!$this->strict && $value == $this->requiredValue || $this->strict && $value === $this->requiredValue) {

--- a/framework/validators/RequiredValidator.php
+++ b/framework/validators/RequiredValidator.php
@@ -59,6 +59,10 @@ class RequiredValidator extends Validator
         if ($this->message === null) {
             $this->message = $this->requiredValue === null ? Yii::t('yii', '{attribute} cannot be blank.')
                 : Yii::t('yii', '{attribute} must be "{requiredValue}".');
+
+            if ($this->requiredValue === null && $this->strict) {
+                $this->message = Yii::t('yii', '{attribute} must be blank.');
+            }
         }
     }
 

--- a/tests/framework/validators/RequiredValidatorTest.php
+++ b/tests/framework/validators/RequiredValidatorTest.php
@@ -31,6 +31,11 @@ class RequiredValidatorTest extends TestCase
         $this->assertFalse($val->validate([]));
         $this->assertTrue($val->validate('not empty'));
         $this->assertTrue($val->validate(['with', 'elements']));
+        $val->strict = true;
+        $this->assertTrue($val->validate(null));
+        $this->assertFalse($val->validate([]));
+        $this->assertFalse($val->validate('should fail'));
+        $this->assertFalse($val->validate(['should', 'fail', 'with', 'elements']));
     }
 
     public function testValidateValueWithValue()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | When `RequiredValidator::requiredValue` is `null` and `RequiredValidator::strict` is `true` and the value in `$value` is `null` then the validation failed.
