### PR TITLE
Fix ODBC Driver 13 for SQL Server error on null

### DIFF
--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -334,7 +334,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
             $columnSchemas = $tableSchema->columns;
             foreach ($columns as $name => $value) {
                 // @see https://github.com/yiisoft/yii2/issues/12599
-                if (isset($columnSchemas[$name]) && $columnSchemas[$name]->type === Schema::TYPE_BINARY && $columnSchemas[$name]->dbType === 'varbinary' && is_string($value)) {
+                if (isset($columnSchemas[$name]) && $columnSchemas[$name]->type === Schema::TYPE_BINARY && $columnSchemas[$name]->dbType === 'varbinary' && (is_string($value) || $value === null)) {
                     $exParams = [];
                     $phName = $this->bindParam($value, $exParams);
                     $columns[$name] = new Expression("CONVERT(VARBINARY, $phName)", $exParams);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | -

Fix Windows ODBC Driver 13 for SQL Server error: "Implicit conversion from data type char to varbinary(max) is not allowed" in case when the value === null
