### PR TITLE
Fix #18047: Console Table Widget width issue with colorized input

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.36 under development
 ------------------------
 
+- Bug #18047: Fix colorization markers output in Table.php (cheeseq)
 - Bug #18028: Fix division by zero exception in Table.php::calculateRowHeight (fourhundredfour)
 - Enh #18019: Allow jQuery 3.5.0 to be installed (wouter90)
 - Bug #18026: Fix `ArrayHelper::getValue()` did not work with `ArrayAccess` objects (mikk150)

--- a/framework/console/widgets/Table.php
+++ b/framework/console/widgets/Table.php
@@ -271,7 +271,7 @@ class Table extends Widget
                     $alreadyPrintedCells[$index] = true;
                 }
                 $chunk = $prefix . $chunk;
-                $repeat = $cellSize - mb_strwidth($this->escapeCharacters($chunk), Yii::$app->charset) - 1;
+                $repeat = $cellSize - Console::ansiStrwidth($chunk) - 1;
                 $buffer .= $chunk;
                 if ($repeat >= 0) {
                     $buffer .= str_repeat(' ', $repeat);
@@ -334,12 +334,9 @@ class Table extends Widget
         foreach ($columns as $column) {
             $columnWidth = max(array_map(function ($val) {
                 if (is_array($val)) {
-                    $encodings = array_fill(0, count($val), Yii::$app->charset);
-                    return max(array_map(function ($listItem) {
-                        return mb_strwidth($this->escapeCharacters($listItem), Yii::$app->charset);
-                    }, $val, $encodings)) + mb_strwidth($this->listPrefix, Yii::$app->charset);
+                    return max(array_map('yii\helpers\Console::ansiStrwidth', $val)) + Console::ansiStrwidth($this->listPrefix);
                 }
-                return mb_strwidth($this->escapeCharacters($val), Yii::$app->charset);
+                return Console::ansiStrwidth($val);
             }, $column)) + 2;
             $this->columnWidths[] = $columnWidth;
             $totalWidth += $columnWidth;
@@ -378,12 +375,9 @@ class Table extends Widget
             return $size == 2 || $columnWidth == 0 ? 0 : ceil($columnWidth / ($size - 2));
         }, $this->columnWidths, array_map(function ($val) {
             if (is_array($val)) {
-                $encodings = array_fill(0, count($val), Yii::$app->charset);
-                return array_map(function ($v) {
-                    return mb_strwidth($this->escapeCharacters($v), Yii::$app->charset);
-                }, $val, $encodings);
+                return array_map('yii\helpers\Console::ansiStrwidth', $val);
             }
-            return mb_strwidth($this->escapeCharacters($val), Yii::$app->charset);
+            return Console::ansiStrwidth($val);
         }, $row));
         return max($rowsPerCell);
     }
@@ -403,16 +397,5 @@ class Table extends Widget
                 : self::DEFAULT_CONSOLE_SCREEN_WIDTH + self::CONSOLE_SCROLLBAR_OFFSET;
         }
         return $this->screenWidth;
-    }
-
-    /**
-     * Trying to escape characters, which may have effect on visible string width, such as
-     * colorization markers
-     *
-     * @param $input
-     * @return null|string|string[]
-     */
-    protected function escapeCharacters($input) {
-        return Console::stripAnsiFormat($input);
     }
 }

--- a/framework/console/widgets/Table.php
+++ b/framework/console/widgets/Table.php
@@ -413,6 +413,6 @@ class Table extends Widget
      * @return null|string|string[]
      */
     protected function escapeCharacters($input) {
-        return preg_replace('/\e[[][A-Za-z0-9];?[0-9]*m?/', '', $input);
+        return Console::stripAnsiFormat($input);
     }
 }

--- a/framework/console/widgets/Table.php
+++ b/framework/console/widgets/Table.php
@@ -266,8 +266,9 @@ class Table extends Widget
                         $finalChunk[$index] = '';
                     }
                 } else {
-                    if(!isset($alreadyPrintedCells[$index]))
+                    if (!isset($alreadyPrintedCells[$index])) {
                         $chunk = $cell;
+                    }
                     $alreadyPrintedCells[$index] = true;
                 }
                 $chunk = $prefix . $chunk;

--- a/framework/helpers/BaseConsole.php
+++ b/framework/helpers/BaseConsole.php
@@ -7,6 +7,7 @@
 
 namespace yii\helpers;
 
+use Yii;
 use yii\console\Markdown as ConsoleMarkdown;
 use yii\base\Model;
 
@@ -341,6 +342,17 @@ class BaseConsole
     public static function ansiStrlen($string)
     {
         return mb_strlen(static::stripAnsiFormat($string));
+    }
+
+    /**
+     * Returns the width of the string without ANSI color codes.
+     * @param string $string the string to measure
+     * @return int the width of the string not counting ANSI format characters
+     * @since 2.0.36
+     */
+    public static function ansiStrwidth($string)
+    {
+        return mb_strwidth(static::stripAnsiFormat($string), Yii::$app->charset);
     }
 
     /**

--- a/tests/framework/console/widgets/TableTest.php
+++ b/tests/framework/console/widgets/TableTest.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\console;
 
 use yii\console\widgets\Table;
+use yii\helpers\Console;
 use yiiunit\TestCase;
 
 /**
@@ -312,6 +313,56 @@ EXPECTED;
                 ->setScreenWidth(200)
                 ->run()
         );
+    }
+
+    public function testColorizedInput()
+    {
+        $table = new Table();
+
+        $expected = <<<"EXPECTED"
+╔═══════╤═══════╤══════════╗
+║ test1 │ test2 │ test3    ║
+╟───────┼───────┼──────────╢
+║ col1  │ \e[33mcol2\e[0m  │ col3     ║
+╟───────┼───────┼──────────╢
+║ col1  │ col2  │ • col3-0 ║
+║       │       │ • \e[31mcol3-1\e[0m ║
+║       │       │ • col3-2 ║
+╚═══════╧═══════╧══════════╝
+
+EXPECTED;
+
+        $this->assertEqualsWithoutLE(
+            $expected,
+            $table
+                ->setHeaders(['test1', 'test2', 'test3'])
+                ->setRows([
+                    ['col1', Console::renderColoredString('%ycol2%n'), 'col3'],
+                    ['col1', 'col2', ['col3-0', Console::renderColoredString('%rcol3-1%n'), 'col3-2']],
+                ])
+                ->run()
+        );
+    }
+
+    public function testColorizedInputStripsANSIMarkersInternally()
+    {
+        $table = new Table();
+
+        $table
+            ->setHeaders(['t1', 't2', 't3'])
+            ->setRows([
+                ['col1', Console::renderColoredString('%ycol2%n'), 'col3'],
+                ['col1', 'col2', ['col3-0', Console::renderColoredString('%rcol3-1%n'), 'col3-2']],
+            ])
+            ->setScreenWidth(200)
+            ->run();
+
+        $columnWidths = \PHPUnit_Framework_Assert::readAttribute($table, "columnWidths");
+
+        $this->assertArrayHasKey(1, $columnWidths);
+        $this->assertEquals(4+2, $columnWidths[1]);
+        $this->assertArrayHasKey(2, $columnWidths);
+        $this->assertEquals(8+2, $columnWidths[2]);
     }
 
     public function testCalculateRowHeightShouldNotThrowDivisionByZeroException()


### PR DESCRIPTION
Made an escaping character method, which invokes when calculating string width. Can someone have a look pls?

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18047 
