### PR TITLE
Issue #17109: better phpdoc for `yii\caching\Cache::getOrSet()` [skip ci]

### DIFF
--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -577,6 +577,9 @@ abstract class Cache extends Component implements CacheInterface
      * @param mixed $key a key identifying the value to be cached. This can be a simple string or
      * a complex data structure consisting of factors representing the key.
      * @param callable|\Closure $callable the callable or closure that will be used to generate a value to be cached.
+     * If you use $callable that can return `false`, then keep in mind that [[getOrSet()]] may work inefficiently
+     * because the [[yii\caching\Cache::get()]] method uses `false` return value to indicate the data item is not found
+     * in the cache. Thus, caching of `false` value will lead to unnecessary internal calls.
      * @param int $duration default duration in seconds before the cache will expire. If not set,
      * [[defaultDuration]] value will be used.
      * @param Dependency $dependency dependency of the cached item. If the dependency changes,


### PR DESCRIPTION
See https://github.com/yiisoft/yii2/issues/17109#issuecomment-464051458