### PR TITLE
test for trusted host + isSecureConnection #17521

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.28 under development
 ------------------------
 
-- no changes in this release.
+- Enh #17521: `Request::$userIpIsAlwaysRemoteIp` added for the resolved X-Forwarded-For case. (kamarton)
 
 
 2.0.27 September 18, 2019

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.28 under development
 ------------------------
 
-- Enh #17521: `Request::$userIpIsAlwaysRemoteIp` added for the resolved X-Forwarded-For case. (kamarton)
+- Enh #17521: `Request::$userIpIsAlwaysRemoteIp` added for the resolved X-Forwarded-For case (kamarton)
 
 
 2.0.27 September 18, 2019

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -1139,15 +1139,17 @@ class Request extends \yii\base\Request
      */
     public function getUserIP()
     {
-        if(!$this->userIpIsAlwaysRemoteIp) {
-            foreach ($this->ipHeaders as $ipHeader) {
-                if ($this->headers->has($ipHeader)) {
-                    return trim(explode(',', $this->headers->get($ipHeader))[0]);
-                }
+        $userIp = $this->getRemoteIP();
+        if ($this->userIpIsAlwaysRemoteIp) {
+            return $userIp;
+        }
+        foreach ($this->ipHeaders as $ipHeader) {
+            if ($this->headers->has($ipHeader)) {
+                return trim(explode(',', $this->headers->get($ipHeader))[0]);
             }
         }
 
-        return $this->getRemoteIP();
+        return $userIp;
     }
 
     /**

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -253,6 +253,14 @@ class Request extends \yii\base\Request
     ];
 
     /**
+     * @var bool If set true, then [[getUserIp]] will always return [[getRemoteIp]] result.
+     * This is needed in cases where the user's IP has already been resolved to [[getRemoteIp()]], e.g. based on X-Forwarded-For HTTP header.
+     * @see $trustedHosts
+     * @since 2.0.28
+     */
+    public $userIpIsAlwaysRemoteIp = false;
+
+    /**
      * @var CookieCollection Collection of request cookies.
      */
     private $_cookies;
@@ -1131,9 +1139,11 @@ class Request extends \yii\base\Request
      */
     public function getUserIP()
     {
-        foreach ($this->ipHeaders as $ipHeader) {
-            if ($this->headers->has($ipHeader)) {
-                return trim(explode(',', $this->headers->get($ipHeader))[0]);
+        if(!$this->userIpIsAlwaysRemoteIp) {
+            foreach ($this->ipHeaders as $ipHeader) {
+                if ($this->headers->has($ipHeader)) {
+                    return trim(explode(',', $this->headers->get($ipHeader))[0]);
+                }
             }
         }
 

--- a/tests/framework/web/RequestTest.php
+++ b/tests/framework/web/RequestTest.php
@@ -741,4 +741,16 @@ class RequestTest extends TestCase
 
         $this->assertSame($expectedMethod, $request->getMethod());
     }
+
+    public function testTrustedHostAndSecureConnection()
+    {
+        $_SERVER['REMOTE_ADDR'] = '30.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '50.0.0.1,30.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+        $request = new Request([
+            'trustedHosts' => ['30.0.0.1'],
+        ]);
+        $this->assertSame('50.0.0.1', $request->userIP);
+        $this->assertSame(true, $request->isSecureConnection);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17521 

`Request::$userIpIsAlwaysRemoteIp` added for resolve the problem.