### PR TITLE
Changed ActiveField __toString method to catch all php 7 error types.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.28 under development
 ------------------------
 
-- no changes in this release.
+- Bug #17853: Fix errors in ActiveField to be properly caught when PHP 7 is used (My6UoT9)
 
 
 2.0.27 September 18, 2019

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -177,6 +177,9 @@ class ActiveField extends Component
         } catch (\Exception $e) {
             ErrorHandler::convertExceptionToError($e);
             return '';
+        } catch (\Throwable $e) {
+            ErrorHandler::convertExceptionToError($e);
+            return '';
         }
     }
 


### PR DESCRIPTION
When developing code, error message related to ActiveField are very obscure. The actual error is not shown. All what is given, is that __toString is not allowed to throw an error.

\Throwable is part of php 7+, so I left the \Exception in for older php.
According to 3v4l.org this seems to work.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   |  ✔️
| Fixed issues  | -
