### PR TITLE
Fix ImageValidator's maxHeight doc

### DIFF
--- a/framework/validators/ImageValidator.php
+++ b/framework/validators/ImageValidator.php
@@ -47,7 +47,7 @@ class ImageValidator extends FileValidator
     /**
      * @var int the maximum width in pixels.
      * Defaults to null, meaning no limit.
-     * @see overWidth for the customized message used when image height is too big.
+     * @see overHeight for the customized message used when image height is too big.
      */
     public $maxHeight;
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | ❌

I found a mistake on `maxHeight` property doc in `ImageValidator` class. In the doc it is mentioned to `@see overWidth ...` but should be `@see overHeight ...`.