### PR TITLE
Session::updateFlashCounters() was called twice

### DIFF
--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -138,7 +138,6 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
 
         if ($this->getIsActive()) {
             Yii::info('Session started', __METHOD__);
-            $this->updateFlashCounters();
         } else {
             $error = error_get_last();
             $message = isset($error['message']) ? $error['message'] : 'Failed to start session.';


### PR DESCRIPTION
one time in Session::init() and a second time in Session::open()
Removing the call in Session::open() fixes the issue.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17623
