### PR TITLE
Fixed an issue where function availability is not checked.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -26,7 +26,7 @@ Yii Framework 2 Change Log
 - Bug #15301: Fixed `ArrayHelper::filter()` to work properly with `0` in values (hhniao)
 - Bug #15322: Fixed PHP 7.2 compatibility of `FileHelper::getExtensionsByMimeType()` (samdark)
 - Bug #15320: Fixed special role checks in `yii\filters\AccessRule::matchRole()` (Izumi-kun)
-- Enh #15332: Always check for availability of `openssl_pseudo_random_bytes`, even if LibreSSL is available. (sammousa)
+- Enh #15332: Always check for availability of `openssl_pseudo_random_bytes`, even if LibreSSL is available (sammousa)
 
 2.0.13.1 November 14, 2017
 --------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -26,6 +26,7 @@ Yii Framework 2 Change Log
 - Bug #15301: Fixed `ArrayHelper::filter()` to work properly with `0` in values (hhniao)
 - Bug #15322: Fixed PHP 7.2 compatibility of `FileHelper::getExtensionsByMimeType()` (samdark)
 - Bug #15320: Fixed special role checks in `yii\filters\AccessRule::matchRole()` (Izumi-kun)
+- Enh #15332: Always check for availability of `openssl_pseudo_random_bytes`, even if LibreSSL is available. (sammousa)
 
 2.0.13.1 November 14, 2017
 --------------------------

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -478,12 +478,12 @@ class Security extends Component
 
         // Since 5.4.0, openssl_random_pseudo_bytes() reads from CryptGenRandom on Windows instead
         // of using OpenSSL library. LibreSSL is OK everywhere but don't use OpenSSL on non-Windows.
-        if ($this->_useLibreSSL
+        if (function_exists('openssl_random_pseudo_bytes')
+            && ($this->_useLibreSSL
             || (
                 DIRECTORY_SEPARATOR !== '/'
                 && substr_compare(PHP_OS, 'win', 0, 3, true) === 0
-                && function_exists('openssl_random_pseudo_bytes')
-            )
+            ))
         ) {
             $key = openssl_random_pseudo_bytes($length, $cryptoStrong);
             if ($cryptoStrong === false) {


### PR DESCRIPTION
I noticed that in my local environment a test was failing.
My local environment has LibreSSL available; the code path that checks for that doesn't check if the function `openssl_pseudo_random_bytes` exists before using it.
The test suite depends on that check to return false to test for proper exceptions.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

