### PR TITLE
Fix #18204: Fix 2.0.36 regression in inline validator and JS validation

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,7 +8,7 @@ Yii Framework 2 Change Log
 - Bug #18170: Fix 2.0.36 regression in passing extra console command arguments to the action (darkdef)
 - Bug #18182: `yii\db\Expression` was not supported as condition in `ActiveRecord::findOne()` and `ActiveRecord::findAll()` (rhertogh)
 - Bug #18189: Fix "Invalid parameter number" in `yii\rbac\DbManager::removeItem()` (samdark)
-
+- Bug #18204: Fix 2.0.36 regression in inline validator and JS validation (samdark)
 
 2.0.36 July 07, 2020
 --------------------

--- a/framework/validators/InlineValidator.php
+++ b/framework/validators/InlineValidator.php
@@ -94,7 +94,7 @@ class InlineValidator extends Validator
             if (is_string($method)) {
                 $method = [$model, $method];
             } elseif ($method instanceof \Closure) {
-                $method = $this->method->bindTo($model);
+                $method = $method->bindTo($model);
             }
             $current = $this->current;
             if ($current === null) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18204 
