### PR TITLE
Fixes #14593: Added `yii\db\Command::EVENT_AFTER_EXECUTE` event that is triggered after command is executed

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.14 under development
 ------------------------
 
+- Enh #14593: Added `yii\db\Command::EVENT_AFTER_EXECUTE` event that is triggered after command is executed (ARHImed82, samdark)
 - Enh #15047: `yii\db\Query::select()` and `yii\db\Query::addSelect()` now check for duplicate column names (wapmorgan)
 - Enh #14643: Added `yii\web\ErrorAction::$layout` property to conveniently set layout from error action config (swods, cebe, samdark)
 - Enh #13465: Added `yii\helpers\FileHelper::findDirectory()` method (ArsSirek, developeruz)

--- a/framework/db/AfterExecuteEvent.php
+++ b/framework/db/AfterExecuteEvent.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db;
+
+use yii\base\Event;
+
+/**
+ * AfterExecuteEvent represents the information available in [[Command::EVENT_AFTER_EXECUTE]].
+ *
+ * @author Alexander Makarov <sam@rmcreative.ru>
+ * @since 2.0.14
+ */
+class AfterExecuteEvent extends Event
+{
+    /**
+     * @var Command command that was executed
+     */
+    public $command;
+}

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -57,6 +57,12 @@ use yii\base\NotSupportedException;
 class Command extends Component
 {
     /**
+     * @event Event an event that is triggered after a command is executed
+     * @since 2.0.14
+     */
+    const EVENT_AFTER_EXECUTE = 'afterExecute';
+
+    /**
      * @var Connection the DB connection that this command is associated with
      */
     public $db;
@@ -1035,6 +1041,10 @@ class Command extends Component
             $n = $this->pdoStatement->rowCount();
 
             $profile and Yii::endProfile($rawSql, __METHOD__);
+
+            $this->trigger(self::EVENT_AFTER_EXECUTE, new AfterExecuteEvent([
+                'command' => $this,
+            ]));
 
             $this->refreshTableSchema();
 

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\db;
 
 use yii\caching\FileCache;
+use yii\db\Command;
 use yii\db\Connection;
 use yii\db\DataReader;
 use yii\db\Exception;
@@ -70,7 +71,12 @@ abstract class CommandTest extends DatabaseTestCase
 
         $sql = 'INSERT INTO {{customer}}([[email]], [[name]], [[address]]) VALUES (\'user4@example.com\', \'user4\', \'address4\')';
         $command = $db->createCommand($sql);
+        $afterExecuteTriggered = false;
+        $command->on(Command::EVENT_AFTER_EXECUTE, function () use (&$afterExecuteTriggered) {
+            $afterExecuteTriggered = true;
+        });
         $this->assertEquals(1, $command->execute());
+        $this->assertTrue($afterExecuteTriggered, 'Command::EVENT_AFTER_EXECUTE event should be triggered.');
 
         $sql = 'SELECT COUNT(*) FROM {{customer}} WHERE [[name]] = \'user4\'';
         $command = $db->createCommand($sql);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14593
