### PR TITLE
Super slow schema queries with MySQL 8.0.16 fix #17444

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.28 under development
 ------------------------
 
-- no changes in this release.
+- Bug #17444: fixed super slow schema queries with MySQL 8.0.16 (kamarton) 
 
 
 2.0.27 September 18, 2019

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.28 under development
 ------------------------
 
-- Bug #17444: fixed super slow schema queries with MySQL 8.0.16 (kamarton) 
+- Bug #17444: fixed super slow schema queries with MySQL 8.0.16 (kamarton)
 
 
 2.0.27 September 18, 2019

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -838,6 +838,20 @@ abstract class Schema extends BaseObject
             return;
         }
 
+        $schema = $metadata['schema'];
+        /* @var $schema TableSchema */
+        if($this instanceof SchemaInterface && $schema->foreignKeys === false) {
+            $schema->foreignKeys = function($table) {
+                /* @var TableSchema $table */
+                if ($this->findColumns($table)) {
+                    $this->findConstraints($table);
+                } else {
+                    $table->foreignKeys = [];
+                }
+            };
+        } elseif($schema->foreignKeys === false) {
+            $schema->foreignKeys = [];
+        }
         unset($metadata['cacheVersion']);
         $this->_tableMetadata[$name] = $metadata;
     }
@@ -855,6 +869,12 @@ abstract class Schema extends BaseObject
 
         $metadata = $this->_tableMetadata[$name];
         $metadata['cacheVersion'] = static::SCHEMA_CACHE_VERSION;
+        $schema = $metadata['schema'];
+        /* @var $schema TableSchema */
+        if(is_callable($schema->foreignKeys)) {
+            $schema->foreignKeys = false;
+        }
+
         $cache->set(
             $this->getCacheKey($name),
             $metadata,

--- a/framework/db/SchemaInterface.php
+++ b/framework/db/SchemaInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db;
+
+/**
+ * [[Schema]] interface for finds.
+ *
+ * @package yii\db
+ */
+interface SchemaInterface
+{
+    /**
+     * Collects the table column metadata.
+     * @param TableSchema $table the table metadata
+     * @return bool whether the table exists in the database
+     */
+    public function findColumns($table);
+
+    /**
+     * Collects the foreign key column details for the given table.
+     *
+     * @param TableSchema $table the table metadata
+     * @throws \Exception
+     */
+    public function findConstraints($table);
+}

--- a/framework/db/TableSchema.php
+++ b/framework/db/TableSchema.php
@@ -14,6 +14,7 @@ use yii\base\InvalidArgumentException;
  * TableSchema represents the metadata of a database table.
  *
  * @property array $columnNames List of column names. This property is read-only.
+ * @property array $foreignKeys see more: [[$internalForeignKeys]]
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -43,7 +44,7 @@ class TableSchema extends BaseObject
      */
     public $sequenceName;
     /**
-     * @var array foreign keys of this table. Each array element is of the following structure:
+     * @var array|callable foreign keys of this table. Each array element is of the following structure:
      *
      * ```php
      * [
@@ -52,12 +53,31 @@ class TableSchema extends BaseObject
      *  'fk2' => 'pk2',  // if composite foreign key
      * ]
      * ```
+     *
+     * If its value is callable, it has not yet been loaded and will be loaded the first time it is used.
      */
-    public $foreignKeys = [];
+    private $internalForeignKeys = [];
     /**
      * @var ColumnSchema[] column metadata of this table. Each array element is a [[ColumnSchema]] object, indexed by column names.
      */
     public $columns = [];
+
+    /**
+     * @return array see more [[$internalForeignKeys]]
+     */
+    public function getForeignKeys() {
+        if(is_callable($this->internalForeignKeys)) {
+            $this->internalForeignKeys = call_user_func($this->internalForeignKeys, $this);
+        }
+        return $this->internalForeignKeys;
+    }
+
+    /**
+     * @param array|callable $value see more [[$internalForeignKeys]]
+     */
+    public function setForeignKeys($value) {
+        $this->internalForeignKeys = $value;
+    }
 
 
     /**

--- a/framework/db/TableSchema.php
+++ b/framework/db/TableSchema.php
@@ -64,10 +64,11 @@ class TableSchema extends BaseObject
 
     /**
      * @return array see more [[$internalForeignKeys]]
+     * @throws \Exception if DB query fails
      */
     public function getForeignKeys() {
         if(is_callable($this->internalForeignKeys)) {
-            $this->internalForeignKeys = call_user_func($this->internalForeignKeys, $this);
+            call_user_func($this->internalForeignKeys, $this);
         }
         return $this->internalForeignKeys;
     }

--- a/framework/db/TableSchema.php
+++ b/framework/db/TableSchema.php
@@ -14,7 +14,7 @@ use yii\base\InvalidArgumentException;
  * TableSchema represents the metadata of a database table.
  *
  * @property array $columnNames List of column names. This property is read-only.
- * @property array $foreignKeys see more: [[$internalForeignKeys]]
+ * @property array $foreignKeys Foreign keys of this table, see more: [[$internalForeignKeys]]
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -44,7 +44,7 @@ class TableSchema extends BaseObject
      */
     public $sequenceName;
     /**
-     * @var array|callable foreign keys of this table. Each array element is of the following structure:
+     * @var array|callable|false foreign keys of this table. Each array element is of the following structure:
      *
      * ```php
      * [
@@ -54,7 +54,8 @@ class TableSchema extends BaseObject
      * ]
      * ```
      *
-     * If its value is callable, it has not yet been loaded and will be loaded the first time it is used.
+     * If value is callable, it has not yet been loaded and will be loaded the first time it is used, see more [[SchemaInterface]]
+     * If value is false, then converting to callable, see more [[SchemaInterface]]
      */
     private $internalForeignKeys = [];
     /**
@@ -120,5 +121,13 @@ class TableSchema extends BaseObject
                 throw new InvalidArgumentException("Primary key '$key' cannot be found in table '{$this->name}'.");
             }
         }
+    }
+
+    /**
+     * Caching prepare
+     * @return static
+     */
+    public function prepareCache() {
+        return clone $this;
     }
 }

