### PR TITLE
Fix #17522: `DbManager::isEmptyUserId()` is now protected

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #17507: Fixed regular expression escaping and simpler condition in `Controller::createAction()` (kamarton)
 - Bug #16305: Fix `FileValidator` mime-type validation failure because of case sensitivity (kamarton)
 - Bug #17355: Fixed Pjax after request event bug (kamarton)
+- Bug #17522: `DbManager::isEmptyUserId()` is now protected (samdark)
 
 
 2.0.25 August 13, 2019

--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -1046,8 +1046,9 @@ class DbManager extends BaseManager
      * Check whether $userId is empty.
      * @param mixed $userId
      * @return bool
+     * @since 2.0.26
      */
-    private function isEmptyUserId($userId)
+    protected function isEmptyUserId($userId)
     {
         return !isset($userId) || $userId === '';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️ (fixes extensibility blocker)
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17522 
