### PR TITLE
Add support for setting charset via connection property

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -39,6 +39,7 @@ Yii Framework 2 Change Log
 - Bug #16322: Fixed strings were not were not compared using timing attack resistant approach while CSRF token validation (samdark, Felix Wiedemann)
 - Chg #16192: `yii\db\Command::logQuery()` is now protected (drlibra)
 - Bug #16377: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
+- Enh #16563: `yii\db\Connection::$charset` can now be used with every PDO driver (sammousa)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -679,7 +679,7 @@ class Connection extends Component
         }
 
         // We always append the charset even if it is ignored by the driver.
-        if (isset($this->charset)) {
+        if (isset($this->charset) && strpos($dsn, 'charset=') === false) {
             $this->dsn .= ';charset=' . $this->charset;
         }
 


### PR DESCRIPTION
Currently there's 2 methods of setting the character set of a database connection:
  - via the DSN
  - via `$charset` property

This PR allows everyone to always use the `$charset` property.
It is fully backwards compatible.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | maybe
| Fixed issues  | #16545 #16530 
