### PR TITLE
Upgrade note for #18083

### DIFF
--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -51,6 +51,12 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to follow the instructions
 for both A and B.
 
+Upgrade from Yii 2.0.35
+-----------------------
+
+* If you have any controllers that override the `init()` method, make sure they are calling `parent::init()` at
+  the beginning, as demonstrated in the [component guide](https://www.yiiframework.com/doc/guide/2.0/en/concept-components).
+
 Upgrade from Yii 2.0.32
 -----------------------
 


### PR DESCRIPTION
Adds a note to UPGRADE.md, to warn people that they should make sure their controllers’ `init()` methods are calling `parent::init()`.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
