### PR TITLE
Fix minor typos in fixture guide

### DIFF
--- a/docs/guide/test-fixtures.md
+++ b/docs/guide/test-fixtures.md
@@ -47,8 +47,8 @@ class UserFixture extends ActiveFixture
 > - Elasticsearch: [[yii\elasticsearch\ActiveFixture]] (since version 2.0.2)
 
 
-The fixture data for an `ActiveFixture` fixture is usually provided in a file located at `FixturePath/data/TableName.php`,
-where `FixturePath` stands for the directory containing the fixture class file, and `TableName`
+The fixture data for an `ActiveFixture` fixture is usually provided in a file located at `fixturepath/data/tablename.php`,
+where `fixturepath` stands for the directory containing the fixture class file, and `tablename`
 is the name of the table associated with the fixture. In the example above, the file should be
 `@app/tests/fixtures/data/user.php`. The data file should return an array of data rows
 to be inserted into the user table. For example,
@@ -107,7 +107,7 @@ In the above, we have shown how to define a fixture about a DB table. To define 
 
 ## Using Fixtures
 
-If you are using [Codeception](http://codeception.com/) to test your code, you can use built-in support for loading
+If you are using [Codeception](http://codeception.com/) to test your code, you can use the built-in support for loading
 and accessing fixtures.
 
 If you are using other testing frameworks, you may use [[yii\test\FixtureTrait]] in your
@@ -154,7 +154,7 @@ You may also assign an alias to a fixture. In the above example, the `UserProfil
 In the test methods, you may then access a fixture object using its alias in `grabFixture()` method. For example,
 
 ```php
-$profile = $I->grabFixture('profiles', 'user1');
+$profile = $I->grabFixture('profiles');
 ```
 
 will return the `UserProfileFixture` object.
@@ -201,7 +201,7 @@ In this way you will avoid collision of fixture data files between tests and use
 > from [[yii\test\ActiveFixture]] for DB fixtures, you should use DB table names as the fixture data file names;
 > If you are extending from [[yii\mongodb\ActiveFixture]] for MongoDB fixtures, you should use collection names as the file names.
 
-The similar hierarchy can be used to organize fixture class files. Instead of using `data` as the root directory, you may
+A similar hierarchy can be used to organize fixture class files. Instead of using `data` as the root directory, you may
 want to use `fixtures` as the root directory to avoid conflict with the data files.
 
 ## Managing fixtures with `yii fixture`
@@ -243,7 +243,7 @@ Fixture classes name should not be plural.
 
 ### Loading fixtures
 
-Fixture classes should be suffixed by `Fixture` class. By default fixtures will be searched under `tests\unit\fixtures` namespace, you can
+Fixture classes should be suffixed by `Fixture`. By default fixtures will be searched under `tests\unit\fixtures` namespace, you can
 change this behavior with config or command options. You can exclude some fixtures due load or unload by specifying `-` before its name like `-User`.
 
 To load fixture, run the following command:
@@ -334,9 +334,9 @@ See extension [guide](https://github.com/yiisoft/yii2-faker) for more docs.
 ## Summary
 
 In the above, we have described how to define and use fixtures. Below we summarize the typical workflow
-of running unit tests related with DB:
+of running DB related unit tests:
 
-1. Use `yii migrate` tool to upgrade your test database to the latest version;
+1. Use the `yii migrate` tool to upgrade your test database to the latest version;
 2. Run a test case:
    - Load fixtures: clean up the relevant DB tables and populate them with fixture data;
    - Perform the actual test;


### PR DESCRIPTION
* Fix typo with `grabFixture()` (remove second argument)
* Use lowercase for filename placeholders to better match real filenames
* Add some missing articles for better readability

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -
