### PR TITLE
store app before unserialize and restore app after unserialize

### DIFF
--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -115,7 +115,9 @@ abstract class Cache extends Component implements CacheInterface
         if ($value === false || $this->serializer === false) {
             return $value;
         } elseif ($this->serializer === null) {
+            $app = \Yii::$app;
             $value = unserialize($value);
+            \Yii::$app = $app;
         } else {
             $value = call_user_func($this->serializer[1], $value);
         }


### PR DESCRIPTION
I try to migrate from 2.3 to 2.4 of Codeception and I got some strange errors. 

For example - if 4 test runs both the last test generate a error. I trace this. And I can see strange behavior: the unserialize of cache table schema will set `\Yii::$app` to `null`.

Directly past same data to unserizlize don't make any effect... But this is happens. May be this is not a unique case...

This PR will propose restore global $app.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
