### PR TITLE
Fix #18203: PDO exception code was not properly passed to `yii\db\Exception`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,7 +12,7 @@ Yii Framework 2 Change Log
 - Bug #18204: Fix 2.0.36 regression in inline validator and JS validation (samdark)
 - Enh #18205: Add `.phpstorm.meta.php` file for better auto-completion in PhpStorm (vjik)
 - Bug #18198: Fix saving tables with trigger by outputting inserted data from insert query with usage of temporary table (darkdef)
-
+- Bug #18203: PDO exception code was not properly passed to `yii\db\Exception` (samdark)
 
 2.0.36 July 07, 2020
 --------------------

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -51,6 +51,12 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to follow the instructions
 for both A and B.
 
+Upgrade from Yii 2.0.36
+-----------------------
+
+* `yii\db\Exception::getCode()` now returns full PDO code that is SQLSTATE string. If you have relied on comparing code
+  with an integer value, adjust your code.
+
 Upgrade from Yii 2.0.35
 -----------------------
 

--- a/framework/db/Exception.php
+++ b/framework/db/Exception.php
@@ -31,8 +31,9 @@ class Exception extends \yii\base\Exception
      */
     public function __construct($message, $errorInfo = [], $code = '', \Exception $previous = null)
     {
+        parent::__construct($message, 0, $previous);
         $this->errorInfo = $errorInfo;
-        parent::__construct($message, $code, $previous);
+        $this->code = $code;
     }
 
     /**

--- a/framework/db/Exception.php
+++ b/framework/db/Exception.php
@@ -26,10 +26,10 @@ class Exception extends \yii\base\Exception
      * Constructor.
      * @param string $message PDO error message
      * @param array $errorInfo PDO error info
-     * @param int $code PDO error code
+     * @param string $code PDO error code
      * @param \Exception $previous The previous exception used for the exception chaining.
      */
-    public function __construct($message, $errorInfo = [], $code = 0, \Exception $previous = null)
+    public function __construct($message, $errorInfo = [], $code = '', \Exception $previous = null)
     {
         $this->errorInfo = $errorInfo;
         parent::__construct($message, $code, $previous);

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -674,7 +674,7 @@ abstract class Schema extends BaseObject
         }
         $message = $e->getMessage() . "\nThe SQL being executed was: $rawSql";
         $errorInfo = $e instanceof \PDOException ? $e->errorInfo : null;
-        return new $exceptionClass($message, $errorInfo, (int)$e->getCode(), $e);
+        return new $exceptionClass($message, $errorInfo, $e->getCode(), $e);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️
| Fixed issues  | #18203
