### PR TITLE
Model key normalization

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,6 +15,7 @@ Yii Framework 2 Change Log
 - Bug #18287: Fix the OUTPUT got SQL syntax error if the column name is MSSQL keyword e.g key (darkdef)
 - Bug #18426: Fix check for route's leading slash in `yii\widgets\Menu` (stevekr)
 - Bug #16492: Fix eager loading Active Record relations when relation key is a subject to a type-casting behavior (bizley)
+- Bug #18435: Fix ensuring Active Record relation links' keys to be strings (bizley)
 
 
 2.0.39.3 November 23, 2020

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -585,22 +585,23 @@ trait ActiveRelationTrait
         if (count($key) > 1) {
             return serialize($key);
         }
-        $key = reset($key);
-        return is_scalar($key) ? $key : serialize($key);
+        return reset($key);
     }
 
     /**
-     * @param mixed $value raw key value.
+     * @param mixed $value raw key value. Since 2.0.40 non-string values must be convertable to string (like special
+     * objects for cross-DBMS relations, for example: `|MongoId`).
      * @return string normalized key value.
      */
     private function normalizeModelKey($value)
     {
-        if (is_object($value) && method_exists($value, '__toString')) {
-            // ensure matching to special objects, which are convertable to string, for cross-DBMS relations, for example: `|MongoId`
-            $value = $value->__toString();
+        try {
+            return (string)$value;
+        } catch (\Exception $e) {
+            throw new InvalidConfigException('Value must be convertable to string.');
+        } catch (\Throwable $e) {
+            throw new InvalidConfigException('Value must be convertable to string.');
         }
-
-        return $value;
     }
 
     /**


### PR DESCRIPTION
Follow-up of the #18434 

This ensures that normalized key is a string. Also it introduces potential minor BC break (at the same time I don't know if anyone is using model keys in a way that can be broken here) but now it is behaving according to the original phpdoc (`return string` in both `normalizeModelKey` and `getModelKey`).

@rob006 