### PR TITLE
fixed configurate trustedHosts of Request component

### DIFF
--- a/docs/guide/runtime-requests.md
+++ b/docs/guide/runtime-requests.md
@@ -175,7 +175,7 @@ In case your proxies are using different headers you can use the request configu
 'request' => [
     // ...
     'trustedHosts' => [
-        '/^10\.0\.2\.\d+$/' => [
+        '10.10.2.0/24' => [
             'X-ProxyUser-Ip',
             'Front-End-Https',
         ],


### PR DESCRIPTION
Request::filterHeaders() call $validator->validate($ip) but IpValidator always return true for PCRE Patterns 
Also when php error_reporting=E_ALL we have PHP Warning "substr() expects parameter 3 to be integer, string given" at IpValidator.php line 557

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
