### PR TITLE
Fix MySQL lock name length limit

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -75,6 +75,7 @@ Yii Framework 2 Change Log
 - Bug #10843: Additional hidden input rendered by `yii\helpers\BaseHtml` methods inherits `disabled` HTML option if provided and set to `true` (bizley)
 - Bug #16424: `yii\db\Transaction::begin()` throws now `NotSupportedException` for nested transaction and DBMS not supporting savepoints (bizley)
 - Bug #15204: `yii\helpers\BaseInflector::slug()` is not removing substrings matching provided replacement from given string anymore (bizley)
+- Bug #16836: Fix `yii\mutex\MysqlMutex` to handle locks with names longer than 64 character (rob006)
 
 
 2.0.15.1 March 21, 2018

--- a/framework/mutex/MysqlMutex.php
+++ b/framework/mutex/MysqlMutex.php
@@ -60,7 +60,7 @@ class MysqlMutex extends DbMutex
             /** @var \yii\db\Connection $db */
             return (bool) $db->createCommand(
                 'SELECT GET_LOCK(:name, :timeout)',
-                [':name' => $name, ':timeout' => $timeout]
+                [':name' => $this->hashLockName($name), ':timeout' => $timeout]
             )->queryScalar();
         });
     }
@@ -77,8 +77,19 @@ class MysqlMutex extends DbMutex
             /** @var \yii\db\Connection $db */
             return (bool) $db->createCommand(
                 'SELECT RELEASE_LOCK(:name)',
-                [':name' => $name]
+                [':name' => $this->hashLockName($name)]
             )->queryScalar();
         });
+    }
+
+    /**
+     * Generate hash for lock name to avoid exceeding lock name length limit.
+     *
+     * @param string $name
+     * @return string
+     * @since 2.0.16
+     */
+    protected function hashLockName($name) {
+        return sha1($name);
     }
 }

--- a/framework/mutex/MysqlMutex.php
+++ b/framework/mutex/MysqlMutex.php
@@ -88,6 +88,7 @@ class MysqlMutex extends DbMutex
      * @param string $name
      * @return string
      * @since 2.0.16
+     * @see https://github.com/yiisoft/yii2/pull/16836
      */
     protected function hashLockName($name) {
         return sha1($name);

--- a/tests/framework/mutex/FileMutexTest.php
+++ b/tests/framework/mutex/FileMutexTest.php
@@ -7,6 +7,7 @@
 
 namespace yiiunit\framework\mutex;
 
+use yii\base\InvalidConfigException;
 use yii\mutex\FileMutex;
 use yiiunit\TestCase;
 
@@ -21,7 +22,7 @@ class FileMutexTest extends TestCase
 
     /**
      * @return FileMutex
-     * @throws \yii\base\InvalidConfigException
+     * @throws InvalidConfigException
      */
     protected function createMutex()
     {
@@ -31,15 +32,21 @@ class FileMutexTest extends TestCase
         ]);
     }
 
-    public function testDeleteLockFile()
+    /**
+     * @dataProvider mutexDataProvider()
+     *
+     * @param string $mutexName
+     * @throws InvalidConfigException
+     */
+    public function testDeleteLockFile($mutexName)
     {
         $mutex = $this->createMutex();
-        $fileName = $mutex->mutexPath . '/' . md5(self::$mutexName) . '.lock';
+        $fileName = $mutex->mutexPath . '/' . md5($mutexName) . '.lock';
 
-        $mutex->acquire(self::$mutexName);
+        $mutex->acquire($mutexName);
         $this->assertFileExists($fileName);
 
-        $mutex->release(self::$mutexName);
+        $mutex->release($mutexName);
         $this->assertFileNotExists($fileName);
     }
 }

--- a/tests/framework/mutex/MutexTestTrait.php
+++ b/tests/framework/mutex/MutexTestTrait.php
@@ -7,6 +7,7 @@
 
 namespace yiiunit\framework\mutex;
 
+use yii\base\InvalidConfigException;
 use yii\mutex\Mutex;
 
 /**
@@ -14,32 +15,57 @@ use yii\mutex\Mutex;
  */
 trait MutexTestTrait
 {
-    public static $mutexName = 'testname';
-
     /**
      * @return Mutex
-     * @throws \yii\base\InvalidConfigException
+     * @throws InvalidConfigException
      */
     abstract protected function createMutex();
 
-    public function testMutexAcquire()
+    /**
+     * @dataProvider mutexDataProvider()
+     *
+     * @param string $mutexName
+     */
+    public function testMutexAcquire($mutexName)
     {
         $mutex = $this->createMutex();
 
-        $this->assertTrue($mutex->acquire(self::$mutexName));
-        $this->assertTrue($mutex->release(self::$mutexName));
+        $this->assertTrue($mutex->acquire($mutexName));
+        $this->assertTrue($mutex->release($mutexName));
     }
 
-    public function testThatMutexLockIsWorking()
+    /**
+     * @dataProvider mutexDataProvider()
+     *
+     * @param string $mutexName
+     */
+    public function testThatMutexLockIsWorking($mutexName)
     {
-        $mutexOne = $this->createMutex();
-        $mutexTwo = $this->createMutex();
+        $mutexOne = $this->createMutex($mutexName);
+        $mutexTwo = $this->createMutex($mutexName);
 
-        $this->assertTrue($mutexOne->acquire(self::$mutexName));
-        $this->assertFalse($mutexTwo->acquire(self::$mutexName));
+        $this->assertTrue($mutexOne->acquire($mutexName));
+        $this->assertFalse($mutexTwo->acquire($mutexName));
 
-        $mutexOne->release(self::$mutexName);
+        $mutexOne->release($mutexName);
 
-        $this->assertTrue($mutexTwo->acquire(self::$mutexName));
+        $this->assertTrue($mutexTwo->acquire($mutexName));
+    }
+
+    public static function mutexDataProvider()
+    {
+        $utf = <<<'UTF'
+𝐘˛𝜄 ӏ𝕤 𝗮 𝔣𝖺𐑈𝝉, 𐑈ℯ𝔠ｕ𝒓𝗲, 𝝰𝞹𝒹 𝖊𝘧𝒇𝗶𝕔𝖎ⅇπτ Ｐ𝘏𝙿 𝖿г𝖺ｍ𝖾ｗσｒ𝐤.
+𝓕lе𝘅ӏᏏlе 𝞬𝖾𝘁 ϱ𝘳ɑ𝖌ｍ𝛼𝓉ͺ𝖼. 
+𝑊ﮭ𝚛𝛞𝓼 𝔯𝕚𝕘һ𝞃 σ𝚞𝞽 ०𝒇 𝐭𝙝ҽ 𝗯𝘰𝘹. 
+𝓗𝚊𝘀 𝓇𝖾𝙖𝐬ﻬ𝓃𝕒ᖯl𝔢 ꓒ𝘦քα𝗎l𝐭ꜱ. 
+😱
+UTF;
+
+        return [
+            'simple name' => ['testname'],
+            'long name' => ['Y' . str_repeat('iiiiiiiiii', 1000)],
+            'UTF-8 garbage' => [$utf],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

> MySQL 5.7.5 and later enforces a maximum length on lock names of 64 characters. Previously, no limit was enforced.

See https://github.com/symfony/symfony/pull/27250
