### PR TITLE
Add support for boolean data attributes to Html::renderTagAttributes()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Enh #17607: Added Yii version 3 DI config compatibility (hiqsol)
 - Bug #17606: Fix error in `AssetBundle` when a disabled bundle with custom init() was still published (onmotion)
 - Bug #17597: PostgreSQL 12 and partitioned tables support (batyrmastyr)
+- Enh #17625: Added support for boolean data attributes to `Html::renderTagAttributes()` (brandonkelly)
 
 2.0.28 October 08, 2019
 -----------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,7 +8,7 @@ Yii Framework 2 Change Log
 - Enh #17607: Added Yii version 3 DI config compatibility (hiqsol)
 - Bug #17606: Fix error in `AssetBundle` when a disabled bundle with custom init() was still published (onmotion)
 - Bug #17597: PostgreSQL 12 and partitioned tables support (batyrmastyr)
-- Enh #17625: Added support for boolean data attributes to `Html::renderTagAttributes()` (brandonkelly)
+- Bug #17625: Fix boolean `data` attributes from subkeys rendering in `Html::renderTagAttributes()` (brandonkelly)
 
 2.0.28 October 08, 2019
 -----------------------

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1955,6 +1955,10 @@ class BaseHtml
                     foreach ($value as $n => $v) {
                         if (is_array($v)) {
                             $html .= " $name-$n='" . Json::htmlEncode($v) . "'";
+                        } else if (is_bool($v)) {
+                            if ($v) {
+                                $html .= " $name-$n";
+                            }
                         } else {
                             $html .= " $name-$n=\"" . static::encode($v) . '"';
                         }

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1955,10 +1955,8 @@ class BaseHtml
                     foreach ($value as $n => $v) {
                         if (is_array($v)) {
                             $html .= " $name-$n='" . Json::htmlEncode($v) . "'";
-                        } else if (is_bool($v)) {
-                            if ($v) {
-                                $html .= " $name-$n";
-                            }
+                        } elseif (is_bool($v) && $v) {
+                            $html .= " $name-$n";
                         } else {
                             $html .= " $name-$n=\"" . static::encode($v) . '"';
                         }

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1955,8 +1955,10 @@ class BaseHtml
                     foreach ($value as $n => $v) {
                         if (is_array($v)) {
                             $html .= " $name-$n='" . Json::htmlEncode($v) . "'";
-                        } elseif (is_bool($v) && $v) {
-                            $html .= " $name-$n";
+                        } elseif (is_bool($v)) {
+                            if ($v) {
+                                $html .= " $name-$n";
+                            }
                         } else {
                             $html .= " $name-$n=\"" . static::encode($v) . '"';
                         }

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1013,6 +1013,21 @@ EOD;
             ],
         ];
         $this->assertEquals(' data-foo=\'[]\'', Html::renderTagAttributes($attributes));
+
+        $attributes = [
+            'data' => [
+                'foo' => true,
+            ],
+        ];
+        $this->assertEquals(' data-foo', Html::renderTagAttributes($attributes));
+
+
+        $attributes = [
+            'data' => [
+                'foo' => false,
+            ],
+        ];
+        $this->assertEquals('', Html::renderTagAttributes($attributes));
     }
 
     public function testAddCssClass()


### PR DESCRIPTION
Currently the following produce inconsistent results:

```php
Html::renderTagAttributes(['data-foo' => true]);
// output: ' data-foo'

Html::renderTagAttributes(['data' => ['foo' => true]]);
// output: ' data-foo="1"'
```

This PR causes boolean `data` sub-keys to be treated the same way top-level boolean keys are treated: `true` will cause the attribute to be added without a value; `false` will prevent the attribute from being added at all.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  |
