### PR TITLE
Fixed wrong description for param $table on addCommentOnTable()

### DIFF
--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -505,7 +505,7 @@ class Migration extends Component implements MigrationInterface
     /**
      * Builds a SQL statement for adding comment to table
      *
-     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $table the table to be commented. The table name will be properly quoted by the method.
      * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
      * @since 2.0.8
      */


### PR DESCRIPTION
 Migration addCommentOnTable() had wrong description for param $table. 