### PR TITLE
WIP: Call help, when required arguments was not provided

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,6 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.14 under development
 ------------------------
+- Enh #15526: Call help, when required arguments was not provided (Valkeru)
 - Enh #15426: Added abilitiy to create and drop database views (igravity, vladis84)
 - Enh #10186: Use native `hash_equals` in `yii\base\Security::compareString()` if available, throw exception if non-strings are compared (aotd1, samdark)
 - Bug #15122: Fixed `yii\db\Command::getRawSql()` to properly replace expressions (hiscaler, samdark)

--- a/framework/base/TooFewArgumentsException.php
+++ b/framework/base/TooFewArgumentsException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\base;
+
+/**
+ * TooFewParametersException represents exception, caused by incomplete set of requiered arguments
+ *
+ * @author Igor Lis (ruwerefox666@gmail.com)
+ * @since 2.0.14
+ */
+class TooFewArgumentsException extends UserException
+{
+    public function getName()
+    {
+        return 'Too Few Arguments';
+    }
+}

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -141,7 +141,12 @@ class Controller extends \yii\base\Controller
             return Yii::$app->runAction('help', [$route]);
         }
 
-        return parent::runAction($id, $params);
+        try {
+            return parent::runAction($id, $params);
+        } catch (Exception $e) {
+            $this->stderr("{$e->getMessage()}", Console::FG_RED);
+            return Yii::$app->runAction('help', ["{$this->getUniqueId()}/$id"]);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | no

Example:
```
valkeru@valkeru-desktop:~/Projects/PHP/yii2/framework [0 ✓] $ ./yii asset/template
Missing required arguments: configFile
DESCRIPTION

Creates template of configuration file for [[actionCompress]].


USAGE

yii asset/template <configFile> [...options...]

- configFile (required): string
  output file name.


OPTIONS

--appconfig: string
  custom application configuration file path.
  If not set, default application configuration is used.

--color: boolean, 0 or 1
  whether to enable ANSI color in the output.
  If not set, ANSI color will only be enabled for terminals that support it.

--help, -h: boolean, 0 or 1
  whether to display help information about current command.

--interactive: boolean, 0 or 1 (defaults to 1)
  whether to run the command interactively.

valkeru@valkeru-desktop:~/Projects/PHP/yii2/framework [0 ✓] $
```