### PR TITLE
Update GridView.php

### DIFF
--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -265,6 +265,13 @@ class GridView extends BaseListView
      */
     public $layout = "{summary}\n{items}\n{pager}";
 
+    /*
+     * To be able to override the base Asset for the GridView to your own.
+     * @see https://github.com/yiisoft/yii2/pull/16844
+     * @var string Class for GridViewAsset without leading slash
+     * Defaults to 'yii\grid\GridViewAsset'.
+     */
+    public $gridViewAssetClass;
 
     /**
      * Initializes the grid view.
@@ -294,10 +301,16 @@ class GridView extends BaseListView
     public function run()
     {
         $view = $this->getView();
-        GridViewAsset::register($view);
         $id = $this->options['id'];
         $options = Json::htmlEncode(array_merge($this->getClientOptions(), ['filterOnFocusOut' => $this->filterOnFocusOut]));
-        $view->registerJs("jQuery('#$id').yiiGridView($options);");
+        $baseGridViewAsset = 'yii\grid\GridViewAsset';
+        if (!($gridViewAsset = $this->gridViewAssetClass) {
+            $gridViewAsset = $baseGridViewAsset;
+        }
+        if (is_subclass_of($gridViewAsset, $baseGridViewAsset) || $gridViewAsset == $baseGridViewAsset) {
+            $gridViewAsset::register($view);
+            $view->registerJs("jQuery('#$id').yiiGridView($options);");
+        }
         parent::run();
     }
 

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -265,7 +265,7 @@ class GridView extends BaseListView
      */
     public $layout = "{summary}\n{items}\n{pager}";
 
-    /*
+    /**
      * To be able to override the base Asset for the GridView to your own.
      * @see https://github.com/yiisoft/yii2/pull/16844
      * @var string Class for GridViewAsset without leading slash

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -304,7 +304,7 @@ class GridView extends BaseListView
         $id = $this->options['id'];
         $options = Json::htmlEncode(array_merge($this->getClientOptions(), ['filterOnFocusOut' => $this->filterOnFocusOut]));
         $baseGridViewAsset = 'yii\grid\GridViewAsset';
-        if (!($gridViewAsset = $this->gridViewAssetClass) {
+        if (!($gridViewAsset = $this->gridViewAssetClass)) {
             $gridViewAsset = $baseGridViewAsset;
         }
         if (is_subclass_of($gridViewAsset, $baseGridViewAsset) || $gridViewAsset == $baseGridViewAsset) {


### PR DESCRIPTION
If you do not want to make changes to yii.gridView.js, let at least be able to override GridViewAsset and connect your version of yii.gridView.js there. 

Because in our application there are no default filters that need to be rewritten when filtering, but the problem with long URLs after parameter substitution when using filtering is very relevant for us. 

Thank you in advance!

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Tests pass?   | yes
| Fixed issues  | https://github.com/yiisoft/yii2/pull/16844
