### PR TITLE
Updated phpdoc return type for getExceptionName

### DIFF
--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -483,7 +483,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
     /**
      * Returns human-readable exception name.
      * @param \Exception $exception
-     * @return string human-readable exception name or null if it cannot be determined
+     * @return string|null human-readable exception name or null if it cannot be determined
      */
     public function getExceptionName($exception)
     {


### PR DESCRIPTION
`getExceptionName` can return null, as described in phpdoc.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | 
| Fixed issues  | 
