### PR TITLE
Fix #12539: `yii\filters\ContentNegotiator` now generates 406 'Not Acceptable' instead of 415 'Unsupported Media Type' on content-type negotiation fail

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #17762: PHP 7.4: Remove special condition for converting PHP errors to exceptions if they occurred inside of `__toString()` call (rob006)
 - Bug #17771: migrate/fresh was not returning exit code (samdark)
 - Bug #17767: Make `Formatter::formatNumber` method protected (TheCodeholic)
+- Bug #12539: `yii\filters\ContentNegotiator` now generates 406 'Not Acceptable' instead of 415 'Unsupported Media Type' on content-type negotiation fail (PowerGamer1)
 
 
 2.0.31 December 18, 2019

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -51,6 +51,12 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to follow the instructions
 for both A and B.
 
+Upgrade from Yii 2.0.31
+-----------------------
+
+* `yii\filters\ContentNegotiator` now generates 406 'Not Acceptable' instead of 415 'Unsupported Media Type' on
+  content-type negotiation fail.
+
 Upgrade from Yii 2.0.30
 -----------------------
 * `yii\helpers\BaseInflector::slug()` now ensures there is no repeating $replacement string occurrences.

--- a/framework/filters/ContentNegotiator.php
+++ b/framework/filters/ContentNegotiator.php
@@ -11,9 +11,9 @@ use Yii;
 use yii\base\ActionFilter;
 use yii\base\BootstrapInterface;
 use yii\web\BadRequestHttpException;
+use yii\web\NotAcceptableHttpException;
 use yii\web\Request;
 use yii\web\Response;
-use yii\web\UnsupportedMediaTypeHttpException;
 
 /**
  * ContentNegotiator supports response format negotiation and application language negotiation.
@@ -87,14 +87,14 @@ class ContentNegotiator extends ActionFilter implements BootstrapInterface
 {
     /**
      * @var string the name of the GET parameter that specifies the response format.
-     * Note that if the specified format does not exist in [[formats]], a [[UnsupportedMediaTypeHttpException]]
+     * Note that if the specified format does not exist in [[formats]], a [[NotAcceptableHttpException]]
      * exception will be thrown.  If the parameter value is empty or if this property is null,
      * the response format will be determined based on the `Accept` HTTP header only.
      * @see formats
      */
     public $formatParam = '_format';
     /**
-     * @var string the name of the GET parameter that specifies the [[\yii\base\Application::language|application language]].
+     * @var string the name of the GET parameter that specifies the [[\yii\base\Application::$language|application language]].
      * Note that if the specified language does not match any of [[languages]], the first language in [[languages]]
      * will be used. If the parameter value is empty or if this property is null,
      * the application language will be determined based on the `Accept-Language` HTTP header only.
@@ -104,7 +104,7 @@ class ContentNegotiator extends ActionFilter implements BootstrapInterface
     /**
      * @var array list of supported response formats. The keys are MIME types (e.g. `application/json`)
      * while the values are the corresponding formats (e.g. `html`, `json`) which must be supported
-     * as declared in [[\yii\web\Response::formatters]].
+     * as declared in [[\yii\web\Response::$formatters]].
      *
      * If this property is empty or not set, response format negotiation will be skipped.
      */
@@ -172,7 +172,7 @@ class ContentNegotiator extends ActionFilter implements BootstrapInterface
      * @param Request $request
      * @param Response $response
      * @throws BadRequestHttpException if an array received for GET parameter [[formatParam]].
-     * @throws UnsupportedMediaTypeHttpException if none of the requested content types is accepted.
+     * @throws NotAcceptableHttpException if none of the requested content types is accepted.
      */
     protected function negotiateContentType($request, $response)
     {
@@ -188,7 +188,7 @@ class ContentNegotiator extends ActionFilter implements BootstrapInterface
                 return;
             }
 
-            throw new UnsupportedMediaTypeHttpException('The requested response format is not supported: ' . $format);
+            throw new NotAcceptableHttpException('The requested response format is not supported: ' . $format);
         }
 
         $types = $request->getAcceptableContentTypes();
@@ -216,7 +216,7 @@ class ContentNegotiator extends ActionFilter implements BootstrapInterface
             return;
         }
 
-        throw new UnsupportedMediaTypeHttpException('None of your requested content types is supported.');
+        throw new NotAcceptableHttpException('None of your requested content types is supported.');
     }
 
     /**

--- a/tests/framework/filters/ContentNegotiatorTest.php
+++ b/tests/framework/filters/ContentNegotiatorTest.php
@@ -117,4 +117,19 @@ class ContentNegotiatorTest extends TestCase
         $this->assertContains('Accept', $varyHeader);
         $this->assertContains('Accept-Language', $varyHeader);
     }
+
+    public function testNegotiateContentType()
+    {
+        $filter = new ContentNegotiator([
+            'formats' => [
+                'application/json' => Response::FORMAT_JSON,
+            ],
+        ]);
+        Yii::$app->request->setAcceptableContentTypes(['application/json' => ['q' => 1, 'version' => '1.0']]);
+        $filter->negotiate();
+        $this->assertSame('json', Yii::$app->response->format);
+        $this->expectException('\yii\web\NotAcceptableHttpException');
+        Yii::$app->request->setAcceptableContentTypes(['application/xml' => ['q' => 1, 'version' => '2.0']]);
+        $filter->negotiate();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️ (upgrade.md updated)
| Tests pass?   | ✔️
| Fixed issues  | #12539
