### PR TITLE
Serialize layer introduction

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -19,6 +19,7 @@ Yii Framework 2 Change Log
 - Enh #12592: Optimized `yii\filters\AccessController` on processing accessrules (dynasource)
 - Enh #12938: Allow to pass additional parameters to `yii\base\View::renderDynamic()` (mikehaertl)
 - Enh #13006: Added a `/` to the `yii\captcha\Captcha::$captchaAction` string to work correctly in a module also (boehsermoe)
+- Enh #15410: Added serialization abstraction layer under `yii\serialize\*` namespace (klimov-paul)
 - Removed methods marked as deprecated in 2.0.x (samdark)
 - Chg #14784: Signature of `yii\web\RequestParserInterface::parse()` changed to accept `yii\web\Request` instance as a sole argument (klimov-paul)
 - Chg #10771: Consistent behavior of `run()` method in all framework widgets. All return the result now for better extensibility (pkirill99, cebe)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -106,6 +106,9 @@ Upgrade from Yii 2.0.x
   be configured there. Creating your own cache implementation you should implement `\Psr\SimpleCache\CacheInterface` or
   extend `yii\caching\SimpleCache` abstract class. Use `yii\caching\CacheInterface` only if you wish to replace `yii\caching\Cache`
   component providing your own solution for cache dependency handling.
+* `yii\caching\SimpleCache::$serializer` now should be `yii\serialize\SerializerInterface` instance or its DI compatible configuration.
+  Thus it does not longer accept pair of serialize/unserialize functions as an array. Use `yii\serialize\CallbackSerializer` or
+  other predefined serializer class from `yii\serialize\*` namespace instead.
 * Console command used to clear cache now calls related actions "clear" instead of "flush".
 * Yii autoloader was removed in favor of Composer-generated one. You should remove explicit inclusion of `Yii.php` from
   your entry `index.php` scripts. In case you have relied on class map, use `composer.json` instead of configuring it

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -107,7 +107,7 @@ Upgrade from Yii 2.0.x
   extend `yii\caching\SimpleCache` abstract class. Use `yii\caching\CacheInterface` only if you wish to replace `yii\caching\Cache`
   component providing your own solution for cache dependency handling.
 * `yii\caching\SimpleCache::$serializer` now should be `yii\serialize\SerializerInterface` instance or its DI compatible configuration.
-  Thus it does not longer accept pair of serialize/unserialize functions as an array. Use `yii\serialize\CallbackSerializer` or
+  Thus it does no longer accept pair of serialize/unserialize functions as an array. Use `yii\serialize\CallbackSerializer` or
   other predefined serializer class from `yii\serialize\*` namespace instead.
 * Console command used to clear cache now calls related actions "clear" instead of "flush".
 * Yii autoloader was removed in favor of Composer-generated one. You should remove explicit inclusion of `Yii.php` from

