### PR TITLE
Minor cleaning of .gitignore files in tests folder

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,1 @@
-/runtime/cache/*
 /data/config.local.php

--- a/tests/runtime/.gitignore
+++ b/tests/runtime/.gitignore
@@ -1,3 +1,2 @@
 *
 !.gitignore
-!/assets/


### PR DESCRIPTION
1) `/runtime/cache/*` already ignored by file `/tests/runtime/.gitignore`
2) `/tests/runtime/assets/` already stays in place due to file `/tests/runtime/asstes/.gitignore`