### PR TITLE
Wrong test removed

### DIFF
--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -1296,6 +1296,8 @@ class Formatter extends Component
      * @return string the formatted result.
      * @throws InvalidArgumentException if the input value is not numeric or the formatting failed.
      * @throws InvalidConfigException when the [PHP intl extension](http://php.net/manual/en/book.intl.php) is not available.
+     *
+     * This formatter does not work well with very big numbers.
      */
     public function asSpellout($value)
     {

--- a/tests/framework/i18n/FormatterNumberTest.php
+++ b/tests/framework/i18n/FormatterNumberTest.php
@@ -525,11 +525,6 @@ class FormatterNumberTest extends TestCase
     {
         $this->assertSame('one hundred twenty-three', $this->formatter->asSpellout(123));
 
-        $this->assertSame(
-            'eighteen quadrillion fourteen trillion three hundred ninety-eight billion five hundred nine million four hundred eighty-one thousand nine hundred eighty-four',
-            $this->formatter->asSpellout('87654321098765436')
-        );
-
         $this->formatter->locale = 'de_DE';
         $this->assertSame('ein­hundert­drei­und­zwanzig', $this->formatter->asSpellout(123));
 


### PR DESCRIPTION
I'm sorry but spellout formatter, just like ordinal one does not work well with very big numbers.

I really don't know why I've put this test here and decided it's fine and dandy.