### PR TITLE
Updating setting parameter User::$accessChecker

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #18028: Fix division by zero exception in Table.php::calculateRowHeight (fourhundredfour)
 - Enh #18019: Allow jQuery 3.5.0 to be installed (wouter90)
 - Bug #18026: Fix `ArrayHelper::getValue()` did not work with `ArrayAccess` objects (mikk150)
+- Enh #18048: Updating setting parameter `User::$accessChecker` (lav45)
 
 
 2.0.35 May 02, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,7 +7,7 @@ Yii Framework 2 Change Log
 - Bug #18028: Fix division by zero exception in Table.php::calculateRowHeight (fourhundredfour)
 - Enh #18019: Allow jQuery 3.5.0 to be installed (wouter90)
 - Bug #18026: Fix `ArrayHelper::getValue()` did not work with `ArrayAccess` objects (mikk150)
-- Enh #18048: Updating setting parameter `User::$accessChecker` (lav45)
+- Enh #18048: Use `Instance::ensure()` to set `User::$accessChecker` (lav45)
 
 
 2.0.35 May 02, 2020

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -11,6 +11,7 @@ use Yii;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
 use yii\base\InvalidValueException;
+use yii\di\Instance;
 use yii\rbac\CheckAccessInterface;
 
 /**
@@ -105,7 +106,8 @@ class User extends Component
      */
     public $authTimeout;
     /**
-     * @var CheckAccessInterface The access checker to use for checking access.
+     * @var CheckAccessInterface|string|array The access checker object to use for checking access or the application
+     * component ID of the access checker.
      * If not set the application auth manager will be used.
      * @since 2.0.9
      */
@@ -165,8 +167,8 @@ class User extends Component
         if ($this->enableAutoLogin && !isset($this->identityCookie['name'])) {
             throw new InvalidConfigException('User::identityCookie must contain the "name" element.');
         }
-        if (!empty($this->accessChecker) && is_string($this->accessChecker)) {
-            $this->accessChecker = Yii::createObject($this->accessChecker);
+        if ($this->accessChecker !== null) {
+            $this->accessChecker = Instance::ensure($this->accessChecker, CheckAccessInterface::class);
         }
     }
 

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -168,7 +168,7 @@ class User extends Component
             throw new InvalidConfigException('User::identityCookie must contain the "name" element.');
         }
         if ($this->accessChecker !== null) {
-            $this->accessChecker = Instance::ensure($this->accessChecker, CheckAccessInterface::class);
+            $this->accessChecker = Instance::ensure($this->accessChecker, '\yii\rbac\CheckAccessInterface');
         }
     }
 

--- a/tests/framework/web/UserTest.php
+++ b/tests/framework/web/UserTest.php
@@ -352,16 +352,39 @@ class UserTest extends TestCase
 
     public function testAccessChecker()
     {
-        $appConfig = [
+        $this->mockWebApplication([
             'components' => [
                 'user' => [
                     'identityClass' => UserIdentity::className(),
                     'accessChecker' => AccessChecker::className()
                 ]
             ],
-        ];
+        ]);
+        $this->assertInstanceOf(AccessChecker::className(), Yii::$app->user->accessChecker);
 
-        $this->mockWebApplication($appConfig);
+        $this->mockWebApplication([
+            'components' => [
+                'user' => [
+                    'identityClass' => UserIdentity::className(),
+                    'accessChecker' => [
+                        'class' => AccessChecker::className(),
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertInstanceOf(AccessChecker::className(), Yii::$app->user->accessChecker);
+
+        $this->mockWebApplication([
+            'components' => [
+                'user' => [
+                    'identityClass' => UserIdentity::className(),
+                    'accessChecker' => 'accessChecker',
+                ],
+                'accessChecker' => [
+                    'class' => AccessChecker::className(),
+                ]
+            ],
+        ]);
         $this->assertInstanceOf(AccessChecker::className(), Yii::$app->user->accessChecker);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #15462

Added a few more ways to configure `\yii\web\User::$accessChecker`

### as array
```php
'components' => [
    'user' => [
        'identityClass' => UserIdentity::className(),
        'accessChecker' => [
            'class' => AccessChecker::className(),
        ],
    ],
],
```

### as component ID
```php
'components' => [
    'user' => [
        'identityClass' => UserIdentity::className(),
        'accessChecker' => 'accessChecker',
    ],
    'accessChecker' => [
        'class' => AccessChecker::className(),
    ]
],
```