### PR TITLE
fix:chinese doc index page sphinx,redis,mogondb,elastic link is inactive

### DIFF
--- a/docs/guide-zh-CN/README.md
+++ b/docs/guide-zh-CN/README.md
@@ -79,10 +79,10 @@ Yii 2.0 权威指南
 * [查询生成器（Query Builder）](db-query-builder.md): 使用简单抽象层查询数据库
 * [活动记录（Active Record）](db-active-record.md): 活动记录对象关系映射（ORM），检索和操作记录、定义关联关系
 * [数据库迁移（Migrations）](db-migrations.md): 在团体开发中对你的数据库使用版本控制
-* [Sphinx](https://github.com/yiisoft/yii2-sphinx/blob/master/docs/guide-zh-CN/README.md)
-* [Redis（yii2-redis）](yii2-redis.md): yii2-redis 扩展详解
-* [MongoDB](https://github.com/yiisoft/yii2-mongodb/blob/master/docs/guide-zh-CN/README.md)
-* [ElasticSearch](https://github.com/yiisoft/yii2-elasticsearch/blob/master/docs/guide-zh-CN/README.md)
+* [Sphinx](https://www.yiiframework.com/extension/yiisoft/yii2-sphinx/doc/guide)
+* [Redis（yii2-redis）](https://www.yiiframework.com/extension/yiisoft/yii2-redis/doc/guide/2.0/zh-cn): yii2-redis 扩展详解
+* [MongoDB](https://www.yiiframework.com/extension/yiisoft/yii2-mongodb/doc/guide)
+* [ElasticSearch](https://www.yiiframework.com/extension/yiisoft/yii2-elasticsearch/doc/guide)
 
 
 接收用户数据（Getting Data from Users）


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌

In this page [Yii 2.0 权威指南](https://www.yiiframework.com/doc/guide/2.0/zh-cn), the follow Spinx,Redis, MongoDB, ElasticSearch is inactive, will return 404 not found error. 

配合数据库工作（WORKING WITH DATABASES）
...
* Sphinx
* Redis（yii2-redis）
* MongoDB
* ElasticSearch


[ci skip]