### PR TITLE
Fix invalid count() and query Copy for inherited Query classes

### DIFF
--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -463,7 +463,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
             return $command->queryScalar();
         }
 
-        $command = (new self())
+        $command = (new static())
             ->select([$selectExpression])
             ->from(['c' => $this])
             ->createCommand($db);
@@ -1282,7 +1282,7 @@ PATTERN;
      */
     public static function create($from)
     {
-        return new self([
+        return new static([
             'where' => $from->where,
             'limit' => $from->limit,
             'offset' => $from->offset,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

It is impossible now to inherit db/Query class without copy-pasting of queryInternal method just to work with inherited class (instead of parent).

The only change is keyword _static_ instead of _self_