### PR TITLE
fixed #17708 (intl number formatter)

### DIFF
--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -1223,10 +1223,6 @@ class Formatter extends Component
         $value = $this->normalizeNumericValue($value);
 
         if ($this->_intlLoaded) {
-            // fix for https://github.com/yiisoft/yii2/issues/17708
-            if ($decimals !== null) {
-                $decimals++;
-            }
             $f = $this->createNumberFormatter(NumberFormatter::SCIENTIFIC, $decimals, $options, $textOptions);
             if (($result = $f->format($value)) === false) {
                 throw new InvalidArgumentException('Formatting scientific number value failed: ' . $f->getErrorCode() . ' ' . $f->getErrorMessage());

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -1219,9 +1219,14 @@ class Formatter extends Component
         if ($value === null) {
             return $this->nullDisplay;
         }
+
         $value = $this->normalizeNumericValue($value);
 
         if ($this->_intlLoaded) {
+            // fix for https://github.com/yiisoft/yii2/issues/17708
+            if ($decimals !== null) {
+                $decimals++;
+            }
             $f = $this->createNumberFormatter(NumberFormatter::SCIENTIFIC, $decimals, $options, $textOptions);
             if (($result = $f->format($value)) === false) {
                 throw new InvalidArgumentException('Formatting scientific number value failed: ' . $f->getErrorCode() . ' ' . $f->getErrorMessage());

--- a/tests/framework/i18n/FormatterNumberTest.php
+++ b/tests/framework/i18n/FormatterNumberTest.php
@@ -515,7 +515,7 @@ class FormatterNumberTest extends TestCase
     public function testIntlAsScientific()
     {
         $value = '123';
-        $this->assertSame('1.23E2', $this->formatter->asScientific($value));
+        $this->assertSame('1.23E2', $this->formatter->asScientific($value, 2));
         $value = '123456';
         $this->assertSame('1.23456E5', $this->formatter->asScientific($value));
         $value = '-123456.123';
@@ -528,7 +528,10 @@ class FormatterNumberTest extends TestCase
         // null display
         $this->assertSame($this->formatter->nullDisplay, $this->formatter->asScientific(null));
 
-        $this->assertSame('8.76543210987654E16', $this->formatter->asScientific('87654321098765436'));
+        // precision (see also https://github.com/yiisoft/yii2/issues/17708)
+        $this->assertSame('9E16', $this->formatter->asScientific('87654321098765436', 0));
+        $this->assertSame('8.8E16', $this->formatter->asScientific('87654321098765436', 1));
+        $this->assertSame('8.765432109877E16', $this->formatter->asScientific('87654321098765436', 12));
     }
 
     public function testAsScientific()
@@ -548,6 +551,11 @@ class FormatterNumberTest extends TestCase
         $this->assertSame($this->formatter->nullDisplay, $this->formatter->asScientific(null));
 
         $this->assertSame('8.765432E+16', $this->formatter->asScientific('87654321098765436'));
+
+        // precision (see also https://github.com/yiisoft/yii2/issues/17708)
+        $this->assertSame('9E+16', $this->formatter->asScientific('87654321098765436', 0));
+        $this->assertSame('8.8E+16', $this->formatter->asScientific('87654321098765436', 1));
+        $this->assertSame('8.765432109877E+16', $this->formatter->asScientific('87654321098765436', 12));
     }
 
     public function testIntlAsSpellout()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️/❌ (if you rely on a bug ;))
| Tests pass?   | ✔️ (hopefully for all versions)
| Fixed issues  | #17708

Looks like the intl formatter and framework implementation are off-by one handling digits?!

btw: How is the intl extension disabled in tests.

---

Addon: Format is also different between both implementation `E5` vs. `E+5`, shouldn't that be fixed also or does this depend on a locale?
