### PR TITLE
Allowed to set custom url parameter name in yii\grid\ActionColumn

### DIFF
--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -126,7 +126,35 @@ class ActionColumn extends Column
      * @since 2.0.4
      */
     public $buttonOptions = [];
-
+    /**
+     * @var string Name of parameter that will passed to url
+     *
+     * For example:
+     * If you want to create URL to view/edit/delete action with name of param not equal to `id`
+     * you should define it like following:
+     *
+     * ```php
+     * [
+     *     'class' => 'yii\grid\ActionColumn',
+     *     'urlParam' => 'name'
+     * ],
+     * ```
+     *
+     * Now url generator will generate URLs as follows: 'view?name=$key', 'edit?name=$key', 'delete?name=$key'.
+     * And in controller you need to rename parameter from `id` to `name`:
+     *
+     * ```php
+     * class UserController extends Controller
+     * {
+     * ...
+     * public function actionView($name) { ... }
+     * public function actionUpdate($name) { ... }
+     * public function actionDelete($name) { ... }
+     * ...
+     * }
+     * ```
+     */
+    public $urlParam = 'id';
 
     /**
      * {@inheritdoc}
@@ -200,7 +228,7 @@ class ActionColumn extends Column
             return call_user_func($this->urlCreator, $action, $model, $key, $index, $this);
         }
 
-        $params = is_array($key) ? $key : ['id' => (string) $key];
+        $params = is_array($key) ? $key : [$this->urlParam => (string) $key];
         $params[0] = $this->controller ? $this->controller . '/' . $action : $action;
 
         return Url::toRoute($params);

--- a/tests/framework/grid/ActionColumnTest.php
+++ b/tests/framework/grid/ActionColumnTest.php
@@ -7,11 +7,13 @@
 
 namespace yiiunit\framework\grid;
 
+use yii\base\Action;
+use yii\base\Module;
 use yii\grid\ActionColumn;
+use yii\web\Controller;
 
 /**
  * @author Vitaly S. <fornit1917@gmail.com>
- *
  * @group grid
  */
 class ActionColumnTest extends \yiiunit\TestCase
@@ -71,7 +73,9 @@ class ActionColumnTest extends \yiiunit\TestCase
 
         //test visible button (condition is callback)
         $column->visibleButtons = [
-            'update' => function ($model, $key, $index) {return $model['id'] == 1;},
+            'update' => function ($model, $key, $index) {
+                return $model['id'] == 1;
+            },
         ];
         $columnContents = $column->renderDataCell(['id' => 1], 1, 0);
         $this->assertContains('update_button', $columnContents);
@@ -85,9 +89,93 @@ class ActionColumnTest extends \yiiunit\TestCase
 
         //test invisible button (condition is callback)
         $column->visibleButtons = [
-            'update' => function ($model, $key, $index) {return $model['id'] != 1;},
+            'update' => function ($model, $key, $index) {
+                return $model['id'] != 1;
+            },
         ];
         $columnContents = $column->renderDataCell(['id' => 1], 1, 0);
         $this->assertNotContains('update_button', $columnContents);
     }
+
+    public function testDefaultUrlParam()
+    {
+        $urlParam = 'id';
+        $actionId = 'view';
+        $column = new ActionColumn();
+
+        $this->innerTestActionColumn($actionId, $column, $urlParam);
+    }
+
+    /**
+     * @dataProvider getColumnActionsWithCustomParam()
+     * @param $actionId
+     * @param $urlParam
+     */
+    public function testCustomUrlParam($actionId, $urlParam)
+    {
+        $column = new ActionColumn(['urlParam' => $urlParam]);
+        $this->innerTestActionColumn($actionId, $column, $urlParam);
+    }
+
+    public function getColumnActionsWithCustomParam()
+    {
+        return [
+            ['edit', null],
+            ['view', 'param'],
+            ['update', 'custom param with space'],
+            ['delete', '_'],
+        ];
+    }
+
+    protected function mockAction($controllerId, $actionID, $moduleID = null, $params = [])
+    {
+        \Yii::$app->controller = $controller = new Controller($controllerId, \Yii::$app);
+        $controller->actionParams = $params;
+        $controller->action = new Action($actionID, $controller);
+
+        if ($moduleID !== null) {
+            $controller->module = new Module($moduleID);
+        }
+    }
+
+    protected function removeMockedAction()
+    {
+        \Yii::$app->controller = null;
+    }
+
+    /**
+     * @param $actionId
+     * @param $urlParam
+     * @param \yii\grid\ActionColumn $column
+     * @param $key
+     * @param $moduleId
+     * @param $controllerId
+     */
+    private function compareUrls(ActionColumn $column, $actionId, $urlParam, $key, $moduleId, $controllerId)
+    {
+        $url = $column->createUrl($actionId, null, $key, 1);
+        $exceptedUrlTemplate = '/index.php?r=%s&%s=%s';
+        $route = urlencode(sprintf('%s/%s/%s', $moduleId, $controllerId, $actionId));
+        $expectedUrl = sprintf($exceptedUrlTemplate, $route, urlencode($urlParam), urlencode($key));
+        $this->assertEquals($expectedUrl, $url);
+    }
+
+    /**
+     * @param $actionId
+     * @param \yii\grid\ActionColumn $column
+     * @param $urlParam
+     */
+    private function innerTestActionColumn($actionId, ActionColumn $column, $urlParam)
+    {
+        $moduleId = 'action-column-test-module';
+        $controllerId = 'test';
+        $key = 'my name';
+
+        $this->mockWebApplication();
+        $this->mockAction($controllerId, $actionId, $moduleId);
+
+        $this->compareUrls($column, $actionId, $urlParam, $key, $moduleId, $controllerId);
+        $this->destroyApplication();
+    }
+
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

In my case I had to custom url parameter name in ActionColumn.
I decided to share it with community.
