### PR TITLE
Fixes CommandTest::testCreateView() cleanup logic

### DIFF
--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -1460,11 +1460,11 @@ SQL;
             ->select('bar')
             ->from('testCreateViewTable')
             ->where(['>', 'bar', '5']);
+        if ($db->getSchema()->getTableSchema('testCreateView')) {
+            $db->createCommand()->dropView('testCreateView')->execute();
+        }
         if ($db->getSchema()->getTableSchema('testCreateViewTable')) {
             $db->createCommand()->dropTable('testCreateViewTable')->execute();
-        }
-        if ($db->getSchema()->getTableSchema('testCreateView') !== null) {
-            $db->createCommand()->dropView('testCreateView')->execute();
         }
         $db->createCommand()->createTable('testCreateViewTable', [
             'id' => Schema::TYPE_PK,


### PR DESCRIPTION
View must be deleted before deleting the tables on which it depends, otherwise we will get errors when rerunning the tests in the same environment.

For example:
```
1) yiiunit\framework\db\mysql\CommandTest::testCreateView
yii\db\Exception: SQLSTATE[HY000]: General error: 1356 View 'yii2_test.testCreateView' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
The SQL being executed was: SHOW FULL COLUMNS FROM `testCreateView`
```

