### PR TITLE
Fixes #15117 `yii\db\Schema::getTableMetadata` cache refreshing

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Bug #16010: Fixed `yii\filters\ContentNegotiator` behavior when GET parameters contain an array (rugabarbo)
 - Bug #14660: Fixed `yii\caching\DbCache` concurrency issue when set values with the same key (rugabarbo)
 - Bug #15988: Fixed bash completion (alekciy)
+- Bug #15117: Fixed `yii\db\Schema::getTableMetadata` cache refreshing (boboldehampsink)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -737,10 +737,10 @@ abstract class Schema extends BaseObject
             }
         }
         $rawName = $this->getRawTableName($name);
-        if ($refresh || !isset($this->_tableMetadata[$rawName])) {
+        if (!isset($this->_tableMetadata[$rawName])) {
             $this->loadTableMetadataFromCache($cache, $rawName);
         }
-        if (!array_key_exists($type, $this->_tableMetadata[$rawName])) {
+        if ($refresh || !array_key_exists($type, $this->_tableMetadata[$rawName])) {
             $this->_tableMetadata[$rawName][$type] = $this->{'loadTable' . ucfirst($type)}($rawName);
             $this->saveTableMetadataToCache($cache, $rawName);
         }

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -107,14 +107,23 @@ abstract class SchemaTest extends DatabaseTestCase
 
     public function testSchemaCache()
     {
+        /* @var $db Connection */
+        $db = $this->getConnection();
+
         /* @var $schema Schema */
-        $schema = $this->getConnection()->schema;
+        $schema = $db->schema;
 
         $schema->db->enableSchemaCache = true;
         $schema->db->schemaCache = new FileCache();
         $noCacheTable = $schema->getTableSchema('type', true);
         $cachedTable = $schema->getTableSchema('type', false);
         $this->assertEquals($noCacheTable, $cachedTable);
+
+        $db->createCommand()->renameTable('type', 'type_test');
+        $noCacheTable = $schema->getTableSchema('type', true);
+        $this->assertNotSame($noCacheTable, $cachedTable);
+
+        $db->createCommand()->renameTable('type_test', 'type');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15117

Before, setting `$refresh` still tried to pull from the cache. With this fix it doesn't and makes sure it loads from table again.
