### PR TITLE
The gridEventHandlers object keys generation updated.

### DIFF
--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -14,7 +14,7 @@
         if (methods[method]) {
             return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
         } else if (typeof method === 'object' || !method) {
-                return methods.init.apply(this, arguments);
+            return methods.init.apply(this, arguments);
         } else {
             $.error('Method ' + method + ' does not exist in jQuery.yiiGridView');
             return false;
@@ -253,6 +253,7 @@
             gridEventHandlers[id] = {};
         }
         $(document).on(event, selector, callback);
-        gridEventHandlers[id][type] = {event: event, selector: selector};
+        var typeKey = (type === 'filter') ? type : type + selector;
+        gridEventHandlers[id][typeKey] = {event: event, selector: selector};
     }
 })(window.jQuery);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | #18090

I checked the problem described in issue #18090 and found that the problem was in rewriting element in `gridEventHandlers` in `yii.gridView.js` file in `initEventHandler` function. 
Looks like the CheckboxColumn was designed to use only once in one GridView Widget. 
After a few different tries to fix this issue and not fail a lot of test, I found this solution, with fails inly one JS test. 
Now all seems to be work good, so I think we need to update *setSelectionColumn method with repeated calls* JS test (line 675 in `yii.gridView.test.js`), because it was designed to work only with one checkbox column. I'm not a big specialist in JS test, so some help needed.