### PR TITLE
Fixes #11401: Fixed `yii\web\DbSession` concurrency issues when writing and regenerating IDs

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.14 under development
 ------------------------
 
+- Bug #11401: Fixed `yii\web\DbSession` concurrency issues when writing and regenerating IDs (samdark, andreasanta, cebe)
 - Bug #15523: `yii\web\Session` settings could now be configured after session is started (StalkAlex, rob006, daniel1302, samdark)
 - Enh #15216: Added `yii\web\ErrorHandler::$traceLine` to allow opening file at line clicked in IDE (vladis84)
 - Enh #14488: Added support for X-Forwarded-Host to `yii\web\Request`, fixed `getServerPort()` usage (si294r, samdark)

--- a/tests/framework/db/sqlite/CommandTest.php
+++ b/tests/framework/db/sqlite/CommandTest.php
@@ -32,7 +32,7 @@ class CommandTest extends \yiiunit\framework\db\CommandTest
     public function testUpsert(array $firstData, array $secondData)
     {
         if (version_compare($this->getConnection(false)->getServerVersion(), '3.8.3', '<')) {
-            $this->markTestSkipped('SQLite < 3.8.3 does nt support "WITH" keyword.');
+            $this->markTestSkipped('SQLite < 3.8.3 does not support "WITH" keyword.');
             return;
         }
 

--- a/tests/framework/web/session/sqlite/DbSessionTest.php
+++ b/tests/framework/web/session/sqlite/DbSessionTest.php
@@ -7,6 +7,8 @@
 
 namespace yiiunit\framework\web\session\sqlite;
 
+use Yii;
+
 /**
  * Class DbSessionTest.
  *
@@ -17,6 +19,15 @@ namespace yiiunit\framework\web\session\sqlite;
  */
 class DbSessionTest extends \yiiunit\framework\web\session\AbstractDbSessionTest
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (version_compare(Yii::$app->get('db')->getServerVersion(), '3.8.3', '<')) {
+            $this->markTestSkipped('SQLite < 3.8.3 does not support "WITH" keyword.');
+        }
+    }
+
     protected function getDriverNames()
     {
         return ['sqlite'];


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #11401
