### PR TITLE
Add PHPDoc for properties "request" and "response" in controllers

### DIFF
--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -34,6 +34,8 @@ use yii\helpers\Inflector;
  * read-only.
  * @property array $passedOptions The names of the options passed during execution. This property is
  * read-only.
+ * @property-read Request $request
+ * @property-read Response $response
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -17,6 +17,9 @@ use yii\helpers\Url;
  *
  * For more details and usage information on Controller, see the [guide article on controllers](guide:structure-controllers).
  *
+ * @property-read Request $request
+ * @property-read Response $response
+ *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */


### PR DESCRIPTION
Add PHPDoc for `request` and `response` in web and console controllers for better auto-completion in IDE.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -