### PR TITLE
do not populate $response when response code is 204

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #17156: Fixes PHP 7.2 warning when a data provider has no data as a parameter for a GridView (evilito)
+- Bug #17180: Do not populate `yii\web\Response::$response` when response code is 204 (mikk150)
 
 
 2.0.16.1 February 28, 2019

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -410,10 +410,6 @@ class Response extends \yii\base\Response
      */
     protected function sendContent()
     {
-        if ($this->getStatusCode() === 204) {
-            return;
-        }
-
         if ($this->stream === null) {
             echo $this->content;
 
@@ -1035,6 +1031,12 @@ class Response extends \yii\base\Response
      */
     protected function prepare()
     {
+        if ($this->statusCode === 204) {
+            $this->content = '';
+            $this->stream = null;
+            return;
+        }
+
         if ($this->stream !== null) {
             return;
         }

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -226,4 +226,32 @@ class ResponseTest extends \yiiunit\TestCase
         $content = ob_get_clean();
         $this->assertSame($content, '');
     }
+
+    public function testSettingContentToNullOn204()
+    {
+        $response = new Response();
+        $response->setStatusCode(204);
+        $response->content = 'not empty content';
+
+        ob_start();
+        $response->send();
+        $content = ob_get_clean();
+        $this->assertSame($content, '');
+        $this->assertSame($response->content, '');
+    }
+
+    public function testSettingStreamToNullOn204()
+    {
+        $response = new Response();
+        $dataFile = \Yii::getAlias('@yiiunit/data/web/data.txt');
+
+        $response->sendFile($dataFile);
+        $response->setStatusCode(204);
+
+        ob_start();
+        $response->send();
+        $content = ob_get_clean();
+        $this->assertSame($content, '');
+        $this->assertNull($response->stream);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #17180 https://github.com/Codeception/Codeception/issues/5418
