### PR TITLE
Increase frequency of lock tries when $timeout is used in FileMutex

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -76,7 +76,9 @@ Yii Framework 2 Change Log
 - Bug #16424: `yii\db\Transaction::begin()` throws now `NotSupportedException` for nested transaction and DBMS not supporting savepoints (bizley)
 - Bug #15204: `yii\helpers\BaseInflector::slug()` is not removing substrings matching provided replacement from given string anymore (bizley)
 - Bug #16101: Fixed Error Handler to clear registered meta tags, link tags, css/js scripts and files in error view (bizley)
-- Bug #16836: Fix `yii\mutex\MysqlMutex` to handle locks with names longer than 64 character (rob006)
+- Bug #16836: Fix `yii\mutex\MysqlMutex` to handle locks with names longer than 64 characters (rob006)
+- Enh #16839: Increase frequency of lock tries for `yii\mutex\FileMutex::acquireLock()` when $timeout is provided (rob006)
+- Enh #16839: Add support for `$timeout` in  `yii\mutex\PgsqlMutex::acquire()` (rob006)
 
 
 2.0.15.1 March 21, 2018

--- a/framework/mutex/PgsqlMutex.php
+++ b/framework/mutex/PgsqlMutex.php
@@ -36,6 +36,8 @@ use yii\base\InvalidConfigException;
  */
 class PgsqlMutex extends DbMutex
 {
+    use RetryAcquireTrait;
+
     /**
      * Initializes PgSQL specific mutex component implementation.
      * @throws InvalidConfigException if [[db]] is not PgSQL connection.
@@ -67,16 +69,16 @@ class PgsqlMutex extends DbMutex
      */
     protected function acquireLock($name, $timeout = 0)
     {
-        if ($timeout !== 0) {
-            throw new InvalidArgumentException('PgsqlMutex does not support timeout.');
-        }
         list($key1, $key2) = $this->getKeysFromName($name);
-        return $this->db->useMaster(function ($db) use ($key1, $key2) {
-            /** @var \yii\db\Connection $db */
-            return (bool) $db->createCommand(
-                'SELECT pg_try_advisory_lock(:key1, :key2)',
-                [':key1' => $key1, ':key2' => $key2]
-            )->queryScalar();
+
+        return $this->retryAcquire($timeout, function () use ($key1, $key2) {
+            return $this->db->useMaster(function ($db) use ($key1, $key2) {
+                /** @var \yii\db\Connection $db */
+                return (bool) $db->createCommand(
+                    'SELECT pg_try_advisory_lock(:key1, :key2)',
+                    [':key1' => $key1, ':key2' => $key2]
+                )->queryScalar();
+            });
         });
     }
 

--- a/framework/mutex/RetryAcquireTrait.php
+++ b/framework/mutex/RetryAcquireTrait.php
@@ -21,7 +21,7 @@ trait RetryAcquireTrait
      * @var int Number of milliseconds between each try in [[acquire()]] until specified timeout times out.
      * By default it is 50 milliseconds - it means that [[acquire()]] may try acquire lock up to 20 times per second.
      */
-    public $retryFrequency = 50;
+    public $retryDelay = 50;
 
 
     private function retryAcquire($timeout, Closure $callback)
@@ -31,6 +31,7 @@ trait RetryAcquireTrait
             if ($callback()) {
                 return true;
             }
+            usleep($this->retryDelay * 1000);
         } while (microtime(true) - $start < $timeout);
 
         return false;

--- a/framework/mutex/RetryAcquireTrait.php
+++ b/framework/mutex/RetryAcquireTrait.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\mutex;
+
+use Closure;
+
+/**
+ * Trait RetryAcquireTrait.
+ *
+ * @author Robert Korulczyk <robert@korulczyk.pl>
+ * @internal
+ */
+trait RetryAcquireTrait
+{
+    /**
+     * @var int Number of milliseconds between each try in [[acquire()]] until specified timeout times out.
+     * By default it is 50 milliseconds - it means that [[acquire()]] may try acquire lock up to 20 times per second.
+     */
+    public $retryFrequency = 50;
+
+
+    private function retryAcquire($timeout, Closure $callback)
+    {
+        $start = microtime(true);
+        do {
+            if ($callback()) {
+                return true;
+            }
+        } while (microtime(true) - $start < $timeout);
+
+        return false;
+    }
+}

--- a/framework/mutex/RetryAcquireTrait.php
+++ b/framework/mutex/RetryAcquireTrait.php
@@ -20,6 +20,7 @@ trait RetryAcquireTrait
     /**
      * @var int Number of milliseconds between each try in [[acquire()]] until specified timeout times out.
      * By default it is 50 milliseconds - it means that [[acquire()]] may try acquire lock up to 20 times per second.
+     * @since 2.0.16
      */
     public $retryDelay = 50;
 

--- a/tests/framework/mutex/MutexTestTrait.php
+++ b/tests/framework/mutex/MutexTestTrait.php
@@ -34,6 +34,19 @@ trait MutexTestTrait
         $this->assertTrue($mutex->release($mutexName));
     }
 
+    public function testTimeout() {
+        $mutex = $this->createMutex();
+        $mutexName = __FUNCTION__;
+
+        $this->assertTrue($mutex->acquire($mutexName));
+        $microtime = microtime(true);
+        $this->assertFalse($mutex->acquire($mutexName, 1));
+        $diff = microtime(true) - $microtime;
+        $this->assertTrue($diff >= 1 && $diff < 2);
+        $this->assertTrue($mutex->release($mutexName));
+        $this->assertFalse($mutex->release($mutexName));
+    }
+
     /**
      * @dataProvider mutexDataProvider()
      *

--- a/tests/framework/mutex/MutexTestTrait.php
+++ b/tests/framework/mutex/MutexTestTrait.php
@@ -34,19 +34,6 @@ trait MutexTestTrait
         $this->assertTrue($mutex->release($mutexName));
     }
 
-    public function testTimeout() {
-        $mutex = $this->createMutex();
-        $mutexName = __FUNCTION__;
-
-        $this->assertTrue($mutex->acquire($mutexName));
-        $microtime = microtime(true);
-        $this->assertFalse($mutex->acquire($mutexName, 1));
-        $diff = microtime(true) - $microtime;
-        $this->assertTrue($diff >= 1 && $diff < 2);
-        $this->assertTrue($mutex->release($mutexName));
-        $this->assertFalse($mutex->release($mutexName));
-    }
-
     /**
      * @dataProvider mutexDataProvider()
      *
@@ -63,6 +50,21 @@ trait MutexTestTrait
         $mutexOne->release($mutexName);
 
         $this->assertTrue($mutexTwo->acquire($mutexName));
+    }
+
+    public function testTimeout()
+    {
+        $mutexName = __FUNCTION__;
+        $mutexOne = $this->createMutex();
+        $mutexTwo = $this->createMutex();
+
+        $this->assertTrue($mutexOne->acquire($mutexName));
+        $microtime = microtime(true);
+        $this->assertFalse($mutexTwo->acquire($mutexName, 1));
+        $diff = microtime(true) - $microtime;
+        $this->assertTrue($diff >= 1 && $diff < 2);
+        $this->assertTrue($mutexOne->release($mutexName));
+        $this->assertFalse($mutexTwo->release($mutexName));
     }
 
     public static function mutexDataProvider()

--- a/tests/framework/mutex/RetryAcquireTraitTest.php
+++ b/tests/framework/mutex/RetryAcquireTraitTest.php
@@ -24,7 +24,8 @@ class RetryAcquireTraitTest extends TestCase
     /**
      * @throws InvalidConfigException
      */
-    public function testRetryAcquire() {
+    public function testRetryAcquire()
+    {
         $mutexName = __FUNCTION__;
         $mutexOne = $this->createMutex();
         $mutexTwo = $this->createMutex();

--- a/tests/framework/mutex/RetryAcquireTraitTest.php
+++ b/tests/framework/mutex/RetryAcquireTraitTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\mutex;
+
+use Yii;
+use yii\base\InvalidConfigException;
+use yiiunit\framework\mutex\mocks\DumbMutex;
+use yiiunit\TestCase;
+
+/**
+ * Class RetryAcquireTraitTest.
+ *
+ * @group mutex
+ *
+ * @author Robert Korulczyk <robert@korulczyk.pl>
+ */
+class RetryAcquireTraitTest extends TestCase
+{
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testRetryAcquire() {
+        $mutexName = __FUNCTION__;
+        $mutexOne = $this->createMutex();
+        $mutexTwo = $this->createMutex();
+
+        $this->assertTrue($mutexOne->acquire($mutexName));
+        $this->assertFalse($mutexTwo->acquire($mutexName, 1));
+
+        $this->assertSame(20, $mutexTwo->attemptsCounter);
+    }
+
+    /**
+     * @return DumbMutex
+     * @throws InvalidConfigException
+     */
+    private function createMutex()
+    {
+        return Yii::createObject([
+            'class' => DumbMutex::className(),
+        ]);
+    }
+}

--- a/tests/framework/mutex/mocks/DumbMutex.php
+++ b/tests/framework/mutex/mocks/DumbMutex.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\mutex\mocks;
+
+use yii\mutex\Mutex;
+use yii\mutex\RetryAcquireTrait;
+
+/**
+ * Class DumbMutex.
+ *
+ * @author Robert Korulczyk <robert@korulczyk.pl>
+ */
+class DumbMutex extends Mutex
+{
+    use RetryAcquireTrait;
+
+    public $attemptsCounter = 0;
+    public static $locked = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function acquireLock($name, $timeout = 0)
+    {
+        return $this->retryAcquire($timeout, function () {
+            $this->attemptsCounter++;
+            if (!static::$locked) {
+                static::$locked = true;
+
+                return true;
+            }
+
+            return false;
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function releaseLock($name)
+    {
+        if (static::$locked) {
+            static::$locked = false;
+
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

This changes frequency of lock tries for `FileMutex::acquireLock()` when `$timeout` is provided (and make it configurable). Previously it was once try per second, now it is 20 tries per second. 

See https://github.com/yiisoft/yii2-queue/pull/244#issuecomment-406853925

