### PR TITLE
Update phpdoc for widget->getId

### DIFF
--- a/framework/base/Widget.php
+++ b/framework/base/Widget.php
@@ -156,7 +156,7 @@ class Widget extends Component implements ViewContextInterface
     /**
      * Returns the ID of the widget.
      * @param bool $autoGenerate whether to generate an ID if it is not set previously
-     * @return string ID of the widget.
+     * @return string|null ID of the widget.
      */
     public function getId($autoGenerate = true)
     {


### PR DESCRIPTION
The private variable `$_id`  is only set when `$autogenerate` is true, else it stays null, and will be returned by the function.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    |❌
| Tests pass?   | ?
| Fixed issues  | 
