### PR TITLE
Add .mjs mimetype

### DIFF
--- a/framework/helpers/mimeTypes.php
+++ b/framework/helpers/mimeTypes.php
@@ -448,6 +448,7 @@ return [
     'mime' => 'message/rfc822',
     'mj2' => 'video/mj2',
     'mjp2' => 'video/mj2',
+    'mjs' => 'text/javascript',
     'mk3d' => 'video/x-matroska',
     'mka' => 'audio/x-matroska',
     'mks' => 'video/x-matroska',


### PR DESCRIPTION
Google and node.js represent `.mjs`  as ecmascript modules:
* https://developers.google.com/web/fundamentals/primers/modules#mjs
* https://nodejs.org/dist/latest-v10.x/docs/api/esm.html#esm_enabling

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | n/a
