### PR TITLE
Auto generate placeholder for `Html::activeInput`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -39,6 +39,7 @@ Yii Framework 2 Change Log
 - Enh #15221: Added support for specifying `--camelCase` console options in `--kebab-case` (brandonkelly)
 - Enh #15221: Added support for the `--<option> <value>` console option syntax (brandonkelly)
 - Enh #15221: Improved the `help/list-action-options` console command output for command options without a description (brandonkelly)
+- Enh #15226: Auto generate placeholder for `Html::activeInput` (developeruz)
 - Enh #15332: Always check for availability of `openssl_pseudo_random_bytes`, even if LibreSSL is available (sammousa)
 - Enh #15335: Added `FileHelper::unlink()` that works well under all OSes (samdark)
 - Enh #15357: Added multi statement support for `yii\db\sqlite\Command` (sergeymakinen)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1313,6 +1313,9 @@ class BaseHtml
         if (!array_key_exists('id', $options)) {
             $options['id'] = static::getInputId($model, $attribute);
         }
+        if (!array_key_exists('placeholder', $options) && $type!='hidden') {
+            $options['placeholder'] = $model->getAttributeLabel($attribute);
+        }
 
         return static::input($type, $name, $value, $options);
     }

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1059,19 +1059,21 @@ EOD;
             [
                 'some text',
                 [],
-                '<input type="text" id="htmltestmodel-name" name="HtmlTestModel[name]" value="some text">',
+                '<input type="text" id="htmltestmodel-name" name="HtmlTestModel[name]" value="some text" placeholder="Name">',
             ],
             [
                 '',
                 [
                     'maxlength' => true,
+                    'placeholder' => 'test'
                 ],
-                '<input type="text" id="htmltestmodel-name" name="HtmlTestModel[name]" value="" maxlength="100">',
+                '<input type="text" id="htmltestmodel-name" name="HtmlTestModel[name]" value="" maxlength="100" placeholder="test">',
             ],
             [
                 '',
                 [
                     'maxlength' => 99,
+                    'placeholder' => null
                 ],
                 '<input type="text" id="htmltestmodel-name" name="HtmlTestModel[name]" value="" maxlength="99">',
             ],
@@ -1102,21 +1104,21 @@ EOD;
             [
                 'some text',
                 [],
-                '<input type="password" id="htmltestmodel-name" name="HtmlTestModel[name]" value="some text">',
+                '<input type="password" id="htmltestmodel-name" name="HtmlTestModel[name]" value="some text" placeholder="Name">',
             ],
             [
                 '',
                 [
                     'maxlength' => true,
                 ],
-                '<input type="password" id="htmltestmodel-name" name="HtmlTestModel[name]" value="" maxlength="100">',
+                '<input type="password" id="htmltestmodel-name" name="HtmlTestModel[name]" value="" maxlength="100" placeholder="Name">',
             ],
             [
                 '',
                 [
                     'maxlength' => 99,
                 ],
-                '<input type="password" id="htmltestmodel-name" name="HtmlTestModel[name]" value="" maxlength="99">',
+                '<input type="password" id="htmltestmodel-name" name="HtmlTestModel[name]" value="" maxlength="99" placeholder="Name">',
             ],
         ];
     }
@@ -1465,7 +1467,7 @@ EOD;
     {
         $expected = '<input type="hidden" name="foo" value=""><input type="file" id="htmltestmodel-types" name="foo">';
         $model = new HtmlTestModel();
-        $actual = Html::activeFileInput($model, 'types', ['name' => 'foo']);
+        $actual = Html::activeFileInput($model, 'types', ['name' => 'foo', 'placeholder' => null]);
         $this->assertEqualsWithoutLE($expected, $actual);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15226