### PR TITLE
fix code completion for `UploadedFile::getInstance()` - may return null

### DIFF
--- a/framework/web/UploadedFile.php
+++ b/framework/web/UploadedFile.php
@@ -76,7 +76,7 @@ class UploadedFile extends BaseObject
      * @param \yii\base\Model $model the data model
      * @param string $attribute the attribute name. The attribute name may contain array indexes.
      * For example, '[1]file' for tabular file uploading; and 'file[1]' for an element in a file array.
-     * @return UploadedFile the instance of the uploaded file.
+     * @return null|UploadedFile the instance of the uploaded file.
      * Null is returned if no file is uploaded for the specified model attribute.
      * @see getInstanceByName()
      */


### PR DESCRIPTION
Method `UploadedFile::getInstance()` may return `null` but it doesn't mentioned in PHPDoc correctly.
Changes are the same with `UploadedFile::getInstanceByName()`

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | more strict return type declaration
