### PR TITLE
Adding optional authorization check

### DIFF
--- a/framework/helpers/Html.php
+++ b/framework/helpers/Html.php
@@ -19,4 +19,22 @@ namespace yii\helpers;
  */
 class Html extends BaseHtml
 {
+  /**
+     * Overriding a method to optionally authorize the output
+     */
+    public static function a($text, $url = NULL, $options = [])
+    {
+        if (isset($options['userCan']))
+        {
+            if (\Yii::$app->user->can($options['userCan']))
+            {
+                return parent::a($text, $url, $options);
+            }
+            else
+            {
+                return '';
+            }
+        }        
+        return parent::a($text, $url, $options);        
+    }
 }


### PR DESCRIPTION
An introduction to override the parent class, BaseHtml, of the Html class methods to check authorization of the user, optionally, before evaluate the output. I started with `a()`

Usage Example:
```
<?= Html::a(Yii::t('app', 'Update'), ['update', 'id' => $model->id,], ['class' => 'btn btn-primary', 'userCan' => 'createPlaylist']) ?>
        <?= Html::a(Yii::t('app', 'Delete'), ['delete', 'id' => $model->id], [
            'class' => 'btn btn-danger',
            'data' => [
                'confirm' => Yii::t('app', 'Are you sure you want to delete this item?'),
                'method' => 'post',
            ],
        ]) ?>
```

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
