### PR TITLE
Fix db/BaseActiveRecord::isAttributeChanged() when attribute is null

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -606,15 +606,19 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function isAttributeChanged($name, $identical = true)
     {
-        if (isset($this->_attributes[$name], $this->_oldAttributes[$name])) {
-            if ($identical) {
-                return $this->_attributes[$name] !== $this->_oldAttributes[$name];
-            }
-
-            return $this->_attributes[$name] != $this->_oldAttributes[$name];
+        if (!array_key_exists($name, $this->_attributes)) {
+            return false;
         }
 
-        return isset($this->_attributes[$name]) || isset($this->_oldAttributes[$name]);
+        if (!array_key_exists($name, $this->_oldAttributes)) {
+            return true;
+        }
+
+        if ($identical) {
+            return $this->_attributes[$name] !== $this->_oldAttributes[$name];
+        }
+
+        return $this->_attributes[$name] != $this->_oldAttributes[$name];
     }
 
     /**

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1813,6 +1813,33 @@ abstract class ActiveRecordTest extends DatabaseTestCase
     {
         $cat = new Cat();
         $this->assertFalse(isset($cat->throwable));
+    }
 
+    public function testIsAttributeChanged()
+    {
+        $order = Order::findOne(1);
+        $this->assertFalse($order->isAttributeChanged('unknown'));
+        $this->assertFalse($order->isAttributeChanged('total'));
+
+        $order->total = null;
+        $order->markAttributeDirty('total');
+        $this->assertTrue($order->isAttributeChanged('total'));
+
+        $order->total = null;
+        $order->setOldAttribute('total', 0);
+        $this->assertTrue($order->isAttributeChanged('total', true));
+        $this->assertFalse($order->isAttributeChanged('total', false));
+
+        $order->setOldAttribute('total', null);
+        $this->assertFalse($order->isAttributeChanged('total'));
+
+        $order->total = 10;
+        $this->assertTrue($order->isAttributeChanged('total'));
+
+        unset($order->total);
+        $this->assertFalse($order->isAttributeChanged('total'));
+
+        $orderNew = new Order;
+        $this->assertFalse($orderNew->isAttributeChanged('total'));
     }
 }


### PR DESCRIPTION
Fix inconsistency when attribute value is null.
Add tests.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #16654
