### PR TITLE
`yii\db\ActiveRecord::findOne()` now accepts column names prefixed with table name

### DIFF
--- a/framework/BaseYii.php
+++ b/framework/BaseYii.php
@@ -93,7 +93,7 @@ class BaseYii
      */
     public static function getVersion()
     {
-        return '2.0.15';
+        return '2.0.15.1';
     }
 
     /**

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -1,6 +1,12 @@
 Yii Framework 2 Change Log
 ==========================
 
+2.0.15.1 under development
+--------------------------
+
+- Bug #15931: `yii\db\ActiveRecord::findOne()` now accepts column names prefixed with table name (cebe)
+
+
 2.0.15 March 20, 2018
 ---------------------
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -1,8 +1,8 @@
 Yii Framework 2 Change Log
 ==========================
 
-2.0.15.1 under development
---------------------------
+2.0.15.1 March 21, 2018
+-----------------------
 
 - Bug #15931: `yii\db\ActiveRecord::findOne()` now accepts column names prefixed with table name (cebe)
 

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -209,8 +209,9 @@ class ActiveRecord extends BaseActiveRecord
         $result = [];
         // valid column names are table column names or column names prefixed with table name
         $columnNames = static::getTableSchema()->getColumnNames();
-        $columnNames = array_merge($columnNames, array_map(function($columnName) {
-            return static::tableName() . ".$columnName";
+        $tableName = static::tableName();
+        $columnNames = array_merge($columnNames, array_map(function($columnName) use ($tableName) {
+            return "$tableName.$columnName";
         }, $columnNames));
         foreach ($condition as $key => $value) {
             if (is_string($key) && !in_array($key, $columnNames, true)) {

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -207,7 +207,11 @@ class ActiveRecord extends BaseActiveRecord
     protected static function filterCondition(array $condition)
     {
         $result = [];
+        // valid column names are table column names or column names prefixed with table name
         $columnNames = static::getTableSchema()->getColumnNames();
+        $columnNames = array_merge($columnNames, array_map(function($columnName) {
+            return static::tableName() . ".$columnName";
+        }, $columnNames));
         foreach ($condition as $key => $value) {
             if (is_string($key) && !in_array($key, $columnNames, true)) {
                 throw new InvalidArgumentException('Key "' . $key . '" is not a column name and can not be used as a filter');

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1648,6 +1648,17 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         CustomerQuery::$joinWithProfile = false;
     }
 
+    public function testFindOneByColumnName()
+    {
+        $model = Customer::findOne(['id' => 1]);
+        $this->assertEquals(1, $model->id);
+
+        CustomerQuery::$joinWithProfile = true;
+        $model = Customer::findOne(['customer.id' => 1]);
+        $this->assertEquals(1, $model->id);
+        CustomerQuery::$joinWithProfile = false;
+    }
+
     public function illegalValuesForFindByCondition()
     {
         return [


### PR DESCRIPTION
fixes #15931

will tag this as 2.0.15.1 if accepted and merge into master manually afterwards.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15931
