### PR TITLE
Savepoint unsupported detection in transaction begin

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -70,6 +70,7 @@ Yii Framework 2 Change Log
 - Bug #16666: Fixed `yii\helpers\ArrayHelper::merge` (rustamwin)
 - Enh: `yii\helpers\UnsetArrayValue`, `yii\helpers\ReplaceArrayValue` object now can be restored after serialization using `var_export()` function (silvefire)
 - Bug #16552: Added check in `yii\db\ActiveQuery::prepare()` to prevent populating already populated relation when another relation is requested with `via` (drlibra)
+- Bug #16424: `yii\db\Transaction::begin()` throws now `NotSupportedException` for nested transaction and DBMS not supporting savepoints (bizley)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/db/Transaction.php
+++ b/framework/db/Transaction.php
@@ -9,6 +9,7 @@ namespace yii\db;
 
 use Yii;
 use yii\base\InvalidConfigException;
+use yii\base\NotSupportedException;
 
 /**
  * Transaction represents a DB transaction.
@@ -109,7 +110,12 @@ class Transaction extends \yii\base\BaseObject
      * At the time of this writing affected DBMS are MSSQL and SQLite.
      *
      * [isolation level]: http://en.wikipedia.org/wiki/Isolation_%28database_systems%29#Isolation_levels
-     * @throws InvalidConfigException if [[db]] is `null`.
+     *
+     * Starting from version 2.0.16, this method throws exception when beginning nested transaction and underlying DBMS
+     * does not support savepoints.
+     * @throws InvalidConfigException if [[db]] is `null`
+     * @throws NotSupportedException if the DBMS does not support nested transactions
+     * @throws Exception if DB connection fails
      */
     public function begin($isolationLevel = null)
     {
@@ -137,6 +143,7 @@ class Transaction extends \yii\base\BaseObject
             $schema->createSavepoint('LEVEL' . $this->_level);
         } else {
             Yii::info('Transaction not started: nested transaction not supported', __METHOD__);
+            throw new NotSupportedException('Transaction not started: nested transaction not supported.');
         }
         $this->_level++;
     }
@@ -170,7 +177,6 @@ class Transaction extends \yii\base\BaseObject
 
     /**
      * Rolls back a transaction.
-     * @throws Exception if the transaction is not active
      */
     public function rollBack()
     {
@@ -194,8 +200,6 @@ class Transaction extends \yii\base\BaseObject
             $schema->rollBackSavepoint('LEVEL' . $this->_level);
         } else {
             Yii::info('Transaction not rolled back: nested transaction not supported', __METHOD__);
-            // throw an exception to fail the outer transaction
-            throw new Exception('Roll back failed: nested transaction not supported.');
         }
     }
 

--- a/tests/framework/db/ConnectionTest.php
+++ b/tests/framework/db/ConnectionTest.php
@@ -229,6 +229,17 @@ abstract class ConnectionTest extends DatabaseTestCase
         });
     }
 
+    public function testNestedTransactionNotSupported()
+    {
+        $connection = $this->getConnection();
+        $connection->enableSavepoint = false;
+        $connection->transaction(function (Connection $db) {
+            $this->assertNotNull($db->transaction);
+            $this->expectException('yii\base\NotSupportedException');
+            $db->beginTransaction();
+        });
+    }
+
     public function testEnableQueryLog()
     {
         $connection = $this->getConnection();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | should
| Fixed issues  | #16424

I agree with @lenyy that throwing exception in rollback is not needed since it will be thrown in `Transaction::begin()`.