### PR TITLE
Fixed drop existing views when console `migrate/fresh` command runs

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -25,6 +25,7 @@ Yii Framework 2 Change Log
 - Bug #14636: Views can now use relative paths even when using themed views (sammousa)
 - Bug #16245: Fixed `__isset()` in `BaseActiveRecord` not catching errors (sammousa)
 - Bug #16266: Fixed `yii\helpers\BaseStringHelper` where explode would not allow 0 as trim string (Thoulah)
+- Bug #16278: Fixed drop existing views when console `migrate/fresh` command runs (developeruz)
 - Bug #16277: Fixed `yii\db\Query::from()` to respect `yii\db\ExpressionInterface` (noname007)
 - Bug #16280: Fixed `yii\base\Model::getActiveValidators()` to return correct validators for attribute on scenario (paweljankowiak06)
 - Enh #16191: Enhanced `yii\helpers\Inflector` to work correctly with UTF-8 (silverfire)

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -310,8 +310,17 @@ class MigrateController extends BaseMigrateController
 
         // Then drop the tables:
         foreach ($schemas as $schema) {
-            $db->createCommand()->dropTable($schema->name)->execute();
-            $this->stdout("Table {$schema->name} dropped.\n");
+            try {
+                $db->createCommand()->dropTable($schema->name)->execute();
+                $this->stdout("Table {$schema->name} dropped.\n");
+            } catch (\Exception $e) {
+                if (strpos($e->getMessage(), 'DROP VIEW to delete view') !== false) {
+                    $db->createCommand()->dropView($schema->name)->execute();
+                    $this->stdout("View {$schema->name} dropped.\n");
+                } else {
+                    $this->stdout("Cannot drop {$schema->name} Table .\n");
+                }
+            }
         }
     }
 

--- a/tests/framework/console/controllers/MigrateControllerTest.php
+++ b/tests/framework/console/controllers/MigrateControllerTest.php
@@ -287,10 +287,14 @@ class MigrateControllerTest extends TestCase
         Yii::$app->db->createCommand("insert into hall_of_fame values(2, 'Alexander Makarov');")
             ->execute();
 
+        Yii::$app->db->createCommand('create view view_hall_of_fame as select * from hall_of_fame')
+            ->execute();
+
         $result = $this->runMigrateControllerAction('fresh');
 
         // Drop worked
         $this->assertContains('Table hall_of_fame dropped.', $result);
+        $this->assertContains('View view_hall_of_fame dropped.', $result);
 
         // Migration was restarted
         $this->assertContains('No new migrations found. Your system is up-to-date.', $result);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #16278 