### PR TITLE
Rectifying wrong instruction

### DIFF
--- a/docs/guide/start-installation.md
+++ b/docs/guide/start-installation.md
@@ -140,7 +140,7 @@ Verifying the Installation <span id="verifying-installation"></span>
 
 After installation is done, either configure your web server (see next section) or use the
 [built-in PHP web server](https://secure.php.net/manual/en/features.commandline.webserver.php) by running the following
-console command while in the project `web` directory:
+console command while in the project root directory:
  
 ```bash
 php yii serve


### PR DESCRIPTION
Hi guys, I have a very humble contribution for newcomers.

The text used to say:
running the following console command while in the project `web` directory

It now says:
running the following console command while in the project root directory

Why:
I tried it, the `web` directory didn't work.

I'm brand new to yii, so to double check if it was an issue with my environment I asked an expert on it. He stated that the yii command-line tool is in the root directory and that it isn't possible to have a new basic install run in the `web` directory if you `curl`ed it just before. 

If it is possible to run it with the `web` directory with other installation methods, then both folders should be suggested.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -
| Is doc issue  | ✔️
