### PR TITLE
Fixed #15826 : JavaScript compareValidator for attributes not in rules

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.16 under development
 ------------------------
 
+- Bug #15826: Fixed JavaScript compareValidator in `yii.validation.js` for attributes not in rules (mgrechanik)
 - Enh #16365: Added $filterOnFocusOut option for GridView (s1lver)
 - Enh #14289: Added `yii\db\Command::executeResetSequence()` to work with Oracle (CedricYii)
 - Enh #9133: Added `yii\behaviors\OptimisticLockBehavior` (tunecino)

--- a/framework/assets/yii.validation.js
+++ b/framework/assets/yii.validation.js
@@ -274,12 +274,11 @@ yii.validation = (function ($) {
             if (options.compareAttribute === undefined) {
                 compareValue = options.compareValue;
             } else {
-                var attributes = $form.data('yiiActiveForm').attributes
-                for (var i = attributes.length - 1; i >= 0; i--) {
-                    if (attributes[i].id === options.compareAttribute) {
-                        compareValue = $(attributes[i].input).val();
-                    }
+                var $target = $('#' + options.compareAttribute);
+                if (!$target.length) {
+                    $target = $form.find('[name="' + options.compareAttributeName + '"]');
                 }
+                compareValue = $target.val();                
             }
 
             if (options.type === 'number') {

--- a/framework/validators/CompareValidator.php
+++ b/framework/validators/CompareValidator.php
@@ -248,6 +248,7 @@ class CompareValidator extends Validator
             $compareAttribute = $this->compareAttribute === null ? $attribute . '_repeat' : $this->compareAttribute;
             $compareValue = $model->getAttributeLabel($compareAttribute);
             $options['compareAttribute'] = Html::getInputId($model, $compareAttribute);
+            $options['compareAttributeName'] = Html::getInputName($model, $compareAttribute);
             $compareLabel = $compareValueOrAttribute = $model->getAttributeLabel($compareAttribute);
         }
 

--- a/tests/js/tests/yii.validation.test.js
+++ b/tests/js/tests/yii.validation.test.js
@@ -1506,13 +1506,8 @@ describe('yii.validation', function () {
         describe('with compareAttribute, "==" operator and 2 identical strings', function () {
             it(VALIDATOR_SUCCESS_MESSAGE, function () {
                 var $form = {
-                    data: function () {
-                        return {
-                            attributes: [{
-                                "id": "input-id",
-                                "input": "#input-id"
-                            }]
-                        }
+                    find: function(){
+                        return $input;
                     }
                 };
                 var messages = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15826
