### PR TITLE
Add `$message` parameter to `TestCase::assertEqualsWithoutLE()`

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -112,13 +112,14 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * Asserting two strings equality ignoring line endings.
      * @param string $expected
      * @param string $actual
+     * @param string $message
      */
-    protected function assertEqualsWithoutLE($expected, $actual)
+    protected function assertEqualsWithoutLE($expected, $actual, $message = '')
     {
         $expected = str_replace("\r\n", "\n", $expected);
         $actual = str_replace("\r\n", "\n", $actual);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertEquals($expected, $actual, $message);
     }
 
     /**


### PR DESCRIPTION
This allows to set custom error message in `assertEqualsWithoutLE()`

This third parameter is already used in some tests, even if it was not supported until now :P:

https://github.com/yiisoft/yii2/blob/ba0a3c00ca36a26f2f34b09d31230e4d83bd831e/tests/framework/mail/BaseMailerTest.php#L273-L274