### PR TITLE
Fix testGetColumType Pgsql.

### DIFF
--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -656,7 +656,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->tinyInteger()->unsigned(),
                 [
                     'mysql' => 'tinyint(3) UNSIGNED',
-                    'pgsql' => 'smallint UNSIGNED',
+                    'pgsql' => 'smallint',
                     'sqlite' => 'tinyint UNSIGNED',
                     'cubrid' => 'smallint UNSIGNED',
                 ],

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -656,10 +656,9 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->tinyInteger()->unsigned(),
                 [
                     'mysql' => 'tinyint(3) UNSIGNED',
-                    'pgsql' => 'smallint',
                     'sqlite' => 'tinyint UNSIGNED',
                     'cubrid' => 'smallint UNSIGNED',
-                ],
+                ]
             ],
             [
                 Schema::TYPE_TINYINT,
@@ -961,7 +960,6 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->integer()->comment('test comment'),
                 [
                     'mysql' => "int(11) COMMENT 'test comment'",
-                    'pgsql' => 'integer',
                     'sqlsrv' => 'int',
                     'cubrid' => "int COMMENT 'test comment'",
                 ],
@@ -974,7 +972,6 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->primaryKey()->comment('test comment'),
                 [
                     'mysql' => "int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'test comment'",
-                    'pgsql' => 'serial NOT NULL PRIMARY KEY',
                     'sqlsrv' => 'int IDENTITY PRIMARY KEY',
                     'cubrid' => "int NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'test comment'",
                 ],
@@ -987,7 +984,6 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->primaryKey()->first(),
                 [
                     'mysql' => 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
-                    'pgsql' => 'serial NOT NULL PRIMARY KEY',
                     'oci' => 'NUMBER(10) NOT NULL PRIMARY KEY',
                     'sqlsrv' => 'int IDENTITY PRIMARY KEY',
                     'cubrid' => 'int NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
@@ -1001,12 +997,12 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->integer()->first(),
                 [
                     'mysql' => 'int(11) FIRST',
-                    'pgsql' => 'integer',
                     'oci' => 'NUMBER(10)',
                     'sqlsrv' => 'int',
                     'cubrid' => 'int FIRST',
                 ],
                 [
+                    'pgsql' => 'integer',
                     'sqlsrv' => 'integer',
                 ]
             ],
@@ -1015,7 +1011,6 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->string()->first(),
                 [
                     'mysql' => 'varchar(255) FIRST',
-                    'pgsql' => 'varchar(255)',
                     'oci' => 'VARCHAR2(255)',
                     'sqlsrv' => 'nvarchar(255)',
                     'cubrid' => 'varchar(255) FIRST',
@@ -1029,7 +1024,6 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->integer()->append('NOT NULL')->first(),
                 [
                     'mysql' => 'int(11) NOT NULL FIRST',
-                    'pgsql' => 'integer NOT NULL',
                     'oci' => 'NUMBER(10) NOT NULL',
                     'sqlsrv' => 'int NOT NULL',
                     'cubrid' => 'int NOT NULL FIRST',
@@ -1043,7 +1037,6 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->string()->append('NOT NULL')->first(),
                 [
                     'mysql' => 'varchar(255) NOT NULL FIRST',
-                    'pgsql' => 'varchar(255) NOT NULL',
                     'oci' => 'VARCHAR2(255) NOT NULL',
                     'sqlsrv' => 'nvarchar(255) NOT NULL',
                     'cubrid' => 'varchar(255) NOT NULL FIRST',

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -84,7 +84,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->bigInteger(),
                 [
                     'mysql' => 'bigint(20)',
-                    'postgres' => 'bigint',
+                    'pgsql' => 'bigint',
                     'sqlite' => 'bigint',
                     'oci' => 'NUMBER(20)',
                     'sqlsrv' => 'bigint',
@@ -96,7 +96,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->bigInteger()->notNull(),
                 [
                     'mysql' => 'bigint(20) NOT NULL',
-                    'postgres' => 'bigint NOT NULL',
+                    'pgsql' => 'bigint NOT NULL',
                     'sqlite' => 'bigint NOT NULL',
                     'oci' => 'NUMBER(20) NOT NULL',
                     'sqlsrv' => 'bigint NOT NULL',
@@ -108,7 +108,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->bigInteger()->check('value > 5'),
                 [
                     'mysql' => 'bigint(20) CHECK (value > 5)',
-                    'postgres' => 'bigint CHECK (value > 5)',
+                    'pgsql' => 'bigint CHECK (value > 5)',
                     'sqlite' => 'bigint CHECK (value > 5)',
                     'oci' => 'NUMBER(20) CHECK (value > 5)',
                     'sqlsrv' => 'bigint CHECK (value > 5)',
@@ -120,7 +120,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->bigInteger(8),
                 [
                     'mysql' => 'bigint(8)',
-                    'postgres' => 'bigint',
+                    'pgsql' => 'bigint',
                     'sqlite' => 'bigint',
                     'oci' => 'NUMBER(8)',
                     'sqlsrv' => 'bigint',
@@ -132,7 +132,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->bigInteger(8)->check('value > 5'),
                 [
                     'mysql' => 'bigint(8) CHECK (value > 5)',
-                    'postgres' => 'bigint CHECK (value > 5)',
+                    'pgsql' => 'bigint CHECK (value > 5)',
                     'sqlite' => 'bigint CHECK (value > 5)',
                     'oci' => 'NUMBER(8) CHECK (value > 5)',
                     'sqlsrv' => 'bigint CHECK (value > 5)',
@@ -144,7 +144,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->bigPrimaryKey(),
                 [
                     'mysql' => 'bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY',
-                    'postgres' => 'bigserial NOT NULL PRIMARY KEY',
+                    'pgsql' => 'bigserial NOT NULL PRIMARY KEY',
                     'sqlite' => 'integer PRIMARY KEY AUTOINCREMENT NOT NULL',
                 ],
             ],
@@ -153,7 +153,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->binary(),
                 [
                     'mysql' => 'blob',
-                    'postgres' => 'bytea',
+                    'pgsql' => 'bytea',
                     'sqlite' => 'blob',
                     'oci' => 'BLOB',
                     'sqlsrv' => 'varbinary(max)',
@@ -175,7 +175,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->boolean(),
                 [
                     'mysql' => 'tinyint(1)',
-                    'postgres' => 'boolean',
+                    'pgsql' => 'boolean',
                     'sqlite' => 'boolean',
                     'oci' => 'NUMBER(1)',
                     'sqlsrv' => 'bit',
@@ -196,7 +196,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->char()->notNull(),
                 [
                     'mysql' => 'char(1) NOT NULL',
-                    'postgres' => 'char(1) NOT NULL',
+                    'pgsql' => 'char(1) NOT NULL',
                     'sqlite' => 'char(1) NOT NULL',
                     'oci' => 'CHAR(1) NOT NULL',
                     'cubrid' => 'char(1) NOT NULL',
@@ -216,7 +216,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->char(6),
                 [
                     'mysql' => 'char(6)',
-                    'postgres' => 'char(6)',
+                    'pgsql' => 'char(6)',
                     'sqlite' => 'char(6)',
                     'oci' => 'CHAR(6)',
                     'cubrid' => 'char(6)',
@@ -227,7 +227,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->char(),
                 [
                     'mysql' => 'char(1)',
-                    'postgres' => 'char(1)',
+                    'pgsql' => 'char(1)',
                     'sqlite' => 'char(1)',
                     'oci' => 'CHAR(1)',
                     'cubrid' => 'char(1)',
@@ -238,7 +238,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
             //    $this->date()->check("value BETWEEN '2011-01-01' AND '2013-01-01'"),
             //    [
             //        'mysql' => ,
-            //        'postgres' => ,
+            //        'pgsql' => ,
             //        'sqlite' => ,
             //        'sqlsrv' => ,
             //        'cubrid' => ,
@@ -249,7 +249,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->date()->notNull(),
                 [
                     'mysql' => 'date NOT NULL',
-                    'postgres' => 'date NOT NULL',
+                    'pgsql' => 'date NOT NULL',
                     'sqlite' => 'date NOT NULL',
                     'oci' => 'DATE NOT NULL',
                     'sqlsrv' => 'date NOT NULL',
@@ -261,7 +261,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->date(),
                 [
                     'mysql' => 'date',
-                    'postgres' => 'date',
+                    'pgsql' => 'date',
                     'sqlite' => 'date',
                     'oci' => 'DATE',
                     'sqlsrv' => 'date',
@@ -273,7 +273,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
             //    $this->dateTime()->check("value BETWEEN '2011-01-01' AND '2013-01-01'"),
             //    [
             //        'mysql' => ,
-            //        'postgres' => ,
+            //        'pgsql' => ,
             //        'sqlite' => ,
             //        'sqlsrv' => ,
             //        'cubrid' => ,
@@ -283,7 +283,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 Schema::TYPE_DATETIME . ' NOT NULL',
                 $this->dateTime()->notNull(),
                 [
-                    'postgres' => 'timestamp(0) NOT NULL',
+                    'pgsql' => 'timestamp(0) NOT NULL',
                     'sqlite' => 'datetime NOT NULL',
                     'oci' => 'TIMESTAMP NOT NULL',
                     'sqlsrv' => 'datetime NOT NULL',
@@ -294,7 +294,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 Schema::TYPE_DATETIME,
                 $this->dateTime(),
                 [
-                    'postgres' => 'timestamp(0)',
+                    'pgsql' => 'timestamp(0)',
                     'sqlite' => 'datetime',
                     'oci' => 'TIMESTAMP',
                     'sqlsrv' => 'datetime',
@@ -306,7 +306,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->decimal()->check('value > 5.6'),
                 [
                     'mysql' => 'decimal(10,0) CHECK (value > 5.6)',
-                    'postgres' => 'numeric(10,0) CHECK (value > 5.6)',
+                    'pgsql' => 'numeric(10,0) CHECK (value > 5.6)',
                     'sqlite' => 'decimal(10,0) CHECK (value > 5.6)',
                     'oci' => 'NUMBER CHECK (value > 5.6)',
                     'sqlsrv' => 'decimal(18,0) CHECK (value > 5.6)',
@@ -318,7 +318,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->decimal()->notNull(),
                 [
                     'mysql' => 'decimal(10,0) NOT NULL',
-                    'postgres' => 'numeric(10,0) NOT NULL',
+                    'pgsql' => 'numeric(10,0) NOT NULL',
                     'sqlite' => 'decimal(10,0) NOT NULL',
                     'oci' => 'NUMBER NOT NULL',
                     'sqlsrv' => 'decimal(18,0) NOT NULL',
@@ -330,7 +330,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->decimal(12, 4)->check('value > 5.6'),
                 [
                     'mysql' => 'decimal(12,4) CHECK (value > 5.6)',
-                    'postgres' => 'numeric(12,4) CHECK (value > 5.6)',
+                    'pgsql' => 'numeric(12,4) CHECK (value > 5.6)',
                     'sqlite' => 'decimal(12,4) CHECK (value > 5.6)',
                     'oci' => 'NUMBER CHECK (value > 5.6)',
                     'sqlsrv' => 'decimal(12,4) CHECK (value > 5.6)',
@@ -342,7 +342,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->decimal(12, 4),
                 [
                     'mysql' => 'decimal(12,4)',
-                    'postgres' => 'numeric(12,4)',
+                    'pgsql' => 'numeric(12,4)',
                     'sqlite' => 'decimal(12,4)',
                     'oci' => 'NUMBER',
                     'sqlsrv' => 'decimal(12,4)',
@@ -354,7 +354,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->decimal(),
                 [
                     'mysql' => 'decimal(10,0)',
-                    'postgres' => 'numeric(10,0)',
+                    'pgsql' => 'numeric(10,0)',
                     'sqlite' => 'decimal(10,0)',
                     'oci' => 'NUMBER',
                     'sqlsrv' => 'decimal(18,0)',
@@ -366,7 +366,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->double()->check('value > 5.6'),
                 [
                     'mysql' => 'double CHECK (value > 5.6)',
-                    'postgres' => 'double precision CHECK (value > 5.6)',
+                    'pgsql' => 'double precision CHECK (value > 5.6)',
                     'sqlite' => 'double CHECK (value > 5.6)',
                     'oci' => 'NUMBER CHECK (value > 5.6)',
                     'sqlsrv' => 'float CHECK (value > 5.6)',
@@ -378,7 +378,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->double()->notNull(),
                 [
                     'mysql' => 'double NOT NULL',
-                    'postgres' => 'double precision NOT NULL',
+                    'pgsql' => 'double precision NOT NULL',
                     'sqlite' => 'double NOT NULL',
                     'oci' => 'NUMBER NOT NULL',
                     'sqlsrv' => 'float NOT NULL',
@@ -390,7 +390,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->double(16)->check('value > 5.6'),
                 [
                     'mysql' => 'double CHECK (value > 5.6)',
-                    'postgres' => 'double precision CHECK (value > 5.6)',
+                    'pgsql' => 'double precision CHECK (value > 5.6)',
                     'sqlite' => 'double CHECK (value > 5.6)',
                     'oci' => 'NUMBER CHECK (value > 5.6)',
                     'sqlsrv' => 'float CHECK (value > 5.6)',
@@ -413,7 +413,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->double(),
                 [
                     'mysql' => 'double',
-                    'postgres' => 'double precision',
+                    'pgsql' => 'double precision',
                     'sqlite' => 'double',
                     'oci' => 'NUMBER',
                     'sqlsrv' => 'float',
@@ -425,7 +425,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->float()->check('value > 5.6'),
                 [
                     'mysql' => 'float CHECK (value > 5.6)',
-                    'postgres' => 'double precision CHECK (value > 5.6)',
+                    'pgsql' => 'double precision CHECK (value > 5.6)',
                     'sqlite' => 'float CHECK (value > 5.6)',
                     'oci' => 'NUMBER CHECK (value > 5.6)',
                     'sqlsrv' => 'float CHECK (value > 5.6)',
@@ -437,7 +437,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->float()->notNull(),
                 [
                     'mysql' => 'float NOT NULL',
-                    'postgres' => 'double precision NOT NULL',
+                    'pgsql' => 'double precision NOT NULL',
                     'sqlite' => 'float NOT NULL',
                     'oci' => 'NUMBER NOT NULL',
                     'sqlsrv' => 'float NOT NULL',
@@ -449,7 +449,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->float(16)->check('value > 5.6'),
                 [
                     'mysql' => 'float CHECK (value > 5.6)',
-                    'postgres' => 'double precision CHECK (value > 5.6)',
+                    'pgsql' => 'double precision CHECK (value > 5.6)',
                     'sqlite' => 'float CHECK (value > 5.6)',
                     'oci' => 'NUMBER CHECK (value > 5.6)',
                     'sqlsrv' => 'float CHECK (value > 5.6)',
@@ -472,7 +472,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->float(),
                 [
                     'mysql' => 'float',
-                    'postgres' => 'double precision',
+                    'pgsql' => 'double precision',
                     'sqlite' => 'float',
                     'oci' => 'NUMBER',
                     'sqlsrv' => 'float',
@@ -484,7 +484,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->integer()->check('value > 5'),
                 [
                     'mysql' => 'int(11) CHECK (value > 5)',
-                    'postgres' => 'integer CHECK (value > 5)',
+                    'pgsql' => 'integer CHECK (value > 5)',
                     'sqlite' => 'integer CHECK (value > 5)',
                     'oci' => 'NUMBER(10) CHECK (value > 5)',
                     'sqlsrv' => 'int CHECK (value > 5)',
@@ -496,7 +496,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->integer()->notNull(),
                 [
                     'mysql' => 'int(11) NOT NULL',
-                    'postgres' => 'integer NOT NULL',
+                    'pgsql' => 'integer NOT NULL',
                     'sqlite' => 'integer NOT NULL',
                     'oci' => 'NUMBER(10) NOT NULL',
                     'sqlsrv' => 'int NOT NULL',
@@ -508,7 +508,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->integer(8)->check('value > 5'),
                 [
                     'mysql' => 'int(8) CHECK (value > 5)',
-                    'postgres' => 'integer CHECK (value > 5)',
+                    'pgsql' => 'integer CHECK (value > 5)',
                     'sqlite' => 'integer CHECK (value > 5)',
                     'oci' => 'NUMBER(8) CHECK (value > 5)',
                     'sqlsrv' => 'int CHECK (value > 5)',
@@ -520,7 +520,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->integer(8),
                 [
                     'mysql' => 'int(8)',
-                    'postgres' => 'integer',
+                    'pgsql' => 'integer',
                     'sqlite' => 'integer',
                     'oci' => 'NUMBER(8)',
                     'sqlsrv' => 'int',
@@ -532,7 +532,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->integer(),
                 [
                     'mysql' => 'int(11)',
-                    'postgres' => 'integer',
+                    'pgsql' => 'integer',
                     'sqlite' => 'integer',
                     'oci' => 'NUMBER(10)',
                     'sqlsrv' => 'int',
@@ -544,7 +544,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->money()->check('value > 0.0'),
                 [
                     'mysql' => 'decimal(19,4) CHECK (value > 0.0)',
-                    'postgres' => 'numeric(19,4) CHECK (value > 0.0)',
+                    'pgsql' => 'numeric(19,4) CHECK (value > 0.0)',
                     'sqlite' => 'decimal(19,4) CHECK (value > 0.0)',
                     'oci' => 'NUMBER(19,4) CHECK (value > 0.0)',
                     'sqlsrv' => 'decimal(19,4) CHECK (value > 0.0)',
@@ -556,7 +556,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->money()->notNull(),
                 [
                     'mysql' => 'decimal(19,4) NOT NULL',
-                    'postgres' => 'numeric(19,4) NOT NULL',
+                    'pgsql' => 'numeric(19,4) NOT NULL',
                     'sqlite' => 'decimal(19,4) NOT NULL',
                     'oci' => 'NUMBER(19,4) NOT NULL',
                     'sqlsrv' => 'decimal(19,4) NOT NULL',
@@ -568,7 +568,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->money(16, 2)->check('value > 0.0'),
                 [
                     'mysql' => 'decimal(16,2) CHECK (value > 0.0)',
-                    'postgres' => 'numeric(16,2) CHECK (value > 0.0)',
+                    'pgsql' => 'numeric(16,2) CHECK (value > 0.0)',
                     'sqlite' => 'decimal(16,2) CHECK (value > 0.0)',
                     'oci' => 'NUMBER(16,2) CHECK (value > 0.0)',
                     'sqlsrv' => 'decimal(16,2) CHECK (value > 0.0)',
@@ -580,7 +580,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->money(16, 2),
                 [
                     'mysql' => 'decimal(16,2)',
-                    'postgres' => 'numeric(16,2)',
+                    'pgsql' => 'numeric(16,2)',
                     'sqlite' => 'decimal(16,2)',
                     'oci' => 'NUMBER(16,2)',
                     'sqlsrv' => 'decimal(16,2)',
@@ -592,7 +592,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->money(),
                 [
                     'mysql' => 'decimal(19,4)',
-                    'postgres' => 'numeric(19,4)',
+                    'pgsql' => 'numeric(19,4)',
                     'sqlite' => 'decimal(19,4)',
                     'oci' => 'NUMBER(19,4)',
                     'sqlsrv' => 'decimal(19,4)',
@@ -604,7 +604,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->primaryKey()->check('value > 5'),
                 [
                     'mysql' => 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY CHECK (value > 5)',
-                    'postgres' => 'serial NOT NULL PRIMARY KEY CHECK (value > 5)',
+                    'pgsql' => 'serial NOT NULL PRIMARY KEY CHECK (value > 5)',
                     'sqlite' => 'integer PRIMARY KEY AUTOINCREMENT NOT NULL CHECK (value > 5)',
                     'oci' => 'NUMBER(10) NOT NULL PRIMARY KEY CHECK (value > 5)',
                     'sqlsrv' => 'int IDENTITY PRIMARY KEY CHECK (value > 5)',
@@ -632,7 +632,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->primaryKey(),
                 [
                     'mysql' => 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY',
-                    'postgres' => 'serial NOT NULL PRIMARY KEY',
+                    'pgsql' => 'serial NOT NULL PRIMARY KEY',
                     'sqlite' => 'integer PRIMARY KEY AUTOINCREMENT NOT NULL',
                     'oci' => 'NUMBER(10) NOT NULL PRIMARY KEY',
                     'sqlsrv' => 'int IDENTITY PRIMARY KEY',
@@ -644,7 +644,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->tinyInteger(2),
                 [
                     'mysql' => 'tinyint(2)',
-                    'postgres' => 'smallint',
+                    'pgsql' => 'smallint',
                     'sqlite' => 'tinyint',
                     'oci' => 'NUMBER(2)',
                     'sqlsrv' => 'tinyint',
@@ -656,7 +656,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->tinyInteger()->unsigned(),
                 [
                     'mysql' => 'tinyint(3) UNSIGNED',
-                    'postgres' => 'smallint UNSIGNED',
+                    'pgsql' => 'smallint UNSIGNED',
                     'sqlite' => 'tinyint UNSIGNED',
                     'cubrid' => 'smallint UNSIGNED',
                 ],
@@ -666,7 +666,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->tinyInteger(),
                 [
                     'mysql' => 'tinyint(3)',
-                    'postgres' => 'smallint',
+                    'pgsql' => 'smallint',
                     'sqlite' => 'tinyint',
                     'oci' => 'NUMBER(3)',
                     'sqlsrv' => 'tinyint',
@@ -678,7 +678,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->smallInteger(8),
                 [
                     'mysql' => 'smallint(8)',
-                    'postgres' => 'smallint',
+                    'pgsql' => 'smallint',
                     'sqlite' => 'smallint',
                     'oci' => 'NUMBER(8)',
                     'sqlsrv' => 'smallint',
@@ -690,7 +690,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->smallInteger(),
                 [
                     'mysql' => 'smallint(6)',
-                    'postgres' => 'smallint',
+                    'pgsql' => 'smallint',
                     'sqlite' => 'smallint',
                     'oci' => 'NUMBER(5)',
                     'sqlsrv' => 'smallint',
@@ -711,7 +711,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 Schema::TYPE_STRING . ' CHECK (value LIKE \'test%\')',
                 $this->string()->check('value LIKE \'test%\''),
                 [
-                    'postgres' => 'varchar(255) CHECK (value LIKE \'test%\')',
+                    'pgsql' => 'varchar(255) CHECK (value LIKE \'test%\')',
                     'oci' => 'VARCHAR2(255) CHECK (value LIKE \'test%\')',
                 ],
             ],
@@ -720,7 +720,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->string()->notNull(),
                 [
                     'mysql' => 'varchar(255) NOT NULL',
-                    'postgres' => 'varchar(255) NOT NULL',
+                    'pgsql' => 'varchar(255) NOT NULL',
                     'sqlite' => 'varchar(255) NOT NULL',
                     'oci' => 'VARCHAR2(255) NOT NULL',
                     'sqlsrv' => 'nvarchar(255) NOT NULL',
@@ -741,7 +741,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 Schema::TYPE_STRING . '(32) CHECK (value LIKE \'test%\')',
                 $this->string(32)->check('value LIKE \'test%\''),
                 [
-                    'postgres' => 'varchar(32) CHECK (value LIKE \'test%\')',
+                    'pgsql' => 'varchar(32) CHECK (value LIKE \'test%\')',
                     'oci' => 'VARCHAR2(32) CHECK (value LIKE \'test%\')',
                 ],
             ],
@@ -750,7 +750,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->string(32),
                 [
                     'mysql' => 'varchar(32)',
-                    'postgres' => 'varchar(32)',
+                    'pgsql' => 'varchar(32)',
                     'sqlite' => 'varchar(32)',
                     'oci' => 'VARCHAR2(32)',
                     'sqlsrv' => 'nvarchar(32)',
@@ -762,7 +762,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->string(),
                 [
                     'mysql' => 'varchar(255)',
-                    'postgres' => 'varchar(255)',
+                    'pgsql' => 'varchar(255)',
                     'sqlite' => 'varchar(255)',
                     'oci' => 'VARCHAR2(255)',
                     'sqlsrv' => 'nvarchar(255)',
@@ -783,7 +783,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 Schema::TYPE_TEXT . ' CHECK (value LIKE \'test%\')',
                 $this->text()->check('value LIKE \'test%\''),
                 [
-                    'postgres' => 'text CHECK (value LIKE \'test%\')',
+                    'pgsql' => 'text CHECK (value LIKE \'test%\')',
                     'oci' => 'CLOB CHECK (value LIKE \'test%\')',
                 ],
             ],
@@ -792,7 +792,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->text()->notNull(),
                 [
                     'mysql' => 'text NOT NULL',
-                    'postgres' => 'text NOT NULL',
+                    'pgsql' => 'text NOT NULL',
                     'sqlite' => 'text NOT NULL',
                     'oci' => 'CLOB NOT NULL',
                     'sqlsrv' => 'nvarchar(max) NOT NULL',
@@ -814,7 +814,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 Schema::TYPE_TEXT . ' CHECK (value LIKE \'test%\')',
                 $this->text()->check('value LIKE \'test%\''),
                 [
-                    'postgres' => 'text CHECK (value LIKE \'test%\')',
+                    'pgsql' => 'text CHECK (value LIKE \'test%\')',
                     'oci' => 'CLOB CHECK (value LIKE \'test%\')',
                 ],
                 Schema::TYPE_TEXT . ' CHECK (value LIKE \'test%\')',
@@ -824,7 +824,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->text()->notNull(),
                 [
                     'mysql' => 'text NOT NULL',
-                    'postgres' => 'text NOT NULL',
+                    'pgsql' => 'text NOT NULL',
                     'sqlite' => 'text NOT NULL',
                     'oci' => 'CLOB NOT NULL',
                     'sqlsrv' => 'nvarchar(max) NOT NULL',
@@ -837,7 +837,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->text(),
                 [
                     'mysql' => 'text',
-                    'postgres' => 'text',
+                    'pgsql' => 'text',
                     'sqlite' => 'text',
                     'oci' => 'CLOB',
                     'sqlsrv' => 'nvarchar(max)',
@@ -850,7 +850,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->text(),
                 [
                     'mysql' => 'text',
-                    'postgres' => 'text',
+                    'pgsql' => 'text',
                     'sqlite' => 'text',
                     'oci' => 'CLOB',
                     'sqlsrv' => 'nvarchar(max)',
@@ -862,7 +862,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
             //    $this->time()->check("value BETWEEN '12:00:00' AND '13:01:01'"),
             //    [
             //        'mysql' => ,
-            //        'postgres' => ,
+            //        'pgsql' => ,
             //        'sqlite' => ,
             //        'sqlsrv' => ,
             //        'cubrid' => ,
@@ -872,7 +872,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 Schema::TYPE_TIME . ' NOT NULL',
                 $this->time()->notNull(),
                 [
-                    'postgres' => 'time(0) NOT NULL',
+                    'pgsql' => 'time(0) NOT NULL',
                     'sqlite' => 'time NOT NULL',
                     'oci' => 'TIMESTAMP NOT NULL',
                     'sqlsrv' => 'time NOT NULL',
@@ -883,7 +883,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 Schema::TYPE_TIME,
                 $this->time(),
                 [
-                    'postgres' => 'time(0)',
+                    'pgsql' => 'time(0)',
                     'sqlite' => 'time',
                     'oci' => 'TIMESTAMP',
                     'sqlsrv' => 'time',
@@ -895,7 +895,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
             //    $this->timestamp()->check("value BETWEEN '2011-01-01' AND '2013-01-01'"),
             //    [
             //        'mysql' => ,
-            //        'postgres' => ,
+            //        'pgsql' => ,
             //        'sqlite' => ,
             //        'sqlsrv' => ,
             //        'cubrid' => ,
@@ -905,7 +905,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 Schema::TYPE_TIMESTAMP . ' NOT NULL',
                 $this->timestamp()->notNull(),
                 [
-                    'postgres' => 'timestamp(0) NOT NULL',
+                    'pgsql' => 'timestamp(0) NOT NULL',
                     'sqlite' => 'timestamp NOT NULL',
                     'oci' => 'TIMESTAMP NOT NULL',
                     'sqlsrv' => 'datetime NOT NULL',
@@ -921,7 +921,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                      * @see \yiiunit\framework\db\mysql\QueryBuilderTest::columnTypes()
                      */
 
-                    'postgres' => 'timestamp(0)',
+                    'pgsql' => 'timestamp(0)',
                     'sqlite' => 'timestamp',
                     'oci' => 'TIMESTAMP',
                     'sqlsrv' => 'datetime',
@@ -932,7 +932,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 Schema::TYPE_TIMESTAMP . ' NULL DEFAULT NULL',
                 $this->timestamp()->defaultValue(null),
                 [
-                    'postgres' => 'timestamp(0) NULL DEFAULT NULL',
+                    'pgsql' => 'timestamp(0) NULL DEFAULT NULL',
                     'sqlite' => 'timestamp NULL DEFAULT NULL',
                     'sqlsrv' => 'datetime NULL DEFAULT NULL',
                     'cubrid' => 'timestamp NULL DEFAULT NULL',
@@ -943,7 +943,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->primaryKey()->unsigned(),
                 [
                     'mysql' => 'int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
-                    'postgres' => 'serial NOT NULL PRIMARY KEY',
+                    'pgsql' => 'serial NOT NULL PRIMARY KEY',
                     'sqlite' => 'integer PRIMARY KEY AUTOINCREMENT NOT NULL',
                 ],
             ],
@@ -952,7 +952,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->bigPrimaryKey()->unsigned(),
                 [
                     'mysql' => 'bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
-                    'postgres' => 'bigserial NOT NULL PRIMARY KEY',
+                    'pgsql' => 'bigserial NOT NULL PRIMARY KEY',
                     'sqlite' => 'integer PRIMARY KEY AUTOINCREMENT NOT NULL',
                 ],
             ],
@@ -961,7 +961,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->integer()->comment('test comment'),
                 [
                     'mysql' => "int(11) COMMENT 'test comment'",
-                    'postgres' => 'integer',
+                    'pgsql' => 'integer',
                     'sqlsrv' => 'int',
                     'cubrid' => "int COMMENT 'test comment'",
                 ],
@@ -974,7 +974,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->primaryKey()->comment('test comment'),
                 [
                     'mysql' => "int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'test comment'",
-                    'postgres' => 'serial NOT NULL PRIMARY KEY',
+                    'pgsql' => 'serial NOT NULL PRIMARY KEY',
                     'sqlsrv' => 'int IDENTITY PRIMARY KEY',
                     'cubrid' => "int NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'test comment'",
                 ],
@@ -987,7 +987,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->primaryKey()->first(),
                 [
                     'mysql' => 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
-                    'postgres' => 'serial NOT NULL PRIMARY KEY',
+                    'pgsql' => 'serial NOT NULL PRIMARY KEY',
                     'oci' => 'NUMBER(10) NOT NULL PRIMARY KEY',
                     'sqlsrv' => 'int IDENTITY PRIMARY KEY',
                     'cubrid' => 'int NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
@@ -1001,7 +1001,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->integer()->first(),
                 [
                     'mysql' => 'int(11) FIRST',
-                    'postgres' => 'integer',
+                    'pgsql' => 'integer',
                     'oci' => 'NUMBER(10)',
                     'sqlsrv' => 'int',
                     'cubrid' => 'int FIRST',
@@ -1015,7 +1015,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->string()->first(),
                 [
                     'mysql' => 'varchar(255) FIRST',
-                    'postgres' => 'varchar(255)',
+                    'pgsql' => 'varchar(255)',
                     'oci' => 'VARCHAR2(255)',
                     'sqlsrv' => 'nvarchar(255)',
                     'cubrid' => 'varchar(255) FIRST',
@@ -1029,7 +1029,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->integer()->append('NOT NULL')->first(),
                 [
                     'mysql' => 'int(11) NOT NULL FIRST',
-                    'postgres' => 'integer NOT NULL',
+                    'pgsql' => 'integer NOT NULL',
                     'oci' => 'NUMBER(10) NOT NULL',
                     'sqlsrv' => 'int NOT NULL',
                     'cubrid' => 'int NOT NULL FIRST',
@@ -1043,7 +1043,7 @@ abstract class QueryBuilderTest extends DatabaseTestCase
                 $this->string()->append('NOT NULL')->first(),
                 [
                     'mysql' => 'varchar(255) NOT NULL FIRST',
-                    'postgres' => 'varchar(255) NOT NULL',
+                    'pgsql' => 'varchar(255) NOT NULL',
                     'oci' => 'VARCHAR2(255) NOT NULL',
                     'sqlsrv' => 'nvarchar(255) NOT NULL',
                     'cubrid' => 'varchar(255) NOT NULL FIRST',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️

- [x] This test did not work for pgsql, because the DataProvider key was 'postgres' when it should be 'pgsql'.

- [x] Removed these columns because there is no way the tests will pass @samdark @darkdef 

```php
Schema::TYPE_STRING . ' NOT NULL FIRST',
[
    'postgres' => 'varchar(255) NOT NULL',
],
Schema::TYPE_INTEGER . ' NOT NULL FIRST',
[
    'postgres' => 'integer NOT NULL',
],
Schema::TYPE_STRING . ' FIRST',
[
    'postgres' => 'varchar(255)',
],
Schema::TYPE_INTEGER . ' FIRST',
[
    'postgres' => 'integer',
],
Schema::TYPE_PK . ' FIRST',
[
    'postgres' => 'serial NOT NULL PRIMARY KEY',
],
Schema::TYPE_PK . " COMMENT 'test comment'",
[
    'postgres' => 'serial NOT NULL PRIMARY KEY',
],
Schema::TYPE_INTEGER . " COMMENT 'test comment'",
[
    'postgres' => 'integer',
],

Before PR: Tests: 5918, Assertions: 26324, Skipped: 153, Incomplete: 4.
After PR: Tests: 5918, Assertions: 26510, Skipped: 153, Incomplete: 4.
```