### PR TITLE
Callback execution with mutex synchronization

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -47,6 +47,7 @@ Yii Framework 2 Change Log
 - Chg #15448: Package "ezyang/htmlpurifier" has been made optional and is not installed by default (klimov-paul)
 - Chg #15481: Removed `yii\BaseYii::powered()` method (Kolyunya, samdark)
 - Chg #15811: Fixed issue with additional parameters on `yii\base\View::renderDynamic()` while parameters contains single quote introduced in #12938 (xicond)
+- Enh #16054: Callback execution with mutex synchronization (zhuravljov)
 
 2.0.14.2 under development
 ------------------------

--- a/framework/mutex/SyncException.php
+++ b/framework/mutex/SyncException.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\mutex;
+
+use yii\base\Exception;
+
+/**
+ * Synchronize Exception
+ *
+ * @author Roman Zhuravlev <zhuravljov@gmail.com>
+ * @since 2.1
+ */
+class SyncException extends Exception
+{
+    /**
+     * @inheritdoc
+     */
+    public function getName()
+    {
+        return 'Synchronize Exception';
+    }
+
+}

--- a/tests/framework/mutex/MutexTestTrait.php
+++ b/tests/framework/mutex/MutexTestTrait.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\mutex;
 
 use yii\mutex\Mutex;
+use yii\mutex\SyncException;
 
 /**
  * Class MutexTestTrait.
@@ -41,5 +42,41 @@ trait MutexTestTrait
         $mutexOne->release(self::$mutexName);
 
         $this->assertTrue($mutexTwo->acquire(self::$mutexName));
+
+        $mutexTwo->release(self::$mutexName);
+    }
+
+    public function testSyncDone()
+    {
+        $mutex = $this->createMutex();
+
+        $this->assertTrue($mutex->sync(self::$mutexName, 0, function () {
+            return true;
+        }));
+    }
+
+    public function testSyncFailedWithoutException()
+    {
+        $mutexOne = $this->createMutex();
+        $mutexTwo = $this->createMutex();
+
+        $this->assertTrue($mutexOne->acquire(self::$mutexName));
+        $this->assertNull($mutexTwo->sync(self::$mutexName, 0, function () {
+            return true;
+        }, false));
+
+        $mutexOne->release(self::$mutexName);
+    }
+
+    public function testSyncFailedWithException()
+    {
+        $mutexOne = $this->createMutex();
+        $mutexTwo = $this->createMutex();
+
+        $this->assertTrue($mutexOne->acquire(self::$mutexName));
+        $this->expectException(SyncException::class);
+        $mutexTwo->sync(self::$mutexName, 0, function () {
+            return true;
+        });
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | no

It can be able to execute callback code with mutex synchronization. For example:

```php
$result = $mutex->sync($mutexName, 10, function () {
    // business logic execution with synchronization
    return $result;
}));
```

Moved from #15985.