### PR TITLE
регистронезависимый  поиск Yii::t

### DIFF
--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -610,10 +610,10 @@ EOD;
     protected function tokensEqual($a, $b)
     {
         if (is_string($a) && is_string($b)) {
-            return $a === $b;
+            return strtolower($a) === strtolower($b);
         }
         if (isset($a[0], $a[1], $b[0], $b[1])) {
-            return $a[0] === $b[0] && $a[1] == $b[1];
+            return strtolower($a[0]) === strtolower($b[0]) && strtolower($a[1]) == strtolower($b[1]);
         }
 
         return false;


### PR DESCRIPTION
Убираем регистрозависимый поиск Yii::t при "yii message/extract".
Теперь будут найдены все варианты: yii::t, Yii::t, YII::t

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
