### PR TITLE
Pretty formated url route to show 404 when 'enablePrettyUrl'=>false

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #17942: Fix for `DbCache` loop in MySQL `QueryBuilder` (alex-code)
 - Bug #17960: Fix unsigned primary key type mapping for SQLite (bizley)
 - Enh #17758: `Query::withQuery()` can be used for CTE (sartor)
+- Enh #17972: Pretty formated url route to show 404 when 'enablePrettyUrl'=>false (Djibril)
 
 
 2.0.34 March 26, 2020

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -360,7 +360,16 @@ class UrlManager extends Component
 
             return [$pathInfo, []];
         }
-
+        try {
+            if ($request->getPathInfo()!=='') {
+                return false;
+            }
+        } catch (\Throwable $th) {
+            return false;
+        }catch (\Exception $e)
+        {
+            return false;
+        }
         Yii::debug('Pretty URL not enabled. Using default URL parsing logic.', __METHOD__);
         $route = $request->getQueryParam($this->routeParam, '');
         if (is_array($route)) {

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -365,10 +365,10 @@ class UrlManager extends Component
                 return false;
             }
         } catch (\Throwable $th) {
-            return false;
+            
         }catch (\Exception $e)
         {
-            return false;
+            
         }
         Yii::debug('Pretty URL not enabled. Using default URL parsing logic.', __METHOD__);
         $route = $request->getQueryParam($this->routeParam, '');

--- a/tests/framework/web/UrlManagerTest.php
+++ b/tests/framework/web/UrlManagerTest.php
@@ -253,6 +253,13 @@ class UrlManagerTest extends TestCase
         $result = $manager->parseRequest($request);
         $this->assertEquals(['site/index', []], $result);
         $this->assertEquals(5, $request->getQueryParam('id'));
+
+        // With path info not '';
+        $request->setPathInfo('pathInfo');
+        $request->setQueryParams([$routeParam => 'site/index', 'id' => 5]);
+        $result = $manager->parseRequest($request);
+        $this->assertFalse($result);
+        $this->assertEquals(5, $request->getQueryParam('id'));
     }
 
     public function testSetBaseUrl()


### PR DESCRIPTION
#17972: Pretty formatted url route to show 404 when 'enablePrettyUrl'=>false, instead of showing home page.
| Q             | A
| ------------- | ---
| Is bugfix?    | 
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17972