### PR TITLE
Use separate driver for DBLib connections due to transaction issues

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 Change Log
 - Bug #18464: Fix bug with processing fallback messages when translation language is set to `null` (bizley)
 - Enh #18457: Add `EVENT_RESET` and `EVENT_FINISH` events to `yii\db\BatchQueryResult` (brandonkelly)
 - Bug #18472: Fix initializing `db` component configuration in `yii\data\ActiveDataProvider` (bizley)
+- Bug #18480: Transactions are not committed using the dblib driver (bbrunekreeft)
 
 
 2.0.40 December 23, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 Change Log
 - Bug #18464: Fix bug with processing fallback messages when translation language is set to `null` (bizley)
 - Enh #18457: Add `EVENT_RESET` and `EVENT_FINISH` events to `yii\db\BatchQueryResult` (brandonkelly)
 - Bug #18472: Fix initializing `db` component configuration in `yii\data\ActiveDataProvider` (bizley)
+- Bug #18477: Fix detecting availability of Xdebug's stack trace in `yii\base\ErrorException` (bizley)
 - Bug #18480: Transactions are not committed using the dblib driver (bbrunekreeft)
 
 

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -694,8 +694,10 @@ class Connection extends Component
                 $driver = strtolower(substr($this->dsn, 0, $pos));
             }
             if (isset($driver)) {
-                if ($driver === 'mssql' || $driver === 'dblib') {
+                if ($driver === 'mssql') {
                     $pdoClass = 'yii\db\mssql\PDO';
+                } elseif ($driver === 'dblib') {
+                    $pdoClass = 'yii\db\mssql\DBLibPDO';
                 } elseif ($driver === 'sqlsrv') {
                     $pdoClass = 'yii\db\mssql\SqlsrvPDO';
                 }

--- a/framework/db/mssql/DBLibPDO.php
+++ b/framework/db/mssql/DBLibPDO.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\db\mssql;
+
+/**
+ * This is an extension of the default PDO class of DBLIB drivers.
+ * It provides workarounds for improperly implemented functionalities of the DBLIB drivers.
+ *
+ * @author Bert Brunekreeft <bbrunekreeft@gmail.com>
+ * @since 2.0
+ */
+class DBLibPDO extends \PDO
+{
+    /**
+     * Returns value of the last inserted ID.
+     * @param string|null $sequence the sequence name. Defaults to null.
+     * @return int last inserted ID value.
+     */
+    public function lastInsertId($sequence = null)
+    {
+        return $this->query('SELECT CAST(COALESCE(SCOPE_IDENTITY(), @@IDENTITY) AS bigint)')->fetchColumn();
+    }
+
+    /**
+     * Retrieve a database connection attribute.
+     *
+     * It is necessary to override PDO's method as some MSSQL PDO driver (e.g. dblib) does not
+     * support getting attributes.
+     * @param int $attribute One of the PDO::ATTR_* constants.
+     * @return mixed A successful call returns the value of the requested PDO attribute.
+     * An unsuccessful call returns null.
+     */
+    public function getAttribute($attribute)
+    {
+        try {
+            return parent::getAttribute($attribute);
+        } catch (\PDOException $e) {
+            switch ($attribute) {
+                case self::ATTR_SERVER_VERSION:
+                    return $this->query("SELECT CAST(SERVERPROPERTY('productversion') AS VARCHAR)")->fetchColumn();
+                default:
+                    throw $e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18480

The DBLib driver seems to support the native PDO beginTransaction, commit and rollback statements.
This PR should resolve #18480.
Tested with transactions on my own test environment.
