### PR TITLE
Issue #12182 support context for translations `Yii::t`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,7 +7,7 @@ Yii Framework 2 Change Log
 - Bug #17094: Fixed response on 204 status. Now it is empty (GHopperMSK)
 - Bug #17098: Fixed message/extract when using message params returned from method calls (rugabarbo)
 - Bug #17089: Fixed caching of related records when `via()` using with callable (rugabarbo)
-- Enh #12182: Extract context for translations (FilipBenco)
+- Enh #12182: Extract context for translations from `Yii::t` calls (FilipBenco)
 
 2.0.16 January 30, 2019
 -----------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #17094: Fixed response on 204 status. Now it is empty (GHopperMSK)
 - Bug #17098: Fixed message/extract when using message params returned from method calls (rugabarbo)
 - Bug #17089: Fixed caching of related records when `via()` using with callable (rugabarbo)
+- Enh #12182: Extract context for translations (FilipBenco)
 
 2.0.16 January 30, 2019
 -----------------------

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -635,7 +635,7 @@ EOD;
                                         if (isset($translatorToken[0])
                                             && $translatorToken[0] === T_COMMENT
                                         ) {
-                                            $message['context'] = trim(mb_substr($translatorToken[1], 3, -3));
+                                            $context['context'] = trim(mb_substr($translatorToken[1], 3, -3));
                                             break;
                                         }
                                     }
@@ -929,14 +929,14 @@ EOD;
         $return = '';
         foreach ($context as $occurence) {
             if (!empty($occurence['file'])) {
-                $return .= "     * {$occurence['file']}\n";
+                $return .= "     * @file {$occurence['file']}\n";
             }
             if (!empty($occurence['context'])) {
-                $return .= "     *  " . str_replace("\n", "\n#. ", $occurence['context']) . "\n";
+                $return .= "     * @description " . str_replace("\n", "\n#. ", $occurence['context']) . "\n";
             }
             if (!empty($occurence['params'])) {
                 foreach ($occurence['params'] as $parameter => $description) {
-                    $return .= "     *  {{$parameter}} {$description}\n";
+                    $return .= "     * @param {{$parameter}} {$description}\n";
                 }
             }
         }

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -585,18 +585,22 @@ EOD;
                                                     $j = 1;
                                                     $stop = false;
                                                     while (!$stop) {
-                                                        if ($buffer[$tokenIndex + $j + 4 + $foundContext] == '(') {
+                                                        $currentIndex = $tokenIndex + $j + 2 + $foundContext;
+                                                        if ($buffer[$currentIndex] == '(') {
                                                             $openParenthesisCount ++;
-                                                        }  elseif ($buffer[$tokenIndex + $j + 4 + $foundContext] == ')') {
+                                                        }  elseif ($buffer[$currentIndex] == ')') {
                                                             $openParenthesisCount --;
                                                         }
-                                                        if (!$openParenthesisCount && (in_array($buffer[$tokenIndex + $j + 4 + $foundContext], [',', ']', ')']))) {
+                                                        if (!$openParenthesisCount && (in_array($buffer[$currentIndex], [',', ']', ')']))) {
+                                                            if ($buffer[$currentIndex] != ',') {
+                                                                $j --;
+                                                            }
                                                             $stop = true;
                                                         }
                                                         $j ++;
                                                     }
 
-                                                    $tokenIndex += 3 + $j + $foundContext;
+                                                    $tokenIndex += 2 + $j + $foundContext;
                                                 } else {
                                                     $params[] = $paramContext;
 
@@ -604,17 +608,21 @@ EOD;
                                                     $j = 1;
                                                     $stop = false;
                                                     while (!$stop) {
-                                                        if ($buffer[$tokenIndex + $j + 2 + $foundContext] === '(') {
+                                                        $currentIndex = $tokenIndex + $j + $foundContext;
+                                                        if ($buffer[$currentIndex] === '(') {
                                                             $openParenthesisCount ++;
-                                                        }  elseif ($buffer[$tokenIndex + $j + 2 + $foundContext] === ')') {
+                                                        }  elseif ($buffer[$currentIndex] === ')') {
                                                             $openParenthesisCount --;
                                                         }
-                                                        if (!$openParenthesisCount && (in_array($buffer[$tokenIndex + $j + 4 + $foundContext], [',', ']', ')']))) {
+                                                        if (!$openParenthesisCount && (in_array($buffer[$currentIndex], [',', ']', ')']))) {
+                                                            if ($buffer[$currentIndex] != ',') {
+                                                                $j --;
+                                                            }
                                                             $stop = true;
                                                         }
                                                         $j ++;
                                                     }
-                                                    $tokenIndex += 1 + $j + $foundContext;
+                                                    $tokenIndex += $j + $foundContext;
                                                 }
                                             }
                                         }

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -634,9 +634,7 @@ EOD;
         }
 
         // extract parameters
