### PR TITLE
Fixed Error Handler to clear view tags, scripts, etc. when rendering error action view

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #17865: Fix invalid db component in `m180523_151638_rbac_updates_indexes_without_prefix` (rvkulikov)
+- Bug #17694: Fixed Error Handler to clear registered view tags, scripts, and files when rendering error view through action view (bizley)
 
 
 2.0.30 November 19, 2019

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,7 +6,6 @@ Yii Framework 2 Change Log
 
 - Bug #17865: Fix invalid db component in `m180523_151638_rbac_updates_indexes_without_prefix` (rvkulikov)
 - Bug #17694: Fixed Error Handler to clear registered view tags, scripts, and files when rendering error view through action view (bizley)
-- Bug #17701: Throw `BadRequetHttpException` when request params can’t be bound to `bool`, `int`, and `float` controller action arguments (brandonkelly)
 - Bug #17701: Throw `BadRequetHttpException` when request params can’t be bound to `int` and `float` controller action arguments (brandonkelly)
 
 

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -105,6 +105,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
         $useErrorView = $response->format === Response::FORMAT_HTML && (!YII_DEBUG || $exception instanceof UserException);
 
         if ($useErrorView && $this->errorAction !== null) {
+            Yii::$app->view->clear();
             $result = Yii::$app->runAction($this->errorAction);
             if ($result instanceof Response) {
                 $response = $result;

--- a/tests/data/controllers/TestController.php
+++ b/tests/data/controllers/TestController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace yiiunit\data\controllers;
+
+use yii\web\Controller;
+use yii\web\ErrorAction;
+
+class TestController extends Controller
+{
+    public $layout = '@yiiunit/data/views/layout.php';
+
+    private $actionConfig = [];
+
+    public function setActionConfig($config = [])
+    {
+        $this->actionConfig = $config;
+    }
+
+    public function actions()
+    {
+        return [
+            'error' => array_merge([
+                'class' => ErrorAction::className(),
+                'view' => '@yiiunit/data/views/error.php',
+            ], $this->actionConfig),
+        ];
+    }
+}

--- a/tests/framework/web/ErrorActionTest.php
+++ b/tests/framework/web/ErrorActionTest.php
@@ -10,8 +10,8 @@ namespace yiiunit\framework\web;
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\base\UserException;
-use yii\web\Controller;
 use yii\web\ErrorAction;
+use yiiunit\data\controllers\TestController;
 use yiiunit\TestCase;
 
 /**
@@ -119,25 +119,5 @@ Exception: yii\web\NotFoundHttpException', $this->getController()->runAction('er
 
         $ds = preg_quote(DIRECTORY_SEPARATOR, '\\');
         $this->expectExceptionMessageRegExp('#The view file does not exist: .*?views' . $ds . 'layouts' . $ds . 'non-existing.php#');
-    }
-}
-
-class TestController extends Controller
-{
-    private $actionConfig;
-
-    public function setActionConfig($config = [])
-    {
-        $this->actionConfig = $config;
-    }
-
-    public function actions()
-    {
-        return [
-            'error' => array_merge([
-                'class' => ErrorAction::className(),
-                'view' => '@yiiunit/data/views/error.php',
-            ], $this->actionConfig),
-        ];
     }
 }

--- a/tests/framework/web/ErrorHandlerTest.php
+++ b/tests/framework/web/ErrorHandlerTest.php
@@ -9,6 +9,7 @@ namespace yiiunit\framework\web;
 
 use Yii;
 use yii\web\NotFoundHttpException;
+use yii\web\View;
 use yiiunit\TestCase;
 
 class ErrorHandlerTest extends TestCase
@@ -17,6 +18,7 @@ class ErrorHandlerTest extends TestCase
     {
         parent::setUp();
         $this->mockWebApplication([
+            'controllerNamespace' => 'yiiunit\\data\\controllers',
             'components' => [
                 'errorHandler' => [
                     'class' => 'yiiunit\framework\web\ErrorHandler',
@@ -51,6 +53,20 @@ Exception: yii\web\NotFoundHttpException', $out);
         $out = Yii::$app->response->data;
         $this->assertEquals('Exception View
 ', $out);
+    }
+
+    public function testClearAssetFilesInErrorActionView()
+    {
+        Yii::$app->getErrorHandler()->errorAction = 'test/error';
+        Yii::$app->getView()->registerJs("alert('hide me')", View::POS_END);
+
+        /** @var ErrorHandler $handler */
+        $handler = Yii::$app->getErrorHandler();
+        ob_start(); // suppress response output
+        $this->invokeMethod($handler, 'renderException', [new NotFoundHttpException()]);
+        ob_get_clean();
+        $out = Yii::$app->response->data;
+        $this->assertNotContains('<script', $out);
     }
 
     public function testRenderCallStackItem()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17694 

I've added TestController in `yiiunit\data\controllers` namespace for testing this and at the same time to use it instead of TestController that was in ErrorActionTest
