### PR TITLE
Fixed a bug with the file russian name "x.jpg"

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.30 under development
 ------------------------
 
-- no changes in this release.
+- Bug #17632: Unicode file name was not correctly parsed in multipart forms (AlexRas007, samdark)
 
 
 2.0.29 October 22, 2019

--- a/framework/web/MultipartFormDataParser.php
+++ b/framework/web/MultipartFormDataParser.php
@@ -217,7 +217,7 @@ class MultipartFormDataParser extends BaseObject implements RequestParserInterfa
     private function parseHeaders($headerContent)
     {
         $headers = [];
-        $headerParts = preg_split('/\\R/s', $headerContent, -1, PREG_SPLIT_NO_EMPTY);
+        $headerParts = preg_split('/\\R/su', $headerContent, -1, PREG_SPLIT_NO_EMPTY);
         foreach ($headerParts as $headerPart) {
             if (strpos($headerPart, ':') === false) {
                 continue;

--- a/tests/framework/web/MultipartFormDataParserTest.php
+++ b/tests/framework/web/MultipartFormDataParserTest.php
@@ -180,4 +180,21 @@ class MultipartFormDataParserTest extends TestCase
         $this->assertNotEmpty($_FILES['someFile']);
         $this->assertFalse(isset($_FILES['existingFile']));
     }
+    
+    public function testParseUnicodeInFileName()
+    {
+        $unicodeName = 'х.jpg'; // this is Russian "х"
+
+        $parser = new MultipartFormDataParser();
+
+        $boundary = '---------------------------703835582829016869506105';
+        $contentType = 'multipart/form-data; boundary=' . $boundary;
+        $rawBody = "--{$boundary}\nContent-Disposition: form-data; name=\"someFile\"; filename=\"$unicodeName\";\nContent-Type: image/jpeg\r\n\r\nsome file content";
+        $rawBody .= "\r\n--{$boundary}--";
+
+        $parser->parse($rawBody, $contentType);
+
+        $this->assertNotEmpty($_FILES['someFile']);
+        $this->assertSame($unicodeName, $_FILES['someFile']['name']);
+    }
 }


### PR DESCRIPTION
Fixed a bug with the file name "x.jpg" "X" is the Russian letter.

Before request:
```
----------------------------703835582829016869506105
Content-Disposition: form-data; name="img_main"; filename="х.jpg"
Content-Type: image/jpeg
...
```

After request:
```
Array (
    [name] => �
    [type] => image/jpeg
    [size] => 1236446
    [error] => 0
    [tmp_name] => C:\OpenServer\userdata\temp\php20B3.tmp
    [tmp_resource] => Resource id #209
)
```


| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
