### PR TITLE
Added default tableOptions for base migration class

### DIFF
--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -78,7 +78,13 @@ class Migration extends Component implements MigrationInterface
      * @since 2.0.13
      */
     public $compact = false;
-
+    /**
+     * @var null|string
+     * Allow to set table options one time in custom base migration
+     * Default is null
+     * @since 3.0.0
+     */
+    public $tableOptions;
 
     /**
      * Initializes the migration.
@@ -311,6 +317,9 @@ class Migration extends Component implements MigrationInterface
      */
     public function createTable($table, $columns, $options = null)
     {
+        if (null === $options) {
+            $options = $this->tableOptions;
+        }
         $time = $this->beginCommand("create table $table");
         $this->db->createCommand()->createTable($table, $columns, $options)->execute();
         foreach ($columns as $column => $type) {

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -79,9 +79,7 @@ class Migration extends Component implements MigrationInterface
      */
     public $compact = false;
     /**
-     * @var null|string
-     * Allow to set table options one time in custom base migration
-     * Default is null
+     * @var null|string default table options to apply when creating a table and not specifying options explicitly.
      * @since 3.0.0
      */
     public $tableOptions;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | no

Позволяет единожды указать нужные свойства для таблиц в базовой миграции проекта, к примеру, `CHARACTER SET` или `ENGINE`, и дальше в каждой новой миграции, при создании таблицы, будет подтягиваться базовая, ЕСЛИ НЕ передать options внутри метода `createTable`