### PR TITLE
Fix BaseInflector::transliterate bug when a transliterator rule is incompatible with ICU version 

### DIFF
--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -504,7 +504,11 @@ class BaseInflector
                 $transliterator = static::$transliterator;
             }
 
-            if ($transliterator instanceof \Transliterator || $transliterator = \Transliterator::create($transliterator)) {
+            if (!$transliterator instanceof \Transliterator) {
+                $transliterator = \Transliterator::create($transliterator);
+            }
+
+            if ($transliterator !== null) {
                 return $transliterator->transliterate($string);
             }
         }

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -499,12 +499,14 @@ class BaseInflector
      */
     public static function transliterate($string, $transliterator = null)
     {
-        if (static::hasIntl() && defined('INTL_ICU_VERSION') && version_compare(INTL_ICU_VERSION, '4.8', '>=')) {
+        if (static::hasIntl()) {
             if ($transliterator === null) {
                 $transliterator = static::$transliterator;
             }
 
-            return transliterator_transliterate($transliterator, $string);
+            if ($transliterator instanceof \Transliterator || $transliterator = \Transliterator::create($transliterator)) {
+                return $transliterator->transliterate($string);
+            }
         }
 
         return strtr($string, static::$transliteration);

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -499,7 +499,7 @@ class BaseInflector
      */
     public static function transliterate($string, $transliterator = null)
     {
-        if (static::hasIntl()) {
+        if (static::hasIntl() && defined('INTL_ICU_VERSION') && version_compare(INTL_ICU_VERSION, '4.8', '>=')) {
             if ($transliterator === null) {
                 $transliterator = static::$transliterator;
             }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Fix Response::sendFile when a transliterator error happened
