### PR TITLE
fix #17914 ActiveRelationTrait compatibility with php 7.4

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #17942: Fix for `DbCache` loop in MySQL `QueryBuilder` (alex-code)
 - Bug #17960: Fix unsigned primary key type mapping for SQLite (bizley)
 - Enh #17758: `Query::withQuery()` can be used for CTE (sartor)
+- Bug #17974: Fix ActiveRelationTrait compatibility with php 7.4 (Ximich)
 
 
 2.0.34 March 26, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,7 +9,7 @@ Yii Framework 2 Change Log
 - Bug #17942: Fix for `DbCache` loop in MySQL `QueryBuilder` (alex-code)
 - Bug #17960: Fix unsigned primary key type mapping for SQLite (bizley)
 - Enh #17758: `Query::withQuery()` can be used for CTE (sartor)
-- Bug #17974: Fix ActiveRelationTrait compatibility with php 7.4 (Ximich)
+- Bug #17974: Fix ActiveRelationTrait compatibility with PHP 7.4 (Ximich)
 
 
 2.0.34 March 26, 2020

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -242,7 +242,7 @@ trait ActiveRelationTrait
                 $viaQuery->asArray($this->asArray);
             }
             $viaQuery->primaryModel = null;
-            $viaModels = $viaQuery->populateRelation($viaName, $primaryModels);
+            $viaModels = array_filter($viaQuery->populateRelation($viaName, $primaryModels));
             $this->filterByModels($viaModels);
         } else {
             $this->filterByModels($primaryModels);


### PR DESCRIPTION
Fix for PHP 7.4

Trying to access array offset on value of type null 
To support "Array-style access of non-arrays" in php 7.4: https://www.php.net/manual/en/migration74.incompatible.php
See previous conversation here: #17769

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17914 #17769
