### PR TITLE
Исправление для #15889

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -40,6 +40,7 @@ Yii Framework 2 Change Log
 - Chg #16192: `yii\db\Command::logQuery()` is now protected, extracted `getCacheKey()` from `queryInternal()` (drlibra)
 - Bug #16377: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
 - Bug #16514: Fixed `yii\di\Container::resolveCallableDependencies` to support callable object (wi1dcard)
+- Bug #15889: Fixed override `yii\helpers\Html::setActivePlaceholder` (lesha724)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1325,7 +1325,7 @@ class BaseHtml
             $options['id'] = static::getInputId($model, $attribute);
         }
 
-        self::setActivePlaceholder($model, $attribute, $options);
+        static::setActivePlaceholder($model, $attribute, $options);
 
         return static::input($type, $name, $value, $options);
     }
@@ -1502,7 +1502,7 @@ class BaseHtml
             $options['id'] = static::getInputId($model, $attribute);
         }
         self::normalizeMaxLength($model, $attribute, $options);
-        self::setActivePlaceholder($model, $attribute, $options);
+        static::setActivePlaceholder($model, $attribute, $options);
         return static::textarea($name, $value, $options);
     }
 

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1729,6 +1729,34 @@ HTML;
         $this->assertContains('placeholder="Name"', $html);
     }
 
+    public function testOverrideSetActivePlaceholder()
+    {
+        $model = new HtmlTestModel();
+
+        $html = MyHtml::activeTextInput($model, 'name', ['placeholder' => true]);
+
+        $this->assertContains('placeholder="My placeholder: Name"', $html);
+    }
+}
+
+/**
+ * Class MyHtml
+ * @package yiiunit\framework\helpers
+ */
+class MyHtml extends Html{
+
+    /**
+     * @param \yii\base\Model $model
+     * @param string $attribute
+     * @param array $options
+     */
+    protected static function setActivePlaceholder($model, $attribute, &$options = [])
+    {
+        if (isset($options['placeholder']) && $options['placeholder'] === true) {
+            $attribute = static::getAttributeName($attribute);
+            $options['placeholder'] = 'My placeholder: '. $model->getAttributeLabel($attribute);
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Добавлена возможность изменить/дополнить метод setActivePlaceholder после переопределиния базового класса Html

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | #15889
