### PR TITLE
Fixed #16514: `resolveCallableDependencies` is not supported callable object. 

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -38,7 +38,7 @@ Yii Framework 2 Change Log
 - Bug #16322: Fixed strings were not were not compared using timing attack resistant approach while CSRF token validation (samdark, Felix Wiedemann)
 - Chg #16192: `yii\db\Command::logQuery()` is now protected (drlibra)
 - Bug #16377: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
-- Bug #16514: Fixed `yii\di\Container::resolveCallableDependencies` to support callable object. (wi1dcard)
+- Bug #16514: Fixed `yii\di\Container::resolveCallableDependencies` to support callable object (wi1dcard)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -38,6 +38,7 @@ Yii Framework 2 Change Log
 - Bug #16322: Fixed strings were not were not compared using timing attack resistant approach while CSRF token validation (samdark, Felix Wiedemann)
 - Chg #16192: `yii\db\Command::logQuery()` is now protected (drlibra)
 - Bug #16377: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
+- Bug #16514: Fixed `yii\di\Container::resolveCallableDependencies` to support callable object. (wi1dcard)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -523,6 +523,8 @@ class Container extends Component
     {
         if (is_array($callback)) {
             $reflection = new \ReflectionMethod($callback[0], $callback[1]);
+        } elseif (is_object($callback)) {
+            $reflection = new \ReflectionMethod($callback, '__invoke');
         } else {
             $reflection = new \ReflectionFunction($callback);
         }

--- a/tests/data/base/CallableClass.php
+++ b/tests/data/base/CallableClass.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\base;
+
+class CallableClass
+{
+    public function __invoke()
+    {
+        return true;
+    }
+}

--- a/tests/framework/BaseYiiTest.php
+++ b/tests/framework/BaseYiiTest.php
@@ -13,6 +13,7 @@ use yii\di\Container;
 use yii\log\Logger;
 use yiiunit\data\base\Singer;
 use yiiunit\TestCase;
+use yiiunit\data\base\CallableClass;
 
 /**
  * BaseYiiTest.
@@ -91,6 +92,8 @@ class BaseYiiTest extends TestCase
         $this->assertTrue(Yii::createObject(function (Singer $singer, $a = 3) {
             return true;
         }));
+
+        $this->assertTrue(Yii::createObject(new CallableClass()));
     }
 
     public function testCreateObjectEmptyArrayException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | Y
| New feature?  | N
| Breaks BC?    | N
| Tests pass?   | Y
| Fixed issues  | #16514 
