### PR TITLE
Fix eager loading Active Record relations when relation key is a subject to a type-casting behavior

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Bug #18339: Fix migrate controller actions to return exit codes (haohetao, bizley)
 - Bug #18287: Fix the OUTPUT got SQL syntax error if the column name is MSSQL keyword e.g key (darkdef)
 - Bug #18426: Fix check for route's leading slash in `yii\widgets\Menu` (stevekr)
+- Bug #16492: Fix eager loading Active Record relations when relation key is a subject to a type-casting behavior (bizley)
 
 
 2.0.39.3 November 23, 2020

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -600,7 +600,7 @@ trait ActiveRelationTrait
             $value = $value->__toString();
         }
 
-        return $value;
+        return (string)$value;
     }
 
     /**

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -236,4 +236,9 @@ class Order extends ActiveRecord
             0 => 'customer_id',
         ];
     }
+
+    public function getQuantityOrderItems()
+    {
+        return $this->hasMany(OrderItem::className(), ['order_id' => 'id', 'quantity' => 'id']);
+    }
 }

--- a/tests/data/ar/OrderItem.php
+++ b/tests/data/ar/OrderItem.php
@@ -7,6 +7,8 @@
 
 namespace yiiunit\data\ar;
 
+use yii\behaviors\AttributeTypecastBehavior;
+
 /**
  * Class OrderItem.
  *
@@ -22,6 +24,22 @@ class OrderItem extends ActiveRecord
     public static function tableName()
     {
         return static::$tableName ?: 'order_item';
+    }
+
+    public function behaviors()
+    {
+        return [
+            'typecast' => [
+                'class' => AttributeTypecastBehavior::className(),
+                'attributeTypes' => [
+                    'order_id' => AttributeTypecastBehavior::TYPE_STRING,
+                ],
+                'typecastAfterValidate' => false,
+                'typecastAfterFind' => true,
+                'typecastAfterSave' => false,
+                'typecastBeforeSave' => false,
+            ],
+        ];
     }
 
     public function getOrder()

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -2080,4 +2080,19 @@ abstract class ActiveRecordTest extends DatabaseTestCase
 
         $this->assertEquals(['1', '01', '001', '001', '2', '2b', '2b', '02'], $alphaIdentifiers);
     }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/16492
+     */
+    public function testEagerLoadingWithTypeCastedCompositeIdentifier()
+    {
+        $aggregation = Order::find()->joinWith('quantityOrderItems', true)->all();
+        foreach ($aggregation as $item) {
+            if ($item->id == 1) {
+                $this->assertEquals(1, $item->quantityOrderItems[0]->order_id);
+            } elseif ($item->id != 1) {
+                $this->assertCount(0, $item->quantityOrderItems);
+            }
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #16492 
