### PR TITLE
Make `yii\test\InitDbFixture` work with non-SQL DBMS

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Bug #15117: Fixed `yii\db\Schema::getTableMetadata` cache refreshing (boboldehampsink)
 - Bug #16073: Fixed regression in Oracle `IN` condition builder for more than 1000 items (cebe)
 - Bug #16120: FileCache: rebuild cache file before touch when different file owner (Slamdunk)
+- Bug #16091: Make `yii\test\InitDbFixture` work with non-SQL DBMS (cebe)
 
 
 2.0.15.1 March 21, 2018

--- a/framework/test/InitDbFixture.php
+++ b/framework/test/InitDbFixture.php
@@ -92,6 +92,9 @@ class InitDbFixture extends DbFixture
      */
     public function checkIntegrity($check)
     {
+        if (!$this->db instanceof \yii\db\Connection) {
+            return;
+        }
         foreach ($this->schemas as $schema) {
             $this->db->createCommand()->checkIntegrity($check, $schema)->execute();
         }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | n/a
| Fixed issues  | fixes #16091