### PR TITLE
Fixes #15783: Regenerate CSRF token only when logging in directly

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.14.2 under development
 ------------------------
 
-- Bug #15783: Regenerate CSRF token only when logging in directly (samdark) 
+- Bug #15783: Regenerate CSRF token only when logging in directly (samdark)
 - Bug #15801: Fixed `has-error` CSS class assignment in `yii\widgets\ActiveField` when attribute name is prefixed with tabular index (FabrizioCaldarelli)
 - Bug #15792: Added missing `yii\db\QueryBuilder::conditionClasses` setter (silverfire)
 - Bug #15822: Fixed `yii\base\Component::off()` not to throw an exception when handler does not exist (silverfire)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.14.2 under development
 ------------------------
 
+- Bug #15783: Regenerate CSRF token only when logging in directly (samdark) 
 - Bug #15801: Fixed `has-error` CSS class assignment in `yii\widgets\ActiveField` when attribute name is prefixed with tabular index (FabrizioCaldarelli)
 - Bug #15792: Added missing `yii\db\QueryBuilder::conditionClasses` setter (silverfire)
 - Bug #15822: Fixed `yii\base\Component::off()` not to throw an exception when handler does not exist (silverfire)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,7 +12,7 @@ Yii Framework 2 Change Log
 - Bug #15804: Fixed `null` values handling for PostgresSQL arrays (silverfire)
 - Bug #15829: Fixed JSONB support in PostgreSQL 9.4 (silverfire)
 - Bug: Fixed encoding of empty `yii\db\ArrayExpression` for PostgreSQL (silverfire)
-- Big: Fixed table schema retrieving for PostgreSQL when the table name was wrapped in quotes (`"`) (silverfire)
+- Bug: Fixed table schema retrieving for PostgreSQL when the table name was wrapped in quotes (`"`) (silverfire)
 
 
 2.0.14.1 February 24, 2018

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -257,11 +257,27 @@ class User extends Component
             } else {
                 $log = "User '$id' logged in from $ip. Session not enabled.";
             }
+
+            $this->regenerateCsrfToken();
+
             Yii::info($log, __METHOD__);
             $this->afterLogin($identity, false, $duration);
         }
 
         return !$this->getIsGuest();
+    }
+
+    /**
+     * Regenerates CSRF token
+     *
+     * @since 2.0.14.2
+     */
+    protected function regenerateCsrfToken()
+    {
+        $request = Yii::$app->getRequest();
+        if ($request->enableCsrfCookie || $this->enableSession) {
+            $request->getCsrfToken(true);
+        }
     }
 
     /**
@@ -649,9 +665,6 @@ class User extends Component
                 $this->sendIdentityCookie($identity, $duration);
             }
         }
-
-        // regenerate CSRF token
-        Yii::$app->getRequest()->getCsrfToken(true);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | -
| Fixed issues  | #15783
