### PR TITLE
Add test for 18031 - User login events not triggered when using \yii\web\HttpBasicAuth login

### DIFF
--- a/tests/framework/filters/auth/BasicAuthTest.php
+++ b/tests/framework/filters/auth/BasicAuthTest.php
@@ -10,6 +10,8 @@ namespace yiiunit\framework\filters\auth;
 use Yii;
 use yii\filters\auth\HttpBasicAuth;
 use yiiunit\framework\filters\stubs\UserIdentity;
+use yii\base\Event;
+use yii\web\User;
 
 /**
  * @group filters
@@ -121,5 +123,20 @@ class BasicAuthTest extends AuthTest
         return [
             ['yii\filters\auth\HttpBasicAuth'],
         ];
+    }
+
+    /**
+     * @dataProvider tokenProvider
+     * @param string|null $token
+     * @param string|null $login
+     */
+    public function testAfterLoginEventIsTriggered18031($token, $login)
+    {
+        $triggered = false;
+        Event::on('\yii\web\User', User::EVENT_AFTER_LOGIN, function ($event) use (&$triggered) {
+            $triggered = true;
+            $this->assertTrue($triggered);
+        });
+        $this->testHttpBasicAuthCustom($token, $login);
     }
 }

--- a/tests/framework/filters/auth/BasicAuthTest.php
+++ b/tests/framework/filters/auth/BasicAuthTest.php
@@ -138,5 +138,6 @@ class BasicAuthTest extends AuthTest
             $this->assertTrue($triggered);
         });
         $this->testHttpBasicAuthCustom($token, $login);
+        Event::off('\yii\web\User', User::EVENT_AFTER_LOGIN); // required because this method runs in foreach loop. See @dataProvider tokenProvider
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | Test for #18031 
