### PR TITLE
Fix #17766: Remove previous PJAX event binding before registering new one

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -32,6 +32,7 @@ Yii Framework 2 Change Log
 - Bug #17745: Fix PostgreSQL query builder drops default value when it is empty (xepozz)
 - Enh #17665: Implement RFC 7239 `Forwarded` header parsing in Request (mikk150, kamarton)
 - Enh #17720: DI 3 support for application core components and default object configurations (sup-ham)
+- Bug #17766: Remove previous PJAX event binding before registering new one (samdark)
 
 
 2.0.30 November 19, 2019

--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -204,7 +204,7 @@ class Pjax extends Widget
         if ($this->formSelector !== false) {
             $formSelector = Json::htmlEncode($this->formSelector !== null ? $this->formSelector : '#' . $id . ' form[data-pjax]');
             $submitEvent = Json::htmlEncode($this->submitEvent);
-            $js .= "\njQuery(document).on($submitEvent, $formSelector, function (event) {jQuery.pjax.submit(event, $options);});";
+            $js .= "\njQuery(document).off($submitEvent, $formSelector).on($submitEvent, $formSelector, function (event) {jQuery.pjax.submit(event, $options);});";
         }
         $view = $this->getView();
         PjaxAsset::register($view);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17766
