### PR TITLE
Fix IE11 compatibility mode redirect

### DIFF
--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -147,7 +147,7 @@ class User extends Component
      * @var array MIME types for which this component should redirect to the [[loginUrl]].
      * @since 2.0.8
      */
-    public $acceptableRedirectTypes = ['text/html', 'application/xhtml+xml'];
+    public $acceptableRedirectTypes = ['text/html', 'application/xhtml+xml', '*/*'];
 
     private $_access = [];
 


### PR DESCRIPTION
In IE11 when you turn on compatibility mode Yii stops redirecting the user to login page.
Problem is that accepted types contains ```*/*``` but is positioned as the last type, not first.
Technically there is 2 option to fix that:
1. Proposed change when we just adding ```*/*``` to acceptableRedirectTypes and system will try to find it at any position
2. We change L758 and move the ```*/*``` check to separate loop where Yii will check ```*/*``` at any position in the array.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | none