-        if (isset($buffer[$tokenIndex], $buffer[$tokenIndex + 1]) && $buffer[$tokenIndex] === ','
-            && ($buffer[$tokenIndex + 1] === '[' || (isset($buffer[$tokenIndex + 1][0]) && $buffer[$tokenIndex + 1][0] == T_ARRAY))
-        ) {
+        if (isset($buffer[$tokenIndex], $buffer[$tokenIndex + 1]) && $buffer[$tokenIndex] === ',' && $this->tokenIsBeginningOfAnArray($buffer[$tokenIndex + 1])) {
             $tokenIndex += 1;
             $params = [];
             while ($buffer[$tokenIndex] != ']' && $buffer[$tokenIndex] != ')') {
@@ -672,6 +670,16 @@ EOD;
     }
 
     /**
+     * Method checks if token stand for beginning of an array
+     * @param $token
+     * @return bool
+     */
+    private function tokenIsBeginningOfAnArray($token)
+    {
+        return $token === '[' || (isset($token[0]) && $token[0] == T_ARRAY);
+    }
+
+    /**
      * @param $currentIndex
      * @param $buffer
      * @return mixed
@@ -686,7 +694,7 @@ EOD;
             }  elseif ($buffer[$currentIndex] == ')') {
                 $openParenthesisCount --;
             }
-            if (!$openParenthesisCount && (in_array($buffer[$currentIndex], [',', ']', ')']))) {
+            if (!$openParenthesisCount && in_array($buffer[$currentIndex], [',', ']', ')'])) {
                 if ($buffer[$currentIndex] != ',') {
                     return $currentIndex;
                 }

--- a/tests/framework/console/controllers/BaseMessageControllerTest.php
+++ b/tests/framework/console/controllers/BaseMessageControllerTest.php
@@ -560,6 +560,22 @@ abstract class BaseMessageControllerTest extends TestCase
     }
 
     /**
+     * @depends testCreateTranslation
+     */
+    public function textExtractMessageContext()
+    {
+
+    }
+
+    /**
+     * @depends testCreateTranslation
+     */
+    public function textExtractMessageParametersContext()
+    {
+
+    }
+
+    /**
      * @see https://github.com/yiisoft/yii2/issues/16828
      */
     public function testPartialTranslator()

--- a/tests/framework/console/controllers/BaseMessageControllerTest.php
+++ b/tests/framework/console/controllers/BaseMessageControllerTest.php
@@ -194,8 +194,8 @@ abstract class BaseMessageControllerTest extends TestCase
         $out = $this->runMessageControllerAction('extract', [$this->configFileName]);
         $out .= $this->runMessageControllerAction('extract', [$this->configFileName]);
 
-        $this->assertNotFalse(strpos($out, 'Nothing to save'),
-            "Controller should respond with \"Nothing to save\" if there's nothing to update. Command output:\n\n" . $out);
+        $this->assertNotFalse(strpos($out, 'Nothing new in'),
+            "Controller should respond with \"Nothing new in\" if there's nothing to update. Command output:\n\n" . $out);
     }
 
     /**

--- a/tests/framework/console/controllers/BaseMessageControllerTest.php
+++ b/tests/framework/console/controllers/BaseMessageControllerTest.php
@@ -612,6 +612,23 @@ abstract class BaseMessageControllerTest extends TestCase
     }
 
     /**
+     * @depends testCreateTranslation
+     */
+    public function testExtractMessageContextAndParametersContext()
+    {
+        $sourceFileContent = "
+            echo PHP_EOL, Yii::t('app', 'Message with main context and {param} description' /* message description */, ['param' /* parameter description */ => '']);
+        ";
+        $this->createSourceFile($sourceFileContent);
+
+        $this->saveConfigFile($this->getConfig(['extractContext' => true]));
+        $this->runMessageControllerAction('extract', [$this->configFileName]);
+
+        $this->assertTrue($this->messageContainsDescription('app', 'Message with main context and {param} description', 'message description'));
+        $this->assertTrue($this->messageParameterContainsDescription('app', 'Message with main context and {param} description', 'param','parameter description'));
+    }
+
+    /**
      * @see https://github.com/yiisoft/yii2/issues/16828
      */
     public function testPartialTranslator()

--- a/tests/framework/console/controllers/BaseMessageControllerTest.php
+++ b/tests/framework/console/controllers/BaseMessageControllerTest.php
@@ -133,6 +133,26 @@ abstract class BaseMessageControllerTest extends TestCase
     abstract protected function getDefaultConfig();
 
     /**
+     * Check if specified message in category contains description
+     *
+     * @param string $category
+     * @param string $message
+     * @param string $description
+     * @return bool
+     */
+    abstract protected function messageContainsDescription($category, $message, $description);
+
+    /**
+     * Check if specified parameter contains description
+     * @param string $category
+     * @param string $message
+     * @param string $parameter
+     * @param string $description parameter description
+     * @return bool
+     */
+    abstract protected function messageParameterContainsDescription($category, $message, $parameter, $description);
+
+    /**
      * Returns config.
      *
      * @param array $additionalConfig
@@ -562,17 +582,33 @@ abstract class BaseMessageControllerTest extends TestCase
     /**
      * @depends testCreateTranslation
      */
-    public function textExtractMessageContext()
+    public function testExtractMessageContext()
     {
+        $sourceFileContent = "
+            echo PHP_EOL, Yii::t('app', 'Message with main context' /* message description */);
+        ";
+        $this->createSourceFile($sourceFileContent);
 
+        $this->saveConfigFile($this->getConfig(['extractContext' => true]));
+        $this->runMessageControllerAction('extract', [$this->configFileName]);
+
+        $this->assertTrue($this->messageContainsDescription('app', 'Message with main context', 'message description'));
     }
 
     /**
      * @depends testCreateTranslation
      */
-    public function textExtractMessageParametersContext()
+    public function testExtractMessageParametersContext()
     {
+        $sourceFileContent = "
+            echo PHP_EOL, Yii::t('app', 'Message with {param} description', ['param' /* parameter description */ => '']);
+        ";
+        $this->createSourceFile($sourceFileContent);
 
+        $this->saveConfigFile($this->getConfig(['extractContext' => true]));
+        $this->runMessageControllerAction('extract', [$this->configFileName]);
+
+        $this->assertTrue($this->messageParameterContainsDescription('app', 'Message with {param} description', 'param','parameter description'));
     }
 
     /**

--- a/tests/framework/console/controllers/DbMessageControllerTest.php
+++ b/tests/framework/console/controllers/DbMessageControllerTest.php
@@ -159,6 +159,22 @@ class DbMessageControllerTest extends BaseMessageControllerTest
             ])->all(static::$db), 'message', 'translation');
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function messageContainsDescription($category, $message, $description)
+    {
+       return true; // DB message does not support message context
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function messageParameterContainsDescription($category, $message, $parameter, $description)
+    {
+        return true; // DB message does not support message context
+    }
+
     // DbMessage tests variants:
 
     /**

--- a/tests/framework/console/controllers/PHPMessageControllerTest.php
+++ b/tests/framework/console/controllers/PHPMessageControllerTest.php
@@ -43,7 +43,7 @@ class PHPMessageControllerTest extends BaseMessageControllerTest
             'messagePath' => $this->messagePath,
             'overwrite' => true,
             'phpFileHeader' => "/*file header*/\n",
-            'phpDocBlock' => '/*doc block*/'
+            'phpDocBlock' => '/*doc block*/',
         ];
     }
 

