### PR TITLE
Fix #17863: `\yii\helpers\BaseInflector::slug()` doesn't work with an…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -31,7 +31,7 @@ Yii Framework 2 Change Log
 - Bug #17803: Fix `ErrorHandler` unregister and register to only change global state when applicable (SamMousa)
 - Enh #17729: Path alias support was added to `yii\web\UploadedFile::saveAs()` (sup-ham)
 - Enh #17792: Add support for `aria` attributes to `yii\helpers\BaseHtml::renderTagAttributes()` (brandonkelly)
-
+- Bug #17863: `\yii\helpers\BaseInflector::slug()` doesn't work with an empty string as a replacement argument. (haruatari)
 
 2.0.31 December 18, 2019
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -31,7 +31,7 @@ Yii Framework 2 Change Log
 - Bug #17803: Fix `ErrorHandler` unregister and register to only change global state when applicable (SamMousa)
 - Enh #17729: Path alias support was added to `yii\web\UploadedFile::saveAs()` (sup-ham)
 - Enh #17792: Add support for `aria` attributes to `yii\helpers\BaseHtml::renderTagAttributes()` (brandonkelly)
-- Bug #17863: `\yii\helpers\BaseInflector::slug()` doesn't work with an empty string as a replacement argument. (haruatari)
+- Bug #17863: `\yii\helpers\BaseInflector::slug()` doesn't work with an empty string as a replacement argument (haruatari)
 
 2.0.31 December 18, 2019
 ------------------------

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -477,7 +477,7 @@ class BaseInflector
      */
     public static function slug($string, $replacement = '-', $lowercase = true)
     {
-        if ($replacement) {
+        if ($replacement !== '') {
             $parts = explode($replacement, static::transliterate($string));
         } else {
             $parts = [static::transliterate($string)];
@@ -489,7 +489,7 @@ class BaseInflector
         }, $parts);
 
         $string = trim(implode($replacement, $replaced), $replacement);
-        if ($replacement) {
+        if ($replacement !== '') {
             $string = preg_replace('#' . preg_quote($replacement) . '+#', $replacement, $string);
         }
 

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -477,7 +477,7 @@ class BaseInflector
      */
     public static function slug($string, $replacement = '-', $lowercase = true)
     {
-        if ($replacement !== '') {
+        if ((string)$replacement !== '') {
             $parts = explode($replacement, static::transliterate($string));
         } else {
             $parts = [static::transliterate($string)];
@@ -489,7 +489,7 @@ class BaseInflector
         }, $parts);
 
         $string = trim(implode($replacement, $replaced), $replacement);
-        if ($replacement !== '') {
+        if ((string)$replacement !== '') {
             $string = preg_replace('#' . preg_quote($replacement) . '+#', $replacement, $string);
         }
 

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -477,7 +477,11 @@ class BaseInflector
      */
     public static function slug($string, $replacement = '-', $lowercase = true)
     {
-        $parts = explode($replacement, static::transliterate($string));
+        if ($replacement) {
+            $parts = explode($replacement, static::transliterate($string));
+        } else {
+            $parts = [static::transliterate($string)];
+        }
 
         $replaced = array_map(function ($element) use ($replacement) {
             $element = preg_replace('/[^a-zA-Z0-9=\s—–-]+/u', '', $element);
@@ -485,7 +489,9 @@ class BaseInflector
         }, $parts);
 
         $string = trim(implode($replacement, $replaced), $replacement);
-        $string = preg_replace('#' . preg_quote($replacement) . '+#', $replacement, $string);
+        if ($replacement) {
+            $string = preg_replace('#' . preg_quote($replacement) . '+#', $replacement, $string);
+        }
 
         return $lowercase ? strtolower($string) : $string;
     }

--- a/tests/framework/helpers/InflectorTest.php
+++ b/tests/framework/helpers/InflectorTest.php
@@ -197,6 +197,7 @@ class InflectorTest extends TestCase
         $this->assertEquals('remove_excess_replacements', Inflector::slug(' _ _ remove excess _ _ replacements_', '_'));
         $this->assertEquals('thisrepisreprepreplacement', Inflector::slug('this is REP-lacement', 'REP'));
         $this->assertEquals('0_100_kmh', Inflector::slug('0-100 Km/h', '_'));
+        $this->assertEquals('testtext', Inflector::slug('test text', ''));
     }
 
     public function testSlugIntl()


### PR DESCRIPTION
… empty string as a replacement argument.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17863
