### PR TITLE
#Fix pagination

### DIFF
--- a/framework/data/Pagination.php
+++ b/framework/data/Pagination.php
@@ -343,7 +343,7 @@ class Pagination extends BaseObject implements Linkable
      */
     protected function getQueryParam($name, $defaultValue = null)
     {
-        if (($params = $this->params) === null) {
+        if (!isset($this->params[$name]) || ($params = $this->params) === null) {
             $request = Yii::$app->getRequest();
             $params = $request instanceof Request ? $request->getQueryParams() : [];
         }


### PR DESCRIPTION
$pagination = new Pagination(['params' => ['cate' => 2]]);
that it doesn't work

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
