### PR TITLE
Facility for DataProvider-oriented custom template rendering through REST APIs

### DIFF
--- a/framework/rest/Serializer.php
+++ b/framework/rest/Serializer.php
@@ -137,7 +137,7 @@ class Serializer extends Component
      * Serializes the given data into a format that can be easily turned into other formats.
      * This method mainly converts the objects of recognized types into array representation.
      * It will not do conversion for unknown object types or non-object data.
-     * The default implementation will handle [[Model]] and [[DataProviderInterface]].
+     * The default implementation will handle [[Model]], [[DataProviderInterface]] and [[TemplateRenderer]].
      * You may override this method to support more object types.
      * @param mixed $data the data to be serialized.
      * @return mixed the converted data.
@@ -150,6 +150,8 @@ class Serializer extends Component
             return $this->serializeModel($data);
         } elseif ($data instanceof DataProviderInterface) {
             return $this->serializeDataProvider($data);
+        } elseif ($data instanceof TemplateRenderer){
+            return $this->serializeTemplateRenderer($data);
         }
 
         return $data;
@@ -296,5 +298,18 @@ class Serializer extends Component
         }
 
         return $models;
+    }
+
+    /**
+     * Serializes a template renderer
+     * @param TemplateRenderer $templateRenderer
+     * @return string the rendered template of the dataProvider
+     */
+    public function serializeTemplateRenderer($templateRenderer){
+        $templateRenderer->dataProvider->prepare(true);
+        if (($pagination = $templateRenderer->dataProvider->getPagination()) !== false) {
+            $this->addPaginationHeaders($pagination);
+        }
+        return $templateRenderer::widget(get_object_vars($templateRenderer));
     }
 }

--- a/framework/rest/TemplateRenderer.php
+++ b/framework/rest/TemplateRenderer.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\rest;
+use \yii\base\Widget;
+
+class TemplateRenderer extends Widget
+{
+	/**
+     * @var \yii\data\DataProviderInterface the data provider for the view. This property is required.
+     */
+	public $dataProvider;
+	/**
+     * @var string the name of the view for rendering the container/wrapper for data items.
+     * The following variables will
+     * be available in the view:
+     * - `$dataProvider`: the data provider
+     * - `$widget`: TemplateRenderer, this widget instance
+     */
+	public $parentView;
+	/**
+     * @var string the name of the view for rendering each data item for rendering each data item.
+     * The following variables will
+     * be available in the view:
+     * - `$model`: mixed, the data model
+     * - `$widget`: TemplateRenderer, this widget instance
+     */
+	public $itemView;
+
+	/**
+     * Runs the widget.
+     */
+	public function run(){
+		$this->dataProvider->prepare(true);
+		return $this->render($this->parentView);
+	}
+
+	/**
+     * Renders the full content according to the template given in $parentView and $itemView
+     * In $parentView, {{variable}} will be replaced by the returned result of TemplateRenderer::renderVariable()
+     * By default, {{items}} will be replaced by the replaced by renderItems() which will contain
+     * the collectively rendered result of $itemView for the models in the current page
+     * @return string the rendering result
+     */
+	public function render($view, $params = []){
+		return preg_replace_callback('/{{(\\w+)}}/', function ($matches){
+            return method_exists($this, "render".ucfirst($matches[1]))? $this->{"render".ucfirst($matches[1])}() : $matches[0];
+        }, $this->view->render($this->parentView, ['dataProvider' => $this->dataProvider, 'widget' => $this] + $params));
+	}
+	
+	/**
+     * Renders the collective result of view specified in $itemView for all the data models.
+     * @return string the rendering result
+     */
+	public function renderItems(){
+		$rows = [];
+		$models = $this->dataProvider->models;
+		foreach($models as $model){
+			$rows[] = $this->view->render($this->itemView, ['model' => $model, 'widget' => $this]);
+		}
+		return implode("\n", $rows);
+	}
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

Facility for DataProvider-oriented custom template rendering through REST which features the following:
- Pagination Headers will be present in the Response Headers just as how it will be present when returning a DataProvider - which helps the client to navigate through the pages.
- Allows pagination, sorting, filtering and all other operations supported by DataProvider.

### Use Cases
 - Suppose they want to deliver the data in CSV like below:
```
title,image,content
ABC,abc.jpg,Content of ABC
MNO,mno.jpg,Content of MNO
XYZ,xyz.jpg,Content of XYZ
```
 - Suppose one has to render the API response in a specific format like below:
```
-begin-
--title=ABC
--image=abc.jpg
--content=Content of ABC
---
--title=MNO
--image=mno.jpg
--content=Content of MNO
---
--title=XYZ
--image=xyz.jpg
--content=Content of XYZ
-end-
```
 - Or in any situation where the user has to deliver custom formatted data through the API.

In all the above cases, the data can be paginated, sorted and filtered.

One can use this by simply returning the TemplateRenderer object as shown in the below code:
```
public function actionTest(){
    $dataProvider = new ActiveDataProvider(['query' => Model::find()->where($condition)])
    return new \yii\rest\TemplateRenderer([
            'dataProvider' => $dataProvider,
            'parentView' => '/path/to/parent-view', //path to the parent or wrapper view file
            'itemView' => '/path/to/item-view', //path to the item view file
        ]);
}
```
