### PR TITLE
Ignore set_time_limit() errors

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.35 under development
 ------------------------
 
-- no changes in this release.
+- Bug #17948: Ignore errors caused by `set_time_limit(0)` (brandonkelly)
 
 
 2.0.34 March 26, 2020

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -430,9 +430,8 @@ class Response extends \yii\base\Response
             return;
         }
 
-        if (function_exists('set_time_limit')) {
-            @set_time_limit(0); // Reset time limit for big files
-        } else {
+        // Try to reset time limit for big files
+        if (!function_exists('set_time_limit') || !@set_time_limit(0)) {
             Yii::warning('set_time_limit() is not available', __METHOD__);
         }
 

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -431,7 +431,7 @@ class Response extends \yii\base\Response
         }
 
         if (function_exists('set_time_limit')) {
-            set_time_limit(0); // Reset time limit for big files
+            @set_time_limit(0); // Reset time limit for big files
         } else {
             Yii::warning('set_time_limit() is not available', __METHOD__);
         }


### PR DESCRIPTION
We have a customer whose hosting environment has a custom PHP module installed, which doesn’t allow `set_time_limit(0)` to be called, even though the function exists. Ignoring the error with `@` has proven to work for them.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
