### PR TITLE
Update Response.php

### DIFF
--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -417,7 +417,7 @@ class Response extends \yii\base\Response
             return;
         }
 
-        set_time_limit(0); // Reset time limit for big files
+        @set_time_limit(0); // Reset time limit for big files
         $chunkSize = 8 * 1024 * 1024; // 8MB per chunk
 
         if (is_array($this->stream)) {


### PR DESCRIPTION
set_time_limit() has been disabled for security reasons on some shared hosting

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
