### PR TITLE
[PoC] Resolving dependencies automatically

### DIFF
--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -436,7 +436,11 @@ class Container extends Component
     private function mergeDependencies($a, $b)
     {
         foreach ($b as $index => $dependency) {
-            $a[$index] = $dependency;
+            $newDependency = $dependency;
+            if ($a[$index] instanceof Instance) {
+                $newDependency = Instance::ensure($dependency, $a[$index]->id, $this);
+            }
+            $a[$index] = $newDependency;
         }
         return $a;
     }

--- a/tests/framework/di/ContainerTest.php
+++ b/tests/framework/di/ContainerTest.php
@@ -621,4 +621,31 @@ class ContainerTest extends TestCase
         $this->assertNull($zeta->unknown);
         $this->assertNull($zeta->unknownNull);
     }
+
+    public function testInstantiatingClassTypedArgument()
+    {
+        // interface typed argument, int key, dependency should be built
+        $bar = (new Container())->get(Bar::className(), [Qux::className()]);
+        $this->assertInstanceOf(Qux::className(), $bar->qux);
+
+        // interface typed argument, string key, dependency should be built
+        $bar2 = (new Container())->get(Bar::className(), ['qux' => Qux::className()]);
+        $this->assertInstanceOf(Qux::className(), $bar2->qux);
+
+        // interface typed optional argument, string key, dependency should be built
+        $alpha = (new Container())->get(Alpha::className(), ['omega' => Qux::className()]);
+        $this->assertInstanceOf(Qux::className(), $alpha->omega);
+
+        // non-typed argument, string key, dependency should NOT be built
+        $car = (new Container())->get(Car::className(), ['color' => Qux::className()]);
+        $this->assertSame(Qux::className(), $car->color);
+
+        // class-typed argument, string key, nested dependency resolving, all dependencies should be built
+        $foo = (new Container())->get(Foo::className(), ['bar' => [
+            'class' => Bar::className(),
+            '__construct()' => [Qux::className()],
+        ]]);
+        $this->assertInstanceOf(Bar::className(), $foo->bar);
+        $this->assertInstanceOf(Qux::className(), $foo->bar->qux);
+    }
 }

--- a/tests/framework/di/ContainerTest.php
+++ b/tests/framework/di/ContainerTest.php
@@ -24,8 +24,8 @@ use yiiunit\framework\di\stubs\Foo;
 use yiiunit\framework\di\stubs\FooProperty;
 use yiiunit\framework\di\stubs\Kappa;
 use yiiunit\framework\di\stubs\Qux;
-use yiiunit\framework\di\stubs\QuxInterface;
 use yiiunit\framework\di\stubs\QuxFactory;
+use yiiunit\framework\di\stubs\QuxInterface;
 use yiiunit\framework\di\stubs\Zeta;
 use yiiunit\TestCase;
 
@@ -647,5 +647,19 @@ class ContainerTest extends TestCase
         ]]);
         $this->assertInstanceOf(Bar::className(), $foo->bar);
         $this->assertInstanceOf(Qux::className(), $foo->bar->qux);
+
+        // interface typed argument, int key, dependency preset but provided again
+        $c = new Container();
+        $c->set('yiiunit\framework\di\stubs\QuxInterface', Qux::className());
+        $bar = $c->get(Bar::className(), [Qux::className()]);
+        $this->assertInstanceOf(Qux::className(), $bar->qux);
+
+        // interface typed argument, int key, dependency already built
+        $bar = (new Container())->get(Bar::className(), [new Qux()]);
+        $this->assertInstanceOf(Qux::className(), $bar->qux);
+
+        // interface typed argument, int key, dependency as Instance of
+        $bar = (new Container())->get(Bar::className(), [Instance::of(Qux::className())]);
+        $this->assertInstanceOf(Qux::className(), $bar->qux);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️ (should)
| Fixed issues  | -

Based on the brief discussion at Slack (https://yii.slack.com/archives/C6H833X42/p1606392783295800) here is my PoC to allow DI container to instantiate class-typed dependencies of an object automatically.

This allows to keep configuration of objects with strings only (class names) and removes the requirement of preconfiguring Container for dependencies (but it's still possible).

I have used `mergeDependencies()` to resolve dependency with provided argument because in `resolveDependencies()` it's already too late (original constructor dependency info is lost) so it obviously requires some refactoring (new method maybe, called before `mergeDependencies()`).

Let me know what you think.