### PR TITLE
#15850: Fixed AssetManager to validate basePath only when neccessary

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.14.2 under development
 ------------------------
 
+- Bug #15850: Fixed `yii\web\AssetManager` to only validate `yii\web\AssetManager::$basePath` when there are files to be published (monzol)
 - Bug #15858: Fixed `Undefined offset` error calling `yii\helpers\Html::errorSummary()` with the same error messages for different model attributes (FabrizioCaldarelli, silverfire)
 - Bug #15783: Regenerate CSRF token only when logging in directly (samdark)
 - Bug #15801: Fixed `has-error` CSS class assignment in `yii\widgets\ActiveField` when attribute name is prefixed with tabular index (FabrizioCaldarelli)

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -203,19 +203,15 @@ class AssetManager extends Component
 
     /**
      * Initializes the component.
-     * @throws InvalidConfigException if [[basePath]] is invalid
      */
     public function init()
     {
         parent::init();
         $this->basePath = Yii::getAlias($this->basePath);
-        if (!is_dir($this->basePath)) {
-            throw new InvalidConfigException("The directory does not exist: {$this->basePath}");
-        } elseif (!is_writable($this->basePath)) {
-            throw new InvalidConfigException("The directory is not writable by the Web process: {$this->basePath}");
+        if(is_dir($this->basePath)) {
+            $this->basePath = realpath($this->basePath);
         }
 
-        $this->basePath = realpath($this->basePath);
         $this->baseUrl = rtrim(Yii::getAlias($this->baseUrl), '/');
     }
 
@@ -443,6 +439,7 @@ class AssetManager extends Component
      *
      * @return array the path (directory or file path) and the URL that the asset is published as.
      * @throws InvalidArgumentException if the asset to be published does not exist.
+     * @throws InvalidConfigException if [[basePath]] is invalid.
      */
     public function publish($path, $options = [])
     {
@@ -454,6 +451,12 @@ class AssetManager extends Component
 
         if (!is_string($path) || ($src = realpath($path)) === false) {
             throw new InvalidArgumentException("The file or directory to be published does not exist: $path");
+        }
+
+        if (!is_dir($this->basePath)) {
+            throw new InvalidConfigException("The directory does not exist: {$this->basePath}");
+        } elseif (!is_writable($this->basePath)) {
+            throw new InvalidConfigException("The directory is not writable by the Web process: {$this->basePath}");
         }
 
         if (is_file($src)) {


### PR DESCRIPTION
Fixed AssetManager to only validate basePath when there are files to be published

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | #15850 
