### PR TITLE
Fix #17902: Ensure there are no invalid characters in URL before doing redirect in UrlNormalizer

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,7 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #18171: Change case of column names in SQL query for `findConstraints` to fix MySQL 8 compatibility (darkdef)
 - Bug #18170: Fix 2.0.36 regression in passing extra console command arguments to the action (darkdef)
-
+- Bug #17902: Ensure there are no invalid characters in URL before doing redirect in UrlNormalizer (samdark)
 
 2.0.36 July 07, 2020
 --------------------

--- a/framework/web/UrlNormalizer.php
+++ b/framework/web/UrlNormalizer.php
@@ -21,7 +21,7 @@ use yii\base\InvalidConfigException;
 class UrlNormalizer extends BaseObject
 {
     /**
-     * Represents permament redirection during route normalization.
+     * Represents permanent redirection during route normalization.
      * @see https://en.wikipedia.org/wiki/HTTP_301
      */
     const ACTION_REDIRECT_PERMANENT = 301;
@@ -114,6 +114,9 @@ class UrlNormalizer extends BaseObject
         if ($this->normalizeTrailingSlash === true) {
             $pathInfo = $this->normalizeTrailingSlash($pathInfo, $suffix);
         }
+
+        // Ensure there is no incorrect characters in pathInfo such as newlines
+        $pathInfo = preg_replace('/\s+/', ' ', $pathInfo);
 
         $normalized = $sourcePathInfo !== $pathInfo;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17902 
