### PR TITLE
Fixes #14806: GridView option $placeFooterAfterBody

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,6 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.14 under development
 ------------------------
+- Enh #14806: Added $placeFooterAfterBody option for GridView (terehru) 
 - Enh #15426: Added abilitiy to create and drop database views (igravity, vladis84)
 - Enh #10186: Use native `hash_equals` in `yii\base\Security::compareString()` if available, throw exception if non-strings are compared (aotd1, samdark)
 - Bug #15122: Fixed `yii\db\Command::getRawSql()` to properly replace expressions (hiscaler, samdark)

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -351,12 +351,15 @@ class GridView extends BaseListView
         $tableHeader = $this->showHeader ? $this->renderTableHeader() : false;
         $tableBody = $this->renderTableBody();
 
+        $tableFooter = false;
+        $tableFooterAfterBody = false;
+        
         if ($this->showFooter) {
-	        $tableFooter = !$this->placeFooterAfterBody ? $this->renderTableFooter() : false;
-	        $tableFooterAfterBody = $this->placeFooterAfterBody ? $this->renderTableFooter() : false;
-        } else {
-            $tableFooter = false;
-	        $tableFooterAfterBody = false;
+            if ($this->placeFooterAfterBody) {
+                $tableFooterAfterBody = $this->renderTableFooter();
+            } else {
+                $tableFooter = $this->renderTableFooter();
+            }	        
         }
 
         $content = array_filter([

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -349,8 +349,15 @@ class GridView extends BaseListView
         $columnGroup = $this->renderColumnGroup();
         $tableHeader = $this->showHeader ? $this->renderTableHeader() : false;
         $tableBody = $this->renderTableBody();
-	    $tableFooter = $this->showFooter ? (!$this->placeFooterAfterBody ? $this->renderTableFooter() : false) : false;
-	    $tableFooterAfterBody = $this->showFooter ? ($this->placeFooterAfterBody ? $this->renderTableFooter() : false) : false;
+
+        if ($this->showFooter) {
+	        $tableFooter = !$this->placeFooterAfterBody ? $this->renderTableFooter() : false;
+	        $tableFooterAfterBody = $this->placeFooterAfterBody ? $this->renderTableFooter() : false;
+        } else {
+            $tableFooter = false;
+	        $tableFooterAfterBody = false;
+        }
+
         $content = array_filter([
             $caption,
             $columnGroup,

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -127,6 +127,10 @@ class GridView extends BaseListView
      * @var bool whether to show the footer section of the grid table.
      */
     public $showFooter = false;
+	/**
+	 * @var bool whether to place footer after body in DOM if $showFooter is true
+	 */
+	public $placeFooterAfterBody = false;
     /**
      * @var bool whether to show the grid view if [[dataProvider]] returns no data.
      */
@@ -345,13 +349,15 @@ class GridView extends BaseListView
         $columnGroup = $this->renderColumnGroup();
         $tableHeader = $this->showHeader ? $this->renderTableHeader() : false;
         $tableBody = $this->renderTableBody();
-        $tableFooter = $this->showFooter ? $this->renderTableFooter() : false;
+	    $tableFooter = $this->showFooter ? (!$this->placeFooterAfterBody ? $this->renderTableFooter() : false) : false;
+	    $tableFooterAfterBody = $this->showFooter ? ($this->placeFooterAfterBody ? $this->renderTableFooter() : false) : false;
         $content = array_filter([
             $caption,
             $columnGroup,
             $tableHeader,
             $tableFooter,
             $tableBody,
+            $tableFooterAfterBody,
         ]);
 
         return Html::tag('table', implode("\n", $content), $this->tableOptions);

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -129,6 +129,7 @@ class GridView extends BaseListView
     public $showFooter = false;
 	/**
 	 * @var bool whether to place footer after body in DOM if $showFooter is true
+     * @since 2.0.14
 	 */
 	public $placeFooterAfterBody = false;
     /**

--- a/tests/framework/grid/GridViewTest.php
+++ b/tests/framework/grid/GridViewTest.php
@@ -121,4 +121,33 @@ class GridViewTest extends \yiiunit\TestCase
             $this->assertNotEquals('otherRelation', $column->attribute);
         }
     }
+
+	/**
+	 * @throws \Exception
+	 */
+	public function testFooter() {
+		$config = [
+			'id'           => 'grid',
+			'dataProvider' => new ArrayDataProvider(['allModels' => []]),
+			'showHeader'   => false,
+			'showFooter'   => true,
+			'options'      => [],
+			'tableOptions' => [],
+			'view'         => new View(),
+			'filterUrl'    => '/',
+		];
+
+		$html = GridView::widget($config);
+		$html = preg_replace("/\r|\n/", '', $html);
+
+		$this->assertTrue(preg_match("/<\/tfoot><tbody>/", $html) === 1);
+
+		// Place footer after body
+		$config['placeFooterAfterBody'] = true;
+
+		$html = GridView::widget($config);
+		$html = preg_replace("/\r|\n/", '', $html);
+
+		$this->assertTrue(preg_match("/<\/tbody><tfoot>/", $html) === 1);
+	}
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14806

` <?= GridView::widget([ 

        'dataProvider' => $dataProvider,
        'showFooter' => true,
        // Set new option, check <tfoot> position in DOM
        'placeFooterAfterBody' => true,
        'columns' => [
            'id',
            ],
        ],
    ]); ?>
`
