### PR TITLE
fix error how try get value by index from int

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.38 under development
 ------------------------
 
-- Bug #18269: fixed attempt trying work with int variable how with string in `yii\base\Model`
+- Bug #18269: Fix integer safe attribute to work properly in `yii\base\Model` (Ladone)
 - Enh #18236: Allow `yii\filters\RateLimiter` to accept a closure function for the `$user` property in order to assign values on runtime (nadar)
 - Bug #18233: Add PHP 8 support (samdark)
 - Bug #18239: Fix support of no-extension files for `FileValidator::validateExtension()` (darkdef)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.38 under development
 ------------------------
 
+- Bug #18269: fixed attempt trying work with int variable how with string in `yii\base\Model`
 - Enh #18236: Allow `yii\filters\RateLimiter` to accept a closure function for the `$user` property in order to assign values on runtime (nadar)
 - Bug #18233: Add PHP 8 support (samdark)
 - Bug #18239: Fix support of no-extension files for `FileValidator::validateExtension()` (darkdef)

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -798,7 +798,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
         }
         $attributes = [];
         foreach ($scenarios[$scenario] as $attribute) {
-            if ($attribute[0] !== '!' && !in_array('!' . $attribute, $scenarios[$scenario])) {
+            if (strncmp($attribute, '!', 1) !== 0 && !in_array('!' . $attribute, $scenarios[$scenario])) {
                 $attributes[] = $attribute;
             }
         }

--- a/tests/framework/base/ModelTest.php
+++ b/tests/framework/base/ModelTest.php
@@ -175,7 +175,7 @@ class ModelTest extends TestCase
         $this->assertTrue($speaker->isAttributeSafe('firstName'));
     }
 
-    public function testSafeAttributes(): void
+    public function testSafeAttributes()
     {
         $model = new RulesModel();
         $model->rules = [

--- a/tests/framework/base/ModelTest.php
+++ b/tests/framework/base/ModelTest.php
@@ -175,6 +175,18 @@ class ModelTest extends TestCase
         $this->assertTrue($speaker->isAttributeSafe('firstName'));
     }
 
+    public function testSafeAttributes(): void
+    {
+        $model = new RulesModel();
+        $model->rules = [
+            [
+                [123456], 'safe',
+            ]
+        ];
+
+        $this->assertTrue($model->isAttributeSafe(123456));
+    }
+
     public function testSafeScenarios()
     {
         $model = new RulesModel();

--- a/tests/framework/base/ModelTest.php
+++ b/tests/framework/base/ModelTest.php
@@ -175,7 +175,7 @@ class ModelTest extends TestCase
         $this->assertTrue($speaker->isAttributeSafe('firstName'));
     }
 
-    public function testSafeAttributes()
+    public function testIsAttributeSafeForIntegerAttribute()
     {
         $model = new RulesModel();
         $model->rules = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌ (I'm not know this thermin)
| Tests pass?   | ✔️
| Fixed issues  | https://github.com/yiisoft/yii2/issues/18269

When safeScenario get int value, in condition case try get 0 index from int
```
-  if ($attribute[0] !== '!' && !in_array('!' . $attribute, $scenarios[$scenario])) {
+  if (strncmp($attribute, '!', 1) !== 0 && !in_array('!' . $attribute, $scenarios[$scenario])) {```