### PR TITLE
Fix ActiveRelationTrait.php for compatibility 7.4

### DIFF
--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -523,7 +523,7 @@ trait ActiveRelationTrait
             // single key
             $attribute = reset($this->link);
             foreach ($models as $model) {
-                if (($value = $model[$attribute]) !== null) {
+                if ($model !== null && ($value = $model[$attribute]) !== null) {
                     if (is_array($value)) {
                         $values = array_merge($values, $value);
                     } elseif ($value instanceof ArrayExpression && $value->getDimension() === 1) {


### PR DESCRIPTION
Fix for PHP 7.4

Trying to access array offset on value of type null
When $model is null on Php 7.4:
if (($value = $model[$attribute]) !== null)

/var/www/builds/cms/3.6.0/vendor/yiisoft/yii2/db/ActiveRelationTrait.php line 526

#0 /var/www/builds/cms/3.6.0/vendor/yiisoft/yii2/db/ActiveRelationTrait.php(526): yii\base\ErrorHandler->handleError()
#1 /var/www/builds/cms/3.6.0/vendor/yiisoft/yii2/db/ActiveRelationTrait.php(246): yii\db\ActiveQuery->filterByModels()
#2 /var/www/builds/cms/3.6.0/vendor/yiisoft/yii2/db/ActiveQueryTrait.php(151): yii\db\ActiveQuery->populateRelation()
#3 /var/www/builds/cms/3.6.0/vendor/yiisoft/yii2/db/ActiveQuery.php(224): yii\db\ActiveQuery->findWith()

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  |❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
