### PR TITLE
Add signature of callable in DI

### DIFF
--- a/docs/guide-es/concept-di-container.md
+++ b/docs/guide-es/concept-di-container.md
@@ -75,7 +75,7 @@ En este caso, el contenedor usará una llamada de retorno PHP registrada para co
 clase. La llamada de retorno se responsabiliza de que dependencias debe inyectar al nuevo objeto creado. Por ejemplo,
 
 ```php
-$container->set('Foo', function () {
+$container->set('Foo', function ($container, $params, $config) {
     return new Foo(new Bar);
 });
 

--- a/docs/guide-fr/concept-di-container.md
+++ b/docs/guide-fr/concept-di-container.md
@@ -99,7 +99,7 @@ $container->get('Foo', [], [
 Dans ce cas, le conteneur utilise une fonction de rappel PRP enregistrée pour construire de nouvelles instances d'une classe. À chaque fois que [[yii\di\Container::get()]] est appelée, la fonction de rappel correspondante est invoquée. Cette fonction de rappel est chargée de la résolution des dépendances et de leur injection appropriée dans les objets nouvellement créés. Par exemple :
 
 ```php
-$container->set('Foo', function () {
+$container->set('Foo', function ($container, $params, $config) {
     $foo = new Foo(new Bar);
     // ... autres initialisations ...
     return $foo;
@@ -113,7 +113,7 @@ Pour cacher la logique complexe de construction des nouveaux objets, vous pouvez
 ```php
 class FooBuilder
 {
-    public static function build()
+    public static function build($container, $params, $config)
     {
         $foo = new Foo(new Bar);
         // ... autres initialisations ...

--- a/docs/guide-ja/concept-di-container.md
+++ b/docs/guide-ja/concept-di-container.md
@@ -114,7 +114,7 @@ $container->get('Foo', [], [
 たとえば
 
 ```php
-$container->set('Foo', function () {
+$container->set('Foo', function ($container, $params, $config) {
     $foo = new Foo(new Bar);
     // ... その他の初期化 ...
     return $foo;
@@ -129,7 +129,7 @@ $foo = $container->get('Foo');
 ```php
 class FooBuilder
 {
-    public static function build()
+    public static function build($container, $params, $config)
     {
         $foo = new Foo(new Bar);
         // ... その他の初期化 ...
@@ -413,7 +413,7 @@ $container->setDefinitions([
         'class' => 'app\components\Response',
         'format' => 'json'
     ],
-    'app\storage\DocumentsReader' => function () {
+    'app\storage\DocumentsReader' => function ($container, $params, $config) {
         $fs = new app\storage\FileStorage('/var/tempfiles');
         return new app\storage\DocumentsReader($fs);
     }

--- a/docs/guide-pt-BR/concept-di-container.md
+++ b/docs/guide-pt-BR/concept-di-container.md
@@ -75,7 +75,7 @@ Cada vez que [[yii\di\Container::get()]] for chamado, o callable correspondente 
 O callable é responsável por resolver as dependências e injetá-las de forma adequada para os objetos recém-criados. Por exemplo:
 
 ```php
-$container->set('Foo', function () {
+$container->set('Foo', function ($container, $params, $config) {
     $foo = new Foo(new Bar);
     // ... Outras inicializações...
     return $foo;
@@ -89,7 +89,7 @@ Para ocultar a lógica complexa da construção de um novo objeto você pode usa
 ```php
 class FooBuilder
 {
-    public static function build()
+    public static function build($container, $params, $config)
     {
         return function () {
             $foo = new Foo(new Bar);

--- a/docs/guide-ru/concept-di-container.md
+++ b/docs/guide-ru/concept-di-container.md
@@ -151,7 +151,7 @@ $container->setDefinitions([
         'class' => 'app\components\Response',
         'format' => 'json'
     ],
-    'app\storage\DocumentsReader' => function () {
+    'app\storage\DocumentsReader' => function ($container, $params, $config) {
         $fs = new app\storage\FileStorage('/var/tempfiles');
         return new app\storage\DocumentsReader($fs);
     }
@@ -243,7 +243,7 @@ $reader = $container->get('app\storage\DocumentsReader');
 Callback отвечает за разрешения зависимостей и внедряет их в соответствии с вновь создаваемыми объектами. Например,
 
 ```php
-$container->set('Foo', function () {
+$container->set('Foo', function ($container, $params, $config) {
     $foo = new Foo(new Bar);
     // ... дополнительная инициализация
     return $foo;
@@ -258,7 +258,7 @@ callable:
 ```php
 class FooBuilder
 {
-    public static function build()
+    public static function build($container, $params, $config)
     {
         $foo = new Foo(new Bar);
         // ... дополнительная инициализация ...

--- a/docs/guide-zh-CN/concept-di-container.md
+++ b/docs/guide-zh-CN/concept-di-container.md
@@ -69,7 +69,7 @@ $container->get('Foo', [], [
 这种情况下，容器将使用一个注册过的 PHP 回调创建一个类的新实例。回调负责解决依赖并将其恰当地注入新创建的对象。例如：
 
 ```php
-$container->set('Foo', function () {
+$container->set('Foo', function ($container, $params, $config) {
     return new Foo(new Bar);
 });
 

--- a/docs/guide/concept-di-container.md
+++ b/docs/guide/concept-di-container.md
@@ -117,7 +117,7 @@ The callable is responsible to resolve the dependencies and inject them appropri
 created objects. For example,
 
 ```php
-$container->set('Foo', function () {
+$container->set('Foo', function ($container, $params, $config) {
     $foo = new Foo(new Bar);
     // ... other initializations ...
     return $foo;
@@ -131,7 +131,7 @@ To hide the complex logic for building a new object, you may use a static class 
 ```php
 class FooBuilder
 {
-    public static function build()
+    public static function build($container, $params, $config)
     {
         $foo = new Foo(new Bar);
         // ... other initializations ...
@@ -421,7 +421,7 @@ $container->setDefinitions([
         'class' => 'app\components\Response',
         'format' => 'json'
     ],
-    'app\storage\DocumentsReader' => function () {
+    'app\storage\DocumentsReader' => function ($container, $params, $config) {
         $fs = new app\storage\FileStorage('/var/tempfiles');
         return new app\storage\DocumentsReader($fs);
     }


### PR DESCRIPTION
Look at this:
https://github.com/yiisoft/yii2/blob/0455e852a7809c28eba293f9076854b62c57019f/framework/di/Container.php#L161-L163

I think we need tell about signature of function :smile_cat: 

I expect to have configured object after use `Yii::createObject()`. I want to info about do it.

Example app config:
```php
    'container' => [
        'definitions' => [
            \yii\queue\cli\VerboseBehavior::class => function ($containerDI, $params, $config) {
                return new class($config) extends \yii\queue\cli\VerboseBehavior
                {
                    public function afterError(\yii\queue\ErrorEvent $event)
                    {
                        if (!($event->error instanceof \components\queue\TemporaryException)) {
                            parent::afterError($event);

                            return;
                        }
                        $this->command->stderr(date('Y-m-d H:i:s'), \yii\helpers\Console::FG_YELLOW);
                        $class = get_class($event->job);
                        $this->command->stderr(" [$event->id] $class (attempt: $event->attempt, pid: $event->workerPid)",
                            \yii\helpers\Console::FG_GREY);
                        $this->command->stderr(' - ', \yii\helpers\Console::FG_YELLOW);
                        $this->command->stderr('TemporaryException', \yii\helpers\Console::BG_RED);
                        $this->command->stderr(PHP_EOL);
                    }
                };
            },
        ],
    ],
```

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  |