### PR TITLE
added support for `__construct()` in class configuration

### DIFF
--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -363,6 +363,13 @@ class Container extends Component
         /* @var $reflection ReflectionClass */
         list($reflection, $dependencies) = $this->getDependencies($class);
 
+        if (isset($config['__construct()'])) {
+            foreach ($config['__construct()'] as $index => $param) {
+                $dependencies[$index] = $param;
+            }
+            unset($config['__construct()']);
+        }
+
         foreach ($params as $index => $param) {
             $dependencies[$index] = $param;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

This small change (copied from yiisoft/di project) allows easier passing of constructor arguments in DI configuration.

Was:

```php
    SomeInterface::class => [
        [
            'class' => SomeClass::class,
            'prop1' => 1,
        ],
        [
            'arg1',
            'arg2',
        ],
    ]
```
 
Become:
 
```php
    SomeInterface::class => [
	'class' => SomeClass::class,
	'prop1' => 1,
	'__construct()' => [
            'arg1',
            'arg2',
        ],
    ]
```
