### PR TITLE
[Bug] MysqlMutexTest and PgsqlMutexTest allows to acquire the same lock multiple times

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -78,6 +78,7 @@ Yii Framework 2 Change Log
 - Bug #15204: `yii\helpers\BaseInflector::slug()` is not removing substrings matching provided replacement from given string anymore (bizley)
 - Bug #16101: Fixed Error Handler to clear registered meta tags, link tags, css/js scripts and files in error view (bizley)
 - Bug #16836: Fix `yii\mutex\MysqlMutex` to handle locks with names longer than 64 characters (rob006)
+- Bug #16838: `yii\mutex\Mutex::acquire()` no longer returns `true` if lock is already acquired by the same component in the same process (rob006)
 - Enh #16839: Increase frequency of lock tries for `yii\mutex\FileMutex::acquireLock()` when $timeout is provided (rob006)
 - Enh #16839: Add support for `$timeout` in  `yii\mutex\PgsqlMutex::acquire()` (rob006)
 - Bug #16828: `yii\console\controllers\MessageController::translator` recognized object' methods and functions calls as identical sets of tokens (erickskrauch)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -62,6 +62,17 @@ Upgrade from Yii 2.0.15
   ```json
   "cebe/markdown": "~1.1.0",
   ```
+  
+* `yii\mutex\Mutex::acquire()` no longer returns `true` if lock is already acquired by the same component in the same process.
+  Make sure that you're not trying to acquire the same lock multiple times in a way that may create infinite loops, for example:
+    
+  ```php
+  if (Yii::$app->mutex->acquire('test')) {
+       while (!Yii::$app->mutex->acquire('test')) {
+           // `Yii::$app->mutex->acquire('test')` will always return `false` here, since lock is already acquired
+      }
+  }
+  ```
 
 
 Upgrade from Yii 2.0.14

--- a/framework/mutex/Mutex.php
+++ b/framework/mutex/Mutex.php
@@ -69,7 +69,7 @@ abstract class Mutex extends Component
      */
     public function acquire($name, $timeout = 0)
     {
-        if ($this->acquireLock($name, $timeout)) {
+        if (!in_array($name, $this->_locks, true) && $this->acquireLock($name, $timeout)) {
             $this->_locks[] = $name;
 
             return true;

--- a/tests/framework/mutex/MutexTestTrait.php
+++ b/tests/framework/mutex/MutexTestTrait.php
@@ -46,10 +46,11 @@ trait MutexTestTrait
 
         $this->assertTrue($mutexOne->acquire($mutexName));
         $this->assertFalse($mutexTwo->acquire($mutexName));
-
-        $mutexOne->release($mutexName);
+        $this->assertTrue($mutexOne->release($mutexName));
+        $this->assertFalse($mutexTwo->release($mutexName));
 
         $this->assertTrue($mutexTwo->acquire($mutexName));
+        $this->assertTrue($mutexTwo->release($mutexName));
     }
 
     /**

--- a/tests/framework/mutex/MutexTestTrait.php
+++ b/tests/framework/mutex/MutexTestTrait.php
@@ -41,8 +41,8 @@ trait MutexTestTrait
      */
     public function testThatMutexLockIsWorking($mutexName)
     {
-        $mutexOne = $this->createMutex($mutexName);
-        $mutexTwo = $this->createMutex($mutexName);
+        $mutexOne = $this->createMutex();
+        $mutexTwo = $this->createMutex();
 
         $this->assertTrue($mutexOne->acquire($mutexName));
         $this->assertFalse($mutexTwo->acquire($mutexName));
@@ -50,6 +50,22 @@ trait MutexTestTrait
         $mutexOne->release($mutexName);
 
         $this->assertTrue($mutexTwo->acquire($mutexName));
+    }
+
+    /**
+     * @dataProvider mutexDataProvider()
+     *
+     * @param string $mutexName
+     */
+    public function testThatMutexLockIsWorkingOnTheSameComponent($mutexName)
+    {
+        $mutex = $this->createMutex();
+
+        $this->assertTrue($mutex->acquire($mutexName));
+        $this->assertFalse($mutex->acquire($mutexName));
+
+        $this->assertTrue($mutex->release($mutexName));
+        $this->assertFalse($mutex->release($mutexName));
     }
 
     public function testTimeout()


### PR DESCRIPTION
I'm not sure if this is a bug, but it is quite surprising and a little scary that I can acquire the same lock multiple times if I use the same component (and the same DB connection).