### PR TITLE
Automatically expand relations in \yii\rest\Serializer

### DIFF
--- a/framework/rest/Serializer.php
+++ b/framework/rest/Serializer.php
@@ -159,6 +159,8 @@ class Serializer extends Component
             return $this->serializeModel($data);
         } elseif ($data instanceof DataProviderInterface) {
             return $this->serializeDataProvider($data);
+        } elseif (is_array($data)) {
+            return $this->serializeModels($data);
         }
 
         return $data;


### PR DESCRIPTION
Since #14219 got merged, the foundation for this patch was accepted. Now, the only remaining thing for a clean solution for rest calls is this.

This patch allows, for example, the following in a `\yii\rest\Controller` (or a `\yii\web\Controller` with a `\yii\rest\Serializer` serializer).

```php
    public function actionGetUser(int $id)
    {
        return User::find($id)
            ->with(['services'])
            ->one();
    }

    public function actionGetAllUsers()
    {
        return User::find()
            ->with(['services'])
            ->all();
    }
```

Output to frontend (`/get-user/1`)
```json
{
  "id": 1,
  "name": "Mike",
  "services": [
    {
      "id": 1,
      "name": "Service 1"
    },
    {
      "id": 2,
      "name": "Service 2"
    }
  ]
}
```

Output to frontend (`/get-all-users`)
```json
[
  {
    "id": 1,
    "name": "Mike",
    "services": [
      {
        "id": 1,
        "name": "Service 1"
      },
      {
        "id": 2,
        "name": "Service 2"
      }
    ]
  },
  {
    "id": 2,
    "name": "Bob",
    "services": [
      {
        "id": 1,
        "name": "Service 1"
      },
      {
        "id": 4,
        "name": "Service 4"
      }
    ]
  }
]
```

The output of this function will be passed to the `\yii\rest\Serializer` and it will automatically include the `services` in the JSON output, since you've loaded it with `with()`.

Currently, this is not possible in yii2. You have to revert to using `asArray()` on the query, but that messes up the types of the attributes, since they are not mapped to the model. You also lose the ability to call functions on the objects before sending them to the frontend.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
