### PR TITLE
Proposal: do not publish dummy asset bundle

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #17573: `EmailValidator` with `checkDNS=true` throws `ErrorException` on bad domains on Alpine (batyrmastyr)
-
+- Bug #17606: Fix error in `AssetBundle` when a disabled bundle with custom init() was still published
 
 2.0.28 October 08, 2019
 -----------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #17573: `EmailValidator` with `checkDNS=true` throws `ErrorException` on bad domains on Alpine (batyrmastyr)
-- Bug #17606: Fix error in `AssetBundle` when a disabled bundle with custom init() was still published
+- Bug #17606: Fix error in `AssetBundle` when a disabled bundle with custom init() was still published (onmotion)
 
 2.0.28 October 08, 2019
 -----------------------

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -278,12 +278,12 @@ class AssetManager extends Component
     protected function loadDummyBundle($name)
     {
         if (!isset($this->_dummyBundles[$name])) {
-            $this->_dummyBundles[$name] = $this->loadBundle($name, [
+            $this->_dummyBundles[$name] = $this->loadBundle(AssetBundle::className(), [
                 'sourcePath' => null,
                 'js' => [],
                 'css' => [],
                 'depends' => [],
-            ]);
+            ], false);
         }
 
         return $this->_dummyBundles[$name];

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -278,12 +278,12 @@ class AssetManager extends Component
     protected function loadDummyBundle($name)
     {
         if (!isset($this->_dummyBundles[$name])) {
-            $this->_dummyBundles[$name] = $this->loadBundle(AssetBundle::className(), [
-                'sourcePath' => null,
-                'js' => [],
-                'css' => [],
-                'depends' => [],
-            ], false);
+            $bundle = Yii::createObject(['class' => $name]);
+            $bundle->sourcePath = null;
+            $bundle->js = [];
+            $bundle->css = [];
+
+            $this->_dummyBundles[$name] = $bundle;
         }
 
         return $this->_dummyBundles[$name];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

**Proposal:**
Change the dummy bundle to a real dummy instance AssetBundle

**The reason**
If used dynamic initializer in some AssetBundle, for example, to initiate js like so
```php
// yii\web\AssetBundle 
public function init()
    {
        $this->sourcePath = '@vendor/webcreate/jquery-ias/src';
        $this->js = [
            'callbacks.js',
        ];
    }
```

If disable whole assetManager bundles `\Yii::$app->assetManager->bundles = false;` expected in accordance with docs *>>[If a value is false, it means the corresponding asset bundle is disabled and getBundle() should return null.](https://www.yiiframework.com/doc/api/2.0/yii-web-assetmanager#$bundles-detail)* But in this case, **$js** will be overridden and assets will still be registered, therefore. Plus it requires unnecessary resource allocation.