### PR TITLE
Fixed inconsistency in use of new InvalidArgumentException #15727.

### DIFF
--- a/build/controllers/DevController.php
+++ b/build/controllers/DevController.php
@@ -8,7 +8,7 @@
 namespace yii\build\controllers;
 
 use Yii;
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\console\Controller;
 use yii\helpers\Console;
 use yii\helpers\FileHelper;
@@ -310,7 +310,7 @@ class DevController extends Controller
         $list = [];
         $handle = opendir($dir);
         if ($handle === false) {
-            throw new InvalidParamException("Unable to open directory: $dir");
+            throw new InvalidArgumentException("Unable to open directory: $dir");
         }
         while (($file = readdir($handle)) !== false) {
             if ($file === '.' || $file === '..') {

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,7 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #15692: Fix ExistValidator with targetRelation ignores filter (developeruz)
 - Bug #15696: Fix magic getter for ActiveRecord (developeruz)
-
+- Enh #15727: Fixed inconsistency in use of InvalidArgumentException (offout)
 
 2.0.14 February 18, 2018
 ------------------------

--- a/framework/console/controllers/FixtureController.php
+++ b/framework/console/controllers/FixtureController.php
@@ -9,7 +9,7 @@ namespace yii\console\controllers;
 
 use Yii;
 use yii\base\InvalidConfigException;
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\console\Controller;
 use yii\console\Exception;
 use yii\console\ExitCode;
@@ -515,7 +515,7 @@ class FixtureController extends Controller
     {
         try {
             return Yii::getAlias('@' . str_replace('\\', '/', $this->namespace));
-        } catch (InvalidParamException $e) {
+        } catch (InvalidArgumentException $e) {
             throw new InvalidConfigException('Invalid fixture namespace: "' . $this->namespace . '". Please, check your FixtureController::namespace parameter');
         }
     }

--- a/framework/console/controllers/FixtureController.php
+++ b/framework/console/controllers/FixtureController.php
@@ -9,7 +9,7 @@ namespace yii\console\controllers;
 
 use Yii;
 use yii\base\InvalidConfigException;
-use yii\base\InvalidArgumentException;
+use yii\base\InvalidParamException;
 use yii\console\Controller;
 use yii\console\Exception;
 use yii\console\ExitCode;
@@ -515,7 +515,7 @@ class FixtureController extends Controller
     {
         try {
             return Yii::getAlias('@' . str_replace('\\', '/', $this->namespace));
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidParamException $e) {
             throw new InvalidConfigException('Invalid fixture namespace: "' . $this->namespace . '". Please, check your FixtureController::namespace parameter');
         }
     }

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -11,7 +11,6 @@ use Yii;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidCallException;
 use yii\base\InvalidConfigException;
-use yii\base\InvalidParamException;
 use yii\base\Model;
 use yii\base\ModelEvent;
 use yii\base\NotSupportedException;
@@ -1610,7 +1609,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
                 } else {
                     try {
                         $relation = $relatedModel->getRelation($relationName);
-                    } catch (InvalidParamException $e) {
+                    } catch (InvalidArgumentException $e) {
                         return $this->generateAttributeLabel($attribute);
                     }
                     /* @var $modelClass ActiveRecordInterface */
@@ -1652,7 +1651,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
                 } else {
                     try {
                         $relation = $relatedModel->getRelation($relationName);
-                    } catch (InvalidParamException $e) {
+                    } catch (InvalidArgumentException $e) {
                         return '';
                     }
                     /* @var $modelClass ActiveRecordInterface */

--- a/framework/db/conditions/ConditionInterface.php
+++ b/framework/db/conditions/ConditionInterface.php
@@ -7,7 +7,7 @@
 
 namespace yii\db\conditions;
 
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\db\ExpressionInterface;
 
 /**
@@ -27,7 +27,7 @@ interface ConditionInterface extends ExpressionInterface
      * @param array $operands array of corresponding operands
      *
      * @return $this
-     * @throws InvalidParamException if input parameters are not suitable for this condition
+     * @throws InvalidArgumentException if input parameters are not suitable for this condition
      */
     public static function fromArrayDefinition($operator, $operands);
 }

--- a/framework/rbac/CheckAccessInterface.php
+++ b/framework/rbac/CheckAccessInterface.php
@@ -22,8 +22,7 @@ interface CheckAccessInterface
      * @param string $permissionName the name of the permission to be checked against
      * @param array $params name-value pairs that will be passed to the rules associated
      * with the roles and permissions assigned to the user.
-     * @return bool whether the user has the specified permission.
-     * @throws \yii\base\InvalidParamException if $permissionName does not refer to an existing permission
+     * @return bool whether the user has the specified permission, false if $permissionName does not refer to an existing permission
      */
     public function checkAccess($userId, $permissionName, $params = []);
 }

