### PR TITLE
Fix wrong overriden application core component configuration when uses Yii3 style

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Bug #17648: Handle empty column arrays in console `Table` widget (alex-code)
 - Bug #17657: Fix migration errors from missing `$schema` in RBAC init file when using MSSQL (PoohOka)
 - Bug #17434: IE Ajax redirect fix for non 11.0 versions (kamarton)
+- Bug #17670: Fix overriding core component class using `__class` (sup-ham, samdark)
 
 2.0.29 October 22, 2019
 -----------------------

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -258,7 +258,7 @@ abstract class Application extends Module
         foreach ($this->coreComponents() as $id => $component) {
             if (!isset($config['components'][$id])) {
                 $config['components'][$id] = $component;
-            } elseif (is_array($config['components'][$id]) && !isset($config['components'][$id]['class'])) {
+            } elseif (is_array($config['components'][$id]) && !isset($config['components'][$id]['class']) && !isset($config['components'][$id]['__class'])) {
                 $config['components'][$id]['class'] = $component['class'];
             }
         }

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -258,7 +258,7 @@ abstract class Application extends Module
         foreach ($this->coreComponents() as $id => $component) {
             if (!isset($config['components'][$id])) {
                 $config['components'][$id] = $component;
-            } elseif (is_array($config['components'][$id]) && !isset($config['components'][$id]['class'], $config['components'][$id]['__class'])) {
+            } elseif (is_array($config['components'][$id]) && !isset($config['components'][$id]['class']) && !isset($config['components'][$id]['__class'])) {
                 $config['components'][$id]['class'] = $component['class'];
             }
         }

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -258,7 +258,7 @@ abstract class Application extends Module
         foreach ($this->coreComponents() as $id => $component) {
             if (!isset($config['components'][$id])) {
                 $config['components'][$id] = $component;
-            } elseif (is_array($config['components'][$id]) && !isset($config['components'][$id]['class']) && !isset($config['components'][$id]['__class'])) {
+            } elseif (is_array($config['components'][$id]) && !isset($config['components'][$id]['class'], $config['components'][$id]['__class'])) {
                 $config['components'][$id]['class'] = $component['class'];
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | 

If you overrides core component config using `__class` in it, you may get an error message: `setting unknown prop __class`. It because the config at this time become like this
```
[
  '__class' => 'MyRequest',
  'prop1' => '1234',
  'class' => 'yii\web\Request',
]
```