### PR TITLE
Null in data filter

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
-- no changes in this release.
+- Enh #18370: Add option to provide a string replacement for `null` value in `yii\data\DataFilter` (bizley)
 
 
 2.0.39 November 10, 2020

--- a/framework/data/ActiveDataFilter.php
+++ b/framework/data/ActiveDataFilter.php
@@ -54,7 +54,7 @@ class ActiveDataFilter extends DataFilter
      *
      * Usually the map can be left empty as filter operator names are consistent with the ones
      * used in [[\yii\db\QueryInterface::where()]]. However, you may want to adjust it in some special cases.
-     * For example, when using PosgreSQL you may want to setup the following map:
+     * For example, when using PostgreSQL you may want to setup the following map:
      *
      * ```php
      * [

--- a/framework/data/DataFilter.php
+++ b/framework/data/DataFilter.php
@@ -239,6 +239,11 @@ class DataFilter extends Model
      * Attribute map will be applied to filter condition in [[normalize()]] method.
      */
     public $attributeMap = [];
+    /**
+     * @var string representation of `null` instead of literal `null` in case the latter cannot be used.
+     * @since 2.0.40
+     */
+    public $nullValue = 'NULL';
 
     /**
      * @var array|\Closure list of error messages responding to invalid filter structure, in format: `[errorKey => message]`.
@@ -359,24 +364,24 @@ class DataFilter extends Model
         if ($validator instanceof BooleanValidator) {
             return self::TYPE_BOOLEAN;
         }
-        
+
         if ($validator instanceof NumberValidator) {
             return $validator->integerOnly ? self::TYPE_INTEGER : self::TYPE_FLOAT;
         }
-        
+
         if ($validator instanceof StringValidator) {
             return self::TYPE_STRING;
         }
-        
+
         if ($validator instanceof EachValidator) {
             return self::TYPE_ARRAY;
         }
-        
+
         if ($validator instanceof DateValidator) {
             if ($validator->type == DateValidator::TYPE_DATETIME) {
                 return self::TYPE_DATETIME;
             }
-            
+
             if ($validator->type == DateValidator::TYPE_TIME) {
                 return self::TYPE_TIME;
             }
@@ -659,7 +664,7 @@ class DataFilter extends Model
             return;
         }
 
-        $model->{$attribute} = $value;
+        $model->{$attribute} = $value === $this->nullValue ? null : $value;
         if (!$model->validate([$attribute])) {
             $this->addError($this->filterAttributeName, $model->getFirstError($attribute));
             return;
@@ -753,6 +758,8 @@ class DataFilter extends Model
             }
             if (is_array($value)) {
                 $result[$key] = $this->normalizeComplexFilter($value);
+            } elseif ($value === $this->nullValue) {
+                $result[$key] = null;
             } else {
                 $result[$key] = $value;
             }

--- a/tests/framework/data/ActiveDataFilterTest.php
+++ b/tests/framework/data/ActiveDataFilterTest.php
@@ -134,6 +134,29 @@ class ActiveDataFilterTest extends TestCase
                     ],
                 ],
             ],
+            [
+                [
+                    'name' => 'NULL',
+                    'number' => 'NULL',
+                    'price' => 'NULL',
+                    'tags' => ['NULL'],
+                ],
+                [
+                    'AND',
+                    ['name' => ''],
+                    ['number' => null],
+                    ['price' => null],
+                    ['tags' => [null]],
+                ],
+            ],
+            [
+                [
+                    'number' => [
+                        'neq' => 'NULL'
+                    ],
+                ],
+                ['!=', 'number', null],
+            ],
         ];
     }
 

--- a/tests/framework/data/DataFilterTest.php
+++ b/tests/framework/data/DataFilterTest.php
@@ -225,6 +225,31 @@ class DataFilterTest extends TestCase
                 true,
                 [],
             ],
+            [
+                [
+                    'name' => [
+                        'eq' => 'NULL',
+                    ],
+                ],
+                true,
+                [],
+            ],
+            [
+                [
+                    'name' => 'NULL',
+                ],
+                true,
+                [],
+            ],
+            [
+                [
+                    'name' => [
+                        'neq' => 'NULL',
+                    ],
+                ],
+                true,
+                [],
+            ],
         ];
     }
 
@@ -363,6 +388,14 @@ class DataFilterTest extends TestCase
                     'datetime' => '2015-06-06 17:46:12',
                 ],
             ],
+            [
+                [
+                    'name' => 'NULL',
+                ],
+                [
+                    'name' => null,
+                ],
+            ],
         ];
     }
 
@@ -401,6 +434,15 @@ class DataFilterTest extends TestCase
 
         $builder->filter = $filter;
         $this->assertEquals($expectedResult, $builder->normalize(false));
+    }
+
+    public function testNormalizeNonDefaultNull()
+    {
+        $builder = new DataFilter();
+        $builder->nullValue = 'abcde';
+        $builder->setSearchModel((new DynamicModel(['name' => null]))->addRule('name', 'string'));
+        $builder->filter = ['name' => 'abcde'];
+        $this->assertEquals(['name' => null], $builder->normalize(false));
     }
 
     public function testSetupErrorMessages()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -

This enables providing `null` value in filters when there is no option to use literal `null` (like through URLs). I have seen SO questions asking for this several times.

I have put this on 2.0.40 to discuss it more before releasing (if at all). Automatic change from `'NULL'` to `null` might be messing apps using `'NULL'` strings currently so maybe it should be `'$NULL'`? I hope this change fills the gap in filters usability but maybe I forgot about something so please take a look if you are interested. All comments are welcomed.