### PR TITLE
[PHP 7.2] - count(): Parameter must be an array or an object that implements Countable

### DIFF
--- a/framework/data/ArrayDataProvider.php
+++ b/framework/data/ArrayDataProvider.php
@@ -123,7 +123,7 @@ class ArrayDataProvider extends BaseDataProvider
      */
     protected function prepareTotalCount()
     {
-        return count($this->allModels);
+        return !$this->allModels ?: count($this->allModels);
     }
 
     /**


### PR DESCRIPTION
count(): Parameter must be an array or an object that implements Countable

https://github.com/kartik-v/yii2-grid/issues/800

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | https://github.com/kartik-v/yii2-grid/issues/800
