### PR TITLE
Fixed regular expression escaping and simpler condition in `Controlle…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #17511: Fixed IPv6 subnets matching in `IpHelper::inRange()` (kamarton)
+- Bug #17507: Fixed regular expression escaping and simpler condition in `Controller::createAction()` (kamarton)
 
 
 2.0.25 August 13, 2019

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -37,6 +37,10 @@ class Controller extends Component implements ViewContextInterface
      * @event ActionEvent an event raised right after executing a controller action.
      */
     const EVENT_AFTER_ACTION = 'afterAction';
+    /**
+     * Action ID to method name generation regexp
+     */
+    const ACTION_ID_METHOD_REGEXP = '!^([a-z0-9_]+-)*[a-z0-9_]+$!';
 
     /**
      * @var string the ID of this controller.
@@ -225,7 +229,7 @@ class Controller extends Component implements ViewContextInterface
         $actionMap = $this->actions();
         if (isset($actionMap[$id])) {
             return Yii::createObject($actionMap[$id], [$id, $this]);
-        } elseif (preg_match('/^[a-z0-9\\-_]+$/', $id) && strpos($id, '--') === false && trim($id, '-') === $id) {
+        } elseif (preg_match(self::ACTION_ID_METHOD_REGEXP, $id)) {
             $methodName = 'action' . str_replace(' ', '', ucwords(str_replace('-', ' ', $id)));
             if (method_exists($this, $methodName)) {
                 $method = new \ReflectionMethod($this, $methodName);

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -40,7 +40,7 @@ class Controller extends Component implements ViewContextInterface
     /**
      * Action ID to method name generation regexp
      */
-    const ACTION_ID_METHOD_REGEXP = '!^([a-z0-9_]+-)*[a-z0-9_]+$!';
+    const ACTION_ID_METHOD_REGEXP = '/^(?:[a-z0-9_]+-)*[a-z0-9_]+$/';
 
     /**
      * @var string the ID of this controller.

--- a/tests/framework/base/ControllerTest.php
+++ b/tests/framework/base/ControllerTest.php
@@ -76,6 +76,35 @@ class ControllerTest extends TestCase
             ['\yiiunit\framework\base\Test1Controller', 'test-test_test_2', 'actionTestTest_test_2'],
         ];
     }
+
+    /**
+     * @param $input
+     * @param $expected
+     *
+     * @dataProvider actionIdMethodProvider
+     */
+    public function testActionIdMethod($input, $expected)
+    {
+        $this->assertSame($expected, preg_match(Controller::ACTION_ID_METHOD_REGEXP, $input));
+    }
+
+    public function actionIdMethodProvider()
+    {
+        return [
+            ['apple-id', 1],
+            ['-apple', 0],
+            ['apple.', 0],
+            ['apple--id', 0],
+            ['a', 1],
+            ['9', 1],
+            ['apple-999', 1],
+            ['app^le-999', 0],
+            ['!', 0],
+            ['apple\33', 0],
+            ['apple333]', 0],
+            ['apple_222', 1],
+        ];
+    }
 }
 
 


### PR DESCRIPTION
…r::createAction()` fixes #17507

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17507 
