### PR TITLE
When uses filter \yii\filters\PageCache, then yii\web\JsonResponseFor…

### DIFF
--- a/framework/web/JsonResponseFormatter.php
+++ b/framework/web/JsonResponseFormatter.php
@@ -117,7 +117,7 @@ class JsonResponseFormatter extends Component implements ResponseFormatterInterf
                 $options |= JSON_PRETTY_PRINT;
             }
             $response->content = Json::encode($response->data, $options);
-        } else {
+        } elseif ($response->content === null) {
             $response->content = 'null';
         }
     }

--- a/tests/framework/web/JsonResponseFormatterTest.php
+++ b/tests/framework/web/JsonResponseFormatterTest.php
@@ -194,4 +194,17 @@ class JsonResponseFormatterTest extends FormatterTest
         $this->formatter->format($this->response);
         $this->assertEquals('null', $this->response->content);
     }
+
+    /**
+     * Formatter must return early sets content,
+     * e.g. content may be sets by PageCache filter
+     */
+    public function testFormatFilledContent()
+    {
+        $content = '{"text": "early seted content"}';
+        $this->response->data = null;
+        $this->response->content = $content;
+        $this->formatter->format($this->response);
+        $this->assertEquals($content, $this->response->content);
+    }
 }


### PR DESCRIPTION
…matter sets Response::$content as null, howerer \yii\filter\PageCache has been restore content

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
New feature?  | no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | #17043

closes #17043