### PR TITLE
Fix getComposer() yii\BaseYii::createObject(null) BaseMailer.php #16327

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.1.0 under development
 -----------------------
 
-- Bug #16327: Fix getComposer() yii\BaseYii::createObject(null) BaseMailer.php #16327. (cjtterabyte)
+- Bug #16327: Fix getComposer() yii\BaseYii::createObject(null) BaseMailer (cjtterabyte)
 - Bug #16065: Remove using `date.timezone` at `yii\base\Application`, use `date_default_timezone_get()` instead (sashsvamir)
 - Bug #12539: `yii\filters\ContentNegotiator` now generates 406 'Not Acceptable' instead of 415 'Unsupported Media Type' on content-type negotiation fail (PowerGamer1)
 - Bug #14458: Fixed `yii\filters\VerbFilter` uses case-insensitive comparison for the HTTP method name (klimov-paul)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.1.0 under development
 -----------------------
 
+- Bug #16327: Fix getComposer() yii\BaseYii::createObject(null) BaseMailer.php #16327. (cjtterabyte)
 - Bug #16065: Remove using `date.timezone` at `yii\base\Application`, use `date_default_timezone_get()` instead (sashsvamir)
 - Bug #12539: `yii\filters\ContentNegotiator` now generates 406 'Not Acceptable' instead of 415 'Unsupported Media Type' on content-type negotiation fail (PowerGamer1)
 - Bug #14458: Fixed `yii\filters\VerbFilter` uses case-insensitive comparison for the HTTP method name (klimov-paul)

--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -94,7 +94,7 @@ abstract class BaseMailer extends Component implements MailerInterface
     public function getComposer()
     {
         if (!is_object($this->_composer) || $this->_composer instanceof \Closure) {
-            if (is_array($this->_composer) && !isset($this->_composer['__class'])) {
+            if (!is_array($this->_composer) && !isset($this->_composer['__class'])) {
                 $this->_composer['__class'] = Composer::class;
             }
             $this->_composer = Yii::createObject($this->_composer);

--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -84,7 +84,7 @@ abstract class BaseMailer extends Component implements MailerInterface
      * @var Composer|array|string|callable message composer.
      * @since 2.1
      */
-    private $_composer;
+    private $_composer = [];
 
 
     /**
@@ -94,7 +94,7 @@ abstract class BaseMailer extends Component implements MailerInterface
     public function getComposer()
     {
         if (!is_object($this->_composer) || $this->_composer instanceof \Closure) {
-            if (!is_array($this->_composer) && !isset($this->_composer['__class'])) {
+            if (is_array($this->_composer) && !isset($this->_composer['__class'])) {
                 $this->_composer['__class'] = Composer::class;
             }
             $this->_composer = Yii::createObject($this->_composer);


### PR DESCRIPTION
Fixed (#16327):  getComposer() yii\BaseYii::createObject(null) BaseMailer.php #16327
