### PR TITLE
Log level changed in yii\db\Connection::open()

### DIFF
--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -605,7 +605,7 @@ class Connection extends Component
         $token = 'Opening DB connection: ' . $this->dsn;
         $enableProfiling = $this->enableProfiling;
         try {
-            Yii::info($token, __METHOD__);
+            Yii::debug($token, __METHOD__);
             if ($enableProfiling) {
                 Yii::beginProfile($token, __METHOD__);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

Logger in yii\db\Connection::open() method should use the same log level as in yii\db\Connection::close()
