### PR TITLE
Fixes #14660: fixed synchronous DbCache::set() with the same key

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.16 under development
 ------------------------
 
+- Bug #14660: Fixed `yii\caching\DbCache` concurrency issue when set values with the same key (rugabarbo)
 - Bug #15988: Fixed bash completion (alekciy)
 
 2.0.15.1 March 21, 2018

--- a/framework/caching/DbCache.php
+++ b/framework/caching/DbCache.php
@@ -205,6 +205,8 @@ class DbCache extends Cache
 
             return true;
         } catch (\Exception $e) {
+            Yii::warning("Unable to update or insert cache data: {$e->getMessage()}", __METHOD__);
+
             return false;
         }
     }
@@ -234,6 +236,8 @@ class DbCache extends Cache
 
             return true;
         } catch (\Exception $e) {
+            Yii::warning("Unable to insert cache data: {$e->getMessage()}", __METHOD__);
+
             return false;
         }
     }

--- a/tests/framework/caching/DbCacheTest.php
+++ b/tests/framework/caching/DbCacheTest.php
@@ -101,4 +101,18 @@ class DbCacheTest extends CacheTestCase
         static::$time++;
         $this->assertFalse($cache->get('expire_testa'));
     }
+
+    public function testSynchronousSetWithTheSameKey()
+    {
+        $KEY = 'sync-test-key';
+        $VALUE = 'sync-test-value';
+
+        $cache = $this->getCacheInstance();
+        static::$time = \time();
+
+        $this->assertTrue($cache->set($KEY, $VALUE, 60));
+        $this->assertTrue($cache->set($KEY, $VALUE, 60));
+
+        $this->assertEquals($VALUE, $cache->get($KEY));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14660
