### PR TITLE
radioList itemsOptions is ignored (#14230)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,7 +7,7 @@ Yii Framework 2 Change Log
 - Bug #15791: Added a warning when the form names conflict (s1lver, rustamwin)
 - Enh #16151: `ActiveQuery::getTableNameAndAlias()` is now protected (s1lver)
 - Bug #16657: Ensure widgets after run event result contains the result of the rendered widget (AdeAttwood)
-- Bug #14230: Fixed `itemsOptions` ignored in `checkBoxList` (s1lver)
+- Bug #14230: Fixed `itemsOptions` ignored in `checkBoxList` and `radioList` (s1lver)
 - Bug #14368: Added `role` attribute for active radio list (s1lver)
 - Bug #16680: Fixed ActiveField 'text' input with maxlength (s1lver)
 - Bug #5341: HasMany via two relations (shirase, cebe)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1041,10 +1041,10 @@ class BaseHtml
             if ($formatter !== null) {
                 $lines[] = call_user_func($formatter, $index, $label, $name, $checked, $value);
             } else {
-                $lines[] = static::radio($name, $checked, array_merge($itemOptions, [
+                $lines[] = static::radio($name, $checked, array_merge([
                     'value' => $value,
                     'label' => $encode ? static::encode($label) : $label,
-                ]));
+                ], $itemOptions));
             }
             $index++;
         }

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -795,6 +795,17 @@ EOD;
 EOD;
         $this->assertEqualsWithoutLE($expected, Html::radioList('test', ['value3'], $this->getDataItems3()));
         $this->assertEqualsWithoutLE($expected, Html::radioList('test', new \ArrayObject(['value3']), $this->getDataItems3()));
+
+        $expected = <<<'EOD'
+<div><label><input type="radio" name="test[]" value="0"> Test Label</label>
+<label><input type="radio" name="test[]" value="0"> Test Label</label></div>
+EOD;
+        $this->assertEqualsWithoutLE($expected, Html::radioList('test', null, $this->getDataItems(), [
+            'itemOptions' => [
+                'value' => 0,
+                'label' => 'Test Label'
+            ]
+        ]));
     }
 
     public function testUl()

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -797,8 +797,8 @@ EOD;
         $this->assertEqualsWithoutLE($expected, Html::radioList('test', new \ArrayObject(['value3']), $this->getDataItems3()));
 
         $expected = <<<'EOD'
-<div><label><input type="radio" name="test[]" value="0"> Test Label</label>
-<label><input type="radio" name="test[]" value="0"> Test Label</label></div>
+<div><label><input type="radio" name="test" value="0"> Test Label</label>
+<label><input type="radio" name="test" value="0"> Test Label</label></div>
 EOD;
         $this->assertEqualsWithoutLE($expected, Html::radioList('test', null, $this->getDataItems(), [
             'itemOptions' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14230
