### PR TITLE
Исправляем поведение виджета ActiveForm

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.16 under development
 ------------------------
-
+- Bug #16527: Fixed return content for `\yii\widgets\ActiveForm::run()` (carono)
 - Bug #15826: Fixed JavaScript compareValidator in `yii.validation.js` for attributes not in rules (mgrechanik)
 - Enh #16365: Added $filterOnFocusOut option for GridView (s1lver)
 - Enh #14289: Added `yii\db\Command::executeResetSequence()` to work with Oracle (CedricYii)

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -221,14 +221,15 @@ class ActiveForm extends Widget
         }
 
         $content = ob_get_clean();
-        echo Html::beginForm($this->action, $this->method, $this->options);
-        echo $content;
+        $html = Html::beginForm($this->action, $this->method, $this->options);
+        $html .= $content;
 
         if ($this->enableClientScript) {
             $this->registerClientScript();
         }
 
-        echo Html::endForm();
+        $html .= Html::endForm();
+        return $html;
     }
 
     /**


### PR DESCRIPTION
В функции run() делаем вместо вывода контента, его возврат, чтобы получить возможность использовать в событии EVENT_AFTER_RUN переменную $result

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | #16527
