### PR TITLE
Fix #17507: Fixed regular expression escaping in `Controller::createAction()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #17511: Fixed IPv6 subnets matching in `IpHelper::inRange()` (kamarton)
-
+- Bug #17507: Fixed regular expression escaping in `Controller::createAction()` (samdark)
 
 2.0.25 August 13, 2019
 ----------------------

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -225,7 +225,9 @@ class Controller extends Component implements ViewContextInterface
         $actionMap = $this->actions();
         if (isset($actionMap[$id])) {
             return Yii::createObject($actionMap[$id], [$id, $this]);
-        } elseif (preg_match('/^[a-z0-9\\-_]+$/', $id) && strpos($id, '--') === false && trim($id, '-') === $id) {
+        }
+
+        if (preg_match('/^[a-z0-9\-_]+$/', $id) && strpos($id, '--') === false && trim($id, '-') === $id) {
             $methodName = 'action' . str_replace(' ', '', ucwords(str_replace('-', ' ', $id)));
             if (method_exists($this, $methodName)) {
                 $method = new \ReflectionMethod($this, $methodName);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17507 
