### PR TITLE
Fix #17457: Fix `phpTypecast()` for MSSQL

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.24 under development
 ------------------------
 
+- Bug #17457: Fixed `phpTypecast()` for MSSQL (alexkart)
 - Bug #17219: Fixed quoting of table names with spaces in MSSQL (alexkart)
 - Bug #10020: Fixed quoting of column names with dots in MSSQL (alexkart)
 - Bug #17424: Subdomain support for `User::loginRequired` (alex-code)

--- a/framework/db/mssql/ColumnSchema.php
+++ b/framework/db/mssql/ColumnSchema.php
@@ -15,9 +15,12 @@ namespace yii\db\mssql;
 class ColumnSchema extends \yii\db\ColumnSchema
 {
     /**
-     * {@inheritdoc}
+     * Prepares default value and converts it according to [[phpType]]
+     * @param mixed $value default value
+     * @return mixed converted value
+     * @since 2.0.24
      */
-    public function phpTypecast($value)
+    public function defaultPhpTypecast($value)
     {
         if ($value !== null) {
             // convert from MSSQL column_default format, e.g. ('1') -> 1, ('string') -> string

--- a/framework/db/mssql/ColumnSchema.php
+++ b/framework/db/mssql/ColumnSchema.php
@@ -24,7 +24,7 @@ class ColumnSchema extends \yii\db\ColumnSchema
     {
         if ($value !== null) {
             // convert from MSSQL column_default format, e.g. ('1') -> 1, ('string') -> string
-            $value = trim($value, "'()");
+            $value = substr(substr($value, 0, 2), 0, -2);
         }
 
         return parent::phpTypecast($value);

--- a/framework/db/mssql/ColumnSchema.php
+++ b/framework/db/mssql/ColumnSchema.php
@@ -24,7 +24,7 @@ class ColumnSchema extends \yii\db\ColumnSchema
     {
         if ($value !== null) {
             // convert from MSSQL column_default format, e.g. ('1') -> 1, ('string') -> string
-            $value = substr(substr($value, 0, 2), 0, -2);
+            $value = substr(substr($value, 2), 0, -2);
         }
 
         return parent::phpTypecast($value);

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -397,7 +397,7 @@ SQL;
             $info['column_default'] = null;
         }
         if (!$column->isPrimaryKey && ($column->type !== 'timestamp' || $info['column_default'] !== 'CURRENT_TIMESTAMP')) {
-            $column->defaultValue = $column->phpTypecast($info['column_default']);
+            $column->defaultValue = $column->defaultPhpTypecast($info['column_default']);
         }
 
         return $column;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17457 

`phpTypecast()` is also called from another place where conversion from MSSQL column_default format is not needed. Switched to the dedicated method for the default value casting.