### PR TITLE
fix TypeError: pair[1] is undefined when query param doesn't have = sign

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.35 under development
 ------------------------
 
+- Bug #17653: Fix `TypeError: pair[1] is undefined` when query param doesn't have = sign (baso10)
 - Bug #17948: Ignore errors caused by `set_time_limit(0)` (brandonkelly)
 - Bug #17810: Fix EachValidator crashing with uninitialized typed properties (ricardomm85)
 - Bug #17942: Fix for `DbCache` loop in MySQL `QueryBuilder` (alex-code)

--- a/framework/assets/yii.js
+++ b/framework/assets/yii.js
@@ -297,7 +297,7 @@ window.yii = (function ($) {
             for (var i = 0, len = pairs.length; i < len; i++) {
                 var pair = pairs[i].split('=');
                 var name = decodeURIComponent(pair[0].replace(/\+/g, '%20'));
-                var value = decodeURIComponent(pair[1].replace(/\+/g, '%20'));
+                var value = pair.length > 1 ? decodeURIComponent(pair[1].replace(/\+/g, '%20')) : '';
                 if (!name.length) {
                     continue;
                 }

--- a/tests/js/tests/yii.test.js
+++ b/tests/js/tests/yii.test.js
@@ -742,6 +742,7 @@ describe('yii', function () {
             'query parameters': ['/posts/index?foo=1&bar=2', {foo: '1', bar: '2'}],
             'query parameter with multiple values (not array)': ['/posts/index?foo=1&foo=2', {'foo': ['1', '2']}],
             'query parameter with multiple values (array)': ['/posts/index?foo[]=1&foo[]=2', {'foo[]': ['1', '2']}],
+            'query parameter with empty value': ['/posts/index?foo=1&foo2', {'foo': '1', 'foo2': ''}],
             'anchor': ['/posts/index#post', {}],
             'query parameters, anchor': ['/posts/index?foo=1&bar=2#post', {foo: '1', bar: '2'}],
             'relative url, query parameters': ['?foo=1&bar=2', {foo: '1', bar: '2'}],


### PR DESCRIPTION
TypeError: pair[1] is undefined

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
