### PR TITLE
Fix namespace issue

### DIFF
--- a/framework/filters/Cors.php
+++ b/framework/filters/Cors.php
@@ -167,7 +167,7 @@ class Cors extends ActionFilter
                 // Per CORS standard (https://fetch.spec.whatwg.org), wildcard origins shouldn't be used together with credentials
                 if (isset($this->cors['Access-Control-Allow-Credentials']) && $this->cors['Access-Control-Allow-Credentials']) {
                     if (YII_DEBUG) {
-                        throw new Exception("Allowing credentials for wildcard origins is insecure. Please specify more restrictive origins or set 'credentials' to false in your CORS configuration.");
+                        throw new \Exception("Allowing credentials for wildcard origins is insecure. Please specify more restrictive origins or set 'credentials' to false in your CORS configuration.");
                     } else {
                         Yii::error("Allowing credentials for wildcard origins is insecure. Please specify more restrictive origins or set 'credentials' to false in your CORS configuration.", __METHOD__);
                     }


### PR DESCRIPTION
Causes an error when `YII_DEBUG` is `true`, `$cors['Origin']` contains `'*'` and `$cors['Access-Control-Allow-Credentials']` is `true`

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | --
| Fixed issues  | --
