### PR TITLE
Bug #15355: Fixed `yii\db\Query::from()` does not work if `yii\db\Exp…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.14 under development
 ------------------------
 
-- Bug #15355: Fixed `yii\db\Query::from()` does not work if `yii\db\Expression` (vladis84)
+- Bug #15355: Fixed `yii\db\Query::from()` does not work with `yii\db\Expression` (vladis84)
 - Bug #8983: Only truncate the original log file for rotation (matthewyang, developeruz)
 - Bug #14276: Fixed I18N format with dotted parameters (developeruz)
 - Bug #14604: Fixed `yii\validators\CompareValidator` `compareAttribute` does not work if `compareAttribute` form ID has been changed (mikk150)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.14 under development
 ------------------------
 
+- Bug #15355: Fixed `yii\db\Query::from()` does not work if `yii\db\Expression` (vladis84)
 - Bug #8983: Only truncate the original log file for rotation (matthewyang, developeruz)
 - Bug #14276: Fixed I18N format with dotted parameters (developeruz)
 - Bug #14604: Fixed `yii\validators\CompareValidator` `compareAttribute` does not work if `compareAttribute` form ID has been changed (mikk150)

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -645,7 +645,7 @@ PATTERN;
      */
     public function from($tables)
     {
-        if (!is_array($tables)) {
+        if (is_string($tables)) {
             $tables = preg_split('/\s*,\s*/', trim($tables), -1, PREG_SPLIT_NO_EMPTY);
         }
         $this->from = $tables;

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -46,6 +46,14 @@ abstract class QueryTest extends DatabaseTestCase
         $this->assertEquals(['user'], $query->from);
     }
 
+    public function testFromTableIsExpression()
+    {
+        $query = new Query();
+        $tables = new Expression('(SELECT id,name FROM user) u');
+        $query->from($tables);
+        $this->assertInstanceOf('\yii\db\Expression', $query->from);
+    }
+
     use GetTablesAliasTestTrait;
     protected function createQuery()
     {


### PR DESCRIPTION
…ression`

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  |  #15355
