### PR TITLE
allow to add event listeners to a pjax widget

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.16 under development
 ------------------------
-
+- Enh #17020: allow to add pjax event listeners to a `\yii\widgets\Pjax` widget (albertborsos)
 - Bug #16991: Removed usage of `utf8_encode()` from `Request::resolvePathInfo()` (GHopperMSK)
 - Bug #16974: Regular Expression Validator to include support for 'u' (UTF-8) modifier (Dzhuneyt)
 - Chg #16941: Set `yii\console\controllers\MigrateController::useTablePrefix` to true as default value (GHopperMSK)

--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -98,6 +98,20 @@ class Pjax extends Widget
      */
     public $clientOptions;
     /**
+     * @var array the event handlers for the underlying Pjax widget.
+     * Keys are the event names and values are javascript code that is passed to the `.on()` function
+     * as the event handler.
+     *
+     * For example you could write the following in your widget configuration:
+     *
+     * ```php
+     * 'clientEvents' => [
+     *     'pjax:end' => "function() { $.pjax.reload({container: '#pjax-second-container', timeout: 10000}); }",
+     * ],
+     * ```
+     */
+    public $clientEvents = [];
+    /**
      * {@inheritdoc}
      * @internal
      */
@@ -213,5 +227,24 @@ class Pjax extends Widget
         if ($js !== '') {
             $view->registerJs($js);
         }
+
+        $this->registerClientEvents($id);
+    }
+
+    /**
+     * Registers a specific Pjax widget events
+     * @param string $id the ID of the widget
+     */
+    protected function registerClientEvents($id)
+    {
+        if (empty($this->clientEvents)) {
+            return;
+        }
+
+        $js = [];
+        foreach ($this->clientEvents as $event => $handler) {
+            $js[] = "jQuery('#$id').on('$event', $handler);";
+        }
+        $this->getView()->registerJs(implode("\n", $js));
     }
 }


### PR DESCRIPTION
allow to add pjax event listeners to a widget via Pjax::clientEvents property

| Q             | A
| ------------- | ---
| Is bugfix?    |no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

based on this ticket: https://github.com/albertborsos/yii2-pjax/issues/2

With this feature it is possible to easily update menu items after a pjax requests.

In my app there is a menu:

```php
    <?php \yii\widgets\Pjax::begin([
        'id' => 'menu-sidebar',
        'linkSelector' => false,
        'clientEvents' => [
            'pjax:end' => new \yii\web\JsExpression("function() { $('.sidebar-menu').tree() }"),
        ],
    ]); ?>
    <?= Menu::widget([
        'items' => [
            // items
        ],
    ])?>
    <?php \yii\widgets\Pjax::end(); ?>
```

and the content, which updates menu items on `pjax:end` (and shows a loading overlay on `pjax:start` )

```php
<?php \yii\widgets\Pjax::begin([
    'id' => 'summary',
    'clientEvents' => [
        'pjax:success' => new \yii\web\JsExpression("function () { $.pjax.reload({container: '#menu-sidebar', timeout: 10000}); }"),
        'pjax:start' => new \yii\web\JsExpression("function() { window.spinner.formSpinnerOverlay('#summary .box'); }"),
    ],
]); ?>
    <div class="nav-tabs-custom box">
        <?= \yii\bootstrap\Tabs::widget([
            'items' => $tabItems,
        ]) ?>
    </div>
<?php \yii\widgets\Pjax::end(); ?>
```
