### PR TITLE
Add support for closure controller actions

### DIFF
--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -91,7 +91,7 @@ class Controller extends Component implements ViewContextInterface
      *
      * This method is meant to be overwritten to declare external actions for the controller.
      * It should return an array, with array keys being action IDs, and array values the corresponding
-     * action class names or action configuration arrays. For example,
+     * action class names, action configuration arrays, or closures. For example,
      *
      * ```php
      * return [
@@ -101,11 +101,15 @@ class Controller extends Component implements ViewContextInterface
      *         'property1' => 'value1',
      *         'property2' => 'value2',
      *     ],
+     *     'action3' => function($param1, $param2) {
+     *         // ...
+     *     },
      * ];
      * ```
      *
      * [[\Yii::createObject()]] will be used later to create the requested action
-     * using the configuration provided here.
+     * using the configurations provided here, unless a closure is defined, in which
+     * case an [[InlineAction]] object will be created.
      */
     public function actions()
     {
@@ -224,6 +228,9 @@ class Controller extends Component implements ViewContextInterface
 
         $actionMap = $this->actions();
         if (isset($actionMap[$id])) {
+            if ($actionMap[$id] instanceof \Closure) {
+                return new InlineAction($id, $this, $actionMap[$id]);
+            }
             return Yii::createObject($actionMap[$id], [$id, $this]);
         } elseif (preg_match('/^[a-z0-9\\-_]+$/', $id) && strpos($id, '--') === false && trim($id, '-') === $id) {
             $methodName = 'action' . str_replace(' ', '', ucwords(str_replace('-', ' ', $id)));

--- a/framework/base/InlineAction.php
+++ b/framework/base/InlineAction.php
@@ -31,7 +31,7 @@ class InlineAction extends Action
     /**
      * @param string $id the ID of this action
      * @param Controller $controller the controller that owns this action
-     * @param string $actionMethod the controller method that this inline action is associated with
+     * @param string|\Closure $actionMethod the controller method or closure that this inline action is associated with
      * @param array $config name-value pairs that will be used to initialize the object properties
      */
     public function __construct($id, $controller, $actionMethod, $config = [])
@@ -49,9 +49,18 @@ class InlineAction extends Action
     public function runWithParams($params)
     {
         $args = $this->controller->bindActionParams($this, $params);
-        Yii::debug('Running action: ' . get_class($this->controller) . '::' . $this->actionMethod . '()', __METHOD__);
+        if ($this->actionMethod instanceof \Closure) {
+            $label = 'function()';
+        } else {
+            $label = get_class($this->controller) . '::' . $this->actionMethod . '()';
+        }
+        Yii::debug('Running action: ' . $label, __METHOD__);
         if (Yii::$app->requestedParams === null) {
             Yii::$app->requestedParams = $args;
+        }
+
+        if ($this->actionMethod instanceof \Closure) {
+            return call_user_func_array($this->actionMethod, $args);
         }
 
         return call_user_func_array([$this->controller, $this->actionMethod], $args);

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -161,7 +161,11 @@ class Controller extends \yii\base\Controller
     public function bindActionParams($action, $params)
     {
         if ($action instanceof InlineAction) {
-            $method = new \ReflectionMethod($this, $action->actionMethod);
+            if ($action->actionMethod instanceof \Closure) {
+                $method = new \ReflectionFunction($action->actionMethod);
+            } else {
+                $method = new \ReflectionMethod($this, $action->actionMethod);
+            }
         } else {
             $method = new \ReflectionMethod($action, 'run');
         }
@@ -600,7 +604,11 @@ class Controller extends \yii\base\Controller
     {
         if (!isset($this->_reflections[$action->id])) {
             if ($action instanceof InlineAction) {
-                $this->_reflections[$action->id] = new \ReflectionMethod($this, $action->actionMethod);
+                if ($action->actionMethod instanceof \Closure) {
+                    $this->_reflections[$action->id] = new \ReflectionFunction($action->actionMethod);
+                } else {
+                    $this->_reflections[$action->id] = new \ReflectionMethod($this, $action->actionMethod);
+                }
             } else {
                 $this->_reflections[$action->id] = new \ReflectionMethod($action, 'run');
             }

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -117,7 +117,11 @@ class Controller extends \yii\base\Controller
     public function bindActionParams($action, $params)
     {
         if ($action instanceof InlineAction) {
-            $method = new \ReflectionMethod($this, $action->actionMethod);
+            if ($action->actionMethod instanceof \Closure) {
+                $method = new \ReflectionFunction($action->actionMethod);
+            } else {
+                $method = new \ReflectionMethod($this, $action->actionMethod);
+            }
         } else {
             $method = new \ReflectionMethod($action, 'run');
         }

--- a/tests/framework/console/ControllerTest.php
+++ b/tests/framework/console/ControllerTest.php
@@ -105,6 +105,15 @@ class ControllerTest extends TestCase
         $this->assertResponseStatus($status, $response);
     }
 
+    public function testClosureAction()
+    {
+        $controller = new FakeController('fake', Yii::$app);
+
+        $params = ['d426,mdmunir', 'single'];
+        $result = $controller->runAction('closure', $params);
+        $this->assertEquals([['d426', 'mdmunir'], 'single', 'default'], $result);
+    }
+
     /**
      * @see https://github.com/yiisoft/yii2/issues/12028
      */

--- a/tests/framework/console/FakeController.php
+++ b/tests/framework/console/FakeController.php
@@ -32,6 +32,15 @@ class FakeController extends Controller
         return $wasCalled;
     }
 
+    public function actions()
+    {
+        return [
+            'closure' => function(array $values, $value, $other = 'default') {
+                return [$values, $value, $other];
+            },
+        ];
+    }
+
     public function options($actionID)
     {
         return array_merge(parent::options($actionID), [

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -75,6 +75,13 @@ class ControllerTest extends TestCase
         $this->assertEquals($this->controller->redirect(['//controller/index', 'slug' => 'äöüß!"§$%&/()'])->headers->get('location'), '/index.php?r=controller%2Findex&slug=%C3%A4%C3%B6%C3%BC%C3%9F%21%22%C2%A7%24%25%26%2F%28%29');
     }
 
+    public function testClosureAction()
+    {
+        $params = ['values' => ['d426', 'mdmunir'], 'value' => 'single'];
+        $result = $this->controller->runAction('closure', $params);
+        $this->assertEquals([['d426', 'mdmunir'], 'single', 'default'], $result);
+    }
+
     protected function setUp()
     {
         parent::setUp();

--- a/tests/framework/web/FakeController.php
+++ b/tests/framework/web/FakeController.php
@@ -17,6 +17,15 @@ class FakeController extends Controller
 {
     public $enableCsrfValidation = false;
 
+    public function actions()
+    {
+        return [
+            'closure' => function(array $values, $value, $other = 'default') {
+                return [$values, $value, $other];
+            },
+        ];
+    }
+
     public function actionAksi1($fromGet, $other = 'default')
     {
     }


### PR DESCRIPTION
We have a use case where it would be nice if controller actions could be defined by closures from `Controller::actions()`, and the closures could end up getting stored in `InlineAction` instances, the same way validation closures get stored in `InlineValidator` instances.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
