### PR TITLE
ActiveRecord::findOne() now accepts quoted table and column names

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -112,6 +112,7 @@ Yii Framework 2 Change Log
 - Bug #16469: Allow cache to be specified as interface and to be configured in DI container (alexeevdv)
 - Bug #16959: Fixed typo in if condition inside `yii\web\DbSession::typecastFields()` that caused problems with session overwriting (silverfire)
 - Bug #15876: `yii\db\ActiveQuery::viaTable()` now throws `InvalidConfigException`, if query is not prepared correctly (silverfire)
+- Bug #15931: `yii\db\ActiveRecord::findOne()` now accepts quoted table and column names using curly and square braces respectively (silverfire)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -207,14 +207,20 @@ class ActiveRecord extends BaseActiveRecord
     protected static function filterCondition(array $condition)
     {
         $result = [];
+        $db = static::getDb();
         // valid column names are table column names or column names prefixed with table name
-        $columnNames = static::getTableSchema()->getColumnNames();
+        $columnNames = [];
         $tableName = static::tableName();
-        $columnNames = array_merge($columnNames, array_map(function($columnName) use ($tableName) {
-            return "$tableName.$columnName";
-        }, $columnNames));
+        $quotedTableName = $db->quoteTableName($tableName);
+
+        foreach (static::getTableSchema()->getColumnNames() as $columnName) {
+            $columnNames[] = $columnName;
+            $columnNames[] = $db->quoteColumnName($columnName);
+            $columnNames[] = "$tableName.$columnName";
+            $columnNames[] = $db->quoteSql("$quotedTableName.[[$columnName]]");
+        }
         foreach ($condition as $key => $value) {
-            if (is_string($key) && !in_array($key, $columnNames, true)) {
+            if (is_string($key) && !in_array($db->quoteSql($key), $columnNames, true)) {
                 throw new InvalidArgumentException('Key "' . $key . '" is not a column name and can not be used as a filter');
             }
             $result[$key] = is_array($value) ? array_values($value) : $value;

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1660,6 +1660,27 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         CustomerQuery::$joinWithProfile = false;
     }
 
+    public function legalValuesForFindByCondition()
+    {
+        return [
+            [['id' => 1]],
+            [['customer.id' => 1]],
+            [['[[id]]' => 1]],
+            [['{{customer}}.[[id]]' => 1]],
+            [['{{%customer}}.[[id]]' => 1]],
+        ];
+    }
+
+    /**
+     * @dataProvider legalValuesForFindByCondition
+     */
+    public function testLegalValuesForFindByCondition($validFilter)
+    {
+        /** @var Query $query */
+        $query = $this->invokeMethod(new Customer(), 'findByCondition', [$validFilter]);
+        Customer::getDb()->queryBuilder->build($query);
+    }
+
     public function illegalValuesForFindByCondition()
     {
         return [


### PR DESCRIPTION
Fixes #15931