### PR TITLE
MSSQL: fix `i18n_init` migration

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #17413, #17418, #17426, #17431: Fixed MSSQL tests (alexkart)
 - Bug #17420: Fixed loading of column default values for MSSQL (alexkart)
 - Bug #17395: Fixed issues with actions that contain underscores in their names (alexkart)
+- Bug #17435: Fixed `i18n_init` migration for MSSQL (alexkart)
 
 
 2.0.22 July 02, 2019

--- a/framework/i18n/migrations/m150207_210500_i18n_init.php
+++ b/framework/i18n/migrations/m150207_210500_i18n_init.php
@@ -38,7 +38,12 @@ class m150207_210500_i18n_init extends Migration
         ], $tableOptions);
 
         $this->addPrimaryKey('pk_message_id_language', '{{%message}}', ['id', 'language']);
-        $this->addForeignKey('fk_message_source_message', '{{%message}}', 'id', '{{%source_message}}', 'id', 'CASCADE', 'RESTRICT');
+        $onUpdateConstraint = 'RESTRICT';
+        if ($this->db->driverName === 'sqlsrv') {
+            // 'NO ACTION' is equivalent to 'RESTRICT' in MSSQL
+            $onUpdateConstraint = 'NO ACTION';
+        }
+        $this->addForeignKey('fk_message_source_message', '{{%message}}', 'id', '{{%source_message}}', 'id', 'CASCADE', $onUpdateConstraint);
         $this->createIndex('idx_source_message_category', '{{%source_message}}', 'category');
         $this->createIndex('idx_message_language', '{{%message}}', 'language');
     }

--- a/tests/framework/db/mssql/DbMessageSourceTest.php
+++ b/tests/framework/db/mssql/DbMessageSourceTest.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mssql;
+
+/**
+ * @group i18n
+ * @group db
+ * @group mssql
+ */
+class DbMessageSourceTest extends \yiiunit\framework\i18n\DbMessageSourceTest
+{
+    protected static $driverName = 'sqlsrv';
+}

--- a/tests/framework/i18n/DbMessageSourceTest.php
+++ b/tests/framework/i18n/DbMessageSourceTest.php
@@ -86,23 +86,22 @@ class DbMessageSourceTest extends I18NTest
 
         static::runConsoleAction('migrate/up', ['migrationPath' => '@yii/i18n/migrations/', 'interactive' => false]);
 
-        static::$db->createCommand()->batchInsert('source_message', ['id', 'category', 'message'], [
-            [1, 'test', 'Hello world!'],
-            [2, 'test', 'The dog runs fast.'],
-            [3, 'test', 'His speed is about {n} km/h.'],
-            [4, 'test', 'His name is {name} and his speed is about {n, number} km/h.'],
-            [5, 'test', 'There {n, plural, =0{no cats} =1{one cat} other{are # cats}} on lying on the sofa!'],
+        static::$db->createCommand()->truncateTable('source_message');
+        static::$db->createCommand()->batchInsert('source_message', ['category', 'message'], [
+            ['test', 'Hello world!'], // id = 1
+            ['test', 'The dog runs fast.'], // id = 2
+            ['test', 'His speed is about {n} km/h.'], // id = 3
+            ['test', 'His name is {name} and his speed is about {n, number} km/h.'], // id = 4
+            ['test', 'There {n, plural, =0{no cats} =1{one cat} other{are # cats}} on lying on the sofa!'], // id = 5
         ])->execute();
 
-        static::$db->createCommand()->batchInsert('message', ['id', 'language', 'translation'], [
-            [1, 'de', 'Hallo Welt!'],
-            [2, 'de-DE', 'Der Hund rennt schnell.'],
-            [2, 'en-US', 'The dog runs fast (en-US).'],
-            [2, 'ru', 'Собака бегает быстро.'],
-            [3, 'de-DE', 'Seine Geschwindigkeit beträgt {n} km/h.'],
-            [4, 'de-DE', 'Er heißt {name} und ist {n, number} km/h schnell.'],
-            [5, 'ru', 'На диване {n, plural, =0{нет кошек} =1{лежит одна кошка} one{лежит # кошка} few{лежит # кошки} many{лежит # кошек} other{лежит # кошки}}!'],
-        ])->execute();
+        static::$db->createCommand()->insert('message', ['id' => 1, 'language' => 'de', 'translation' => 'Hallo Welt!'])->execute();
+        static::$db->createCommand()->insert('message', ['id' => 2, 'language' => 'de-DE', 'translation' => 'Der Hund rennt schnell.'])->execute();
+        static::$db->createCommand()->insert('message', ['id' => 2, 'language' => 'en-US', 'translation' => 'The dog runs fast (en-US).'])->execute();
+        static::$db->createCommand()->insert('message', ['id' => 2, 'language' => 'ru', 'translation' => 'Собака бегает быстро.'])->execute();
+        static::$db->createCommand()->insert('message', ['id' => 3, 'language' => 'de-DE', 'translation' => 'Seine Geschwindigkeit beträgt {n} km/h.'])->execute();
+        static::$db->createCommand()->insert('message', ['id' => 4, 'language' => 'de-DE', 'translation' => 'Er heißt {name} und ist {n, number} km/h schnell.'])->execute();
+        static::$db->createCommand()->insert('message', ['id' => 5, 'language' => 'ru', 'translation' => 'На диване {n, plural, =0{нет кошек} =1{лежит одна кошка} one{лежит # кошка} few{лежит # кошки} many{лежит # кошек} other{лежит # кошки}}!'])->execute();
     }
 
     public static function tearDownAfterClass()
@@ -116,10 +115,10 @@ class DbMessageSourceTest extends I18NTest
     }
 
     /**
-     * @throws \yii\base\InvalidParamException
+     * @return \yii\db\Connection
      * @throws \yii\db\Exception
      * @throws \yii\base\InvalidConfigException
-     * @return \yii\db\Connection
+     * @throws \yii\base\InvalidParamException
      */
     public static function getConnection()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

Fixed `m150207_210500_i18n_init.php` migration for MSSQL as there is no `RESTRICT` constraint in MSSQL. The equivalent is `NO ACTION`.
Added `\yiiunit\framework\db\mssql\DbMessageSourceTest` for testing this migration.

Also, changed `batchInsert()` to the `message` table in this test to single inserts as `batchInsert()` incorrectly inserts russian text into the table.
```sql
INSERT INTO [message] ([id], [language], [translation])
VALUES (2, 'ru', 'Собака бегает быстро.'),
       (5, 'ru', 'На диване {n, plural, =0{нет кошек} =1{лежит одна кошка} one{лежит # кошка} few{лежит # кошки} many{лежит # кошек} other{лежит # кошки}}!')
```
Strings should be repended with `N`:
```sql
INSERT INTO [message] ([id], [language], [translation])
VALUES (2, 'ru', N'Собака бегает быстро.'),
       (5, 'ru', N'На диване {n, plural, =0{нет кошек} =1{лежит одна кошка} one{лежит # кошка} few{лежит # кошки} many{лежит # кошек} other{лежит # кошки}}!')
```
or maybe use prepared statement. Should be a separate issue.