### PR TITLE
Fixed #14135 `yii\web\Request::getBodyParam()` crashes on object body

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Enh #15496: CSRF token is now regenerated on changing identity (samdark, rhertogh)
 - Enh #15417: Added `yii\validators\FileValidator::$minFiles` (vladis84)
 - Bug #8983: Only truncate the original log file for rotation (matthewyang, developeruz)
+- Bug #14135: Fixed `yii\web\Response::getBodyParam()` crashes on object type body params (klimov-paul)
 - Bug #14157: Add support for loading default value `CURRENT_TIMESTAMP` of MySQL `datetime` field (rossoneri)
 - Bug #14276: Fixed I18N format with dotted parameters (developeruz)
 - Bug #14484: Fixed `yii\validators\UniqueValidator` for target classes with a default scope (laszlovl, developeruz)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,7 +7,7 @@ Yii Framework 2 Change Log
 - Enh #15496: CSRF token is now regenerated on changing identity (samdark, rhertogh)
 - Enh #15417: Added `yii\validators\FileValidator::$minFiles` (vladis84)
 - Bug #8983: Only truncate the original log file for rotation (matthewyang, developeruz)
-- Bug #14135: Fixed `yii\web\Response::getBodyParam()` crashes on object type body params (klimov-paul)
+- Bug #14135: Fixed `yii\web\Request::getBodyParam()` crashes on object type body params (klimov-paul)
 - Bug #14157: Add support for loading default value `CURRENT_TIMESTAMP` of MySQL `datetime` field (rossoneri)
 - Bug #14276: Fixed I18N format with dotted parameters (developeruz)
 - Bug #14484: Fixed `yii\validators\UniqueValidator` for target classes with a default scope (laszlovl, developeruz)

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -582,6 +582,15 @@ class Request extends \yii\base\Request
     {
         $params = $this->getBodyParams();
 
+        if (is_object($params)) {
+            // unable to use `ArrayHelper::getValue()` due to different dots in key logic and lack of exception handling
+            try {
+                return $params->{$name};
+            } catch (\Exception $e) {
+                return $defaultValue;
+            }
+        }
+
         return isset($params[$name]) ? $params[$name] : $defaultValue;
     }
 

--- a/tests/framework/web/RequestTest.php
+++ b/tests/framework/web/RequestTest.php
@@ -609,4 +609,28 @@ class RequestTest extends TestCase
 
         $_SERVER = $original;
     }
+
+    public function testGetBodyParam()
+    {
+        $request = new Request();
+
+        $request->setBodyParams([
+            'someParam' => 'some value',
+            'param.dot' => 'value.dot',
+        ]);
+        $this->assertSame('some value', $request->getBodyParam('someParam'));
+        $this->assertSame('value.dot', $request->getBodyParam('param.dot'));
+        $this->assertSame(null, $request->getBodyParam('unexisting'));
+        $this->assertSame('default', $request->getBodyParam('unexisting', 'default'));
+
+        // @see https://github.com/yiisoft/yii2/issues/14135
+        $bodyParams = new \stdClass();
+        $bodyParams->someParam = 'some value';
+        $bodyParams->{'param.dot'} = 'value.dot';
+        $request->setBodyParams($bodyParams);
+        $this->assertSame('some value', $request->getBodyParam('someParam'));
+        $this->assertSame('value.dot', $request->getBodyParam('param.dot'));
+        $this->assertSame(null, $request->getBodyParam('unexisting'));
+        $this->assertSame('default', $request->getBodyParam('unexisting', 'default'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14135 
