### PR TITLE
Removed unnecessary ternary operator

### DIFF
--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -188,7 +188,7 @@ class Component extends BaseObject
         } elseif (strncmp($name, 'as ', 3) === 0) {
             // as behavior: attach behavior
             $name = trim(substr($name, 3));
-            $this->attachBehavior($name, $value instanceof Behavior ? $value : Yii::createObject($value));
+            $this->attachBehavior($name, $value);
 
             return;
         }


### PR DESCRIPTION
Why is there ternary operator which creating Behavior before calling attachBehavior() if attachBehaviorInternal() does it later? I think it is not necessary. 

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | no
