### PR TITLE
Check if widget has $options property

### DIFF
--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -763,7 +763,9 @@ class ActiveField extends Component
      */
     public function widget($class, $config = [])
     {
-        if (property_exists($class, 'options')) {
+        if (property_exists($class, 'options')
+            || (is_subclass_of($class, 'yii\base\BaseObject') && method_exists ($class, 'setOptions'))
+        ) {
             foreach ($this->inputOptions as $key => $value) {
                 if (!isset($config['options'][$key])) {
                     $config['options'][$key] = $value;

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -763,9 +763,11 @@ class ActiveField extends Component
      */
     public function widget($class, $config = [])
     {
-        foreach ($this->inputOptions as $key => $value) {
-            if (!isset($config['options'][$key])) {
-                $config['options'][$key] = $value;
+        if (property_exists($class, 'options')) {
+            foreach ($this->inputOptions as $key => $value) {
+                if (!isset($config['options'][$key])) {
+                    $config['options'][$key] = $value;
+                }
             }
         }
         /* @var $class \yii\base\Widget */


### PR DESCRIPTION
Make sure the widget has an `options` property before moving `inputOptions` to it.
This fixes backwards compatibility issues that might be caused by a8d4f8538e6996a5b1153e714bb7b14e210b30cd
For a workaround and more info please see #17230

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #17230
