### PR TITLE
Fix #17934: Fix regression in Oracle when binding several string parameters

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,8 @@ Yii Framework 2 Change Log
 
 - Bug #17932: Fix regression in detection of AJAX requests (samdark)
 
+- Bug #17932: Fix regression in detection of AJAX requests (samdark)
+- Bug #17934: Fix regression in Oracle when binding several string parameters (fen1xpv, samdark)
 
 2.0.33 March 24, 2020
 ---------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,8 +5,6 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #17932: Fix regression in detection of AJAX requests (samdark)
-
-- Bug #17932: Fix regression in detection of AJAX requests (samdark)
 - Bug #17934: Fix regression in Oracle when binding several string parameters (fen1xpv, samdark)
 
 2.0.33 March 24, 2020

--- a/framework/db/oci/Command.php
+++ b/framework/db/oci/Command.php
@@ -21,10 +21,11 @@ class Command extends \yii\db\Command
      */
     protected function bindPendingParams()
     {
+        $paramsPassedByReference = [];
         foreach ($this->pendingParams as $name => $value) {
             if (\PDO::PARAM_STR === $value[1]) {
-                $passedByRef = $value[0];
-                $this->pdoStatement->bindParam($name, $passedByRef, $value[1], strlen($value[0]));
+                $paramsPassedByReference[$name] = $value[0];
+                $this->pdoStatement->bindParam($name, $paramsPassedByReference[$name], $value[1], strlen($value[0]));
             } else {
                 $this->pdoStatement->bindValue($name, $value[0], $value[1]);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17934
