### PR TITLE
Add support for setting Response::$stream to a callable

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Enh #18200: Add `maxlength` attribute by default to the input text when it is an active field within a `yii\grid\DataColumn` (rad8329)
+- Enh #18394: Add support for setting `yii\web\Response::$stream` to a callable (brandonkelly)
 
 2.0.39.2 November 13, 2020
 --------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.40 under development
 ------------------------
 
-- no changes in this release.
+- Enh #18394: Add support for setting `yii\web\Response::$stream` to a callable (brandonkelly)
 
 
 2.0.39.3 November 23, 2020
@@ -12,7 +12,6 @@ Yii Framework 2 Change Log
 
 - Bug #18396: Fix not throw `InvalidConfigException` when failed to instantiate class via DI container in some cases (vjik)
 - Enh #18200: Add `maxlength` attribute by default to the input text when it is an active field within a `yii\grid\DataColumn` (rad8329)
-- Enh #18394: Add support for setting `yii\web\Response::$stream` to a callable (brandonkelly)
 
 
 2.0.39.2 November 13, 2020

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -138,9 +138,12 @@ class Response extends \yii\base\Response
      */
     public $content;
     /**
-     * @var resource|array the stream to be sent. This can be a stream handle or an array of stream handle,
-     * the begin position and the end position. Note that when this property is set, the [[data]] and [[content]]
-     * properties will be ignored by [[send()]].
+     * @var resource|array|callable the stream to be sent. This can be a stream handle or an array of stream handle,
+     * the begin position and the end position. Alternatively it can be set to a callable, which returns
+     * (or [yields](https://www.php.net/manual/en/language.generators.syntax.php)) an array of strings that should
+     * be echoed and flushed out one by one.
+     *
+     * Note that when this property is set, the [[data]] and [[content]] properties will be ignored by [[send()]].
      */
     public $stream;
     /**
@@ -439,6 +442,15 @@ class Response extends \yii\base\Response
         // Try to reset time limit for big files
         if (!function_exists('set_time_limit') || !@set_time_limit(0)) {
             Yii::warning('set_time_limit() is not available', __METHOD__);
+        }
+
+        if (is_callable($this->stream)) {
+            $data = call_user_func($this->stream);
+            foreach ($data as $datum) {
+                echo $datum;
+                flush();
+            }
+            return;
         }
 
         $chunkSize = 8 * 1024 * 1024; // 8MB per chunk


### PR DESCRIPTION
A Craft customer has a need for streaming data from a controller (craftcms/cms#7148), and I realized there’s no elegant way to do that currently, outside of manually sending the response headers and then echoing/flushing the data out piece by piece, which would bypass the typical response events like `EVENT_BEFORE_SEND`, etc.

With this PR, it would be possible to set `yii\web\Response::$stream` to a callable, which would be looped through and the results would be echoed/printed one-by-one, within the normal response flow.

```php
$this->response->stream = function() {
    for ($i = 1; $i <= 3; $i++) {
        yield "$i\n";
    }
};
```

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
