### PR TITLE
Fix #18297: Fix Controller (web and console) to work with php8

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #16418: Fixed `yii\data\Pagination::getLinks()` to return links to the first and the last pages regardless of the current page (ptz-nerf, bizley)
+- Bug #18297: Replace usage of deprecated `ReflectionParameter::isArray()` method in PHP8 (baletskyi)
 
 
 2.0.38 September 14, 2020

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -211,7 +211,12 @@ class Controller extends \yii\base\Controller
             }
 
             if ($key !== null) {
-                if ($param->isArray()) {
+                if (PHP_VERSION_ID >= 80000) {
+                    $isArray = ($type = $param->getType()) instanceof \ReflectionNamedType && $type->getName() === 'array';
+                } else {
+                    $isArray = $param->isArray();
+                }
+                if ($isArray) {
                     $params[$key] = $params[$key] === '' ? [] : preg_split('/\s*,\s*/', $params[$key]);
                 }
                 $args[] = $actionParams[$key] = $params[$key];

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -8,7 +8,6 @@
 namespace yii\web;
 
 use Yii;
-use yii\base\ErrorException;
 use yii\base\Exception;
 use yii\base\InlineAction;
 use yii\helpers\Url;
@@ -130,7 +129,12 @@ class Controller extends \yii\base\Controller
             $name = $param->getName();
             if (array_key_exists($name, $params)) {
                 $isValid = true;
-                if ($param->isArray()) {
+                if (PHP_VERSION_ID >= 80000) {
+                    $isArray = ($type = $param->getType()) instanceof \ReflectionNamedType && $type->getName() === 'array';
+                } else {
+                    $isArray = $param->isArray();
+                }
+                if ($isArray) {
                     $params[$name] = (array)$params[$name];
                 } elseif (is_array($params[$name])) {
                     $isValid = false;


### PR DESCRIPTION
Replace usage of deprecated `ReflectionParameter::isArray()` method with `ReflectionNamedType::getName() === 'array'` in PHP8

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️(PHP7.4) / ✔️(PHP8.0)
| Fixed issues  | #18297
