### PR TITLE
Fix #17810 EachValidator crashing with uninitialized typed properties

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.35 under development
 ------------------------
 
-- no changes in this release.
+ - Bug #17810: Fix EachValidator crashing with uninitialized typed properties (ricardomm85)
 
 
 2.0.34 March 26, 2020

--- a/framework/base/DynamicModel.php
+++ b/framework/base/DynamicModel.php
@@ -174,15 +174,26 @@ class DynamicModel extends Model
      * You can also directly manipulate [[validators]] to add or remove validation rules.
      * This method provides a shortcut.
      * @param string|array $attributes the attribute(s) to be validated by the rule
-     * @param mixed $validator the validator for the rule.This can be a built-in validator name,
-     * a method name of the model class, an anonymous function, or a validator class name.
+     * @param string|Validator|\Closure $validator the validator. This can be either:
+     *  * a built-in validator name listed in [[builtInValidators]];
+     *  * a method name of the model class;
+     *  * an anonymous function;
+     *  * a validator class name.
+     *  * a Validator.
      * @param array $options the options (name-value pairs) to be applied to the validator
      * @return $this the model itself
      */
     public function addRule($attributes, $validator, $options = [])
     {
         $validators = $this->getValidators();
-        $validators->append(Validator::createValidator($validator, $this, (array)$attributes, $options));
+
+        if ($validator instanceof Validator) {
+            $validator->attributes = (array)$attributes;
+        } else {
+            $validator = Validator::createValidator($validator, $this, (array)$attributes, $options);
+        }
+
+        $validators->append($validator);
 
         return $this;
     }

--- a/framework/validators/EachValidator.php
+++ b/framework/validators/EachValidator.php
@@ -8,6 +8,7 @@
 namespace yii\validators;
 
 use Yii;
+use yii\base\DynamicModel;
 use yii\base\InvalidConfigException;
 use yii\base\Model;
 
