### PR TITLE
Context component get

### DIFF
--- a/framework/BaseYii.php
+++ b/framework/BaseYii.php
@@ -547,4 +547,33 @@ class BaseYii
     {
         return get_object_vars($object);
     }
+
+    /**
+     * Returns the component instance with the specified ID.
+     * In case there is a current controller running component will be requested from its owner module, otherwise
+     * it will be taken from current application instance.
+     * In case there is no application instance yet - a dummy application will be created.
+     * @param string $id component ID (e.g. `db`).
+     * @return object the component of the specified ID.
+     * @since 2.0.14
+     */
+    public static function get($id)
+    {
+        if (static::$app === null) {
+            $argv = isset($_SERVER['argv']) ? $_SERVER['argv'] : null; // bypass possible errors at `\yii\console\Application::loadConfig()`
+            static::$app = new \yii\console\Application([
+                'id' => 'yii',
+                'basePath' => __DIR__,
+            ]);
+            if ($argv !== null) {
+                $_SERVER['argv'] = $argv;
+            }
+        }
+
+        if (isset(static::$app->controller)) {
+            return static::$app->controller->module->get($id);
+        }
+
+        return static::$app->get($id);
+    }
 }

--- a/framework/base/ActionFilter.php
+++ b/framework/base/ActionFilter.php
@@ -17,6 +17,8 @@ namespace yii\base;
  *
  * For more details and usage information on ActionFilter, see the [guide article on filters](guide:structure-filters).
  *
