### PR TITLE
Fixed `yii\db\ActiveRecord::refresh()` method does not use an alias in the condition

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.14 under development
 ------------------------
-- Bug #15522: Fixed `yii\db\ActiveRecord::refesh()` method does not use an alias in the condition (vladis84)
+- Bug #15522: Fixed `yii\db\ActiveRecord::refresh()` method does not use an alias in the condition (vladis84)
 - Enh #15476: Added `\yii\widgets\ActiveForm::$validationStateOn` to be able to specify where to add class for invalid fields (samdark)
 - Enh #13996: Added `yii\web\View::registerJsVar()` method that allows registering JavaScript variables (Eseperio, samdark)
 - Enh #9771: Assign hidden input with its own set of HTML options via `$hiddenOptions` in activeFileInput `$options` (HanafiAhmat)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.14 under development
 ------------------------
-
+- Buq #15522: Fixed `yii\db\ActiveRecord::refesh()` method does not use an alias in the condition (vladis84)
 - Enh #15476: Added `\yii\widgets\ActiveForm::$validationStateOn` to be able to specify where to add class for invalid fields (samdark)
 - Enh #13996: Added `yii\web\View::registerJsVar()` method that allows registering JavaScript variables (Eseperio, samdark)
 - Enh #9771: Assign hidden input with its own set of HTML options via `$hiddenOptions` in activeFileInput `$options` (HanafiAhmat)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.14 under development
 ------------------------
-- Buq #15522: Fixed `yii\db\ActiveRecord::refesh()` method does not use an alias in the condition (vladis84)
+- Bug #15522: Fixed `yii\db\ActiveRecord::refesh()` method does not use an alias in the condition (vladis84)
 - Enh #15476: Added `\yii\widgets\ActiveForm::$validationStateOn` to be able to specify where to add class for invalid fields (samdark)
 - Enh #13996: Added `yii\web\View::registerJsVar()` method that allows registering JavaScript variables (Eseperio, samdark)
 - Enh #9771: Assign hidden input with its own set of HTML options via `$hiddenOptions` in activeFileInput `$options` (HanafiAhmat)

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -194,13 +194,17 @@ class ActiveRecord extends BaseActiveRecord
      */
     public function refresh()
     {
+        $query = static::find();
+        $tableName = key($query->getTablesUsedInFrom());
         $pk = [];
         // disambiguate column names in case ActiveQuery adds a JOIN
         foreach ($this->getPrimaryKey(true) as $key => $value) {
-            $pk[static::tableName() . '.' . $key] = $value;
+            $pk[$tableName . '.' . $key] = $value;
         }
+        $query->where($pk);
+
         /* @var $record BaseActiveRecord */
-        $record = static::findOne($pk);
+        $record = $query->one();
         return $this->refreshInternal($record);
     }
 

--- a/tests/data/ar/CustomerWithAlias.php
+++ b/tests/data/ar/CustomerWithAlias.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace yiiunit\data\ar;
+
+/**
+ * Class Customer.
+ *
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property string $address
+ * @property int $status
+ *
+ * @method CustomerQuery findBySql($sql, $params = []) static
+ */
+class CustomerWithAlias extends ActiveRecord
+{
+    const STATUS_ACTIVE = 1;
+    const STATUS_INACTIVE = 2;
+
+    public $status2;
+
+    public $sumTotal;
+    
+    public static function tableName()
+    {
+        return 'customer';
+    }
+    
+    /**
+     * {@inheritdoc}
+     * @return CustomerQuery
+     */
+    public static function find()
+    {
+        $activeQuery = new CustomerQuery(get_called_class());
+        $activeQuery->alias('csr');
+        return $activeQuery;
+    }
+}

--- a/tests/framework/ar/ActiveRecordTestTrait.php
+++ b/tests/framework/ar/ActiveRecordTestTrait.php
@@ -275,6 +275,16 @@ trait ActiveRecordTestTrait
         $this->assertEquals('user1', $customer->name);
     }
 
+    public function testRefresh_querySetAlias_findRecord()
+    {
+        $customer = new \yiiunit\data\ar\CustomerWithAlias();
+        $customer->id = 1;
+
+        $customer->refresh();
+
+        $this->assertEquals(1, $customer->id);
+    }
+
     public function testEquals()
     {
         /* @var $customerClass \yii\db\ActiveRecordInterface */


### PR DESCRIPTION
… the condition

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15522