### PR TITLE
[enh] Add AssetController::actionPublish()

### DIFF
--- a/framework/console/controllers/AssetController.php
+++ b/framework/console/controllers/AssetController.php
@@ -210,6 +210,21 @@ class AssetController extends Controller
     }
 
     /**
+     * Publish asset files according to this configuration.
+     * In the process, the asset packages in the configuration file will be published in the Web-accessible directory.
+     * @param string $configFile configuration file name.
+     */
+    public function actionPublish($configFile)
+    {
+        $this->loadConfiguration($configFile);
+        $assetManager = $this->getAssetManager();
+        $bundles = $this->loadBundles($this->bundles);
+        foreach ($bundles as $bundle) {
+            $bundle->publish($assetManager);
+        }
+    }
+
+    /**
      * Applies configuration from the given file to self instance.
      * @param string $configFile configuration file name.
      * @throws \yii\console\Exception on failure.

--- a/tests/framework/console/controllers/AssetControllerTest.php
+++ b/tests/framework/console/controllers/AssetControllerTest.php
@@ -416,9 +416,11 @@ EOL;
 
         foreach (array_keys($cssFiles) as $cssFile) {
             $this->assertFileExists($assetPath . '/' . $cssFile);
+            $this->assertFileEquals($sourcePath . '/' . $cssFile, $assetPath . '/' . $cssFile);
         }
         foreach (array_keys($jsFiles) as $jsFile) {
             $this->assertFileExists($assetPath . '/' . $jsFile);
+            $this->assertFileEquals($sourcePath . '/' . $jsFile, $assetPath . '/' . $jsFile);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  |

This method helps to solve one of the important problems of the first run of the project after deployment. 

With the advent of HTTP/2 compression of files is not required. And in some cases, it is impossible without rewriting the JS code of some components, because when compressed, they begin to conflict with each other.

In the process, `AssetController::actionPublish()` will publish all asset packages from the configuration file in the Web-accessible directory.
