### PR TITLE
Fix action name in commentaries (list -> index) [skip ci]

### DIFF
--- a/framework/filters/HttpCache.php
+++ b/framework/filters/HttpCache.php
@@ -17,7 +17,7 @@ use yii\base\ActionFilter;
  * It is an action filter that can be added to a controller and handles the `beforeAction` event.
  *
  * To use HttpCache, declare it in the `behaviors()` method of your controller class.
- * In the following example the filter will be applied to the `list`-action and
+ * In the following example the filter will be applied to the `index` action and
  * the Last-Modified header will contain the date of the last update to the user table in the database.
  *
  * ```php


### PR DESCRIPTION
The action name referenced in the commentary (list) was different from the action name used in the example (index)

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | -
| Fixed issues  | -

![yii2_httpcache_issue](https://user-images.githubusercontent.com/2081014/38939372-28fcba2c-42fe-11e8-9953-b866f426569d.PNG)

