### PR TITLE
Allows configure `Connection::dsn` by key=>value array

### DIFF
--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -1158,14 +1158,15 @@ class Connection extends Component
     private function buildDSN(array $config)
     {
         if (isset($config['driver'])) {
+            $parts = [];
             $driver = $config['driver'];
             unset($config['driver']);
 
-            $config = array_map(function($key, $value) {
-                return "$key=$value";
-            }, array_keys($config), array_values($config));
+            foreach ($config as $key => $value) {
+                $parts[] = "$key=$value";
+            }
 
-            return "$driver:" . implode(';', $config);
+            return "$driver:" . implode(';', $parts);
         } else {
             throw new InvalidConfigException("Connection 'driver' must be set.");
         }

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -153,7 +153,7 @@ class Connection extends Component
     const EVENT_ROLLBACK_TRANSACTION = 'rollbackTransaction';
 
     /**
-     * @var string the Data Source Name, or DSN, contains the information required to connect to the database.
+     * @var string|array the Data Source Name, or DSN, contains the information required to connect to the database.
      * Please refer to the [PHP manual](http://php.net/manual/en/pdo.construct.php) on
      * the format of the DSN string.
      *
@@ -442,6 +442,15 @@ class Connection extends Component
      */
     private $_queryCacheInfo = [];
 
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (is_array($this->dsn)) {
+            $this->dsn = $this->buildDSN($this->dsn);
+        }
+    }
 
     /**
      * Returns a value indicating whether the DB connection is established.
@@ -1138,6 +1147,28 @@ class Connection extends Component
         }
 
         return null;
+    }
+
+    /**
+     * Build the Data Source Name or DSN
+     * @param array $config the DSN configurations
+     * @return string the formated DSN
+     * @throws InvalidConfigException if 'driver' key was not defined
+     */
+    private function buildDSN(array $config)
+    {
+        if (isset($config['driver'])) {
+            $driver = $config['driver'];
+            unset($config['driver']);
+
+            $config = array_map(function($key, $value) {
+                return "$key=$value";
+            }, array_keys($config), array_values($config));
+
+            return "$driver:" . implode(';', $config);
+        } else {
+            throw new InvalidConfigException("Connection 'driver' must be set.");
+        }
     }
 
     /**

--- a/tests/framework/db/ConnectionTest.php
+++ b/tests/framework/db/ConnectionTest.php
@@ -482,4 +482,17 @@ abstract class ConnectionTest extends DatabaseTestCase
         $this->assertFalse($cache->exists($cacheKey), 'Caching is disabled');
         $connection->close();
     }
+
+    public function testDSNConfig()
+    {
+        $connection = new Connection([
+            'dsn' => [
+                'driver' => 'mysql',
+                'host' => '127.0.0.1',
+                'dbname' => 'yiitest'
+            ]
+        ]);
+
+        $this->assertEquals('mysql:host=127.0.0.1;dbname=yiitest', $connection->dsn);
+    }
 }

--- a/tests/framework/db/ConnectionTest.php
+++ b/tests/framework/db/ConnectionTest.php
@@ -485,14 +485,17 @@ abstract class ConnectionTest extends DatabaseTestCase
 
     public function testDSNConfig()
     {
-        $connection = new Connection([
-            'dsn' => [
-                'driver' => 'mysql',
-                'host' => '127.0.0.1',
-                'dbname' => 'yiitest'
-            ]
-        ]);
+        $dsn = [
+            'driver' => 'mysql',
+            'host' => '127.0.0.1',
+            'dbname' => 'yiitest'
+        ];
 
+        $connection = new Connection(['dsn' => $dsn]);
         $this->assertEquals('mysql:host=127.0.0.1;dbname=yiitest', $connection->dsn);
+
+        unset($dsn['driver']);
+        $this->expectException('yii\base\InvalidConfigException');
+        $connection = new Connection(['dsn' => $dsn]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

This is useful to configure connection by enviroment vars

```php
<?php

return [
    'class' => yii\db\Connection::className(),
    'dsn' => [
        'driver' => getenv('DB_DRIVER'),
        'host' => getenv('DB_HOST') ,
        'dbname' => getenv('DB_DATABASE')
    ],
    'username' => getenv('DB_USERNAME'),
    'password' => getenv('DB_PASSWORD'),
    'charset' => 'utf8',
    'enableSchemaCache' => YII_ENV !== 'dev',
];

```
