### PR TITLE
fix flushing cache from console

### DIFF
--- a/framework/console/controllers/CacheController.php
+++ b/framework/console/controllers/CacheController.php
@@ -267,8 +267,10 @@ class CacheController extends Controller
 
             if ($component instanceof CacheInterface) {
                 $caches[$name] = get_class($component);
-            } elseif (is_array($component) && isset($component['class']) && $this->isCacheClass($component['class'])) {
-                $caches[$name] = $component['class'];
+            } elseif (is_array($component) && isset($component['class'])) {
+                if($this->isCacheClass($component['class'])){
+                    $caches[$name] = $component['class'];
+                }
             } elseif (is_string($component) && $this->isCacheClass($component)) {
                 $caches[$name] = $component;
             } elseif (Yii::$app->has($name)) {

--- a/framework/console/controllers/CacheController.php
+++ b/framework/console/controllers/CacheController.php
@@ -271,7 +271,7 @@ class CacheController extends Controller
                 $caches[$name] = $component['class'];
             } elseif (is_string($component) && $this->isCacheClass($component)) {
                 $caches[$name] = $component;
-            } elseif ($component instanceof \Closure) {
+            } elseif (Yii::$app->has($name)) {
                 $cache = Yii::$app->get($name);
                 if ($this->isCacheClass($cache)) {
                     $cacheClass = get_class($cache);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | -

When using following application configurations console cache can't find cache component

```php
return [
    //...
    'container' => [
        //...
        'singletons' => [
             //...
            'cache-main' => [
                'class' => \yii\caching\FileCache::class,
            ],
            //...
        ],
        //...
    ],
    //...
    'components' => [
        //...
        'cache' => 'cache-main',
        //...
    ],
    //...
];
```

But in this case, `\yii\web\AssetManager` should be configured...