### PR TITLE
improved dockerized tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,5 +23,10 @@ require_once __DIR__ . '/../framework/Yii.php';
 
 Yii::setAlias('@yiiunit', __DIR__);
 
+if (getenv('TEST_RUNTIME_PATH')) {
+    Yii::setAlias('@yiiunit/runtime', getenv('TEST_RUNTIME_PATH'));
+    Yii::setAlias('@runtime', getenv('TEST_RUNTIME_PATH'));
+}
+
 require_once __DIR__ . '/compatibility.php';
 require_once __DIR__ . '/TestCase.php';

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     # Tmpfs volume (experimental, asset tests may fail)
     #tmpfs:
     #  - /project/tests/runtime
+    environment:
+      - TEST_RUNTIME_PATH=/tmp/runtime
 
 networks:
   default:

--- a/tests/framework/grid/CheckboxColumnTest.php
+++ b/tests/framework/grid/CheckboxColumnTest.php
@@ -27,8 +27,8 @@ class CheckboxColumnTest extends TestCase
         $this->mockApplication();
         Yii::setAlias('@webroot', '@yiiunit/runtime');
         Yii::setAlias('@web', 'http://localhost/');
-        Yii::$app->assetManager->bundles['yii\web\JqueryAsset'] = false;
         FileHelper::createDirectory(Yii::getAlias('@webroot/assets'));
+        Yii::$app->assetManager->bundles['yii\web\JqueryAsset'] = false;
     }
 
     public function testInputName()


### PR DESCRIPTION
- added ENV variable for using custom runtime folder
- create assets directory before using asset-manager

| Q             | A
| ------------- | ---
| Is bugfix?    | yes (when using host-volumes for debugging tests)
| New feature?  | yes (ENV var)
| Breaks BC?    | no
| Tests pass?   | yes(!)

When running and/or debugging tests from a host-volume with Docker, several tests fail due to disk-sync issues, therefore I added a variable to use a custom runtime folder, if not set it behaves like before.

Although the asset directory is available as empty folder from the repo, I also had issues with it in the above setup, when it was not create before the asset-manager was used.