### PR TITLE
Use `Instance::ensure()` to initialize `UrlManager::$cache`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Bug #17828: Fix `yii\web\UploadedFile::saveAs()` failing when error value in `$_FILES` entry is a string (haveyaseen)
 - Bug #17829: `yii\helpers\ArrayHelper::filter` now correctly filters data when passing a filter with more than 2 levels (rhertogh)
 - Enh #7622: Allow `yii\data\ArrayDataProvider` to control the sort flags for `sortModels` through `yii\data\Sort::sortFlags` property (askobara)
+- Enh #16721: Use `Instance::ensure()` to initialize `UrlManager::$cache` (rob006)
 - Bug #17863: `\yii\helpers\BaseInflector::slug()` doesn't work with an empty string as a replacement argument (haruatari)
 - Bug #17881: `yii\db\Query::queryScalar()` wasn’t reverting the `select`, `orderBy`, `limit`, and `offset` params if an exception occurred (brandonkelly)
 - Bug #17875: Use `move_uploaded_file()` function instead of `copy()` and `unlink()` for saving uploaded files in case of POST request (sup-ham)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -101,6 +101,10 @@ Upgrade from Yii 2.0.32
   
 * `UploadedFile` class `deleteTempFile()` and `isUploadedFile()` methods introduced in 2.0.32 were removed.
 
+* Exception will be thrown if `UrlManager::$cache` configuration is incorrect (previously misconfiguration was silently 
+  ignored and `UrlManager` continue to work without cache). Make sure that `UrlManager::$cache` is correctly configured 
+  or set it to `null` to explicitly disable cache.
+
 Upgrade from Yii 2.0.31
 -----------------------
 

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -11,6 +11,7 @@ use Yii;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
 use yii\caching\CacheInterface;
+use yii\di\Instance;
 use yii\helpers\Url;
 
 /**
@@ -118,12 +119,14 @@ class UrlManager extends Component
      */
     public $routeParam = 'r';
     /**
-     * @var CacheInterface|string the cache object or the application component ID of the cache object.
+     * @var CacheInterface|array|string the cache object or the application component ID of the cache object.
+     * This can also be an array that is used to create a [[CacheInterface]] instance in case you do not want to use
+     * an application component.
      * Compiled URL rules will be cached through this cache object, if it is available.
      *
      * After the UrlManager object is created, if you want to change this property,
      * you should only assign it with a cache object.
-     * Set this property to `false` if you do not want to cache the URL rules.
+     * Set this property to `false` or `null` if you do not want to cache the URL rules.
      *
      * Cache entries are stored for the time set by [[\yii\caching\Cache::$defaultDuration|$defaultDuration]] in
      * the cache configuration, which is unlimited by default. You may want to tune this value if your [[rules]]
@@ -182,8 +185,8 @@ class UrlManager extends Component
         if (!$this->enablePrettyUrl) {
             return;
         }
-        if (is_string($this->cache)) {
-            $this->cache = Yii::$app->get($this->cache, false);
+        if ($this->cache !== false && $this->cache !== null) {
+            $this->cache = Instance::ensure($this->cache, 'yii\caching\CacheInterface');
         }
         if (empty($this->rules)) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ?
| Tests pass?   | ✔️
| Fixed issues  | #16721

This allows to pass configuration component for `UrlManager::$cache` (like in many other similar cases) so you could create custom cache instance just for `UrlManger` without a need to declare it as global component (see https://github.com/yiisoft/yii2/issues/16721#issuecomment-422143911 and https://github.com/yiisoft/yii2/issues/16721#issuecomment-422315982).

Technically this could be a BC break - previously misconfiguration (for example typo in component name) was silently ignored. Now it will throw an exception if configured cache component cannot be initialized. IMO this is a bugfix - configuration errors should not be hidden in this way, especially in such cases where lack of cache affects performance and it is easy to miss it.