### PR TITLE
Add resetCounter method to BaseDataProvider

### DIFF
--- a/framework/data/BaseDataProvider.php
+++ b/framework/data/BaseDataProvider.php
@@ -275,4 +275,13 @@ abstract class BaseDataProvider extends Component implements DataProviderInterfa
         $this->_models = null;
         $this->_keys = null;
     }
+
+    /**
+     * Reset the counter.
+     * Used for testing purposes.
+     */
+    public static function resetCounter()
+    {
+        self::$counter = 0;
+    }
 }


### PR DESCRIPTION
This adds the ability to reset the ActiveDataProvider counter while being run in Test Cases.

Take this test case example

```php
    // a lot of test cases that create tens of active data provider instances which increases the $counter property...

    public function it_list_orders_sorted_by_its_id_descending(FunctionalTester $I, Scenario $scenario)
    {
        // Here is its usage:
        \Yii\Data\ActiveDataProvider::resetCounter();

        $I->wantTo('List orders sorted by its id descending');
        $I->sendGET('/v1/my-orders-api-endpoint', ['sort' => '-orderId', 'fields' => 'orderId,deliveryDate']);
        $I->seeResponseIsJson();
        $I->seeResponseCodeIsSuccessful();
        $response = Json::decode($I->grabResponse());
        // more assertions...
    }
   
    // a lot of test cases that create tens of active data provider instances which increases the $counter property...
```

Without using `resetCounter` we must maintain the `sort` parameter which will end up like `dp-14-sort`.

**Note** I know there is another solution for this by using Reflection APIs but I think IMO this is more readable and elegant solution.