@@ -128,48 +129,38 @@ class EachValidator extends Validator
      */
     public function validateAttribute($model, $attribute)
     {
-        // PHP 7.4 Typed properties not initialized
-        if(property_exists($model, $attribute) && !isset($model->$attribute)) {
-            return;
-        }
-
-        $value = $model->$attribute;
-        if (!is_array($value) && !$value instanceof \ArrayAccess) {
+        $arrayOfValues = $model->$attribute;
+        if (!is_array($arrayOfValues) && !$arrayOfValues instanceof \ArrayAccess) {
             $this->addError($model, $attribute, $this->message, []);
             return;
         }
 
-        $validator = $this->getValidator($model); // ensure model context while validator creation
+        $dynamicModel = new DynamicModel($model->getAttributes());
+        $dynamicModel->addRule($attribute, $this->getValidator($model));
 
-        $detectedErrors = $model->getErrors($attribute);
-        $filteredValue = $model->$attribute;
-        foreach ($value as $k => $v) {
-            $model->clearErrors($attribute);
-            $model->$attribute = $v;
-            if (!$validator->skipOnEmpty || !$validator->isEmpty($v)) {
-                $validator->validateAttribute($model, $attribute);
+        foreach ($arrayOfValues as $k => $v) {
+            $dynamicModel->defineAttribute($attribute, $v);
+            $dynamicModel->validate();
+
+            $arrayOfValues[$k] = $dynamicModel->$attribute; // filtered values like 'trim'
+
+            if (!$dynamicModel->hasErrors($attribute)) {
+                continue;
             }
-            $filteredValue[$k] = $model->$attribute;
-            if ($model->hasErrors($attribute)) {
-                if ($this->allowMessageFromRule) {
-                    $validationErrors = $model->getErrors($attribute);
-                    $detectedErrors = array_merge($detectedErrors, $validationErrors);
-                } else {
-                    $model->clearErrors($attribute);
-                    $this->addError($model, $attribute, $this->message, ['value' => $v]);
-                    $detectedErrors[] = $model->getFirstError($attribute);
-                }
-                $model->$attribute = $value;
 
-                if ($this->stopOnFirstError) {
-                    break;
-                }
+            if ($this->allowMessageFromRule) {
+                $validationErrors = $dynamicModel->getErrors($attribute);
+                $model->addErrors([$attribute => $validationErrors]);
+            } else {
+                $this->addError($model, $attribute, $this->message, ['value' => $v]);
+            }
+
+            if ($this->stopOnFirstError) {
+                break;
             }
         }
 
-        $model->$attribute = $filteredValue;
-        $model->clearErrors($attribute);
-        $model->addErrors([$attribute => $detectedErrors]);
+        $model->$attribute = $arrayOfValues;
     }
 
     /**

--- a/framework/validators/EachValidator.php
+++ b/framework/validators/EachValidator.php
@@ -128,6 +128,9 @@ class EachValidator extends Validator
      */
     public function validateAttribute($model, $attribute)
     {
+        // PHP 7.4 Typed properties not initialized
+        if(!isset($model->$attribute)) return;
+
         $value = $model->$attribute;
         if (!is_array($value) && !$value instanceof \ArrayAccess) {
             $this->addError($model, $attribute, $this->message, []);

--- a/framework/validators/EachValidator.php
+++ b/framework/validators/EachValidator.php
@@ -129,7 +129,9 @@ class EachValidator extends Validator
     public function validateAttribute($model, $attribute)
     {
         // PHP 7.4 Typed properties not initialized
-        if(!isset($model->$attribute)) return;
+        if(property_exists($model, $attribute) && !isset($model->$attribute)) {
+            return;
+        }
 
         $value = $model->$attribute;
         if (!is_array($value) && !$value instanceof \ArrayAccess) {

--- a/tests/data/validators/models/FakedValidationModel.php
+++ b/tests/data/validators/models/FakedValidationModel.php
@@ -88,4 +88,9 @@ class FakedValidationModel extends Model
     {
         return $this->inlineValArgs;
     }
+
+    public function attributes()
+    {
+        return array_keys($this->attr);
+    }
 }

--- a/tests/data/validators/models/ValidatorTestTypedPropModel.php
+++ b/tests/data/validators/models/ValidatorTestTypedPropModel.php
@@ -11,5 +11,5 @@ use yii\base\Model;
 
 class ValidatorTestTypedPropModel extends Model
 {
-    public array $arrayTypedProperty;
+    public array $arrayTypedProperty = [true, false];
 }

--- a/tests/data/validators/models/ValidatorTestTypedPropModel.php
+++ b/tests/data/validators/models/ValidatorTestTypedPropModel.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\validators\models;
+
+use yii\base\Model;
+
+class ValidatorTestTypedPropModel extends Model
+{
+    public array $arrayTypedProperty;
+}

--- a/tests/framework/validators/EachValidatorTest.php
+++ b/tests/framework/validators/EachValidatorTest.php
@@ -12,6 +12,7 @@ use yii\validators\EachValidator;
 use yiiunit\data\base\ArrayAccessObject;
 use yiiunit\data\base\TraversableObject;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\data\validators\models\ValidatorTestTypedPropModel;
 use yiiunit\TestCase;
 
 /**
@@ -199,5 +200,19 @@ class EachValidatorTest extends TestCase
         $this->assertFalse($model->hasErrors('array'));
 
         $this->assertTrue($validator->validate($model->attr_array));
+    }
+
+    public function testTypedProperties()
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped('Can not be tested on PHP < 7.4');
+            return;
+        }
+
+        $model = new ValidatorTestTypedPropModel();
+
+        $validator = new EachValidator(['rule' => ['boolean']]);
+        $validator->validateAttribute($model, 'arrayTypedProperty');
+        $this->assertFalse($model->hasErrors('array'));
     }
 }

--- a/tests/framework/validators/EachValidatorTest.php
+++ b/tests/framework/validators/EachValidatorTest.php
@@ -7,10 +7,8 @@
 
 namespace yiiunit\framework\validators;
 
-use yii\db\ArrayExpression;
 use yii\validators\EachValidator;
 use yiiunit\data\base\ArrayAccessObject;
-use yiiunit\data\base\TraversableObject;
 use yiiunit\data\validators\models\FakedValidationModel;
 use yiiunit\data\validators\models\ValidatorTestTypedPropModel;
 use yiiunit\TestCase;
@@ -202,6 +200,14 @@ class EachValidatorTest extends TestCase
         $this->assertTrue($validator->validate($model->attr_array));
     }
 
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/17810
+     *
+     * Do not reuse model property for storing value
+     * of different type during validation.
+     * (ie: public array $dummy; where $dummy is array of booleans,
+     * validator will try to assign these booleans one by one to $dummy)
+     */
     public function testTypedProperties()
     {
         if (PHP_VERSION_ID < 70400) {
@@ -213,6 +219,6 @@ class EachValidatorTest extends TestCase
 
         $validator = new EachValidator(['rule' => ['boolean']]);
         $validator->validateAttribute($model, 'arrayTypedProperty');
-        $this->assertFalse($model->hasErrors('array'));
+        $this->assertFalse($model->hasErrors('arrayTypedProperty'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  |  #17810 


When EachValidator is used in a uninitialized typed property (PHP 7.4) it generates a fatal error.
"Fatal error: Uncaught Error: Typed property XXX must not be accessed before initialization..."

Keep in mind that uninitialized is not the same as null.
Just added a check ( isset() ) before performing EachValidator logic.


