### PR TITLE
activeListInput-unselect

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.28 under development
 ------------------------
 
-- no changes in this release.
+- Bug #17575: Allow `['unselect' => false]` in active list inputs (alex-code)
 
 
 2.0.27 September 18, 2019

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1826,6 +1826,8 @@ class BaseHtml
         $selection = isset($options['value']) ? $options['value'] : static::getAttributeValue($model, $attribute);
         if (!array_key_exists('unselect', $options)) {
             $options['unselect'] = '';
+        } elseif ($options['unselect'] === false) {
+            unset($options['unselect']);
         }
         if (!array_key_exists('id', $options)) {
             $options['id'] = static::getInputId($model, $attribute);


### PR DESCRIPTION
Allow `['unselect' => false]` to omit hidden input.

e.g.
```php
Html::activeRadioList($model, 'attribute', [
  'Value 1' => 1,
  'Value 2' => 2
], [
  'unselect' => false
])
```

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| Breaks BC?    | ❌
