### PR TITLE
Adding support for custom rule in EachValidator

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Enh #18019: Allow jQuery 3.5.0 to be installed (wouter90)
 - Bug #18026: Fix `ArrayHelper::getValue()` did not work with `ArrayAccess` objects (mikk150)
 - Enh #18048: Use `Instance::ensure()` to set `User::$accessChecker` (lav45)
+- Bug #18051: Fix missing support for custom validation method in EachValidator (bizley)
 
 
 2.0.35 May 02, 2020

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -209,10 +209,13 @@ class Validator extends Component
     {
         $params['attributes'] = $attributes;
 
-        if ($type instanceof \Closure || ($model->hasMethod($type) && !isset(static::$builtInValidators[$type]))) {
-            // method-based validator
+        if ($type instanceof \Closure) {
             $params['class'] = __NAMESPACE__ . '\InlineValidator';
             $params['method'] = $type;
+        } elseif (!isset(static::$builtInValidators[$type]) && $model->hasMethod($type)) {
+            // method-based validator
+            $params['class'] = __NAMESPACE__ . '\InlineValidator';
+            $params['method'] = [$model, $type];
         } else {
             if (isset(static::$builtInValidators[$type])) {
                 $type = static::$builtInValidators[$type];

--- a/tests/data/base/Speaker.php
+++ b/tests/data/base/Speaker.php
@@ -49,4 +49,9 @@ class Speaker extends Model
             'duplicates' => ['firstName', 'firstName', '!underscore_style', '!underscore_style'],
         ];
     }
+
+    public function customValidatingMethod($attribute, $params, $validator)
+    {
+        $this->addError($attribute, 'Custom method error');
+    }
 }

--- a/tests/framework/validators/EachValidatorTest.php
+++ b/tests/framework/validators/EachValidatorTest.php
@@ -238,4 +238,15 @@ class EachValidatorTest extends TestCase
         $this->assertEquals('This is the custom label must be a valid IP address.', $model->getFirstError('customLabel'));
         $this->assertEquals('First Name is invalid.', $model->getFirstError('firstName'));
     }
+
+    public function testCustomMethod()
+    {
+        $model = new Speaker();
+        $model->firstName = ['a', 'b'];
+
+        $validator = new EachValidator(['rule' => ['customValidatingMethod']]);
+        $validator->validateAttribute($model, 'firstName');
+
+        $this->assertEquals('Custom method error', $model->getFirstError('firstName'));
+    }
 }

--- a/tests/framework/validators/ValidatorTest.php
+++ b/tests/framework/validators/ValidatorTest.php
@@ -71,7 +71,7 @@ class ValidatorTest extends TestCase
         $this->assertSame(['c', 'd', 'e'], $val->except);
         $val = TestValidator::createValidator('inlineVal', $model, ['val_attr_a'], ['params' => ['foo' => 'bar']]);
         $this->assertInstanceOf(InlineValidator::className(), $val);
-        $this->assertSame('inlineVal', $val->method);
+        $this->assertSame('inlineVal', $val->method[1]);
         $this->assertSame(['foo' => 'bar'], $val->params);
     }
 
@@ -317,7 +317,7 @@ class ValidatorTest extends TestCase
         $model = new DynamicModel();
         $model->defineAttribute(1);
         $model->addRule([1], SafeValidator::className());
-    
+
         $this->assertNull($model->{1});
         $this->assertTrue($model->validate([1]));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | should
| Fixed issues  | #18051 

This changes a bit how the InlineValidator is created in case of model-method-based inline validators. Instead of just passing a method's name now there is an array with an instance of Model in question and the method's name. This works thanks to the fact that `call_user_func` can take such array as first parameter so there should be no BC change.

Since EachValidator creates a new instance of DynamicModel internally this change allows inline validators defined in the original model to be used.

I haven't checked all possible drawbacks here. Definitely now method that is inline validator cannot have limited visibility but I haven't checked if it could be the case before this change.

Please take a look and see if this can be the solution to the issue. If so, I will add changelog.