### PR TITLE
Option --composerNoProgress for dev apps building

### DIFF
--- a/build/controllers/DevController.php
+++ b/build/controllers/DevController.php
@@ -33,6 +33,10 @@ class DevController extends Controller
      */
     public $useHttp = false;
     /**
+     * @var bool whether to use --no-progress option when running composer
+     */
+    public $composerNoProgress = false;
+    /**
      * @var array
      */
     public $apps = [
@@ -172,7 +176,11 @@ class DevController extends Controller
         // composer update
         $this->stdout("updating composer for app '$app'...\n", Console::BOLD);
         chdir($appDir);
-        passthru('composer update --prefer-dist');
+        $command = 'composer update --prefer-dist';
+        if ($this->composerNoProgress) {
+            $command .= ' --no-progress';
+        }
+        passthru($command);
         $this->stdout("done.\n", Console::BOLD, Console::FG_GREEN);
 
         // link directories
@@ -223,7 +231,11 @@ class DevController extends Controller
         // composer update
         $this->stdout("updating composer for extension '$extension'...\n", Console::BOLD);
         chdir($extensionDir);
-        passthru('composer update --prefer-dist');
+        $command = 'composer update --prefer-dist';
+        if ($this->composerNoProgress) {
+            $command .= ' --no-progress';
+        }
+        passthru($command);
         $this->stdout("done.\n", Console::BOLD, Console::FG_GREEN);
 
         // link directories
@@ -242,6 +254,7 @@ class DevController extends Controller
         $options = parent::options($actionID);
         if (\in_array($actionID, ['ext', 'app', 'all'], true)) {
             $options[] = 'useHttp';
+            $options[] = 'composerNoProgress';
         }
 
         return $options;


### PR DESCRIPTION
Use case: going to use it here https://github.com/rugabarbo/yii2-contributor-vagrant/blob/master/vagrant/provision/once-as-vagrant.sh#L26 for silent composer downloads while vagrant machine building.