### PR TITLE
Add maxlength attribute to text filter for #18200 issue

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 Change Log
 2.0.39.2 November 13, 2020
 --------------------------
 
+- Enh #18200: Add `maxlength` attribute by default to the input text when it is an active field within a `yii\grid\DataColumn` (rad8329)
 - Bug #18378: Fix not taking default value when unable to resolve abstract class via DI container (vjik)
 
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,13 +4,11 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
-- no changes in this release.
-
+- Enh #18200: Add `maxlength` attribute by default to the input text when it is an active field within a `yii\grid\DataColumn` (rad8329)
 
 2.0.39.2 November 13, 2020
 --------------------------
 
-- Enh #18200: Add `maxlength` attribute by default to the input text when it is an active field within a `yii\grid\DataColumn` (rad8329)
 - Bug #18378: Fix not taking default value when unable to resolve abstract class via DI container (vjik)
 
 

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -206,8 +206,9 @@ class DataColumn extends Column
                     0 => $this->grid->formatter->booleanFormat[0],
                 ], $options) . $error;
             }
+            $options = array_merge(['maxlength' => true], $this->filterInputOptions);
 
-            return Html::activeTextInput($model, $this->attribute, $this->filterInputOptions) . $error;
+            return Html::activeTextInput($model, $this->attribute, $options) . $error;
         }
 
         return parent::renderFilterCellContent();

--- a/tests/data/base/Singer.php
+++ b/tests/data/base/Singer.php
@@ -14,15 +14,23 @@ use yii\base\Model;
  */
 class Singer extends Model
 {
+    public static $tableName;
+
     public $firstName;
     public $lastName;
     public $test;
+
+    public static function tableName()
+    {
+        return static::$tableName ?: 'singer';
+    }
 
     public function rules()
     {
         return [
             [['lastName'], 'default', 'value' => 'Lennon'],
             [['lastName'], 'required'],
+            [['lastName'], 'string', 'max' => 25],
             [['underscore_style'], 'yii\captcha\CaptchaValidator'],
             [['test'], 'required', 'when' => function ($model) { return $model->firstName === 'cebe'; }],
         ];

--- a/tests/framework/grid/DataColumnTest.php
+++ b/tests/framework/grid/DataColumnTest.php
@@ -8,11 +8,13 @@
 namespace yiiunit\framework\grid;
 
 use Yii;
+use yii\data\ActiveDataProvider;
 use yii\data\ArrayDataProvider;
 use yii\grid\DataColumn;
 use yii\grid\GridView;
 use yiiunit\data\ar\ActiveRecord;
 use yiiunit\data\ar\Order;
+use yiiunit\data\base\Singer;
 
 /**
  * @author Dmitry Naumenko <d.naumenko.a@gmail.com>
@@ -88,6 +90,43 @@ class DataColumnTest extends \yiiunit\TestCase
             ],
         ]);
         //print_r($grid->columns);exit();
+        $dataColumn = $grid->columns[0];
+        $method = new \ReflectionMethod($dataColumn, 'renderFilterCellContent');
+        $method->setAccessible(true);
+        $result = $method->invoke($dataColumn);
+        $this->assertEquals($result, $filterInput);
+    }
+
+    /**
+     * @see DataColumn::$filter
+     * @see DataColumn::renderFilterCellContent()
+     */
+    public function testFilterHasMaxLengthWhenIsAnActiveTextInput()
+    {
+        $this->mockApplication([
+            'components' => [
+                'db' => [
+                    'class' => '\yii\db\Connection',
+                    'dsn' => 'sqlite::memory:',
+                ],
+            ],
+        ]);
+
+        ActiveRecord::$db = Yii::$app->getDb();
+        Yii::$app->getDb()->createCommand()->createTable(Singer::tableName(), [
+            'firstName' => 'string',
+            'lastName' => 'string'
+        ])->execute();
+
+        $filterInput = '<input type="text" class="form-control" name="Singer[lastName]" maxlength="25">';
+        $grid = new GridView([
+            'dataProvider' => new ActiveDataProvider(),
+            'filterModel' => new Singer(),
+            'columns' => [
+                0 => 'lastName'
+            ],
+        ]);
+
         $dataColumn = $grid->columns[0];
         $method = new \ReflectionMethod($dataColumn, 'renderFilterCellContent');
         $method->setAccessible(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️ It's labeled as a bug, however I don't think so
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18200

Filter text field within `maxlength` attribute in tag to add double-check validation (HTML element and model rule)