+ * @property Controller|Module $owner the owner of this behavior.
+ *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -437,7 +437,7 @@ class Controller extends Component implements ViewContextInterface
     public function getView()
     {
         if ($this->_view === null) {
-            $this->_view = Yii::$app->getView();
+            $this->_view = $this->module->get('view');
         }
 
         return $this->_view;

--- a/framework/filters/AccessControl.php
+++ b/framework/filters/AccessControl.php
@@ -99,6 +99,9 @@ class AccessControl extends ActionFilter
     {
         parent::init();
         if ($this->user !== false) {
+            if (is_string($this->user) && $this->owner->module->has($this->user)) {
+                $this->user = Yii::get($this->user);
+            }
             $this->user = Instance::ensure($this->user, User::className());
         }
         foreach ($this->rules as $i => $rule) {
@@ -117,7 +120,7 @@ class AccessControl extends ActionFilter
     public function beforeAction($action)
     {
         $user = $this->user;
-        $request = Yii::$app->getRequest();
+        $request = Yii::get('request');
         /* @var $rule AccessRule */
         foreach ($this->rules as $rule) {
             if ($allow = $rule->allows($action, $user, $request)) {

--- a/framework/filters/AccessControl.php
+++ b/framework/filters/AccessControl.php
@@ -98,12 +98,7 @@ class AccessControl extends ActionFilter
     public function init()
     {
         parent::init();
-        if ($this->user !== false) {
-            if (is_string($this->user) && $this->owner->module->has($this->user)) {
-                $this->user = Yii::get($this->user);
-            }
-            $this->user = Instance::ensure($this->user, User::className());
-        }
+
         foreach ($this->rules as $i => $rule) {
             if (is_array($rule)) {
                 $this->rules[$i] = Yii::createObject(array_merge($this->ruleConfig, $rule));
@@ -119,6 +114,13 @@ class AccessControl extends ActionFilter
      */
     public function beforeAction($action)
     {
+        if ($this->user !== false) {
+            if (is_string($this->user) && $action->controller->module->has($this->user)) {
+                $this->user = $action->controller->module->get($this->user);
+            }
+            $this->user = Instance::ensure($this->user, User::className());
+        }
+
         $user = $this->user;
         $request = Yii::get('request');
         /* @var $rule AccessRule */

--- a/framework/filters/AjaxFilter.php
+++ b/framework/filters/AjaxFilter.php
@@ -48,7 +48,7 @@ class AjaxFilter extends ActionFilter
     public function init()
     {
         if ($this->request === null) {
-            $this->request = Yii::$app->getRequest();
+            $this->request = Yii::get('request');
         }
     }
 

--- a/framework/filters/ContentNegotiator.php
+++ b/framework/filters/ContentNegotiator.php
@@ -151,8 +151,8 @@ class ContentNegotiator extends ActionFilter implements BootstrapInterface
      */
     public function negotiate()
     {
-        $request = $this->request ?: Yii::$app->getRequest();
-        $response = $this->response ?: Yii::$app->getResponse();
+        $request = $this->request ?: Yii::get('request');
+        $response = $this->response ?: Yii::get('response');
         if (!empty($this->formats)) {
             $this->negotiateContentType($request, $response);
         }

--- a/framework/filters/Cors.php
+++ b/framework/filters/Cors.php
@@ -97,8 +97,8 @@ class Cors extends ActionFilter
      */
     public function beforeAction($action)
     {
-        $this->request = $this->request ?: Yii::$app->getRequest();
-        $this->response = $this->response ?: Yii::$app->getResponse();
+        $this->request = $this->request ?: Yii::get('request');
+        $this->response = $this->response ?: Yii::get('response');
 
         $this->overrideDefaultSettings($action);
 

--- a/framework/filters/HostControl.php
+++ b/framework/filters/HostControl.php
@@ -113,6 +113,16 @@ class HostControl extends ActionFilter
      * @see \yii\web\Request::getHostInfo()
      */
     public $fallbackHostInfo = '';
+    /**
+     * @var \yii\web\Request the current request. If not set, the `request` application component will be used.
+     * @since 2.0.14
+     */
+    public $request;
+    /**
+     * @var \yii\web\Response the response to be sent. If not set, the `response` application component will be used.
+     * @since 2.0.14
+     */
+    public $response;
 
 
     /**
@@ -120,6 +130,13 @@ class HostControl extends ActionFilter
      */
     public function beforeAction($action)
     {
+        if ($this->request === null) {
+            $this->request = Yii::get('request');
+        }
+        if ($this->response === null) {
+            $this->response = Yii::get('response');
+        }
+
         $allowedHosts = $this->allowedHosts;
         if ($allowedHosts instanceof \Closure) {
             $allowedHosts = call_user_func($allowedHosts, $action);
@@ -142,7 +159,7 @@ class HostControl extends ActionFilter
 
         // replace invalid host info to prevent using it in further processing
         if ($this->fallbackHostInfo !== null) {
-            Yii::$app->getRequest()->setHostInfo($this->fallbackHostInfo);
+            $this->request->setHostInfo($this->fallbackHostInfo);
         }
 
         if ($this->denyCallback !== null) {
@@ -167,12 +184,13 @@ class HostControl extends ActionFilter
         $exception = new NotFoundHttpException(Yii::t('yii', 'Page not found.'));
 
         // use regular error handling if $this->fallbackHostInfo was set
-        if (!empty(Yii::$app->getRequest()->hostName)) {
+        if (!empty($this->request->hostName)) {
             throw $exception;
         }
 
-        $response = Yii::$app->getResponse();
-        $errorHandler = Yii::$app->getErrorHandler();
+        $response = $this->response;
+        /* @var $errorHandler \yii\web\ErrorHandler */
+        $errorHandler = Yii::get('errorHandler');
 
         $response->setStatusCode($exception->statusCode, $exception->getMessage());
         $response->data = $errorHandler->renderFile($errorHandler->errorView, ['exception' => $exception]);

--- a/framework/filters/PageCache.php
+++ b/framework/filters/PageCache.php
@@ -134,17 +134,6 @@ class PageCache extends ActionFilter
 
 
     /**
-     * @inheritdoc
-     */
-    public function init()
-    {
-        parent::init();
-        if ($this->view === null) {
-            $this->view = $this->owner->getView();
-        }
-    }
-
-    /**
      * This method is invoked right before an action is to be executed (after all possible filters.)
      * You may override this method to do last-minute preparation for the action.
      * @param Action $action the action to be executed.
@@ -154,6 +143,10 @@ class PageCache extends ActionFilter
     {
         if (!$this->enabled) {
             return true;
+        }
+
+        if ($this->view === null) {
+            $this->view = $this->owner->getView();
         }
 
         $this->cache = Instance::ensure($this->cache, 'yii\caching\CacheInterface');

--- a/framework/filters/PageCache.php
+++ b/framework/filters/PageCache.php
@@ -140,7 +140,7 @@ class PageCache extends ActionFilter
     {
         parent::init();
         if ($this->view === null) {
-            $this->view = Yii::$app->getView();
+            $this->view = $this->owner->getView();
         }
     }
 
@@ -162,7 +162,8 @@ class PageCache extends ActionFilter
             $this->dependency = Yii::createObject($this->dependency);
         }
 
-        $response = Yii::$app->getResponse();
+        /* @var $response \yii\web\Response */
+        $response = Yii::get('response');
         $data = $this->cache->get($this->calculateCacheKey());
         if (!is_array($data) || !isset($data['cacheVersion']) || $data['cacheVersion'] !== 1) {
             $this->view->cacheStack[] = $this;

--- a/framework/filters/RateLimiter.php
+++ b/framework/filters/RateLimiter.php
@@ -68,10 +68,10 @@ class RateLimiter extends ActionFilter
     public function init()
     {
         if ($this->request === null) {
-            $this->request = Yii::$app->getRequest();
+            $this->request = Yii::get('request');
         }
         if ($this->response === null) {
-            $this->response = Yii::$app->getResponse();
+            $this->response = Yii::get('response');
         }
     }
 
@@ -80,8 +80,10 @@ class RateLimiter extends ActionFilter
      */
     public function beforeAction($action)
     {
-        if ($this->user === null && Yii::$app->getUser()) {
-            $this->user = Yii::$app->getUser()->getIdentity(false);
+        if ($this->user === null && $action->controller->module->has('user')) {
+            /* @var $webUser \yii\web\User */
+            $webUser = $action->controller->module->get('user');
+            $this->user = $webUser->getIdentity(false);
         }
 
         if ($this->user instanceof RateLimitInterface) {

--- a/framework/filters/VerbFilter.php
+++ b/framework/filters/VerbFilter.php
@@ -96,7 +96,9 @@ class VerbFilter extends Behavior
             return $event->isValid;
         }
 
-        $verb = Yii::$app->getRequest()->getMethod();
+        /* @var $request \yii\web\Request */
+        $request = Yii::get('request');
+        $verb = $request->getMethod();
         $allowed = array_map('strtoupper', $verbs);
         if (!in_array($verb, $allowed)) {
             $event->isValid = false;

--- a/framework/filters/auth/AuthMethod.php
+++ b/framework/filters/auth/AuthMethod.php
@@ -51,12 +51,12 @@ abstract class AuthMethod extends ActionFilter implements AuthInterface
      */
     public function beforeAction($action)
     {
-        $response = $this->response ?: Yii::$app->getResponse();
+        $response = $this->response ?: Yii::get('response');
 
         try {
             $identity = $this->authenticate(
-                $this->user ?: Yii::$app->getUser(),
-                $this->request ?: Yii::$app->getRequest(),
+                $this->user ?: Yii::get('user'),
+                $this->request ?: Yii::get('request'),
                 $response
             );
         } catch (UnauthorizedHttpException $e) {

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -299,7 +299,7 @@ class BaseHtml
      */
     public static function csrfMetaTags()
     {
-        $request = Yii::$app->getRequest();
+        $request = Yii::get('request');
         if ($request instanceof Request && $request->enableCsrfValidation) {
             return static::tag('meta', '', ['name' => 'csrf-param', 'content' => $request->csrfParam]) . "\n    "
                 . static::tag('meta', '', ['name' => 'csrf-token', 'content' => $request->getCsrfToken()]) . "\n";
@@ -333,7 +333,7 @@ class BaseHtml
 
         $hiddenInputs = [];
 
-        $request = Yii::$app->getRequest();
+        $request = Yii::get('request');
         if ($request instanceof Request) {
             if (strcasecmp($method, 'get') && strcasecmp($method, 'post')) {
                 // simulate PUT, DELETE, etc. via POST

--- a/framework/helpers/BaseUrl.php
+++ b/framework/helpers/BaseUrl.php
@@ -300,9 +300,9 @@ class BaseUrl
         $url = static::to($url);
 
         if ($name === null) {
-            Yii::$app->getUser()->setReturnUrl($url);
+            Yii::get('user')->setReturnUrl($url);
         } else {
-            Yii::$app->getSession()->set($name, $url);
+            Yii::get('session')->set($name, $url);
         }
     }
 
@@ -319,10 +319,10 @@ class BaseUrl
     public static function previous($name = null)
     {
         if ($name === null) {
-            return Yii::$app->getUser()->getReturnUrl();
+            return Yii::get('user')->getReturnUrl();
         }
 
-        return Yii::$app->getSession()->get($name);
+        return Yii::get('session')->get($name);
     }
 
     /**
@@ -427,7 +427,7 @@ class BaseUrl
      */
     public static function current(array $params = [], $scheme = false)
     {
-        $currentParams = Yii::$app->getRequest()->getQueryParams();
+        $currentParams = Yii::get('request')->getQueryParams();
         $currentParams[0] = '/' . Yii::$app->controller->getRoute();
         $route = array_replace_recursive($currentParams, $params);
         return static::toRoute($route, $scheme);
@@ -439,6 +439,6 @@ class BaseUrl
      */
     protected static function getUrlManager()
     {
-        return static::$urlManager ?: Yii::$app->getUrlManager();
+        return static::$urlManager ?: Yii::get('urlManager');
     }
 }

--- a/tests/framework/BaseYiiTest.php
+++ b/tests/framework/BaseYiiTest.php
@@ -172,4 +172,26 @@ class BaseYiiTest extends TestCase
 
         BaseYii::setLogger(null);
     }
+
+    /**
+     * @covers \yii\BaseYii::get()
+     */
+    public function testGet()
+    {
+        $component = BaseYii::get('formatter');
+        $this->assertTrue($component instanceof \yii\i18n\Formatter);
+
+        $this->mockApplication([
+            'components' => [
+                'foo' => [
+                    'class' => 'yii\console\Request'
+                ],
+            ]
+        ]);
+        $component = BaseYii::get('foo');
+        $this->assertTrue($component instanceof \yii\console\Request);
+
+        $this->expectException('yii\base\InvalidConfigException');
+        $component = BaseYii::get('unexisting');
+    }
 }

--- a/tests/framework/BaseYiiTest.php
+++ b/tests/framework/BaseYiiTest.php
@@ -178,8 +178,8 @@ class BaseYiiTest extends TestCase
      */
     public function testGet()
     {
-        $component = BaseYii::get('formatter');
-        $this->assertTrue($component instanceof \yii\i18n\Formatter);
+        $component = BaseYii::get('view');
+        $this->assertTrue($component instanceof \yii\base\View);
 
         $this->mockApplication([
             'components' => [

--- a/tests/framework/base/ActionFilterTest.php
+++ b/tests/framework/base/ActionFilterTest.php
@@ -114,6 +114,7 @@ class ActionFilterTest extends TestCase
         $method->setAccessible(true);
 
         $controller = new \yii\web\Controller('test', Yii::$app);
+        $filter->owner = $controller;
 
         // active by default
         $this->assertTrue($method->invokeArgs($filter, [new Action('index', $controller)]));

--- a/tests/framework/console/controllers/MigrateControllerTestTrait.php
+++ b/tests/framework/console/controllers/MigrateControllerTestTrait.php
@@ -67,12 +67,8 @@ trait MigrateControllerTestTrait
      */
     protected function createMigrateController(array $config = [])
     {
-        $module = $this->getMockBuilder('yii\\base\\Module')
-            ->setMethods(['fake'])
-            ->setConstructorArgs(['console'])
-            ->getMock();
         $class = $this->migrateControllerClass;
-        $migrateController = new $class('migrate', $module);
+        $migrateController = new $class('migrate', Yii::$app);
         $migrateController->interactive = false;
         $migrateController->migrationPath = $this->migrationPath;
         return Yii::configure($migrateController, $config);

--- a/tests/framework/filters/AjaxFilterTest.php
+++ b/tests/framework/filters/AjaxFilterTest.php
@@ -39,7 +39,7 @@ class AjaxFilterTest extends TestCase
         $this->mockWebApplication();
         $controller = new Controller('id', Yii::$app);
         $action = new Action('test', $controller);
-        $filter = new AjaxFilter();
+        $filter = new AjaxFilter(['owner' => $controller]);
 
         $filter->request = $this->mockRequest(true);
         $this->assertTrue($filter->beforeAction($action));

--- a/tests/framework/filters/HostControlTest.php
+++ b/tests/framework/filters/HostControlTest.php
@@ -93,11 +93,12 @@ class HostControlTest extends TestCase
     {
         $_SERVER['HTTP_HOST'] = $host;
 
-        $filter = new HostControl();
-        $filter->allowedHosts = $allowedHosts;
-
         $controller = new Controller('id', Yii::$app);
         $action = new Action('test', $controller);
+
+        $filter = new HostControl();
+        $filter->owner = $controller;
+        $filter->allowedHosts = $allowedHosts;
 
         if ($allowed) {
             $this->assertTrue($filter->beforeAction($action));
@@ -124,28 +125,32 @@ class HostControlTest extends TestCase
 
     public function testDenyCallback()
     {
+        $controller = new Controller('test', Yii::$app);
+        $action = new Action('test', $controller);
+
         $filter = new HostControl();
+        $filter->owner = $controller;
         $filter->allowedHosts = ['example.com'];
         $this->denyCallBackCalled = false;
         $filter->denyCallback = function () {
             $this->denyCallBackCalled = true;
         };
 
-        $controller = new Controller('test', Yii::$app);
-        $action = new Action('test', $controller);
         $this->assertFalse($filter->beforeAction($action));
         $this->assertTrue($this->denyCallBackCalled, 'denyCallback should have been called.');
     }
 
     public function testDefaultHost()
     {
+        $controller = new Controller('test', Yii::$app);
+        $action = new Action('test', $controller);
+
         $filter = new HostControl();
+        $filter->owner = $controller;
         $filter->allowedHosts = ['example.com'];
         $filter->fallbackHostInfo = 'http://yiiframework.com';
         $filter->denyCallback = function () {};
 
-        $controller = new Controller('test', Yii::$app);
-        $action = new Action('test', $controller);
         $filter->beforeAction($action);
 
         $this->assertSame('yiiframework.com', Yii::$app->getRequest()->getHostName());
@@ -156,12 +161,14 @@ class HostControlTest extends TestCase
         $this->expectException('yii\web\NotFoundHttpException');
         $this->expectExceptionMessage('Page not found.');
 
+        $controller = new Controller('test', Yii::$app);
+        $action = new Action('test', $controller);
+
         $filter = new HostControl();
+        $filter->owner = $controller;
         $filter->allowedHosts = ['example.com'];
         $filter->fallbackHostInfo = 'http://yiiframework.com';
 
-        $controller = new Controller('test', Yii::$app);
-        $action = new Action('test', $controller);
         $filter->beforeAction($action);
     }
 }

--- a/tests/framework/filters/HttpCacheTest.php
+++ b/tests/framework/filters/HttpCacheTest.php
@@ -9,6 +9,7 @@ namespace yiiunit\framework\filters;
 
 use Yii;
 use yii\filters\HttpCache;
+use yii\web\Controller;
 
 /**
  * @group filters
@@ -27,7 +28,7 @@ class HttpCacheTest extends \yiiunit\TestCase
 
     public function testDisabled()
     {
-        $httpCache = new HttpCache();
+        $httpCache = new HttpCache(['owner' => new Controller('test', Yii::$app)]);
         $this->assertTrue($httpCache->beforeAction(null));
         $httpCache->enabled = false;
         $this->assertTrue($httpCache->beforeAction(null));
@@ -35,7 +36,7 @@ class HttpCacheTest extends \yiiunit\TestCase
 
     public function testEmptyPragma()
     {
-        $httpCache = new HttpCache();
+        $httpCache = new HttpCache(['owner' => new Controller('test', Yii::$app)]);
         $httpCache->etagSeed = function ($action, $params) {
             return '';
         };
@@ -50,8 +51,8 @@ class HttpCacheTest extends \yiiunit\TestCase
      */
     public function testValidateCache()
     {
-        $httpCache = new HttpCache();
         $request = Yii::$app->getRequest();
+        $httpCache = new HttpCache(['request' => $request]);
 
         $method = new \ReflectionMethod($httpCache, 'validateCache');
         $method->setAccessible(true);
@@ -83,7 +84,7 @@ class HttpCacheTest extends \yiiunit\TestCase
      */
     public function testGenerateEtag()
     {
-        $httpCache = new HttpCache();
+        $httpCache = new HttpCache(['owner' => new Controller('test', Yii::$app)]);
         $httpCache->weakEtag = false;
 
         $httpCache->etagSeed = function ($action, $params) {

--- a/tests/framework/filters/RateLimiterTest.php
+++ b/tests/framework/filters/RateLimiterTest.php
@@ -9,8 +9,10 @@ namespace yiiunit\framework\filters;
 
 use Prophecy\Argument;
 use Yii;
+use yii\base\Action;
 use yii\filters\RateLimiter;
 use yii\log\Logger;
+use yii\web\Controller;
 use yii\web\Request;
 use yii\web\Response;
 use yii\web\User;
@@ -103,7 +105,7 @@ class RateLimiterTest extends TestCase
         Yii::$app->set('user', $user);
         $rateLimiter = new RateLimiter();
 
-        $result = $rateLimiter->beforeAction('test');
+        $result = $rateLimiter->beforeAction(new Action('test', new Controller('test', Yii::$app)));
 
         $this->assertContains('Rate limit skipped: user not logged in.', Yii::getLogger()->messages);
         $this->assertTrue($result);

--- a/tests/framework/helpers/UrlTest.php
+++ b/tests/framework/helpers/UrlTest.php
@@ -67,7 +67,7 @@ class UrlTest extends TestCase
         $controller->action = new Action($actionID, $controller);
 
         if ($moduleID !== null) {
-            $controller->module = new Module($moduleID);
+            $controller->module = new Module($moduleID, Yii::$app);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14800

Related to #14800.
This PR introduces a static method `Yii::get()`, which will pick a component from current module or application as a fallback.