### PR TITLE
Issue #18248 Render only one stack trace for chained exceptions on console

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Enh #18236: Allow `yii\filters\RateLimiter` to accept a closure function for the `$user` property in order to assign values on runtime (nadar)
+- Bug #18248: Render only one stack trace on console for chained exceptions (mikehaertl)
 - Bug #18233: Add PHP 8 support (samdark)
 - Bug #18239: Fix support of no-extension files for `FileValidator::validateExtension()` (darkdef)
 - Bug #18229: Add flag for recognize SyBase databases on uses pdo_dblib (darkdef)

--- a/framework/console/ErrorHandler.php
+++ b/framework/console/ErrorHandler.php
@@ -29,6 +29,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
      */
     protected function renderException($exception)
     {
+        $previous = $exception->getPrevious();
         if ($exception instanceof UnknownCommandException) {
             // display message and suggest alternatives in case of unknown command
             $message = $this->formatMessage($exception->getName() . ': ') . $exception->command;
@@ -55,7 +56,9 @@ class ErrorHandler extends \yii\base\ErrorHandler
             if ($exception instanceof \yii\db\Exception && !empty($exception->errorInfo)) {
                 $message .= "\n" . $this->formatMessage("Error Info:\n", [Console::BOLD]) . print_r($exception->errorInfo, true);
             }
-            $message .= "\n" . $this->formatMessage("Stack trace:\n", [Console::BOLD]) . $exception->getTraceAsString();
+            if ($previous === null) {
+                $message .= "\n" . $this->formatMessage("Stack trace:\n", [Console::BOLD]) . $exception->getTraceAsString();
+            }
         } else {
             $message = $this->formatMessage('Error: ') . $exception->getMessage();
         }
@@ -65,8 +68,8 @@ class ErrorHandler extends \yii\base\ErrorHandler
         } else {
             echo $message . "\n";
         }
-        if (YII_DEBUG && ($previous = $exception->getPrevious()) !== null) {
-            $causedBy = "\n" . $this->formatMessage('Caused by: ', [Console::BOLD]);
+        if (YII_DEBUG && $previous !== null) {
+            $causedBy = $this->formatMessage('Caused by: ', [Console::BOLD]);
             if (PHP_SAPI === 'cli') {
                 Console::stderr($causedBy);
             } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  |❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18248 
