### PR TITLE
Speed up fetching MySQL constraints (fixes #15776)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Bug #15829: Fixed JSONB support in PostgreSQL 9.4 (silverfire)
 - Bug: Fixed encoding of empty `yii\db\ArrayExpression` for PostgreSQL (silverfire)
 - Bug: Fixed table schema retrieving for PostgreSQL when the table name was wrapped in quotes (silverfire)
+- Bug #15776: Fixed slow MySQL constraints retrieving speed (MartijnHols, sergeymakinen)
 
 
 2.0.14.1 February 24, 2018

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,7 +13,7 @@ Yii Framework 2 Change Log
 - Bug #15829: Fixed JSONB support in PostgreSQL 9.4 (silverfire)
 - Bug: Fixed encoding of empty `yii\db\ArrayExpression` for PostgreSQL (silverfire)
 - Bug: Fixed table schema retrieving for PostgreSQL when the table name was wrapped in quotes (silverfire)
-- Bug #15776: Fixed slow MySQL constraints retrieving speed (MartijnHols, sergeymakinen)
+- Bug #15776: Fixed slow MySQL constraints retrieving (MartijnHols, sergeymakinen)
 
 
 2.0.14.1 February 24, 2018

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -488,27 +488,45 @@ SQL;
     private function loadTableConstraints($tableName, $returnType)
     {
         static $sql = <<<'SQL'
-SELECT DISTINCT
+SELECT
     `kcu`.`CONSTRAINT_NAME` AS `name`,
     `kcu`.`COLUMN_NAME` AS `column_name`,
     `tc`.`CONSTRAINT_TYPE` AS `type`,
     CASE
-        WHEN :schemaName IS NULL AND `kcu`.`REFERENCED_TABLE_SCHEMA` = `sch`.`name` THEN NULL
+        WHEN :schemaName IS NULL AND `kcu`.`REFERENCED_TABLE_SCHEMA` = DATABASE() THEN NULL
         ELSE `kcu`.`REFERENCED_TABLE_SCHEMA`
     END AS `foreign_table_schema`,
     `kcu`.`REFERENCED_TABLE_NAME` AS `foreign_table_name`,
     `kcu`.`REFERENCED_COLUMN_NAME` AS `foreign_column_name`,
     `rc`.`UPDATE_RULE` AS `on_update`,
     `rc`.`DELETE_RULE` AS `on_delete`,
-    `kcu`.`ORDINAL_POSITION` as `position`
-FROM (SELECT DATABASE() AS `name`) AS `sch`
-INNER JOIN `information_schema`.`KEY_COLUMN_USAGE` AS `kcu`
-    ON `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName, `sch`.`name`) AND `kcu`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `kcu`.`TABLE_NAME` = :tableName
-LEFT JOIN `information_schema`.`REFERENTIAL_CONSTRAINTS` AS `rc`
-    ON `rc`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `rc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME`
-LEFT JOIN `information_schema`.`TABLE_CONSTRAINTS` AS `tc`
-    ON `tc`.`TABLE_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `tc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME`
-ORDER BY `kcu`.`ORDINAL_POSITION` ASC
+    `kcu`.`ORDINAL_POSITION` AS `position`
+FROM
+    `information_schema`.`KEY_COLUMN_USAGE` AS `kcu`,
+    `information_schema`.`REFERENTIAL_CONSTRAINTS` AS `rc`,
+    `information_schema`.`TABLE_CONSTRAINTS` AS `tc`
+WHERE
+    `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName, DATABASE()) AND `kcu`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `kcu`.`TABLE_NAME` = :tableName
+    AND `rc`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `rc`.`TABLE_NAME` = :tableName AND `rc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME`
+    AND `tc`.`TABLE_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `tc`.`TABLE_NAME` = :tableName AND `tc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME` AND `tc`.`CONSTRAINT_TYPE` = 'FOREIGN KEY'
+UNION
+SELECT
+    `kcu`.`CONSTRAINT_NAME` AS `name`,
+    `kcu`.`COLUMN_NAME` AS `column_name`,
+    `tc`.`CONSTRAINT_TYPE` AS `type`,
+    NULL AS `foreign_table_schema`,
+    NULL AS `foreign_table_name`,
+    NULL AS `foreign_column_name`,
+    NULL AS `on_update`,
+    NULL AS `on_delete`,
+    `kcu`.`ORDINAL_POSITION` AS `position`
+FROM
+    `information_schema`.`KEY_COLUMN_USAGE` AS `kcu`,
+    `information_schema`.`TABLE_CONSTRAINTS` AS `tc`
+WHERE
+    `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName, DATABASE()) AND `kcu`.`TABLE_NAME` = :tableName
+    AND `tc`.`TABLE_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `tc`.`TABLE_NAME` = :tableName AND `tc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME` AND `tc`.`CONSTRAINT_TYPE` IN ('PRIMARY KEY', 'UNIQUE')
+ORDER BY `position` ASC
 SQL;
 
         $resolvedName = $this->resolveTableName($tableName);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15776 

Big kudos to @berosoboy & @MartijnHols. :)

Just for reference, here is my version that I forgot to add initially:

```sql
SELECT DISTINCT
    `kcu`.`CONSTRAINT_NAME` AS `name`,
    `kcu`.`COLUMN_NAME` AS `column_name`,
    `tc`.`CONSTRAINT_TYPE` AS `type`,
    CASE
        WHEN :schemaName IS NULL AND `kcu`.`REFERENCED_TABLE_SCHEMA` = `kcu`.`TABLE_SCHEMA` THEN NULL
        ELSE `kcu`.`REFERENCED_TABLE_SCHEMA`
    END AS `foreign_table_schema`,
    `kcu`.`REFERENCED_TABLE_NAME` AS `foreign_table_name`,
    `kcu`.`REFERENCED_COLUMN_NAME` AS `foreign_column_name`,
    `rc`.`UPDATE_RULE` AS `on_update`,
    `rc`.`DELETE_RULE` AS `on_delete`,
    `kcu`.`ORDINAL_POSITION` AS `position`
FROM `information_schema`.`KEY_COLUMN_USAGE` AS `kcu`
INNER JOIN `information_schema`.`TABLE_CONSTRAINTS` AS `tc`
    ON `tc`.`TABLE_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `tc`.`TABLE_NAME` = :tableName AND `tc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME`
LEFT JOIN `information_schema`.`REFERENTIAL_CONSTRAINTS` AS `rc` # FORCE INDEX (`TABLE_NAME`)
    ON `rc`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `rc`.`TABLE_NAME` = :tableName
WHERE `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName, DATABASE()) AND `kcu`.`TABLE_NAME` = :tableName
ORDER BY `kcu`.`ORDINAL_POSITION` ASC
```

As `FORCE INDEX` doesn't seem to recognize keys in `information_schema`, this version is obviously slower.