### PR TITLE
Fixes #15496: CSRF token is now regenerated on changing identity

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 -----------------------
 
 - Enh #15496: CSRF token is now regenerated on changing identity (samdark, rhertogh, makcumka2000)
+- Bug #15783: Regenerate CSRF token only when logging in directly (samdark, makcumka2000)
 
 2.0.13.3 March 21, 2018
 -----------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -1,6 +1,11 @@
 Yii Framework 2 Change Log
 ==========================
 
+2.0.13.4 under development
+-----------------------
+
+- Enh #15496: CSRF token is now regenerated on changing identity (samdark, rhertogh, makcumka2000)
+
 2.0.13.3 March 21, 2018
 -----------------------
 

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -638,6 +638,9 @@ class User extends Component
                 $this->sendIdentityCookie($identity, $duration);
             }
         }
+
+        // regenerate CSRF token
+        Yii::$app->getRequest()->getCsrfToken(true);
     }
 
     /**

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -246,11 +246,25 @@ class User extends Component
             } else {
                 $log = "User '$id' logged in from $ip. Session not enabled.";
             }
+
+            $this->regenerateCsrfToken();
+
             Yii::info($log, __METHOD__);
             $this->afterLogin($identity, false, $duration);
         }
 
         return !$this->getIsGuest();
+    }
+
+    /**
+     * Regenerates CSRF token
+     */
+    protected function regenerateCsrfToken()
+    {
+        $request = Yii::$app->getRequest();
+        if ($request->enableCsrfCookie || $this->enableSession) {
+            $request->getCsrfToken(true);
+        }
     }
 
     /**
@@ -638,9 +652,6 @@ class User extends Component
                 $this->sendIdentityCookie($identity, $duration);
             }
         }
-
-        // regenerate CSRF token
-        Yii::$app->getRequest()->getCsrfToken(true);
     }
 
     /**

--- a/tests/framework/helpers/UrlTest.php
+++ b/tests/framework/helpers/UrlTest.php
@@ -30,6 +30,7 @@ class UrlTest extends TestCase
             'components' => [
                 'request' => [
                     'class' => 'yii\web\Request',
+                    'cookieValidationKey' => '123',
                     'scriptUrl' => '/base/index.php',
                     'hostInfo' => 'http://example.com/',
                     'url' => '/base/index.php&r=site%2Fcurrent&id=42',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15496
