### PR TITLE
Fix #18046: Add test for current ArrayHelper::merge() behavior

### DIFF
--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -493,6 +493,17 @@ class ArrayHelperTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testMergeWithNumericKeys()
+    {
+        $a = [10 => [1]];
+        $b = [10 => [2]];
+
+        $result = ArrayHelper::merge($a, $b);
+
+        $expected = [10 => [1], 11 => [2]];
+        $this->assertEquals($expected, $result);
+    }
+
     public function testMergeWithUnset()
     {
         $a = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18046
