### PR TITLE
getValue() returns now the getDefaultValue()

### DIFF
--- a/framework/behaviors/BlameableBehavior.php
+++ b/framework/behaviors/BlameableBehavior.php
@@ -110,7 +110,7 @@ class BlameableBehavior extends AttributeBehavior
             return $userId;
         }
 
-        return parent::getValue($event);
+        return $this->getDefaultValue($event);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | yii\behaviors\BlameableBehavior::getValue() should return BlameableBehavior::getDefaultValue() instead of parent::defaultValue()
