### PR TITLE
#16580: Check for unused php message files in MessageController if $r…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.16 under development
 ------------------------
 
+- Enh #16580: Check for unused php message files in MessageController if `$removeUnused` option is on (Groonya)
 - Bug #16903: Fixed 'yii\validators\NumberValidator' method 'isNotNumber' returns false for true/false value (annechko)
 - Bug #16648: Html::strtolower() was corrupting UTF-8 strings (Kolyunya)
 - Bug #13977: Skip validation if file input does not exist (RobinKamps, s1lver)

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -665,6 +665,10 @@ EOD;
             $this->stdout("Saving messages to $coloredFileName...\n");
             $this->saveMessagesCategoryToPHP($msgs, $file, $overwrite, $removeUnused, $sort, $category, $markUnused);
         }
+
+        if ($removeUnused) {
+            $this->checkForUnusedPhpMessageFiles($dirName, array_keys($messages));
+        }
     }
 
     /**
@@ -880,6 +884,17 @@ EOD;
             $this->stdout("Translation saved.\n", Console::FG_GREEN);
         } else {
             $this->stdout("Nothing to save.\n", Console::FG_GREEN);
+        }
+    }
+
+    private function checkForUnusedPhpMessageFiles($dirName, $existedCategories)
+    {
+        $messageFiles = FileHelper::findFiles($dirName);
+        foreach ($messageFiles as $file) {
+            $category = preg_replace('#\.php$#', '', basename($file));
+            if (!in_array($category, $existedCategories, true)) {
+                $this->stdout("File {$file} doesn't has any translations and can be deleted.\n", Console::FG_YELLOW);
+            }
         }
     }
 

--- a/tests/framework/console/controllers/PHPMessageControllerTest.php
+++ b/tests/framework/console/controllers/PHPMessageControllerTest.php
@@ -122,4 +122,29 @@ class PHPMessageControllerTest extends BaseMessageControllerTest
         $expected = "<?php\n/*file header*/\n/*doc block*/\n";
         $this->assertEqualsWithoutLE($expected, $head);
     }
+
+    public function testUnusedMessageFileWarning()
+    {
+        $category = 'test_delete_category';
+        $this->saveMessages(['test message' => 'test translation'], $category);
+        $filePath = $this->getMessageFilePath($category);
+
+        $this->saveConfigFile($this->getConfig([
+            'removeUnused' => true,
+        ]));
+        $out = $this->runMessageControllerAction('extract', [$this->configFileName]);
+        $this->assertNotFalse(strpos($out, "File {$filePath} doesn't has any translations and can be deleted."),
+            "Controller should respond with \"File {$filePath} doesn't has any translations and can be deleted\" 
+            if there's no translation in file anymore and \"removeUnused\" option equals true. Command output:\n\n" . $out);
+
+
+        $this->saveConfigFile($this->getConfig([
+            'removeUnused' => false,
+        ]));
+        $out = $this->runMessageControllerAction('extract', [$this->configFileName]);
+
+        $this->assertFalse(strpos($out, "File {$filePath} doesn't has any translations and can be deleted."),
+            "Controller should not respond with \"File {$filePath} doesn't has any translations and can be deleted\" 
+            if there's no translation in file anymore but \"removeUnused\" option equals false. Command output:\n\n" . $out);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no (I'm not sure)
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #16580 

I think files deleting is dangerous because we don't know what categories already exists (user can put his own files in messages dir), so I just implemented a notice.