### PR TITLE
Log targets export exceptions

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -27,6 +27,7 @@ Yii Framework 2 Change Log
 - Bug #14135: Fixed `yii\web\Request::getBodyParam()` crashes on object type body params (klimov-paul)
 - Bug #14157: Add support for loading default value `CURRENT_TIMESTAMP` of MySQL `datetime` field (rossoneri)
 - Bug #14276: Fixed I18N format with dotted parameters (developeruz)
+- Bug #14296: Fixed log targets to throw exception in case log can not be properly exported (bizley)
 - Bug #14484: Fixed `yii\validators\UniqueValidator` for target classes with a default scope (laszlovl, developeruz)
 - Bug #14604: Fixed `yii\validators\CompareValidator` `compareAttribute` does not work if `compareAttribute` form ID has been changed (mikk150)
 - Bug #14903: Fixed route with extra dashes is executed controller while it should not (developeruz)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -58,6 +58,8 @@ Upgrade from Yii 2.0.13
 
 * `yii\base\Security::compareString()` is now throwing `yii\base\InvalidParamException` in case non-strings are compared.
 
+* Log targets (like `yii\log\EmailTarget`) are now throwing `yii\log\LogRuntimeException` in case log can not be properly exported.
+
 Upgrade from Yii 2.0.12
 -----------------------
 

--- a/framework/log/EmailTarget.php
+++ b/framework/log/EmailTarget.php
@@ -72,6 +72,8 @@ class EmailTarget extends Target
 
     /**
      * Sends log messages to specified email addresses.
+     * Starting from version 2.0.14, this method throws LogRuntimeException in case the log can not be exported.
+     * @throws LogRuntimeException
      */
     public function export()
     {
@@ -82,7 +84,10 @@ class EmailTarget extends Target
         }
         $messages = array_map([$this, 'formatMessage'], $this->messages);
         $body = wordwrap(implode("\n", $messages), 70);
-        $this->composeMessage($body)->send($this->mailer);
+        $message = $this->composeMessage($body);
+        if (!$message->send($this->mailer)) {
+            throw new LogRuntimeException('Unable to export log through email!');
+        }
     }
 
     /**

--- a/framework/log/LogRuntimeException.php
+++ b/framework/log/LogRuntimeException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\log;
+
+/**
+ * LogRuntimeException represents an exception caused by problems with log delivery.
+ *
+ * @author Bizley <pawel@positive.codes>
+ * @since 2.0.14
+ */
+class LogRuntimeException extends \yii\base\Exception
+{
+    /**
+     * @return string the user-friendly name of this exception
+     */
+    public function getName()
+    {
+        return 'Log Runtime';
+    }
+}

--- a/framework/log/SyslogTarget.php
+++ b/framework/log/SyslogTarget.php
@@ -61,12 +61,16 @@ class SyslogTarget extends Target
 
     /**
      * Writes log messages to syslog.
+     * Starting from version 2.0.14, this method throws LogRuntimeException in case the log can not be exported.
+     * @throws LogRuntimeException
      */
     public function export()
     {
         openlog($this->identity, $this->options, $this->facility);
         foreach ($this->messages as $message) {
-            syslog($this->_syslogLevels[$message[1]], $this->formatMessage($message));
+            if (syslog($this->_syslogLevels[$message[1]], $this->formatMessage($message)) === false) {
+                throw new LogRuntimeException('Unable to export log through system log!');
+            }
         }
         closelog();
     }

--- a/tests/framework/log/EmailTargetTest.php
+++ b/tests/framework/log/EmailTargetTest.php
@@ -65,6 +65,7 @@ class EmailTargetTest extends TestCase
         $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
             ->setMethods(['setTextBody', 'send', 'setSubject'])
             ->getMockForAbstractClass();
+        $message->method('send')->willReturn(true);
 
         $this->mailer->expects($this->once())->method('compose')->willReturn($message);
 
@@ -109,6 +110,7 @@ class EmailTargetTest extends TestCase
         $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
             ->setMethods(['setTextBody', 'send', 'setSubject'])
             ->getMockForAbstractClass();
+        $message->method('send')->willReturn(true);
 
         $this->mailer->expects($this->once())->method('compose')->willReturn($message);
 
@@ -135,6 +137,33 @@ class EmailTargetTest extends TestCase
                 [$message2, $message2[0]],
             ]
         );
+        $mailTarget->export();
+    }
+
+    /**
+     * @covers \yii\log\EmailTarget::export()
+     *
+     * See https://github.com/yiisoft/yii2/issues/14296
+     */
+    public function testExportWithSendFailure()
+    {
+        $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
+            ->setMethods(['send'])
+            ->getMockForAbstractClass();
+        $message->method('send')->willReturn(false);
+        $this->mailer->expects($this->once())->method('compose')->willReturn($message);
+        $mailTarget = $this->getMockBuilder('yii\\log\\EmailTarget')
+            ->setMethods(['formatMessage'])
+            ->setConstructorArgs([
+                [
+                    'mailer' => $this->mailer,
+                    'message' => [
+                        'to' => 'developer@example.com',
+                    ],
+                ],
+            ])
+            ->getMock();
+        $this->expectException('yii\log\LogRuntimeException');
         $mailTarget->export();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14296

This fix adds condition check for log targets exporting and in case of failure exception is thrown.
Exception is caught by dispatcher and the warning can be passed to the next log target if there are any left.