### PR TITLE
Fixed #15858 BaseHtml::collectErrors with showAllErrors = true

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,6 +15,7 @@ Yii Framework 2 Change Log
 - Bug: Fixed encoding of empty `yii\db\ArrayExpression` for PostgreSQL (silverfire)
 - Bug: Fixed table schema retrieving for PostgreSQL when the table name was wrapped in quotes (silverfire)
 - Bug #15776: Fixed slow MySQL constraints retrieving (MartijnHols, berosoboy, sergeymakinen)
+- Bug #15858: Fixed BaseHtml::collectErrors with $showAllErrors = true, which is used by BaseHtml::errorSummary (florinro)
 
 
 

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1256,7 +1256,7 @@ class BaseHtml
         }
 
         if ($encode) {
-            for ($i = 0, $linesCount = count($lines); $i < $linesCount; $i++) {
+            foreach ($lines as $i => $message) {
                 $lines[$i] = Html::encode($lines[$i]);
             }
         }


### PR DESCRIPTION
I just replaced the iteration with a foreach

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15859 
