### PR TITLE
Fix #17964: Fix `UrlValidator` for url like `http://localhost`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #17948: Ignore errors caused by `set_time_limit(0)` (brandonkelly)
 - Bug #17810: Fix EachValidator crashing with uninitialized typed properties (ricardomm85)
 - Bug #17942: Fix for `DbCache` loop in MySQL `QueryBuilder` (alex-code)
+- Bug #17964: Fix `UrlValidator` for url like `http://localhost` (germanow)
 
 
 2.0.34 March 26, 2020

--- a/framework/validators/UrlValidator.php
+++ b/framework/validators/UrlValidator.php
@@ -28,7 +28,7 @@ class UrlValidator extends Validator
      * The pattern may contain a `{schemes}` token that will be replaced
      * by a regular expression which represents the [[validSchemes]].
      */
-    public $pattern = '/^{schemes}:\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(?::\d{1,5})?(?:$|[?\/#])/i';
+    public $pattern = '/^{schemes}:\/\/(([A-Z0-9][A-Z0-9_-]*)((\.)?[A-Z0-9][A-Z0-9_-]*)+)(?::\d{1,5})?(?:$|[?\/#])/i';
     /**
      * @var array list of URI schemes which should be considered valid. By default, http and https
      * are considered to be valid schemes.

--- a/tests/framework/validators/UrlValidatorTest.php
+++ b/tests/framework/validators/UrlValidatorTest.php
@@ -30,6 +30,7 @@ class UrlValidatorTest extends TestCase
         $this->assertFalse($val->validate('google.de'));
         $this->assertTrue($val->validate('http://google.de'));
         $this->assertTrue($val->validate('https://google.de'));
+        $this->assertTrue($val->validate('http://localhost'));
         $this->assertFalse($val->validate('htp://yiiframework.com'));
         $this->assertTrue($val->validate('https://www.google.de/search?q=yii+framework&ie=utf-8&oe=utf-8'
                                         . '&rls=org.mozilla:de:official&client=firefox-a&gws_rd=cr'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17964
