### PR TITLE
Allow FileMutex to be explicitly told it is operating on a Windows filesystem

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -42,6 +42,7 @@ Yii Framework 2 Change Log
 - Bug #16514: Fixed `yii\di\Container::resolveCallableDependencies` to support callable object (wi1dcard)
 - Bug #15889: Fixed override `yii\helpers\Html::setActivePlaceholder` (lesha724)
 - Enh #16522: Allow jQuery 3.3 (Slamdunk)
+- Enh #16603: Added `yii\mutex\FileMutex::$isWindows` for Windows file shares on Unix guest machines (brandonkelly)  
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/mutex/FileMutex.php
+++ b/framework/mutex/FileMutex.php
@@ -63,6 +63,7 @@ class FileMutex extends Mutex
      * @var bool whether file handling should assume a Windows file system.
      * This value will determine how [[releaseLock()]] goes about deleting the lock file.
      * If not set, it will be determined by checking the DIRECTORY_SEPARATOR constant.
+     * @since 2.0.16
      */
     public $isWindows;
 

--- a/framework/mutex/FileMutex.php
+++ b/framework/mutex/FileMutex.php
@@ -59,6 +59,12 @@ class FileMutex extends Mutex
      * but read-only for other users.
      */
     public $dirMode = 0775;
+    /**
+     * @var bool whether file handling should assume a Windows file system.
+     * This value will determine how [[releaseLock()]] goes about deleting the lock file.
+     * If not set, it will be determined by checking the DIRECTORY_SEPARATOR constant.
+     */
+    public $isWindows;
 
     /**
      * @var resource[] stores all opened lock files. Keys are lock names and values are file handles.
@@ -77,6 +83,9 @@ class FileMutex extends Mutex
         $this->mutexPath = Yii::getAlias($this->mutexPath);
         if (!is_dir($this->mutexPath)) {
             FileHelper::createDirectory($this->mutexPath, $this->dirMode, true);
+        }
+        if ($this->isWindows === null) {
+            $this->isWindows = DIRECTORY_SEPARATOR === '\\';
         }
     }
 
@@ -149,7 +158,7 @@ class FileMutex extends Mutex
             return false;
         }
 
-        if (DIRECTORY_SEPARATOR === '\\') {
+        if ($this->isWindows) {
             // Under windows it's not possible to delete a file opened via fopen (either by own or other process).
             // That's why we must first unlock and close the handle and then *try* to delete the lock file.
             flock($this->_files[$name], LOCK_UN);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #16603
