### PR TITLE
refactor console/controllers/MessageController

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -47,6 +47,7 @@ Yii Framework 2 Change Log
 - Bug #16552: Added check in `yii\db\ActiveQuery::prepare()` to prevent populating already populated relation when another relation is requested with `via` (drlibra)
 - Enh #16522: Allow jQuery 3.3 (Slamdunk)
 - Enh #16603: Added `yii\mutex\FileMutex::$isWindows` for Windows file shares on Unix guest machines (brandonkelly)  
+- Enh #16643: Refactor commands/controllers/MessageController method extractMessagesFromTokens a little bit (thyseus)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -579,7 +579,7 @@ EOD;
      * @param array $buffer
      * @return bool
      */
-    protected function isBufferValid(array $buffer): bool
+    private function isBufferValid(array $buffer): bool
     {
         return isset($buffer[0][0], $buffer[1], $buffer[2][0])
             && $buffer[0][0] === T_CONSTANT_ENCAPSED_STRING

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -518,7 +518,7 @@ EOD;
 
                     if ($pendingParenthesisCount === 0) {
                         // end of translator call or end of something that we can't extract
-                        if (isset($buffer[0][0], $buffer[1], $buffer[2][0]) && $buffer[0][0] === T_CONSTANT_ENCAPSED_STRING && $buffer[1] === ',' && $buffer[2][0] === T_CONSTANT_ENCAPSED_STRING) {
+                        if ($this->isBufferValid($buffer)) {
                             // is valid call we can extract
                             $category = stripcslashes($buffer[0][1]);
                             $category = mb_substr($category, 1, -1);
@@ -527,7 +527,9 @@ EOD;
                                 $fullMessage = mb_substr($buffer[2][1], 1, -1);
                                 $i = 3;
                                 while ($i < count($buffer) - 1 && !is_array($buffer[$i]) && $buffer[$i] === '.') {
-                                    $fullMessage .= mb_substr($buffer[$i + 1][1], 1, -1);
+                                    if (isset($buffer[$i+1], $buffer[$i+1][1])) {
+                                        $fullMessage .= mb_substr($buffer[$i + 1][1], 1, -1);
+                                    }
                                     $i += 2;
                                 }
 
@@ -538,7 +540,8 @@ EOD;
                             $nestedTokens = array_slice($buffer, 3);
                             if (count($nestedTokens) > $translatorTokensCount) {
                                 // search for possible nested translator calls
-                                $messages = array_merge_recursive($messages, $this->extractMessagesFromTokens($nestedTokens, $translatorTokens, $ignoreCategories));
+                                $messages = array_merge_recursive($messages,
+                                    $this->extractMessagesFromTokens($nestedTokens, $translatorTokens, $ignoreCategories));
                             }
                         } else {
                             // invalid call or dynamic call we can't extract
@@ -568,6 +571,19 @@ EOD;
         }
 
         return $messages;
+    }
+
+    /**
+     * Checks if the given buffer has the correct format.
+     *
+     * @param array $buffer
+     * @return bool
+     */
+    protected function isBufferValid(array $buffer): bool
+    {
+        return isset($buffer[0][0], $buffer[1], $buffer[2][0])
+            && $buffer[0][0] === T_CONSTANT_ENCAPSED_STRING
+            && $buffer[1] === ',' && $buffer[2][0] === T_CONSTANT_ENCAPSED_STRING;
     }
 
     /**

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -579,7 +579,7 @@ EOD;
      * @param array $buffer
      * @return bool
      */
-    private function isBufferValid(array $buffer): bool
+    private function isBufferValid(array $buffer)
     {
         return isset($buffer[0][0], $buffer[1], $buffer[2][0])
             && $buffer[0][0] === T_CONSTANT_ENCAPSED_STRING


### PR DESCRIPTION
refactor console/controllers/MessageController extractMessagesFromTokens method a little bit.

This fixes a `Uninitialized string offset: 1` for me.
Actually it should be refactored _even more_, but this is just a start.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  |no
| Breaks BC?    | no
| Tests pass?   | yes

