### PR TITLE
Fixed selectOption position in build select query

### DIFF
--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -1228,9 +1228,10 @@ class QueryBuilder extends \yii\base\BaseObject
      */
     public function buildSelect($columns, &$params, $distinct = false, $selectOption = null)
     {
-        $select = $distinct ? 'SELECT DISTINCT' : 'SELECT';
-        if ($selectOption !== null) {
-            $select .= ' ' . $selectOption;
+        $select = $selectOption !== null ? 'SELECT ' . $selectOption : 'SELECT';
+
+        if ($distinct) {
+            $select .= ' DISTINCT';
         }
 
         if (empty($columns)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌, but may be for some users
| Tests pass?   | ✔️

The existing implementation of select queries building has got a flaw. If you are using the distinct() the query may be built incorrectly. For example for Oracle it does not allow to use database hints together with a distinct(), because order are matter.

Query:
```Table::find()->distinct()->select(['t.COLUMN'], '/*+INDEX ("t" I_UK)*/')```
built as:
```SELECT DISTINCT /*+INDEX ("t" I_UK)*/ "t"."COLUMN" FROM "SCHEMA"."TABLE"```

After changes built this query as:
```SELECT /*+INDEX ("t" I_UK)*/ DISTINCT "t"."COLUMN" FROM "SCHEMA"."TABLE"```
