### PR TITLE
Update m170907_052038_rbac_add_index_on_auth_assignment_user_id.php

### DIFF
--- a/framework/rbac/migrations/m170907_052038_rbac_add_index_on_auth_assignment_user_id.php
+++ b/framework/rbac/migrations/m170907_052038_rbac_add_index_on_auth_assignment_user_id.php
@@ -42,6 +42,8 @@ class m170907_052038_rbac_add_index_on_auth_assignment_user_id extends Migration
     public function up()
     {
         $authManager = $this->getAuthManager();
+        $this->db = $authManager->db;
+
         $this->createIndex($this->index, $authManager->assignmentTable, $this->column);
     }
 
@@ -51,6 +53,8 @@ class m170907_052038_rbac_add_index_on_auth_assignment_user_id extends Migration
     public function down()
     {
         $authManager = $this->getAuthManager();
+        $this->db = $authManager->db;
+
         $this->dropIndex($this->index, $authManager->assignmentTable);
     }
 }


### PR DESCRIPTION
When the authManager DB Connection is not the default one the migration fails

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes/no
| Tests pass?   | yes
| Fixed issues  | #16271
