### PR TITLE
Fixed parameters binding for mysql when prepare emulation is off

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -26,6 +26,7 @@ Yii Framework 2 Change Log
 - Bug #18110: Add quotes to return value of viewName in MSSQL schema. It is `[someView]` now (darkdef)
 - Bug #17985: Convert migrationNamespaces to array if needed (darkdef)
 - Bug #18134: Expression as columnName should not be quoted in likeCondition (darkdef)
+- Bug #18147: Fixed parameters binding for mysql when prepare emulation is off (rskrzypczak)
 
 
 2.0.35 May 02, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -26,7 +26,7 @@ Yii Framework 2 Change Log
 - Bug #18110: Add quotes to return value of viewName in MSSQL schema. It is `[someView]` now (darkdef)
 - Bug #17985: Convert migrationNamespaces to array if needed (darkdef)
 - Bug #18134: Expression as columnName should not be quoted in likeCondition (darkdef)
-- Bug #18147: Fixed parameters binding for mysql when prepare emulation is off (rskrzypczak)
+- Bug #18147: Fixed parameters binding for MySQL when prepare emulation is off (rskrzypczak)
 
 
 2.0.35 May 02, 2020

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -512,9 +512,9 @@ FROM
     `information_schema`.`REFERENTIAL_CONSTRAINTS` AS `rc`,
     `information_schema`.`TABLE_CONSTRAINTS` AS `tc`
 WHERE
-    `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName, DATABASE()) AND `kcu`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `kcu`.`TABLE_NAME` = :tableName
-    AND `rc`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `rc`.`TABLE_NAME` = :tableName AND `rc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME`
-    AND `tc`.`TABLE_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `tc`.`TABLE_NAME` = :tableName AND `tc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME` AND `tc`.`CONSTRAINT_TYPE` = 'FOREIGN KEY'
+    `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName1, DATABASE()) AND `kcu`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `kcu`.`TABLE_NAME` = :tableName
+    AND `rc`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `rc`.`TABLE_NAME` = :tableName1 AND `rc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME`
+    AND `tc`.`TABLE_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `tc`.`TABLE_NAME` = :tableName2 AND `tc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME` AND `tc`.`CONSTRAINT_TYPE` = 'FOREIGN KEY'
 UNION
 SELECT
     `kcu`.`CONSTRAINT_NAME` AS `name`,
@@ -530,15 +530,21 @@ FROM
     `information_schema`.`KEY_COLUMN_USAGE` AS `kcu`,
     `information_schema`.`TABLE_CONSTRAINTS` AS `tc`
 WHERE
-    `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName, DATABASE()) AND `kcu`.`TABLE_NAME` = :tableName
-    AND `tc`.`TABLE_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `tc`.`TABLE_NAME` = :tableName AND `tc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME` AND `tc`.`CONSTRAINT_TYPE` IN ('PRIMARY KEY', 'UNIQUE')
+    `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName2, DATABASE()) AND `kcu`.`TABLE_NAME` = :tableName3
+    AND `tc`.`TABLE_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `tc`.`TABLE_NAME` = :tableName4 AND `tc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME` AND `tc`.`CONSTRAINT_TYPE` IN ('PRIMARY KEY', 'UNIQUE')
 ORDER BY `position` ASC
 SQL;
 
         $resolvedName = $this->resolveTableName($tableName);
         $constraints = $this->db->createCommand($sql, [
             ':schemaName' => $resolvedName->schemaName,
+            ':schemaName1' => $resolvedName->schemaName,
+            ':schemaName2' => $resolvedName->schemaName,
             ':tableName' => $resolvedName->name,
+            ':tableName1' => $resolvedName->name,
+            ':tableName2' => $resolvedName->name,
+            ':tableName3' => $resolvedName->name,
+            ':tableName4' => $resolvedName->name
         ])->queryAll();
         $constraints = $this->normalizePdoRowKeyCase($constraints, true);
         $constraints = ArrayHelper::index($constraints, null, ['type', 'name']);


### PR DESCRIPTION
The same as here: https://github.com/yiisoft/yii2/commit/2201bf14e239477b52cfb1f331e0c7b92d98e2cb
When PDO::ATTR_EMULATE_PREPARES => false in DB config this uses native preparation which means that you cannot use the same parameter twice.

It only works when $emulatePrepare = true, but it's usually false, so it doesn't work :)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -
