### PR TITLE
Abort dev app installation process if error occurred during cloning.

### DIFF
--- a/build/controllers/DevController.php
+++ b/build/controllers/DevController.php
@@ -164,7 +164,11 @@ class DevController extends Controller
             }
 
             $this->stdout("cloning application repo '$app' from '$repo'...\n", Console::BOLD);
-            passthru('git clone ' . escapeshellarg($repo) . ' ' . $appDir);
+            passthru('git clone ' . escapeshellarg($repo) . ' ' . $appDir, $returnVar);
+            if ($returnVar !== 0) {
+                $this->stdout("Error occurred while cloning repository.\n", Console::BOLD, Console::FG_RED);
+                return 1;
+            }
             $this->stdout("done.\n", Console::BOLD, Console::FG_GREEN);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

If it can't clone fork repository it continues the installation process and throws an exception: `PHP Warning 'yii\base\ErrorException' with message 'chdir(): No such file or directory (errno 2)'`