### PR TITLE
Improve performance of select() and addSelect()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #17341: Fixed error from yii.activeForm.js in strict mode (mikehaertl)
 - Enh #17345: Improved performance of `yii\db\Connection::quoteColumnName()` (brandonkelly)
+- Enh #17344: Improved performance of `yii\db\Connection::addSelect()` (brandonkelly)
 
 
 2.0.20 June 04, 2019

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -656,8 +656,12 @@ PATTERN;
         foreach ($columns as $columnAlias => $columnDefinition) {
             if (is_string($columnAlias)) {
                 $select[$columnAlias] = $columnDefinition;
-            } else if (is_string($columnDefinition) && preg_match('/^\w+$/', $columnDefinition)) {
-                $select[$columnDefinition] = $columnDefinition;
+            } elseif (is_string($columnDefinition) && strpos($columnDefinition, '(') === false) {
+                if (preg_match('/^(.*?)(?i:\s+as\s+|\s+)([\w\-_\.]+)$/', $columnDefinition, $matches)) {
+                    $select[$matches[2]] = $matches[1];
+                } else {
+                    $select[$columnDefinition] = $columnDefinition;
+                }
             } else {
                 $select[] = $columnDefinition;
             }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -657,16 +657,25 @@ PATTERN;
             if (is_string($columnAlias)) {
                 // Already in the normalized format, good for them
                 $select[$columnAlias] = $columnDefinition;
-            } elseif (is_string($columnDefinition) && preg_match('/^(.*?)(?i:\s+as\s+|\s+)([\w\-_\.]+)$/', $columnDefinition, $matches)) {
-                // Using "columnName as alias" or "columnName alias" syntax
-                $select[$matches[2]] = $matches[1];
-            } elseif (is_string($columnDefinition) && strpos($columnDefinition, '(') === false) {
-                // Normal column name, just alias it to itself to ensure it's not selected twice
-                $select[$columnDefinition] = $columnDefinition;
-            } else {
-                // Either a string calling a function, DB expression, or sub-query
-                $select[] = $columnDefinition;
+                continue;
             }
+            if (is_string($columnDefinition)) {
+                if (
+                    preg_match('/^(.*?)(?i:\s+as\s+|\s+)([\w\-_\.]+)$/', $columnDefinition, $matches) &&
+                    !preg_match('/^\d+$/', $matches[2])
+                ) {
+                    // Using "columnName as alias" or "columnName alias" syntax
+                    $select[$matches[2]] = $matches[1];
+                    continue;
+                }
+                if (strpos($columnDefinition, '(') === false) {
+                    // Normal column name, just alias it to itself to ensure it's not selected twice
+                    $select[$columnDefinition] = $columnDefinition;
+                    continue;
+                }
+            }
+            // Either a string calling a function, DB expression, or sub-query
+            $select[] = $columnDefinition;
         }
         return $select;
     }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -655,14 +655,16 @@ PATTERN;
         $select = [];
         foreach ($columns as $columnAlias => $columnDefinition) {
             if (is_string($columnAlias)) {
+                // Already in the normalized format, good for them
                 $select[$columnAlias] = $columnDefinition;
+            } elseif (is_string($columnDefinition) && preg_match('/^(.*?)(?i:\s+as\s+|\s+)([\w\-_\.]+)$/', $columnDefinition, $matches)) {
+                // Using "columnName as alias" or "columnName alias" syntax
+                $select[$matches[2]] = $matches[1];
             } elseif (is_string($columnDefinition) && strpos($columnDefinition, '(') === false) {
-                if (preg_match('/^(.*?)(?i:\s+as\s+|\s+)([\w\-_\.]+)$/', $columnDefinition, $matches)) {
-                    $select[$matches[2]] = $matches[1];
-                } else {
-                    $select[$columnDefinition] = $columnDefinition;
-                }
+                // Normal column name, just alias it to itself to ensure it's not selected twice
+                $select[$columnDefinition] = $columnDefinition;
             } else {
+                // Either a string calling a function, DB expression, or sub-query
                 $select[] = $columnDefinition;
             }
         }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -649,7 +649,7 @@ PATTERN;
     {
         if ($columns instanceof ExpressionInterface) {
             $columns = [$columns];
-        } else if (!is_array($columns)) {
+        } elseif (!is_array($columns)) {
             $columns = preg_split('/\s*,\s*/', trim($columns), -1, PREG_SPLIT_NO_EMPTY);
         }
         $select = [];

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -656,7 +656,7 @@ PATTERN;
         foreach ($columns as $columnAlias => $columnDefinition) {
             if (is_string($columnAlias)) {
                 $select[$columnAlias] = $columnDefinition;
-            } else if (preg_match('/^\w+$/', $columnDefinition)) {
+            } else if (is_string($columnDefinition) && preg_match('/^\w+$/', $columnDefinition)) {
                 $select[$columnDefinition] = $columnDefinition;
             } else {
                 $select[] = $columnDefinition;

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -1247,7 +1247,7 @@ class QueryBuilder extends \yii\base\BaseObject
             } elseif ($column instanceof Query) {
                 list($sql, $params) = $this->build($column, $params);
                 $columns[$i] = "($sql) AS " . $this->db->quoteColumnName($i);
-            } elseif (is_string($i)) {
+            } elseif (is_string($i) && $i !== $column) {
                 if (strpos($column, '(') === false) {
                     $column = $this->db->quoteColumnName($column);
                 }

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -1642,7 +1642,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
             ->from('tablename');
         list($sql, $params) = $this->getQueryBuilder()->build($query);
         $expected = $this->replaceQuotes(
-            'SELECT [[t]].[[id]] AS [[ID]], [[gsm]].[[username]] AS [[GSM]], [[part]].[[Part]], [[t]].[[Part_Cost]] AS [[Part Cost]], st_x(location::geometry) as lon,'
+            'SELECT [[t]].[[id]] AS [[ID]], [[gsm]].[[username]] AS [[GSM]], [[part]].[[Part]], [[t]].[[Part_Cost]] AS [[Part Cost]], st_x(location::geometry) AS [[lon]],'
             . ' case t.Status_Id when 1 then \'Acknowledge\' when 2 then \'No Action\' else \'Unknown Action\' END as [[Next Action]] FROM [[tablename]]');
         $this->assertEquals($expected, $sql);
         $this->assertEmpty($params);

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -54,6 +54,10 @@ abstract class QueryTest extends DatabaseTestCase
         $this->assertEquals(['a' => 'field1', 'b' => 'field 1'], $query->select);
 
         $query = new Query();
+        $query->addSelect(['field1 a', 'field 1 b']);
+        $this->assertEquals(['a' => 'field1', 'b' => 'field 1'], $query->select);
+
+        $query = new Query();
         $query->select(['name' => 'firstname', 'lastname']);
         $query->addSelect(['firstname', 'surname' => 'lastname']);
         $query->addSelect(['firstname', 'lastname']);

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -26,7 +26,7 @@ abstract class QueryTest extends DatabaseTestCase
 
         $query = new Query();
         $query->select('id, name', 'something')->distinct(true);
-        $this->assertEquals(['id', 'name'], $query->select);
+        $this->assertEquals(['id' => 'id', 'name' => 'name'], $query->select);
         $this->assertTrue($query->distinct);
         $this->assertEquals('something', $query->selectOption);
 

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -32,42 +32,42 @@ abstract class QueryTest extends DatabaseTestCase
 
         $query = new Query();
         $query->addSelect('email');
-        $this->assertEquals(['email'], $query->select);
+        $this->assertEquals(['email' => 'email'], $query->select);
 
         $query = new Query();
         $query->select('id, name');
         $query->addSelect('email');
-        $this->assertEquals(['id', 'name', 'email'], $query->select);
+        $this->assertEquals(['id' => 'id', 'name' => 'name', 'email' => 'email'], $query->select);
 
         $query = new Query();
         $query->select('name, lastname');
         $query->addSelect('name');
-        $this->assertEquals(['name', 'lastname'], $query->select);
+        $this->assertEquals(['name' => 'name', 'lastname' => 'lastname'], $query->select);
 
         $query = new Query();
         $query->addSelect(['*', 'abc']);
         $query->addSelect(['*', 'bca']);
-        $this->assertEquals(['*', 'abc', 'bca'], $query->select);
+        $this->assertEquals(['*', 'abc' => 'abc', 'bca' => 'bca'], $query->select);
 
         $query = new Query();
         $query->addSelect(['field1 as a', 'field 1 as b']);
-        $this->assertEquals(['field1 as a', 'field 1 as b'], $query->select);
+        $this->assertEquals(['a' => 'field1', 'b' => 'field1'], $query->select);
 
         $query = new Query();
         $query->select(['name' => 'firstname', 'lastname']);
         $query->addSelect(['firstname', 'surname' => 'lastname']);
         $query->addSelect(['firstname', 'lastname']);
-        $this->assertEquals(['name' => 'firstname', 'lastname', 'firstname', 'surname' => 'lastname'], $query->select);
+        $this->assertEquals(['name' => 'firstname', 'lastname' => 'lastname', 'firstname' => 'firstname', 'surname' => 'lastname'], $query->select);
 
         $query = new Query();
         $query->select('name, name, name as X, name as X');
-        $this->assertEquals(['name', 'name as X'], array_values($query->select));
+        $this->assertEquals(['name' => 'name', 'X' => 'name'], array_values($query->select));
 
         /** @see https://github.com/yiisoft/yii2/issues/15676 */
         $query = (new Query())->select('id');
-        $this->assertSame(['id'], $query->select);
+        $this->assertSame(['id' => 'id'], $query->select);
         $query->select(['id', 'brand_id']);
-        $this->assertSame(['id', 'brand_id'], $query->select);
+        $this->assertSame(['id' => 'id', 'brand_id' => 'brand_id'], $query->select);
 
         /** @see https://github.com/yiisoft/yii2/issues/15676 */
         $query = (new Query())->select(['prefix' => 'LEFT(name, 7)', 'prefix_key' => 'LEFT(name, 7)']);

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -20,7 +20,7 @@ abstract class QueryTest extends DatabaseTestCase
         // default
         $query = new Query();
         $query->select('*');
-        $this->assertEquals(['*'], $query->select);
+        $this->assertEquals(['*' => '*'], $query->select);
         $this->assertNull($query->distinct);
         $this->assertNull($query->selectOption);
 
@@ -47,7 +47,7 @@ abstract class QueryTest extends DatabaseTestCase
         $query = new Query();
         $query->addSelect(['*', 'abc']);
         $query->addSelect(['*', 'bca']);
-        $this->assertEquals(['*', 'abc' => 'abc', 'bca' => 'bca'], $query->select);
+        $this->assertEquals(['*' => '*', 'abc' => 'abc', 'bca' => 'bca'], $query->select);
 
         $query = new Query();
         $query->addSelect(['field1 as a', 'field 1 as b']);

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -51,7 +51,7 @@ abstract class QueryTest extends DatabaseTestCase
 
         $query = new Query();
         $query->addSelect(['field1 as a', 'field 1 as b']);
-        $this->assertEquals(['a' => 'field1', 'b' => 'field1'], $query->select);
+        $this->assertEquals(['a' => 'field1', 'b' => 'field 1'], $query->select);
 
         $query = new Query();
         $query->select(['name' => 'firstname', 'lastname']);

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -73,11 +73,11 @@ abstract class QueryTest extends DatabaseTestCase
         $query = (new Query())->select(['prefix' => 'LEFT(name, 7)', 'prefix_key' => 'LEFT(name, 7)']);
         $this->assertSame(['prefix' => 'LEFT(name, 7)', 'prefix_key' => 'LEFT(name, 7)'], $query->select);
         $query->addSelect(['LEFT(name,7) as test']);
-        $this->assertSame(['prefix' => 'LEFT(name, 7)', 'prefix_key' => 'LEFT(name, 7)', 'LEFT(name,7) as test'], $query->select);
+        $this->assertSame(['prefix' => 'LEFT(name, 7)', 'prefix_key' => 'LEFT(name, 7)', 'test' => 'LEFT(name,7)'], $query->select);
         $query->addSelect(['LEFT(name,7) as test']);
-        $this->assertSame(['prefix' => 'LEFT(name, 7)', 'prefix_key' => 'LEFT(name, 7)', 'LEFT(name,7) as test'], $query->select);
+        $this->assertSame(['prefix' => 'LEFT(name, 7)', 'prefix_key' => 'LEFT(name, 7)', 'test' => 'LEFT(name,7)'], $query->select);
         $query->addSelect(['test' => 'LEFT(name,7)']);
-        $this->assertSame(['prefix' => 'LEFT(name, 7)', 'prefix_key' => 'LEFT(name, 7)', 'LEFT(name,7) as test', 'test' => 'LEFT(name,7)'], $query->select);
+        $this->assertSame(['prefix' => 'LEFT(name, 7)', 'prefix_key' => 'LEFT(name, 7)', 'test' => 'LEFT(name,7)'], $query->select);
 
         /** @see https://github.com/yiisoft/yii2/issues/15731 */
         $selectedCols = [

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -61,7 +61,7 @@ abstract class QueryTest extends DatabaseTestCase
 
         $query = new Query();
         $query->select('name, name, name as X, name as X');
-        $this->assertEquals(['name' => 'name', 'X' => 'name'], array_values($query->select));
+        $this->assertEquals(['name' => 'name', 'X' => 'name'], $query->select);
 
         /** @see https://github.com/yiisoft/yii2/issues/15676 */
         $query = (new Query())->select('id');


### PR DESCRIPTION
We just profiled a 25.8s request with Blackfire, and found that 11.5s / 44.5% was spent on `yii\db\Query::getUniqueColumns()` (called by `select()` and `addSelect()`), and its callee, `getUnaliasedColumnsFromSelect()`.

<img width="423" alt="Screen Shot 2019-06-06 at 3 21 25 PM" src="https://user-images.githubusercontent.com/47792/59070991-b7551800-8871-11e9-866a-ba756773c31c.png">

[View on Blackfire ➡️](https://blackfire.io/profiles/26b68fc8-ccb8-424c-a9b6-06010fbb06e9/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=yii%5Cdb%5CQuery%3A%3AgetUniqueColumns%3F34f7364a45ee985db52f3b3a2c668108&callname=main())

We rewrote `select()` and `addSelect()` to be more efficient, avoiding `getUniqueColumns()` altogether and ensuring uniqueness by normalizing SELECT columns similar to the way `orderBy()` / `normalizeOrderBy()` works. Now aliases are always normalized into the `['alias' => 'column']` syntax, and even un-aliased _column names_ (excluding expressions, sub-selects, and strings with parentheses) are aliased to themselves (`['column' => 'column']`).

The result:  `select()` isn’t even showing up on Blackfire’s radar anymore, and `addSelect()` is only taking up 663ms (17.3x faster), bringing the request time down to 14.1s (1.8x faster).

<img width="425" alt="Screen Shot 2019-06-06 at 3 53 03 PM" src="https://user-images.githubusercontent.com/47792/59071380-3565ee80-8873-11e9-9de8-413ef2574b3f.png">

[View on Blackfire ➡️](https://blackfire.io/profiles/62b0108f-2492-406b-8352-a6c8bfd8cc14/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=craft%5Cdb%5CQuery%3A%3AaddSelect&callname=main())

We hope that is a performance improvement worth considering :)

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes