### PR TITLE
Removing repeated description about inline actions

### DIFF
--- a/docs/guide/structure-controllers.md
+++ b/docs/guide/structure-controllers.md
@@ -250,11 +250,6 @@ For example, `index` becomes `actionIndex`, and `hello-world` becomes `actionHel
   method does NOT define an inline action.
 
 
-Inline actions are the most commonly defined actions because they take little effort to create. However,
-if you plan to reuse the same action in different places, or if you want to redistribute an action,
-you should consider defining it as a *standalone action*.
-
-
 ### Standalone Actions <span id="standalone-actions"></span>
 
 Standalone actions are defined in terms of action classes extending [[yii\base\Action]] or its child classes.


### PR DESCRIPTION
The same content is already described at line 230 ("Inline actions take less effort...")

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Documentation revision | ✔️
| Fixed issues  | No issues related
