### PR TITLE
10.3.10-MariaDB-1:10 fix defaultValues for current_timestamp()

### DIFF
--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -287,7 +287,8 @@ SQL;
         $column->phpType = $this->getColumnPhpType($column);
 
         if (!$column->isPrimaryKey) {
-            if (($column->type === 'timestamp' || $column->type ==='datetime') && $info['default'] === 'CURRENT_TIMESTAMP') {
+            if (($column->type === 'timestamp' || $column->type ==='datetime') &&
+                $info['default'] === 'CURRENT_TIMESTAMP' || $info['default'] === 'current_timestamp()') {
                 $column->defaultValue = new Expression('CURRENT_TIMESTAMP');
             } elseif (isset($type) && $type === 'bit') {
                 $column->defaultValue = bindec(trim($info['default'], 'b\''));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| Breaks BC? | no
| Tests pass? | yes



