### PR TITLE
\yii\log\FileTarget directory creation is moved to export() method

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -54,6 +54,7 @@ Yii Framework 2 Change Log
 - Bug #15628: Fixed `yii\validators\DateValidator` to respect time when the `format` property is set to UNIX Epoch format (silverfire, gayHacker)
 - Bug #15644: Avoid wrong default selection on a dropdown, checkbox list, and radio list, when a option has a key equals to zero (berosoboy)
 - Bug #15658: Fixed `yii\filters\auth\HttpBasicAuth` not to switch identity, when user is already authenticated and identity does not get changed (silverfire)
+- Bug #15662: Fixed `yii\log\FileTarget` not to create log directory during init process (alexeevdv)
 - Enh #3087: Added `yii\helpers\BaseHtml::error()` "errorSource" option to be able to customize errors display (yanggs07, developeruz, silverfire)
 - Enh #3250: Added support for events partial wildcard matching (klimov-paul)
 - Enh #5515: Added default value for `yii\behaviors\BlameableBehavior` for cases when the user is guest (dmirogin)

--- a/framework/log/FileTarget.php
+++ b/framework/log/FileTarget.php
@@ -72,7 +72,6 @@ class FileTarget extends Target
      */
     public $rotateByCopy = true;
 
-
     /**
      * Initializes the route.
      * This method is invoked after the route is created by the route manager.

--- a/framework/log/FileTarget.php
+++ b/framework/log/FileTarget.php
@@ -85,10 +85,6 @@ class FileTarget extends Target
         } else {
             $this->logFile = Yii::getAlias($this->logFile);
         }
-        $logPath = dirname($this->logFile);
-        if (!is_dir($logPath)) {
-            FileHelper::createDirectory($logPath, $this->dirMode, true);
-        }
         if ($this->maxLogFiles < 1) {
             $this->maxLogFiles = 1;
         }
@@ -105,6 +101,11 @@ class FileTarget extends Target
      */
     public function export()
     {
+        $logPath = dirname($this->logFile);
+        if (!is_dir($logPath)) {
+            FileHelper::createDirectory($logPath, $this->dirMode, true);
+        }
+
         $text = implode("\n", array_map([$this, 'formatMessage'], $this->messages)) . "\n";
         if (($fp = @fopen($this->logFile, 'a')) === false) {
             throw new InvalidConfigException("Unable to append to log file: {$this->logFile}");

--- a/framework/log/FileTarget.php
+++ b/framework/log/FileTarget.php
@@ -102,9 +102,7 @@ class FileTarget extends Target
     public function export()
     {
         $logPath = dirname($this->logFile);
-        if (!is_dir($logPath)) {
-            FileHelper::createDirectory($logPath, $this->dirMode, true);
-        }
+        FileHelper::createDirectory($logPath, $this->dirMode, true);
 
         $text = implode("\n", array_map([$this, 'formatMessage'], $this->messages)) . "\n";
         if (($fp = @fopen($this->logFile, 'a')) === false) {

--- a/tests/framework/log/FileTargetTest.php
+++ b/tests/framework/log/FileTargetTest.php
@@ -34,7 +34,8 @@ class FileTargetTest extends TestCase
     }
 
     /**
-     * @test
+     * Tests that log directory isn't created during init process
+     * @see https://github.com/yiisoft/yii2/issues/15662
      */
     public function testInit()
     {

--- a/tests/framework/log/FileTargetTest.php
+++ b/tests/framework/log/FileTargetTest.php
@@ -10,6 +10,7 @@ namespace yiiunit\framework\log;
 use Yii;
 use yii\helpers\FileHelper;
 use yii\log\Dispatcher;
+use yii\log\FileTarget;
 use yii\log\Logger;
 use yiiunit\TestCase;
 
@@ -30,6 +31,22 @@ class FileTargetTest extends TestCase
             [true],
             [false],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function testInit()
+    {
+        $logFile = Yii::getAlias('@yiiunit/runtime/log/filetargettest.log');
+        FileHelper::removeDirectory(dirname($logFile));
+        new FileTarget([
+            'logFile' => Yii::getAlias('@yiiunit/runtime/log/filetargettest.log'),
+        ]);
+        $this->assertFileNotExists(
+            dirname($logFile),
+            'Log directory should not be created during init process'
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15662
