### PR TITLE
Fix of Oracle tests for proper skipping

### DIFF
--- a/tests/framework/db/oci/QueryBuilderTest.php
+++ b/tests/framework/db/oci/QueryBuilderTest.php
@@ -127,8 +127,13 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
          * Different pdo_oci8 versions may or may not implement PDO::quote(), so
          * yii\db\Schema::quoteValue() may or may not quote \.
          */
-        $encodedBackslash = substr($this->getDb()->quoteValue('\\'), 1, -1);
-        $this->likeParameterReplacements[$encodedBackslash] = '\\';
+        try {
+            $encodedBackslash = substr($this->getDb()->quoteValue('\\'), 1, -1);
+            $this->likeParameterReplacements[$encodedBackslash] = '\\';
+        } catch (\Exception $e) {
+            $this->markTestSkipped('Could not execute Connection::quoteValue() method: ' . $e->getMessage());
+        }
+
         return parent::likeConditionProvider();
     }
 


### PR DESCRIPTION
PHPUnit must get the data that will be passed to the tests, before executing them. That's why you can't prevent the dataProvider to be executed using `$this->markTestSkipped()` inside a test. Instead, you must use a skipping inside data provider when the test cannot be executed.

Now Oracle tests are skipped without fails when Oracle isn't installed:
```
$ vendor/bin/phpunit --filter=BuildLikeCondition --group=oci --verbose

...

There was 1 skipped test:

1) yiiunit\framework\db\oci\QueryBuilderTest::testBuildLikeCondition
Test for yiiunit\framework\db\oci\QueryBuilderTest::testBuildLikeCondition skipped by data provider
Could not execute Connection::quoteValue() method: Connection::dsn cannot be empty.
```