### PR TITLE
normalizePath for windows network shares that start with two backslashes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -18,6 +18,7 @@ Yii Framework 2 Change Log
 - Enh #15496: CSRF token is now regenerated on changing identity (samdark, rhertogh)
 - Enh #15417: Added `yii\validators\FileValidator::$minFiles` (vladis84)
 - Bug #8983: Only truncate the original log file for rotation (matthewyang, developeruz)
+- Bug #13034: Fixed `normalizePath` for windows network shares that start with two backslashes (developeruz)
 - Bug #14135: Fixed `yii\web\Request::getBodyParam()` crashes on object type body params (klimov-paul)
 - Bug #14157: Add support for loading default value `CURRENT_TIMESTAMP` of MySQL `datetime` field (rossoneri)
 - Bug #14276: Fixed I18N format with dotted parameters (developeruz)

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -62,7 +62,11 @@ class BaseFileHelper
             return $path;
         }
         // the path may contain ".", ".." or double slashes, need to clean them up
-        $parts = [];
+        if (strpos($path, "{$ds}{$ds}") === 0 && $ds == '\\') {
+            $parts = [$ds];
+        } else {
+            $parts = [];
+        }
         foreach (explode($ds, $path) as $part) {
             if ($part === '..' && !empty($parts) && end($parts) !== '..') {
                 array_pop($parts);

--- a/tests/framework/helpers/FileHelperTest.php
+++ b/tests/framework/helpers/FileHelperTest.php
@@ -739,6 +739,12 @@ class FileHelperTest extends TestCase
         $this->assertEquals("..{$ds}a", FileHelper::normalizePath('././..\\a'));
         $this->assertEquals("..{$ds}a", FileHelper::normalizePath('./..\\a/../a'));
         $this->assertEquals("..{$ds}b", FileHelper::normalizePath('./..\\a/../b'));
+
+        // Windows file system may have paths for network shares that start with two backslashes
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx
+        // https://github.com/yiisoft/yii2/issues/13034
+        $this->assertEquals('\\\\server\share\path\file', FileHelper::normalizePath('\\\\server\share\path\file', '\\'));
+
     }
 
     public function testLocalizedDirectory()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes, I hope so
| Fixed issues  | #13034