### PR TITLE
Fixes #17235: `FileHelper::normalizePath()` now accepts stream wrappers

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #17220: Fixed error when using non-InputWidget in active form field (s1lver)
+- Bug #17235: `yii\helpers\FileHelper::normalizePath()` now accepts stream wrappers (razvanphp)
 
 
 2.0.17 March 22, 2019

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -50,6 +50,9 @@ class BaseFileHelper
      * - Turn multiple consecutive slashes into a single one (e.g. "/a///b/c" becomes "/a/b/c")
      * - Remove ".." and "." based on their meanings (e.g. "/a/./b/../c" becomes "/a/c")
      *
+     * Note: For registered stream wrappers, the consecutive slashes rule
+     * and ".."/"." translations are skipped.
+     *
      * @param string $path the file/directory path to be normalized
      * @param string $ds the directory separator to be used in the normalized result. Defaults to `DIRECTORY_SEPARATOR`.
      * @return string the normalized file/directory path
@@ -59,6 +62,12 @@ class BaseFileHelper
         $path = rtrim(strtr($path, '/\\', $ds . $ds), $ds);
         if (strpos($ds . $path, "{$ds}.") === false && strpos($path, "{$ds}{$ds}") === false) {
             return $path;
+        }
+        // fix #17235 stream wrappers
+        foreach (stream_get_wrappers() as $protocol) {
+            if (strpos($path, "{$protocol}://") === 0) {
+                return $path;
+            }
         }
         // the path may contain ".", ".." or double slashes, need to clean them up
         if (strpos($path, "{$ds}{$ds}") === 0 && $ds == '\\') {

--- a/tests/framework/helpers/FileHelperTest.php
+++ b/tests/framework/helpers/FileHelperTest.php
@@ -745,6 +745,9 @@ class FileHelperTest extends TestCase
         // https://github.com/yiisoft/yii2/issues/13034
         $this->assertEquals('\\\\server\share\path\file', FileHelper::normalizePath('\\\\server\share\path\file', '\\'));
 
+        // Stream Wrappers should not have the double slases stripped
+        // https://github.com/yiisoft/yii2/issues/17235
+        $this->assertEquals('ftp://192.168.1.100/test', FileHelper::normalizePath('ftp://192.168.1.100/test/'));
     }
 
     public function testLocalizedDirectory()

--- a/tests/framework/helpers/FileHelperTest.php
+++ b/tests/framework/helpers/FileHelperTest.php
@@ -745,7 +745,7 @@ class FileHelperTest extends TestCase
         // https://github.com/yiisoft/yii2/issues/13034
         $this->assertEquals('\\\\server\share\path\file', FileHelper::normalizePath('\\\\server\share\path\file', '\\'));
 
-        // Stream Wrappers should not have the double slases stripped
+        // Stream Wrappers should not have the double slashes stripped
         // https://github.com/yiisoft/yii2/issues/17235
         $this->assertEquals('ftp://192.168.1.100/test', FileHelper::normalizePath('ftp://192.168.1.100/test/'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #17235 
