### PR TITLE
Fix typos in example in "Adding custom Conditions and Expressions"

### DIFF
--- a/docs/guide/db-query-builder.md
+++ b/docs/guide/db-query-builder.md
@@ -915,15 +915,16 @@ class AllGreaterConditionBuilder implements \yii\db\ExpressionBuilderInterface
     use \yii\db\ExpressionBuilderTrait; // Contains constructor and `queryBuilder` property.
 
     /**
-     * @param AllGreaterCondition $condition the condition to be built
+     * @param ExpressionInterface $condition the condition to be built
      * @param array $params the binding parameters.
+     * @return AllGreaterCondition
      */ 
-    public function build(ExpressionInterface $condition, array &$params = [])
+    public function build(ExpressionInterface $expression, array &$params = [])
     {
         $value = $condition->getValue();
         
         $conditions = [];
-        foreach ($condition->getColumns() as $column) {
+        foreach ($expression->getColumns() as $column) {
             $conditions[] = new SimpleCondition($column, '>', $value);
         }
 

--- a/docs/guide/db-query-builder.md
+++ b/docs/guide/db-query-builder.md
@@ -912,13 +912,13 @@ namespace app\db\conditions;
 
 class AllGreaterConditionBuilder implements \yii\db\ExpressionBuilderInterface
 {
-    use \yii\db\Condition\ExpressionBuilderTrait; // Contains constructor and `queryBuilder` property.
+    use \yii\db\ExpressionBuilderTrait; // Contains constructor and `queryBuilder` property.
 
     /**
      * @param AllGreaterCondition $condition the condition to be built
      * @param array $params the binding parameters.
      */ 
-    public function build(ConditionInterface $condition, &$params)
+    public function build(ExpressionInterface $condition, array &$params = [])
     {
         $value = $condition->getValue();
         
@@ -927,7 +927,7 @@ class AllGreaterConditionBuilder implements \yii\db\ExpressionBuilderInterface
             $conditions[] = new SimpleCondition($column, '>', $value);
         }
 
-        return $this->queryBuider->buildCondition(new AndCondition($conditions), $params);
+        return $this->queryBuilder->buildCondition(new AndCondition($conditions), $params);
     }
 }
 ```


### PR DESCRIPTION
This example was non-working. Just fixed some typos

| Q             | A
| ------------- | ---
| Is bugfix?    | probably yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | doesn't matter 