--- a/framework/rbac/ManagerInterface.php
+++ b/framework/rbac/ManagerInterface.php
@@ -83,7 +83,7 @@ interface ManagerInterface extends CheckAccessInterface
      * @param string $roleName name of the role to file child roles for
      * @return Role[] Child roles. The array is indexed by the role names.
      * First element is an instance of the parent Role itself.
-     * @throws \yii\base\InvalidParamException if Role was not found that are getting by $roleName
+     * @throws \yii\base\InvalidArgumentException if Role was not found that are getting by $roleName
      * @since 2.0.10
      */
     public function getChildRoles($roleName);

--- a/framework/web/JsonParser.php
+++ b/framework/web/JsonParser.php
@@ -7,7 +7,7 @@
 
 namespace yii\web;
 
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\helpers\Json;
 
 /**
@@ -50,7 +50,7 @@ class JsonParser implements RequestParserInterface
         try {
             $parameters = Json::decode($rawBody, $this->asArray);
             return $parameters === null ? [] : $parameters;
-        } catch (InvalidParamException $e) {
+        } catch (InvalidArgumentException $e) {
             if ($this->throwException) {
                 throw new BadRequestHttpException('Invalid JSON data in request body: ' . $e->getMessage());
             }

--- a/tests/framework/base/SecurityTest.php
+++ b/tests/framework/base/SecurityTest.php
@@ -880,7 +880,7 @@ TEXT;
 
     /**
      * @dataProvider randomKeyInvalidInputs
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      * @param mixed $input
      */
     public function testRandomKeyInvalidInput($input)
@@ -1276,7 +1276,7 @@ TEXT;
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      */
     public function testMaskingInvalidStrings()
     {

--- a/tests/framework/db/GetTablesAliasTestTrait.php
+++ b/tests/framework/db/GetTablesAliasTestTrait.php
@@ -132,7 +132,7 @@ trait GetTablesAliasTestTrait
         $expression = new \yii\db\Expression('(SELECT id FROM user)');
         $query->from = $expression;
 
-        $this->expectException('yii\base\InvalidParamException');
+        $this->expectException('yii\base\InvalidArgumentException');
         $this->expectExceptionMessage('To use Expression in from() method, pass it in array format with alias.');
         $tables = $query->getTablesUsedInFrom();
 

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -344,18 +344,18 @@ class ArrayHelperTest extends TestCase
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      */
-    public function testMultisortInvalidParamExceptionDirection()
+    public function testMultisorInvalidArgumentExceptionDirection()
     {
         $data = ['foo' => 'bar'];
         ArrayHelper::multisort($data, ['foo'], []);
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      */
-    public function testMultisortInvalidParamExceptionSortFlag()
+    public function testMultisortInvalidArgumentExceptionSortFlag()
     {
         $data = ['foo' => 'bar'];
         ArrayHelper::multisort($data, ['foo'], ['foo'], []);
@@ -1189,7 +1189,7 @@ class ArrayHelperTest extends TestCase
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      * @expectedExceptionMessage Argument $haystack must be an array or implement Traversable
      */
     public function testInException()
@@ -1210,7 +1210,7 @@ class ArrayHelperTest extends TestCase
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      * @expectedExceptionMessage Argument $needles must be an array or implement Traversable
      */
     public function testIsSubsetException()

--- a/tests/framework/helpers/FileHelperTest.php
+++ b/tests/framework/helpers/FileHelperTest.php
@@ -312,7 +312,7 @@ class FileHelperTest extends TestCase
             $dirName => [],
         ]);
 
-        $this->expectException('yii\base\InvalidParamException');
+        $this->expectException('yii\base\InvalidArgumentException');
 
         $dirName = $this->testFilePath . DIRECTORY_SEPARATOR . 'test_dir';
         FileHelper::copyDirectory($dirName, $dirName);
@@ -328,7 +328,7 @@ class FileHelperTest extends TestCase
             'backup' => ['data' => []],
         ]);
 
