### PR TITLE
Enh #18483: Add property `yii\log\Logger::dbEventNames` - an array wi…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.41 under development
 ------------------------
 
-- Enh #18483: Add property `yii\log\Logger::dbEventNames` - an array with event names used to get statistical results (profiling) of DB queries (atiline)
+- Enh #18483: Add `yii\log\Logger::$dbEventNames` that allows specifying event names used to get statistical results (profiling) of DB queries (atiline)
 - Enh #18455: Add ability to use separate attributes for data model and filter model of `yii\grid\GridView` in `yii\grid\DataColumn` (PowerGamer1)
 - Enh #18447: Do not use `getLastInsertID` to get PK from insert query to lower collision probability for concurrent inserts (darkdef)
 - Bug #18448: Fix issues in queries and tests for older MSSQL versions (darkdef)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.41 under development
 ------------------------
 
-- Enh #18483: Add property `yii\log\Logger::dbEventNames` - an array with event names used to get statistical results (profiling) of DB queries (atiline).
+- Enh #18483: Add property `yii\log\Logger::dbEventNames` - an array with event names used to get statistical results (profiling) of DB queries (atiline)
 - Enh #18455: Add ability to use separate attributes for data model and filter model of `yii\grid\GridView` in `yii\grid\DataColumn` (PowerGamer1)
 - Enh #18447: Do not use `getLastInsertID` to get PK from insert query to lower collision probability for concurrent inserts (darkdef)
 - Bug #18448: Fix issues in queries and tests for older MSSQL versions (darkdef)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.41 under development
 ------------------------
 
+- Enh #18483: Add property `yii\log\Logger::dbEventNames` - an array with event names used to get statistical results (profiling) of DB queries (atiline).
 - Enh #18455: Add ability to use separate attributes for data model and filter model of `yii\grid\GridView` in `yii\grid\DataColumn` (PowerGamer1)
 - Enh #18447: Do not use `getLastInsertID` to get PK from insert query to lower collision probability for concurrent inserts (darkdef)
 - Bug #18448: Fix issues in queries and tests for older MSSQL versions (darkdef)

--- a/framework/log/Logger.php
+++ b/framework/log/Logger.php
@@ -111,6 +111,10 @@ class Logger extends Component
      * @var Dispatcher the message dispatcher
      */
     public $dispatcher;
+    /**
+     * @var array of event names used to get statistical results of DB queries.
+     */
+    public $dbEventNames = ['yii\db\Command::query', 'yii\db\Command::execute'];
 
 
     /**
@@ -252,7 +256,7 @@ class Logger extends Component
      */
     public function getDbProfiling()
     {
-        $timings = $this->getProfiling(['yii\db\Command::query', 'yii\db\Command::execute']);
+        $timings = $this->getProfiling($this->dbEventNames);
         $count = count($timings);
         $time = 0;
         foreach ($timings as $timing) {

--- a/framework/log/Logger.php
+++ b/framework/log/Logger.php
@@ -113,6 +113,7 @@ class Logger extends Component
     public $dispatcher;
     /**
      * @var array of event names used to get statistical results of DB queries.
+     * @since 2.0.41
      */
     public $dbEventNames = ['yii\db\Command::query', 'yii\db\Command::execute'];
 


### PR DESCRIPTION
…th event names used to get statistical results (profiling) of DB queries.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18483
