### PR TITLE
Ability to use separate attributes for data model and filter model of `yii\grid\GridView` in `yii\grid\DataColumn`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.41 under development
 ------------------------
 
+- Enh: added ability to use separate attributes for data model and filter model of `yii\grid\GridView` in `yii\grid\DataColumn` (PowerGamer1)
 - Enh #18447: Do not use `getLastInsertID` to get PK from insert query to lower collision probability for concurrent inserts (darkdef)
 - Bug #18448: Fix issues in queries and tests for older MSSQL versions (darkdef)
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.41 under development
 ------------------------
 
-- Enh: added ability to use separate attributes for data model and filter model of `yii\grid\GridView` in `yii\grid\DataColumn` (PowerGamer1)
+- Enh #18455: Add ability to use separate attributes for data model and filter model of `yii\grid\GridView` in `yii\grid\DataColumn` (PowerGamer1)
 - Enh #18447: Do not use `getLastInsertID` to get PK from insert query to lower collision probability for concurrent inserts (darkdef)
 - Bug #18448: Fix issues in queries and tests for older MSSQL versions (darkdef)
 

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -117,7 +117,23 @@ class DataColumn extends Column
      * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
      */
     public $filterInputOptions = ['class' => 'form-control', 'id' => null];
+    /**
+     * @var string the attribute name of the [[GridView::filterModel]] associated with this column. If not set,
+     * will have the same value as [[attribute]].
+     */
+    public $filterAttribute;
 
+
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        parent::init();
+        if($this->filterAttribute === null) {
+            $this->filterAttribute = $this->attribute;
+        }
+    }
 
     /**
      * {@inheritdoc}
@@ -161,7 +177,7 @@ class DataColumn extends Column
                 $model = $modelClass::instance();
                 $label = $model->getAttributeLabel($this->attribute);
             } elseif ($this->grid->filterModel !== null && $this->grid->filterModel instanceof Model) {
-                $label = $this->grid->filterModel->getAttributeLabel($this->attribute);
+                $label = $this->grid->filterModel->getAttributeLabel($this->filterAttribute);
             } else {
                 $models = $provider->getModels();
                 if (($model = reset($models)) instanceof Model) {
@@ -189,26 +205,26 @@ class DataColumn extends Column
 
         $model = $this->grid->filterModel;
 
-        if ($this->filter !== false && $model instanceof Model && $this->attribute !== null && $model->isAttributeActive($this->attribute)) {
-            if ($model->hasErrors($this->attribute)) {
+        if ($this->filter !== false && $model instanceof Model && $this->attribute !== null && $model->isAttributeActive($this->filterAttribute)) {
+            if ($model->hasErrors($this->filterAttribute)) {
                 Html::addCssClass($this->filterOptions, 'has-error');
-                $error = ' ' . Html::error($model, $this->attribute, $this->grid->filterErrorOptions);
+                $error = ' ' . Html::error($model, $this->filterAttribute, $this->grid->filterErrorOptions);
             } else {
                 $error = '';
             }
             if (is_array($this->filter)) {
                 $options = array_merge(['prompt' => ''], $this->filterInputOptions);
-                return Html::activeDropDownList($model, $this->attribute, $this->filter, $options) . $error;
+                return Html::activeDropDownList($model, $this->filterAttribute, $this->filter, $options) . $error;
             } elseif ($this->format === 'boolean') {
                 $options = array_merge(['prompt' => ''], $this->filterInputOptions);
-                return Html::activeDropDownList($model, $this->attribute, [
+                return Html::activeDropDownList($model, $this->filterAttribute, [
                     1 => $this->grid->formatter->booleanFormat[1],
                     0 => $this->grid->formatter->booleanFormat[0],
                 ], $options) . $error;
             }
             $options = array_merge(['maxlength' => true], $this->filterInputOptions);
 
-            return Html::activeTextInput($model, $this->attribute, $options) . $error;
+            return Html::activeTextInput($model, $this->filterAttribute, $options) . $error;
         }
 
         return parent::renderFilterCellContent();

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -120,6 +120,7 @@ class DataColumn extends Column
     /**
      * @var string the attribute name of the [[GridView::filterModel]] associated with this column. If not set,
      * will have the same value as [[attribute]].
+     * @since 2.0.41
      */
     public $filterAttribute;
 

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -205,7 +205,7 @@ class DataColumn extends Column
 
         $model = $this->grid->filterModel;
 
-        if ($this->filter !== false && $model instanceof Model && $this->attribute !== null && $model->isAttributeActive($this->filterAttribute)) {
+        if ($this->filter !== false && $model instanceof Model && $this->filterAttribute !== null && $model->isAttributeActive($this->filterAttribute)) {
             if ($model->hasErrors($this->filterAttribute)) {
                 Html::addCssClass($this->filterOptions, 'has-error');
                 $error = ' ' . Html::error($model, $this->filterAttribute, $this->grid->filterErrorOptions);

--- a/tests/framework/grid/DataColumnTest.php
+++ b/tests/framework/grid/DataColumnTest.php
@@ -235,4 +235,33 @@ HTML
 HTML
             , $result);
     }
+
+    /**
+     * @see DataColumn::$filterAttribute
+     * @see DataColumn::renderFilterCellContent()
+     */
+    public function testFilterInputWithFilterAttribute()
+    {
+        $this->mockApplication();
+
+        $grid = new GridView([
+            'dataProvider' => new ArrayDataProvider([
+                'allModels' => [],
+            ]),
+            'columns' => [
+                0 => [
+                    'attribute' => 'username',
+                    'filterAttribute' => 'user_id',
+                ],
+            ],
+            'filterModel' => new \yiiunit\data\base\RulesModel(['rules' => [['user_id', 'safe']]]),
+        ]);
+
+        $dataColumn = $grid->columns[0];
+        $method = new \ReflectionMethod($dataColumn, 'renderFilterCellContent');
+        $method->setAccessible(true);
+        $result = $method->invoke($dataColumn);
+
+        $this->assertEquals('<input type="text" class="form-control" name="RulesModel[user_id]">', $result);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -

In a use case like this: https://www.yiiframework.com/wiki/653/displaying-sorting-and-filtering-model-relations-on-a-gridview it is better to separate the actual "data" model (GridView table is filled with data of this model) from the "filter" model (the one specified in GridView::filterModel and used to setup validation rules for filter inputs).

While currently it it possible to specify GridView::filterModel as an object of a class different from "data" model, when GridView renders the filter inputs it assumes that GridView::filterModel will have attributes with same name as the ones specified in DataColumn::attribute which are actually the attributes of "data" model. This leads to workarounds like in the link above where the user has to define DataColumn::attribute with the name from "filter" model and DataColumn::value to render the value of actual "data" model attribute which might have a different name.

With this PR the user can setup DataColumn::attribute with the attribute from data model (eliminating the need to define DataColumn::value) and setup any attribute name from "filter" model in DataColumn::filterAttribute eliminating the need to ensure that "data" model and related "filter" model attribute have the same name.

P.S. The doc comment for `DataColumn::filterAttribute` might need adding `@since` version note.