--- a/tests/framework/console/controllers/PHPMessageControllerTest.php
+++ b/tests/framework/console/controllers/PHPMessageControllerTest.php
@@ -44,6 +44,7 @@ class PHPMessageControllerTest extends BaseMessageControllerTest
             'overwrite' => true,
             'phpFileHeader' => "/*file header*/\n",
             'phpDocBlock' => '/*doc block*/',
+            'extractContext' => true
         ];
     }
 

--- a/tests/framework/console/controllers/PHPMessageControllerTest.php
+++ b/tests/framework/console/controllers/PHPMessageControllerTest.php
@@ -43,8 +43,7 @@ class PHPMessageControllerTest extends BaseMessageControllerTest
             'messagePath' => $this->messagePath,
             'overwrite' => true,
             'phpFileHeader' => "/*file header*/\n",
-            'phpDocBlock' => '/*doc block*/',
-            'extractContext' => true
+            'phpDocBlock' => '/*doc block*/'
         ];
     }
 
@@ -94,6 +93,28 @@ class PHPMessageControllerTest extends BaseMessageControllerTest
         }
 
         return require $messageFilePath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function messageContainsDescription($category, $message, $description)
+    {
+        $fileData = file_get_contents($this->getMessageFilePath($category));
+        $messagePosition = strpos($fileData, $message);
+        $descriptionPosition = strpos($fileData, '@description ' . $description);
+        return $messagePosition !== false && $descriptionPosition !== false && $messagePosition > $descriptionPosition;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function messageParameterContainsDescription($category, $message, $parameter, $description)
+    {
+        $fileData = file_get_contents($this->getMessageFilePath($category));
+        $messagePosition = strpos($fileData, $message);
+        $parameterPosition = strpos($fileData, '@param {' . $parameter . '} ' . $description);
+        return $messagePosition !== false && $parameterPosition !== false && $messagePosition > $parameterPosition;
     }
 
     // By default phpunit runs inherited test after inline tests, so `testCreateTranslation()` would be run after

--- a/tests/framework/console/controllers/POMessageControllerTest.php
+++ b/tests/framework/console/controllers/POMessageControllerTest.php
@@ -66,7 +66,7 @@ class POMessageControllerTest extends BaseMessageControllerTest
 
         $data = [];
         foreach ($messages as $message => $translation) {
-            $data[$category . chr(4) . $message] = $translation;
+            $data[$category . chr(4) . $message]['text'] = $translation;
         }
 
         $gettext->save($messageFilePath, $data);

--- a/tests/framework/console/controllers/POMessageControllerTest.php
+++ b/tests/framework/console/controllers/POMessageControllerTest.php
@@ -85,4 +85,26 @@ class POMessageControllerTest extends BaseMessageControllerTest
         $gettext = new GettextPoFile();
         return $gettext->load($messageFilePath, $category);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function messageContainsDescription($category, $message, $description)
+    {
+        $fileData = file_get_contents($this->getMessageFilePath($category));
+        $messagePosition = strpos($fileData, $message);
+        $descriptionPosition = strpos($fileData, '#. ' . $description);
+        return $messagePosition !== false && $descriptionPosition !== false && $messagePosition > $descriptionPosition;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function messageParameterContainsDescription($category, $message, $parameter, $description)
+    {
+        $fileData = file_get_contents($this->getMessageFilePath($category));
+        $messagePosition = strpos($fileData, $message);
+        $parameterPosition = strpos($fileData, '#. {' . $parameter . '} ' . $description);
+        return $messagePosition !== false && $parameterPosition !== false && $messagePosition > $parameterPosition;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | https://github.com/yiisoft/i18n/issues/4 (it was moved form yii2 before I was able to finish it.. :/ )

THIS IS DRAFTED PULL REQUEST. Please look at this, and tell mi four opinion, or what I should improve. I would be very happy, if this feature became part of Yii framework. Thanks!

Message command is able to extract message context from `Yii:t()` calls containing `/* */` comments. To allow message context extraction, you need to set `extractContext` paramter to `true`.

After integrating this into Yii2, I will then port this also to upcoming Yii3.

## Reasoning
Our applications run in multiple markets and thus have to support multiple languages. Currently it is quite impossible, to just use extract command and send generated files to our translators, because the have no knowledge, where and how is some message used in our application. Mainly if for one English sentence there might be multiple Slovak translations, depending on context and vice versa. 
Also, translators have no idea, in which format or what kind of values can have parameters, used in messages.
Much deeper discussion about this topic can be found here: [yiisoft/yii-core/issues/70](https://github.com/yiisoft/yii-core/issues/70)

## Goal & Inspirations
To be able to add some context to translation messages, that can be used also in external localisation management tools like [Crowdin](https://crowdin.com/).
Similar approach is used for example in wordpress: https://codex.wordpress.org/I18n_for_WordPress_Developers

## Features
- Extract context for messages and params
- Locate file, from which was context for given message extracted. In case, message is used in multiple files, all files with given context are located and context is extracted.

## Context extraction
### Main Message context
Message description should be specified as comment `/* */`, be inside `Yii::t()` call and follow directly after message and before params.
`Yii:t('category', 'message' /* mesasge description */)`
`Yii:t('category', 'message with {param}' /* mesasge description */, ['param' => 'parameter'])`

### Message Parameter context
Parameter description should be specified as comment `/* */`, be inside `Yii::t()` call.
For named parameters, it should follow directly after parameter name (key).
`Yii:t('category', 'message with {param}', ['param' /* param description */ => $param])`
For unnamed parameters, it should be before parameter value:
`Yii:t('category', 'message with {0}', [/* param description */ $param])`

## How extracted context is saved
```php
<?php // views/site/index.php
echo Yii:t(
    'category',
    'message with {param} and {anotherParam}' /* message description */,
    ['param' /* parameter description */ => $value, 'anotherParam' => $anotherValue]
);
```
### PHPMessageSource
Result is saved normally into `category.php` message file. Context is saved in comments above extracted message. 
```php
<?php // messages/en_US/category.php
return [
/**
 * @file views/site/index.php
 * @description message description
 * @param {param} parameter description
 * @param {anotherParam}
 */
'message with {param} and {anotherParam}'  => ''
];
```
### POMessageSource
Result is saved in PO file. Context is saved in `#.` gettext paramters, which refers to extracted comments and `#:` which refers to message reference. For more info about PO file format: [PO Format manual](https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html)
```gettext
#: views/site/index.php
#. message description
#. {param} parameter description
#. {anotherParam}
msgctxt "category"
msgid "message with {param} and {anotherParam}"
msgstr ""

```
### DBMessageSource
not yet implemented. I think, I will store it in custom table, containing context for each occurrence of some message, but I am open to discussion.