### PR TITLE
fix: #13749 Yii opens db connection even when hits query cache

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -19,7 +19,7 @@ Yii Framework 2 Change Log
 - Bug #17881: `yii\db\Query::queryScalar()` wasn’t reverting the `select`, `orderBy`, `limit`, and `offset` params if an exception occurred (brandonkelly)
 - Bug #17875: Use `move_uploaded_file()` function instead of `copy()` and `unlink()` for saving uploaded files in case of POST request (sup-ham)
 - Bug #17884: Fix 0 values in console Table rendered as empty string (mikehaertl)
-
+- Bug #13749: Fix Yii opens db connection even when hits query cache (shushenghong)
 
 2.0.32 January 21, 2020
 -----------------------

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -1148,7 +1148,6 @@ class Command extends Component
                 }
             }
         }
-        $rawSql = $rawSql ?: $this->getRawSql();
 
         $this->prepare(true);
 

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -1140,8 +1140,7 @@ class Command extends Component
             if (is_array($info)) {
                 /* @var $cache \yii\caching\CacheInterface */
                 $cache = $info[0];
-                $rawSql = $rawSql ?: $this->getRawSql();
-                $cacheKey = $this->getCacheKey($method, $fetchMode, $rawSql);
+                $cacheKey = $this->getCacheKey($method, $fetchMode);
                 $result = $cache->get($cacheKey);
                 if (is_array($result) && isset($result[0])) {
                     Yii::debug('Query result served from cache', 'yii\db\Command::query');
@@ -1191,15 +1190,17 @@ class Command extends Component
      * @return array the cache key
      * @since 2.0.16
      */
-    protected function getCacheKey($method, $fetchMode, $rawSql)
+    protected function getCacheKey($method, $fetchMode)
     {
+        ksort($this->params);
         return [
             __CLASS__,
             $method,
             $fetchMode,
             $this->db->dsn,
             $this->db->username,
-            $rawSql,
+            $this->getSql(),
+            json_encode($this->params),
         ];
     }
 

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -1140,7 +1140,7 @@ class Command extends Component
             if (is_array($info)) {
                 /* @var $cache \yii\caching\CacheInterface */
                 $cache = $info[0];
-                $cacheKey = $this->getCacheKey($method, $fetchMode, $rawSql);
+                $cacheKey = $this->getCacheKey($method, $fetchMode);
                 $result = $cache->get($cacheKey);
                 if (is_array($result) && isset($result[0])) {
                     Yii::debug('Query result served from cache', 'yii\db\Command::query');
@@ -1187,11 +1187,10 @@ class Command extends Component
      * @param string $method method of PDOStatement to be called
      * @param int $fetchMode the result fetch mode. Please refer to [PHP manual](https://secure.php.net/manual/en/function.PDOStatement-setFetchMode.php)
      * for valid fetch modes.
-     * @param string $rawSql Deprecated since 2.0.33, the raw SQL with parameter values inserted into the corresponding placeholders
      * @return array the cache key
      * @since 2.0.16
      */
-    protected function getCacheKey($method, $fetchMode, $rawSql)
+    protected function getCacheKey($method, $fetchMode)
     {
         $params = $this->params;
         ksort($params);

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -1140,7 +1140,7 @@ class Command extends Component
             if (is_array($info)) {
                 /* @var $cache \yii\caching\CacheInterface */
                 $cache = $info[0];
-                $cacheKey = $this->getCacheKey($method, $fetchMode);
+                $cacheKey = $this->getCacheKey($method, $fetchMode, $rawSql);
                 $result = $cache->get($cacheKey);
                 if (is_array($result) && isset($result[0])) {
                     Yii::debug('Query result served from cache', 'yii\db\Command::query');
@@ -1148,6 +1148,7 @@ class Command extends Component
                 }
             }
         }
+        $rawSql = $rawSql ?: $this->getRawSql();
 
         $this->prepare(true);
 
@@ -1186,13 +1187,14 @@ class Command extends Component
      * @param string $method method of PDOStatement to be called
      * @param int $fetchMode the result fetch mode. Please refer to [PHP manual](https://secure.php.net/manual/en/function.PDOStatement-setFetchMode.php)
      * for valid fetch modes.
-     * @param string $rawSql the raw SQL with parameter values inserted into the corresponding placeholders
+     * @param string $rawSql Deprecated since 2.0.33, the raw SQL with parameter values inserted into the corresponding placeholders
      * @return array the cache key
      * @since 2.0.16
      */
-    protected function getCacheKey($method, $fetchMode)
+    protected function getCacheKey($method, $fetchMode, $rawSql)
     {
-        ksort($this->params);
+        $params = $this->params;
+        ksort($params);
         return [
             __CLASS__,
             $method,
@@ -1200,7 +1202,7 @@ class Command extends Component
             $this->db->dsn,
             $this->db->username,
             $this->getSql(),
-            json_encode($this->params),
+            json_encode($params),
         ];
     }
 

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -395,7 +395,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         // https://github.com/yiisoft/yii2/issues/13749#issuecomment-481657224
         $key = [__METHOD__, $this->db->dsn];
         $cache = null;
-        $schemaCache = is_string($this->db->schemaCache) ? \Yii::$app->get($this->db->schemaCache, false) : $this->db->schemaCache;
+        $schemaCache = ( \Yii::$app && is_string($this->db->schemaCache) ) ? \Yii::$app->get($this->db->schemaCache, false) : $this->db->schemaCache;
         if ( $this->db->enableSchemaCache && $schemaCache instanceof CacheInterface ) {
             $cache = $schemaCache;
         }

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -393,10 +393,10 @@ class QueryBuilder extends \yii\db\QueryBuilder
         // use cache to prevent open mysql connection
         // https://github.com/yiisoft/yii2/issues/13749#issuecomment-481657224
         $key = [__METHOD__, $this->db->dsn];
-        $version = \Yii::$app->cache ? \Yii::$app->cache->get($key) : null;
+        $version = isset(\Yii::$app->cache) ? \Yii::$app->cache->get($key) : null;
         if( !$version ) {
             $version = $this->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
-            \Yii::$app->cache ? \Yii::$app->cache->set($key, $version) : null;
+            isset(\Yii::$app->cache) ? \Yii::$app->cache->set($key, $version) : null;
         }
         
         return version_compare($version, '5.6.4', '>=');

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -390,7 +390,15 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     private function supportsFractionalSeconds()
     {
-        $version = $this->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+        // use cache to prevent open mysql connection
+        // https://github.com/yiisoft/yii2/issues/13749#issuecomment-481657224
+        $key = [__METHOD__, $this->db->dsn];
+        $version = \Yii::$app->cache ? \Yii::$app->cache->get($key) : null;
+        if( !$version ) {
+            $version = $this->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+            \Yii::$app->cache ? \Yii::$app->cache->set($key, $version) : null;
+        }
+        
         return version_compare($version, '5.6.4', '>=');
     }
 

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -395,11 +395,9 @@ class QueryBuilder extends \yii\db\QueryBuilder
         // https://github.com/yiisoft/yii2/issues/13749#issuecomment-481657224
         $key = [__METHOD__, $this->db->dsn];
         $cache = null;
-        if ( $this->db->enableSchemaCache ) {
-            $schemaCache = is_string($this->db->schemaCache) ? \Yii::$app->get($this->db->schemaCache, false) : $this->db->schemaCache;
-            if ($schemaCache instanceof CacheInterface) {
-                $cache = $schemaCache;
-            }
+        $schemaCache = is_string($this->db->schemaCache) ? \Yii::$app->get($this->db->schemaCache, false) : $this->db->schemaCache;
+        if ( $this->db->enableSchemaCache && $schemaCache instanceof CacheInterface ) {
+            $cache = $schemaCache;
         }
         $version = $cache ? $cache->get($key) : null;
         if( !$version ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️ remove $rawsql parameter from yii\db\Command::getCacheKey()
| Tests pass?   | ✔️
| Fixed issues  | #13749 Yii opens db connection even when hits query cache
