### PR TITLE
Update tutorial-core-validators.md

### DIFF
--- a/docs/guide/tutorial-core-validators.md
+++ b/docs/guide/tutorial-core-validators.md
@@ -191,8 +191,8 @@ or `1970-01-01` in the input field of a date picker.
 This validator does not validate data. Instead, it assigns a default value to the attributes being validated
 if the attributes are empty.
 
-- `value`: the default value or a PHP callable that returns the default value which will be assigned to
-  the attributes being validated if they are empty. The signature of the PHP callable should be as follows,
+- `value`: the default value or a closure as callback that returns the default value which will be assigned to
+  the attributes being validated if they are empty. The signature of the closure should be as follows,
 
 ```php
 function foo($model, $attribute) {


### PR DESCRIPTION
The `DefaultValueValidator` works only with closures not with any callable as suggested.
See https://github.com/yiisoft/yii2/blob/f8337a15c2d48951b4e3b34d331e61e2eb784b97/framework/validators/DefaultValueValidator.php#L47

```
    /**
     * {@inheritdoc}
     */
    public function validateAttribute($model, $attribute)
    {
        if ($this->isEmpty($model->$attribute)) {
            if ($this->value instanceof \Closure) {
                $model->$attribute = call_user_func($this->value, $model, $attribute);
            } else {
                $model->$attribute = $this->value;
            }
        }
    }
```

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
