### PR TITLE
Added method call support in DI and Yii::configure

### DIFF
--- a/framework/BaseYii.php
+++ b/framework/BaseYii.php
@@ -563,7 +563,11 @@ class BaseYii
     public static function configure($object, $properties)
     {
         foreach ($properties as $name => $value) {
-            $object->$name = $value;
+            if (substr($name, -2) === '()') {
+                call_user_func_array([$object, substr($name, 0, -2)], $value);
+            } else {
+                $object->$name = $value;
+            }
         }
 
         return $object;

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -55,6 +55,7 @@ Yii Framework 2 Change Log
 - Chg #11397: `yii\i18n\MessageFormatter` polyfills and `yii\i18n\MessageFormatter::parse()` method were removed resulting in performance boost. See UPGRADE for compatibility notes (samdark)
 - Chg #16247: Cloning components will now clone their behaviors as well (brandonkelly)
 - Enh #16487: Added circular reference detection in DI container (hiqsol)
+- Enh #16495: Added method call support in DI and `Yii::configure()` (hiqsol)
 
 2.0.14.2 under development
 ------------------------

--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -402,7 +402,11 @@ class Container extends Component
 
         $object = $reflection->newInstanceArgs($dependencies);
         foreach ($config as $name => $value) {
-            $object->$name = $value;
+            if (substr($name, -2) === '()') {
+                call_user_func_array([$object, substr($name, 0, -2)], $value);
+            } else {
+                $object->$name = $value;
+            }
         }
 
         return $object;

--- a/tests/framework/di/ContainerTest.php
+++ b/tests/framework/di/ContainerTest.php
@@ -20,6 +20,7 @@ use yiiunit\framework\di\stubs\BarSetter;
 use yiiunit\framework\di\stubs\Foo;
 use yiiunit\framework\di\stubs\FooProperty;
 use yiiunit\framework\di\stubs\Qux;
+use yiiunit\framework\di\stubs\QuxHolder;
 use yiiunit\framework\di\stubs\QuxInterface;
 use yiiunit\TestCase;
 
@@ -339,5 +340,35 @@ class ContainerTest extends TestCase
 
         $this->expectException(CircularReferenceException::class);
         $container->get(Bar::class);
+    }
+
+    public function testMethodCallInConfigurable()
+    {
+        $container = new Container();
+        $qux = new Qux();
+        $container->set('barSetter', [
+            '__class' => BarSetter::class,
+            'setQux()' => [$qux],
+        ]);
+
+        $res = $container->get('barSetter');
+        $this->assertInstanceOf(BarSetter::class, $res);
+        $this->assertSame($qux, $res->getQux());
+    }
+
+    public function testMethodCall()
+    {
+        $container = new Container();
+        $qux = new Qux();
+        $container->set('quxHolder', [
+            '__class' => QuxHolder::class,
+            'setQux()' => [$qux],
+            'otherQux' => $qux,
+        ]);
+
+        $res = $container->get('quxHolder');
+        $this->assertInstanceOf(QuxHolder::class, $res);
+        $this->assertSame($qux, $res->getQux());
+        $this->assertSame($qux, $res->otherQux);
     }
 }

--- a/tests/framework/di/stubs/QuxHolder.php
+++ b/tests/framework/di/stubs/QuxHolder.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\di\stubs;
+
+/**
+ * Plain object. Not Configurable.
+ * @author Andrii Vasyliev <sol@hiqdev.com>
+ * @since 3.0.0
+ */
+class QuxHolder
+{
+    /**
+     * @var QuxInterface
+     */
+    private $qux;
+
+    /**
+     * @var QuxInterface
+     */
+    public $otherQux;
+
+    /**
+     * @return QuxInterface
+     */
+    public function getQux()
+    {
+        return $this->qux;
+    }
+
+    /**
+     * @param mixed $qux
+     */
+    public function setQux(QuxInterface $qux)
+    {
+        $this->qux = $qux;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

Cannot leave `Yii::configure()` untouched to have consistent behavior for all objects.