### PR TITLE
try to check if property exist

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -202,7 +202,7 @@ class BaseArrayHelper
             $key = substr($key, $pos + 1);
         }
 
-        if (is_object($array)) {
+        if (is_object($array) && isset($array->$key)) {
             // this is expected to fail if the property does not exist, or __get() is not implemented
             // it is not reliably possible to check whether a property is accessible beforehand
             return $array->$key;


### PR DESCRIPTION
I have a really simple php configure file return an object. like:
```
<?php
return (object) array(
	'attributes' => (object) array(
		'id' => '27019',
	)
);

```
Try to get 'scene' with default value 1 passed in , but return null. 
Through `isset` check not the best idea , but just don't make things worse, isn't it?

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
