### PR TITLE
Fix #15724: MigrateController::optionAliases() have 2 same keys

### DIFF
--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -160,7 +160,7 @@ class MigrateController extends BaseMigrateController
     public function optionAliases()
     {
         return array_merge(parent::optionAliases(), [
-            'c' => 'comment',
+            'C' => 'comment',
             'f' => 'fields',
             'p' => 'migrationPath',
             't' => 'migrationTable',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15724
