### PR TITLE
add formatter->asText cut string feature

### DIFF
--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -477,14 +477,35 @@ class Formatter extends Component
     }
 
     /**
+     * Cut the value as short text.
+     *
+     * @param [type] $value the value to be cut.
+     * @param array $options string cut options.
+     * @return string the cut string result.
+     */
+    public function cut($value, $options = [])
+    {
+        $options = array_merge(
+            ['width' => 0, 'suffixSymbol' => '...'],
+            $options
+        );
+        return mb_strimwidth($value, 0, $options['width'], $options['suffixSymbol']);
+    }
+    
+    /**
      * Formats the value as an HTML-encoded plain text.
      * @param string $value the value to be formatted.
+     * @param array $options string cut options.
      * @return string the formatted result.
      */
-    public function asText($value)
+    public function asText($value, $options = [])
     {
         if ($value === null) {
             return $this->nullDisplay;
+        }
+        
+        if (isset($options['width'])) {
+            $value = $this->cut($value, $options);
         }
 
         return Html::encode($value);

--- a/tests/framework/i18n/FormatterTest.php
+++ b/tests/framework/i18n/FormatterTest.php
@@ -112,6 +112,18 @@ class FormatterTest extends TestCase
         $value = '<>';
         $this->assertSame('&lt;&gt;', $this->formatter->asText($value));
 
+        // cut string
+        $value = '我在年青時候也曾經做過許多夢，後來大半忘卻了，但自己也並不以爲可惜';
+        $this->assertSame('我在年青時候...', $this->formatter->asText($value, ['width' => 15]));
+        $value = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.';
+        $this->assertSame('Lorem ipsum dolor...', $this->formatter->asText($value, ['width' => 20]));
+        $value = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.';
+        $this->assertSame('Lorem ipsum dolor s~', $this->formatter->asText($value, ['width' => 20, 'suffixSymbol' => '~']));
+        $value = 123456789;
+        $this->assertSame("12...", $this->formatter->asText($value, ['width' => 5]));
+        $value = '<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.</p>';
+        $this->assertSame('&lt;p&gt;Lorem ipsum do...', $this->formatter->asText($value, ['width' => 20]));
+
         // null display
         $this->assertSame($this->formatter->nullDisplay, $this->formatter->asText(null));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | no

This is a commonly used feature, I found that yii2 is not available, I think it would be helpful to add it.

### Use case:
#### With formatter component
```php
$intro = Yii::$app->formatter->asText($model->description, ['width' => 20]);
```
#### With GridView widget
```php
$widget = GridView::begin([
     'dataProvider' => $dataProvider,
     'filterModel' => $searchModel,
     'columns' => [
          ['class' => 'yii\grid\SerialColumn'],
          'id',
          [
               'attribute' => 'title',
               'format' => ['text', ['width' => 20]],
          ],
          [
               'attribute' => 'description',
               'format' => ['text', ['width' => 40, 'suffixSymbol' => '---']]
          ],
          'link:url',
          'weight',
     ],
]);
```

![Annotation 2019-10-29 204308](https://user-images.githubusercontent.com/9459560/67768143-d8224200-fa8c-11e9-9f69-e380d8abc586.jpg)
