### PR TITLE
Fix GridView JS test to click on all elements in a group instead of only first element

### DIFF
--- a/tests/js/tests/yii.gridView.test.js
+++ b/tests/js/tests/yii.gridView.test.js
@@ -128,8 +128,7 @@ describe('yii.gridView', function () {
      * @param $el
      */
     function click($el) {
-        var e = $.Event('click');
-        $el.trigger(e);
+        $el.click();
     }
 
     /**


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ?
| Fixed issues  | related to #17713
