### PR TITLE
Allow `\yii\console\widgets\Table` to render empty table

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -82,6 +82,7 @@ Yii Framework 2 Change Log
 - Enh #16839: Increase frequency of lock tries for `yii\mutex\FileMutex::acquireLock()` when $timeout is provided (rob006)
 - Enh #16839: Add support for `$timeout` in  `yii\mutex\PgsqlMutex::acquire()` (rob006)
 - Bug #16828: `yii\console\controllers\MessageController::translator` recognized object' methods and functions calls as identical sets of tokens (erickskrauch)
+- Bug #16858: Allow `\yii\console\widgets\Table` to render empty table when headers provided but no columns (damiandziaduch)
 
 
 2.0.15.1 March 21, 2018

--- a/framework/console/widgets/Table.php
+++ b/framework/console/widgets/Table.php
@@ -310,7 +310,11 @@ class Table extends Widget
         $screenWidth = $this->getScreenWidth() - self::CONSOLE_SCROLLBAR_OFFSET;
 
         $headerCount = count($this->_headers);
-        $rowColCount = max(array_map('count', $this->_rows));
+        if (empty($this->_rows)) {
+            $rowColCount = 0;
+        } else {
+            $rowColCount = max(array_map('count', $this->_rows));
+        }
         $count = max($headerCount, $rowColCount);
         for ($i = 0; $i < $count; $i++) {
             $columns[] = ArrayHelper::getColumn($this->_rows, $i);

--- a/tests/framework/console/widgets/TableTest.php
+++ b/tests/framework/console/widgets/TableTest.php
@@ -269,4 +269,20 @@ EXPECTED;
         ])->setScreenWidth(200)->run()
         );
     }
+
+    public function testEmptyTable()
+    {
+        $table = new Table();
+
+        $expected = <<<'EXPECTED'
+╔═══════╤═══════╤═══════╗
+║ test1 │ test2 │ test3 ║
+╚═══════╧═══════╧═══════╝
+
+EXPECTED;
+
+        $this->assertEqualsWithoutLE($expected, $table->setHeaders(['test1', 'test2', 'test3'])
+            ->setRows([])->setScreenWidth(200)->run()
+        );
+    }
 }


### PR DESCRIPTION
When headers provided but no columns.
Ref #16858

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #16858