### PR TITLE
fix timezone

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.1.0 under development
 -----------------------
 
+- Bug #16065: Remove using `date.timezone` at `yii\base\Application`, use `date_default_timezone_get()` instead (sashsvamir)
 - Bug #12539: `yii\filters\ContentNegotiator` now generates 406 'Not Acceptable' instead of 415 'Unsupported Media Type' on content-type negotiation fail (PowerGamer1)
 - Bug #14458: Fixed `yii\filters\VerbFilter` uses case-insensitive comparison for the HTTP method name (klimov-paul)
 - Enh #879: Caching implementation refactored according to PSR-16 'Simple Cache' specification (klimov-paul)

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -245,8 +245,6 @@ abstract class Application extends Module
         if (isset($config['timeZone'])) {
             $this->setTimeZone($config['timeZone']);
             unset($config['timeZone']);
-        } elseif (!ini_get('date.timezone')) {
-            $this->setTimeZone('UTC');
         }
 
         if (isset($config['container'])) {


### PR DESCRIPTION
In php > 7.0 was removing warning on empty setting `date.timezone`, so now we don't need set this on Application::preInit(), because `date_default_timezone_get()` always return timezone.

#16065 