### PR TITLE
Update Schema.php

### DIFF
--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -287,7 +287,7 @@ SQL;
         $column->phpType = $this->getColumnPhpType($column);
 
         if (!$column->isPrimaryKey) {
-            if (($column->type === 'timestamp' || $column->type ==='datetime') && $info['default'] === 'CURRENT_TIMESTAMP') {
+            if (($column->type === 'timestamp' || $column->type ==='datetime') && in_array($info['default'], ['CURRENT_TIMESTAMP', 'current_timestamp()'])) {
                 $column->defaultValue = new Expression('CURRENT_TIMESTAMP');
             } elseif (isset($type) && $type === 'bit') {
                 $column->defaultValue = bindec(trim($info['default'], 'b\''));


### PR DESCRIPTION
MariaDB 10.2
default value of timestamp field current_timestamp()

but migrate field type $this->timestamp()->defaultExpression('CURRENT_TIMESTAMP')->notNull()

INSERT INTO `user_favourite` (`user_id`, `item_id`, `created_at`) VALUES (11, 10, 'current_timestamp()')

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
