### PR TITLE
Allow DI references in array in dependencies

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.36 under development
 ------------------------
 
+- Enh #18127: Add resolving DI references inside of arrays in dependencies (hiqsol)
 - Bug #18047: Fix colorization markers output in Table.php (cheeseq)
 - Bug #18028: Fix division by zero exception in Table.php::calculateRowHeight (fourhundredfour)
 - Enh #18019: Allow jQuery 3.5.0 to be installed (wouter90)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.36 under development
 ------------------------
 
-- Enh #18127: Add resolving DI references inside of arrays in dependencies (hiqsol)
+- Bug #18127: Add resolving DI references inside of arrays in dependencies (hiqsol)
 - Bug #18047: Fix colorization markers output in Table.php (cheeseq)
 - Bug #18028: Fix division by zero exception in Table.php::calculateRowHeight (fourhundredfour)
 - Enh #18019: Allow jQuery 3.5.0 to be installed (wouter90)

--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -487,6 +487,8 @@ class Container extends Component
                     $class = $reflection->getName();
                     throw new InvalidConfigException("Missing required parameter \"$name\" when instantiating \"$class\".");
                 }
+            } elseif (is_array($dependency)) {
+                $dependencies[$index] = $this->resolveDependencies($dependency, $reflection);
             }
         }
 

--- a/tests/framework/di/stubs/Corge.php
+++ b/tests/framework/di/stubs/Corge.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\di\stubs;
+
+use yii\base\BaseObject;
+
+class Corge extends BaseObject
+{
+    public $map;
+
+    public function __construct(array $map, $config = [])
+    {
+        $this->map = $map;
+        parent::__construct($config);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️


Extremely needed for handler maps and like.
Example container config:

```php
return [
    ContentTypeMiddleware::class => [
        '__construct()' => [
            Instance::of(StreamFactory::class),
            [
                'json' => Intance::of(JsonFormatter::class),
                'yaml' => Intance::of(YamlFormatter::class),
            ],
        ],
    ],
];
```

I'll add tests if the idea is ok.
Also same stuff can be implemented in `yiisoft/di`
