### PR TITLE
Closes #17070. Strip invalid character from fallback file name

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 Change Log
 - Enh #17348: Improved performance of `yii\db\Connection::quoteTableName()` (brandonkelly)
 - Enh #17353: Added `sameSite` support for `yii\web\Cookie` and `yii\web\Session::cookieParams` (rhertogh)
 - Bug #17341: Allow callable objects to be set to `\yii\filters\AccessRule::$roleParams` (alexkart)
+- Bug #17070: Strip invalid character from fallback file name (alexkart)
 
 
 2.0.20 June 04, 2019

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -781,8 +781,8 @@ class Response extends \yii\base\Response
     protected function getDispositionHeaderValue($disposition, $attachmentName)
     {
         $fallbackName = str_replace(
-            ['%', '/', '\\', '"'],
-            ['_', '_', '_', '\\"'],
+            ['%', '/', '\\', '"', "\x7F"],
+            ['_', '_', '_', '\\"', '_'],
             Inflector::transliterate($attachmentName, Inflector::TRANSLITERATE_LOOSE)
         );
         $utfName = rawurlencode(str_replace(['%', '/', '\\'], '', $attachmentName));

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -262,10 +262,6 @@ class ResponseTest extends \yiiunit\TestCase
 
         $response->sendFile($dataFile, "test\x7Ftest.txt");
 
-        ob_start();
-        $response->send();
-        $content = ob_get_clean();
-
         $this->assertSame("attachment; filename=\"test_test.txt\"; filename*=utf-8''test%7Ftest.txt", $response->headers['content-disposition']);
     }
 }

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -254,4 +254,18 @@ class ResponseTest extends \yiiunit\TestCase
         $this->assertSame($content, '');
         $this->assertNull($response->stream);
     }
+
+    public function testSendFileWithInvalidCharactersInFileName()
+    {
+        $response = new Response();
+        $dataFile = \Yii::getAlias('@yiiunit/data/web/data.txt');
+
+        $response->sendFile($dataFile, "test\x7Ftest.txt");
+
+        ob_start();
+        $response->send();
+        $content = ob_get_clean();
+
+        $this->assertSame("attachment; filename=\"test_test.txt\"; filename*=utf-8''test%7Ftest.txt", $response->headers['content-disposition']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #17070

Comment: https://github.com/yiisoft/yii2/issues/17070#issuecomment-501284488