--- a/framework/db/cubrid/Schema.php
+++ b/framework/db/cubrid/Schema.php
@@ -138,17 +138,19 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
             }
         }
 
-        $foreignKeys = $pdo->cubrid_schema(\PDO::CUBRID_SCH_IMPORTED_KEYS, $table->name);
-        foreach ($foreignKeys as $key) {
-            if (isset($table->foreignKeys[$key['FK_NAME']])) {
-                $table->foreignKeys[$key['FK_NAME']][$key['FKCOLUMN_NAME']] = $key['PKCOLUMN_NAME'];
+        $foreignKeysInput = $pdo->cubrid_schema(\PDO::CUBRID_SCH_IMPORTED_KEYS, $table->name);
+        $foreignKeys = [];
+        foreach ($foreignKeysInput as $key) {
+            if (isset($foreignKeys[$key['FK_NAME']])) {
+                $foreignKeys[$key['FK_NAME']][$key['FKCOLUMN_NAME']] = $key['PKCOLUMN_NAME'];
             } else {
-                $table->foreignKeys[$key['FK_NAME']] = [
+                $foreignKeys[$key['FK_NAME']] = [
                     $key['PKTABLE_NAME'],
                     $key['FKCOLUMN_NAME'] => $key['PKCOLUMN_NAME'],
                 ];
             }
         }
+        $table->foreignKeys = $foreignKeys;
 
         return $table;
     }

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -570,13 +570,14 @@ SQL;
             ':object' => $object,
         ])->queryAll();
 
