### PR TITLE
#17933: Log warning instead of erroring when URLManager is unable to initialize cache

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.34 under development
 ------------------------
 
+- Bug #17933: Use DummyCache by default (samdark)
 - Bug #17935: Reset DB quoted table/column name caches when the connection is closed (brandonkelly)
 - Bug #17932: Fix regression in detection of AJAX requests (samdark)
 - Bug #17934: Fix regression in Oracle when binding several string parameters (fen1xpv, samdark)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.34 under development
 ------------------------
 
-- Bug #17933: Use DummyCache by default (samdark)
+- Bug #17933: Log warning instead of erroring when URLManager is unable to initialize cache (samdark)
 - Bug #17935: Reset DB quoted table/column name caches when the connection is closed (brandonkelly)
 - Bug #17932: Fix regression in detection of AJAX requests (samdark)
 - Bug #17934: Fix regression in Oracle when binding several string parameters (fen1xpv, samdark)

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -631,8 +631,7 @@ abstract class Application extends Module
             'mailer' => ['class' => 'yii\swiftmailer\Mailer'],
             'urlManager' => ['class' => 'yii\web\UrlManager'],
             'assetManager' => ['class' => 'yii\web\AssetManager'],
-            'security' => ['class' => 'yii\base\Security'],
-            'cache' => ['class' => 'yii\caching\DummyCache'],
+            'security' => ['class' => 'yii\base\Security']
         ];
     }
 

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -632,6 +632,7 @@ abstract class Application extends Module
             'urlManager' => ['class' => 'yii\web\UrlManager'],
             'assetManager' => ['class' => 'yii\web\AssetManager'],
             'security' => ['class' => 'yii\base\Security'],
+            'cache' => ['class' => 'yii\caching\DummyCache'],
         ];
     }
 

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -186,7 +186,11 @@ class UrlManager extends Component
             return;
         }
         if ($this->cache !== false && $this->cache !== null) {
-            $this->cache = Instance::ensure($this->cache, 'yii\caching\CacheInterface');
+            try {
+                $this->cache = Instance::ensure($this->cache, 'yii\caching\CacheInterface');
+            } catch (InvalidConfigException $e) {
+                Yii::warning('Unable to use cache for URL manager: ' . $e->getMessage());
+            }
         }
         if (empty($this->rules)) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17933
