### PR TITLE
BatchQueryResult reset/finish events

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Enh #18447: Do not use `getLastInsertID` to get PK from insert query to lower collision probability for concurrent inserts (darkdef)
 - Bug #18448: Fix issues in queries and tests for older MSSQL versions (darkdef)
+- Enh #18457: Add `EVENT_RESET` and `EVENT_FINISH` events to `yii\db\BatchQueryResult` (brandonkelly)
 
 
 2.0.40 December 23, 2020


### PR DESCRIPTION
This PR adds new `EVENT_RESET` and `EVENT_FINISH` events to `yii\db\BatchQueryResult`. With these in place, it can be possible to [open a new unbuffered MySQL connection](https://www.yiiframework.com/doc/guide/2.0/en/db-query-builder#batch-query-mysql) for just the duration needed by a batched query, and then close it once the cursor has reached the end.

Real world usage: https://github.com/craftcms/cms/commit/662dbf199e90c5a67d8e7432ae1cc8b4f751bb45#diff-83772e0b3826d092cca0e5b1eb833373320d8dc106d735c9ebbab093962dc567R216-R223

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | craftcms/cms#7338


