### PR TITLE
Issue #14834: skip 'TIMESTAMP' definition test when NO_ZERO_DATE enabled

### DIFF
--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -918,7 +918,11 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 Schema::TYPE_TIMESTAMP,
                 $this->timestamp(),
                 [
-                    'mysql' => 'timestamp',
+                    /**
+                     * MySQL has its own TIMESTAMP test realization
+                     * @see \yiiunit\framework\db\mysql\QueryBuilderTest::columnTypes()
+                     */
+
                     'postgres' => 'timestamp(0)',
                     'sqlite' => 'timestamp',
                     'oci' => 'TIMESTAMP',

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -85,6 +85,24 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
             ];
         }
 
+        /**
+         * @link https://github.com/yiisoft/yii2/issues/14834
+         */
+        $sqlModes = $this->getConnection(false)->createCommand('SELECT @@sql_mode')->queryScalar();
+        $sqlModes = explode(',', $sqlModes);
+        if (in_array('NO_ZERO_DATE', $sqlModes, true)) {
+            $this->markTestIncomplete(
+                "MySQL doesn't allow the 'TIMESTAMP' column definition when the NO_ZERO_DATE mode enabled. " .
+                "This definition test was skipped."
+            );
+        } else {
+            $columns[] = [
+                Schema::TYPE_TIMESTAMP,
+                $this->timestamp(),
+                'timestamp',
+            ];
+        }
+
         return array_merge(parent::columnTypes(), $columns);
     }
 


### PR DESCRIPTION
This is a temporary patch to be able to run tests on local configurations without additional MySQL 5.7 tuning. This will not affect travis builds because travis running with NO_ZERO_DATE disabled.