### PR TITLE
Removes unnecessary `integerOnly` option

### DIFF
--- a/docs/guide/input-validation.md
+++ b/docs/guide/input-validation.md
@@ -221,7 +221,7 @@ values are stored in an attribute:
 ```php
 ['age', 'trim'],
 ['age', 'default', 'value' => null],
-['age', 'integer', 'integerOnly' => true, 'min' => 0],
+['age', 'integer', 'min' => 0],
 ['age', 'filter', 'filter' => 'intval', 'skipOnEmpty' => true],
 ```
 


### PR DESCRIPTION
`integer` validator already has `'integerOnly' => true`.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
