### PR TITLE
Updates to ErrorHandler, add missing type hint \Throwable

### DIFF
--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -298,7 +298,7 @@ abstract class ErrorHandler extends Component
 
     /**
      * Renders the exception.
-     * @param \Exception $exception the exception to be rendered.
+     * @param \Exception|\Error\Throwable $exception the exception to be rendered.
      */
     abstract protected function renderException($exception);
 
@@ -336,7 +336,7 @@ abstract class ErrorHandler extends Component
      *
      * This method can be used to convert exceptions inside of methods like `__toString()`
      * to PHP errors because exceptions cannot be thrown inside of them.
-     * @param \Exception $exception the exception to convert to a PHP error.
+     * @param \Exception|\Throwable $exception the exception to convert to a PHP error.
      */
     public static function convertExceptionToError($exception)
     {
@@ -345,7 +345,7 @@ abstract class ErrorHandler extends Component
 
     /**
      * Converts an exception into a simple string.
-     * @param \Exception|\Error $exception the exception being converted
+     * @param \Exception|\Error|\Throwable  $exception the exception being converted
      * @return string the string representation of the exception.
      */
     public static function convertExceptionToString($exception)
@@ -363,7 +363,7 @@ abstract class ErrorHandler extends Component
 
     /**
      * Converts an exception into a string that has verbose information about the exception and its trace.
-     * @param \Exception|\Error $exception the exception being converted
+     * @param \Exception|\Error|\Throwable  $exception the exception being converted
      * @return string the string representation of the exception.
      *
      * @since 2.0.14

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -298,7 +298,7 @@ abstract class ErrorHandler extends Component
 
     /**
      * Renders the exception.
-     * @param \Exception|\Error\Throwable $exception the exception to be rendered.
+     * @param \Exception|\Error|\Throwable $exception the exception to be rendered.
      */
     abstract protected function renderException($exception);
 

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -295,7 +295,7 @@ class Response extends \yii\base\Response
 
     /**
      * Sets the response status code based on the exception.
-     * @param \Exception|\Error $e the exception object.
+     * @param \Exception|\Error|\Throwable $e the exception object.
      * @throws InvalidArgumentException if the status code is invalid.
      * @return $this the response object itself
      * @since 2.0.12


### PR DESCRIPTION
This change might be incomplete, as is. I only checked these 2 files which are in the PR. Most likely there are more spots where `\Throwable` is missing as typehint.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | 
| Fixed issues  |