### PR TITLE
Handle empty row column arrays

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.30 under development
 ------------------------
 
-- no changes in this release.
+- Bug #17648: Handle empty column arrays in console `Table` widget (alex-code)
 
 
 2.0.29 October 22, 2019

--- a/framework/console/widgets/Table.php
+++ b/framework/console/widgets/Table.php
@@ -131,7 +131,11 @@ class Table extends Widget
      */
     public function setRows(array $rows)
     {
-        $this->rows = array_map('array_values', $rows);
+        $this->rows = array_map(function($row) {
+            return array_map(function($value) {
+                return $value ?: ' ';
+            }, array_values($row));
+        }, $rows);
         return $this;
     }
 

--- a/tests/framework/console/widgets/TableTest.php
+++ b/tests/framework/console/widgets/TableTest.php
@@ -285,4 +285,22 @@ EXPECTED;
             ->setRows([])->setScreenWidth(200)->run()
         );
     }
+    
+    public function testEmptyTableCell()
+    {
+        $table = new Table();
+
+        $expected = <<<'EXPECTED'
+╔═══════╤═══════╗
+║ test1 │ test2 ║
+╟───────┼───────╢
+║ test  │       ║
+╚═══════╧═══════╝
+
+EXPECTED;
+
+        $this->assertEqualsWithoutLE($expected, $table->setHeaders(['test1', 'test2'])
+            ->setRows([['test', []]])->setScreenWidth(200)->run()
+        );
+    }
 }


### PR DESCRIPTION
Fix for #17627
Handle empty column arrays

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #17627