### PR TITLE
Missin third parameter in function preg_match. Test was skipped.

### DIFF
--- a/tests/framework/ChangeLogTest.php
+++ b/tests/framework/ChangeLogTest.php
@@ -18,7 +18,7 @@ class ChangeLogTest extends TestCase
     public function changeProvider()
     {
 
-        $lines = preg_split("~\R~", file_get_contents(__DIR__ . '/../../framework/CHANGELOG.md'), PREG_SPLIT_NO_EMPTY);
+        $lines = preg_split("~\R~", file_get_contents(__DIR__ . '/../../framework/CHANGELOG.md'), -1, PREG_SPLIT_NO_EMPTY);
 
         // Don't check last 1500 lines, they are old and often don't obey the standard.
         $lastIndex = count($lines) - 1500;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -