### PR TITLE
Fix Event off method undefined index error

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -34,7 +34,7 @@ Yii Framework 2 Change Log
 - Bug #16301: Fixed `yii\web\User::setIdentity()` to clear access check cache while setting identity object to `null` (Izumi-kun)
 - Bug #16322: Fixed strings were not were not compared using timing attack resistant approach while CSRF token validation (samdark, Felix Wiedemann)
 - Chg #16192: `yii\db\Command::logQuery()` is now protected (drlibra)
-- Bug: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
+- Bug #16377: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -34,6 +34,7 @@ Yii Framework 2 Change Log
 - Bug #16301: Fixed `yii\web\User::setIdentity()` to clear access check cache while setting identity object to `null` (Izumi-kun)
 - Bug #16322: Fixed strings were not were not compared using timing attack resistant approach while CSRF token validation (samdark, Felix Wiedemann)
 - Chg #16192: `yii\db\Command::logQuery()` is now protected (drlibra)
+- Bug: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/base/Event.php
+++ b/framework/base/Event.php
@@ -164,19 +164,21 @@ class Event extends BaseObject
 
         // wildcard event names
         $removed = false;
-        foreach (self::$_eventWildcards[$name][$class] as $i => $event) {
-            if ($event[0] === $handler) {
-                unset(self::$_eventWildcards[$name][$class][$i]);
-                $removed = true;
+        if (isset(self::$_eventWildcards[$name][$class])) {
+            foreach (self::$_eventWildcards[$name][$class] as $i => $event) {
+                if ($event[0] === $handler) {
+                    unset(self::$_eventWildcards[$name][$class][$i]);
+                    $removed = true;
+                }
             }
-        }
-        if ($removed) {
-            self::$_eventWildcards[$name][$class] = array_values(self::$_eventWildcards[$name][$class]);
-            // remove empty wildcards to save future redundant regex checks :
-            if (empty(self::$_eventWildcards[$name][$class])) {
-                unset(self::$_eventWildcards[$name][$class]);
-                if (empty(self::$_eventWildcards[$name])) {
-                    unset(self::$_eventWildcards[$name]);
+            if ($removed) {
+                self::$_eventWildcards[$name][$class] = array_values(self::$_eventWildcards[$name][$class]);
+                // remove empty wildcards to save future redundant regex checks :
+                if (empty(self::$_eventWildcards[$name][$class])) {
+                    unset(self::$_eventWildcards[$name][$class]);
+                    if (empty(self::$_eventWildcards[$name])) {
+                        unset(self::$_eventWildcards[$name]);
+                    }
                 }
             }
         }

--- a/tests/framework/base/EventTest.php
+++ b/tests/framework/base/EventTest.php
@@ -91,6 +91,14 @@ class EventTest extends TestCase
         $this->assertTrue(Event::hasHandlers('yiiunit\framework\base\SomeInterface', SomeInterface::EVENT_SUPER_EVENT));
     }
 
+    public function testOffUnmatchedHandler()
+    {
+        $this->assertFalse(Event::hasHandlers(Post::className(), 'afterSave'));
+        Event::on(Post::className(), 'afterSave', [$this, 'bla-bla']);
+        $this->assertFalse(Event::off(Post::className(), 'afterSave', [$this, 'bla-bla-bla']));
+        $this->assertTrue(Event::off(Post::className(), 'afterSave', [$this, 'bla-bla']));
+    }
+
     /**
      * @depends testOn
      * @depends testHasHandlers


### PR DESCRIPTION
This fatal error happens when one tries to delete (off) an event that matches the class & event name but has different event handlers. The method should return false instead.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | none
