### PR TITLE
Allow SameSite cookie prior to PHP 7.3 #18006

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 Change Log
 - Bug #17960: Fix unsigned primary key type mapping for SQLite (bizley)
 - Enh #17758: `Query::withQuery()` can be used for CTE (sartor)
 - Bug #17974: Fix ActiveRelationTrait compatibility with PHP 7.4 (Ximich)
+- Enh #18006: Allow SameSite cookie pre PHP 7.3 (scottix)
 
 
 2.0.34 March 26, 2020

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -411,8 +411,10 @@ class Response extends \yii\base\Response
                     'sameSite' => !empty($cookie->sameSite) ? $cookie->sameSite : null,
                 ]);
             } else {
+                // Work around for setting sameSite cookie prior PHP 7.3
+                // https://stackoverflow.com/questions/39750906/php-setcookie-samesite-strict/46971326#46971326
                 if (!is_null($cookie->sameSite)) {
-                    throw new InvalidConfigException(get_class($cookie) . '::sameSite is not supported by PHP versions < 7.3.0 (set it to null in this environment)');
+                    $cookie->path .= '; samesite=' . $cookie->sameSite;
                 }
                 setcookie($cookie->name, $value, $cookie->expire, $cookie->path, $cookie->domain, $cookie->secure, $cookie->httpOnly);
             }

--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -399,7 +399,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
                 session_set_cookie_params($data);
             } else {
                 if (!empty($data['samesite'])) {
-                    throw new InvalidConfigException('samesite cookie is not supported by PHP versions < 7.3.0 (set it to null in this environment)');
+                    $data['path'] .= '; samesite=' . $data['samesite'];
                 }
                 session_set_cookie_params($data['lifetime'], $data['path'], $data['domain'], $data['secure'], $data['httponly']);
             }

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -311,4 +311,21 @@ class ResponseTest extends \yiiunit\TestCase
 
         $this->assertSame("attachment; filename=\"test_test.txt\"; filename*=utf-8''test%7Ftest.txt", $response->headers['content-disposition']);
     }
+
+    public function testSameSiteCookie()
+    {
+        $response = new Response();
+        $response->cookies->add(new \yii\web\Cookie([
+            'name'     => 'test',
+            'value'    => 'testValue',
+            'sameSite' => \yii\web\Cookie::SAME_SITE_STRICT,
+        ]));
+
+        ob_start();
+        $response->send();
+        $content = ob_get_clean();
+
+        // Only way to test is that it doesn't create any errors
+        $this->assertEquals('', $content);
+    }
 }


### PR DESCRIPTION
Not sure how we can test setcookie other than making sure it doesn't crash

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18006 
