### PR TITLE
Fix #18406 - avoid PDOExceptions when working with autocommitted transactions

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Enh #18381: The `yii\web\AssetManager` `$basePath` readable and writeable check has been moved to the `checkBasePathPermission()`. This check will run once before `publishFile()` and `publishDirectory()` (nadar)
 - Bug #18199: Fix content body response on 304 HTTP status code, according to RFC 7232 (rad8329)
 - Enh #18394: Add support for setting `yii\web\Response::$stream` to a callable (brandonkelly)
+- Bug #18406: Fix PDO exception when committing or rolling back an autocommitted transaction in PHP 8 (brandonkelly)
 
 
 2.0.39.3 November 23, 2020

--- a/tests/framework/db/mysql/ConnectionTest.php
+++ b/tests/framework/db/mysql/ConnectionTest.php
@@ -7,6 +7,8 @@
 
 namespace yiiunit\framework\db\mysql;
 
+use yii\db\Connection;
+
 /**
  * @group db
  * @group mysql
@@ -14,4 +16,18 @@ namespace yiiunit\framework\db\mysql;
 class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
 {
     protected $driverName = 'mysql';
+
+    public function testTransactionAutocommit()
+    {
+        /** @var Connection $connection */
+        $connection = $this->getConnection(true);
+        $connection->transaction(function (Connection $db) {
+            // create table will cause the transaction to be implicitly committed
+            // (see https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html)
+            $name = 'test_implicit_transaction_table';
+            $db->createCommand()->createTable($name, ['id' => 'pk'])->execute();
+            $db->createCommand()->dropTable($name)->execute();
+        });
+        // If we made it this far without an error, then everything's working
+    }
 }

--- a/tests/framework/db/mysql/ConnectionTest.php
+++ b/tests/framework/db/mysql/ConnectionTest.php
@@ -17,6 +17,9 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
 {
     protected $driverName = 'mysql';
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testTransactionAutocommit()
     {
         /** @var Connection $connection */


### PR DESCRIPTION
This fixes #18406 by checking if there is an active transaction before committing/rolling back transactions.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18406 
