### PR TITLE
Added Changed renderSelectOptions method of the BaseHtml,make the dropDownList component of the yii framework support adding several attributes to the select option.

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1859,6 +1859,11 @@ class BaseHtml
             } else {
                 $attrs = isset($options[$key]) ? $options[$key] : [];
                 $attrs['value'] = (string) $key;
+                if (isset($tagOptions['itemAttr']) && !empty($tagOptions['itemAttr'])) {
+                    foreach ($tagOptions['itemAttr'] as $attrKey => $attrValue) {
+                        $attrs[$attrKey] = (string)$attrValue;
+                    }
+                }
                 if (!array_key_exists('selected', $attrs)) {
                     $attrs['selected'] = $selection !== null &&
                         (!ArrayHelper::isTraversable($selection) && !strcmp($key, $selection)


### PR DESCRIPTION
Changed renderSelectOptions method of the BaseHtml,make the dropDownList component of the yii framework support adding several attributes to the select option.The array $option key use itemAttr,and value of the itemAttr  is an array.For example,Html::dropDownList('dropDown',null,$userArr,['class'=>'form-control','itemAttr'=>['id'=>$itemId]]).

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
