### PR TITLE
Optimize comment of LinkPager

### DIFF
--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -100,7 +100,7 @@ class LinkPager extends Widget
      */
     public $nextPageLabel = '&raquo;';
     /**
-     * @var string|bool the text label for the previous page button. Note that this will NOT be HTML-encoded.
+     * @var string|bool the text label for the "previous" page button. Note that this will NOT be HTML-encoded.
      * If this property is false, the "previous" page button will not be displayed.
      */
     public $prevPageLabel = '&laquo;';


### PR DESCRIPTION
Which losts the quote for `previous` .

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
