### PR TITLE
Updating the DocBlock for the upsert() Function

### DIFF
--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -535,7 +535,7 @@ class Command extends Component
      * If `true` is passed, the column data will be updated to match the insert column data.
      * If `false` is passed, no update will be performed if the column data already exists.
      * @param array $params the parameters to be bound to the command.
-     * @return $this the command object itself.
+     * @return string the resulting SQL.
      * @since 2.0.14
      */
     public function upsert($table, $insertColumns, $updateColumns = true, $params = [])


### PR DESCRIPTION
Changing the return type and description for the DocBlock of the upsert() function.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | none
