### PR TITLE
Fix #17767: Make `Formatter::formatNumber` method protected

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,7 +7,7 @@ Yii Framework 2 Change Log
 - Bug #17744: Fix a bug with setting incorrect `defaultValue` to AR column with `CURRENT_TIMESTAMP(x)` as default expression (MySQL >= 5.6.4) (bizley)
 - Bug #17749: Dispatcher fix if target crashed in PHP 7.0+ (kamarton)
 - Bug #17762: PHP 7.4: Remove special condition for converting PHP errors to exceptions if they occurred inside of `__toString()` call (rob006)
-
+- Bug #17767: Make `Formatter::formatNumber` method protected (TheCodeholic)
 
 2.0.31 December 18, 2019
 ------------------------

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -1656,6 +1656,7 @@ class Formatter extends Component
      * @param array $textOptions optional configuration for the number formatter. This parameter will be merged with [[numberFormatterTextOptions]].
      * @return array [parameters for Yii::t containing formatted number, internal position of size unit]
      * @throws InvalidArgumentException if the input value is not numeric or the formatting failed.
+     * @since 2.0.32
      */
     protected function formatNumber($value, $decimals, $maxPosition, $formatBase, $options, $textOptions)
     {

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -1657,7 +1657,7 @@ class Formatter extends Component
      * @return array [parameters for Yii::t containing formatted number, internal position of size unit]
      * @throws InvalidArgumentException if the input value is not numeric or the formatting failed.
      */
-    private function formatNumber($value, $decimals, $maxPosition, $formatBase, $options, $textOptions)
+    protected function formatNumber($value, $decimals, $maxPosition, $formatBase, $options, $textOptions)
     {
         $value = $this->normalizeNumericValue($value);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17767 
