### PR TITLE
Introduced foreign values for fixture data

### DIFF
--- a/framework/test/ActiveFixture.php
+++ b/framework/test/ActiveFixture.php
@@ -76,6 +76,19 @@ class ActiveFixture extends BaseActiveFixture
         $this->data = [];
         $table = $this->getTableSchema();
         foreach ($this->getData() as $alias => $row) {
+            foreach ($row as $key => $value) {
+                if (is_array($value)) {
+                    list($modelClass, $modelAlias, $property) = $value;
+                    if (!key_exists($modelClass, $this->dependInstances)) {
+                        throw new \Exception("Missing fixture data " . $modelClass);
+                    }
+                    $model = $this->dependInstances[$modelClass]->getModel($modelAlias);
+                    if ($model === null) {
+                        throw new \Exception("Missing fixture data " . $modelAlias . " of " . $modelClass);
+                    }
+                    $row[$key] = $this->dependInstances[$modelClass]->getModel($modelAlias)->$property;
+                }
+            }
             $primaryKeys = $this->db->schema->insert($table->fullName, $row);
             $this->data[$alias] = array_merge($row, $primaryKeys);
         }

--- a/framework/test/Fixture.php
+++ b/framework/test/Fixture.php
@@ -39,6 +39,13 @@ class Fixture extends Component
 
 
     /**
+     * @var array the fixtures that this fixture depends on. This must be a list of the dependent
+     * fixture instances.
+     */
+    public $dependInstances = [];
+
+
+    /**
      * Loads the fixture.
      * This method is called before performing every test method.
      * You should override this method with concrete implementation about how to set up the fixture.

--- a/framework/test/FixtureTrait.php
+++ b/framework/test/FixtureTrait.php
@@ -200,6 +200,11 @@ trait FixtureTrait
                 $name = isset($aliases[$class]) ? $aliases[$class] : $class;
                 unset($instances[$name]);  // unset so that the fixture is added to the last in the next line
                 $instances[$name] = $fixture;
+                foreach ($stack as $instance) {
+                    if ($instance instanceof Fixture && in_array($class, $instance->depends)) {
+                        $instance->dependInstances[$fixture->modelClass] = $fixture;
+                    }
+                } 
             } else {
                 $class = ltrim($fixture['class'], '\\');
                 $name = isset($aliases[$class]) ? $aliases[$class] : $class;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

I suggest to introduce format into fixture data:
```['ActiveRecordModelName', 'ForeignModelDataAlias', 'ModelProperty']```

It will be beneficial to get foreign data from dependent fixtures, especially the generated data like id, updated_at etc.

Example of use:
```['app\models\User', 'disabled_user', 'id']```

It was made to work, so feedback is welcome.

Unfortunately it is not possible to implement such feature without changes in Yii2 itself.
