### PR TITLE
Adds dbmanager cache into an examle

### DIFF
--- a/docs/guide/security-authorization.md
+++ b/docs/guide/security-authorization.md
@@ -225,6 +225,7 @@ return [
     'components' => [
         'authManager' => [
             'class' => 'yii\rbac\DbManager',
+            'cache' => 'cache',
         ],
         // ...
     ],

--- a/docs/guide/security-authorization.md
+++ b/docs/guide/security-authorization.md
@@ -225,7 +225,8 @@ return [
     'components' => [
         'authManager' => [
             'class' => 'yii\rbac\DbManager',
-            'cache' => 'cache',
+            // uncomment if you want to cache RBAC items hierarchy
+            // 'cache' => 'cache',
         ],
         // ...
     ],


### PR DESCRIPTION
When I used the RBAC first time, I didn't know about the dbmanager caching. I was relaying on the examples only. Then I saw many queries in my logs and started searching to eventually find the cache property.

I think there isn't a situation, when someone doesn't use caching for dbmanager rbac, so i'ts very helpful to put it in the example above.

Hope I'm correct.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
