### PR TITLE
Allow $variations to be a string for PageCache & FragmentCache

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -22,6 +22,7 @@ Yii Framework 2 Change Log
 - Enh #5515: Added default value for `yii\behaviors\BlameableBehavior` for cases when the user is guest (dmirogin)
 - Enh #8752: Allow specify `$attributeNames` as a string for `yii\base\Model` `validate()` method (developeruz)
 - Enh #9137: Added `Access-Control-Allow-Method` header for the OPTIONS request (developeruz)
+- Enh #9253: Allow `variations` to be a string for `yii\filters\PageCache` and `yii\widgets\FragmentCache` (schojniak, developeruz)
 - Enh #14043: Added `yii\helpers\IpHelper` (silverfire, cebe)
 - Enh #7996: Short syntax for verb in GroupUrlRule (schojniak, developeruz)
 - Enh #14568: Refactored migration templates to use `safeUp()` and `safeDown()` methods (Kolyunya)

--- a/framework/filters/PageCache.php
+++ b/framework/filters/PageCache.php
@@ -88,7 +88,7 @@ class PageCache extends ActionFilter
      */
     public $dependency;
     /**
-     * @var array list of factors that would cause the variation of the content being cached.
+     * @var string[]|string list of factors that would cause the variation of the content being cached.
      * Each factor is a string representing a variation (e.g. the language, a GET parameter).
      * The following variation setting will cause the content to be cached in different versions
      * according to the current application language:
@@ -323,12 +323,6 @@ class PageCache extends ActionFilter
         if ($this->varyByRoute) {
             $key[] = Yii::$app->requestedRoute;
         }
-        if (is_array($this->variations)) {
-            foreach ($this->variations as $value) {
-                $key[] = $value;
-            }
-        }
-
-        return $key;
+        return array_merge($key, (array)$this->variations);
     }
 }

--- a/framework/widgets/FragmentCache.php
+++ b/framework/widgets/FragmentCache.php
@@ -53,7 +53,7 @@ class FragmentCache extends Widget
      */
     public $dependency;
     /**
-     * @var array list of factors that would cause the variation of the content being cached.
+     * @var string[]|string list of factors that would cause the variation of the content being cached.
      * Each factor is a string representing a variation (e.g. the language, a GET parameter).
      * The following variation setting will cause the content to be cached in different versions
      * according to the current application language:
@@ -189,13 +189,6 @@ class FragmentCache extends Widget
      */
     protected function calculateKey()
     {
-        $factors = [__CLASS__, $this->getId()];
-        if (is_array($this->variations)) {
-            foreach ($this->variations as $factor) {
-                $factors[] = $factor;
-            }
-        }
-
-        return $factors;
+        return array_merge([__CLASS__, $this->getId()], (array)$this->variations);
     }
 }

--- a/tests/framework/filters/PageCacheTest.php
+++ b/tests/framework/filters/PageCacheTest.php
@@ -446,4 +446,18 @@ class PageCacheTest extends TestCase
             ob_end_clean();
         }
     }
+
+    public function testCalculateCacheKey()
+    {
+        $expected = ['yii\filters\PageCache', 'test', 'ru'];
+        Yii::$app->requestedRoute = 'test';
+        $keys = $this->invokeMethod(new PageCache(['variations' => ['ru']]), 'calculateCacheKey');
+        $this->assertEquals($expected, $keys);
+
+        $keys = $this->invokeMethod(new PageCache(['variations' => 'ru']), 'calculateCacheKey');
+        $this->assertEquals($expected, $keys);
+
+        $keys = $this->invokeMethod(new PageCache(), 'calculateCacheKey');
+        $this->assertEquals(['yii\filters\PageCache', 'test'], $keys);
+    }
 }

--- a/tests/framework/widgets/FragmentCacheTest.php
+++ b/tests/framework/widgets/FragmentCacheTest.php
@@ -194,5 +194,50 @@ class FragmentCacheTest extends \yiiunit\TestCase
         }
     }
 
+    public function testVariations()
+    {
+        ob_start();
+        ob_implicit_flush(false);
+        $view = new View();
+        $this->assertTrue($view->beginCache('test', ['variations' => ['ru']]), 'Cached fragment should not be exist');
+        echo 'cached fragment';
+        $view->endCache();
+
+        $cached = ob_get_clean();
+        $this->assertEquals('cached fragment', $cached);
+
+        ob_start();
+        ob_implicit_flush(false);
+        $this->assertFalse($view->beginCache('test', ['variations' => ['ru']]), 'Cached fragment should be exist');
+
+        $cachedEn = ob_get_clean();
+        $this->assertEquals($cached, $cachedEn);
+
+        $this->assertTrue($view->beginCache('test', ['variations' => ['en']]), 'Cached fragment should not be exist');
+        echo 'cached fragment';
+        $view->endCache();
+        $this->assertFalse($view->beginCache('test', ['variations' => ['en']]), 'Cached fragment should be exist');
+
+        //without variations
+        ob_start();
+        ob_implicit_flush(false);
+        $view = new View();
+        $this->assertTrue($view->beginCache('test'), 'Cached fragment should not be exist');
+        echo 'cached fragment';
+        $view->endCache();
+        $cached = ob_get_clean();
+        $this->assertEquals('cached fragment', $cached);
+
+        //with variations as a string
+        ob_start();
+        ob_implicit_flush(false);
+        $this->assertTrue($view->beginCache('test', ['variations' => 'uz']), 'Cached fragment should not be exist');
+        echo 'cached fragment';
+        $view->endCache();
+        $cached = ob_get_clean();
+        $this->assertEquals('cached fragment', $cached);
+        $this->assertFalse($view->beginCache('test', ['variations' => 'uz']), 'Cached fragment should be exist');
+    }
+
     // TODO test dynamic replacements
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Replacement for #9253 