### PR TITLE
Fixed yii\web\Response event classes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,7 +7,6 @@ Yii Framework 2 Change Log
 - Bug #17935: Reset DB quoted table/column name caches when the connection is closed (brandonkelly)
 - Bug #17932: Fix regression in detection of AJAX requests (samdark)
 - Bug #17934: Fix regression in Oracle when binding several string parameters (fen1xpv, samdark)
-- Bug #17939: Fix event class names for `yii\web\Response` (brandonkelly)
 
 
 2.0.33 March 24, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #17935: Reset DB quoted table/column name caches when the connection is closed (brandonkelly)
 - Bug #17932: Fix regression in detection of AJAX requests (samdark)
 - Bug #17934: Fix regression in Oracle when binding several string parameters (fen1xpv, samdark)
+- Bug #17939: Fix event class names for `yii\web\Response` (brandonkelly)
 
 
 2.0.33 March 24, 2020

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -62,15 +62,15 @@ use yii\helpers\Url;
 class Response extends \yii\base\Response
 {
     /**
-     * @event ResponseEvent an event that is triggered at the beginning of [[send()]].
+     * @event \yii\base\Event an event that is triggered at the beginning of [[send()]].
      */
     const EVENT_BEFORE_SEND = 'beforeSend';
     /**
-     * @event ResponseEvent an event that is triggered at the end of [[send()]].
+     * @event \yii\base\Event an event that is triggered at the end of [[send()]].
      */
     const EVENT_AFTER_SEND = 'afterSend';
     /**
-     * @event ResponseEvent an event that is triggered right after [[prepare()]] is called in [[send()]].
+     * @event \yii\base\Event an event that is triggered right after [[prepare()]] is called in [[send()]].
      * You may respond to this event to filter the response content before it is sent to the client.
      */
     const EVENT_AFTER_PREPARE = 'afterPrepare';


### PR DESCRIPTION
The event constants in `yii\web\Response` claim to use a `ResponseEvent` class that doesn’t exist. Fixed to reference `yii\base\Event` instead. (Fully qualified class name because there’s no other reference to `yii\base\Event` in that class, so importing it would just end up getting automatically removed by PhpStorm code reformatting.)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
