### PR TITLE
Added `not` parameter to the `yii\validators\RequiredValidator`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -53,9 +53,6 @@ Yii Framework 2 Change Log
 - Enh #15360: Refactored `BaseConsole::updateProgress()` (developeruz)
 - Enh #15415: Added transaction/retry support for `yii\db\Command` (sergeymakinen)
 - Enh #15391: Added `not` parameter to the `yii\validators\RequiredValidator` (developeruz)
-- Enh #3250: Added support for events partial wildcard matching (klimov-paul)
-- Bug #15317: Regenerate CSRF token if an empty value is given (sammousa)
-- Bug #15380: `FormatConverter::convertDateIcuToPhp()` now converts `a` ICU symbols to `A` (brandonkelly)
 - Enh: Added check to `yii\base\Model::formName()` to prevent source path disclosure when form is represented by an anonymous class (silverfire)
 - Chg #15420: Handle OPTIONS request in `yii\filter\Cors` so the preflight check isn't passed trough authentication filters (michaelarnauts, leandrogehlen)
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -52,6 +52,10 @@ Yii Framework 2 Change Log
 - Enh #15357: Added multi statement support for `yii\db\sqlite\Command` (sergeymakinen)
 - Enh #15360: Refactored `BaseConsole::updateProgress()` (developeruz)
 - Enh #15415: Added transaction/retry support for `yii\db\Command` (sergeymakinen)
+- Enh #15391: Added `not` parameter to the `yii\validators\RequiredValidator` (developeruz)
+- Enh #3250: Added support for events partial wildcard matching (klimov-paul)
+- Bug #15317: Regenerate CSRF token if an empty value is given (sammousa)
+- Bug #15380: `FormatConverter::convertDateIcuToPhp()` now converts `a` ICU symbols to `A` (brandonkelly)
 - Enh: Added check to `yii\base\Model::formName()` to prevent source path disclosure when form is represented by an anonymous class (silverfire)
 - Chg #15420: Handle OPTIONS request in `yii\filter\Cors` so the preflight check isn't passed trough authentication filters (michaelarnauts, leandrogehlen)
 

--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -23,12 +23,19 @@ yii.validation = (function ($) {
         required: function (value, messages, options) {
             var valid = false;
             if (options.requiredValue === undefined) {
-                var isString = typeof value == 'string' || value instanceof String;
-                if (options.strict && value !== undefined || !options.strict && !pub.isEmpty(isString ? $.trim(value) : value)) {
+                if(isRequiredValueEmpty(options, value)) {
                     valid = true;
                 }
-            } else if (!options.strict && value == options.requiredValue || options.strict && value === options.requiredValue) {
-                valid = true;
+            } else {
+                if (options.strict) {
+                    if ((options.not && value !== options.requiredValue) || (!options.not && value === options.requiredValue)) {
+                        valid = true;
+                    }
+                } else {
+                    if ((options.not && value != options.requiredValue) || (!options.not && value == options.requiredValue)) {
+                        valid = true;
+                    }
+                }
             }
 
             if (!valid) {
@@ -446,6 +453,24 @@ yii.validation = (function ($) {
         if (options.maxHeight && image.height > options.maxHeight) {
             messages.push(options.overHeight.replace(/\{file\}/g, file.name));
         }
+    }
+
+    function isRequiredValueEmpty(options, value) {
+        if (options.strict) {
+            if ((options.not && value === undefined) || (!options.not && value !== undefined)) {
+                return true;
+            }
+        }
+
+        if (!options.strict) {
+            var isString = typeof value == 'string' || value instanceof String;
+            var isEmptyString = pub.isEmpty(isString ? $.trim(value) : value);
+            if ((options.not && isEmptyString) || (!options.not && !isEmptyString)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     return pub;

--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -23,7 +23,7 @@ yii.validation = (function ($) {
         required: function (value, messages, options) {
             var valid = false;
             if (options.requiredValue === undefined) {
-                if(isRequiredValueEmpty(options, value)) {
+                if (isRequiredValueEmpty(options, value)) {
                     valid = true;
                 }
             } else {

--- a/framework/validators/RequiredValidator.php
+++ b/framework/validators/RequiredValidator.php
@@ -81,11 +81,9 @@ class RequiredValidator extends Validator
             if ($this->checkIsEmpty($value)) {
                 return null;
             }
+            return [$this->message, []];
         } elseif ($this->checkIsEqual($value)) {
             return null;
-        }
-        if ($this->requiredValue === null) {
-            return [$this->message, []];
         }
 
         return [$this->message, [
@@ -150,6 +148,9 @@ class RequiredValidator extends Validator
         }
         if ($this->strict) {
             $options['strict'] = 1;
+        }
+        if ($this->not) {
+            $options['not'] = 1;
         }
 
         $options['message'] = $this->formatMessage($options['message'], [

--- a/tests/framework/validators/RequiredValidatorTest.php
+++ b/tests/framework/validators/RequiredValidatorTest.php
@@ -66,4 +66,19 @@ class RequiredValidatorTest extends TestCase
         $val->validateAttribute($m, 'attr_val');
         $this->assertFalse($m->hasErrors('attr_val'));
     }
+
+    public function testValidateNot()
+    {
+        $val = new RequiredValidator(['not' => true]);
+        $this->assertTrue($val->validate(null));
+        $this->assertFalse($val->validate('55'));
+
+        $val = new RequiredValidator(['requiredValue' => 55, 'not' => true]);
+        $this->assertTrue($val->validate(45));
+        $this->assertFalse($val->validate(55));
+
+        $val = new RequiredValidator(['requiredValue' => 55, 'strict' => true, 'not' => true]);
+        $this->assertFalse($val->validate(55));
+        $this->assertTrue($val->validate('55'));
+    }
 }

--- a/tests/js/tests/yii.validation.test.js
+++ b/tests/js/tests/yii.validation.test.js
@@ -123,6 +123,7 @@ describe('yii.validation', function () {
         withData({
             'empty string': ['', {}, false],
             'empty string, strict mode': ['', {strict: true}, true],
+            'empty string with not parameter': ['', {not: true}, true],
             'string containing whitespace': [' ', {}, false],
             'string containing whitespace, strict mode': [' ', {strict: true}, true],
             'non-empty string': ['a', {}, true],
@@ -134,6 +135,11 @@ describe('yii.validation', function () {
             'string and required value set to integer with the same value, strict mode': [
                 '1',
                 {requiredValue: 1, strict: true},
+                false
+            ],
+            'required value with not mode': [
+                1,
+                {requiredValue: 1, not: true},
                 false
             ],
             'integer and required value set to same integer, strict mode': [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15391

I am not sure about naming because "not required" doesn't mean "prohibited". Also, I need some help with client-side validation. 