-        $this->expectException('yii\base\InvalidParamException');
+        $this->expectException('yii\base\InvalidArgumentException');
 
         FileHelper::copyDirectory(
             $this->testFilePath . DIRECTORY_SEPARATOR . 'backup',

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1524,7 +1524,7 @@ EOD;
     public function testAttributeNameValidation($name, $expected)
     {
         if (!isset($expected)) {
-            $this->expectException('yii\base\InvalidParamException');
+            $this->expectException('yii\base\InvalidArgumentException');
             Html::getAttributeName($name);
         } else {
             $this->assertEquals($expected, Html::getAttributeName($name));
@@ -1538,7 +1538,7 @@ EOD;
      */
     public function testAttributeNameException($name)
     {
-        $this->expectException('yii\base\InvalidParamException');
+        $this->expectException('yii\base\InvalidArgumentException');
         Html::getAttributeName($name);
     }
 
@@ -1571,10 +1571,10 @@ EOD;
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      * @expectedExceptionMessage Attribute name must contain word characters only.
      */
-    public function testGetAttributeValueInvalidParamException()
+    public function testGetAttributeValueInvalidArgumentException()
     {
         $model = new HtmlTestModel();
         Html::getAttributeValue($model, '-');
@@ -1606,20 +1606,20 @@ EOD;
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      * @expectedExceptionMessage Attribute name must contain word characters only.
      */
-    public function testGetInputNameInvalidParamExceptionAttribute()
+    public function testGetInputNameInvalidArgumentExceptionAttribute()
     {
         $model = new HtmlTestModel();
         Html::getInputName($model, '-');
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      * @expectedExceptionMessageRegExp /(.*)formName\(\) cannot be empty for tabular inputs.$/
      */
-    public function testGetInputNameInvalidParamExceptionFormName()
+    public function testGetInputNameInvalidArgumentExceptionFormName()
     {
         $model = $this->getMockBuilder('yii\\base\\Model')->getMock();
         $model->method('formName')->willReturn('');

--- a/tests/framework/helpers/JsonTest.php
+++ b/tests/framework/helpers/JsonTest.php
@@ -171,15 +171,15 @@ class JsonTest extends TestCase
 
         // exception
         $json = '{"a":1,"b":2';
-        $this->expectException('yii\base\InvalidParamException');
+        $this->expectException('yii\base\InvalidArgumentException');
         Json::decode($json);
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      * @expectedExceptionMessage Invalid JSON data.
      */
-    public function testDecodeInvalidParamException()
+    public function testDecodeInvalidArgumentException()
     {
         Json::decode([]);
     }
@@ -190,7 +190,7 @@ class JsonTest extends TestCase
         try {
             $json = "{'a': '1'}";
             Json::decode($json);
-        } catch (\yii\base\InvalidParamException $e) {
+        } catch (\yii\base\InvalidArgumentException $e) {
             $this->assertSame(BaseJson::$jsonErrorMessages['JSON_ERROR_SYNTAX'], $e->getMessage());
         }
 
@@ -200,7 +200,7 @@ class JsonTest extends TestCase
             $data = ['a' => $fp];
             Json::encode($data);
             fclose($fp);
-        } catch (\yii\base\InvalidParamException $e) {
+        } catch (\yii\base\InvalidArgumentException $e) {
             if (PHP_VERSION_ID >= 50500) {
                 $this->assertSame(BaseJson::$jsonErrorMessages['JSON_ERROR_UNSUPPORTED_TYPE'], $e->getMessage());
             } else {

--- a/tests/framework/helpers/MarkdownTest.php
+++ b/tests/framework/helpers/MarkdownTest.php
@@ -44,10 +44,10 @@ TEXT;
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      * @expectedExceptionMessage Markdown flavor 'undefined' is not defined.
      */
-    public function testProcessInvalidParamException()
+    public function testProcessInvalidArgumentException()
     {
         Markdown::process('foo', 'undefined');
     }

--- a/tests/framework/helpers/UrlTest.php
+++ b/tests/framework/helpers/UrlTest.php
@@ -114,7 +114,7 @@ class UrlTest extends TestCase
         // In case there is no controller, an exception should be thrown for relative route
         $this->removeMockedAction();
 
-        $this->expectException('yii\base\InvalidParamException');
+        $this->expectException('yii\base\InvalidArgumentException');
         Url::toRoute('site/view');
     }
 
@@ -234,7 +234,7 @@ class UrlTest extends TestCase
         //In case there is no controller, throw an exception
         $this->removeMockedAction();
 
-        $this->expectException('yii\base\InvalidParamException');
+        $this->expectException('yii\base\InvalidArgumentException');
         Url::to(['site/view']);
     }
 

--- a/tests/framework/i18n/FormatterDateTest.php
+++ b/tests/framework/i18n/FormatterDateTest.php
@@ -49,7 +49,7 @@ class FormatterDateTest extends TestCase
         $this->assertSame(date('M j, Y', $value), $this->formatter->format($value, 'date'));
         $this->assertSame(date('M j, Y', $value), $this->formatter->format($value, 'DATE'));
         $this->assertSame(date('Y/m/d', $value), $this->formatter->format($value, ['date', 'php:Y/m/d']));
-        $this->expectException('\yii\base\InvalidParamException');
+        $this->expectException('\yii\base\InvalidArgumentException');
         $this->assertSame(date('Y-m-d', $value), $this->formatter->format($value, 'data'));
     }
 
@@ -518,7 +518,7 @@ class FormatterDateTest extends TestCase
     {
         return [
             ['2015-01-01 00:00:00', '2014-13-01 00:00:00'],
-            [false, 'asdfg', 'yii\base\InvalidParamException'],
+            [false, 'asdfg', 'yii\base\InvalidArgumentException'],
 //            [(string)strtotime('now'), 'now'], // fails randomly
         ];
     }

--- a/tests/framework/i18n/FormatterNumberTest.php
+++ b/tests/framework/i18n/FormatterNumberTest.php
@@ -110,7 +110,7 @@ class FormatterNumberTest extends TestCase
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      */
     public function testAsIntegerException()
     {
@@ -118,7 +118,7 @@ class FormatterNumberTest extends TestCase
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      */
     public function testAsIntegerException2()
     {

--- a/tests/framework/i18n/FormatterTest.php
+++ b/tests/framework/i18n/FormatterTest.php
@@ -52,7 +52,7 @@ class FormatterTest extends TestCase
         $this->assertSame(date('M j, Y', $value), $this->formatter->format($value, 'date'));
         $this->assertSame(date('M j, Y', $value), $this->formatter->format($value, 'DATE'));
         $this->assertSame(date('Y/m/d', $value), $this->formatter->format($value, ['date', 'php:Y/m/d']));
-        $this->expectException('\yii\base\InvalidParamException');
+        $this->expectException('\yii\base\InvalidArgumentException');
         $this->assertSame(date('Y-m-d', $value), $this->formatter->format($value, 'data'));
         $this->assertSame(date('Y-m-d', $value), $this->formatter->format($value, function ($value) {
             return date('Y-m-d', $value);
@@ -237,7 +237,7 @@ class FormatterTest extends TestCase
             [
                 'Wrong value is casted properly',
                 ['NaN'], '0 millimeters', '0 mm',
-                ['yii\base\InvalidParamException', "'NaN' is not a numeric value"],
+                ['yii\base\InvalidArgumentException', "'NaN' is not a numeric value"],
             ],
             [
                 'Negative value works',
@@ -336,7 +336,7 @@ class FormatterTest extends TestCase
             [
                 'Wrong value is casted properly',
                 ['NaN'], '0 grams', '0 g',
-                ['yii\base\InvalidParamException', "'NaN' is not a numeric value"],
+                ['yii\base\InvalidArgumentException', "'NaN' is not a numeric value"],
             ],
             [
                 'Negative value works',

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -7,7 +7,6 @@
 
 namespace yiiunit\framework\rbac;
 
-use yii\base\InvalidParamException;
 use yii\rbac\BaseManager;
 use yii\rbac\Item;
 use yii\rbac\Permission;

--- a/tests/framework/rbac/PhpManagerTest.php
+++ b/tests/framework/rbac/PhpManagerTest.php
@@ -137,7 +137,7 @@ class PhpManagerTest extends ManagerTestCase
     }
 
     /**
-     * @expectedException \yii\base\InvalidParamException
+     * @expectedException \yii\base\InvalidArgumentException
      */
     public function testOverwriteName()
     {


### PR DESCRIPTION
Replaced PHPDoc @throw InvalidParamException tags with InvalidArgumentException.
Replaced catch InvalidParamException with catch InvalidArgumentException.
Removed @throw InvalidParamException in CheckAccessInterface because it never thrown in framework realizations, reworked PHPDoc return comment.
Replaced expectException InvalidParamException in tests with expectException InvalidArgumentException.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15727
