### PR TITLE
Fixed random fails of RetryAcquireTraitTest

### DIFF
--- a/tests/framework/mutex/RetryAcquireTraitTest.php
+++ b/tests/framework/mutex/RetryAcquireTraitTest.php
@@ -33,7 +33,17 @@ class RetryAcquireTraitTest extends TestCase
         $this->assertTrue($mutexOne->acquire($mutexName));
         $this->assertFalse($mutexTwo->acquire($mutexName, 1));
 
-        $this->assertSame(20, $mutexTwo->attemptsCounter);
+        $this->assertGreaterThanOrEqual(1, count($mutexTwo->attemptsTime));
+        $this->assertLessThanOrEqual(20, count($mutexTwo->attemptsTime));
+
+        foreach ($mutexTwo->attemptsTime as $i => $attemptTime) {
+            if ($i === 0) {
+                continue;
+            }
+
+            $intervalMilliseconds = ($mutexTwo->attemptsTime[$i] - $mutexTwo->attemptsTime[$i-1]) * 1000;
+            $this->assertGreaterThanOrEqual($mutexTwo->retryDelay, $intervalMilliseconds);
+        }
     }
 
     /**

--- a/tests/framework/mutex/mocks/DumbMutex.php
+++ b/tests/framework/mutex/mocks/DumbMutex.php
@@ -19,7 +19,7 @@ class DumbMutex extends Mutex
 {
     use RetryAcquireTrait;
 
-    public $attemptsCounter = 0;
+    public $attemptsTime = [];
     public static $locked = false;
 
     /**
@@ -28,7 +28,7 @@ class DumbMutex extends Mutex
     protected function acquireLock($name, $timeout = 0)
     {
         return $this->retryAcquire($timeout, function () {
-            $this->attemptsCounter++;
+            $this->attemptsTime[] = \microtime(true);
             if (!static::$locked) {
                 static::$locked = true;
 


### PR DESCRIPTION
Property `RetryAcquireTrait::$retryDelay` sets the minimum delay, but not the exact delay. In fact, delay may be longer. Because of this, sometimes less than 20 blocking attempts occur. Checking the exact number of locks sometimes leads to the following errors:
```
$ vendor/bin/phpunit --filter=testRetryAcquire
PHPUnit 4.8.34 by Sebastian Bergmann and contributors.

F

You should really fix these slow tests (>500ms)...
 1. 1050ms to run yiiunit\framework\mutex\RetryAcquireTraitTest:testRetryAcquire

Time: 4.08 seconds, Memory: 44.00MB

There was 1 failure:

1) yiiunit\framework\mutex\RetryAcquireTraitTest::testRetryAcquire
Failed asserting that 19 is identical to 20.

/yii2/tests/framework/mutex/RetryAcquireTraitTest.php:36
/yii2/vendor/phpunit/phpunit/phpunit:52

FAILURES!
Tests: 1, Assertions: 3, Failures: 1.
```

I reworked the test so that it checks duration of delays, but not the exact number of blocking attempts.