### PR TITLE
[minor]  Use root NS specification for opcoded functions

### DIFF
--- a/build/controllers/ClassmapController.php
+++ b/build/controllers/ClassmapController.php
@@ -60,7 +60,7 @@ class ClassmapController extends Controller
             if (strpos($file, $root) !== 0) {
                 throw new Exception("Something wrong: $file\n");
             }
-            $path = str_replace('\\', '/', substr($file, strlen($root)));
+            $path = str_replace('\\', '/', substr($file, \strlen($root)));
             $map[$path] = "  'yii" . substr(str_replace('/', '\\', $path), 0, -4) . "' => YII2_PATH . '$path',";
         }
         ksort($map);

--- a/build/controllers/DevController.php
+++ b/build/controllers/DevController.php
@@ -98,17 +98,17 @@ class DevController extends Controller
      */
     public function actionRun($command)
     {
-        $command = implode(' ', func_get_args());
+        $command = implode(' ', \func_get_args());
 
         // root of the dev repo
-        $base = dirname(dirname(__DIR__));
+        $base = \dirname(\dirname(__DIR__));
         $dirs = $this->listSubDirs("$base/extensions");
         $dirs = array_merge($dirs, $this->listSubDirs("$base/apps"));
         asort($dirs);
 
         $oldcwd = getcwd();
         foreach ($dirs as $dir) {
-            $displayDir = substr($dir, strlen($base));
+            $displayDir = substr($dir, \strlen($base));
             $this->stdout("Running '$command' in $displayDir...\n", Console::BOLD);
             chdir($dir);
             passthru($command);
@@ -137,7 +137,7 @@ class DevController extends Controller
     public function actionApp($app, $repo = null)
     {
         // root of the dev repo
-        $base = dirname(dirname(__DIR__));
+        $base = \dirname(\dirname(__DIR__));
         $appDir = "$base/apps/$app";
 
         if (!file_exists($appDir)) {
@@ -188,7 +188,7 @@ class DevController extends Controller
     public function actionExt($extension, $repo = null)
     {
         // root of the dev repo
-        $base = dirname(dirname(__DIR__));
+        $base = \dirname(\dirname(__DIR__));
         $extensionDir = "$base/extensions/$extension";
 
         if (!file_exists($extensionDir)) {
@@ -234,7 +234,7 @@ class DevController extends Controller
     public function options($actionID)
     {
         $options = parent::options($actionID);
-        if (in_array($actionID, ['ext', 'app', 'all'], true)) {
+        if (\in_array($actionID, ['ext', 'app', 'all'], true)) {
             $options[] = 'useHttp';
         }
 

--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -147,7 +147,7 @@ class PhpDocController extends Controller
         }
 
         if ($root === null) {
-            $root = dirname(YII2_PATH);
+            $root = \dirname(YII2_PATH);
             $extensionPath = "$root/extensions";
             foreach (scandir($extensionPath) as $extension) {
                 if (ctype_alpha($extension) && is_dir($extensionPath . '/' . $extension)) {
@@ -172,7 +172,7 @@ class PhpDocController extends Controller
                 }
             }
         } elseif (preg_match('~extensions/([\w-]+)[\\\\/]?$~', $root, $matches)) {
-            $extensionPath = dirname(rtrim($root, '\\/'));
+            $extensionPath = \dirname(rtrim($root, '\\/'));
             $this->setUpExtensionAliases($extensionPath);
 
             list(, $extension) = $matches;
@@ -195,7 +195,7 @@ class PhpDocController extends Controller
 //                return [];
 //            }
         } elseif (preg_match('~apps/([\w-]+)[\\\\/]?$~', $root, $matches)) {
-            $extensionPath = dirname(dirname(rtrim($root, '\\/'))) . '/extensions';
+            $extensionPath = \dirname(\dirname(rtrim($root, '\\/'))) . '/extensions';
             $this->setUpExtensionAliases($extensionPath);
 
             list(, $appName) = $matches;
@@ -326,7 +326,7 @@ class PhpDocController extends Controller
                     $codeBlock = !$codeBlock;
                     $listIndent = '';
                 } elseif (preg_match('/^(\s*)([0-9]+\.|-|\*|\+) /', $docLine, $matches)) {
-                    $listIndent = str_repeat(' ', strlen($matches[0]));
+                    $listIndent = str_repeat(' ', \strlen($matches[0]));
                     $tag = false;
                     $lines[$i] = $indent . ' * ' . $docLine;
                     continue;
@@ -532,10 +532,10 @@ class PhpDocController extends Controller
         if (trim($oldDoc) != trim($newDoc)) {
             $fileContent = explode("\n", file_get_contents($file));
             $start = $ref->getStartLine() - 2;
-            $docStart = $start - count(explode("\n", $oldDoc)) + 1;
+            $docStart = $start - \count(explode("\n", $oldDoc)) + 1;
 
             $newFileContent = [];
-            $n = count($fileContent);
+            $n = \count($fileContent);
             for ($i = 0; $i < $n; $i++) {
                 if ($i > $start || $i < $docStart) {
                     $newFileContent[] = $fileContent[$i];
@@ -562,7 +562,7 @@ class PhpDocController extends Controller
     protected function cleanDocComment($doc)
     {
         $lines = explode("\n", $doc);
-        $n = count($lines);
+        $n = \count($lines);
         for ($i = 0; $i < $n; $i++) {
             $lines[$i] = rtrim($lines[$i]);
             if (trim($lines[$i]) == '*' && trim($lines[$i + 1]) == '*') {
@@ -603,7 +603,7 @@ class PhpDocController extends Controller
 
         // if no properties or other tags where present add properties at the end
         if ($propertyPosition === false) {
-            $propertyPosition = count($lines) - 2;
+            $propertyPosition = \count($lines) - 2;
         }
 
         $finalDoc = '';
@@ -626,22 +626,22 @@ class PhpDocController extends Controller
         $namespace = $namespace['name'];
         $classes = $this->match('#\n(?:abstract )?class (?<name>\w+)( extends .+)?( implements .+)?\n\{(?<content>.*)\n\}(\n|$)#', $file);
 
-        if (count($classes) > 1) {
+        if (\count($classes) > 1) {
             $this->stderr("[ERR] There should be only one class in a file: $fileName\n", Console::FG_RED);
 
             return false;
         }
-        if (count($classes) < 1) {
+        if (\count($classes) < 1) {
             $interfaces = $this->match('#\ninterface (?<name>\w+)( extends .+)?\n\{(?<content>.*)\n\}(\n|$)#', $file);
-            if (count($interfaces) == 1) {
+            if (\count($interfaces) == 1) {
                 return false;
-            } elseif (count($interfaces) > 1) {
+            } elseif (\count($interfaces) > 1) {
                 $this->stderr("[ERR] There should be only one interface in a file: $fileName\n", Console::FG_RED);
             } else {
                 $traits = $this->match('#\ntrait (?<name>\w+)\n\{(?<content>.*)\n\}(\n|$)#', $file);
-                if (count($traits) == 1) {
+                if (\count($traits) == 1) {
                     return false;
-                } elseif (count($traits) > 1) {
+                } elseif (\count($traits) > 1) {
                     $this->stderr("[ERR] There should be only one class/trait/interface in a file: $fileName\n", Console::FG_RED);
                 } else {
                     $this->stderr("[ERR] No class in file: $fileName\n", Console::FG_RED);
@@ -682,7 +682,7 @@ class PhpDocController extends Controller
 
             ksort($props);
 
-            if (count($props) > 0) {
+            if (\count($props) > 0) {
                 $phpdoc .= " *\n";
                 foreach ($props as $propName => &$prop) {
                     $docline = ' * @';
@@ -773,7 +773,7 @@ class PhpDocController extends Controller
             return '';
         }
 
-        return strtoupper(substr($str, 0, 1)) . substr($str, 1) . ($str[strlen($str) - 1] != '.' ? '.' : '');
+        return strtoupper(substr($str, 0, 1)) . substr($str, 1) . ($str[\strlen($str) - 1] != '.' ? '.' : '');
     }
 
     protected function getPropParam($prop, $param)

--- a/build/controllers/ReleaseController.php
+++ b/build/controllers/ReleaseController.php
@@ -82,7 +82,7 @@ class ReleaseController extends Controller
             throw new Exception('Sorry, but releases should be run interactively to ensure you actually verify what you are doing ;)');
         }
         if ($this->basePath === null) {
-            $this->basePath = dirname(dirname(__DIR__));
+            $this->basePath = \dirname(\dirname(__DIR__));
         }
         $this->basePath = rtrim($this->basePath, '\\/');
         return parent::beforeAction($action);
@@ -183,7 +183,7 @@ class ReleaseController extends Controller
      */
     public function actionRelease(array $what)
     {
-        if (count($what) > 1) {
+        if (\count($what) > 1) {
             $this->stdout("Currently only one simultaneous release is supported.\n");
             return 1;
         }
@@ -315,7 +315,7 @@ class ReleaseController extends Controller
      */
     public function actionSortChangelog(array $what)
     {
-        if (count($what) > 1) {
+        if (\count($what) > 1) {
             $this->stdout("Currently only one simultaneous release is supported.\n");
             return 1;
         }
@@ -376,7 +376,7 @@ class ReleaseController extends Controller
     {
         foreach ($what as $w) {
             if (strncmp('app-', $w, 4) === 0) {
-                if (!empty($limit) && !in_array('app', $limit)) {
+                if (!empty($limit) && !\in_array('app', $limit)) {
                     throw new Exception('Only the following types are allowed: ' . implode(', ', $limit) . "\n");
                 }
                 if (!is_dir($appPath = "{$this->basePath}/apps/" . substr($w, 4))) {
@@ -386,7 +386,7 @@ class ReleaseController extends Controller
                     $this->ensureGitClean($appPath);
                 }
             } elseif ($w === 'framework') {
-                if (!empty($limit) && !in_array('framework', $limit)) {
+                if (!empty($limit) && !\in_array('framework', $limit)) {
                     throw new Exception('Only the following types are allowed: ' . implode(', ', $limit) . "\n");
                 }
                 if (!is_dir($fwPath = "{$this->basePath}/framework")) {
@@ -396,7 +396,7 @@ class ReleaseController extends Controller
                     $this->ensureGitClean($fwPath);
                 }
             } else {
-                if (!empty($limit) && !in_array('ext', $limit)) {
+                if (!empty($limit) && !\in_array('ext', $limit)) {
                     throw new Exception('Only the following types are allowed: ' . implode(', ', $limit) . "\n");
                 }
                 if (!is_dir($extPath = "{$this->basePath}/extensions/$w")) {
@@ -414,7 +414,7 @@ class ReleaseController extends Controller
     {
         $this->stdout("\n");
         $this->stdout($h = "Preparing framework release version $version", Console::BOLD);
-        $this->stdout("\n" . str_repeat('-', strlen($h)) . "\n\n", Console::BOLD);
+        $this->stdout("\n" . str_repeat('-', \strlen($h)) . "\n\n", Console::BOLD);
 
         if (!$this->confirm('Make sure you are on the right branch for this release and that it tracks the correct remote branch! Continue?')) {
             exit(1);
@@ -552,7 +552,7 @@ class ReleaseController extends Controller
     {
         $this->stdout("\n");
         $this->stdout($h = "Preparing release for application  $name  version $version", Console::BOLD);
-        $this->stdout("\n" . str_repeat('-', strlen($h)) . "\n\n", Console::BOLD);
+        $this->stdout("\n" . str_repeat('-', \strlen($h)) . "\n\n", Console::BOLD);
 
         if (!$this->confirm('Make sure you are on the right branch for this release and that it tracks the correct remote branch! Continue?')) {
             exit(1);
@@ -670,7 +670,7 @@ class ReleaseController extends Controller
     {
         $this->stdout("\n");
         $this->stdout($h = "Preparing release for extension  $name  version $version", Console::BOLD);
-        $this->stdout("\n" . str_repeat('-', strlen($h)) . "\n\n", Console::BOLD);
+        $this->stdout("\n" . str_repeat('-', \strlen($h)) . "\n\n", Console::BOLD);
 
         if (!$this->confirm('Make sure you are on the right branch for this release and that it tracks the correct remote branch! Continue?')) {
             exit(1);
@@ -817,7 +817,7 @@ class ReleaseController extends Controller
         $headline = $version . ' ' . date('F d, Y');
         $this->sed(
             '/' . $v . ' under development\n(-+?)\n/',
-            $headline . "\n" . str_repeat('-', strlen($headline)) . "\n",
+            $headline . "\n" . str_repeat('-', \strlen($headline)) . "\n",
             $this->getChangelogs($what)
         );
     }
@@ -825,7 +825,7 @@ class ReleaseController extends Controller
     protected function openChangelogs($what, $version)
     {
         $headline = "\n$version under development\n";
-        $headline .= str_repeat('-', strlen($headline) - 2) . "\n\n- no changes in this release.\n";
+        $headline .= str_repeat('-', \strlen($headline) - 2) . "\n\n- no changes in this release.\n";
         foreach ($this->getChangelogs($what) as $file) {
             $lines = explode("\n", file_get_contents($file));
             $hl = [
@@ -919,7 +919,7 @@ class ReleaseController extends Controller
     protected function getChangelogs($what)
     {
         $changelogs = [];
-        if (in_array('framework', $what)) {
+        if (\in_array('framework', $what)) {
             $changelogs[] = $this->getFrameworkChangelog();
         }
 
@@ -947,13 +947,13 @@ class ReleaseController extends Controller
     protected function composerSetStability($what, $version)
     {
         $apps = [];
-        if (in_array('app-advanced', $what)) {
+        if (\in_array('app-advanced', $what)) {
             $apps[] = $this->basePath . '/apps/advanced/composer.json';
         }
-        if (in_array('app-basic', $what)) {
+        if (\in_array('app-basic', $what)) {
             $apps[] = $this->basePath . '/apps/basic/composer.json';
         }
-        if (in_array('app-benchmark', $what)) {
+        if (\in_array('app-benchmark', $what)) {
             $apps[] = $this->basePath . '/apps/benchmark/composer.json';
         }
         if (empty($apps)) {

--- a/build/controllers/Utf8Controller.php
+++ b/build/controllers/Utf8Controller.php
@@ -29,7 +29,7 @@ class Utf8Controller extends Controller
     public function actionCheckGuide($directory = null)
     {
         if ($directory === null) {
-            $directory = dirname(dirname(__DIR__)) . '/docs';
+            $directory = \dirname(\dirname(__DIR__)) . '/docs';
         }
         if (is_file($directory)) {
             $files = [$directory];
@@ -90,7 +90,7 @@ class Utf8Controller extends Controller
         }
 
         $hexcode = dechex($this->unicodeOrd($char));
-        $hexcode = str_repeat('0', max(4 - strlen($hexcode), 0)) . $hexcode;
+        $hexcode = str_repeat('0', max(4 - \strlen($hexcode), 0)) . $hexcode;
 
         $this->stdout("  at $line:$pos FOUND $what: 0x$hexcode '$char' http://unicode-table.com/en/$hexcode/\n");
     }
@@ -105,20 +105,20 @@ class Utf8Controller extends Controller
      */
     private function unicodeOrd($c)
     {
-        $h = ord($c[0]);
+        $h = \ord($c[0]);
         if ($h <= 0x7F) {
             return $h;
         } elseif ($h < 0xC2) {
             return false;
         } elseif ($h <= 0xDF) {
-            return ($h & 0x1F) << 6 | (ord($c[1]) & 0x3F);
+            return ($h & 0x1F) << 6 | (\ord($c[1]) & 0x3F);
         } elseif ($h <= 0xEF) {
-            return ($h & 0x0F) << 12 | (ord($c[1]) & 0x3F) << 6
-                                     | (ord($c[2]) & 0x3F);
+            return ($h & 0x0F) << 12 | (\ord($c[1]) & 0x3F) << 6
+                                     | (\ord($c[2]) & 0x3F);
         } elseif ($h <= 0xF4) {
-            return ($h & 0x0F) << 18 | (ord($c[1]) & 0x3F) << 12
-                                     | (ord($c[2]) & 0x3F) << 6
-                                     | (ord($c[3]) & 0x3F);
+            return ($h & 0x0F) << 18 | (\ord($c[1]) & 0x3F) << 12
+                                     | (\ord($c[2]) & 0x3F) << 6
+                                     | (\ord($c[3]) & 0x3F);
         }
 
         return false;

--- a/tests/data/ar/Animal.php
+++ b/tests/data/ar/Animal.php
@@ -26,7 +26,7 @@ class Animal extends ActiveRecord
     public function init()
     {
         parent::init();
-        $this->type = get_called_class();
+        $this->type = \get_called_class();
     }
 
     public function getDoes()

--- a/tests/data/ar/Customer.php
+++ b/tests/data/ar/Customer.php
@@ -100,6 +100,6 @@ class Customer extends ActiveRecord
      */
     public static function find()
     {
-        return new CustomerQuery(get_called_class());
+        return new CustomerQuery(\get_called_class());
     }
 }

--- a/tests/data/validators/TestValidator.php
+++ b/tests/data/validators/TestValidator.php
@@ -18,7 +18,7 @@ class TestValidator extends Validator
     {
         $this->markAttributeValidated($attribute);
         if ($this->_setErrorOnValidateAttribute == true) {
-            $this->addError($object, $attribute, sprintf('%s##%s', $attribute, get_class($object)));
+            $this->addError($object, $attribute, sprintf('%s##%s', $attribute, \get_class($object)));
         }
     }
 

--- a/tests/data/validators/models/FakedValidationModel.php
+++ b/tests/data/validators/models/FakedValidationModel.php
@@ -46,14 +46,14 @@ class FakedValidationModel extends Model
 
     public function inlineVal($attribute, $params = [], $validator)
     {
-        $this->inlineValArgs = func_get_args();
+        $this->inlineValArgs = \func_get_args();
 
         return true;
     }
 
     public function clientInlineVal($attribute, $params = [], $validator)
     {
-        return func_get_args();
+        return \func_get_args();
     }
 
     public function __get($name)

--- a/tests/framework/ar/ActiveRecordTestTrait.php
+++ b/tests/framework/ar/ActiveRecordTestTrait.php
@@ -1105,7 +1105,7 @@ trait ActiveRecordTestTrait
         Event::on(BaseActiveRecord::className(), BaseActiveRecord::EVENT_AFTER_FIND, function ($event) use (&$afterFindCalls) {
             /* @var $ar BaseActiveRecord */
             $ar = $event->sender;
-            $afterFindCalls[] = [get_class($ar), $ar->getIsNewRecord(), $ar->getPrimaryKey(), $ar->isRelationPopulated('orders')];
+            $afterFindCalls[] = [\get_class($ar), $ar->getIsNewRecord(), $ar->getPrimaryKey(), $ar->isRelationPopulated('orders')];
         });
 
         $customer = $customerClass::findOne(1);
@@ -1160,7 +1160,7 @@ trait ActiveRecordTestTrait
         Event::on(BaseActiveRecord::className(), BaseActiveRecord::EVENT_AFTER_REFRESH, function ($event) use (&$afterRefreshCalls) {
             /* @var $ar BaseActiveRecord */
             $ar = $event->sender;
-            $afterRefreshCalls[] = [get_class($ar), $ar->getIsNewRecord(), $ar->getPrimaryKey(), $ar->isRelationPopulated('orders')];
+            $afterRefreshCalls[] = [\get_class($ar), $ar->getIsNewRecord(), $ar->getPrimaryKey(), $ar->isRelationPopulated('orders')];
         });
 
         $customer = $customerClass::findOne(1);

--- a/tests/framework/db/AnyCaseValue.php
+++ b/tests/framework/db/AnyCaseValue.php
@@ -18,7 +18,7 @@ class AnyCaseValue extends CompareValue
      */
     public function __construct($value, $config = [])
     {
-        if (is_array($value)) {
+        if (\is_array($value)) {
             $this->value = array_map('strtolower', $value);
         } else {
             $this->value = strtolower($value);

--- a/tests/framework/db/ColumnSchemaBuilderTest.php
+++ b/tests/framework/db/ColumnSchemaBuilderTest.php
@@ -70,7 +70,7 @@ abstract class ColumnSchemaBuilderTest extends DatabaseTestCase
         $builder = $this->getColumnSchemaBuilder($type, $length);
         foreach ($calls as $call) {
             $method = array_shift($call);
-            call_user_func_array([$builder, $method], $call);
+            \call_user_func_array([$builder, $method], $call);
         }
 
         self::assertEquals($expected, $builder->__toString());

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -144,7 +144,7 @@ abstract class CommandTest extends DatabaseTestCase
 
     public function testBindParamValue()
     {
-        if (defined('HHVM_VERSION') && $this->driverName === 'pgsql') {
+        if (\defined('HHVM_VERSION') && $this->driverName === 'pgsql') {
             $this->markTestSkipped('HHVMs PgSQL implementation has some specific behavior that breaks some parts of this test.');
         }
 
@@ -205,14 +205,14 @@ SQL;
         $this->assertEquals($floatCol, $row['float_col']);
         if ($this->driverName === 'mysql' || $this->driverName === 'sqlite' || $this->driverName === 'oci') {
             $this->assertEquals($blobCol, $row['blob_col']);
-        } elseif (defined('HHVM_VERSION') && $this->driverName === 'pgsql') {
+        } elseif (\defined('HHVM_VERSION') && $this->driverName === 'pgsql') {
             // HHVMs pgsql implementation does not seem to support blob columns correctly.
         } else {
             $this->assertInternalType('resource', $row['blob_col']);
             $this->assertEquals($blobCol, stream_get_contents($row['blob_col']));
         }
         $this->assertEquals($numericCol, $row['numeric_col']);
-        if ($this->driverName === 'mysql' || $this->driverName === 'oci' || (defined('HHVM_VERSION') && in_array($this->driverName, ['sqlite', 'pgsql']))) {
+        if ($this->driverName === 'mysql' || $this->driverName === 'oci' || (\defined('HHVM_VERSION') && \in_array($this->driverName, ['sqlite', 'pgsql']))) {
             $this->assertEquals($boolCol, (int) $row['bool_col']);
         } else {
             $this->assertEquals($boolCol, $row['bool_col']);
@@ -266,7 +266,7 @@ SQL;
         $sql = 'SELECT * FROM {{customer}}';
         $command = $db->createCommand($sql);
         $result = $command->queryOne();
-        $this->assertTrue(is_array($result) && isset($result['id']));
+        $this->assertTrue(\is_array($result) && isset($result['id']));
 
         // FETCH_OBJ, customized via fetchMode property
         $sql = 'SELECT * FROM {{customer}}';
@@ -279,7 +279,7 @@ SQL;
         $sql = 'SELECT * FROM {{customer}}';
         $command = $db->createCommand($sql);
         $result = $command->queryOne([], \PDO::FETCH_NUM);
-        $this->assertTrue(is_array($result) && isset($result[0]));
+        $this->assertTrue(\is_array($result) && isset($result[0]));
     }
 
     public function testBatchInsert()
@@ -346,7 +346,7 @@ SQL;
             $db->createCommand()->batchInsert('type', $cols, $data)->execute();
 
             $data = $db->createCommand('SELECT int_col, char_col, float_col, bool_col FROM {{type}} WHERE [[int_col]] IN (1,2,3) ORDER BY [[int_col]];')->queryAll();
-            $this->assertEquals(3, count($data));
+            $this->assertEquals(3, \count($data));
             $this->assertEquals(1, $data[0]['int_col']);
             $this->assertEquals(2, $data[1]['int_col']);
             $this->assertEquals(3, $data[2]['int_col']);

--- a/tests/framework/db/DatabaseTestCase.php
+++ b/tests/framework/db/DatabaseTestCase.php
@@ -37,7 +37,7 @@ abstract class DatabaseTestCase extends TestCase
             $pdo_database = 'oci8';
         }
 
-        if (!extension_loaded('pdo') || !extension_loaded($pdo_database)) {
+        if (!\extension_loaded('pdo') || !\extension_loaded($pdo_database)) {
             $this->markTestSkipped('pdo and ' . $pdo_database . ' extension are required.');
         }
         $this->mockApplication();

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -434,7 +434,7 @@ abstract class QueryTest extends DatabaseTestCase
      */
     public function testCountHavingWithoutGroupBy()
     {
-        if (!in_array($this->driverName, ['mysql'])) {
+        if (!\in_array($this->driverName, ['mysql'])) {
             $this->markTestSkipped("{$this->driverName} does not support having without group by.");
         }
 

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -60,14 +60,14 @@ abstract class SchemaTest extends DatabaseTestCase
         $schema = $connection->schema;
 
         $tables = $schema->getTableNames();
-        $this->assertTrue(in_array('customer', $tables));
-        $this->assertTrue(in_array('category', $tables));
-        $this->assertTrue(in_array('item', $tables));
-        $this->assertTrue(in_array('order', $tables));
-        $this->assertTrue(in_array('order_item', $tables));
-        $this->assertTrue(in_array('type', $tables));
-        $this->assertTrue(in_array('animal', $tables));
-        $this->assertTrue(in_array('animal_view', $tables));
+        $this->assertTrue(\in_array('customer', $tables));
+        $this->assertTrue(\in_array('category', $tables));
+        $this->assertTrue(\in_array('item', $tables));
+        $this->assertTrue(\in_array('order', $tables));
+        $this->assertTrue(\in_array('order_item', $tables));
+        $this->assertTrue(\in_array('type', $tables));
+        $this->assertTrue(\in_array('animal', $tables));
+        $this->assertTrue(\in_array('animal_view', $tables));
     }
 
     /**
@@ -84,7 +84,7 @@ abstract class SchemaTest extends DatabaseTestCase
         $schema = $connection->schema;
 
         $tables = $schema->getTableSchemas();
-        $this->assertEquals(count($schema->getTableNames()), count($tables));
+        $this->assertEquals(\count($schema->getTableNames()), \count($tables));
         foreach ($tables as $table) {
             $this->assertInstanceOf('yii\db\TableSchema', $table);
         }
@@ -94,10 +94,10 @@ abstract class SchemaTest extends DatabaseTestCase
     {
         $db = $this->getConnection(false);
         $db->slavePdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_LOWER);
-        $this->assertEquals(count($db->schema->getTableNames()), count($db->schema->getTableSchemas()));
+        $this->assertEquals(\count($db->schema->getTableNames()), \count($db->schema->getTableSchemas()));
 
         $db->slavePdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_UPPER);
-        $this->assertEquals(count($db->schema->getTableNames()), count($db->schema->getTableSchemas()));
+        $this->assertEquals(\count($db->schema->getTableNames()), \count($db->schema->getTableSchemas()));
     }
 
     public function testGetNonExistingTableSchema()
@@ -481,7 +481,7 @@ abstract class SchemaTest extends DatabaseTestCase
             $this->assertSame($expected['size'], $column->size, "size of column $name does not match.");
             $this->assertSame($expected['precision'], $column->precision, "precision of column $name does not match.");
             $this->assertSame($expected['scale'], $column->scale, "scale of column $name does not match.");
-            if (is_object($expected['defaultValue'])) {
+            if (\is_object($expected['defaultValue'])) {
                 $this->assertInternalType('object', $column->defaultValue, "defaultValue of column $name is expected to be an object but it is not.");
                 $this->assertEquals((string) $expected['defaultValue'], (string) $column->defaultValue, "defaultValue of column $name does not match.");
             } else {
@@ -729,13 +729,13 @@ abstract class SchemaTest extends DatabaseTestCase
 
     private function assertMetadataEquals($expected, $actual)
     {
-        $this->assertInternalType(strtolower(gettype($expected)), $actual);
-        if (is_array($expected)) {
+        $this->assertInternalType(strtolower(\gettype($expected)), $actual);
+        if (\is_array($expected)) {
             $this->normalizeArrayKeys($expected, false);
             $this->normalizeArrayKeys($actual, false);
         }
         $this->normalizeConstraints($expected, $actual);
-        if (is_array($expected)) {
+        if (\is_array($expected)) {
             $this->normalizeArrayKeys($expected, true);
             $this->normalizeArrayKeys($actual, true);
         }
@@ -768,7 +768,7 @@ abstract class SchemaTest extends DatabaseTestCase
 
     private function normalizeConstraints(&$expected, &$actual)
     {
-        if (is_array($expected)) {
+        if (\is_array($expected)) {
             foreach ($expected as $key => $value) {
                 if (!$value instanceof Constraint || !isset($actual[$key]) || !$actual[$key] instanceof Constraint) {
                     continue;

--- a/tests/framework/db/cubrid/SchemaTest.php
+++ b/tests/framework/db/cubrid/SchemaTest.php
@@ -119,7 +119,7 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
      */
     private function convertPropertiesToAnycase($object, $isProperty = false)
     {
-        if (!$isProperty && is_array($object)) {
+        if (!$isProperty && \is_array($object)) {
             $result = [];
             foreach ($object as $name => $value) {
                 $result[] = $this->convertPropertiesToAnycase($value);
@@ -128,11 +128,11 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
             return $result;
         }
 
-        if (is_object($object)) {
+        if (\is_object($object)) {
             foreach (array_keys((array) $object) as $name) {
                 $object->$name = $this->convertPropertiesToAnycase($object->$name, true);
             }
-        } elseif (is_array($object) || is_string($object)) {
+        } elseif (\is_array($object) || \is_string($object)) {
             $object = new AnyCaseValue($object);
         }
 

--- a/tests/framework/db/mysql/connection/DeadLockTest.php
+++ b/tests/framework/db/mysql/connection/DeadLockTest.php
@@ -35,14 +35,14 @@ class DeadLockTest extends \yiiunit\framework\db\mysql\ConnectionTest
             $this->markTestSkipped('Skipping PHP 5 on Travis since it segfaults with pcntl');
         }
 
-        if (!function_exists('pcntl_fork')) {
+        if (!\function_exists('pcntl_fork')) {
             $this->markTestSkipped('pcntl_fork() is not available');
         }
-        if (!function_exists('posix_kill')) {
+        if (!\function_exists('posix_kill')) {
             $this->markTestSkipped('posix_kill() is not available');
         }
         // HHVM does not support this (?)
-        if (!function_exists('pcntl_sigtimedwait')) {
+        if (!\function_exists('pcntl_sigtimedwait')) {
             $this->markTestSkipped('pcntl_sigtimedwait() is not available');
         }
 
@@ -194,10 +194,10 @@ class DeadLockTest extends \yiiunit\framework\db\mysql\ConnectionTest
             $this->log("child 1: ! sql error $sqlError: $driverError: $driverMessage");
             return 1;
         } catch (\Exception $e) {
-            $this->log('child 1: ! exit <<' . get_class($e) . ' #' . $e->getCode() . ': ' . $e->getMessage() . "\n" . $e->getTraceAsString() . '>>');
+            $this->log('child 1: ! exit <<' . \get_class($e) . ' #' . $e->getCode() . ': ' . $e->getMessage() . "\n" . $e->getTraceAsString() . '>>');
             return 1;
         } catch (\Throwable $e) {
-            $this->log('child 1: ! exit <<' . get_class($e) . ' #' . $e->getCode() . ': ' . $e->getMessage() . "\n" . $e->getTraceAsString() . '>>');
+            $this->log('child 1: ! exit <<' . \get_class($e) . ' #' . $e->getCode() . ': ' . $e->getMessage() . "\n" . $e->getTraceAsString() . '>>');
             return 1;
         }
         $this->log('child 1: exit');
@@ -254,10 +254,10 @@ class DeadLockTest extends \yiiunit\framework\db\mysql\ConnectionTest
             $this->log("child 2: ! sql error $sqlError: $driverError: $driverMessage");
             return 1;
         } catch (\Exception $e) {
-            $this->log('child 2: ! exit <<' . get_class($e) . ' #' . $e->getCode() . ': ' . $e->getMessage() . "\n" . $e->getTraceAsString() . '>>');
+            $this->log('child 2: ! exit <<' . \get_class($e) . ' #' . $e->getCode() . ': ' . $e->getMessage() . "\n" . $e->getTraceAsString() . '>>');
             return 1;
         } catch (\Throwable $e) {
-            $this->log('child 2: ! exit <<' . get_class($e) . ' #' . $e->getCode() . ': ' . $e->getMessage() . "\n" . $e->getTraceAsString() . '>>');
+            $this->log('child 2: ! exit <<' . \get_class($e) . ' #' . $e->getCode() . ': ' . $e->getMessage() . "\n" . $e->getTraceAsString() . '>>');
             return 1;
         }
         $this->log('child 2: exit');

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -79,7 +79,7 @@ class CommandTest extends \yiiunit\framework\db\CommandTest
      */
     public function testSaveSerializedObject()
     {
-        if (defined('HHVM_VERSION')) {
+        if (\defined('HHVM_VERSION')) {
             $this->markTestSkipped('HHVMs PgSQL implementation does not seem to support blob colums in the way they are used here.');
         }
 

--- a/tests/framework/db/sqlite/ConnectionTest.php
+++ b/tests/framework/db/sqlite/ConnectionTest.php
@@ -119,7 +119,7 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
 
             $hit_slaves[$db->getSlave()->dsn] = true;
             $hit_masters[$db->getMaster()->dsn] = true;
-            if (count($hit_slaves) === $slavesCount && count($hit_masters) === $mastersCount) {
+            if (\count($hit_slaves) === $slavesCount && \count($hit_masters) === $mastersCount) {
                 break;
             }
         }
@@ -144,7 +144,7 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
 
             $hit_slaves[$db->getSlave()->dsn] = true;
             $hit_masters[$db->getMaster()->dsn] = true;
-            if (count($hit_slaves) === $slavesCount) {
+            if (\count($hit_slaves) === $slavesCount) {
                 break;
             }
         }

--- a/tests/framework/di/ContainerTest.php
+++ b/tests/framework/di/ContainerTest.php
@@ -170,7 +170,7 @@ class ContainerTest extends TestCase
 
 
         $myFunc = function ($a, NumberValidator $b, $c = 'default') {
-            return[$a, get_class($b), $c];
+            return[$a, \get_class($b), $c];
         };
         $result = Yii::$container->invoke($myFunc, ['a']);
         $this->assertEquals(['a', 'yii\validators\NumberValidator', 'default'], $result);
@@ -306,7 +306,7 @@ class ContainerTest extends TestCase
      */
     public function testVariadicConstructor()
     {
-        if (defined('HHVM_VERSION')) {
+        if (\defined('HHVM_VERSION')) {
             static::markTestSkipped('Can not test on HHVM because it does not support variadics.');
         }
 
@@ -319,7 +319,7 @@ class ContainerTest extends TestCase
      */
     public function testVariadicCallable()
     {
-        if (defined('HHVM_VERSION')) {
+        if (\defined('HHVM_VERSION')) {
             static::markTestSkipped('Can not test on HHVM because it does not support variadics.');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | n/a

The optimization (the functions have opcodes) is effective for PHP 7.0+
