### PR TITLE
Add optional param `--silent-exit-on-exception` in `yii\console\Controller`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -20,6 +20,7 @@ Yii Framework 2 Change Log
 - Bug #18101: Fix behavior of OUTPUT INSERTED.* for SQL Server query: "insert default values"; correct MSSQL unit tests; turn off profiling echo message in migration test (darkdef)
 - Bug #18105: Fix for old trigger in RBAC migration with/without prefixTable (darkdef)
 - Enh #18120: Include path to the log file into error message if `FileTarget::export` fails (uaoleg)
+- Enh #15202: Add optional param `--silent-exit-on-exception` in `yii\console\Controller` (egorrishe)
 
 
 2.0.35 May 02, 2020

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -63,7 +63,7 @@ abstract class ErrorHandler extends Component
 
     public function init()
     {
-        $this->silentExitOnException = isset($this->silentExitOnException) ? $this->silentExitOnException : YII_ENV_TEST;
+        $this->silentExitOnException = $this->silentExitOnException !== null ? $this->silentExitOnException : YII_ENV_TEST;
         parent::init();
     }
 

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -41,6 +41,11 @@ abstract class ErrorHandler extends Component
      * @var \Exception|null the exception that is being handled currently.
      */
     public $exception;
+    /**
+     * @var bool if TRUE - `handleException()` will finish script with `ExitCode::OK`.
+     * FALSE - `ExitCode::UNSPECIFIED_ERROR`.
+     */
+    public $silentExitOnException;
 
     /**
      * @var string Used to reserve memory for fatal error handler.
@@ -55,6 +60,12 @@ abstract class ErrorHandler extends Component
      */
     private $_registered = false;
 
+
+    public function init()
+    {
+        $this->silentExitOnException = isset($this->silentExitOnException) ? $this->silentExitOnException : YII_ENV_TEST;
+        parent::init();
+    }
 
     /**
      * Register this error handler.
@@ -121,7 +132,7 @@ abstract class ErrorHandler extends Component
                 $this->clearOutput();
             }
             $this->renderException($exception);
-            if (!YII_ENV_TEST) {
+            if (!$this->silentExitOnException) {
                 \Yii::getLogger()->flush(true);
                 if (defined('HHVM_VERSION')) {
                     flush();

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -44,6 +44,7 @@ abstract class ErrorHandler extends Component
     /**
      * @var bool if TRUE - `handleException()` will finish script with `ExitCode::OK`.
      * FALSE - `ExitCode::UNSPECIFIED_ERROR`.
+     * @since 2.0.36
      */
     public $silentExitOnException;
 

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -65,12 +65,26 @@ class Controller extends \yii\base\Controller
      * @since 2.0.10
      */
     public $help;
+    /**
+     * @var bool if TRUE - script finish with `ExitCode::OK` in case of exception.
+     * FALSE - `ExitCode::UNSPECIFIED_ERROR`.
+     * Default: `YII_ENV_TEST`
+     */
+    public $silentExitOnException;
 
     /**
      * @var array the options passed during execution.
      */
     private $_passedOptions = [];
 
+
+    public function beforeAction($action)
+    {
+        $silentExit = isset($this->silentExitOnException) ? $this->silentExitOnException : YII_ENV_TEST;
+        Yii::$app->errorHandler->silentExitOnException = $silentExit;
+
+        return parent::beforeAction($action);
+    }
 
     /**
      * Returns a value indicating whether ANSI color is enabled.
@@ -398,7 +412,7 @@ class Controller extends \yii\base\Controller
     public function options($actionID)
     {
         // $actionId might be used in subclasses to provide options specific to action id
-        return ['color', 'interactive', 'help'];
+        return ['color', 'interactive', 'help', 'silentExitOnException'];
     }
 
     /**

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -69,6 +69,7 @@ class Controller extends \yii\base\Controller
      * @var bool if TRUE - script finish with `ExitCode::OK` in case of exception.
      * FALSE - `ExitCode::UNSPECIFIED_ERROR`.
      * Default: `YII_ENV_TEST`
+     * @since 2.0.36
      */
     public $silentExitOnException;
 

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -80,7 +80,7 @@ class Controller extends \yii\base\Controller
 
     public function beforeAction($action)
     {
-        $silentExit = isset($this->silentExitOnException) ? $this->silentExitOnException : YII_ENV_TEST;
+        $silentExit = $this->silentExitOnException !== null ? $this->silentExitOnException : YII_ENV_TEST;
         Yii::$app->errorHandler->silentExitOnException = $silentExit;
 
         return parent::beforeAction($action);

--- a/tests/framework/console/controllers/HelpControllerTest.php
+++ b/tests/framework/console/controllers/HelpControllerTest.php
@@ -128,6 +128,7 @@ action:route to action
 --interactive: whether to run the command interactively.
 --color: whether to enable ANSI color in the output.If not set, ANSI color will only be enabled for terminals that support it.
 --help: whether to display help information about current command.
+--silent-exit-on-exception: if TRUE - script finish with `ExitCode\:\:OK` in case of exception.FALSE - `ExitCode\:\:UNSPECIFIED_ERROR`.Default\: `YII_ENV_TEST`
 
 STRING
         , $result);


### PR DESCRIPTION
**Example**:
- `./tests/bin/yii fixture/load 'notExistedFixture' --interactive=0 --silent-exit-on-exception=0`
    - this command will crash with exit code `1`

**Backward compatibility** - default behavior remain the same. 
Next commands are equal, and crash with exit code `0`:
- `./tests/bin/yii fixture/load 'notExistedFixture' --interactive=0`
- `./tests/bin/yii fixture/load 'notExistedFixture' --interactive=0 --silent-exit-on-exception=1`

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #15202
