### PR TITLE
fixes for Sql Server 2008 and early

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.41 under development
 ------------------------
 
-- no changes in this release.
+- Enh #18448: Fix in queries and tests for old MSSQL version (darkdef) 
 
 
 2.0.40 December 23, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,8 +4,8 @@ Yii Framework 2 Change Log
 2.0.41 under development
 ------------------------
 
-- Enh #18448: Fix in queries and tests for old MSSQL version (darkdef) 
 - Enh #18447: Do not use `getLastInsertID` to get PK from insert query to lower collision probability for concurrent inserts (darkdef)
+- Enh #18448: Fix in queries and tests for old MSSQL version (darkdef)
 
 
 2.0.40 December 23, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Enh #18447: Do not use `getLastInsertID` to get PK from insert query to lower collision probability for concurrent inserts (darkdef)
-- Enh #18448: Fix in queries and tests for old MSSQL version (darkdef)
+- Bug #18448: Fix issues in queries and tests for older MSSQL versions (darkdef)
 
 
 2.0.40 December 23, 2020

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -122,6 +122,9 @@ class QueryBuilder extends \yii\db\QueryBuilder
         $sql = preg_replace('/^([\s(])*SELECT(\s+DISTINCT)?(?!\s*TOP\s*\()/i', "\\1SELECT\\2 rowNum = ROW_NUMBER() over ($orderBy),", $sql);
 
         if ($this->hasLimit($limit)) {
+            if ($limit instanceof Expression) {
+                $limit = '('. (string)$limit . ')';
+            }
             $sql = "SELECT TOP $limit * FROM ($sql) sub";
         } else {
             $sql = "SELECT * FROM ($sql) sub";

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -540,7 +540,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         list(, $placeholders, $values, $params) = $this->prepareInsertValues($table, $insertColumns, $params);
 
         /**
-         * fix number of select query params for old sql server version, without correct offset support
+         * Fix number of select query params for old MSSQL version that does not support offset correctly.
          * @see QueryBuilder::oldBuildOrderByAndLimit
          */
         $insertNamesUsing = $insertNames;

--- a/tests/framework/db/mssql/ActiveRecordTest.php
+++ b/tests/framework/db/mssql/ActiveRecordTest.php
@@ -64,11 +64,14 @@ END';
     {
         $db = $this->getConnection();
 
-        $sql = 'CREATE OR ALTER FUNCTION TESTFUNC(@Number INT)
+        $sql = 'IF OBJECT_ID(\'TESTFUNC\') IS NOT NULL EXEC(\'DROP FUNCTION TESTFUNC\')';
+        $db->createCommand($sql)->execute();
+
+        $sql = 'CREATE FUNCTION TESTFUNC(@Number INT)
 RETURNS VARCHAR(15)
 AS
 BEGIN
-      RETURN (SELECT TRY_CONVERT(VARCHAR(15),@Number))
+      RETURN (SELECT CONVERT(VARCHAR(15),@Number))
 END';
         $db->createCommand($sql)->execute();
 


### PR DESCRIPTION
- correct drop trigger function in function `tests\framework\db\mssql\ActiveRecordTest::testSaveWithComputedColumn`
- fix number of select query params for old sql server version, without correct offset support in function `framework\db\mssql\QueryBuilder::upsert`

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️/❌
| Fixed issues  | 
