### PR TITLE
Remove unnecessary `else` in `yii\base\BaseObject::__set`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -47,6 +47,7 @@ Yii Framework 2 Change Log
 - Bug #16552: Added check in `yii\db\ActiveQuery::prepare()` to prevent populating already populated relation when another relation is requested with `via` (drlibra)
 - Enh #16522: Allow jQuery 3.3 (Slamdunk)
 - Enh #16603: Added `yii\mutex\FileMutex::$isWindows` for Windows file shares on Unix guest machines (brandonkelly)  
+- Enh: Remove unnecessary `else` in `yii\base\BaseObject::__set` (wi1dcard)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/base/BaseObject.php
+++ b/framework/base/BaseObject.php
@@ -159,9 +159,9 @@ class BaseObject implements Configurable
             $this->$setter($value);
         } elseif (method_exists($this, 'get' . $name)) {
             throw new InvalidCallException('Setting read-only property: ' . get_class($this) . '::' . $name);
-        } else {
-            throw new UnknownPropertyException('Setting unknown property: ' . get_class($this) . '::' . $name);
         }
+
+        throw new UnknownPropertyException('Setting unknown property: ' . get_class($this) . '::' . $name);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | N
| New feature?  | N
| Breaks BC?    | N
| Tests pass?   | Y
| Fixed issues  | 

Remove unnecessary `else` in `yii\base\BaseObject::__set`, so that it looks like the `__get` method.