### PR TITLE
fix yiisoft#17602 suppress ErrorException if dns_get_record returned f…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.29 under development
 ------------------------
 
-- no changes in this release.
+- Bug #17573: `EmailValidator` with `checkDNS=true` throws `ErrorException` on bad domains on Alpine (batyrmastyr)
 
 
 2.0.28 October 08, 2019

--- a/framework/validators/EmailValidator.php
+++ b/framework/validators/EmailValidator.php
@@ -9,6 +9,7 @@ namespace yii\validators;
 
 use Yii;
 use yii\base\InvalidConfigException;
+use yii\base\UserException;
 use yii\helpers\Json;
 use yii\web\JsExpression;
 
@@ -112,14 +113,25 @@ class EmailValidator extends Validator
     protected function isDNSValid($domain)
     {
         if (checkdnsrr($domain . '.', 'MX')) {
-            $mxRecords = dns_get_record($domain . '.', DNS_MX);
+            try {
+                // dns_get_record can return true and emit Warning that may or may not be converted to UserException
+                $mxRecords = dns_get_record($domain . '.', DNS_MX);
+            } catch (UserException $exception) {
+                return false;
+            }
+
             if ($mxRecords !== false && count($mxRecords) > 0) {
                 return true;
             }
         }
 
         if (checkdnsrr($domain . '.', 'A')) {
-            $aRecords = dns_get_record($domain . '.', DNS_A);
+            try {
+                $aRecords = dns_get_record($domain . '.', DNS_A);
+            } catch (UserException $exception) {
+                return false;
+            }
+
             if ($aRecords !== false && count($aRecords) > 0) {
                 return true;
             }

--- a/framework/validators/EmailValidator.php
+++ b/framework/validators/EmailValidator.php
@@ -112,11 +112,7 @@ class EmailValidator extends Validator
      */
     protected function isDNSValid($domain)
     {
-        if ($this->hasDNSRecord($domain, true)) {
-            return true;
-        }
-
-        return $this->hasDNSRecord($domain, false) === true;
+        return $this->hasDNSRecord($domain, true) || $this->hasDNSRecord($domain, false) === true;
     }
 
     private function hasDNSRecord($domain, $mx)
@@ -130,7 +126,6 @@ class EmailValidator extends Validator
             // dns_get_record can return false and emit Warning that may or may not be converted to ErrorException
             $records = dns_get_record($normalizedDomain, ($mx ? DNS_MX : DNS_A));
         } catch (ErrorException $exception) {
-            Yii::warning($exception->getMessage(). '. Domain: "' . $domain . '"', __METHOD__);
             return false;
         }
 

--- a/framework/validators/EmailValidator.php
+++ b/framework/validators/EmailValidator.php
@@ -115,16 +115,16 @@ class EmailValidator extends Validator
         return $this->hasDNSRecord($domain, true) || $this->hasDNSRecord($domain, false);
     }
 
-    private function hasDNSRecord($domain, $mx)
+    private function hasDNSRecord($domain, $isMX)
     {
         $normalizedDomain = $domain . '.';
-        if (!checkdnsrr($normalizedDomain, ($mx ? 'MX' : 'A'))) {
+        if (!checkdnsrr($normalizedDomain, ($isMX ? 'MX' : 'A'))) {
             return false;
         }
 
         try {
             // dns_get_record can return false and emit Warning that may or may not be converted to ErrorException
-            $records = dns_get_record($normalizedDomain, ($mx ? DNS_MX : DNS_A));
+            $records = dns_get_record($normalizedDomain, ($isMX ? DNS_MX : DNS_A));
         } catch (ErrorException $exception) {
             return false;
         }

--- a/framework/validators/EmailValidator.php
+++ b/framework/validators/EmailValidator.php
@@ -112,7 +112,7 @@ class EmailValidator extends Validator
      */
     protected function isDNSValid($domain)
     {
-        return $this->hasDNSRecord($domain, true) || $this->hasDNSRecord($domain, false) === true;
+        return $this->hasDNSRecord($domain, true) || $this->hasDNSRecord($domain, false);
     }
 
     private function hasDNSRecord($domain, $mx)

--- a/framework/validators/EmailValidator.php
+++ b/framework/validators/EmailValidator.php
@@ -128,17 +128,13 @@ class EmailValidator extends Validator
 
         try {
             // dns_get_record can return false and emit Warning that may or may not be converted to ErrorException
-            $mxRecords = dns_get_record($normalizedDomain, ($mx ? DNS_MX : DNS_A));
+            $records = dns_get_record($normalizedDomain, ($mx ? DNS_MX : DNS_A));
         } catch (ErrorException $exception) {
             Yii::warning($exception->getMessage(). '. Domain: "' . $domain . '"', __METHOD__);
             return false;
         }
 
-        if ($mxRecords !== false && count($mxRecords) > 0) {
-            return true;
-        }
-
-        return false;
+        return !empty($records);
     }
 
     private function idnToAscii($idn)


### PR DESCRIPTION
…alse and emitted Warning that was converted to ErrorException

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17602
