### PR TITLE
fix #17740: `yii\helpers\BaseInflector::slug()` doesn't replace multip…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,7 +15,7 @@ Yii Framework 2 Change Log
 - Bug #17723: Fix incorrect type-casting of reflection type to string (samdark)
 - Bug #17725: Ensure we do not use external polyfills for pbkdf2() as these may be implemented incorrectly (samdark)
 - Bug #17710: Fix MemCache duration normalization to avoid memcached/system timestamp mismatch (samdark)
-
+- Bug #17740: `yii\helpers\BaseInflector::slug()` is not replace multiple replacement string occurrences to single one (batyrmastyr)
 
 2.0.30 November 19, 2019
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,7 +15,7 @@ Yii Framework 2 Change Log
 - Bug #17723: Fix incorrect type-casting of reflection type to string (samdark)
 - Bug #17725: Ensure we do not use external polyfills for pbkdf2() as these may be implemented incorrectly (samdark)
 - Bug #17710: Fix MemCache duration normalization to avoid memcached/system timestamp mismatch (samdark)
-- Bug #17740: `yii\helpers\BaseInflector::slug()` is not replace multiple replacement string occurrences to single one (batyrmastyr)
+- Bug #17740: `yii\helpers\BaseInflector::slug()` doesn't replace multiple replacement string occurrences to single one (batyrmastyr)
 
 2.0.30 November 19, 2019
 ------------------------

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -51,6 +51,11 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to follow the instructions
 for both A and B.
 
+Upgrade from Yii 2.0.30
+-----------------------
+* `yii\helpers\BaseInflector::slug()` now ensures there is no repeating $replacement string occurrences.
+  In case you rely on Yii 2.0.16 - 2.0.30 behavior, consider replacing `Inflector` with your own implementation.
+
 Upgrade from Yii 2.0.20
 -----------------------
 

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -485,6 +485,7 @@ class BaseInflector
         }, $parts);
 
         $string = trim(implode($replacement, $replaced), $replacement);
+        $string = preg_replace('#'.preg_quote($replacement).'+#', $replacement, $string);
 
         return $lowercase ? strtolower($string) : $string;
     }

--- a/tests/framework/helpers/InflectorTest.php
+++ b/tests/framework/helpers/InflectorTest.php
@@ -194,6 +194,7 @@ class InflectorTest extends TestCase
     {
         $this->assertEquals('dont_replace_replacement', Inflector::slug('dont replace_replacement', '_'));
         $this->assertEquals('remove_trailing_replacements', Inflector::slug('_remove trailing replacements_', '_'));
+        $this->assertEquals('remove_excess_replacements', Inflector::slug(' _ _ remove excess _ _ replacements_', '_'));
         $this->assertEquals('thisrepisreprepreplacement', Inflector::slug('this is REP-lacement', 'REP'));
         $this->assertEquals('0_100_kmh', Inflector::slug('0-100 Km/h', '_'));
     }


### PR DESCRIPTION
…le replacement string occurrences to single one

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17740
