### PR TITLE
Fix content body response on 304 code for #18199 issue

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
-- Bug #18199: Fix content body response on 304 http status code, according to rfc7232 (rad8329)
+- Bug #18199: Fix content body response on 304 http status code, according to RFC 7232 (rad8329)
 - Bug #18396: Fix not throw `InvalidConfigException` when failed to instantiate class via DI container in some cases (vjik)
 - Enh #18200: Add `maxlength` attribute by default to the input text when it is an active field within a `yii\grid\DataColumn` (rad8329)
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
+- Bug #18199: Fix content body response on 304 http status code, according to rfc7232 (rad8329)
 - Enh #18200: Add `maxlength` attribute by default to the input text when it is an active field within a `yii\grid\DataColumn` (rad8329)
 
 2.0.39.2 November 13, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
-- Bug #18199: Fix content body response on 304 http status code, according to RFC 7232 (rad8329)
+- Bug #18199: Fix content body response on 304 HTTP status code, according to RFC 7232 (rad8329)
 - Enh #18394: Add support for setting `yii\web\Response::$stream` to a callable (brandonkelly)
 
 

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -1067,7 +1067,7 @@ class Response extends \yii\base\Response
      */
     protected function prepare()
     {
-        if ($this->statusCode === 204 || $this->statusCode === 304) {
+        if (in_array($this->getStatusCode(), [204, 304])) {
             // A 204/304 response cannot contain a message body according to rfc7231/rfc7232
             $this->content = '';
             $this->stream = null;

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -1061,10 +1061,14 @@ class Response extends \yii\base\Response
      * Prepares for sending the response.
      * The default implementation will convert [[data]] into [[content]] and set headers accordingly.
      * @throws InvalidConfigException if the formatter for the specified format is invalid or [[format]] is not supported
+     *
+     * @see https://tools.ietf.org/html/rfc7231#page-53
+     * @see https://tools.ietf.org/html/rfc7232#page-18
      */
     protected function prepare()
     {
-        if ($this->statusCode === 204) {
+        if ($this->statusCode === 204 || $this->statusCode === 304) {
+            // A 204/304 response cannot contain a message body according to rfc7231/rfc7232
             $this->content = '';
             $this->stream = null;
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18199

Fix content body response on 304 http status code, according to rfc7232
