### PR TITLE
Fixed has-error class to ActiveField div container when attribute nam…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.14.2 under development
 ------------------------
 
+- Bug #15801: Fixed has-error class to ActiveField div container when attribute name is tabular (FabrizioCaldarelli)
 - Bug #15792: Added missing `yii\db\QueryBuilder::conditionClasses` setter (silverfire)
 
 
@@ -2131,6 +2132,3 @@ Yii Framework 2 Change Log
 
   - [Smarty View Renderer](https://github.com/yiisoft/yii2-smarty)
   - [Twig View Renderer](https://github.com/yiisoft/yii2-twig)
-
-
-

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.14.2 under development
 ------------------------
 
-- Bug #15801: Fixed has-error class to ActiveField div container when attribute name is tabular (FabrizioCaldarelli)
+- Bug #15801: Fixed `has-error` CSS class assignment in `yii\widgets\ActiveField` when attribute name is prefixed with tabular index (FabrizioCaldarelli)
 - Bug #15792: Added missing `yii\db\QueryBuilder::conditionClasses` setter (silverfire)
 
 

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -930,7 +930,10 @@ class ActiveField extends Component
      */
     protected function addErrorClassIfNeeded(&$options)
     {
-        if ($this->model->hasErrors($this->attribute)) {
+        // Get proper attribute name when attribute name is tabular.
+        $attributeName = yii\helpers\BaseHtml::getAttributeName($this->attribute);
+
+        if ($this->model->hasErrors($attributeName)) {
             Html::addCssClass($options, $this->form->errorCssClass);
         }
     }

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -931,7 +931,7 @@ class ActiveField extends Component
     protected function addErrorClassIfNeeded(&$options)
     {
         // Get proper attribute name when attribute name is tabular.
-        $attributeName = yii\helpers\BaseHtml::getAttributeName($this->attribute);
+        $attributeName = yii\helpers\Html::getAttributeName($this->attribute);
 
         if ($this->model->hasErrors($attributeName)) {
             Html::addCssClass($options, $this->form->errorCssClass);

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -931,7 +931,7 @@ class ActiveField extends Component
     protected function addErrorClassIfNeeded(&$options)
     {
         // Get proper attribute name when attribute name is tabular.
-        $attributeName = yii\helpers\Html::getAttributeName($this->attribute);
+        $attributeName = Html::getAttributeName($this->attribute);
 
         if ($this->model->hasErrors($attributeName)) {
             Html::addCssClass($options, $this->form->errorCssClass);

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -247,6 +247,17 @@ EOT;
         $this->assertEquals($expectedValue, $this->activeField->parts['{label}']);
     }
 
+    public function testTabularInputErrors()
+    {
+        $this->activeField->attribute = '[0]'.$this->attributeName;
+        $this->helperModel->addError($this->attributeName, 'Error Message');
+
+        $expectedValue = '<div class="form-group field-activefieldtestmodel-0-attributename has-error">';
+        $actualValue = $this->activeField->begin();
+
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+
     public function hintDataProvider()
     {
         return [


### PR DESCRIPTION
Fixed has-error class to ActiveField div container when attribute name is tabular

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | https://github.com/yiisoft/yii2/issues/15801
