### PR TITLE
fix #17930 client attribute id is same when multiple models on same form

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,8 +4,7 @@ Yii Framework 2 Change Log
 2.0.34 under development
 ------------------------
 
-- no changes in this release.
-
+- Bug #17930: client attribute id is same when multiple models on same form (shushenghong)
 
 2.0.33 March 24, 2020
 ---------------------

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -847,7 +847,7 @@ class ActiveField extends Component
         $options = [];
 
         $inputID = $this->getInputId();
-        $options['id'] = Html::getInputId($this->model, $this->attribute);
+        $options['id'] = $inputID;
         $options['name'] = $this->attribute;
 
         $options['container'] = isset($this->selectors['container']) ? $this->selectors['container'] : ".field-$inputID";

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -460,7 +460,7 @@ EOD;
         $actualValue = $this->activeField->getClientOptions();
 
         $this->assertArraySubset([
-            'id' => 'activefieldtestmodel-attributename',
+            'id' => 'custom-input-id',
             'name' => $this->attributeName,
             'container' => '.field-custom-input-id',
             'input' => '#custom-input-id',
@@ -470,7 +470,7 @@ EOD;
         $actualValue = $this->activeField->getClientOptions();
 
         $this->assertArraySubset([
-            'id' => 'activefieldtestmodel-attributename',
+            'id' => 'custom-textinput-id',
             'name' => $this->attributeName,
             'container' => '.field-custom-textinput-id',
             'input' => '#custom-textinput-id',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17930
