### PR TITLE
modification to #using-default-roles section

### DIFF
--- a/docs/guide/security-authorization.md
+++ b/docs/guide/security-authorization.md
@@ -617,7 +617,7 @@ assign each user to an RBAC role. Let's use an example to show how this can be d
 
 Assume in the user table, you have a `group` column which uses 1 to represent the administrator group and 2 the author group.
 You plan to have two RBAC roles `admin` and `author` to represent the permissions for these two groups, respectively.
-You can set up the RBAC data as follows,
+You can set up the RBAC data as follows, first create a class:
 
 
 ```php
@@ -648,11 +648,9 @@ class UserGroupRule extends Rule
 }
 ```
 
-```php
-/*
-* Create your own command/migration like the section above
-*/
+Then create your own command/migration as explained [in the previous section](#generating-rbac-data):
 
+```php
 $auth = Yii::$app->authManager;
 
 $rule = new \app\rbac\UserGroupRule;

--- a/docs/guide/security-authorization.md
+++ b/docs/guide/security-authorization.md
@@ -646,6 +646,12 @@ class UserGroupRule extends Rule
         return false;
     }
 }
+```
+
+```php
+/*
+* Create your own command/migration like the section above
+*/
 
 $auth = Yii::$app->authManager;
 


### PR DESCRIPTION
It wasn't clear where put the "authmanager" initialization code.
I specify that the user need to create his command or migration script in a separate files

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
