### PR TITLE
Fixes #7640: oci/QueryBuilder wrong namespace

### DIFF
--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -56,7 +56,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
     protected function defaultExpressionBuilders()
     {
         return array_merge(parent::defaultExpressionBuilders(), [
-            'yii\db\conditions\InCondition' => 'yii\db\conditions\oci\InConditionBuilder',
+            'yii\db\conditions\InCondition' => 'yii\db\oci\conditions\InConditionBuilder',
             'yii\db\conditions\LikeCondition' => 'yii\db\oci\conditions\LikeConditionBuilder',
         ]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #7640

Fix commit d165863 