### PR TITLE
Fix #15621

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -96,6 +96,7 @@ Yii Framework 2 Change Log
 - Enh: Added check to `yii\base\Model::formName()` to prevent source path disclosure when form is represented by an anonymous class (silverfire)
 - Chg #15420: Handle OPTIONS request in `yii\filter\Cors` so the preflight check isn't passed trough authentication filters (michaelarnauts, leandrogehlen)
 - Enh #15595: `yii\data\DataFilter` can now handle `lt`,`gt`,`lte` and `gte` on `yii\validators\DateValidator` (mikk150)
+- Bug #15621: Fixed `yii\web\User::getIdentity()` returning `null` if an exception had been thrown when it was called previously (brandonkelly)
 
 2.0.13.1 November 14, 2017
 --------------------------

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -187,8 +187,16 @@ class User extends Component
     {
         if ($this->_identity === false) {
             if ($this->enableSession && $autoRenew) {
-                $this->_identity = null;
-                $this->renewAuthStatus();
+                try {
+                    $this->_identity = null;
+                    $this->renewAuthStatus();
+                } catch (\Exception $e) {
+                    $this->_identity = false;
+                    throw $e;
+                } catch (\Throwable $e) {
+                    $this->_identity = false;
+                    throw $e;
+                }
             } else {
                 return null;
             }

--- a/tests/framework/web/UserTest.php
+++ b/tests/framework/web/UserTest.php
@@ -25,8 +25,6 @@ use yii\rbac\PhpManager;
 use yii\web\Cookie;
 use yii\web\CookieCollection;
 use yii\web\ForbiddenHttpException;
-use yii\web\IdentityInterface;
-use yii\web\User;
 use yiiunit\TestCase;
 
 /**


### PR DESCRIPTION
Let yii\web\User::$_identity stay set to false if an exception is thrown as a result of calling renewAuthStatus()

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15621
