### PR TITLE
Fixes #15286: incorrect formatting of time with tz-information

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.16 under development
 ------------------------
 
+- Bug #15286: Fixed incorrect formatting of time with timezone information (rugabarbo)
 - Bug #17021: Fix to do not remove existing message category files in a subfolder (albertborsos)
 - Bug #16991: Removed usage of `utf8_encode()` from `Request::resolvePathInfo()` (GHopperMSK)
 - Bug #16974: Regular Expression Validator to include support for 'u' (UTF-8) modifier (Dzhuneyt)

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -841,7 +841,7 @@ class Formatter extends Component
                 return [
                     $timestamp,
                     !($info['hour'] === false && $info['minute'] === false && $info['second'] === false),
-                    !($info['year'] === false && $info['month'] === false && $info['day'] === false),
+                    !($info['year'] === false && $info['month'] === false && $info['day'] === false && empty($info['zone'])),
                 ];
             }
 

--- a/tests/framework/i18n/FormatterDateTest.php
+++ b/tests/framework/i18n/FormatterDateTest.php
@@ -754,6 +754,28 @@ class FormatterDateTest extends TestCase
     }
 
     /**
+     * @see https://github.com/yiisoft/yii2/issues/15286
+     */
+    public function testTimeWithTimezoneInfo()
+    {
+        $this->formatter->defaultTimeZone = 'UTC';
+        $this->formatter->timeZone = 'Etc/GMT-3';
+
+        $time = '16:22:00.44297+03';
+
+        $this->formatter->timeFormat = 'php:H:i:s';
+        $this->assertSame('16:22:00', $this->formatter->asTime($time));
+
+        $this->formatter->timeFormat = 'HH:mm:ss';
+        $this->assertSame('16:22:00', $this->formatter->asTime($time));
+    }
+
+    public function testIntlTimeWithTimezoneInfo()
+    {
+        $this->testTimeWithTimezoneInfo();
+    }
+
+    /**
      * @see https://github.com/yiisoft/yii2/issues/6263.
      *
      * it is a PHP bug: https://bugs.php.net/bug.php?id=45543


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #15286