### PR TITLE
Russian translation: fix markdown syntax of runtime-handling-errors

### DIFF
--- a/docs/guide-ru/runtime-handling-errors.md
+++ b/docs/guide-ru/runtime-handling-errors.md
@@ -114,13 +114,12 @@ class SiteController extends Controller
         ];
     }
 }
- ```
- 
+```
+
 Приведённый выше код задаёт действие `error` используя класс [[yii\web\ErrorAction]], который рендерит ошибку используя
 отображение `error`.
 
 Вместо использования [[yii\web\ErrorAction]] вы можете создать действие `error` как обычный метод:
- 
 
 ```php
 public function actionError()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes (doc)
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | --
| Fixed issues  | --

![image](https://user-images.githubusercontent.com/4408379/43679120-3c93c0a6-9828-11e8-85ef-b1c9eb4518b8.png)

Page - https://www.yiiframework.com/doc/guide/2.0/ru/runtime-handling-errors