### PR TITLE
fix Request::resolvePathInfo urldecode

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -937,8 +937,6 @@ class Request extends \yii\base\Request
             $pathInfo = substr($pathInfo, 0, $pos);
         }
 
-        $pathInfo = urldecode($pathInfo);
-
         // try to encode in UTF8 if not so
         // http://w3.org/International/questions/qa-forms-utf-8.html
         if (!preg_match('%^(?:


### PR DESCRIPTION
Have slug path: `/prod/2%2F3`
which consists of 2 parts: `prod` and `2/3`

Request::resolvePathInfo() doing:
```$pathInfo = urldecode($pathInfo);```

after which path converted into incorrect: `/prod/2/3` 
and now my slug path consists of 3 parts: `prod`, `2` and `3` instead of 2.
Removing incorrect `urldecode` of path fix problem.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | 
| Tests pass?   | 
| Fixed issues  | 18266
