### PR TITLE
Set $useTablePrefix to true

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.16 under development
 ------------------------
 
+- Chg #16941: Set `yii\console\controllers\MigrateController::useTablePrefix` to true as default value
 - Bug #16966: Fix ArrayExpression support in related tables (GHopperMSK)
 - Bug #16891: Fixed Pagination::totalCount initialized incorrectly (taobig)
 - Bug #16028: Fix serialization of complex cache keys that contain non-UTF sequences (rugabarbo)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.16 under development
 ------------------------
 
-- Chg #16941: Set `yii\console\controllers\MigrateController::useTablePrefix` to true as default value
+- Chg #16941: Set `yii\console\controllers\MigrateController::useTablePrefix` to true as default value (GHopperMSK)
 - Bug #16966: Fix ArrayExpression support in related tables (GHopperMSK)
 - Bug #16891: Fixed Pagination::totalCount initialized incorrectly (taobig)
 - Bug #16028: Fix serialization of complex cache keys that contain non-UTF sequences (rugabarbo)

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -112,7 +112,7 @@ class MigrateController extends BaseMigrateController
      * name is `post` the generator wil return `{{%post}}`.
      * @since 2.0.8
      */
-    public $useTablePrefix = false;
+    public $useTablePrefix = true;
     /**
      * @var array column definition strings used for creating migration code.
      *

--- a/tests/data/console/migrate_create/add_columns_fk.php
+++ b/tests/data/console/migrate_create/add_columns_fk.php
@@ -11,12 +11,12 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles adding columns to table `{table}`.
+ * Handles adding columns to table `{{%{table}}}`.
  * Has foreign keys to the tables:
  *
- * - `user`
- * - `product`
- * - `user_order`
+ * - `{{%user}}`
+ * - `{{%product}}`
+ * - `{{%user_order}}`
  */
 class {$class} extends Migration
 {
@@ -25,58 +25,58 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->addColumn('{table}', 'user_id', \$this->integer());
-        \$this->addColumn('{table}', 'product_id', \$this->integer()->unsigned()->notNull());
-        \$this->addColumn('{table}', 'order_id', \$this->integer()->notNull());
-        \$this->addColumn('{table}', 'created_at', \$this->dateTime()->notNull());
+        \$this->addColumn('{{%{table}}}', 'user_id', \$this->integer());
+        \$this->addColumn('{{%{table}}}', 'product_id', \$this->integer()->unsigned()->notNull());
+        \$this->addColumn('{{%{table}}}', 'order_id', \$this->integer()->notNull());
+        \$this->addColumn('{{%{table}}}', 'created_at', \$this->dateTime()->notNull());
 
         // creates index for column `user_id`
         \$this->createIndex(
-            'idx-{table}-user_id',
-            '{table}',
+            '{{%idx-{table}-user_id}}',
+            '{{%{table}}}',
             'user_id'
         );
 
-        // add foreign key for table `user`
+        // add foreign key for table `{{%user}}`
         \$this->addForeignKey(
-            'fk-{table}-user_id',
-            '{table}',
+            '{{%fk-{table}-user_id}}',
+            '{{%{table}}}',
             'user_id',
-            'user',
+            '{{%user}}',
             'id',
             'CASCADE'
         );
 
         // creates index for column `product_id`
         \$this->createIndex(
-            'idx-{table}-product_id',
-            '{table}',
+            '{{%idx-{table}-product_id}}',
+            '{{%{table}}}',
             'product_id'
         );
 
-        // add foreign key for table `product`
+        // add foreign key for table `{{%product}}`
         \$this->addForeignKey(
-            'fk-{table}-product_id',
-            '{table}',
+            '{{%fk-{table}-product_id}}',
+            '{{%{table}}}',
             'product_id',
-            'product',
+            '{{%product}}',
             'id',
             'CASCADE'
         );
 
         // creates index for column `order_id`
         \$this->createIndex(
-            'idx-{table}-order_id',
-            '{table}',
+            '{{%idx-{table}-order_id}}',
+            '{{%{table}}}',
             'order_id'
         );
 
-        // add foreign key for table `user_order`
+        // add foreign key for table `{{%user_order}}`
         \$this->addForeignKey(
-            'fk-{table}-order_id',
-            '{table}',
+            '{{%fk-{table}-order_id}}',
+            '{{%{table}}}',
             'order_id',
-            'user_order',
+            '{{%user_order}}',
             'id',
             'CASCADE'
         );
@@ -87,46 +87,46 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        // drops foreign key for table `user`
+        // drops foreign key for table `{{%user}}`
         \$this->dropForeignKey(
-            'fk-{table}-user_id',
-            '{table}'
+            '{{%fk-{table}-user_id}}',
+            '{{%{table}}}'
         );
 
         // drops index for column `user_id`
         \$this->dropIndex(
-            'idx-{table}-user_id',
-            '{table}'
+            '{{%idx-{table}-user_id}}',
+            '{{%{table}}}'
         );
 
-        // drops foreign key for table `product`
+        // drops foreign key for table `{{%product}}`
         \$this->dropForeignKey(
-            'fk-{table}-product_id',
-            '{table}'
+            '{{%fk-{table}-product_id}}',
+            '{{%{table}}}'
         );
 
         // drops index for column `product_id`
         \$this->dropIndex(
-            'idx-{table}-product_id',
-            '{table}'
+            '{{%idx-{table}-product_id}}',
+            '{{%{table}}}'
         );
 
-        // drops foreign key for table `user_order`
+        // drops foreign key for table `{{%user_order}}`
         \$this->dropForeignKey(
-            'fk-{table}-order_id',
-            '{table}'
+            '{{%fk-{table}-order_id}}',
+            '{{%{table}}}'
         );
 
         // drops index for column `order_id`
         \$this->dropIndex(
-            'idx-{table}-order_id',
-            '{table}'
+            '{{%idx-{table}-order_id}}',
+            '{{%{table}}}'
         );
 
-        \$this->dropColumn('{table}', 'user_id');
-        \$this->dropColumn('{table}', 'product_id');
-        \$this->dropColumn('{table}', 'order_id');
-        \$this->dropColumn('{table}', 'created_at');
+        \$this->dropColumn('{{%{table}}}', 'user_id');
+        \$this->dropColumn('{{%{table}}}', 'product_id');
+        \$this->dropColumn('{{%{table}}}', 'order_id');
+        \$this->dropColumn('{{%{table}}}', 'created_at');
     }
 }
 

