### PR TITLE
pgsql: fix non-standart schema (public ) for column types

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,7 +15,7 @@ Yii Framework 2 Change Log
 - Bug #18526: Fix `yii\caching\DbCache` to work with MSSQL, add `normalizeTableRowData()` to `yii\db\mssql\QueryBuilder::upsert()` (darkdef)
 - Bug #14343: Fix `yii\test\ActiveFixture` to use model's DB connection instead of the default one (margori, bizley)
 - Bug #17631: Fix `yii\widgets\BaseListView` to properly render custom summary (sjaakp, bizley)
-- Bug #18325: Fix `yii\db\pgsql\Schema` to respect non-default PgSQL schema name for data types (theonedemon, silverfire) 
+- Bug #18325: Fix `yii\db\pgsql\Schema` to respect non-default PgSQL schema name for data types (theonedemon, silverfire)
 
 
 2.0.41.1 March 04, 2021

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,6 +15,7 @@ Yii Framework 2 Change Log
 - Bug #18526: Fix `yii\caching\DbCache` to work with MSSQL, add `normalizeTableRowData()` to `yii\db\mssql\QueryBuilder::upsert()` (darkdef)
 - Bug #14343: Fix `yii\test\ActiveFixture` to use model's DB connection instead of the default one (margori, bizley)
 - Bug #17631: Fix `yii\widgets\BaseListView` to properly render custom summary (sjaakp, bizley)
+- Bug #18325: Fix `yii\db\pgsql\Schema` to respect non-default PgSQL schema name for data types (theonedemon, silverfire) 
 
 
 2.0.41.1 March 04, 2021

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -476,6 +476,7 @@ SELECT
     a.attname AS column_name,
     COALESCE(td.typname, tb.typname, t.typname) AS data_type,
     COALESCE(td.typtype, tb.typtype, t.typtype) AS type_type,
+    (SELECT nspname FROM pg_namespace WHERE oid = COALESCE(td.typnamespace, tb.typnamespace, t.typnamespace)) AS type_scheme,
     a.attlen AS character_maximum_length,
     pg_catalog.col_description(c.oid, a.attnum) AS column_comment,
     a.atttypmod AS modifier,
@@ -592,7 +593,11 @@ SQL;
         $column->allowNull = $info['is_nullable'];
         $column->autoIncrement = $info['is_autoinc'];
         $column->comment = $info['column_comment'];
-        $column->dbType = $info['data_type'];
+        if (!empty($info['type_scheme']) && $this->defaultSchema !== $info['type_scheme']) {
+            $column->dbType = $info['type_scheme'] . '.' . $info['data_type'];
+        } else {
+            $column->dbType = $info['data_type'];
+        }
         $column->defaultValue = $info['column_default'];
         $column->enumValues = ($info['enum_values'] !== null) ? explode(',', str_replace(["''"], ["'"], $info['enum_values'])) : null;
         $column->unsigned = false; // has no meaning in PG

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -593,7 +593,8 @@ SQL;
         $column->allowNull = $info['is_nullable'];
         $column->autoIncrement = $info['is_autoinc'];
         $column->comment = $info['column_comment'];
-        if (!empty($info['type_scheme']) && $this->defaultSchema !== $info['type_scheme']) {
+        if ($info['type_scheme'] !== null && !in_array($info['type_scheme'], [$this->defaultSchema, 'pg_catalog'], true)
+        ) {
             $column->dbType = $info['type_scheme'] . '.' . $info['data_type'];
         } else {
             $column->dbType = $info['data_type'];

--- a/tests/data/ar/EnumTypeInCustomSchema.php
+++ b/tests/data/ar/EnumTypeInCustomSchema.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace yiiunit\data\ar;
+
+use yii\db\ArrayExpression;
+
+/**
+ * Class EnumTypeInCustomSchema
+ *
+ * @property int $id
+ * @property ArrayExpression $test_type
+ */
+class EnumTypeInCustomSchema extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%schema2.custom_type_test_table}}';
+    }
+}

--- a/tests/data/postgres.sql
+++ b/tests/data/postgres.sql
@@ -424,3 +424,12 @@ CREATE TABLE "T_upsert_1"
 (
     "a" INT NOT NULL PRIMARY KEY
 );
+
+CREATE TYPE "schema2"."my_type" AS enum('VAL1', 'VAL2', 'VAL3');
+CREATE TABLE "schema2"."custom_type_test_table" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "test_type" "schema2"."my_type"[]
+);
+INSERT INTO "schema2"."custom_type_test_table" ("test_type")
+VALUES (array['VAL2']::"schema2"."my_type"[]);
+

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -10,6 +10,7 @@ namespace yiiunit\framework\db\pgsql;
 use yii\db\conditions\ExistsConditionBuilder;
 use yii\db\Expression;
 use yiiunit\data\ar\ActiveRecord;
+use yiiunit\data\ar\EnumTypeInCustomSchema;
 use yiiunit\data\ar\Type;
 
 /**
@@ -348,5 +349,21 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         $result['3: foreign key'][2][0]->foreignSchemaName = 'public';
         $result['3: index'][2] = [];
         return $result;
+    }
+
+    public function testCustomTypeInNonDefaultSchema()
+    {
+        $connection = $this->getConnection();
+        ActiveRecord::$db = $this->getConnection();
+
+        $schema = $connection->schema->getTableSchema('schema2.custom_type_test_table');
+        $model = EnumTypeInCustomSchema::find()->one();
+        $this->assertSame(['VAL2'], $model->test_type->getValue());
+
+        $model->test_type = ['VAL1'];
+        $model->save();
+
+        $modelAfterUpdate = EnumTypeInCustomSchema::find()->one();
+        $this->assertSame(['VAL1'], $modelAfterUpdate->test_type->getValue());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️


postgresql
```
create schema test;
create type test.my_type as enum('VAl1', 'VAL2', 'VAl3');
create table test.test(test_type test.my_type[]) ;
```

Yii model
```
class Test extends ActiveRecord
{
    /**
     * {@inheritDoc}
     */
    public static function tableName()
    {
        return '{{%test.test}}';
    }
}
```

php test-case
```
$model = new \app\models\test\Test();
$model->test_type = ['VAL2'];
$model->save(false);
```

