### PR TITLE
Added method isDirty() and isAttributeDirty() for ActiveRecord

### DIFF
--- a/framework/behaviors/SluggableBehavior.php
+++ b/framework/behaviors/SluggableBehavior.php
@@ -190,7 +190,7 @@ class SluggableBehavior extends AttributeBehavior
         }
 
         foreach ((array) $this->attribute as $attribute) {
-            if ($this->owner->isAttributeChanged($attribute)) {
+            if ($this->owner->isAttributeDirty($attribute)) {
                 return true;
             }
         }

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -600,10 +600,11 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * @param string $name the name of the attribute.
      * @param bool $identical whether the comparison of new and old value is made for
      * identical values using `===`, defaults to `true`. Otherwise `==` is used for comparison.
-     * This parameter is available since version 2.0.4.
      * @return bool whether the attribute has been changed
+     * This parameter was available since version 2.0.4 under the name isAttributeChanged().
+     * @since 3.0.0
      */
-    public function isAttributeChanged($name, $identical = true)
+    public function isAttributeDirty($name, $identical = true)
     {
         if (isset($this->_attributes[$name], $this->_oldAttributes[$name])) {
             if ($identical) {
@@ -614,6 +615,30 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
         }
 
         return isset($this->_attributes[$name]) || isset($this->_oldAttributes[$name]);
+    }
+
+    /**
+     * Returns a value indicating whether the model has at least one attribute dirty.
+     * @return bool whether the model has at least one attribute dirty
+     * @since 3.0.0
+     */
+    public function isDirty()
+    {
+        if ($this->_attributes === [] and $this->attributes() === []) {
+            return false;
+        }
+
+        if ($this->_oldAttributes === null) {
+            return true;
+        }
+
+        foreach ($this->_attributes as $name => $value) {
+            if (!array_key_exists($name, $this->_oldAttributes) || $value !== $this->_oldAttributes[$name]) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -600,8 +600,8 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * @param string $name the name of the attribute.
      * @param bool $identical whether the comparison of new and old value is made for
      * identical values using `===`, defaults to `true`. Otherwise `==` is used for comparison.
+     * This parameter is available since version 2.0.4.
      * @return bool whether the attribute has been changed
-     * This parameter was available since version 2.0.4 under the name isAttributeChanged().
      * @since 3.0.0
      */
     public function isAttributeDirty($name, $identical = true)
@@ -624,16 +624,12 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function isDirty()
     {
-        if ($this->_attributes === [] and $this->attributes() === []) {
-            return false;
-        }
-
-        if ($this->_oldAttributes === null) {
+        if ($this->getIsNewRecord()) {
             return true;
         }
 
         foreach ($this->_attributes as $name => $value) {
-            if (!array_key_exists($name, $this->_oldAttributes) || $value !== $this->_oldAttributes[$name]) {
+            if ($this->isAttributeDirty($name)) {
                 return true;
             }
         }

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1807,4 +1807,16 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertFalse(isset($cat->throwable));
 
     }
+
+    public function testIsDirty()
+    {
+        $order = new Order();
+        $this->assertTrue($order->isDirty());
+
+        $order->setIsNewRecord(false);
+        $this->assertFalse($order->isDirty());
+
+        $order->quantity = 2;
+        $this->assertTrue($order->isDirty());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | 
| Fixed issues  |  #16336

BC: Removed isAttributeChanged() in favor to isAttributeDirty() to have better naming consistency.
Added: isAttributeDirty().
Added: isDirty().
