### PR TITLE
Bug #16552: Cached relatation is not used in relation through `via`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -41,6 +41,7 @@ Yii Framework 2 Change Log
 - Bug #16377: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
 - Bug #16514: Fixed `yii\di\Container::resolveCallableDependencies` to support callable object (wi1dcard)
 - Bug #15889: Fixed override `yii\helpers\Html::setActivePlaceholder` (lesha724)
+- Bug #16552: Added check in `yii\db\ActiveQuery::prepare()` to prevent populating already populated relation when another relation is requested with `via`. (drlibra)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -41,7 +41,7 @@ Yii Framework 2 Change Log
 - Bug #16377: Fixed `yii\base\Event:off()` undefined index error when event handler does not match (razvanphp)
 - Bug #16514: Fixed `yii\di\Container::resolveCallableDependencies` to support callable object (wi1dcard)
 - Bug #15889: Fixed override `yii\helpers\Html::setActivePlaceholder` (lesha724)
-- Bug #16552: Added check in `yii\db\ActiveQuery::prepare()` to prevent populating already populated relation when another relation is requested with `via`. (drlibra)
+- Bug #16552: Added check in `yii\db\ActiveQuery::prepare()` to prevent populating already populated relation when another relation is requested with `via` (drlibra)
 - Enh #16522: Allow jQuery 3.3 (Slamdunk)
 
 2.0.15.1 March 21, 2018

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -172,11 +172,19 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 /* @var $viaQuery ActiveQuery */
                 list($viaName, $viaQuery) = $this->via;
                 if ($viaQuery->multiple) {
-                    $viaModels = $viaQuery->all();
-                    $this->primaryModel->populateRelation($viaName, $viaModels);
+                    if ($this->primaryModel->isRelationPopulated($viaName)) {
+                        $viaModels = $this->primaryModel->$viaName;
+                    } else {
+                        $viaModels = $viaQuery->all();
+                        $this->primaryModel->populateRelation($viaName, $viaModels);
+                    }
                 } else {
-                    $model = $viaQuery->one();
-                    $this->primaryModel->populateRelation($viaName, $model);
+                    if ($this->primaryModel->isRelationPopulated($viaName)) {
+                        $model = $this->primaryModel->$viaName;
+                    } else {
+                        $model = $viaQuery->one();
+                        $this->primaryModel->populateRelation($viaName, $model);
+                    }
                     $viaModels = $model === null ? [] : [$model];
                 }
                 $this->filterByModels($viaModels);


### PR DESCRIPTION
Added check in `yii\db\ActiveQuery::prepare()` to prevent populating already populated relation when another relation is requested with `via`

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #16552 

I am not sure that I made the sentence in the changelog right.
