### PR TITLE
Improve performance of quoteTableName()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #17341: Fixed error from yii.activeForm.js in strict mode (mikehaertl)
 - Enh #17345: Improved performance of `yii\db\Connection::quoteColumnName()` (brandonkelly)
+- Enh #17348: Improved performance of `yii\db\Connection::quoteTableName()` (brandonkelly)
 
 
 2.0.20 June 04, 2019

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -442,6 +442,10 @@ class Connection extends Component
      */
     private $_queryCacheInfo = [];
     /**
+     * @var string[] quoted table name cache for [[quoteTableName()]] calls
+     */
+    private $_quotedTableNames;
+    /**
      * @var string[] quoted column name cache for [[quoteColumnName()]] calls
      */
     private $_quotedColumnNames;
@@ -895,7 +899,10 @@ class Connection extends Component
      */
     public function quoteTableName($name)
     {
-        return $this->getSchema()->quoteTableName($name);
+        if (isset($this->_quotedTableNames[$name])) {
+            return $this->_quotedTableNames[$name];
+        }
+        return $this->_quotedTableNames[$name] = $this->getSchema()->quoteTableName($name);
     }
 
     /**


### PR DESCRIPTION
Similar to #17345, this PR memoizes the results of `yii\db\Connection::quoteTableName()` for improved performance when the same table name needs to be quoted several times.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes