### PR TITLE
Fixes DateValidatorTest for ICU 55.1

### DIFF
--- a/tests/framework/validators/DateValidatorTest.php
+++ b/tests/framework/validators/DateValidatorTest.php
@@ -305,7 +305,7 @@ class DateValidatorTest extends TestCase
     {
         // prepare data for specific ICU version, see https://github.com/yiisoft/yii2/issues/15140
         switch (true) {
-            case (version_compare(INTL_ICU_VERSION, '57.1', '>=')):
+            case (version_compare(INTL_ICU_VERSION, '55.1', '>=')):
                 $enGB_dateTime_valid = '31/05/2017, 12:30';
                 $enGB_dateTime_invalid = '05/31/2017, 12:30';
                 $deDE_dateTime_valid = '31.05.2017, 12:30';


### PR DESCRIPTION
I have installed ICU of version `55.1` and tests fail on it. That's because 'short' datetime format has been changed earlier - starting with version 55.1

See for example Symfony changes for ICU 55: https://github.com/symfony/symfony/commit/4f224ef4aba981ee88d5c7e637a6297f6a75aa37#diff-564fc4b01393077657880495f2be7b17R54