--- a/tests/data/console/migrate_create/add_columns_test.php
+++ b/tests/data/console/migrate_create/add_columns_test.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles adding columns to table `{table}`.
+ * Handles adding columns to table `{{%{table}}}`.
  */
 class {$class} extends Migration
 {
@@ -20,10 +20,10 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->addColumn('{table}', 'title', \$this->string(10)->notNull());
-        \$this->addColumn('{table}', 'body', \$this->text()->notNull());
-        \$this->addColumn('{table}', 'price', \$this->money(11,2)->notNull());
-        \$this->addColumn('{table}', 'created_at', \$this->dateTime());
+        \$this->addColumn('{{%{table}}}', 'title', \$this->string(10)->notNull());
+        \$this->addColumn('{{%{table}}}', 'body', \$this->text()->notNull());
+        \$this->addColumn('{{%{table}}}', 'price', \$this->money(11,2)->notNull());
+        \$this->addColumn('{{%{table}}}', 'created_at', \$this->dateTime());
     }
 
     /**
@@ -31,10 +31,10 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->dropColumn('{table}', 'title');
-        \$this->dropColumn('{table}', 'body');
-        \$this->dropColumn('{table}', 'price');
-        \$this->dropColumn('{table}', 'created_at');
+        \$this->dropColumn('{{%{table}}}', 'title');
+        \$this->dropColumn('{{%{table}}}', 'body');
+        \$this->dropColumn('{{%{table}}}', 'price');
+        \$this->dropColumn('{{%{table}}}', 'created_at');
     }
 }
 

--- a/tests/data/console/migrate_create/create_fields.php
+++ b/tests/data/console/migrate_create/create_fields.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation of table `{table}`.
+ * Handles the creation of table `{{%{table}}}`.
  */
 class {$class} extends Migration
 {
@@ -20,7 +20,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->createTable('{table}', [
+        \$this->createTable('{{%{table}}}', [
             'id' => \$this->primaryKey(),
             'title' => \$this->string(10)->notNull()->unique()->defaultValue("test"),
             'body' => \$this->text()->notNull(),
@@ -34,7 +34,7 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->dropTable('{table}');
+        \$this->dropTable('{{%{table}}}');
     }
 }
 

--- a/tests/data/console/migrate_create/create_foreign_key.php
+++ b/tests/data/console/migrate_create/create_foreign_key.php
@@ -11,12 +11,12 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation of table `{table}`.
+ * Handles the creation of table `{{%{table}}}`.
  * Has foreign keys to the tables:
  *
- * - `user`
- * - `product`
- * - `user_order`
+ * - `{{%user}}`
+ * - `{{%product}}`
+ * - `{{%user_order}}`
  */
 class {$class} extends Migration
 {
@@ -25,7 +25,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->createTable('{table}', [
+        \$this->createTable('{{%{table}}}', [
             'id' => \$this->primaryKey(),
             'user_id' => \$this->integer(),
             'product_id' => \$this->integer()->unsigned()->notNull(),
@@ -35,51 +35,51 @@ class {$class} extends Migration
 
         // creates index for column `user_id`
         \$this->createIndex(
-            'idx-{table}-user_id',
-            '{table}',
+            '{{%idx-{table}-user_id}}',
+            '{{%{table}}}',
             'user_id'
         );
 
-        // add foreign key for table `user`
+        // add foreign key for table `{{%user}}`
         \$this->addForeignKey(
-            'fk-{table}-user_id',
-            '{table}',
+            '{{%fk-{table}-user_id}}',
+            '{{%{table}}}',
             'user_id',
-            'user',
+            '{{%user}}',
             'id',
             'CASCADE'
         );
 
         // creates index for column `product_id`
         \$this->createIndex(
-            'idx-{table}-product_id',
-            '{table}',
+            '{{%idx-{table}-product_id}}',
+            '{{%{table}}}',
             'product_id'
         );
 
-        // add foreign key for table `product`
+        // add foreign key for table `{{%product}}`
         \$this->addForeignKey(
-            'fk-{table}-product_id',
-            '{table}',
+            '{{%fk-{table}-product_id}}',
+            '{{%{table}}}',
             'product_id',
-            'product',
+            '{{%product}}',
             'id',
             'CASCADE'
         );
 
         // creates index for column `order_id`
         \$this->createIndex(
-            'idx-{table}-order_id',
-            '{table}',
+            '{{%idx-{table}-order_id}}',
+            '{{%{table}}}',
             'order_id'
         );
 
-        // add foreign key for table `user_order`
+        // add foreign key for table `{{%user_order}}`
         \$this->addForeignKey(
-            'fk-{table}-order_id',
-            '{table}',
+            '{{%fk-{table}-order_id}}',
+            '{{%{table}}}',
             'order_id',
-            'user_order',
+            '{{%user_order}}',
             'id',
             'CASCADE'
         );
@@ -90,43 +90,43 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        // drops foreign key for table `user`
+        // drops foreign key for table `{{%user}}`
         \$this->dropForeignKey(
-            'fk-{table}-user_id',
-            '{table}'
+            '{{%fk-{table}-user_id}}',
+            '{{%{table}}}'
         );
 
         // drops index for column `user_id`
         \$this->dropIndex(
-            'idx-{table}-user_id',
-            '{table}'
+            '{{%idx-{table}-user_id}}',
+            '{{%{table}}}'
         );
 
-        // drops foreign key for table `product`
+        // drops foreign key for table `{{%product}}`
         \$this->dropForeignKey(
-            'fk-{table}-product_id',
-            '{table}'
+            '{{%fk-{table}-product_id}}',
+            '{{%{table}}}'
         );
 
         // drops index for column `product_id`
         \$this->dropIndex(
-            'idx-{table}-product_id',
-            '{table}'
+            '{{%idx-{table}-product_id}}',
+            '{{%{table}}}'
         );
 
-        // drops foreign key for table `user_order`
+        // drops foreign key for table `{{%user_order}}`
         \$this->dropForeignKey(
-            'fk-{table}-order_id',
-            '{table}'
+            '{{%fk-{table}-order_id}}',
+            '{{%{table}}}'
         );
 
         // drops index for column `order_id`
         \$this->dropIndex(
-            'idx-{table}-order_id',
-            '{table}'
+            '{{%idx-{table}-order_id}}',
+            '{{%{table}}}'
         );
 
-        \$this->dropTable('{table}');
+        \$this->dropTable('{{%{table}}}');
     }
 }
 

--- a/tests/data/console/migrate_create/create_id_pk.php
+++ b/tests/data/console/migrate_create/create_id_pk.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation of table `{table}`.
+ * Handles the creation of table `{{%{table}}}`.
  */
 class {$class} extends Migration
 {
@@ -20,7 +20,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->createTable('{table}', [
+        \$this->createTable('{{%{table}}}', [
             'id' => \$this->primaryKey(),
             'address' => \$this->string(),
             'address2' => \$this->string(),
@@ -33,7 +33,7 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->dropTable('{table}');
+        \$this->dropTable('{{%{table}}}');
     }
 }
 

--- a/tests/data/console/migrate_create/create_test.php
+++ b/tests/data/console/migrate_create/create_test.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation of table `{table}`.
+ * Handles the creation of table `{{%{table}}}`.
  */
 class {$class} extends Migration
 {
@@ -20,7 +20,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->createTable('{table}', [
+        \$this->createTable('{{%{table}}}', [
             'id' => \$this->primaryKey(),
         ]);
     }
@@ -30,7 +30,7 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->dropTable('{table}');
+        \$this->dropTable('{{%{table}}}');
     }
 }
 

--- a/tests/data/console/migrate_create/create_title_pk.php
+++ b/tests/data/console/migrate_create/create_title_pk.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation of table `{table}`.
+ * Handles the creation of table `{{%{table}}}`.
  */
 class {$class} extends Migration
 {
@@ -20,7 +20,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->createTable('{table}', [
+        \$this->createTable('{{%{table}}}', [
             'title' => \$this->primaryKey(),
             'body' => \$this->text()->notNull(),
             'price' => \$this->money(11,2),
@@ -32,7 +32,7 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->dropTable('{table}');
+        \$this->dropTable('{{%{table}}}');
     }
 }
 

--- a/tests/data/console/migrate_create/create_title_with_comma_default_values.php
+++ b/tests/data/console/migrate_create/create_title_with_comma_default_values.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation of table `test`.
+ * Handles the creation of table `{{%test}}`.
  */
 class {$class} extends Migration
 {
@@ -20,7 +20,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->createTable('test', [
+        \$this->createTable('{{%test}}', [
             'id' => \$this->primaryKey(),
             'title' => \$this->string(10)->notNull()->unique()->defaultValue(",te,st"),
             'body' => \$this->text()->notNull()->defaultValue(",test"),
@@ -33,7 +33,7 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->dropTable('test');
+        \$this->dropTable('{{%test}}');
     }
 }
 

--- a/tests/data/console/migrate_create/create_unsigned_big_pk.php
+++ b/tests/data/console/migrate_create/create_unsigned_big_pk.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation of table `{table}`.
+ * Handles the creation of table `{{%{table}}}`.
  */
 class {$class} extends Migration
 {
@@ -20,7 +20,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->createTable('{table}', [
+        \$this->createTable('{{%{table}}}', [
             'brand_id' => \$this->bigPrimaryKey()->unsigned(),
         ]);
     }
@@ -30,7 +30,7 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->dropTable('{table}');
+        \$this->dropTable('{{%{table}}}');
     }
 }
 

--- a/tests/data/console/migrate_create/create_unsigned_pk.php
+++ b/tests/data/console/migrate_create/create_unsigned_pk.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation of table `{table}`.
+ * Handles the creation of table `{{%{table}}}`.
  */
 class {$class} extends Migration
 {
@@ -20,7 +20,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->createTable('{table}', [
+        \$this->createTable('{{%{table}}}', [
             'brand_id' => \$this->primaryKey()->unsigned(),
         ]);
     }
@@ -30,7 +30,7 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->dropTable('{table}');
+        \$this->dropTable('{{%{table}}}');
     }
 }
 

--- a/tests/data/console/migrate_create/drop_columns_test.php
+++ b/tests/data/console/migrate_create/drop_columns_test.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles dropping columns from table `{table}`.
+ * Handles dropping columns from table `{{%{table}}}`.
  */
 class {$class} extends Migration
 {
@@ -20,10 +20,10 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->dropColumn('{table}', 'title');
-        \$this->dropColumn('{table}', 'body');
-        \$this->dropColumn('{table}', 'price');
-        \$this->dropColumn('{table}', 'created_at');
+        \$this->dropColumn('{{%{table}}}', 'title');
+        \$this->dropColumn('{{%{table}}}', 'body');
+        \$this->dropColumn('{{%{table}}}', 'price');
+        \$this->dropColumn('{{%{table}}}', 'created_at');
     }
 
     /**
@@ -31,10 +31,10 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->addColumn('{table}', 'title', \$this->string(10)->notNull());
-        \$this->addColumn('{table}', 'body', \$this->text()->notNull());
-        \$this->addColumn('{table}', 'price', \$this->money(11,2)->notNull());
-        \$this->addColumn('{table}', 'created_at', \$this->dateTime());
+        \$this->addColumn('{{%{table}}}', 'title', \$this->string(10)->notNull());
+        \$this->addColumn('{{%{table}}}', 'body', \$this->text()->notNull());
+        \$this->addColumn('{{%{table}}}', 'price', \$this->money(11,2)->notNull());
+        \$this->addColumn('{{%{table}}}', 'created_at', \$this->dateTime());
     }
 }
 

--- a/tests/data/console/migrate_create/drop_fields.php
+++ b/tests/data/console/migrate_create/drop_fields.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the dropping of table `{table}`.
+ * Handles the dropping of table `{{%{table}}}`.
  */
 class {$class} extends Migration
 {
@@ -20,7 +20,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->dropTable('{table}');
+        \$this->dropTable('{{%{table}}}');
     }
 
     /**
@@ -28,7 +28,7 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->createTable('{table}', [
+        \$this->createTable('{{%{table}}}', [
             'id' => \$this->primaryKey(),
             'body' => \$this->text()->notNull(),
             'price' => \$this->money(11,2),

--- a/tests/data/console/migrate_create/drop_products_from_store_table.php
+++ b/tests/data/console/migrate_create/drop_products_from_store_table.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the dropping of table `{table}`.
+ * Handles the dropping of table `{{%{table}}}`.
  */
 class {$class} extends Migration
 {
@@ -20,7 +20,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->dropTable('{table}');
+        \$this->dropTable('{{%{table}}}');
     }
 
     /**
@@ -28,7 +28,7 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->createTable('{table}', [
+        \$this->createTable('{{%{table}}}', [
             'id' => \$this->primaryKey(),
         ]);
     }

--- a/tests/data/console/migrate_create/drop_test.php
+++ b/tests/data/console/migrate_create/drop_test.php
@@ -11,7 +11,7 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the dropping of table `{table}`.
+ * Handles the dropping of table `{{%{table}}}`.
  */
 class {$class} extends Migration
 {
@@ -20,7 +20,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->dropTable('{table}');
+        \$this->dropTable('{{%{table}}}');
     }
 
     /**
@@ -28,7 +28,7 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        \$this->createTable('{table}', [
+        \$this->createTable('{{%{table}}}', [
             'id' => \$this->primaryKey(),
         ]);
     }

--- a/tests/data/console/migrate_create/junction_test.php
+++ b/tests/data/console/migrate_create/junction_test.php
@@ -11,11 +11,11 @@ return <<<CODE
 use yii\db\Migration;
 
 /**
- * Handles the creation of table `post_tag`.
+ * Handles the creation of table `{{%post_tag}}`.
  * Has foreign keys to the tables:
  *
- * - `post`
- * - `tag`
+ * - `{{%post}}`
+ * - `{{%tag}}`
  */
 class {$class} extends Migration
 {
@@ -24,7 +24,7 @@ class {$class} extends Migration
      */
     public function safeUp()
     {
-        \$this->createTable('post_tag', [
+        \$this->createTable('{{%post_tag}}', [
             'post_id' => \$this->integer(),
             'tag_id' => \$this->integer(),
             'PRIMARY KEY(post_id, tag_id)',
@@ -32,34 +32,34 @@ class {$class} extends Migration
 
         // creates index for column `post_id`
         \$this->createIndex(
-            'idx-post_tag-post_id',
-            'post_tag',
+            '{{%idx-post_tag-post_id}}',
+            '{{%post_tag}}',
             'post_id'
         );
 
-        // add foreign key for table `post`
+        // add foreign key for table `{{%post}}`
         \$this->addForeignKey(
-            'fk-post_tag-post_id',
-            'post_tag',
+            '{{%fk-post_tag-post_id}}',
+            '{{%post_tag}}',
             'post_id',
-            'post',
+            '{{%post}}',
             'id',
             'CASCADE'
         );
 
         // creates index for column `tag_id`
         \$this->createIndex(
-            'idx-post_tag-tag_id',
-            'post_tag',
+            '{{%idx-post_tag-tag_id}}',
+            '{{%post_tag}}',
             'tag_id'
         );
 
-        // add foreign key for table `tag`
+        // add foreign key for table `{{%tag}}`
         \$this->addForeignKey(
-            'fk-post_tag-tag_id',
-            'post_tag',
+            '{{%fk-post_tag-tag_id}}',
+            '{{%post_tag}}',
             'tag_id',
-            'tag',
+            '{{%tag}}',
             'id',
             'CASCADE'
         );
@@ -70,31 +70,31 @@ class {$class} extends Migration
      */
     public function safeDown()
     {
-        // drops foreign key for table `post`
+        // drops foreign key for table `{{%post}}`
         \$this->dropForeignKey(
-            'fk-post_tag-post_id',
-            'post_tag'
+            '{{%fk-post_tag-post_id}}',
+            '{{%post_tag}}'
         );
 
         // drops index for column `post_id`
         \$this->dropIndex(
-            'idx-post_tag-post_id',
-            'post_tag'
+            '{{%idx-post_tag-post_id}}',
+            '{{%post_tag}}'
         );
 
-        // drops foreign key for table `tag`
+        // drops foreign key for table `{{%tag}}`
         \$this->dropForeignKey(
-            'fk-post_tag-tag_id',
-            'post_tag'
+            '{{%fk-post_tag-tag_id}}',
+            '{{%post_tag}}'
         );
 
         // drops index for column `tag_id`
         \$this->dropIndex(
-            'idx-post_tag-tag_id',
-            'post_tag'
+            '{{%idx-post_tag-tag_id}}',
+            '{{%post_tag}}'
         );
 
-        \$this->dropTable('post_tag');
+        \$this->dropTable('{{%post_tag}}');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #16941 set `yii\console\controllers\MigrateController::useTablePrefix` to true as default value
