### PR TITLE
incorrect float to string conversion in yii\helper\BaseStringHelper

### DIFF
--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -361,7 +361,7 @@ class BaseStringHelper
      */
     public static function floatToString($number)
     {
-        return sprintf("%F", $number);
+        return sprintf('%F', $number);
     }
 
     /**

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -361,9 +361,7 @@ class BaseStringHelper
      */
     public static function floatToString($number)
     {
-        // . and , are the only decimal separators known in ICU data,
-        // so its safe to call str_replace here
-        return str_replace(',', '.', (string) $number);
+        return number_format($number, ini_get('precision'), '.', '');
     }
 
     /**

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -361,7 +361,7 @@ class BaseStringHelper
      */
     public static function floatToString($number)
     {
-        return number_format($number, ini_get('precision'), '.', '');
+        return sprintf("%F", $number);
     }
 
     /**


### PR DESCRIPTION
on my system,  (string) $number in line
   return str_replace(',', '.', (string) $number);
is converted to scientific notation, so it returns this 1.51643E+9 instead of 1516425820.449680. 

By the way this result is being used in \yii\log\Target::getTime(), this is obviously not the expected output of this code, yet I can not find anything in my php configuration/environment that would explain this. Although, it seems that I am only encountering this when I am using cli. 

I am seeing this on fedora ( latest php) and debian 9, running:

$ php --version
PHP 7.1.12-2+0~20171207160618.12+stretch~1.gbp5c91f3 (cli) (built: Dec  7 2017 16:06:20) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies
    with Zend OPcache v7.1.12-2+0~20171207160618.12+stretch~1.gbp5c91f3, Copyright (c) 1999-2017, by Zend Technologies



it seems number_format() is a more foolproof and setting independent way of accomplishing this conversion

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
