### PR TITLE
Fix #7622: Allow `yii\data\ArrayDataProvider` to control the sort flags

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #17843: Fix `yii\web\Session::setCookieParamsInternal` check param "samesite" (schevgeny)
 - Bug #17828: Fix `yii\web\UploadedFile::saveAs()` failing when error value in `$_FILES` entry is a string (haveyaseen)
 - Bug #17829: `yii\helpers\ArrayHelper::filter` now correctly filters data when passing a filter with more than 2 levels (rhertogh)
+- Enh #7622: Allow `yii\data\ArrayDataProvider` to control the sort flags for `sortModels` through `yii\data\Sort::sortFlags` property (askobara)
 
 
 2.0.32 January 21, 2020

--- a/framework/data/ArrayDataProvider.php
+++ b/framework/data/ArrayDataProvider.php
@@ -136,7 +136,7 @@ class ArrayDataProvider extends BaseDataProvider
     {
         $orders = $sort->getOrders();
         if (!empty($orders)) {
-            ArrayHelper::multisort($models, array_keys($orders), array_values($orders));
+            ArrayHelper::multisort($models, array_keys($orders), array_values($orders), $sort->sortFlags);
         }
 
         return $models;

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -186,6 +186,12 @@ class Sort extends BaseObject
      */
     public $urlManager;
 
+    /**
+     * @var int Allow to control a value of the fourth parameter which will be
+     * passed to [[ArrayHelper::multisort()]]
+     * @since 2.0.33
+     */
+    public $sortFlags = SORT_REGULAR;
 
     /**
      * Normalizes the [[attributes]] property.

--- a/tests/framework/data/ArrayDataProviderTest.php
+++ b/tests/framework/data/ArrayDataProviderTest.php
@@ -184,4 +184,30 @@ class ArrayDataProviderTest extends TestCase
         $dataProvider = new ArrayDataProvider(['allModels' => $mixedArray, 'pagination' => $pagination]);
         $this->assertEquals(['key1', 9], $dataProvider->getKeys());
     }
+
+    public function testSortFlags()
+    {
+        $simpleArray = [['sortField' => 1], ['sortField' => 2], ['sortField' => 11]];
+        $dataProvider = new ArrayDataProvider(
+            [
+                'allModels' => $simpleArray,
+                'sort' => [
+                    'sortFlags' => SORT_STRING,
+                    'attributes' => [
+                        'sort' => [
+                            'asc' => ['sortField' => SORT_ASC],
+                            'desc' => ['sortField' => SORT_DESC],
+                            'label' => 'Sorting',
+                            'default' => 'asc',
+                        ],
+                    ],
+                    'defaultOrder' => [
+                        'sort' => SORT_ASC,
+                    ],
+                ],
+            ]
+        );
+        $sortedArray = [['sortField' => 1], ['sortField' => 11], ['sortField' => 2]];
+        $this->assertEquals($sortedArray, $dataProvider->getModels());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #7622 
