### PR TITLE
Fix #17760: Fix `JSON::encode()` for `\DateTimeInterface` under PHP 7.4

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #17762: PHP 7.4: Remove special condition for converting PHP errors to exceptions if they occurred inside of `__toString()` call (rob006)
 - Bug #17771: migrate/fresh was not returning exit code (samdark)
 - Bug #17767: Make `Formatter::formatNumber` method protected (TheCodeholic)
+- Bug #17760: Fix `JSON::encode()` for `\DateTimeInterface` under PHP 7.4 (samdark) 
 
 
 2.0.31 December 18, 2019

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,7 +9,7 @@ Yii Framework 2 Change Log
 - Bug #17762: PHP 7.4: Remove special condition for converting PHP errors to exceptions if they occurred inside of `__toString()` call (rob006)
 - Bug #17771: migrate/fresh was not returning exit code (samdark)
 - Bug #17767: Make `Formatter::formatNumber` method protected (TheCodeholic)
-- Bug #17760: Fix `JSON::encode()` for `\DateTimeInterface` under PHP 7.4 (samdark) 
+- Bug #17760: Fix `JSON::encode()` for `\DateTimeInterface` under PHP 7.4 (samdark)
 
 
 2.0.31 December 18, 2019

--- a/framework/helpers/BaseJson.php
+++ b/framework/helpers/BaseJson.php
@@ -151,9 +151,17 @@ class BaseJson
                 $expressions['"' . $token . '"'] = $data->expression;
 
                 return $token;
-            } elseif ($data instanceof \JsonSerializable) {
+            }
+
+            if ($data instanceof \JsonSerializable) {
                 return static::processData($data->jsonSerialize(), $expressions, $expPrefix);
-            } elseif ($data instanceof Arrayable) {
+            }
+
+            if ($data instanceof \DateTimeInterface) {
+                return static::processData((array)$data, $expressions, $expPrefix);
+            }
+
+            if ($data instanceof Arrayable) {
                 $data = $data->toArray();
             } elseif ($data instanceof \SimpleXMLElement) {
                 $data = (array) $data;

--- a/tests/framework/helpers/JsonTest.php
+++ b/tests/framework/helpers/JsonTest.php
@@ -226,7 +226,7 @@ class JsonTest extends TestCase
      */
     public function testEncodeDateTime()
     {
-        $input = new \DateTime('October 12, 2014');
+        $input = new \DateTime('October 12, 2014', 'UTC');
         $output = Json::encode($input);
         $this->assertEquals('{"date":"2014-10-12 00:00:00.000000","timezone_type":3,"timezone":"UTC"}', $output);
     }

--- a/tests/framework/helpers/JsonTest.php
+++ b/tests/framework/helpers/JsonTest.php
@@ -226,7 +226,7 @@ class JsonTest extends TestCase
      */
     public function testEncodeDateTime()
     {
-        $input = new \DateTime('October 12, 2014', 'UTC');
+        $input = new \DateTime('October 12, 2014', new \DateTimeZone('UTC'));
         $output = Json::encode($input);
         $this->assertEquals('{"date":"2014-10-12 00:00:00.000000","timezone_type":3,"timezone":"UTC"}', $output);
     }

--- a/tests/framework/helpers/JsonTest.php
+++ b/tests/framework/helpers/JsonTest.php
@@ -220,6 +220,16 @@ class JsonTest extends TestCase
         $expectedHtml = '["Error message. Here are some chars: < >","Error message. Here are even more chars: \"\""]';
         $this->assertEquals($expectedHtml, Json::errorSummary($model, $options));
     }
+
+    /**
+     * @link https://github.com/yiisoft/yii2/issues/17760
+     */
+    public function testEncodeDateTime()
+    {
+        $input = new \DateTime('October 12, 2014');
+        $output = Json::encode($input);
+        $this->assertEquals('{"date":"2014-10-12 00:00:00.000000","timezone_type":3,"timezone":"UTC"}', $output);
+    }
 }
 
 class JsonModel extends DynamicModel implements \JsonSerializable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17760
