### PR TITLE
master/slave → primary/replica

### DIFF
--- a/docs/guide-es/db-dao.md
+++ b/docs/guide-es/db-dao.md
@@ -439,8 +439,8 @@ try {
 
 Muchos DBMS soportan [replicación de bases de datos](http://en.wikipedia.org/wiki/Replication_(computing)#Database_replication) para tener
 una mejor disponibilidad de la base de datos y un mejor tiempo de respuesta del servidor. Con la replicación de bases
-de datos, los datos están replicados en los llamados *servidores maestros* (master servers) y *servidores esclavos*
-(slave servers). Todas las escrituras y actualizaciones deben hacerse en el servidor maestro, mientras que las lecturas
+de datos, los datos están replicados en los llamados *servidores maestros* (primary servers) y *servidores esclavos*
+(replica servers). Todas las escrituras y actualizaciones deben hacerse en el servidor maestro, mientras que las lecturas
 se efectuarán en los servidores esclavos.
 
 Para aprovechar las ventajas de la replicación de la base de datos y lograr una división de lecuta-escritura, se puede configurar
@@ -451,13 +451,13 @@ el componente [[yii\db\Connection]] como se muestra a continuación:
     'class' => 'yii\db\Connection',
 
     // configuración para el maestro
-    'dsn' => 'dsn for master server',
-    'username' => 'master',
+    'dsn' => 'dsn for primary server',
+    'username' => 'primary',
     'password' => '',
 
     // configuración para los esclavos
-    'slaveConfig' => [
-        'username' => 'slave',
+    'replicaConfig' => [
+        'username' => 'replica',
         'password' => '',
         'attributes' => [
             // utiliza un tiempo de espera de conexión más pequeña
@@ -466,11 +466,11 @@ el componente [[yii\db\Connection]] como se muestra a continuación:
     ],
 
     // listado de configuraciones de esclavos
-    'slaves' => [
-        ['dsn' => 'dsn for slave server 1'],
-        ['dsn' => 'dsn for slave server 2'],
-        ['dsn' => 'dsn for slave server 3'],
-        ['dsn' => 'dsn for slave server 4'],
+    'replicas' => [
+        ['dsn' => 'dsn for replica server 1'],
+        ['dsn' => 'dsn for replica server 2'],
+        ['dsn' => 'dsn for replica server 3'],
+        ['dsn' => 'dsn for replica server 4'],
     ],
 ]
 ```
@@ -492,7 +492,7 @@ $db->createCommand("UPDATE user SET username='demo' WHERE id=1")->execute();
 
 > Info: Las consultas realizadas llamando a [[yii\db\Command::execute()]] se consideran consultas de escritura,
   mientras que todas las demás se ejecutan mediante alguno de los métodos "query" de [[yii\db\Command]] son consultas
-  de lectura. Se puede obtener la conexión de esclavo activa mediante `$db->slave`.
+  de lectura. Se puede obtener la conexión de esclavo activa mediante `$db->replica`.
 
 El componente `Connection` soporta el balanceo de carga y la conmutación de errores entre esclavos. Cuando se realiza
 una consulta de lectura por primera vez, el componente `Connection` elegirá un esclavo aleatorio e intentará realizar
@@ -511,8 +511,8 @@ También se pueden configurar múltiples maestros con múltiples esclavos. Por e
     'class' => 'yii\db\Connection',
 
     // configuracion habitual para los maestros
-    'masterConfig' => [
-        'username' => 'master',
+    'primaryConfig' => [
+        'username' => 'primary',
         'password' => '',
         'attributes' => [
             // utilizar un tiempo de espera de conexión más pequeña
@@ -521,14 +521,14 @@ También se pueden configurar múltiples maestros con múltiples esclavos. Por e
     ],
 
     // listado de configuraciones de maestros
-    'masters' => [
-        ['dsn' => 'dsn for master server 1'],
-        ['dsn' => 'dsn for master server 2'],
+    'primaries' => [
+        ['dsn' => 'dsn for primary server 1'],
+        ['dsn' => 'dsn for primary server 2'],
     ],
 
     // configuración habitual para esclavos
-    'slaveConfig' => [
-        'username' => 'slave',
+    'replicaConfig' => [
+        'username' => 'replica',
         'password' => '',
         'attributes' => [
             // utilizar un tiempo de espera de conexión más pequeña
@@ -537,11 +537,11 @@ También se pueden configurar múltiples maestros con múltiples esclavos. Por e
     ],
 
     // listado de configuración de esclavos
-    'slaves' => [
-        ['dsn' => 'dsn for slave server 1'],
-        ['dsn' => 'dsn for slave server 2'],
-        ['dsn' => 'dsn for slave server 3'],
-        ['dsn' => 'dsn for slave server 4'],
+    'replicas' => [
+        ['dsn' => 'dsn for replica server 1'],
+        ['dsn' => 'dsn for replica server 2'],
+        ['dsn' => 'dsn for replica server 3'],
+        ['dsn' => 'dsn for replica server 4'],
     ],
 ]
 ```
@@ -550,7 +550,7 @@ La configuración anterior especifica dos maestros y cuatro esclavos. El compone
 balanceo de carga y la conmutación de errores entre maestros igual que hace con los esclavos. La diferencia es que
 cuando no se encuentra ningún maestro disponible se lanza una excepción.
 
-> Note: cuando se usa la propiedad [[yii\db\Connection::masters|masters]] para configurar uno o múltiples maestros, se
+> Note: cuando se usa la propiedad [[yii\db\Connection::primaries|primaries]] para configurar uno o múltiples maestros, se
   ignorarán todas las otras propiedades que especifiquen una conexión de base de datos
   (ej. `dsn`, `username`, `password`), junto con el mismo objeto `Connection`.
 
@@ -577,19 +577,19 @@ Si se quiere empezar la transacción con una conexión a un esclavo, se debe hac
 continuación:
 
 ```php
-$transaction = $db->slave->beginTransaction();
+$transaction = $db->replica->beginTransaction();
 ```
 
 A veces, se puede querer forzar el uso de una conexión maestra para realizar una consulta de lectura. Se puede lograr
-usando el método `useMaster()`:
+usando el método `usePrimary()`:
 
 ```php
-$rows = $db->useMaster(function ($db) {
+$rows = $db->usePrimary(function ($db) {
     return $db->createCommand('SELECT * FROM user LIMIT 10')->queryAll();
 });
 ```
 
-También se puede utilizar directamente estableciendo `$db->enableSlaves` a `false` para que se redirijan todas las
+También se puede utilizar directamente estableciendo `$db->enableReplicas` a `false` para que se redirijan todas las
 consultas a la conexión del maestro.
 
 ## Trabajando con Esquemas de Bases de Datos <span id="database-schema"></span>

--- a/docs/guide-fr/db-dao.md
+++ b/docs/guide-fr/db-dao.md
@@ -425,12 +425,12 @@ Pour tirer parti de la réplication des bases de données et réaliser l'éclate
 
     // configuration pour le maître
     'dsn' => 'dsn pour le serveur maître',
-    'username' => 'master',
+    'username' => 'primary',
     'password' => '',
 
     //  configuration commune pour les esclaves
-    'slaveConfig' => [
-        'username' => 'slave',
+    'replicaConfig' => [
+        'username' => 'replica',
         'password' => '',
         'attributes' => [
             // utilise un temps d'attente de connexion plus court
@@ -439,7 +439,7 @@ Pour tirer parti de la réplication des bases de données et réaliser l'éclate
     ],
 
     // liste des configurations d'esclave
-    'slaves' => [
+    'replicas' => [
         ['dsn' => 'dsn pour le serveur esclave 1'],
         ['dsn' => 'dsn pour le serveur esclave 2'],
         ['dsn' => 'dsn pour le serveur esclave 3'],
@@ -461,7 +461,7 @@ $rows = Yii::$app->db->createCommand('SELECT * FROM user LIMIT 10')->queryAll();
 Yii::$app->db->createCommand("UPDATE user SET username='demo' WHERE id=1")->execute();
 ```
 
-> Info: les requêtes effectuées en appelant [[yii\db\Command::execute()]] sont considérées comme des requêtes en écriture, tandis que toutes les autres requêtes faites via l'une des méthodes « *query* » sont des requêtes en lecture. Vous pouvez obtenir la connexion couramment active à un des esclaves via `Yii::$app->db->slave`.
+> Info: les requêtes effectuées en appelant [[yii\db\Command::execute()]] sont considérées comme des requêtes en écriture, tandis que toutes les autres requêtes faites via l'une des méthodes « *query* » sont des requêtes en lecture. Vous pouvez obtenir la connexion couramment active à un des esclaves via `Yii::$app->db->replica`.
 
 Le composant `Connection` prend en charge l'équilibrage de charge et de basculement entre esclaves. Lorsque vous effectuez une requête en lecture par la première fois, le composant `Connection` sélectionne un esclave de façon aléatoire et essaye de s'y connecter. Si l'esclave set trouvé « mort », il en essaye un autre. Si aucun des esclaves n'est disponible, il se connecte au maître. En configurant un [[yii\db\Connection::serverStatusCache|cache d'état du serveur]], le composant mémorise le serveur « mort » et ainsi, pendant un [[yii\db\Connection::serverRetryInterval|certain intervalle de temps]], n'essaye plus de s'y connecter.
 
@@ -476,8 +476,8 @@ Vous pouvez aussi configurer plusieurs maîtres avec plusieurs esclaves. Par exe
     'class' => 'yii\db\Connection',
 
     // configuration commune pour les maîtres
-    'masterConfig' => [
-        'username' => 'master',
+    'primaryConfig' => [
+        'username' => 'primary',
         'password' => '',
         'attributes' => [
             // utilise un temps d'attente de connexion plus court 
@@ -486,14 +486,14 @@ Vous pouvez aussi configurer plusieurs maîtres avec plusieurs esclaves. Par exe
     ],
 
     // liste des configurations de maître
-    'masters' => [
-        ['dsn' => 'dsn for master server 1'],
-        ['dsn' => 'dsn for master server 2'],
+    'primaries' => [
+        ['dsn' => 'dsn for primary server 1'],
+        ['dsn' => 'dsn for primary server 2'],
     ],
 
     // configuration commune pour les esclaves
-    'slaveConfig' => [
-        'username' => 'slave',
+    'replicaConfig' => [
+        'username' => 'replica',
         'password' => '',
         'attributes' => [
             // use a smaller connection timeout
@@ -502,18 +502,18 @@ Vous pouvez aussi configurer plusieurs maîtres avec plusieurs esclaves. Par exe
     ],
 
     // liste des configurations d'esclave 
-    'slaves' => [
-        ['dsn' => 'dsn for slave server 1'],
-        ['dsn' => 'dsn for slave server 2'],
-        ['dsn' => 'dsn for slave server 3'],
-        ['dsn' => 'dsn for slave server 4'],
+    'replicas' => [
+        ['dsn' => 'dsn for replica server 1'],
+        ['dsn' => 'dsn for replica server 2'],
+        ['dsn' => 'dsn for replica server 3'],
+        ['dsn' => 'dsn for replica server 4'],
     ],
 ]
 ```
 
 La configuration ci-dessus spécifie deux maîtres et quatre esclaves. Le composant `Connection` prend aussi en charge l'équilibrage de charge et le basculement entre maîtres juste comme il le fait pour les esclaves. Une différence est que, si aucun des maîtres n'est disponible, une exception est levée.
 
-> Note: lorsque vous utilisez la propriété [[yii\db\Connection::masters|masters]] pour configurer un ou plusieurs maîtres, toutes les autres propriétés pour spécifier une connexion à une base de données (p. ex. `dsn`, `username`, `password`) avec l'objet `Connection` lui-même sont ignorées.
+> Note: lorsque vous utilisez la propriété [[yii\db\Connection::primaries|primaries]] pour configurer un ou plusieurs maîtres, toutes les autres propriétés pour spécifier une connexion à une base de données (p. ex. `dsn`, `username`, `password`) avec l'objet `Connection` lui-même sont ignorées.
 
 
 Par défaut, les transactions utilisent la connexion au maître. De plus, dans une transaction, toutes les opérations de base de données utilisent la connexion au maître. Par exemple :
@@ -538,18 +538,18 @@ try {
 Si vous voulez démarrer une transaction avec une connexion à un esclave, vous devez le faire explicitement, comme ceci :
 
 ```php
-$transaction = Yii::$app->db->slave->beginTransaction();
+$transaction = Yii::$app->db->replica->beginTransaction();
 ```
 
-Parfois, vous désirez forcer l'utilisation de la connexion au maître pour effectuer une requête en lecture . Cela est possible avec la méthode `useMaster()` :
+Parfois, vous désirez forcer l'utilisation de la connexion au maître pour effectuer une requête en lecture . Cela est possible avec la méthode `usePrimary()` :
 
 ```php
-$rows = Yii::$app->db->useMaster(function ($db) {
+$rows = Yii::$app->db->usePrimary(function ($db) {
     return $db->createCommand('SELECT * FROM user LIMIT 10')->queryAll();
 });
 ```
 
-Vous pouvez aussi définir directement `Yii::$app->db->enableSlaves` à `false` (faux) pour rediriger toutes les requêtes vers la connexion au maître.
+Vous pouvez aussi définir directement `Yii::$app->db->enableReplicas` à `false` (faux) pour rediriger toutes les requêtes vers la connexion au maître.
 
 
 ## Travail avec le schéma de la base de données <span id="database-schema"></span>

--- a/docs/guide-ja/db-dao.md
+++ b/docs/guide-ja/db-dao.md
@@ -491,12 +491,12 @@ try {
 
     // マスタの構成
     'dsn' => 'マスタ・サーバの DSN',
-    'username' => 'master',
+    'username' => 'primary',
     'password' => '',
 
     // スレーブの共通の構成
-    'slaveConfig' => [
-        'username' => 'slave',
+    'replicaConfig' => [
+        'username' => 'replica',
         'password' => '',
         'attributes' => [
             // 短かめの接続タイムアウトを使う
@@ -505,7 +505,7 @@ try {
     ],
 
     // スレーブの構成のリスト
-    'slaves' => [
+    'replicas' => [
         ['dsn' => 'スレーブ・サーバ 1 の DSN'],
         ['dsn' => 'スレーブ・サーバ 2 の DSN'],
         ['dsn' => 'スレーブ・サーバ 3 の DSN'],
@@ -531,7 +531,7 @@ Yii::$app->db->createCommand("UPDATE user SET username='demo' WHERE id=1")->exec
 
 > Info: [[yii\db\Command::execute()]] を呼ぶことで実行されるクエリは、書き込みのクエリと見なされ、
   [[yii\db\Command]] の "query" メソッドのうちの一つによって実行されるその他すべてのクエリは、読み出しクエリと見なされます。
-  現在アクティブなスレーブ接続は `Yii::$app->db->slave` によって取得することが出来ます。
+  現在アクティブなスレーブ接続は `Yii::$app->db->replica` によって取得することが出来ます。
 
 `Connection` コンポーネントは、スレーブ間のロード・バランス調整とフェイルオーバーをサポートしています。
 読み出しクエリを最初に実行するときに、`Connection` コンポーネントはランダムにスレーブを選んで接続を試みま・す。
@@ -553,8 +553,8 @@ Yii::$app->db->createCommand("UPDATE user SET username='demo' WHERE id=1")->exec
     'class' => 'yii\db\Connection',
 
     // マスタの共通の構成
-    'masterConfig' => [
-        'username' => 'master',
+    'primaryConfig' => [
+        'username' => 'primary',
         'password' => '',
         'attributes' => [
             // 短かめの接続タイムアウトを使う
@@ -563,14 +563,14 @@ Yii::$app->db->createCommand("UPDATE user SET username='demo' WHERE id=1")->exec
     ],
 
     // マスタの構成のリスト
-    'masters' => [
+    'primaries' => [
         ['dsn' => 'マスタ・サーバ 1 の DSN'],
         ['dsn' => 'マスタ・サーバ 2 の DSN'],
     ],
 
     // スレーブの共通の構成
-    'slaveConfig' => [
-        'username' => 'slave',
+    'replicaConfig' => [
+        'username' => 'replica',
         'password' => '',
         'attributes' => [
             // 短かめの接続タイムアウトを使う
@@ -579,7 +579,7 @@ Yii::$app->db->createCommand("UPDATE user SET username='demo' WHERE id=1")->exec
     ],
 
     // スレーブの構成のリスト
-    'slaves' => [
+    'replicas' => [
         ['dsn' => 'スレーブ・サーバ 1 の DSN'],
         ['dsn' => 'スレーブ・サーバ 2 の DSN'],
         ['dsn' => 'スレーブ・サーバ 3 の DSN'],
@@ -592,7 +592,7 @@ Yii::$app->db->createCommand("UPDATE user SET username='demo' WHERE id=1")->exec
 `Connection` コンポーネントは、スレーブ間での場合と同じように、マスタ間でのロード・バランス調整とフェイルオーバーをサポートしています。
 一つ違うのは、マスタが一つも利用できないときは例外が投げられる、という点です。
 
-> Note: [[yii\db\Connection::masters|masters]] プロパティを使って一つまたは複数のマスタを構成する場合は、
+> Note: [[yii\db\Connection::primaries|primaries]] プロパティを使って一つまたは複数のマスタを構成する場合は、
   データベース接続を定義する `Connection` オブジェクト自体の他のプロパティ
   (例えば、`dsn`、`username`、`password`) は全て無視されます。
 
@@ -623,19 +623,19 @@ try {
 スレーブ接続を使ってトランザクションを開始したいときは、次のように、明示的にそうする必要があります。
 
 ```php
-$transaction = Yii::$app->db->slave->beginTransaction();
+$transaction = Yii::$app->db->replica->beginTransaction();
 ```
 
 時として、読み出しクエリの実行にマスタ接続を使うことを強制したい場合があります。
-これは、`useMaster()` メソッドを使うことによって達成できます。
+これは、`usePrimary()` メソッドを使うことによって達成できます。
 
 ```php
-$rows = Yii::$app->db->useMaster(function ($db) {
+$rows = Yii::$app->db->usePrimary(function ($db) {
     return $db->createCommand('SELECT * FROM user LIMIT 10')->queryAll();
 });
 ```
 
-直接に `Yii::$app->db->enableSlaves` を `false` に設定して、全てのクエリをマスタ接続に向けることも出来ます。
+直接に `Yii::$app->db->enableReplicas` を `false` に設定して、全てのクエリをマスタ接続に向けることも出来ます。
 
 
 ## データベース・スキーマを扱う <span id="database-schema"></span>

--- a/docs/guide-zh-CN/db-dao.md
+++ b/docs/guide-zh-CN/db-dao.md
@@ -484,13 +484,13 @@ try {
     'class' => 'yii\db\Connection',
 
     // 主库的配置
-    'dsn' => 'dsn for master server',
-    'username' => 'master',
+    'dsn' => 'dsn for primary server',
+    'username' => 'primary',
     'password' => '',
 
     // 从库的通用配置
-    'slaveConfig' => [
-        'username' => 'slave',
+    'replicaConfig' => [
+        'username' => 'replica',
         'password' => '',
         'attributes' => [
             // 使用一个更小的连接超时
@@ -499,11 +499,11 @@ try {
     ],
 
     // 从库的配置列表
-    'slaves' => [
-        ['dsn' => 'dsn for slave server 1'],
-        ['dsn' => 'dsn for slave server 2'],
-        ['dsn' => 'dsn for slave server 3'],
-        ['dsn' => 'dsn for slave server 4'],
+    'replicas' => [
+        ['dsn' => 'dsn for replica server 1'],
+        ['dsn' => 'dsn for replica server 2'],
+        ['dsn' => 'dsn for replica server 3'],
+        ['dsn' => 'dsn for replica server 4'],
     ],
 ]
 ```
@@ -525,7 +525,7 @@ Yii::$app->db->createCommand("UPDATE user SET username='demo' WHERE id=1")->exec
 
 > Info: 通过调用 [[yii\db\Command::execute()]] 来执行的语句都被视为写操作，
   而其他所有通过调用 [[yii\db\Command]] 中任一 "query" 方法来执行的语句都被视为读操作。
-  你可以通过 `Yii::$app->db->slave` 来获取当前有效的从库连接。
+  你可以通过 `Yii::$app->db->replica` 来获取当前有效的从库连接。
 
 `Connection` 组件支持从库间的负载均衡和失效备援，
 当第一次执行读操作时，`Connection` 组件将随机地挑选出一个从库并尝试与之建立连接，
@@ -547,8 +547,8 @@ Yii::$app->db->createCommand("UPDATE user SET username='demo' WHERE id=1")->exec
     'class' => 'yii\db\Connection',
 
     // 主库通用的配置
-    'masterConfig' => [
-        'username' => 'master',
+    'primaryConfig' => [
+        'username' => 'primary',
         'password' => '',
         'attributes' => [
             // use a smaller connection timeout
@@ -557,14 +557,14 @@ Yii::$app->db->createCommand("UPDATE user SET username='demo' WHERE id=1")->exec
     ],
 
     // 主库配置列表
-    'masters' => [
-        ['dsn' => 'dsn for master server 1'],
-        ['dsn' => 'dsn for master server 2'],
+    'primaries' => [
+        ['dsn' => 'dsn for primary server 1'],
+        ['dsn' => 'dsn for primary server 2'],
     ],
 
     // 从库的通用配置
-    'slaveConfig' => [
-        'username' => 'slave',
+    'replicaConfig' => [
+        'username' => 'replica',
         'password' => '',
         'attributes' => [
             // use a smaller connection timeout
@@ -573,11 +573,11 @@ Yii::$app->db->createCommand("UPDATE user SET username='demo' WHERE id=1")->exec
     ],
 
     // 从库配置列表
-    'slaves' => [
-        ['dsn' => 'dsn for slave server 1'],
-        ['dsn' => 'dsn for slave server 2'],
-        ['dsn' => 'dsn for slave server 3'],
-        ['dsn' => 'dsn for slave server 4'],
+    'replicas' => [
+        ['dsn' => 'dsn for replica server 1'],
+        ['dsn' => 'dsn for replica server 2'],
+        ['dsn' => 'dsn for replica server 3'],
+        ['dsn' => 'dsn for replica server 4'],
     ],
 ]
 ```
@@ -586,7 +586,7 @@ Yii::$app->db->createCommand("UPDATE user SET username='demo' WHERE id=1")->exec
 `Connection` 组件在主库之间，也支持如从库间般的负载均衡和失效备援。
 唯一的差别是，如果没有主库可用，将抛出一个异常。
 
-> Note: 当你使用 [[yii\db\Connection::masters|masters]] 属性来配置一个或多个主库时，
+> Note: 当你使用 [[yii\db\Connection::primaries|primaries]] 属性来配置一个或多个主库时，
   所有其他指定数据库连接的属性 (例如 `dsn`, `username`, `password`) 
   与 `Connection` 对象本身将被忽略。
 
@@ -617,19 +617,19 @@ try {
 如果你想在从库上开启事务，你应该明确地像下面这样做：
 
 ```php
-$transaction = Yii::$app->db->slave->beginTransaction();
+$transaction = Yii::$app->db->replica->beginTransaction();
 ```
 
 有时，你或许想要强制使用主库来执行读查询。
-这可以通过 `useMaster()` 方法来完成：
+这可以通过 `usePrimary()` 方法来完成：
 
 ```php
-$rows = Yii::$app->db->useMaster(function ($db) {
+$rows = Yii::$app->db->usePrimary(function ($db) {
     return $db->createCommand('SELECT * FROM user LIMIT 10')->queryAll();
 });
 ```
 
-你也可以明确地将 `Yii::$app->db->enableSlaves` 设置为 false 来将所有的读操作指向主库连接。
+你也可以明确地将 `Yii::$app->db->enableReplicas` 设置为 false 来将所有的读操作指向主库连接。
 
 
 ## 操纵数据库模式（Working with Database Schema） <span id="database-schema"></span>

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,6 +15,20 @@ Yii Framework 2 Change Log
 - Bug #13828: Fix retrieving inserted data for a primary key of type uniqueidentifier for SQL Server 2005 or later (darkdef)
 - Bug #17474: Fix retrieving inserted data for a primary key of type trigger for SQL Server 2005 or later (darkdef)
 - Bug #18001: Fix getting table metadata for tables `(` in their name (floor12)
+- Enh: Use “primary”/“replica” terminology instead of “master”/“slave” (brandonkelly)
+  - Added `yii\db\Connection::$enableReplicas` and deprecated `$enableSlaves` via magic methods.
+  - Added `yii\db\Connection::$replicas` and deprecated `$slaves` via magic methods.
+  - Added `yii\db\Connection::$replicaConfig` and deprecated `$slaveConfig` via magic methods.
+  - Added `yii\db\Connection::$primaries` and deprecated `$masters` via magic methods.
+  - Added `yii\db\Connection::$primaryConfig` and deprecated `$masterConfig` via magic methods.
+  - Added `yii\db\Connection::$shufflePrimaries` and deprecated `$shuffleMasters` via magic methods.
+  - Added `yii\db\Connection::getReplicaPdo()` and deprecated `getSlavePdo()`.
+  - Added `yii\db\Connection::getPrimaryPdo()` and deprecated `getMasterPdo()`.
+  - Added `yii\db\Connection::getReplica()` and deprecated `getSlave()`.
+  - Added `yii\db\Connection::getPrimary()` and deprecated `getMaster()`.
+  - Added `yii\db\Connection::usePrimary()` and deprecated `useMaster()`.
+  - Added `yii\validators\ExistValidator::$forcePrimaryDb` and deprecated `$forceMasterDb` via magic methods.
+  - Added `yii\validators\UniqueValidator::$forcePrimaryDb` and deprecated `$forceMasterDb` via magic methods.
 
 
 2.0.35 May 02, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,7 +15,7 @@ Yii Framework 2 Change Log
 - Bug #13828: Fix retrieving inserted data for a primary key of type uniqueidentifier for SQL Server 2005 or later (darkdef)
 - Bug #17474: Fix retrieving inserted data for a primary key of type trigger for SQL Server 2005 or later (darkdef)
 - Bug #18001: Fix getting table metadata for tables `(` in their name (floor12)
-- Enh: Use “primary”/“replica” terminology instead of “master”/“slave” (brandonkelly)
+- Enh #18102: Use “primary”/“replica” terminology instead of “master”/“slave” (brandonkelly)
   - Added `yii\db\Connection::$enableReplicas` and deprecated `$enableSlaves` via magic methods.
   - Added `yii\db\Connection::$replicas` and deprecated `$slaves` via magic methods.
   - Added `yii\db\Connection::$replicaConfig` and deprecated `$slaveConfig` via magic methods.

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -248,13 +248,13 @@ class Command extends Component
         $sql = $this->getSql();
 
         if ($this->db->getTransaction()) {
-            // master is in a transaction. use the same connection.
+            // primary is in a transaction. use the same connection.
             $forRead = false;
         }
         if ($forRead || $forRead === null && $this->db->getSchema()->isReadQuery($sql)) {
-            $pdo = $this->db->getSlavePdo();
+            $pdo = $this->db->getReplicaPdo();
         } else {
-            $pdo = $this->db->getMasterPdo();
+            $pdo = $this->db->getPrimaryPdo();
         }
 
         try {

--- a/framework/db/ConnectionDeprecationsTrait.php
+++ b/framework/db/ConnectionDeprecationsTrait.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db;
+
+use PDO;
+
+/**
+ * @internal This trait is only used to denote deprecated magic properties of [[Connection]] for IDEs via a
+ * `@mixin` tag. It is never actually loaded at runtime.
+ *
+ * @author Brandon Kelly <brandon@craftcms.com>
+ * @since 2.0.36
+ */
+trait ConnectionDeprecationsTrait
+{
+    /**
+     * @var bool whether to enable read/write splitting by using [[Connection::$replicas]] to read data.
+     * @deprecated since 2.0.36. Use [[Connection::$enableReplicas]] instead.
+     */
+    public $enableSlaves;
+    /**
+     * @var array list of replica connection configurations. Each configuration is used to create a replica DB connection.
+     * @deprecated since 2.0.36. Use [[Connection::$replicas]] instead.
+     */
+    public $slaves;
+    /**
+     * @var array the configuration that should be merged with every replica configuration listed in
+     * [[Connection::$replicas]].
+     * @deprecated since 2.0.36. Use [[Connection::$replicaConfig]] instead.
+     */
+    public $slaveConfig;
+    /**
+     * @var array list of primary connection configurations. Each configuration is used to create a primary DB connection.
+     * @deprecated since 2.0.36. Use [[Connection::$primaries]] instead.
+     */
+    public $masters;
+    /**
+     * @var array the configuration that should be merged with every primary configuration listed in
+     * [[Connection::$primaries]].
+     * @deprecated since 2.0.36. Use [[Connection::$primaryConfig]] instead.
+     */
+    public $masterConfig;
+    /**
+     * @var bool whether to shuffle [[Connection::$primaries]] before getting one.
+     * @deprecated since 2.0.36. Use [[Connection::$shufflePrimaries]] instead.
+     */
+    public $shuffleMasters;
+    /**
+     * @var Connection|null The currently active primary connection. `null` is returned if no primary connection is
+     * available. This property is read-only.
+     * @deprecated since 2.0.36. Use [[Connection::$primary]] instead.
+     */
+    public $master;
+    /**
+     * @var PDO The PDO instance for the currently active primary connection. This property is read-only.
+     * @deprecated since 2.0.36. Use [[Connection::$primaryPdo]] instead.
+     */
+    public $masterPdo;
+    /**
+     * @var Connection The currently active replica connection. This property is read-only.
+     * @deprecated since 2.0.36. Use [[Connection::$replica]] instead.
+     */
+    public $slave;
+    /**
+     * @var PDO The PDO instance for the currently active replica connection. This property is read-only.
+     * @deprecated since 2.0.36. Use [[Connection::$slavePdo]] instead.
+     */
+    public $slavePdo;
+}

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -89,7 +89,7 @@ class Migration extends Component implements MigrationInterface
         parent::init();
         $this->db = Instance::ensure($this->db, Connection::className());
         $this->db->getSchema()->refresh();
-        $this->db->enableSlaves = false;
+        $this->db->enableReplicas = false;
     }
 
     /**

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -459,7 +459,7 @@ abstract class Schema extends BaseObject
             return $str;
         }
 
-        if (($value = $this->db->getSlavePdo()->quote($str)) !== false) {
+        if (($value = $this->db->getReplicaPdo()->quote($str)) !== false) {
             return $value;
         }
 
@@ -696,7 +696,7 @@ abstract class Schema extends BaseObject
     public function getServerVersion()
     {
         if ($this->_serverVersion === null) {
-            $this->_serverVersion = $this->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+            $this->_serverVersion = $this->db->getReplicaPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
         }
         return $this->_serverVersion;
     }
@@ -810,7 +810,7 @@ abstract class Schema extends BaseObject
      */
     protected function normalizePdoRowKeyCase(array $row, $multiple)
     {
-        if ($this->db->getSlavePdo()->getAttribute(\PDO::ATTR_CASE) !== \PDO::CASE_UPPER) {
+        if ($this->db->getReplicaPdo()->getAttribute(\PDO::ATTR_CASE) !== \PDO::CASE_UPPER) {
             return $row;
         }
 

--- a/framework/db/cubrid/Schema.php
+++ b/framework/db/cubrid/Schema.php
@@ -91,7 +91,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     protected function findTableNames($schema = '')
     {
-        $pdo = $this->db->getSlavePdo();
+        $pdo = $this->db->getReplicaPdo();
         $tables = $pdo->cubrid_schema(\PDO::CUBRID_SCH_TABLE);
         $tableNames = [];
         foreach ($tables as $table) {
@@ -109,7 +109,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     protected function loadTableSchema($name)
     {
-        $pdo = $this->db->getSlavePdo();
+        $pdo = $this->db->getReplicaPdo();
 
         $tableInfo = $pdo->cubrid_schema(\PDO::CUBRID_SCH_TABLE, $name);
 
@@ -158,7 +158,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     protected function loadTablePrimaryKey($tableName)
     {
-        $primaryKey = $this->db->getSlavePdo()->cubrid_schema(\PDO::CUBRID_SCH_PRIMARY_KEY, $tableName);
+        $primaryKey = $this->db->getReplicaPdo()->cubrid_schema(\PDO::CUBRID_SCH_PRIMARY_KEY, $tableName);
         if (empty($primaryKey)) {
             return null;
         }
@@ -182,7 +182,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
             3 => 'SET NULL',
         ];
 
-        $foreignKeys = $this->db->getSlavePdo()->cubrid_schema(\PDO::CUBRID_SCH_IMPORTED_KEYS, $tableName);
+        $foreignKeys = $this->db->getReplicaPdo()->cubrid_schema(\PDO::CUBRID_SCH_IMPORTED_KEYS, $tableName);
         $foreignKeys = ArrayHelper::index($foreignKeys, null, 'FK_NAME');
         ArrayHelper::multisort($foreignKeys, 'KEY_SEQ', SORT_ASC, SORT_NUMERIC);
         $result = [];
@@ -385,7 +385,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     private function loadTableConstraints($tableName, $returnType)
     {
-        $constraints = $this->db->getSlavePdo()->cubrid_schema(\PDO::CUBRID_SCH_CONSTRAINT, $tableName);
+        $constraints = $this->db->getReplicaPdo()->cubrid_schema(\PDO::CUBRID_SCH_CONSTRAINT, $tableName);
         $constraints = ArrayHelper::index($constraints, null, ['TYPE', 'NAME']);
         ArrayHelper::multisort($constraints, 'KEY_ORDER', SORT_ASC, SORT_NUMERIC);
         $result = [

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -403,7 +403,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
         $version = $cache ? $cache->get($key) : null;
         if (!$version) {
-            $version = $this->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+            $version = $this->db->getReplicaPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
             if ($cache) {
                 $cache->set($key, $version, $this->db->schemaCacheDuration);
             }

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -327,7 +327,7 @@ SQL;
             throw $e;
         }
         foreach ($columns as $info) {
-            if ($this->db->slavePdo->getAttribute(\PDO::ATTR_CASE) !== \PDO::CASE_LOWER) {
+            if ($this->db->replicaPdo->getAttribute(\PDO::ATTR_CASE) !== \PDO::CASE_LOWER) {
                 $info = array_change_key_case($info, CASE_LOWER);
             }
             $column = $this->loadColumnSchema($info);
@@ -475,7 +475,7 @@ SQL;
     protected function isOldMysql()
     {
         if ($this->_oldMysql === null) {
-            $version = $this->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+            $version = $this->db->getReplicaPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
             $this->_oldMysql = version_compare($version, '5.1', '<=');
         }
 

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -154,8 +154,8 @@ EOD;
             if (count($tableSchema->primaryKey)>1) {
                 throw new InvalidArgumentException("Can't reset sequence for composite primary key in table: $table");
             }
-            // use master connection to get the biggest PK value
-            $value = $this->db->useMaster(function (Connection $db) use ($tableSchema) {
+            // use primary connection to get the biggest PK value
+            $value = $this->db->usePrimary(function (Connection $db) use ($tableSchema) {
                 return $db->createCommand(
                     'SELECT MAX("' . $tableSchema->primaryKey[0] . '") FROM "'. $tableSchema->name . '"'
                 )->queryScalar();

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -57,7 +57,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
         if ($this->defaultSchema === null) {
             $username = $this->db->username;
             if (empty($username)) {
-                $username = isset($this->db->masters[0]['username']) ? $this->db->masters[0]['username'] : '';
+                $username = isset($this->db->primaries[0]['username']) ? $this->db->primaries[0]['username'] : '';
             }
             $this->defaultSchema = strtoupper($username);
         }
@@ -134,7 +134,7 @@ SQL;
         $rows = $command->queryAll();
         $names = [];
         foreach ($rows as $row) {
-            if ($this->db->slavePdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_LOWER) {
+            if ($this->db->replicaPdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_LOWER) {
                 $row = array_change_key_case($row, CASE_UPPER);
             }
             $names[] = $row['TABLE_NAME'];
@@ -337,7 +337,7 @@ SQL;
         }
 
         foreach ($columns as $column) {
-            if ($this->db->slavePdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_LOWER) {
+            if ($this->db->replicaPdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_LOWER) {
                 $column = array_change_key_case($column, CASE_UPPER);
             }
             $c = $this->createColumn($column);
@@ -382,9 +382,9 @@ SQL;
     public function getLastInsertID($sequenceName = '')
     {
         if ($this->db->isActive) {
-            // get the last insert id from the master connection
+            // get the last insert id from the primary connection
             $sequenceName = $this->quoteSimpleTableName($sequenceName);
-            return $this->db->useMaster(function (Connection $db) use ($sequenceName) {
+            return $this->db->usePrimary(function (Connection $db) use ($sequenceName) {
                 return $db->createCommand("SELECT {$sequenceName}.CURRVAL FROM DUAL")->queryScalar();
             });
         } else {
@@ -467,7 +467,7 @@ SQL;
         ]);
         $constraints = [];
         foreach ($command->queryAll() as $row) {
-            if ($this->db->slavePdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_LOWER) {
+            if ($this->db->replicaPdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_LOWER) {
                 $row = array_change_key_case($row, CASE_UPPER);
             }
 

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -221,7 +221,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         // enable to have ability to alter several tables
-        $this->db->getMasterPdo()->setAttribute(\PDO::ATTR_EMULATE_PREPARES, true);
+        $this->db->getPrimaryPdo()->setAttribute(\PDO::ATTR_EMULATE_PREPARES, true);
 
         return $command;
     }

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -368,7 +368,7 @@ SQL;
 
         $constraints = [];
         foreach ($this->db->createCommand($sql)->queryAll() as $constraint) {
-            if ($this->db->slavePdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_UPPER) {
+            if ($this->db->replicaPdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_UPPER) {
                 $constraint = array_change_key_case($constraint, CASE_LOWER);
             }
             if ($constraint['foreign_table_schema'] !== $this->defaultSchema) {
@@ -439,7 +439,7 @@ SQL;
         $uniqueIndexes = [];
 
         foreach ($this->getUniqueIndexInformation($table) as $row) {
-            if ($this->db->slavePdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_UPPER) {
+            if ($this->db->replicaPdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_UPPER) {
                 $row = array_change_key_case($row, CASE_LOWER);
             }
             $column = $row['columnname'];
@@ -536,7 +536,7 @@ SQL;
             return false;
         }
         foreach ($columns as $column) {
-            if ($this->db->slavePdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_UPPER) {
+            if ($this->db->replicaPdo->getAttribute(\PDO::ATTR_CASE) === \PDO::CASE_UPPER) {
                 $column = array_change_key_case($column, CASE_LOWER);
             }
             $column = $this->loadColumnSchema($column);

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -206,7 +206,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
             $tableName = $db->quoteTableName($tableName);
             if ($value === null) {
                 $key = $this->db->quoteColumnName(reset($table->primaryKey));
-                $value = $this->db->useMaster(function (Connection $db) use ($key, $tableName) {
+                $value = $this->db->usePrimary(function (Connection $db) use ($key, $tableName) {
                     return $db->createCommand("SELECT MAX($key) FROM $tableName")->queryScalar();
                 });
             } else {

--- a/framework/mutex/MysqlMutex.php
+++ b/framework/mutex/MysqlMutex.php
@@ -56,7 +56,7 @@ class MysqlMutex extends DbMutex
      */
     protected function acquireLock($name, $timeout = 0)
     {
-        return $this->db->useMaster(function ($db) use ($name, $timeout) {
+        return $this->db->usePrimary(function ($db) use ($name, $timeout) {
             /** @var \yii\db\Connection $db */
             return (bool) $db->createCommand(
                 'SELECT GET_LOCK(:name, :timeout)',
@@ -73,7 +73,7 @@ class MysqlMutex extends DbMutex
      */
     protected function releaseLock($name)
     {
-        return $this->db->useMaster(function ($db) use ($name) {
+        return $this->db->usePrimary(function ($db) use ($name) {
             /** @var \yii\db\Connection $db */
             return (bool) $db->createCommand(
                 'SELECT RELEASE_LOCK(:name)',

--- a/framework/mutex/OracleMutex.php
+++ b/framework/mutex/OracleMutex.php
@@ -88,7 +88,7 @@ class OracleMutex extends DbMutex
         $timeout = abs((int) $timeout);
 
         // inside pl/sql scopes pdo binding not working correctly :(
-        $this->db->useMaster(function ($db) use ($name, $timeout, $releaseOnCommit, &$lockStatus) {
+        $this->db->usePrimary(function ($db) use ($name, $timeout, $releaseOnCommit, &$lockStatus) {
             /** @var \yii\db\Connection $db */
             $db->createCommand(
                 'DECLARE
@@ -115,7 +115,7 @@ END;',
     protected function releaseLock($name)
     {
         $releaseStatus = null;
-        $this->db->useMaster(function ($db) use ($name, &$releaseStatus) {
+        $this->db->usePrimary(function ($db) use ($name, &$releaseStatus) {
             /** @var \yii\db\Connection $db */
             $db->createCommand(
                 'DECLARE

--- a/framework/mutex/PgsqlMutex.php
+++ b/framework/mutex/PgsqlMutex.php
@@ -73,7 +73,7 @@ class PgsqlMutex extends DbMutex
         list($key1, $key2) = $this->getKeysFromName($name);
 
         return $this->retryAcquire($timeout, function () use ($key1, $key2) {
-            return $this->db->useMaster(function ($db) use ($key1, $key2) {
+            return $this->db->usePrimary(function ($db) use ($key1, $key2) {
                 /** @var \yii\db\Connection $db */
                 return (bool) $db->createCommand(
                     'SELECT pg_try_advisory_lock(:key1, :key2)',
@@ -92,7 +92,7 @@ class PgsqlMutex extends DbMutex
     protected function releaseLock($name)
     {
         list($key1, $key2) = $this->getKeysFromName($name);
-        return $this->db->useMaster(function ($db) use ($key1, $key2) {
+        return $this->db->usePrimary(function ($db) use ($key1, $key2) {
             /** @var \yii\db\Connection $db */
             return (bool) $db->createCommand(
                 'SELECT pg_advisory_unlock(:key1, :key2)',

--- a/framework/validators/ForceMasterDbTrait.php
+++ b/framework/validators/ForceMasterDbTrait.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\validators;
+
+/**
+ * @internal This trait is only used to denote deprecated magic properties of [[ExistValidator]] for IDEs via a
+ * `@mixin` tag. It is never actually loaded at runtime.
+ *
+ * @author Brandon Kelly <brandon@craftcms.com>
+ * @since 2.0.36
+ */
+trait ForceMasterDbTrait
+{
+    /**
+     * @var bool whether this validator is forced to always use primary DB connection
+     * @deprecated since 2.0.36. Use [[ExistValidator::$forcePrimaryDb]] instead.
+     */
+    public $forceMasterDb = true;
+}

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -114,7 +114,7 @@ class DbSession extends MultiFieldSession
             return;
         }
 
-        $row = $this->db->useMaster(function() use ($oldID) {
+        $row = $this->db->usePrimary(function() use ($oldID) {
             return (new Query())->from($this->sessionTable)
                ->where(['id' => $oldID])
                ->createCommand($this->db)

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -1296,7 +1296,7 @@ SQL;
     public function testColumnCase()
     {
         $db = $this->getConnection(false);
-        $this->assertEquals(\PDO::CASE_NATURAL, $db->slavePdo->getAttribute(\PDO::ATTR_CASE));
+        $this->assertEquals(\PDO::CASE_NATURAL, $db->replicaPdo->getAttribute(\PDO::ATTR_CASE));
 
         $sql = 'SELECT [[customer_id]], [[total]] FROM {{order}}';
         $rows = $db->createCommand($sql)->queryAll();
@@ -1304,13 +1304,13 @@ SQL;
         $this->assertTrue(isset($rows[0]['customer_id']));
         $this->assertTrue(isset($rows[0]['total']));
 
-        $db->slavePdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_LOWER);
+        $db->replicaPdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_LOWER);
         $rows = $db->createCommand($sql)->queryAll();
         $this->assertTrue(isset($rows[0]));
         $this->assertTrue(isset($rows[0]['customer_id']));
         $this->assertTrue(isset($rows[0]['total']));
 
-        $db->slavePdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_UPPER);
+        $db->replicaPdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_UPPER);
         $rows = $db->createCommand($sql)->queryAll();
         $this->assertTrue(isset($rows[0]));
         $this->assertTrue(isset($rows[0]['CUSTOMER_ID']));

--- a/tests/framework/db/ConnectionTest.php
+++ b/tests/framework/db/ConnectionTest.php
@@ -409,29 +409,29 @@ abstract class ConnectionTest extends DatabaseTestCase
 
 
     /**
-     * Test whether slave connection is recovered when call getSlavePdo() after close().
+     * Test whether replica connection is recovered when getReplicaPdo() is called after close().
      *
      * @see https://github.com/yiisoft/yii2/issues/14165
      */
     public function testGetPdoAfterClose()
     {
         $connection = $this->getConnection();
-        $connection->slaves[] = [
+        $connection->replicas[] = [
             'dsn' => $connection->dsn,
             'username' => $connection->username,
             'password' => $connection->password,
         ];
-        $this->assertNotNull($connection->getSlavePdo(false));
+        $this->assertNotNull($connection->getReplicaPdo(false));
         $connection->close();
 
-        $masterPdo = $connection->getMasterPdo();
-        $this->assertNotFalse($masterPdo);
-        $this->assertNotNull($masterPdo);
+        $primaryPdo = $connection->getPrimaryPdo();
+        $this->assertNotFalse($primaryPdo);
+        $this->assertNotNull($primaryPdo);
 
-        $slavePdo = $connection->getSlavePdo(false);
-        $this->assertNotFalse($slavePdo);
-        $this->assertNotNull($slavePdo);
-        $this->assertNotSame($masterPdo, $slavePdo);
+        $replicaPdo = $connection->getReplicaPdo(false);
+        $this->assertNotFalse($replicaPdo);
+        $this->assertNotNull($replicaPdo);
+        $this->assertNotSame($primaryPdo, $replicaPdo);
     }
 
     public function testServerStatusCacheWorks()
@@ -440,12 +440,12 @@ abstract class ConnectionTest extends DatabaseTestCase
         Yii::$app->set('cache', $cache);
 
         $connection = $this->getConnection(true, false);
-        $connection->masters[] = [
+        $connection->primaries[] = [
             'dsn' => $connection->dsn,
             'username' => $connection->username,
             'password' => $connection->password,
         ];
-        $connection->shuffleMasters = false;
+        $connection->shufflePrimaries = false;
 
         $cacheKey = ['yii\db\Connection::openFromPoolSequentially', $connection->dsn];
 
@@ -455,7 +455,7 @@ abstract class ConnectionTest extends DatabaseTestCase
         $connection->close();
 
         $cacheKey = ['yii\db\Connection::openFromPoolSequentially', 'host:invalid'];
-        $connection->masters[0]['dsn'] = 'host:invalid';
+        $connection->primaries[0]['dsn'] = 'host:invalid';
         try {
             $connection->open();
         } catch (InvalidConfigException $e) {
@@ -470,12 +470,12 @@ abstract class ConnectionTest extends DatabaseTestCase
         Yii::$app->set('cache', $cache);
 
         $connection = $this->getConnection(true, false);
-        $connection->masters[] = [
+        $connection->primaries[] = [
             'dsn' => $connection->dsn,
             'username' => $connection->username,
             'password' => $connection->password,
         ];
-        $connection->shuffleMasters = false;
+        $connection->shufflePrimaries = false;
         $connection->serverStatusCache = false;
 
         $cacheKey = ['yii\db\Connection::openFromPoolSequentially', $connection->dsn];
@@ -486,7 +486,7 @@ abstract class ConnectionTest extends DatabaseTestCase
         $connection->close();
 
         $cacheKey = ['yii\db\Connection::openFromPoolSequentially', 'host:invalid'];
-        $connection->masters[0]['dsn'] = 'host:invalid';
+        $connection->primaries[0]['dsn'] = 'host:invalid';
         try {
             $connection->open();
         } catch (InvalidConfigException $e) {

--- a/tests/framework/db/DatabaseTestCase.php
+++ b/tests/framework/db/DatabaseTestCase.php
@@ -130,15 +130,15 @@ abstract class DatabaseTestCase extends TestCase
                 return $sql;
         }
     }
-    
+
     /**
      * @return \yii\db\Connection
      */
-    protected function getConnectionWithInvalidSlave()
+    protected function getConnectionWithInvalidReplica()
     {
         $config = array_merge($this->database, [
             'serverStatusCache' => new DummyCache(),
-            'slaves' => [
+            'replicas' => [
                 [], // invalid config
             ],
         ]);

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -105,10 +105,10 @@ abstract class SchemaTest extends DatabaseTestCase
     public function testGetTableSchemasWithAttrCase()
     {
         $db = $this->getConnection(false);
-        $db->slavePdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_LOWER);
+        $db->replicaPdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_LOWER);
         $this->assertEquals(\count($db->schema->getTableNames()), \count($db->schema->getTableSchemas()));
 
-        $db->slavePdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_UPPER);
+        $db->replicaPdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_UPPER);
         $this->assertEquals(\count($db->schema->getTableNames()), \count($db->schema->getTableSchemas()));
     }
 
@@ -757,7 +757,7 @@ abstract class SchemaTest extends DatabaseTestCase
         }
 
         $connection = $this->getConnection(false);
-        $connection->getSlavePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
+        $connection->getReplicaPdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
         $constraints = $connection->getSchema()->{'getTable' . ucfirst($type)}($tableName, true);
         $this->assertMetadataEquals($expected, $constraints);
     }
@@ -775,7 +775,7 @@ abstract class SchemaTest extends DatabaseTestCase
         }
 
         $connection = $this->getConnection(false);
-        $connection->getSlavePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
+        $connection->getReplicaPdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
         $constraints = $connection->getSchema()->{'getTable' . ucfirst($type)}($tableName, true);
         $this->assertMetadataEquals($expected, $constraints);
     }

--- a/tests/framework/db/cubrid/QueryBuilderTest.php
+++ b/tests/framework/db/cubrid/QueryBuilderTest.php
@@ -57,7 +57,7 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
 
     public function testCommentColumn()
     {
-        $version = $this->getQueryBuilder(false)->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+        $version = $this->getQueryBuilder(false)->db->getReplicaPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
         if (version_compare($version, '10.0', '<')) {
             $this->markTestSkipped('Comments on columns are supported starting with CUBRID 10.0.');
             return;

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -126,7 +126,7 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
         /**
          * @link https://github.com/yiisoft/yii2/issues/14367
          */
-        $mysqlVersion = $this->getDb()->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+        $mysqlVersion = $this->getDb()->getReplicaPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
         $supportsFractionalSeconds = version_compare($mysqlVersion,'5.6.4', '>=');
         if ($supportsFractionalSeconds) {
             $expectedValues = [

--- a/tests/framework/helpers/VarDumperTest.php
+++ b/tests/framework/helpers/VarDumperTest.php
@@ -177,13 +177,13 @@ RESULT;
         $exportResult = VarDumper::export($var);
         $this->assertNotEmpty($exportResult);
 
-        $master = new \StdClass();
-        $slave = new \StdClass();
-        $master->slave = $slave;
-        $slave->master = $master;
-        $master->function = function () {return true;};
+        $foo = new \StdClass();
+        $bar = new \StdClass();
+        $foo->bar = $bar;
+        $bar->foo = $foo;
+        $foo->function = function () {return true;};
 
-        $exportResult = VarDumper::export($master);
+        $exportResult = VarDumper::export($foo);
         $this->assertNotEmpty($exportResult);
     }
 

--- a/tests/framework/validators/ExistValidatorTest.php
+++ b/tests/framework/validators/ExistValidatorTest.php
@@ -235,26 +235,26 @@ abstract class ExistValidatorTest extends DatabaseTestCase
         $val->validateAttribute($m, 'id');
         $this->assertTrue($m->hasErrors('id'));
     }
-    
-    public function testForceMaster()
+
+    public function testForcePrimary()
     {
-        $connection = $this->getConnectionWithInvalidSlave();
+        $connection = $this->getConnectionWithInvalidReplica();
         ActiveRecord::$db = $connection;
 
         $model = null;
-        $connection->useMaster(function() use (&$model) {
+        $connection->usePrimary(function() use (&$model) {
             $model = ValidatorTestMainModel::findOne(2);
         });
 
         $validator = new ExistValidator([
-            'forceMasterDb' => true,
+            'forcePrimaryDb' => true,
             'targetRelation' => 'references',
         ]);
         $validator->validateAttribute($model, 'id');
 
         $this->expectException('\yii\base\InvalidConfigException');
         $validator = new ExistValidator([
-            'forceMasterDb' => false,
+            'forcePrimaryDb' => false,
             'targetRelation' => 'references',
         ]);
         $validator->validateAttribute($model, 'id');

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -445,7 +445,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
             $this->fail('Query is crashed because "with" relation cannot be loaded');
         }
     }
-    
+
     /**
      * Test join with doesn't attempt to eager load joinWith relations
      * @see https://github.com/yiisoft/yii2/issues/17389
@@ -463,26 +463,26 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
             $this->fail('Query is crashed because "joinWith" relation cannot be loaded');
         }
     }
-    
-    public function testForceMaster()
+
+    public function testForcePrimary()
     {
-        $connection = $this->getConnectionWithInvalidSlave();
+        $connection = $this->getConnectionWithInvalidReplica();
         ActiveRecord::$db = $connection;
 
         $model = null;
-        $connection->useMaster(function() use (&$model) {
+        $connection->usePrimary(function() use (&$model) {
             $model = WithCustomer::find()->one();
         });
 
         $validator = new UniqueValidator([
-            'forceMasterDb' => true,
+            'forcePrimaryDb' => true,
             'targetAttribute' => ['status', 'profile_id']
         ]);
         $validator->validateAttribute($model, 'email');
 
         $this->expectException('\yii\base\InvalidConfigException');
         $validator = new UniqueValidator([
-            'forceMasterDb' => false,
+            'forcePrimaryDb' => false,
             'targetAttribute' => ['status', 'profile_id']
         ]);
         $validator->validateAttribute($model, 'email');
@@ -504,9 +504,9 @@ class WithCustomer extends Customer {
 class JoinWithCustomer extends Customer {
     public static function find() {
         $res = parent::find();
-        
+
         $res->joinWith('profile');
-        
+
         return $res;
     }
 }


### PR DESCRIPTION
There is a growing call for the tech industry to move away from “master”/“slave” terminology in the interest of inclusion, especially toward the Black community.

In that spirit, this PR deprecates those terms as they relate to read/write splitting, in favor of “primary” and “replica” – which I’d argue are not just more inclusive terms, but also more semantically correct. (The replica servers are not merely “taking orders” from their “master” server; they are replicating it.)

I’ve managed to do this in a non-breaking way, by keeping old master/slave methods around as aliases for the new ones, and adding magic getter/setter methods for the old master/slave properties. I’ve also introduced a couple traits to document the now-deprecated properties, based on https://stackoverflow.com/a/51890536/1688568.

<img width="335" alt="Code that demonstrates how PhpStorm recognizes yii\db\Connection::$master as deprecated" src="https://user-images.githubusercontent.com/47792/84574389-fb1f0f00-ad5a-11ea-8cc6-45615abbd958.png">


| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
