### PR TITLE
Updated setActivePlaceholder to be consistent with activeLabel

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.14.1 under development
 --------------------------
 
+- Bug #15742: Updated setActivePlaceholder to be consistent with activeLabel (edwards-sj)
 - Bug #15692: Fix ExistValidator with targetRelation ignores filter (developeruz)
 - Bug #15696: Fix magic getter for ActiveRecord (developeruz)
 

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1386,6 +1386,7 @@ class BaseHtml
     protected static function setActivePlaceholder($model, $attribute, &$options = [])
     {
         if (isset($options['placeholder']) && $options['placeholder'] === true) {
+            $attribute = static::getAttributeName($attribute);
             $options['placeholder'] = $model->getAttributeLabel($attribute);
         }
     }

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1698,6 +1698,16 @@ HTML;
 
         $this->assertContains('placeholder="Custom placeholder"', $html);
     }
+
+    public function testActiveTextInput_placeholderFillFromModelTabular()
+    {
+        $model = new HtmlTestModel();
+
+        $html = Html::activeTextInput($model, '[0]name', ['placeholder' => true]);
+
+        $this->assertContains('placeholder="Name"', $html);
+    }
+
 }
 
 /**


### PR DESCRIPTION
Updated setActivePlaceholder to be consistent with activeLabel for when indexes are present in the attribute name

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15740