### PR TITLE
(fix) BaseFileHelper::createDirectory() now catch Throwable after cat…

### DIFF
--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -636,13 +636,10 @@ class BaseFileHelper
         if ($recursive && !is_dir($parentDir) && $parentDir !== $path) {
             static::createDirectory($parentDir, $mode, true);
         }
-        try {
-            if (!mkdir($path, $mode)) {
-                return false;
-            }
-        } catch (\Exception $e) {
-            if (!is_dir($path)) {// https://github.com/yiisoft/yii2/issues/9288
-                throw new \yii\base\Exception("Failed to create directory \"$path\": " . $e->getMessage(), $e->getCode(), $e);
+        if (false === @mkdir($path, $mode)) {
+            $error = error_get_last();// https://github.com/yiisoft/yii2/issues/9288
+            if (false === is_dir($path)) {
+                throw new \yii\base\Exception("Failed to create directory \"$path\": " . $error['message'], $error['type']);
             }
         }
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

---

EN:  
BaseFileHelper::createDirectory() catching mkdir() error via @ and error_get_last() because when it called via __toString method ErrorHandler marks file exists warning as fatal error and PHP exit.

RU:
BaseFileHelper::createDirectory() ловит ошибки mkdir() через @ и error_get_last(), потому что когда функция вызвана из метода __toString, то ErrorHandler отмечает предупреждение file exists как фатальную ошибку, и PHP завершает работу.