### PR TITLE
Make cache key more unique (more scoped)

### DIFF
--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -86,7 +86,7 @@ class DbManager extends BaseManager
      * @see cache
      * @since 2.0.3
      */
-    public $cacheKey = 'rbac';
+    public $cacheKey = __CLASS__;
 
     /**
      * @var Item[] all auth items (name => Item)


### PR DESCRIPTION
For example DB Schema model also uses CLASS constant as basis for cache key
https://github.com/yiisoft/yii2-framework/blob/master/db/Schema.php#L713

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

