### PR TITLE
Added data-name attribute to ActionColumn::initDefaultButton()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -20,6 +20,7 @@ Yii Framework 2 Change Log
 - Bug #17449: Fixed order of SQL column build syntax for MySQL migration (choken)
 - Bug #17457: Fixed `phpTypecast()` for MSSQL (alexkart)
 - Bug #17469: Fixed updating `Yii` logger instance when setting new logger via configuration (samdark)
+- Enh #17502: Added `data-name` attribute to `ActionColumn::initDefaultButton()` (rhertogh)
 
 
 2.0.23 July 16, 2019

--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -178,6 +178,7 @@ class ActionColumn extends Column
                     'title' => $title,
                     'aria-label' => $title,
                     'data-pjax' => '0',
+                    'data-name' => $name,
                 ], $additionalOptions, $this->buttonOptions);
                 $icon = Html::tag('span', '', ['class' => "glyphicon glyphicon-$iconName"]);
                 return Html::a($icon, $url, $options);


### PR DESCRIPTION
Added `data-name` attribute to the `ActionColumn::initDefaultButton()` function generation.
This helps to programmatically access the buttons

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -
