### PR TITLE
Improve quoteColumnName() performance

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #17341: Fixed error from yii.activeForm.js in strict mode (mikehaertl)
+- Enh #17345: Improved performance of `yii\db\Connection::quoteColumnName()` (brandonkelly)
 
 
 2.0.20 June 04, 2019

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -441,6 +441,10 @@ class Connection extends Component
      * @var array query cache parameters for the [[cache()]] calls
      */
     private $_queryCacheInfo = [];
+    /**
+     * @var string[] quoted column name cache for [[quoteColumnName()]] calls
+     */
+    private $_quotedColumnNames;
 
 
     /**
@@ -904,7 +908,10 @@ class Connection extends Component
      */
     public function quoteColumnName($name)
     {
-        return $this->getSchema()->quoteColumnName($name);
+        if (isset($this->_quotedColumnNames[$name])) {
+            return $this->_quotedColumnNames[$name];
+        }
+        return $this->_quotedColumnNames[$name] = $this->getSchema()->quoteColumnName($name);
     }
 
     /**


### PR DESCRIPTION
When profiling a long-running request, we noticed that `yii\db\Connection::quoteColumnName()` was a particularly heavy hitter. By memoizing its results, we were able to take it from 1.77s down to 131ms.

Here are the Blackfire profiles:

[Before ➡️](https://blackfire.io/profiles/26b68fc8-ccb8-424c-a9b6-06010fbb06e9/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=yii%5Cdb%5CConnection%3A%3AquoteColumnName%3Ff00dc918117e345938b92b556774aea2&callname=main())
[After ➡️](https://blackfire.io/profiles/6b945003-0a13-4b57-8625-a87a8640a2f1/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=yii%5Cdb%5CConnection%3A%3AquoteTableName%3Ff00dc918117e345938b92b556774aea2&callname=main())

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no