### PR TITLE
(fix) Widget::getId() generates same identifiers when ajax request

### DIFF
--- a/framework/base/Widget.php
+++ b/framework/base/Widget.php
@@ -161,7 +161,7 @@ class Widget extends Component implements ViewContextInterface
     public function getId($autoGenerate = true)
     {
         if ($autoGenerate && $this->_id === null) {
-            $this->_id = static::$autoIdPrefix . static::$counter++;
+            $this->_id = static::$autoIdPrefix . substr(md5(random_bytes(5)), 0, 8) . static::$counter++;
         }
 
         return $this->_id;

--- a/tests/framework/widgets/ActiveFormTest.php
+++ b/tests/framework/widgets/ActiveFormTest.php
@@ -120,16 +120,15 @@ HTML
         $view->method('registerJs')->with($this->matches("jQuery('#w0').yiiActiveForm([], {\"validateOnSubmit\":false});"));
         $view->method('registerAssetBundle')->willReturn(true);
 
-        Widget::$counter = 0;
         ob_start();
         ob_implicit_flush(false);
 
-        $form = ActiveForm::begin(['view' => $view, 'validateOnSubmit' => false]);
+        $form = ActiveForm::begin(['id' => 'w0', 'view' => $view, 'validateOnSubmit' => false]);
         $form->field($model, 'name');
         $form::end();
 
         // Disable clientScript will not call `View->registerJs()`
-        $form = ActiveForm::begin(['view' => $view, 'enableClientScript' => false]);
+        $form = ActiveForm::begin(['id' => 'w1', 'view' => $view, 'enableClientScript' => false]);
         $form->field($model, 'name');
         $form::end();
         ob_get_clean();

--- a/tests/framework/widgets/PjaxTest.php
+++ b/tests/framework/widgets/PjaxTest.php
@@ -18,7 +18,7 @@ class PjaxTest extends TestCase
     {
         ListView::$counter = 0;
         Pjax::$counter = 0;
-        $nonPjaxWidget1 = new ListView(['dataProvider' => new ArrayDataProvider()]);
+        $nonPjaxWidget1 = new ListView([ 'dataProvider' => new ArrayDataProvider()]);
         ob_start();
         $pjax1 = new Pjax();
         ob_end_clean();
@@ -27,10 +27,10 @@ class PjaxTest extends TestCase
         $pjax2 = new Pjax();
         ob_end_clean();
 
-        $this->assertEquals('w0', $nonPjaxWidget1->options['id']);
-        $this->assertEquals('w1', $nonPjaxWidget2->options['id']);
-        $this->assertEquals('p0', $pjax1->options['id']);
-        $this->assertEquals('p1', $pjax2->options['id']);
+        $this->assertRegExp('/^w[a-z0-9]{8}0$/', $nonPjaxWidget1->options['id']);
+        $this->assertRegExp('/^w[a-z0-9]{8}1$/', $nonPjaxWidget2->options['id']);
+        $this->assertRegExp('/^p[a-z0-9]{8}0$/', $pjax1->options['id']);
+        $this->assertRegExp('/^p[a-z0-9]{8}1$/', $pjax2->options['id']);
     }
 
     protected function setUp()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | 

---

EN: Widget::getId() generates same identifiers when ajax request, because counter was reset to zero every request. This creates conflicts when JavaScript/jQuery linking to widgets identifiers, bu they already exists on page.

RU: Widget::getId() генерирует одинаковые идентификаторы при AJAX-запросах, так как при каждом запросе счётчик сбрасывается в ноль. Это создаёт конфликты, когда JavaScript/jQuery завязывается на идентификаторы виджетов, но они уже есть на странице.