### PR TITLE
Add blank lines before ```php if needed

### DIFF
--- a/docs/guide-fr/structure-filters.md
+++ b/docs/guide-fr/structure-filters.md
@@ -88,6 +88,7 @@ Yii fournit un jeu de filtres couramment utilisés, que l'on trouve en premier l
 *AccessControl* (contrôle d'accès) fournit un contrôle d'accès simple basé sur un jeu de [[yii\filters\AccessControl::rules|règles]]. En particulier, avant qu'une action ne soit exécutée, *AccessControl* examine les règles listées et trouve la première qui  correspond aux variables du contexte courant (comme l'adresse IP, l'état de connexion de l'utilisateur, etc.). La règle qui correspond détermine si l'exécution de l'action requise doit être autorisée ou refusée. Si aucune des règles ne correspond, l'accès est refusé. 
 
 L'exemple suivant montre comment autoriser les utilisateurs authentifiés à accéder aux actions `create` et `update` tout en refusant l'accès à ces actions aux autres utilisateurs.
+
 ```php
 use yii\filters\AccessControl;
 
@@ -141,6 +142,7 @@ Les filtres de méthode d'authentification sont communément utilisés dans la m
 *ContentNegotiator* (négociateur de contenu) prend en charge la négociation des formats de réponse et la négociation de langue d'application. Il essaye de déterminer le format de la réponse et/ou la langue en examinant les paramètres de la méthode `GET` et ceux de l'entête HTTP `Accept`.
 
 Dans l'exemple qui suit, le filtre *ContentNegotiator* est configuré pour prendre en charge JSON et XML en tant que formats de réponse, et anglais (États-Unis) et allemand en tant que langues. 
+
 ```php
 use yii\filters\ContentNegotiator;
 use yii\web\Response;


### PR DESCRIPTION
The documentation builder need a blank line before a code block:
* https://www.yiiframework.com/doc/guide/2.0/fr/structure-filters#access-control
> refusant l'accès à ces actions aux autres utilisateurs. `php use yii\filters\AccessControl;
* https://www.yiiframework.com/doc/guide/2.0/fr/structure-filters#content-negotiator
> de réponse, et anglais (États-Unis) et allemand en tant que langues. `php use yii\filters\ContentNegotiator; use

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Is typo?    | ✔️
