### PR TITLE
Closes #17486. Fix error when using `batch()` without `$db` parameter…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.25 under development
 ------------------------
 
-- no changes in this release.
+- Bug #17486: Fixed error when using `batch()` without `$db` parameter with MSSQL (alexkart)
 
 
 2.0.24 July 30, 2019

--- a/framework/db/BatchQueryResult.php
+++ b/framework/db/BatchQueryResult.php
@@ -151,8 +151,8 @@ class BatchQueryResult extends BaseObject implements \Iterator
 
     /**
      * Reads and collects rows for batch
-     * @since 2.0.23
      * @return array
+     * @since 2.0.23
      */
     protected function getRows()
     {
@@ -165,7 +165,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
             }
         } catch (\PDOException $e) {
             $errorCode = isset($e->errorInfo[1]) ? $e->errorInfo[1] : null;
-            if ($this->db->driverName !== 'sqlsrv' || $errorCode !== $this->mssqlNoMoreRowsErrorCode) {
+            if ($this->getDbDriverName() !== 'sqlsrv' || $errorCode !== $this->mssqlNoMoreRowsErrorCode) {
                 throw $e;
             }
         }
@@ -201,5 +201,23 @@ class BatchQueryResult extends BaseObject implements \Iterator
     public function valid()
     {
         return !empty($this->_batch);
+    }
+
+    /**
+     * Gets db driver name from the db connection that is passed to the `batch()`, if it is not passed it uses
+     * connection from the active record model
+     * @return string|null
+     */
+    private function getDbDriverName()
+    {
+        if (isset($this->db->driverName)) {
+            return $this->db->driverName;
+        }
+
+        if (isset($this->_batch[0]->db->driverName)) {
+            return $this->_batch[0]->db->driverName;
+        }
+
+        return null;
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,9 +23,6 @@ require_once __DIR__ . '/../framework/Yii.php';
 
 Yii::setAlias('@yiiunit', __DIR__);
 
-//Yii::setAlias('@yiiunit/runtime', '/home/vagrant/yiiunit/runtime');
-//Yii::setAlias('@runtime', getenv('/home/vagrant/yiiunit/runtime'));
-
 if (getenv('TEST_RUNTIME_PATH')) {
     Yii::setAlias('@yiiunit/runtime', getenv('TEST_RUNTIME_PATH'));
     Yii::setAlias('@runtime', getenv('TEST_RUNTIME_PATH'));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,9 @@ require_once __DIR__ . '/../framework/Yii.php';
 
 Yii::setAlias('@yiiunit', __DIR__);
 
+//Yii::setAlias('@yiiunit/runtime', '/home/vagrant/yiiunit/runtime');
+//Yii::setAlias('@runtime', getenv('/home/vagrant/yiiunit/runtime'));
+
 if (getenv('TEST_RUNTIME_PATH')) {
     Yii::setAlias('@yiiunit/runtime', getenv('TEST_RUNTIME_PATH'));
     Yii::setAlias('@runtime', getenv('TEST_RUNTIME_PATH'));

--- a/tests/framework/db/BatchQueryResultTest.php
+++ b/tests/framework/db/BatchQueryResultTest.php
@@ -108,6 +108,16 @@ abstract class BatchQueryResultTest extends DatabaseTestCase
         $this->assertCount(0, $customers[2]->orders);
     }
 
+    public function testBatchWithoutDbParameter()
+    {
+        $query = Customer::find()->orderBy('id')->limit(3);
+        $customers = $this->getAllRowsFromBach($query->batch(2));
+        $this->assertCount(3, $customers);
+        $this->assertEquals('user1', $customers[0]->name);
+        $this->assertEquals('user2', $customers[1]->name);
+        $this->assertEquals('user3', $customers[2]->name);
+    }
+
     protected function getAllRowsFromBach(BatchQueryResult $batch)
     {
         $allRows = [];


### PR DESCRIPTION
… with MSSQL

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17486
