### PR TITLE
Fixed issue with PageCache storing empty pages

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.16 under development
 ------------------------
 - Bug #16910: Fix messages sorting on extract (Groonya)
-
+- Bug #16969: Fix `yii\filters\PageCache` incorrectly storing empty data in some cases (sammousa)
 - Bug #15683: Fixed file as array uploading in MultipartFormDataParser (Groonya)
 - Bug #16822: Create config dir recursively in message/config (Groonya)
 - Bug #16580: Delete unused php message files in MessageController if `$removeUnused` option is on (Groonya)

--- a/framework/filters/PageCache.php
+++ b/framework/filters/PageCache.php
@@ -231,7 +231,6 @@ class PageCache extends ActionFilter implements DynamicContentAwareInterface
      */
     public function cacheResponse()
     {
-
         $this->view->popDynamicContent();
         $beforeCacheResponseResult = $this->beforeCacheResponse();
         if ($beforeCacheResponseResult === false) {

--- a/framework/filters/PageCache.php
+++ b/framework/filters/PageCache.php
@@ -231,6 +231,7 @@ class PageCache extends ActionFilter implements DynamicContentAwareInterface
      */
     public function cacheResponse()
     {
+
         $this->view->popDynamicContent();
         $beforeCacheResponseResult = $this->beforeCacheResponse();
         if ($beforeCacheResponseResult === false) {
@@ -239,6 +240,7 @@ class PageCache extends ActionFilter implements DynamicContentAwareInterface
         }
 
         $response = Yii::$app->getResponse();
+        $response->off(Response::EVENT_AFTER_SEND, [$this, 'cacheResponse']);
         $data = [
             'cacheVersion' => static::PAGE_CACHE_VERSION,
             'cacheData' => is_array($beforeCacheResponseResult) ? $beforeCacheResponseResult : null,


### PR DESCRIPTION
Fixed issue with PageCache storing empty pages when multiple RESPONSE_AFTER_SEND events are triggered

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
Fixed issues  | See https://github.com/Codeception/Codeception/issues/5296
