### PR TITLE
Fix nested forms issue with yii.gridView.js

### DIFF
--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -160,7 +160,7 @@
                 'class': 'gridview-filter-form',
                 style: 'display:none',
                 'data-pjax': ''
-            }).appendTo($grid);
+            }).appendTo('body');
             $.each(data, function (name, values) {
                 $.each(values, function (index, value) {
                     $form.append($('<input/>').attr({type: 'hidden', name: name, value: value}));


### PR DESCRIPTION
Appending dynamically created filter form to <body> rather than to $grid element results in leaner structure free of nested form issue in case GridView widget with active filters is positioned inside another form. This change has no other impact on GridView performance.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -
