### PR TITLE
basePath check moved to init

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
-- Enc #: The `yii\web\AssetManager` `$basePath` writeable check has been moved to the initializer of the class instead of making this check whenever a file will be pbulished (nadar)
+- Enc #18381: The `yii\web\AssetManager` `$basePath` writeable check has been moved to the initializer of the class instead of making this check whenever a file will be pbulished (nadar)
 
 
 2.0.39.2 November 13, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
-- Enh #18381: The `yii\web\AssetManager` `$basePath` writeable check has been moved to the initializer of the class instead of making this check whenever a file will be published (nadar)
+- Enh #18381: The `yii\web\AssetManager` `$basePath` readable and writeable check has been moved to the `checkBasePathPermission()`. This check will run once before `publishFile()` and `publishDirectory()`. (nadar)
 - Enh #18200: Add `maxlength` attribute by default to the input text when it is an active field within a `yii\grid\DataColumn` (rad8329)
 
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
-- no changes in this release.
+- Enc #: The `yii\web\AssetManager` `$basePath` writeable check has been moved to the initializer of the class instead of making this check whenever a file will be pbulished (nadar)
 
 
 2.0.39.2 November 13, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
-- Enh #18381: The `yii\web\AssetManager` `$basePath` writeable check has been moved to the initializer of the class instead of making this check whenever a file will be pbulished (nadar)
+- Enh #18381: The `yii\web\AssetManager` `$basePath` writeable check has been moved to the initializer of the class instead of making this check whenever a file will be published (nadar)
 
 
 2.0.39.2 November 13, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
-- Enh #18381: The `yii\web\AssetManager` `$basePath` readable and writeable check has been moved to the `checkBasePathPermission()`. This check will run once before `publishFile()` and `publishDirectory()`. (nadar)
+- Enh #18381: The `yii\web\AssetManager` `$basePath` readable and writeable check has been moved to the `checkBasePathPermission()`. This check will run once before `publishFile()` and `publishDirectory()` (nadar)
 - Enh #18200: Add `maxlength` attribute by default to the input text when it is an active field within a `yii\grid\DataColumn` (rad8329)
 
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
-- Enc #18381: The `yii\web\AssetManager` `$basePath` writeable check has been moved to the initializer of the class instead of making this check whenever a file will be pbulished (nadar)
+- Enh #18381: The `yii\web\AssetManager` `$basePath` writeable check has been moved to the initializer of the class instead of making this check whenever a file will be pbulished (nadar)
 
 
 2.0.39.2 November 13, 2020

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -212,6 +212,10 @@ class AssetManager extends Component
         if (!is_dir($this->basePath)) {
             throw new InvalidConfigException("The directory does not exist: {$this->basePath}");
         }
+        
+        if (!is_writable($this->basePath)) {
+            throw new InvalidConfigException("The directory is not writable by the Web process: {$this->basePath}");
+        }
 
         $this->basePath = realpath($this->basePath);
         $this->baseUrl = rtrim(Yii::getAlias($this->baseUrl), '/');
@@ -437,10 +441,6 @@ class AssetManager extends Component
 
         if (!is_string($path) || ($src = realpath($path)) === false) {
             throw new InvalidArgumentException("The file or directory to be published does not exist: $path");
-        }
-
-        if (!is_writable($this->basePath)) {
-            throw new InvalidConfigException("The directory is not writable by the Web process: {$this->basePath}");
         }
 
         if (is_file($src)) {

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -214,6 +214,7 @@ class AssetManager extends Component
         $this->baseUrl = rtrim(Yii::getAlias($this->baseUrl), '/');
     }
 
