### PR TITLE
Update Request.php (add file methods)

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -10,6 +10,7 @@ namespace yii\web;
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\validators\IpValidator;
+use yii\web\UploadedFile;
 
 /**
  * The web Request class represents an HTTP request.
@@ -595,6 +596,42 @@ class Request extends \yii\base\Request
         }
 
         return isset($params[$name]) ? $params[$name] : $defaultValue;
+    }
+
+
+    /**
+     * Returns an uploaded file according to the given file input name or the given model attribute.
+     * The name can be a plain string or a string like an array element (e.g. 'Post[imageFile]', or 'Post[0][imageFile]')
+	 * or "imageFile" (if $model is the data model).
+     * @param string $name the name of the file input field.
+	 * @param \yii\base\Model $model the data model
+     * @return null|UploadedFile the instance of the uploaded file.
+     * Null is returned if no file is uploaded for the specified name.
+     */
+    public function file($name, $model = null)
+    {
+        if($model === null)
+            return UploadedFile::getInstanceByName($name);
+        else
+		    return UploadedFile::getInstance($model, $name);
+    }
+
+    /**
+     * Returns an array of uploaded files corresponding to the specified file input name or the given model attribute.
+     * This is mainly used when multiple files were uploaded and saved as 'files[0]', 'files[1]',
+     * 'files[n]'..., and you can retrieve them all by passing 'files' as the name.
+     * @param string $name the name of the array of files
+	 * @param \yii\base\Model $model the data model
+     * @return UploadedFile[] the array of UploadedFile objects. Empty array is returned
+     * if no adequate upload was found. Please note that this array will contain
+     * all files from all sub-arrays regardless how deeply nested they are.
+     */
+    public function files($name, $model = null)
+    {
+        if($model === null)
+		    return UploadedFile::getInstancesByName($name);
+		else
+			return UploadedFile::getInstances($model, $name);
     }
 
     /**


### PR DESCRIPTION
Add methods Request::file($name) and Request::files($name).
input[type=text] and input[type=file] it's one request.
The request object must have a methods to retrieve the uploaded files.

This is ugly code:
$form->attributes = Yii::$app->request->post();
$form->file           = UploadedFile::getInstance($form, 'file');

This is a beautiful code:
$form->attributes = Yii::$app->request->post();
$form->file           = Yii::$app->request->file('file');

| Q             | A
| ------------- | ---
| New feature?  | yes

