### PR TITLE
Fixed (#17220)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.18 under development
 ------------------------
 
-- no changes in this release.
+- Bug #17220: Fixed error when using non-InputWidget in active form field (s1lver)
 
 
 2.0.17 March 22, 2019

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -760,7 +760,6 @@ class ActiveField extends Component
      * @param string $class the widget class name.
      * @param array $config name-value pairs that will be used to initialize the widget.
      * @return $this the field object itself.
-     * @throws \Exception
      */
     public function widget($class, $config = [])
     {

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -746,6 +746,9 @@ class ActiveField extends Component
      * If you want to use a widget that does not have `model` and `attribute` properties,
      * please use [[render()]] instead.
      *
+     * While widgets extending from [[Widget]] work with active field, it is preferred to use
+     * [[InputWidget]] as a base class.
+     *
      * For example to use the [[MaskedInput]] widget to get some date input, you can use
      * the following code, assuming that `$form` is your [[ActiveForm]] instance:
      *

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -760,19 +760,20 @@ class ActiveField extends Component
      * @param string $class the widget class name.
      * @param array $config name-value pairs that will be used to initialize the widget.
      * @return $this the field object itself.
+     * @throws \Exception
      */
     public function widget($class, $config = [])
     {
-        foreach ($this->inputOptions as $key => $value) {
-            if (!isset($config['options'][$key])) {
-                $config['options'][$key] = $value;
-            }
-        }
         /* @var $class \yii\base\Widget */
         $config['model'] = $this->model;
         $config['attribute'] = $this->attribute;
         $config['view'] = $this->form->getView();
         if (is_subclass_of($class, 'yii\widgets\InputWidget')) {
+            foreach ($this->inputOptions as $key => $value) {
+                if (!isset($config['options'][$key])) {
+                    $config['options'][$key] = $value;
+                }
+            }
             $config['field'] = $this;
             if (isset($config['options'])) {
                 if ($this->form->validationStateOn === ActiveForm::VALIDATION_STATE_ON_INPUT) {


### PR DESCRIPTION
Fixed error if the $config param not already include 'options' key

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | #17220
