### PR TITLE
fix for non-seekable streams

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM ${DOCKER_YII2_PHP_IMAGE}
 # Project source-code
 WORKDIR /project
 ADD composer.* /project/
+# Apply testing patches
+ADD tests/phpunit_mock_objects.patch /project/tests/phpunit_mock_objects.patch
+ADD tests/phpunit_getopt.patch /project/tests/phpunit_getopt.patch
+# Install packgaes
 RUN /usr/local/bin/composer install --prefer-dist
 ADD ./ /project
 ENV PATH /project/vendor/bin:${PATH}

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.39 under development
 ------------------------
 
-- Bug #18290: Test and fix for non-seekable streams (schmunk42)
+- Bug #18290: Fix response with non-seekable streams (schmunk42)
 - Bug #16418: Fixed `yii\data\Pagination::getLinks()` to return links to the first and the last pages regardless of the current page (ptz-nerf, bizley)
 - Bug #18297: Replace usage of deprecated `ReflectionParameter::isArray()` method in PHP8 (baletskyi)
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.39 under development
 ------------------------
 
-- no changes in this release.
+- Bug #18290: Test and fix for non-seekable streams (schmunk42)
 
 
 2.0.38 September 14, 2020

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -590,8 +590,10 @@ class Response extends \yii\base\Response
         } else {
             if ($this->isSeekable($handle)) {
                 fseek($handle, 0, SEEK_END);
+                $fileSize = ftell($handle);
+            } else {
+                $fileSize = 0;
             }
-            $fileSize = ftell($handle);
         }
 
         $range = $this->getHttpRange($fileSize);

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -441,7 +441,13 @@ class Response extends \yii\base\Response
 
         if (is_array($this->stream)) {
             list($handle, $begin, $end) = $this->stream;
-            fseek($handle, $begin);
+
+            // only seek if stream is seekable
+            $metaData = stream_get_meta_data($handle);
+            if (isset($metaData['seekable']) && $metaData['seekable'] === true) {
+                fseek($handle, $begin);
+            }
+
             while (!feof($handle) && ($pos = ftell($handle)) <= $end) {
                 if ($pos + $chunkSize > $end) {
                     $chunkSize = $end - $pos + 1;

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -1103,7 +1103,8 @@ class Response extends \yii\base\Response
      * @param $handle
      * @return bool
      */
-    private function isSeekable($handle){
+    private function isSeekable($handle)
+    {
         if (!is_resource($handle)) {
             return true;
         }

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -443,8 +443,7 @@ class Response extends \yii\base\Response
             list($handle, $begin, $end) = $this->stream;
 
             // only seek if stream is seekable
-            $metaData = stream_get_meta_data($handle);
-            if (isset($metaData['seekable']) && $metaData['seekable'] === true) {
+            if ($this->isSeekable($handle)) {
                 fseek($handle, $begin);
             }
 
@@ -589,7 +588,9 @@ class Response extends \yii\base\Response
         if (isset($options['fileSize'])) {
             $fileSize = $options['fileSize'];
         } else {
-            fseek($handle, 0, SEEK_END);
+            if ($this->isSeekable($handle)) {
+                fseek($handle, 0, SEEK_END);
+            }
             $fileSize = ftell($handle);
         }
 
@@ -1093,6 +1094,23 @@ class Response extends \yii\base\Response
             } else {
                 throw new InvalidArgumentException('Response content must be a string or an object implementing __toString().');
             }
+        }
+    }
+
+    /**
+     * Checks if a stream is seekable
+     *
+     * @param $handle
+     * @return bool
+     */
+    private function isSeekable($handle){
+        if (!is_resource($handle)) {
+            return true;
+        }
+
+        $metaData = stream_get_meta_data($handle);
+        if (isset($metaData['seekable']) && $metaData['seekable'] === true) {
+            return true;
         }
     }
 }

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -1110,8 +1110,6 @@ class Response extends \yii\base\Response
         }
 
         $metaData = stream_get_meta_data($handle);
-        if (isset($metaData['seekable']) && $metaData['seekable'] === true) {
-            return true;
-        }
+        return isset($metaData['seekable']) && $metaData['seekable'] === true;
     }
 }

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -191,6 +191,9 @@ class ResponseTest extends \yiiunit\TestCase
         $this->assertEquals($statusCode, $this->response->getStatusCode());
     }
 
+    /**
+     * @see https://github.com/yiisoft/yii2/pull/18290
+     */
     public function testNonSeekableStream()
     {
         $stream = fopen('php://output', 'r+');

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -201,7 +201,7 @@ class ResponseTest extends \yiiunit\TestCase
         $this->response
             ->sendStreamAsFile($stream, 'test-stream')
             ->send();
-        $content = ob_get_clean();
+        ob_get_clean();
         static::assertEquals(200, $this->response->statusCode);
     }
 

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -191,6 +191,17 @@ class ResponseTest extends \yiiunit\TestCase
         $this->assertEquals($statusCode, $this->response->getStatusCode());
     }
 
+    public function testNonSeekableStream()
+    {
+        $stream = fopen('php://output', 'r+');
+        ob_start();
+        $this->response
+            ->sendStreamAsFile($stream, 'test-stream')
+            ->send();
+        $content = ob_get_clean();
+        static::assertEquals(200, $this->response->statusCode);
+    }
+
     public function dataProviderSetStatusCodeByException()
     {
         $data = [


### PR DESCRIPTION
prevents error message `fseek(): stream does not support seeking`

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | should not
| Tests pass?   | see CI
| Fixed issues  | Issue from Slack "eseperio 1.9.2020"

In our case we got streams (images) from AWS S3 which threw the above error.
We could not determine the underlying reason, but in all cases we need to check if a stream is seekable before calling `fseek()`, this might also apply to other code in the `Response` class.

CC: @eluhr @handcode