### PR TITLE
Throw BadRequestHttpException when request params can't be bound to controller action

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #17865: Fix invalid db component in `m180523_151638_rbac_updates_indexes_without_prefix` (rvkulikov)
+- Enh #17701: Throw `BadRequetHttpException` when request params can’t be bound to `bool`, `int`, and `float` controller action arguments (brandonkelly)
 
 
 2.0.30 November 19, 2019

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -133,24 +133,22 @@ class Controller extends \yii\base\Controller
                     $params[$name] = (array)$params[$name];
                 } elseif (is_array($params[$name])) {
                     $isValid = false;
-                } elseif (PHP_VERSION_ID >= 70000 && ($type = $param->getType()) !== null) {
-                    if ($type->allowsNull() && ($params[$name] === null || $params[$name] === '')) {
-                        $params[$name] = null;
-                    } elseif ($type->isBuiltin()) {
-                        switch ((string)$type) {
-                            case 'bool':
-                                $params[$name] = filter_var($params[$name], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-                                break;
-                            case 'float':
-                                $params[$name] = filter_var($params[$name], FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
-                                break;
-                            case 'int':
-                                $params[$name] = filter_var($params[$name], FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
-                                break;
-                        }
-                        if ($params[$name] === null) {
-                            $isValid = false;
-                        }
+                } elseif (
+                    PHP_VERSION_ID >= 70000 &&
+                    ($type = $param->getType()) !== null &&
+                    $type->isBuiltin() &&
+                    ($params[$name] !== null || !$type->allowsNull())
+                ) {
+                    switch ((string)$type) {
+                        case 'int':
+                            $params[$name] = filter_var($params[$name], FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
+                            break;
+                        case 'float':
+                            $params[$name] = filter_var($params[$name], FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
+                            break;
+                    }
+                    if ($params[$name] === null) {
+                        $isValid = false;
                     }
                 }
                 if (!$isValid) {

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -128,15 +128,37 @@ class Controller extends \yii\base\Controller
         foreach ($method->getParameters() as $param) {
             $name = $param->getName();
             if (array_key_exists($name, $params)) {
+                $isValid = true;
                 if ($param->isArray()) {
-                    $args[] = $actionParams[$name] = (array) $params[$name];
-                } elseif (!is_array($params[$name])) {
-                    $args[] = $actionParams[$name] = $params[$name];
-                } else {
+                    $params[$name] = (array)$params[$name];
+                } elseif (is_array($params[$name])) {
+                    $isValid = false;
+                } elseif (PHP_VERSION_ID >= 70000 && ($type = $param->getType()) !== null) {
+                    if ($type->allowsNull() && ($params[$name] === null || $params[$name] === '')) {
+                        $params[$name] = null;
+                    } elseif ($type->isBuiltin()) {
+                        switch ((string)$type) {
+                            case 'bool':
+                                $params[$name] = filter_var($params[$name], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                                break;
+                            case 'float':
+                                $params[$name] = filter_var($params[$name], FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
+                                break;
+                            case 'int':
+                                $params[$name] = filter_var($params[$name], FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
+                                break;
+                        }
+                        if ($params[$name] === null) {
+                            $isValid = false;
+                        }
+                    }
+                }
+                if (!$isValid) {
                     throw new BadRequestHttpException(Yii::t('yii', 'Invalid data received for parameter "{param}".', [
                         'param' => $name,
                     ]));
                 }
+                $args[] = $actionParams[$name] = $params[$name];
                 unset($params[$name]);
             } elseif ($param->isDefaultValueAvailable()) {
                 $args[] = $actionParams[$name] = $param->getDefaultValue();

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -59,15 +59,14 @@ class ControllerTest extends TestCase
 
         $aksi1 = new InlineAction('aksi1', $this->controller, 'actionAksi1');
 
-        $params = ['foo' => 'yes', 'bar' => '100', 'baz' => ''];
-        list($foo, $bar, $baz) = $this->controller->bindActionParams($aksi1, $params);
-        $this->assertSame(true, $foo);
-        $this->assertSame(100, $bar);
-        $this->assertSame(null, $baz);
+        $params = ['foo' => '100', 'bar' => null];
+        list($foo, $bar) = $this->controller->bindActionParams($aksi1, $params);
+        $this->assertSame(100, $foo);
+        $this->assertSame(null, $bar);
 
-        $params = ['foo' => 'yes', 'bar' => 'oops', 'baz' => ''];
+        $params = ['foo' => 'oops', 'bar' => null];
         $this->expectException('yii\web\BadRequestHttpException');
-        $this->expectExceptionMessage('Invalid data received for parameter "bar".');
+        $this->expectExceptionMessage('Invalid data received for parameter "foo".');
         $this->controller->bindActionParams($aksi1, $params);
     }
 

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -32,6 +32,45 @@ class ControllerTest extends TestCase
         $this->assertEquals('avaliable', $other);
     }
 
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/17701
+     */
+    public function testBindTypedActionParams()
+    {
+        if (PHP_VERSION_ID < 70000) {
+            $this->markTestSkipped('Can not be tested on PHP < 7.0');
+            return;
+        }
+
+        // Use the PHP7 controller for this test
+        $this->controller = new FakePhp7Controller('fake', new \yii\web\Application([
+            'id' => 'app',
+            'basePath' => __DIR__,
+
+            'components' => [
+                'request' => [
+                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                    'scriptFile' => __DIR__ . '/index.php',
+                    'scriptUrl' => '/index.php',
+                ],
+            ],
+        ]));
+        $this->mockWebApplication(['controller' => $this->controller]);
+
+        $aksi1 = new InlineAction('aksi1', $this->controller, 'actionAksi1');
+
+        $params = ['foo' => 'yes', 'bar' => '100', 'baz' => ''];
+        list($foo, $bar, $baz) = $this->controller->bindActionParams($aksi1, $params);
+        $this->assertSame(true, $foo);
+        $this->assertSame(100, $bar);
+        $this->assertSame(null, $baz);
+
+        $params = ['foo' => 'yes', 'bar' => 'oops', 'baz' => ''];
+        $this->expectException('yii\web\BadRequestHttpException');
+        $this->expectExceptionMessage('Invalid data received for parameter "bar".');
+        $this->controller->bindActionParams($aksi1, $params);
+    }
+
     public function testAsJson()
     {
         $data = [

--- a/tests/framework/web/FakePhp7Controller.php
+++ b/tests/framework/web/FakePhp7Controller.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\web;
+
+use yii\web\Controller;
+
+/**
+ * @author Brandon Kelly <branodn@craftcms.com>
+ * @since 2.0.31
+ */
+class FakePhp7Controller extends Controller
+{
+    public $enableCsrfValidation = false;
+
+    public function actionAksi1(bool $foo, int $bar, float $baz = null)
+    {
+    }
+}

--- a/tests/framework/web/FakePhp7Controller.php
+++ b/tests/framework/web/FakePhp7Controller.php
@@ -17,7 +17,7 @@ class FakePhp7Controller extends Controller
 {
     public $enableCsrfValidation = false;
 
-    public function actionAksi1(bool $foo, int $bar, float $baz = null)
+    public function actionAksi1(int $foo, float $bar = null)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17701