-        $table->foreignKeys = [];
+        $foreignKeys = [];
         foreach ($rows as $row) {
-            if (!isset($table->foreignKeys[$row['fk_name']])) {
-                $table->foreignKeys[$row['fk_name']][] = $row['uq_table_name'];
+            if (!isset($foreignKeys[$row['fk_name']])) {
+                $foreignKeys[$row['fk_name']][] = $row['uq_table_name'];
             }
-            $table->foreignKeys[$row['fk_name']][$row['fk_column_name']] = $row['uq_column_name'];
+            $foreignKeys[$row['fk_name']][$row['fk_column_name']] = $row['uq_column_name'];
         }
+        $table->foreignKeys = $foreignKeys;
     }
 
     /**

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -418,6 +418,7 @@ SQL;
             // table does not exist, try to determine the foreign keys using the table creation sql
             $sql = $this->getCreateTableSql($table);
             $regexp = '/FOREIGN KEY\s+\(([^\)]+)\)\s+REFERENCES\s+([^\(^\s]+)\s*\(([^\)]+)\)/mi';
+            $foreignKeys = [];
             if (preg_match_all($regexp, $sql, $matches, PREG_SET_ORDER)) {
                 foreach ($matches as $match) {
                     $fks = array_map('trim', explode(',', str_replace('`', '', $match[1])));
@@ -426,9 +427,9 @@ SQL;
                     foreach ($fks as $k => $name) {
                         $constraint[$name] = $pks[$k];
                     }
-                    $table->foreignKeys[md5(serialize($constraint))] = $constraint;
+                    $foreignKeys[md5(serialize($constraint))] = $constraint;
                 }
-                $table->foreignKeys = array_values($table->foreignKeys);
+                $table->foreignKeys = array_values($foreignKeys);
             }
         }
     }

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -16,6 +16,7 @@ use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\ForeignKeyConstraint;
 use yii\db\IndexConstraint;
+use yii\db\SchemaInterface;
 use yii\db\TableSchema;
 use yii\helpers\ArrayHelper;
 
@@ -25,7 +26,7 @@ use yii\helpers\ArrayHelper;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-class Schema extends \yii\db\Schema implements ConstraintFinderInterface
+class Schema extends \yii\db\Schema implements ConstraintFinderInterface, SchemaInterface
 {
     use ConstraintFinderTrait;
 
@@ -319,7 +320,7 @@ SQL;
      * @return bool whether the table exists in the database
      * @throws \Exception if DB query fails
      */
-    protected function findColumns($table)
+    public function findColumns($table)
     {
         $sql = 'SHOW FULL COLUMNS FROM ' . $this->quoteTableName($table->fullName);
         try {
@@ -373,7 +374,7 @@ SQL;
      * @param TableSchema $table the table metadata
      * @throws \Exception
      */
-    protected function findConstraints($table)
+    public function findConstraints($table)
     {
         $sql = <<<'SQL'
 SELECT

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -123,7 +123,14 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
         $this->resolveTableNames($table, $name);
 
         if ($this->findColumns($table)) {
-            $this->findConstraints($table);
+            $table->foreignKeys = function($table) {
+                /* @var TableSchema $table */
+                if ($this->findColumns($table)) {
+                    $this->findConstraints($table);
+                } else {
+                    $table->foreignKeys = [];
+                }
+            };
             return $table;
         }
 

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -385,9 +385,11 @@ SQL;
             }
             $constraints[$name]['columns'][$constraint['column_name']] = $constraint['foreign_column_name'];
         }
+        $foreignKeys = [];
         foreach ($constraints as $name => $constraint) {
-            $table->foreignKeys[$name] = array_merge([$constraint['tableName']], $constraint['columns']);
+            $foreignKeys[$name] = array_merge([$constraint['tableName']], $constraint['columns']);
         }
+        $table->foreignKeys = $foreignKeys;
     }
 
     /**

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -254,15 +254,17 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
     {
         $sql = 'PRAGMA foreign_key_list(' . $this->quoteSimpleTableName($table->name) . ')';
         $keys = $this->db->createCommand($sql)->queryAll();
+        $foreignKeys = [];
         foreach ($keys as $key) {
             $id = (int) $key['id'];
-            if (!isset($table->foreignKeys[$id])) {
-                $table->foreignKeys[$id] = [$key['table'], $key['from'] => $key['to']];
+            if (!isset($foreignKeys[$id])) {
+                $foreignKeys[$id] = [$key['table'], $key['from'] => $key['to']];
             } else {
                 // composite FK
-                $table->foreignKeys[$id][$key['from']] = $key['to'];
+                $foreignKeys[$id][$key['from']] = $key['to'];
             }
         }
+        $table->foreignKeys = $foreignKeys;
     }
 
     /**

--- a/tests/data/config.php
+++ b/tests/data/config.php
@@ -28,8 +28,8 @@ $config = [
         ],
         'mysql' => [
             'dsn' => 'mysql:host=127.0.0.1;dbname=yiitest',
-            'username' => 'root',
-            'password' => 'root',
+            'username' => 'sh',
+            'password' => '123',
             'fixture' => __DIR__ . '/mysql.sql',
         ],
         'sqlite' => [


### PR DESCRIPTION
**work in progress**

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | WIP
| Fixed issues  | #17444

Fixed with a simple solution: >99.99% of the use, no required loading of constraints. It loads on first use.

- [ ] Serialization of 'Closure' is not allowed
  - prepare for cache, callable change to false
- [x] fix drivers
- [x] local unit test