### PR TITLE
Bugfix #16469: Allow cache to be specified as interface

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -92,6 +92,7 @@ Yii Framework 2 Change Log
 - Bug #14950: Fixed `yii\i18n\Formatter` methods `asInteger`, `asDecimal`, `asPercent`, and `asCurrency` outputs for very big numbers (bizley)
 - Bug #16897: Fixed `yii\db\sqlite\Schema` missing primary key constraint detection in case of `INTEGER PRIMARY KEY` (bizley)
 - Bug #16687: Add missing translations for `nl-NL` durations used in `yii\i18n\Formatter::asDuration()` (alexeevdv)
+- Bug #16469: Allow cache to be specified as interface and to be configured in DI container (alexeevdv)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/console/controllers/CacheController.php
+++ b/framework/console/controllers/CacheController.php
@@ -290,7 +290,7 @@ class CacheController extends Controller
      */
     private function isCacheClass($className)
     {
-        return is_subclass_of($className, 'yii\caching\CacheInterface');
+        return is_subclass_of($className, 'yii\caching\CacheInterface') || $className === 'yii\caching\CacheInterface';
     }
 
     /**

--- a/tests/framework/console/controllers/CacheControllerTest.php
+++ b/tests/framework/console/controllers/CacheControllerTest.php
@@ -53,6 +53,7 @@ class CacheControllerTest extends TestCase
                 'secondCache' => function () {
                     return new ArrayCache();
                 },
+                'thirdCache' => 'yii\caching\CacheInterface',
                 'session' => 'yii\web\CacheSession', // should be ignored at `actionFlushAll()`
                 'db' => [
                     'class' => isset($config['class']) ? $config['class'] : 'yii\db\Connection',
@@ -62,6 +63,13 @@ class CacheControllerTest extends TestCase
                     'enableSchemaCache' => true,
                     'schemaCache' => 'firstCache',
                 ],
+            ],
+            'container' => [
+                'singletons' => [
+                    'yii\caching\CacheInterface' => [
+                        'class' => 'yii\caching\DummyCache',
+                    ],
+                ]
             ],
         ]);
 
@@ -140,11 +148,13 @@ class CacheControllerTest extends TestCase
     public function testFlushAll()
     {
         Yii::$app->firstCache->set('firstKey', 'firstValue');
-        Yii::$app->secondCache->set('thirdKey', 'secondValue');
+        Yii::$app->secondCache->set('secondKey', 'secondValue');
+        Yii::$app->thirdCache->set('thirdKey', 'thirdValue');
 
         $this->_cacheController->actionFlushAll();
 
         $this->assertFalse(Yii::$app->firstCache->get('firstKey'), 'first cache data should be flushed');
-        $this->assertFalse(Yii::$app->secondCache->get('thirdKey'), 'second cache data should be flushed');
+        $this->assertFalse(Yii::$app->secondCache->get('secondKey'), 'second cache data should be flushed');
+        $this->assertFalse(Yii::$app->thirdCache->get('thirdKey'), 'third cache data should be flushed');
     }
 }

--- a/tests/framework/console/controllers/CacheControllerTest.php
+++ b/tests/framework/console/controllers/CacheControllerTest.php
@@ -67,7 +67,7 @@ class CacheControllerTest extends TestCase
             'container' => [
                 'singletons' => [
                     'yii\caching\CacheInterface' => [
-                        'class' => 'yii\caching\DummyCache',
+                        'class' => 'yii\caching\ArrayCache',
                     ],
                 ]
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #16469 
