### PR TITLE
Fix for PDO_DBLIB (MSSQL). 

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,7 +10,8 @@ Yii Framework 2 Change Log
 - Enh #18048: Use `Instance::ensure()` to set `User::$accessChecker` (lav45)
 - Bug #18051: Fix missing support for custom validation method in EachValidator (bizley)
 - Bug #18041: Fix RBAC migration for MSSQL (darkdef)
-- Bug #18081: Fix for PDO_DBLIB/MSSQL. Set flag ANSI_NULL_DFLT_ON to ON for current connect to DB. (darkdef)
+- Bug #18081: Fix for PDO_DBLIB/MSSQL. Set flag ANSI_NULL_DFLT_ON to ON for current connect to DB (darkdef)
+
 
 2.0.35 May 02, 2020
 -------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,7 +10,7 @@ Yii Framework 2 Change Log
 - Enh #18048: Use `Instance::ensure()` to set `User::$accessChecker` (lav45)
 - Bug #18051: Fix missing support for custom validation method in EachValidator (bizley)
 - Bug #18041: Fix RBAC migration for MSSQL (darkdef)
-
+- Bug #18081: Fix for PDO_DBLIB/MSSQL. Set flag ANSI_NULL_DFLT_ON to ON for current connect to DB. (darkdef)
 
 2.0.35 May 02, 2020
 -------------------

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -720,6 +720,9 @@ class Connection extends Component
                 $this->pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $this->emulatePrepare);
             }
         }
+        if (in_array($this->getDriverName(), ['mssql', 'dblib'], true)) {
+            $this->pdo->exec('SET ANSI_NULL_DFLT_ON ON');
+        }
         if ($this->charset !== null && in_array($this->getDriverName(), ['pgsql', 'mysql', 'mysqli', 'cubrid'], true)) {
             $this->pdo->exec('SET NAMES ' . $this->pdo->quote($this->charset));
         }


### PR DESCRIPTION
Set flag ANSI_NULL_DFLT_ON to ON for current connect to DB.

This flag modifies the behavior of the session to override default nullability of new columns.
By default, for some versions of dblib + freetds, this flag is off.
ANSI recommends default behavior - NULL for new fields without default setted null/not null

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️/❌
| Fixed issues  | ❌
