### PR TITLE
Fixed #16351

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -39,6 +39,7 @@ Yii Framework 2 Change Log
 - Bug #16322: Fixed strings were not were not compared using timing attack resistant approach while CSRF token validation (samdark, Felix Wiedemann)
 - Chg #16192: `yii\db\Command::logQuery()` is now protected (drlibra)
 - Bug #16377: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
+- Bug #16531: Fix a PHP error that would occur when using `yii\web\Response:sendContent()` in an environment where `set_time_limit()` was disabled (angrybrad)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -39,7 +39,7 @@ Yii Framework 2 Change Log
 - Bug #16322: Fixed strings were not were not compared using timing attack resistant approach while CSRF token validation (samdark, Felix Wiedemann)
 - Chg #16192: `yii\db\Command::logQuery()` is now protected (drlibra)
 - Bug #16377: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
-- Bug #16531: Fix a PHP error that would occur when using `yii\web\Response:sendContent()` in an environment where `set_time_limit()` was disabled (angrybrad)
+- Bug #16531: Fixed a PHP error that would occur when using `yii\web\Response:sendContent()` in an environment where `set_time_limit()` was disabled (angrybrad)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -416,7 +416,9 @@ class Response extends \yii\base\Response
             return;
         }
 
-        set_time_limit(0); // Reset time limit for big files
+        if (strpos(ini_get('disable_functions'), 'set_time_limit') === false) {
+            set_time_limit(0); // Reset time limit for big files
+        }
         $chunkSize = 8 * 1024 * 1024; // 8MB per chunk
 
         if (is_array($this->stream)) {


### PR DESCRIPTION
Fixed a PHP error that would occur when using `yii\web\Response:sendContent()` in an environment where `set_time_limit()` was disabled.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 16531
