### PR TITLE
Fixes #17098: fixed message/extract when using message params returned from method calls

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #17094: Fixed response on 204 status. Now it is empty (GHopperMSK)
+- Bug #17098: Fixed message/extract when using message params returned from method calls (rugabarbo)
 
 
 2.0.16 January 30, 2019


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #17098 
