### PR TITLE
Typo fix "Enntêtes HTTP"

### DIFF
--- a/docs/guide-fr/runtime-requests.md
+++ b/docs/guide-fr/runtime-requests.md
@@ -93,7 +93,7 @@ et avant le nom du script d'entrée.
 
 
 
-## Enntêtes HTTP  <span id="http-headers"></span> 
+## Entêtes HTTP  <span id="http-headers"></span> 
 
 Vous pouvez obtenir les entêtes HTTP via la [[yii\web\HeaderCollection|collection d'entêtes]] qui est retournée par la propriété [[yii\web\Request::headers]]. Par exemple :
 


### PR DESCRIPTION
Typo fix on "Enntêtes HTTP", should be "Entêtes HTTP" instead.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ? 
| Tests pass?   | ? 
| Fixed issues  | #18349