### PR TITLE
Fix #17469: Fixed updating `Yii` logger instance when setting new logger via configuration

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Bug #16796: Fixed addition and removal of table and column comments in MSSQL (sdlins)
 - Bug #17449: Fixed order of SQL column build syntax for MySQL migration (choken)
 - Bug #17437: Fixed generating namespaced migrations (bizley)
+- Bug #17469: Fixed updating `Yii` logger instance when setting new logger via configuration (samdark)
 
 
 2.0.23 July 16, 2019

--- a/framework/log/Dispatcher.php
+++ b/framework/log/Dispatcher.php
@@ -131,6 +131,7 @@ class Dispatcher extends Component
         }
         $this->_logger = $value;
         $this->_logger->dispatcher = $this;
+        Yii::setLogger($this->_logger);
     }
 
     /**

--- a/tests/framework/log/DispatcherTest.php
+++ b/tests/framework/log/DispatcherTest.php
@@ -88,6 +88,16 @@ namespace yiiunit\framework\log {
             $this->assertEquals(42, $dispatcher->getLogger()->traceLevel);
         }
 
+        public function testSetNewLoggerUpdatesGlobalLogger()
+        {
+            $dispatcher = new Dispatcher();
+            $this->assertSame(Yii::getLogger(), $dispatcher->getLogger());
+
+            $newLogger = new Logger();
+            $dispatcher->setLogger($newLogger);
+            $this->assertSame(Yii::getLogger(), $dispatcher->getLogger());
+        }
+
         /**
          * @covers \yii\log\Dispatcher::setLogger()
          */


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17469 
