### PR TITLE
Negative timezone in tests for date-only validation with non-UTC timezone

### DIFF
--- a/tests/framework/validators/DateValidatorTest.php
+++ b/tests/framework/validators/DateValidatorTest.php
@@ -687,6 +687,196 @@ class DateValidatorTest extends TestCase
         $this->assertFalse($model->hasErrors('attr_date'));
         $this->assertFalse($model->hasErrors('attr_timestamp'));
         $this->assertSame(1497477600, $model->attr_timestamp);
+
+        // ICU, timeZone => America/Jamaica, timestampAttributeTimeZone => UTC (default)
+        $val = new DateValidator([
+            'format' => 'yyyy-MM-dd',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'timeZone' => 'America/Jamaica',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2017-06-15';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2017-06-15 00:00:00', $model->attr_timestamp);
+
+        // PHP, timeZone => America/Jamaica, timestampAttributeTimeZone => UTC (default)
+        $val = new DateValidator([
+            'format' => 'php:Y-m-d',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'timeZone' => 'America/Jamaica',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2017-06-15';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2017-06-15 00:00:00', $model->attr_timestamp);
+
+        // ICU, timeZone => UTC (default), timestampAttributeTimeZone => America/Jamaica
+        $val = new DateValidator([
+            'format' => 'yyyy-MM-dd',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'timeZone' => 'UTC',
+            'timestampAttributeTimeZone' => 'America/Jamaica',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2017-06-15';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2017-06-14 19:00:00', $model->attr_timestamp);
+
+        // PHP, timeZone => UTC (default), timestampAttributeTimeZone => America/Jamaica
+        $val = new DateValidator([
+            'format' => 'php:Y-m-d',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'timeZone' => 'UTC',
+            'timestampAttributeTimeZone' => 'America/Jamaica',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2017-06-15';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2017-06-14 19:00:00', $model->attr_timestamp);
+
+        // ICU, timeZone => America/Jamaica, timestampAttributeTimeZone => America/Jamaica
+        $val = new DateValidator([
+            'format' => 'yyyy-MM-dd',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'timeZone' => 'America/Jamaica',
+            'timestampAttributeTimeZone' => 'America/Jamaica',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2017-06-15';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2017-06-14 19:00:00', $model->attr_timestamp);
+
+        // PHP, timeZone => America/Jamaica, timestampAttributeTimeZone => America/Jamaica
+        $val = new DateValidator([
+            'format' => 'php:Y-m-d',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'timeZone' => 'America/Jamaica',
+            'timestampAttributeTimeZone' => 'America/Jamaica',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2017-06-15';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2017-06-14 19:00:00', $model->attr_timestamp);
+
+        // ICU, defaultTimeZone => America/Jamaica, timestampAttributeTimeZone => UTC (default)
+        $val = new DateValidator([
+            'format' => 'yyyy-MM-dd',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'defaultTimeZone' => 'America/Jamaica',
+            'timestampAttributeTimeZone' => 'UTC',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2020-01-27';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2020-01-27 05:00:00', $model->attr_timestamp);
+
+        // PHP, defaultTimeZone => America/Jamaica, timestampAttributeTimeZone => UTC (default)
+        $val = new DateValidator([
+            'format' => 'php:Y-m-d',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'defaultTimeZone' => 'America/Jamaica',
+            'timestampAttributeTimeZone' => 'UTC',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2020-01-27';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2020-01-27 05:00:00', $model->attr_timestamp);
+
+        // ICU, defaultTimeZone => UTC (default), timestampAttributeTimeZone => America/Jamaica
+        $val = new DateValidator([
+            'format' => 'yyyy-MM-dd',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'defaultTimeZone' => 'UTC',
+            'timestampAttributeTimeZone' => 'America/Jamaica',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2020-01-27';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2020-01-26 19:00:00', $model->attr_timestamp);
+
+        // PHP, defaultTimeZone => UTC (default), timestampAttributeTimeZone => America/Jamaica
+        $val = new DateValidator([
+            'format' => 'php:Y-m-d',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'defaultTimeZone' => 'UTC',
+            'timestampAttributeTimeZone' => 'America/Jamaica',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2020-01-27';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2020-01-26 19:00:00', $model->attr_timestamp);
+
+        // ICU, defaultTimeZone => America/Jamaica, timestampAttributeTimeZone => America/Jamaica
+        $val = new DateValidator([
+            'format' => 'yyyy-MM-dd',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'defaultTimeZone' => 'America/Jamaica',
+            'timestampAttributeTimeZone' => 'America/Jamaica',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2020-01-27';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2020-01-27 00:00:00', $model->attr_timestamp);
+
+        // PHP, defaultTimeZone => America/Jamaica, timestampAttributeTimeZone => America/Jamaica
+        $val = new DateValidator([
+            'format' => 'php:Y-m-d',
+            'timestampAttribute' => 'attr_timestamp',
+            'timestampAttributeFormat' => 'yyyy-MM-dd HH:mm:ss',
+            'defaultTimeZone' => 'America/Jamaica',
+            'timestampAttributeTimeZone' => 'America/Jamaica',
+        ]);
+        $model = new FakedValidationModel();
+        $model->attr_date = '2020-01-27';
+        $model->attr_timestamp = true;
+        $val->validateAttribute($model, 'attr_date');
+        $this->assertFalse($model->hasErrors('attr_date'));
+        $this->assertFalse($model->hasErrors('attr_timestamp'));
+        $this->assertSame('2020-01-27 00:00:00', $model->attr_timestamp);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Related issues  | #18351, #14795 

This is just few more tests to the date validator, which has been recently improved. There was a lack of tests with a negative time zone, and this PR slightly fixes it.