### PR TITLE
check locks exists in FileMutex::$_files property or in the folder

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Enh #18381: The `yii\web\AssetManager` `$basePath` readable and writeable check has been moved to the `checkBasePathPermission()`. This check will run once before `publishFile()` and `publishDirectory()` (nadar)
 - Bug #18199: Fix content body response on 304 HTTP status code, according to RFC 7232 (rad8329)
 - Enh #18394: Add support for setting `yii\web\Response::$stream` to a callable (brandonkelly)
+- Bug #18405: Fix `yii\mutex\FileMutex` to check and release locks from correct property (albertborsos)
 
 
 2.0.39.3 November 23, 2020


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

I tried to use FileMutex, but I realised it checks for acquired lock files in `$_locks` property instead of `$_files` property. Also if jobs runs over, the latter job finds nothing in `$_files` because it is an other process, so I checked for the existing `*.lock` file.