### PR TITLE
Added Getter for Table Alias

### DIFF
--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -68,6 +68,7 @@ use yii\base\InvalidConfigException;
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @author Carsten Brandt <mail@cebe.cc>
+ * @author Dmitriy Malyar <softkoc@gmail.com>
  * @since 2.0
  */
 class ActiveQuery extends Query implements ActiveQueryInterface
@@ -613,6 +614,20 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         }
 
         return [$tableName, $alias];
+    }
+    
+    /**
+     * Return table alias.
+     *
+     * @return string
+     */
+    public function getAlias()
+    {
+        if (!$this->from) {
+            $this->alias('default');
+        }
+
+        return array_keys($this->from)[0];
     }
 
     /**


### PR DESCRIPTION
Adds the flexibility of using aliases.
Example Query:

```php
public function active()
{
    return $this->andWhere(['=', "$this->alias.status", 'active']);
}

User::find()->alias('instructor')->active()->all();
```

Result:

```sql
SELECT * FROM user instructor WHERE instructor.status = 'active';
```

| Q             | A
| ------------- | ---
| Is bugfix?    |❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
