### PR TITLE
Add AppVeyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,8 +25,10 @@ install:
     - echo memory_limit=512M >> php.ini
     - echo extension_dir=ext >> php.ini
     - echo extension=php_curl.dll >> php.ini
-    - echo extension=php_openssl.dll >> php.ini
+    - echo extension=php_fileinfo.dll >> php.ini
+    - echo extension=php_gd2.dll >> php.ini
     - echo extension=php_mbstring.dll >> php.ini
+    - echo extension=php_openssl.dll >> php.ini
     - IF NOT EXIST C:\tools\composer.phar (cd C:\tools && appveyor DownloadFile https://getcomposer.org/download/1.4.1/composer.phar)
 
 before_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ clone_folder: C:\projects\yii2
 
 environment:
     matrix:
-        - php_ver: 7.2
+        - php_ver: 7.2.4
 
 cache:
     - '%APPDATA%\Composer'
@@ -27,6 +27,7 @@ install:
     - echo extension=php_curl.dll >> php.ini
     - echo extension=php_fileinfo.dll >> php.ini
     - echo extension=php_gd2.dll >> php.ini
+    - echo extension=php_intl.dll >> php.ini
     - echo extension=php_mbstring.dll >> php.ini
     - echo extension=php_openssl.dll >> php.ini
     - IF NOT EXIST C:\tools\composer.phar (cd C:\tools && appveyor DownloadFile https://getcomposer.org/download/1.4.1/composer.phar)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,38 @@
+build: false
+version: dev-{build}
+shallow_clone: true
+clone_folder: C:\projects\yii2
+
+environment:
+    matrix:
+        - php_ver: 7.2
+
+cache:
+    - '%APPDATA%\Composer'
+    - '%LOCALAPPDATA%\Composer'
+    - C:\tools\php -> .appveyor.yml
+    - C:\tools\composer.phar -> .appveyor.yml
+
+init:
+    - SET PATH=C:\tools\php;%PATH%
+
+install:
+    - ps: Set-Service wuauserv -StartupType Manual
+    - IF NOT EXIST C:\tools\php (choco install --yes --allow-empty-checksums php --version %php_ver% --params '/InstallDir:C:\tools\php')
+    - cd C:\tools\php
+    - copy php.ini-production php.ini
+    - echo date.timezone="UTC" >> php.ini
+    - echo memory_limit=512M >> php.ini
+    - echo extension_dir=ext >> php.ini
+    - echo extension=php_curl.dll >> php.ini
+    - echo extension=php_openssl.dll >> php.ini
+    - echo extension=php_mbstring.dll >> php.ini
+    - IF NOT EXIST C:\tools\composer.phar (cd C:\tools && appveyor DownloadFile https://getcomposer.org/download/1.4.1/composer.phar)
+
+before_test:
+    - cd C:\projects\yii2
+    - php C:\tools\composer.phar update --no-interaction --no-progress --prefer-stable --no-ansi
+
+test_script:
+    - cd C:\projects\yii2
+    - vendor\bin\phpunit --exclude-group mssql,mysql,pgsql,sqlite,db,oci,wincache,xcache,zenddata,cubrid

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,7 @@
 # Ignore some meta files when creating an archive of this repository
 # We do not ignore any content, because this repo represents the 
 # `yiisoft/yii2-dev` package, which is expected to ship all tests and docs.
+/.appveyor.yml      export-ignore
 /.github            export-ignore
 /.editorconfig      export-ignore
 /.gitattributes     export-ignore


### PR DESCRIPTION
Reference: https://github.com/yiisoft/yii2/pull/16120#discussion_r182399254

We need to have at least one Windows build, otherwise Windows-awareness would be a waste of time.

Here I'm using `.appveyor.yml` with a starting dot, which is not the default and you have to specify the filename in the settings.

Example: https://ci.appveyor.com/project/Slamdunk/yii2/build/dev-4