### PR TITLE
Support aria-* attributes like data-* attributes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Bug #17767: Make `Formatter::formatNumber` method protected (TheCodeholic)
 - Bug #12539: `yii\filters\ContentNegotiator` now generates 406 'Not Acceptable' instead of 415 'Unsupported Media Type' on content-type negotiation fail (PowerGamer1)
 - Bug #17760: Fix `JSON::encode()` for `\DateTimeInterface` under PHP 7.4 (samdark)
+- Enh #17792: Added support for `aria` attributes to `yii\helpers\BaseHtml::renderTagAttributes()` (brandonkelly)
 
 
 2.0.31 December 18, 2019

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -93,7 +93,7 @@ class BaseHtml
      * will be generated instead of one: `data-name="xyz" data-age="13"`.
      * @since 2.0.3
      */
-    public static $dataAttributes = ['data', 'data-ng', 'ng'];
+    public static $dataAttributes = ['aria', 'data', 'data-ng', 'ng'];
 
 
     /**
@@ -1919,12 +1919,14 @@ class BaseHtml
      *
      * The values of attributes will be HTML-encoded using [[encode()]].
      *
-     * The "data" attribute is specially handled when it is receiving an array value. In this case,
-     * the array will be "expanded" and a list data attributes will be rendered. For example,
-     * if `'data' => ['id' => 1, 'name' => 'yii']`, then this will be rendered:
-     * `data-id="1" data-name="yii"`.
-     * Additionally `'data' => ['params' => ['id' => 1, 'name' => 'yii'], 'status' => 'ok']` will be rendered as:
-     * `data-params='{"id":1,"name":"yii"}' data-status="ok"`.
+     * `aria` and `data` attributes get special handling when they are set to an array value. In these cases,
+     * the array will be "expanded" and a list of ARIA/data attributes will be rendered. For example,
+     * `'aria' => ['role' => 'checkbox', 'value' => 'true']` would be rendered as
+     * `aria-role="checkbox" aria-value="true"`.
+     *
+     * If a nested `data` value is set to an array, it will be JSON-encoded. For example,
+     * `'data' => ['params' => ['id' => 1, 'name' => 'yii']]` would be rendered as
+     * `data-params='{"id":1,"name":"yii"}'`.
      *
      * @param array $attributes attributes to be rendered. The attribute values will be HTML-encoded using [[encode()]].
      * @return string the rendering result. If the attributes are not empty, they will be rendered

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1188,6 +1188,7 @@ EOD;
 
     public function testDataAttributes()
     {
+        $this->assertEquals('<link src="xyz" aria-a="1" aria-b="c">', Html::tag('link', '', ['src' => 'xyz', 'aria' => ['a' => 1, 'b' => 'c']]));
         $this->assertEquals('<link src="xyz" data-a="1" data-b="c">', Html::tag('link', '', ['src' => 'xyz', 'data' => ['a' => 1, 'b' => 'c']]));
         $this->assertEquals('<link src="xyz" ng-a="1" ng-b="c">', Html::tag('link', '', ['src' => 'xyz', 'ng' => ['a' => 1, 'b' => 'c']]));
         $this->assertEquals('<link src="xyz" data-ng-a="1" data-ng-b="c">', Html::tag('link', '', ['src' => 'xyz', 'data-ng' => ['a' => 1, 'b' => 'c']]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

This PR adds support for `aria-*` attributes to BaseHtml::renderTagAttributes(), in the same way that `data-*` attributes are handled.