### PR TITLE
blind fix for oracle InCondition builder

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,8 @@ Yii Framework 2 Change Log
 - Bug #14660: Fixed `yii\caching\DbCache` concurrency issue when set values with the same key (rugabarbo)
 - Bug #15988: Fixed bash completion (alekciy)
 - Bug #15117: Fixed `yii\db\Schema::getTableMetadata` cache refreshing (boboldehampsink)
+- Bug #16073: Fixed regression in Oracle `IN` condition builder for more than 1000 items (cebe)
+
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/db/oci/conditions/InConditionBuilder.php
+++ b/framework/db/oci/conditions/InConditionBuilder.php
@@ -65,7 +65,8 @@ class InConditionBuilder extends \yii\db\conditions\InConditionBuilder
         for ($i = 0; $i < $count; $i += $maxParameters) {
             $slices[] = $this->queryBuilder->createConditionFromArray([$operator, $column, array_slice($values, $i, $maxParameters)]);
         }
+        array_unshift($slices, ($operator === 'IN') ? 'OR' : 'AND');
 
-        return $this->queryBuilder->buildCondition([($operator === 'IN') ? 'OR' : 'AND', $slices], $params);
+        return $this->queryBuilder->buildCondition($slices, $params);
     }
 }


### PR DESCRIPTION
condition should be an array like `['OR', ['IN', 'col', [...]], ['IN', 'col', [...]], ...]` instead of `['OR', [  ['IN', 'col', [...]], ['IN', 'col', [...]]  ]]`

This should have already broken the test at https://github.com/yiisoft/yii2/blob/ac687aab292088a1a3525f10930e7a1f0403173b/tests/framework/db/oci/QueryBuilderTest.php#L135
but as we are not running oracle tests on travis it got unnoticed.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  |no
| Breaks BC?    | no
| Tests pass?   | **someone with an oracle environment should check this.**
| Fixed issues  | fixes #16073
