### PR TITLE
Check db driver have useMaster or not for calling.

### DIFF
--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -142,7 +142,7 @@ class UniqueValidator extends Validator
 
         $modelExists = false;
 
-        if ($this->forceMasterDb) {
+        if ($this->forceMasterDb && method_exists($db, 'useMaster') {
             $db->useMaster(function () use ($targetClass, $conditions, $model, &$modelExists) {
                 $modelExists = $this->modelExists($targetClass, $conditions, $model);
             });


### PR DESCRIPTION
Breaking change in mongodb or another driver.
In checking unique validation in mongodb validator error occurred in calling useMaster but in mongodb this is not exist and this is breaking change in older driver.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
