### PR TITLE
Fix for `Command::getRawSql`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -24,6 +24,7 @@ Yii Framework 2 Change Log
 - Bug #17884: Fix 0 values in console Table rendered as empty string (mikehaertl)
 - Bug #13749: Fix Yii opens db connection even when hits query cache (shushenghong)
 - Bug #17909: Reset DB schema, transaction, and driver name when the connection is closed (brandonkelly)
+- Bug #17920: Fix for `Command::getRawSql` and `Expression` in params (alex-code)
 
 2.0.32 January 21, 2020
 -----------------------

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -206,13 +206,13 @@ class Command extends Component
             if (is_string($name) && strncmp(':', $name, 1)) {
                 $name = ':' . $name;
             }
-            if (is_string($value)) {
-                $params[$name] = $this->db->quoteValue($value);
+            if (is_string($value) || $value instanceof Expression) {
+                $params[$name] = $this->db->quoteValue((string)$value);
             } elseif (is_bool($value)) {
                 $params[$name] = ($value ? 'TRUE' : 'FALSE');
             } elseif ($value === null) {
                 $params[$name] = 'NULL';
-            } elseif ((!is_object($value) && !is_resource($value)) || $value instanceof Expression) {
+            } elseif (!is_object($value) && !is_resource($value)) {
                 $params[$name] = $value;
             }
         }

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -1357,8 +1357,13 @@ SQL;
             [
                 'SELECT * FROM customer WHERE id IN (:ids)',
                 [':ids' => new Expression(implode(', ', [1, 2]))],
-                'SELECT * FROM customer WHERE id IN (1, 2)',
+                'SELECT * FROM customer WHERE id IN (\'1, 2\')',
             ],
+            [
+                'SELECT NOW() = :now',
+                [':now' => new Expression('NOW()')],
+                'SELECT NOW() = \'NOW()\'',
+            ]
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️

`Expression`s in params are treated as strings and quoted when bound but not quoted in `Command::getRawSql`

```php
(new \yii\db\Query)
  ->from('my_table')
  ->where('NOW() = :now', [':now' => new yii\db\Expression('NOW()')])
  ->scalar());
```
Will actually execute as on MySQL (with quotes)
```php
SELECT * FROM `my_table` WHERE NOW() = 'NOW()'
```
The DB query log on the debug toolbar causes a bit of confusion as it reports the query as (without quotes)
```php
SELECT * FROM `my_table` WHERE NOW() = NOW()
```

This may have BC implications if anyone has used `Command::getRawSql` and `Expression`s in params and isn't expecting the quotes.