### PR TITLE
Bug #17708: Explicitly define precision to be 15 for FormatterNumberTest::testIntlAsScientific

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,7 +7,7 @@ Yii Framework 2 Change Log
 - Bug #17865: Fix invalid db component in `m180523_151638_rbac_updates_indexes_without_prefix` (rvkulikov)
 - Bug #17694: Fixed Error Handler to clear registered view tags, scripts, and files when rendering error view through action view (bizley)
 - Bug #17701: Throw `BadRequetHttpException` when request params can’t be bound to `int` and `float` controller action arguments (brandonkelly)
-
+- Bug #17708: Explicitly define precision to be 15 for FormatterNumberTest::testIntlAsScientific (My6UoT9)
 
 2.0.30 November 19, 2019
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #17701: Throw `BadRequetHttpException` when request params can’t be bound to `int` and `float` controller action arguments (brandonkelly)
 - Bug #17708: Explicitly define precision to be 15 for FormatterNumberTest::testIntlAsScientific (My6UoT9)
 
+
 2.0.30 November 19, 2019
 ------------------------
 

--- a/tests/framework/i18n/FormatterNumberTest.php
+++ b/tests/framework/i18n/FormatterNumberTest.php
@@ -528,7 +528,7 @@ class FormatterNumberTest extends TestCase
         // null display
         $this->assertSame($this->formatter->nullDisplay, $this->formatter->asScientific(null));
 
-        $this->assertSame('8.76543210987654E16', $this->formatter->asScientific('87654321098765436'));
+        $this->assertSame('8.76543210987654E16', $this->formatter->asScientific('87654321098765436', 15));
     }
 
     public function testAsScientific()

--- a/tests/framework/i18n/FormatterNumberTest.php
+++ b/tests/framework/i18n/FormatterNumberTest.php
@@ -528,7 +528,7 @@ class FormatterNumberTest extends TestCase
         // null display
         $this->assertSame($this->formatter->nullDisplay, $this->formatter->asScientific(null));
 
-        $this->assertSame('8.76543210987654E16', $this->formatter->asScientific('87654321098765436', 15));
+        $this->assertSame('8.765432109876544E16', $this->formatter->asScientific('87654321098765436'));
     }
 
     public function testAsScientific()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