+    private $_isBasePathPermissionChecked = null;
     /**
      * Check whether the basePath exists and is writeable.
      *
@@ -221,6 +222,11 @@ class AssetManager extends Component
      */
     public function checkBasePathPermission()
     {
+        // if the check is been done already, skip further checks
+        if ($this->_isBasePathPermissionChecked) {
+            return;
+        }
+
         if (!is_dir($this->basePath)) {
             throw new InvalidConfigException("The directory does not exist: {$this->basePath}");
         }
@@ -228,6 +234,8 @@ class AssetManager extends Component
         if (!is_writable($this->basePath)) {
             throw new InvalidConfigException("The directory is not writable by the Web process: {$this->basePath}");
         }
+
+        $this->_isBasePathPermissionChecked = true;
     }
 
     /**

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -209,6 +209,18 @@ class AssetManager extends Component
     {
         parent::init();
         $this->basePath = Yii::getAlias($this->basePath);
+
+        $this->basePath = realpath($this->basePath);
+        $this->baseUrl = rtrim(Yii::getAlias($this->baseUrl), '/');
+    }
+
+    /**
+     * Check whether the basePath exists and is writeable.
+     *
+     * @since 2.0.40
+     */
+    public function checkBasePathPermission()
+    {
         if (!is_dir($this->basePath)) {
             throw new InvalidConfigException("The directory does not exist: {$this->basePath}");
         }
@@ -216,9 +228,6 @@ class AssetManager extends Component
         if (!is_writable($this->basePath)) {
             throw new InvalidConfigException("The directory is not writable by the Web process: {$this->basePath}");
         }
-
-        $this->basePath = realpath($this->basePath);
-        $this->baseUrl = rtrim(Yii::getAlias($this->baseUrl), '/');
     }
 
     /**
@@ -458,6 +467,8 @@ class AssetManager extends Component
      */
     protected function publishFile($src)
     {
+        $this->checkBasePathPermission();
+
         $dir = $this->hash($src);
         $fileName = basename($src);
         $dstDir = $this->basePath . DIRECTORY_SEPARATOR . $dir;
@@ -513,6 +524,8 @@ class AssetManager extends Component
      */
     protected function publishDirectory($src, $options)
     {
+        $this->checkBasePathPermission();
+
         $dir = $this->hash($src);
         $dstDir = $this->basePath . DIRECTORY_SEPARATOR . $dir;
         if ($this->linkAssets) {

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -214,7 +214,8 @@ class AssetManager extends Component
         $this->baseUrl = rtrim(Yii::getAlias($this->baseUrl), '/');
     }
 
-    private $_isBasePathPermissionChecked = null;
+    private $_isBasePathPermissionChecked;
+
     /**
      * Check whether the basePath exists and is writeable.
      *

--- a/tests/framework/web/AssetBundleTest.php
+++ b/tests/framework/web/AssetBundleTest.php
@@ -186,7 +186,7 @@ class AssetBundleTest extends \yiiunit\TestCase
             $this->markTestSkipped("This test can only be performed with reliable chmod. It's unreliable on your system.");
         }
 
-        // exception should be throw when creating asset manager (see https://github.com/yiisoft/yii2/pull/18381)
+        // Exception should be thrown when creating asset manager (see https://github.com/yiisoft/yii2/pull/18381)
         $this->setExpectedException('yii\base\InvalidConfigException', 'The directory is not writable by the Web process');
         $view = $this->getView(['basePath' => '@testReadOnlyAssetPath']);
         $bundle = new TestSourceAsset();

--- a/tests/framework/web/AssetBundleTest.php
+++ b/tests/framework/web/AssetBundleTest.php
@@ -186,10 +186,11 @@ class AssetBundleTest extends \yiiunit\TestCase
             $this->markTestSkipped("This test can only be performed with reliable chmod. It's unreliable on your system.");
         }
 
+        // exception should be throw when creating asset manager (see https://github.com/yiisoft/yii2/pull/18381)
+        $this->setExpectedException('yii\base\InvalidConfigException', 'The directory is not writable by the Web process');
         $view = $this->getView(['basePath' => '@testReadOnlyAssetPath']);
         $bundle = new TestSourceAsset();
 
-        $this->setExpectedException('yii\base\InvalidConfigException', 'The directory is not writable by the Web process');
         $bundle->publish($view->getAssetManager());
 
         FileHelper::removeDirectory($path);

--- a/tests/framework/web/AssetBundleTest.php
+++ b/tests/framework/web/AssetBundleTest.php
@@ -186,11 +186,10 @@ class AssetBundleTest extends \yiiunit\TestCase
             $this->markTestSkipped("This test can only be performed with reliable chmod. It's unreliable on your system.");
         }
 
-        // Exception should be thrown when creating asset manager (see https://github.com/yiisoft/yii2/pull/18381)
-        $this->setExpectedException('yii\base\InvalidConfigException', 'The directory is not writable by the Web process');
         $view = $this->getView(['basePath' => '@testReadOnlyAssetPath']);
         $bundle = new TestSourceAsset();
 
+        $this->setExpectedException('yii\base\InvalidConfigException', 'The directory is not writable by the Web process');
         $bundle->publish($view->getAssetManager());
 
         FileHelper::removeDirectory($path);


### PR DESCRIPTION
Move the basePath check into the initializer of the AssetManager.

Discussion see https://forum.yiiframework.com/t/publish-assetmanager-files-to-cdn/130920/3

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?  | ✔️
