### PR TITLE
resolves issue #17852

### DIFF
--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -243,6 +243,7 @@ class Controller extends \yii\base\Controller
      * ```
      *
      * @param string $string the string to print
+     * @param int ...$args additional parameters to decorate the output
      * @return int|bool Number of bytes printed or false on error
      */
     public function stdout($string)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17852

It was also possible to add `...`(three dot) inside the function param, but I skipped as it's available from **5.6** and we are supporting **5.4**
