### PR TITLE
Fix query specific columns are removed

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,8 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #15878: Fixed migration with a comment containing an apostrophe (MarcoMoreno)
+- Bug: Fixed some select columns with alias are removed (alitain)
+
 
 
 2.0.14.2 March 13, 2018

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -672,7 +672,7 @@ PATTERN;
                     }
                 } elseif (is_int($columnAlias)) {
                     $existsInSelect = in_array($columnDefinition, $unaliasedColumns, true);
-                    $existsInResultSet = in_array($columnDefinition, $result, true);
+                    $existsInResultSet = ($key = array_search($columnDefinition, $result)) !== false && is_int($key) && $result[$key] === $columnDefinition;
                     if ($existsInSelect || $existsInResultSet) {
                         continue;
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  |

if I have a query e.g.
```php
User::find()->select(['author'=>'username','username'])->one();
```
the `username` attribute will be removed.