### PR TITLE
Fixed `ActiveQuery::findWith` behavior that violates container configuration

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -76,6 +76,7 @@ Yii Framework 2 Change Log
 - Enh #15422: Added default roles dynamic definition support via closure for `yii\rbac\BaseManager` (deltacube)
 - Enh: Added check to `yii\base\Model::formName()` to prevent source path disclosure when form is represented by an anonymous class (silverfire)
 - Chg #15420: Handle OPTIONS request in `yii\filter\Cors` so the preflight check isn't passed trough authentication filters (michaelarnauts, leandrogehlen)
+- Bug #15540: Fixed `ActiveQuery::findWith` behavior that violates container configuration for `ActiveRecord` classes. (prowwid)
 
 2.0.13.1 November 14, 2017
 --------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -76,7 +76,7 @@ Yii Framework 2 Change Log
 - Enh #15422: Added default roles dynamic definition support via closure for `yii\rbac\BaseManager` (deltacube)
 - Enh: Added check to `yii\base\Model::formName()` to prevent source path disclosure when form is represented by an anonymous class (silverfire)
 - Chg #15420: Handle OPTIONS request in `yii\filter\Cors` so the preflight check isn't passed trough authentication filters (michaelarnauts, leandrogehlen)
-- Bug #15540: Fixed `ActiveQuery::findWith` behavior that violates container configuration for `ActiveRecord` classes. (prowwid)
+- Bug #15540: Fixed `ActiveQuery::findWith` behavior that violates container configuration for `ActiveRecord` classes (prowwid)
 
 2.0.13.1 November 14, 2017
 --------------------------

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -162,7 +162,7 @@ trait ActiveQueryTrait
     {
         $primaryModel = reset($models);
         if (!$primaryModel instanceof ActiveRecordInterface) {
-            $primaryModel = new $this->modelClass();
+            $primaryModel = \Yii::createObject($this->modelClass);
         }
         $relations = $this->normalizeRelations($primaryModel, $with);
         /* @var $relation ActiveQuery */


### PR DESCRIPTION
PR for issue [#15540](https://github.com/yiisoft/yii2/issues/15540)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15540 
