### PR TITLE
fix migrate used config `migrationNamespaces` throw class 'xxx' not found

### DIFF
--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -714,6 +714,8 @@ abstract class BaseMigrateController extends Controller
      */
     protected function migrateUp($class)
     {
+        $class = str_replace('/', '\\', $class);
+        
         if ($class === self::BASE_MIGRATION) {
             return true;
         }


### PR DESCRIPTION
optimize class address query path.
config file input ```migrationNamesapces``` and value like ```modules/something/migrations```, we should change `/` to `\`

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/✔️
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
