### PR TITLE
Detects circular array references in VarDumper::dumpInternal

### DIFF
--- a/framework/helpers/BaseVarDumper.php
+++ b/framework/helpers/BaseVarDumper.php
@@ -65,7 +65,7 @@ class BaseVarDumper
      * @param mixed $var variable to be dumped
      * @param int $level depth level
      */
-    private static function dumpInternal($var, $level)
+    private static function dumpInternal($var, $level, $seenArrays = [])
     {
         switch (gettype($var)) {
             case 'boolean':
@@ -90,6 +90,7 @@ class BaseVarDumper
                 self::$_output .= '{unknown}';
                 break;
             case 'array':
+                $seenArrays[] = $var;
                 if (self::$_depth <= $level) {
                     self::$_output .= '[...]';
                 } elseif (empty($var)) {
@@ -102,7 +103,12 @@ class BaseVarDumper
                         self::$_output .= "\n" . $spaces . '    ';
                         self::dumpInternal($key, 0);
                         self::$_output .= ' => ';
-                        self::dumpInternal($var[$key], $level + 1);
+                        if (is_array($var[$key]) && in_array($var[$key], $seenArrays, true)) {
+                            self::$_output .= '*RECURSION*';
+                        }
+                        else {
+                            self::dumpInternal($var[$key], $level + 1, $seenArrays);
+                        }
                     }
                     self::$_output .= "\n" . $spaces . ']';
                 }

--- a/tests/framework/helpers/VarDumperTest.php
+++ b/tests/framework/helpers/VarDumperTest.php
@@ -55,6 +55,25 @@ class VarDumperTest extends TestCase
         $this->assertContains('[price] => 19', $dumpResult);
     }
 
+    public function testDumpRecursive()
+    {
+        $var = [
+            'copyVar' => null,
+            'vars' => [
+                'recursive' => null,
+            ],
+            'recursive' => [],
+        ];
+        $var['copyVar'] = $var;
+        $var['vars']['recursive'] = &$var;
+        $var['recursive']['anotherRecursive'] = &$var['recursive'];
+
+        $dumpResult = VarDumper::dumpAsString($var);
+        $this->assertNotContains("'copyVar' => *RECURSION*", $dumpResult);
+        $this->assertContains("'recursive' => *RECURSION*", $dumpResult);
+        $this->assertContains("'anotherRecursive' => *RECURSION*", $dumpResult);
+    }
+
     /**
      * Data provider for [[testExport()]].
      * @return array test data


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes (except hhvm)
| Fixed issues  | #15506