--- a/framework/serialize/CallbackSerializer.php
+++ b/framework/serialize/CallbackSerializer.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\serialize;
+
+use yii\base\BaseObject;
+
+/**
+ * CallbackSerializer serializes data via custom PHP callback.
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 2.1.0
+ */
+class CallbackSerializer extends BaseObject implements SerializerInterface
+{
+    /**
+     * @var callable PHP callback, which should be used to serialize value.
+     */
+    public $serialize;
+    /**
+     * @var callable PHP callback, which should be used to unserialize value.
+     */
+    public $unserialize;
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize($value)
+    {
+        return call_user_func($this->serialize, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($value)
+    {
+        return call_user_func($this->unserialize, $value);
+    }
+}

--- a/framework/serialize/IgbinarySerializer.php
+++ b/framework/serialize/IgbinarySerializer.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\serialize;
+
+use yii\base\BaseObject;
+
+/**
+ * IgbinarySerializer uses [Igbinary PHP extension](http://pecl.php.net/package/igbinary) for serialization.
+ * Make sure you have 'igbinary' PHP extension install at your system before attempt to use this serializer.
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 2.1.0
+ */
+class IgbinarySerializer extends BaseObject implements SerializerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize($value)
+    {
+        return igbinary_serialize($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($value)
+    {
+        return igbinary_unserialize($value);
+    }
+}

--- a/framework/serialize/JsonSerializer.php
+++ b/framework/serialize/JsonSerializer.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\serialize;
+
+use yii\base\BaseObject;
+use yii\helpers\Json;
+
+/**
+ * JsonSerializer serializes data in JSON format.
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 2.1.0
+ */
+class JsonSerializer extends BaseObject implements SerializerInterface
+{
+    /**
+     * @var integer the encoding options. For more details please refer to
+     * <http://www.php.net/manual/en/function.json-encode.php>.
+     * Default is `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE`.
+     */
+    public $options = 320;
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize($value)
+    {
+        return Json::encode($value, $this->options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($value)
+    {
+        return Json::decode($value);
+    }
+}

--- a/framework/serialize/PhpSerializer.php
+++ b/framework/serialize/PhpSerializer.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\serialize;
+
+use yii\base\BaseObject;
+
+/**
+ * PhpSerializer uses native PHP `serialize()` and `unserialize()` functions for the serialization.
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 2.1.0
+ */
+class PhpSerializer extends BaseObject implements SerializerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize($value)
+    {
+        return serialize($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($value)
+    {
+        return unserialize($value);
+    }
+}

--- a/framework/serialize/SerializerInterface.php
+++ b/framework/serialize/SerializerInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\serialize;
+
+/**
+ * SerializerInterface defines serializer interface.
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 2.1.0
+ */
+interface SerializerInterface
+{
+    /**
+     * Serializes given value.
+     * @param mixed $value value to be serialized
+     * @return string serialized value.
+     */
+    public function serialize($value);
+
+    /**
+     * Restores value from its serialized representations
+     * @param string $value serialized string.
+     * @return mixed restored value
+     */
+    public function unserialize($value);
+}

--- a/tests/framework/serialize/CallbackSerializerTest.php
+++ b/tests/framework/serialize/CallbackSerializerTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\serialize;
+
+use yii\serialize\CallbackSerializer;
+
+/**
+ * @group serialize
+ */
+class CallbackSerializerTest extends SerializerTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createSerializer()
+    {
+        return new CallbackSerializer([
+            'serialize' => 'serialize',
+            'unserialize' => 'unserialize',
+        ]);
+    }
+}

--- a/tests/framework/serialize/IgbinarySerializerTest.php
+++ b/tests/framework/serialize/IgbinarySerializerTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\serialize;
+
+use yii\serialize\IgbinarySerializer;
+
+/**
+ * @group serialize
+ */
+class IgbinarySerializerTest extends SerializerTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        if (!function_exists('igbinary_serialize')) {
+            $this->markTestSkipped('igbinary extension is required.');
+            return;
+        }
+
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createSerializer()
+    {
+        return new IgbinarySerializer();
+    }
+}

--- a/tests/framework/serialize/JsonSerializerTest.php
+++ b/tests/framework/serialize/JsonSerializerTest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\serialize;
+
+use yii\serialize\JsonSerializer;
+
+/**
+ * @group serialize
+ */
+class JsonSerializerTest extends SerializerTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createSerializer()
+    {
+        return new JsonSerializer();
+    }
+}

--- a/tests/framework/serialize/PhpSerializerTest.php
+++ b/tests/framework/serialize/PhpSerializerTest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\serialize;
+
+use yii\serialize\PhpSerializer;
+
+/**
+ * @group serialize
+ */
+class PhpSerializerTest extends SerializerTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createSerializer()
+    {
+        return new PhpSerializer();
+    }
+}

--- a/tests/framework/serialize/SerializerTest.php
+++ b/tests/framework/serialize/SerializerTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\serialize;
+
+use yiiunit\TestCase;
+
+/**
+ * @group serialize
+ */
+abstract class SerializerTest extends TestCase
+{
+    /**
+     * Creates serializer instance for the tests.
+     * @return \yii\serialize\SerializerInterface
+     */
+    abstract protected function createSerializer();
+
+    /**
+     * Data provider for [[testSerialize()]]
+     * @return array test data.
+     */
+    public function dataProviderSerialize()
+    {
+        return [
+            ['some-string'],
+            [345],
+            [56.89],
+            [['some' => 'array']],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderSerialize
+     *
+     * @param mixed $value
+     */
+    public function testSerialize($value)
+    {
+        $serializer = $this->createSerializer();
+
+        $serialized = $serializer->serialize($value);
+        $this->assertTrue(is_string($serialized));
+
+        $this->assertEquals($value, $serializer->unserialize($serialized));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | 

Inspired by https://github.com/yiisoft/yii2-queue/pull/147

'Serialize' abstraction layer introduced, allowing easy support for different serialization methods, which are in demand by data operation libraries like `yii2-queue`.

Serialization layer applied for `SimpleCache`.