### PR TITLE
`BaseDataProvider::getModels()` add `$forcePrepare` param.

### DIFF
--- a/framework/data/BaseDataProvider.php
+++ b/framework/data/BaseDataProvider.php
@@ -107,11 +107,12 @@ abstract class BaseDataProvider extends Component implements DataProviderInterfa
 
     /**
      * Returns the data models in the current page.
+     * @param bool $forcePrepare whether to force data preparation even if it has been done before.
      * @return array the list of data models in the current page.
      */
-    public function getModels()
+    public function getModels($forcePrepare = false)
     {
-        $this->prepare();
+        $this->prepare($forcePrepare);
 
         return $this->_models;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | -

```php
$array = [
    [
        'user_id' => 1,
        'math' => 90,
        'physical' => 80,
        'biological' => 70,
    ],
    [
        'user_id' => 2,
        'math' => 70,
        'physical' => 80,
        'biological' => 90,
    ],
    [
        'user_id' => 3,
        'math' => 80,
        'physical' => 90,
        'biological' => 80,
    ],
];

$dataProvider = new ArrayDataProvider([
    'allModels' => $array,
    'sort' => [
        'attributes' => [
            'math',
            'physical',
            'biological',
        ],
    ],
]);
```

before:

```php
$sort = $dataProvider->getSort();

$sort->setAttributeOrders(['math' => SORT_DESC], false);
$dataProvider->prepare(true);
$math = $dataProvider->getModels();

$sort->setAttributeOrders(['physical' => SORT_DESC], false);
$dataProvider->prepare(true);
$physical = $dataProvider->getModels();

$sort->setAttributeOrders(['biological' => SORT_DESC], false);
$dataProvider->prepare(true);
$biological = $dataProvider->getModels();
```

after:

```php
$sort = $dataProvider->getSort();

$sort->setAttributeOrders(['math' => SORT_DESC], false);
$math = $dataProvider->getModels(true);

$sort->setAttributeOrders(['physical' => SORT_DESC], false);
$physical = $dataProvider->getModels(true);

$sort->setAttributeOrders(['biological' => SORT_DESC], false);
$biological = $dataProvider->getModels(true);
```