### PR TITLE
Added type null to @return annotation

### DIFF
--- a/framework/db/ActiveRecordInterface.php
+++ b/framework/db/ActiveRecordInterface.php
@@ -212,7 +212,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      * ```
      *
      * @param mixed $condition primary key value or a set of column values
-     * @return static ActiveRecord instance matching the condition, or `null` if nothing matches.
+     * @return static|null ActiveRecord instance matching the condition, or `null` if nothing matches.
      */
     public static function findOne($condition);
 


### PR DESCRIPTION
Added type null to @return annotation of ActiveRecordInterface::findOne() function.
BaseActiveRecord::findOne() has @return static|null but ActiveRecordInterface::findOne() @return static
[phpstan](https://github.com/phpstan/phpstan) on level 4 returns "If condition is always true." error for next example of code:
```php
if ($user = User::findOne($id)) {
    // some code
}
```
but variable $user can be null

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
