### PR TITLE
Closes #16509. Remove cut parameter of the wordwrap function.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.20 under development
 ------------------------
 
-- no changes in this release.
+- Bug #16509: Fixed console command help text wordwrap for multi-byte strings (alexkart)
 
 
 2.0.19 May 21, 2019

--- a/framework/helpers/BaseConsole.php
+++ b/framework/helpers/BaseConsole.php
@@ -684,7 +684,7 @@ class BaseConsole
             return $text;
         }
         $pad = str_repeat(' ', $indent);
-        $lines = explode("\n", wordwrap($text, $size[0] - $indent, "\n", true));
+        $lines = explode("\n", wordwrap($text, $size[0] - $indent, "\n"));
         $first = true;
         foreach ($lines as $i => $line) {
             if ($first) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #16509

I'm not sure if there is a better solution but setting `$cut = false` makes it look better.
Before:

![b74efb1022bebe873f44bdc05305249c](https://user-images.githubusercontent.com/8249105/58164023-b5922e80-7c8d-11e9-847c-aa81a9ca37a6.png)

After:

![8747961e2706cd1117b54683f54f001c](https://user-images.githubusercontent.com/8249105/58164042-bf1b9680-7c8d-11e9-8aed-c678e4b5b437.png)

![59dafb67b67d9a3cc79e444a3483a539](https://user-images.githubusercontent.com/8249105/58164044-bf1b9680-7c8d-11e9-8168-e0ab9e655d8c.png)
