### PR TITLE
Update path configuration for composer-asset-plugin

### DIFF
--- a/docs/guide/structure-assets.md
+++ b/docs/guide/structure-assets.md
@@ -266,9 +266,11 @@ will be placed, if you want to publish them using Yii:
 
 ```json
 "config": {
-    "asset-installer-paths": {
-        "npm-asset-library": "vendor/npm",
-        "bower-asset-library": "vendor/bower"
+    "fxp-asset": {
+        "installer-paths": {
+            "npm-asset-library": "vendor/npm",
+            "bower-asset-library": "vendor/bower"
+        }
     }
 }
 ```


### PR DESCRIPTION
Composer install don't take "installer-paths" on the level of "config". The path which works: "config" => "fxp-asset" => "installer-paths"

Documentation
