### PR TITLE
Fixed bug where component behaviors could be double-attached

### DIFF
--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -311,9 +311,9 @@ class Component extends BaseObject
 
         if ($this->_behaviors !== null) {
             $behaviors = $this->_behaviors;
-            $this->_behaviors = null;
+            $this->_behaviors = [];
             foreach ($behaviors as $name => $behavior) {
-                $this->attachBehavior($name, clone $behavior);
+                $this->attachBehaviorInternal($name, clone $behavior);
             }
         }
     }


### PR DESCRIPTION
This fixes a 3.0 bug introduced in #16430.

If a component's behaviors() method returns any behaviors without a name, then cloning it would result in the behavior getting attached twice.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
