### PR TITLE
Support for rendering objects with ResponseFormatterInterface.

### DIFF
--- a/framework/web/DataResponseInterface.php
+++ b/framework/web/DataResponseInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\web;
+
+/**
+ * DataResponseInterface specifies the interface needed to format a response before it is sent out.
+ *
+ * @author Edin Omeragic <edin.omeragic@gmail.com>
+ * @since 2.0
+ */
+interface DataResponseInterface
+{
+    /**
+     * Formats the specified response.
+     * @param Response $response the response to be formatted.
+     */
+    public function format($response);
+}

--- a/framework/web/DataResponseInterface.php
+++ b/framework/web/DataResponseInterface.php
@@ -11,7 +11,7 @@ namespace yii\web;
  * DataResponseInterface specifies the interface needed to format a response before it is sent out.
  *
  * @author Edin Omeragic <edin.omeragic@gmail.com>
- * @since 2.0
+ * @since 2.42
  */
 interface DataResponseInterface
 {

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link http://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -1090,7 +1091,7 @@ class Response extends \yii\base\Response
             return;
         }
 
-        if ($this->data instanceof ResponseFormatterInterface) {
+        if ($this->data instanceof DataResponseInterface) {
             $this->data->format($this);
             return;
         }

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -1090,6 +1090,11 @@ class Response extends \yii\base\Response
             return;
         }
 
+        if ($this->data instanceof ResponseFormatterInterface) {
+            $this->data->format($this);
+            return;
+        }
+
         if (isset($this->formatters[$this->format])) {
             $formatter = $this->formatters[$this->format];
             if (!is_object($formatter)) {

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -402,7 +402,6 @@ class ResponseTest extends \yiiunit\TestCase
         $content = ob_get_clean();
 
         $this->assertNotNull($response->data);
-        $this->assertInstanceOf(ResponseFormatterInterface::class, $response->data);
         $this->assertSame($content,  $response->data->message);
     }
 }

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -17,7 +17,7 @@ use yii\web\Request;
 use yii\web\Response;
 use yii\web\ResponseFormatterInterface;
 use yiiunit\framework\web\mocks\TestRequestComponent;
-use yiiunit\framework\web\stubs\ResponseFormatter;
+use yiiunit\framework\web\stubs\ResponseResult;
 
 /**
  * @group web
@@ -395,7 +395,7 @@ class ResponseTest extends \yiiunit\TestCase
     public function testUsingDataAsResponseFormatter()
     {
         $response = new Response();
-        $response->data = new ResponseFormatter("test");
+        $response->data = new ResponseResult("test");
 
         ob_start();
         $response->send();

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -15,7 +15,9 @@ use yii\helpers\StringHelper;
 use yii\web\HttpException;
 use yii\web\Request;
 use yii\web\Response;
+use yii\web\ResponseFormatterInterface;
 use yiiunit\framework\web\mocks\TestRequestComponent;
+use yiiunit\framework\web\stubs\ResponseFormatter;
 
 /**
  * @group web
@@ -388,5 +390,19 @@ class ResponseTest extends \yiiunit\TestCase
         $content = ob_get_clean();
         $this->assertSame($content, '');
         $this->assertNull($response->stream);
+    }
+
+    public function testUsingDataAsResponseFormatter()
+    {
+        $response = new Response();
+        $response->data = new ResponseFormatter("test");
+
+        ob_start();
+        $response->send();
+        $content = ob_get_clean();
+
+        $this->assertNotNull($response->data);
+        $this->assertInstanceOf(ResponseFormatterInterface::class, $response->data);
+        $this->assertSame($content,  $response->data->message);
     }
 }

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -402,6 +402,6 @@ class ResponseTest extends \yiiunit\TestCase
         $content = ob_get_clean();
 
         $this->assertNotNull($response->data);
-        $this->assertSame($content,  $response->data->message);
+        $this->assertSame($content, $response->data->message);
     }
 }

--- a/tests/framework/web/stubs/ResponseFormatter.php
+++ b/tests/framework/web/stubs/ResponseFormatter.php
@@ -18,7 +18,8 @@ class ResponseFormatter implements ResponseFormatterInterface
         $this->message = $message;
     }
 
-    public function format($request) {
+    public function format($request)
+    {
         $request->content = $this->message;
     }
 }

--- a/tests/framework/web/stubs/ResponseFormatter.php
+++ b/tests/framework/web/stubs/ResponseFormatter.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\web\stubs;
+
+use yii\web\ResponseFormatterInterface;
+
+class ResponseFormatter implements ResponseFormatterInterface
+{
+    public $message;
+
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+
+    public function format($request) {
+        $request->content = $this->message;
+    }
+}

--- a/tests/framework/web/stubs/ResponseResult.php
+++ b/tests/framework/web/stubs/ResponseResult.php
@@ -7,9 +7,9 @@
 
 namespace yiiunit\framework\web\stubs;
 
-use yii\web\ResponseFormatterInterface;
+use yii\web\DataResponseInterface;
 
-class ResponseFormatter implements ResponseFormatterInterface
+class ResponseResult implements DataResponseInterface
 {
     public $message;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

Adds support for rendering objects that implements ResponseFormatterInterface. For example:

```php
class CustomResponse implements ResponseFormatterInterface
{
    private string $message;

    public function __construct(string $message)
    {
        $this->message = $message;
    }

    public function format($response)
    {
        $response->setStatusCode(200);
        $response->getHeaders()->add("Content-Type", "application/json; charset=UTF-8");
        $response->content = \yii\helpers\Json::encode([
            'message' => $this->message
        ]);
    }
}
```

Then somewhere in controller, it would be possible to:

```php
public function actionHello()
{
    return new CustomResponse("Hello World");
}
```
