### PR TITLE
Fix regular expression illegal character #17434

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.27 under development
 ------------------------
 
-- no changes in this release.
+- Bug #17434: Fix regular expression illegal character; Repeated fix for Internet Explorer 11 AJAX redirect bug in case of 301 and 302 response codes (`XMLHttpRequest: Network Error 0x800c0008`) (kamarton)
 
 
 2.0.26 September 03, 2019

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -870,7 +870,7 @@ class Response extends \yii\base\Response
 
         if ($checkAjax) {
             if ($request->getIsAjax()) {
-                if (in_array($statusCode, [301, 302]) && preg_match('/Trident.*\brv\:11\./' /* IE11 */, $request->userAgent)) {
+                if (in_array($statusCode, [301, 302]) && preg_match('/Trident.*\brv:11\./' /* IE11 */, $request->userAgent)) {
                     $statusCode = 200;
                 }
                 if ($request->getIsPjax()) {


### PR DESCRIPTION
Removing a accidentally typed character that causes a regular expression to fails (not match) in some environments.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17434 
