### PR TITLE
Allow bool param binding in actions

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.33 under development
 ------------------------
 
+- Enh #17929: Actions can now have bool typed params bound (alex-code)
 - Enh #17827: Add `StringValidator::$strict` that can be turned off to allow any scalars (adhayward, samdark)
 - Bug #16145: Fix `Html` helper `checkboxList()`, `radioList()`, `renderSelectOptions()`, `dropDownList()`, `listBox()` methods to work properly with traversable selection (samdark)
 - Bug #17797: Fix for `activeListInput` options (alex-code)

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -147,6 +147,9 @@ class Controller extends \yii\base\Controller
                         case 'float':
                             $params[$name] = filter_var($params[$name], FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
                             break;
+                        case 'bool':
+                            $params[$name] = filter_var($params[$name], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                            break;
                     }
                     if ($params[$name] === null) {
                         $isValid = false;

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -59,10 +59,12 @@ class ControllerTest extends TestCase
 
         $aksi1 = new InlineAction('aksi1', $this->controller, 'actionAksi1');
 
-        $params = ['foo' => '100', 'bar' => null];
-        list($foo, $bar) = $this->controller->bindActionParams($aksi1, $params);
+        $params = ['foo' => '100', 'bar' => null, 'true' => true, 'false' => false];
+        list($foo, $bar, $true, $false) = $this->controller->bindActionParams($aksi1, $params);
         $this->assertSame(100, $foo);
         $this->assertSame(null, $bar);
+        $this->assertSame(true, $true);
+        $this->assertSame(false, $false);
 
         $params = ['foo' => 'oops', 'bar' => null];
         $this->expectException('yii\web\BadRequestHttpException');

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -59,7 +59,7 @@ class ControllerTest extends TestCase
 
         $aksi1 = new InlineAction('aksi1', $this->controller, 'actionAksi1');
 
-        $params = ['foo' => '100', 'bar' => null, 'true' => true, 'false' => false];
+        $params = ['foo' => '100', 'bar' => null, 'true' => 'on', 'false' => 'false'];
         list($foo, $bar, $true, $false) = $this->controller->bindActionParams($aksi1, $params);
         $this->assertSame(100, $foo);
         $this->assertSame(null, $bar);

--- a/tests/framework/web/FakePhp7Controller.php
+++ b/tests/framework/web/FakePhp7Controller.php
@@ -17,7 +17,7 @@ class FakePhp7Controller extends Controller
 {
     public $enableCsrfValidation = false;
 
-    public function actionAksi1(int $foo, float $bar = null)
+    public function actionAksi1(int $foo, float $bar = null, bool $true, bool $false)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

Allow boolean parameters to be bound to actions.