### PR TITLE
Clear a couple more Connection caches on close()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.34 under development
 ------------------------
 
-- no changes in this release.
+- Bug #17935: Reset DB quoted table/column name caches when the connection is closed (brandonkelly)
 
 
 2.0.33 March 24, 2020

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -664,6 +664,9 @@ class Connection extends Component
         $this->_schema = null;
         $this->_transaction = null;
         $this->_driverName = null;
+        $this->_queryCacheInfo = [];
+        $this->_quotedTableNames = null;
+        $this->_quotedColumnNames = null;
     }
 
     /**


### PR DESCRIPTION
This is a continuation of #17910. If a DB connection is closed, it should be prepared for the possibility that it will be reopened with a different driver set, in which case any cached quoted table/column names should be cleared out.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
