### PR TITLE
Add deep merge for configuration of definitions

### DIFF
--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -168,7 +168,7 @@ class Container extends Component
             $concrete = $definition['class'];
             unset($definition['class']);
 
-            $config = array_merge($definition, $config);
+            $config = array_merge_recursive($definition, $config);
             $params = $this->mergeParams($class, $params);
 
             if ($concrete === $class) {


### PR DESCRIPTION
If I try to use 2 level configuration of class (for example pluginOptions['assumeNearbyYear'])
config:
```
    'container' => [
        'definitions' => [
            \kartik\date\DatePicker::class => [
                'pluginOptions' => [
                    'assumeNearbyYear' => true,
                ],
            ],
        ],
    ],

```
usage:
```
            ->widget(DatePicker::class, [
                'pluginOptions' => [
                    'autoclose' => true,
                    'format' => 'dd.mm.yyyy',
                    'todayHighlight' => true,
                    'endDate' => '0d',
                ],
                'removeButton' => false,
            ]);

```

I lose my 2 level configuration params from definitions
for 
https://github.com/yiisoft/yii2/blob/f2d32fab77393c700b40d872866a62000174f6c9/framework/di/Container.php#L171
I have `$definition`
```
Array
(
    [pluginOptions] => Array
        (
            [assumeNearbyYear] => 1
        )

)
```
and `$config`
```
Array
(
    [pluginOptions] => Array
        (
            [autoclose] => 1
            [format] => dd.mm.yyyy
            [todayHighlight] => 1
            [endDate] => 0d
        )

    [removeButton] => 
    ...
```
so... array_merge set `pluginOptions` from `config` only, i.e. I have
 `$config`
```
Array
(
    [pluginOptions] => Array
        (
            [autoclose] => 1
            [format] => dd.mm.yyyy
            [todayHighlight] => 1
            [endDate] => 0d
        )

    [removeButton] => 
    ...
```
same array after merge

I think this behavir is wrong. 
I think we must use recursive merging:
 `$config`
```
Array
(
    [pluginOptions] => Array
        (
            [assumeNearbyYear] => 1
            [autoclose] => 1
            [format] => dd.mm.yyyy
            [todayHighlight] => 1
            [endDate] => 0d
        )

    [removeButton] => 
    ...
```

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️/❌
| Fixed issues  | #17241
