### PR TITLE
Fix #18046: Fix `\yii\helpers\ArrayHelper::merge()` for numeric keys

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Enh #18019: Allow jQuery 3.5.0 to be installed (wouter90)
-
+- Bug #18046: Fix `\yii\helpers\ArrayHelper::merge()` for numeric keys (samdark)
 
 2.0.35 May 02, 2020
 -------------------

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -124,14 +124,14 @@ class BaseArrayHelper
                     unset($res[$k]);
                 } elseif ($v instanceof ReplaceArrayValue) {
                     $res[$k] = $v->value;
+                } elseif (is_array($v) && isset($res[$k]) && is_array($res[$k])) {
+                    $res[$k] = static::merge($res[$k], $v);
                 } elseif (is_int($k)) {
                     if (array_key_exists($k, $res)) {
                         $res[] = $v;
                     } else {
                         $res[$k] = $v;
                     }
-                } elseif (is_array($v) && isset($res[$k]) && is_array($res[$k])) {
-                    $res[$k] = static::merge($res[$k], $v);
                 } else {
                     $res[$k] = $v;
                 }

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -413,6 +413,21 @@ class ArrayHelperTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/18046
+     */
+    public function testMergeWithNumericKeys()
+    {
+        $a = [10 => [2]];
+        $b = [10 => [20]];
+
+        $expected = [
+            10 => [2, 20]
+        ];
+
+        $this->assertEquals($expected, \yii\helpers\ArrayHelper::merge($a, $b));
+    }
+
     public function testMergeWithUnset()
     {
         $a = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18046
