### PR TITLE
solve issue #16396. this error (Invalid parameter number:) occured be…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -35,7 +35,7 @@ Yii Framework 2 Change Log
 - Bug #16322: Fixed strings were not were not compared using timing attack resistant approach while CSRF token validation (samdark, Felix Wiedemann)
 - Chg #16192: `yii\db\Command::logQuery()` is now protected (drlibra)
 - Bug #16377: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
-- Bug #16396: fixed `yii\db\ActiveRecord::refresh` Invalid parameter number when used append to in NestedSetsBehavior (ava-darabi)
+- Bug #16396: Fixed `yii\db\ActiveRecord::refresh` Invalid parameter number when used append to in NestedSetsBehavior (ava-darabi)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -35,6 +35,7 @@ Yii Framework 2 Change Log
 - Bug #16322: Fixed strings were not were not compared using timing attack resistant approach while CSRF token validation (samdark, Felix Wiedemann)
 - Chg #16192: `yii\db\Command::logQuery()` is now protected (drlibra)
 - Bug #16377: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
+- Bug #16396: fixed `yii\db\ActiveRecord::refresh` Invalid parameter number when used append to in NestedSetsBehavior (ava-darabi)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -235,7 +235,7 @@ class ActiveRecord extends BaseActiveRecord
         foreach ($this->getPrimaryKey(true) as $key => $value) {
             $pk[$tableName . '.' . $key] = $value;
         }
-        $query->where($pk);
+        $query->andWhere($pk);
 
         /* @var $record BaseActiveRecord */
         $record = $query->one();


### PR DESCRIPTION
…cause in refresh function a condition added with ->where, I change it to ->andWhere to solve the issue

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #16396 
