### PR TITLE
Fixes #16028: valid serialization of complex cache keys that contain non-UTF sequences

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.16 under development
 ------------------------
 
+- Bug #16028: Fix serialization of complex cache keys that contain non-UTF sequences (rugabarbo)
 - Bug #15850: check basePath is writable on publish in AssetManager (Groonya)
 - Bug #16910: Fix messages sorting on extract (Groonya)
 - Bug #16969: Fix `yii\filters\PageCache` incorrectly storing empty data in some cases (sammousa)

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -79,6 +79,19 @@ abstract class Cache extends Component implements CacheInterface
      */
     public $defaultDuration = 0;
 
+    /**
+     * @var bool whether [igbinary serialization](http://pecl.php.net/package/igbinary) is available or not.
+     */
+    private $_igbinaryAvailable = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        parent::init();
+        $this->_igbinaryAvailable = \extension_loaded('igbinary');
+    }
 
     /**
      * Builds a normalized cache key from a given key.
@@ -95,7 +108,13 @@ abstract class Cache extends Component implements CacheInterface
         if (is_string($key)) {
             $key = ctype_alnum($key) && StringHelper::byteLength($key) <= 32 ? $key : md5($key);
         } else {
-            $key = md5(json_encode($key));
+            if ($this->_igbinaryAvailable) {
+                $serializedKey = igbinary_serialize($key);
+            } else {
+                $serializedKey = serialize($key);
+            }
+
+            $key = md5($serializedKey);
         }
 
         return $this->keyPrefix . $key;

--- a/tests/framework/caching/ArrayCacheTest.php
+++ b/tests/framework/caching/ArrayCacheTest.php
@@ -52,4 +52,24 @@ class ArrayCacheTest extends CacheTestCase
         static::$microtime++;
         $this->assertFalse($cache->get('expire_testa'));
     }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/16028
+     */
+    public function testSerializationOfComplexKeysThatContainNonUTFSequences()
+    {
+        $cache = $this->getCacheInstance();
+
+        $firstCacheKey = $cache->buildKey([
+            "First example of invalid UTF-8 sequence: \xF5",
+            "Valid UTF-8 string",
+        ]);
+
+        $secondCacheKey = $cache->buildKey([
+            "Second example of invalid UTF-8 sequence: \xF6",
+            "Valid UTF-8 string",
+        ]);
+
+        $this->assertNotEquals($firstCacheKey, $secondCacheKey);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #16028
