### PR TITLE
Allowing non-GET-verb URL rules to have a URL created

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,7 +14,7 @@ Yii Framework 2 Change Log
 - Bug #18479: Fix invalid argument type for `preg_split` in `\yii\console\Controller` (gazooz)
 - Bug #18477: Fix detecting availability of Xdebug's stack trace in `yii\base\ErrorException` (bizley)
 - Bug #18480: Transactions are not committed using the dblib driver (bbrunekreeft)
-- Enh #18487: Allowing non-GET-verb URL rules to have a URL created (bizley)
+- Enh #18487: Allow creating URLs for non-GET-verb rules (bizley)
 
 
 2.0.40 December 23, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Bug #18479: Fix invalid argument type for `preg_split` in `\yii\console\Controller` (gazooz)
 - Bug #18477: Fix detecting availability of Xdebug's stack trace in `yii\base\ErrorException` (bizley)
 - Bug #18480: Transactions are not committed using the dblib driver (bbrunekreeft)
+- Enh #18487: Allowing non-GET-verb URL rules to have a URL created (bizley)
 
 
 2.0.40 December 23, 2020

--- a/framework/rest/UrlRule.php
+++ b/framework/rest/UrlRule.php
@@ -205,9 +205,6 @@ class UrlRule extends CompositeUrlRule
         $config['verb'] = $verbs;
         $config['pattern'] = rtrim($prefix . '/' . strtr($pattern, $this->tokens), '/');
         $config['route'] = $action;
-        if (!empty($verbs) && !in_array('GET', $verbs)) {
-            $config['mode'] = WebUrlRule::PARSING_ONLY;
-        }
         $config['suffix'] = $this->suffix;
 
         return Yii::createObject($config);

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -245,10 +245,6 @@ class UrlManager extends Component
                 $rule = ['route' => $rule];
                 if (preg_match("/^((?:($verbs),)*($verbs))\\s+(.*)$/", $key, $matches)) {
                     $rule['verb'] = explode(',', $matches[1]);
-                    // rules that are not applicable for GET requests should not be used to create URLs
-                    if (!in_array('GET', $rule['verb'], true)) {
-                        $rule['mode'] = UrlRule::PARSING_ONLY;
-                    }
                     $key = $matches[4];
                 }
                 $rule['pattern'] = $key;

--- a/tests/framework/rest/UrlRuleTest.php
+++ b/tests/framework/rest/UrlRuleTest.php
@@ -323,7 +323,7 @@ class UrlRuleTest extends TestCase
                     'extraPatterns' => [
                         '{id}/my' => 'my',
                         'my' => 'my',
-                        // this should not create a URL, no GET definition
+                        // since 2.0.41 this should create a URL (previously it was false)
                         'POST {id}/my2' => 'my2',
                     ],
                 ],
@@ -339,7 +339,7 @@ class UrlRuleTest extends TestCase
                     [['v1/channel/my'], 'v1/channels/my'],
                     [['v1/channel/my', 'id' => 42], 'v1/channels/42/my'],
                     [['v1/channel/my2'], false],
-                    [['v1/channel/my2', 'id' => 42], false],
+                    [['v1/channel/my2', 'id' => 42], 'v1/channels/42/my2'],
                 ],
             ],
         ];
@@ -419,11 +419,16 @@ class UrlRuleTest extends TestCase
                     [['v1/channel/index'], 'v1/channels', WebUrlRule::CREATE_STATUS_SUCCESS],
                     [['v1/channel/index', 'offset' => 1], 'v1/channels?offset=1', WebUrlRule::CREATE_STATUS_SUCCESS],
                     [['v1/channel/view', 'id' => 42], 'v1/channels/42', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/view'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
                     [['v1/channel/options'], 'v1/channels', WebUrlRule::CREATE_STATUS_SUCCESS],
                     [['v1/channel/options', 'id' => 42], 'v1/channels/42', WebUrlRule::CREATE_STATUS_SUCCESS],
-                    [['v1/channel/delete'], false, WebUrlRule::CREATE_STATUS_PARSING_ONLY],
+                    [['v1/channel/delete'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
+                    [['v1/channel/delete', 'id' => 43], 'v1/channels/43', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/create'], 'v1/channels', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/update', 'id' => 44], 'v1/channels/44', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/update'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
+
                     [['v1/missing/view'], false, WebUrlRule::CREATE_STATUS_ROUTE_MISMATCH],
-                    [['v1/channel/view'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
                 ],
             ],
             'multiple controllers' => [
@@ -438,13 +443,23 @@ class UrlRuleTest extends TestCase
                     [['v1/channel/view', 'id' => 42], 'v1/channel/42', WebUrlRule::CREATE_STATUS_SUCCESS],
                     [['v1/channel/options'], 'v1/channel', WebUrlRule::CREATE_STATUS_SUCCESS],
                     [['v1/channel/options', 'id' => 42], 'v1/channel/42', WebUrlRule::CREATE_STATUS_SUCCESS],
-                    [['v1/channel/delete'], false, WebUrlRule::CREATE_STATUS_PARSING_ONLY],
+                    [['v1/channel/delete'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
+                    [['v1/channel/delete', 'id' => 43], 'v1/channel/43', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/create'], 'v1/channel', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/channel/update'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
+                    [['v1/channel/update', 'id' => 45], 'v1/channel/45', WebUrlRule::CREATE_STATUS_SUCCESS],
+
                     [['v1/user/index'], 'v1/u', WebUrlRule::CREATE_STATUS_SUCCESS],
                     [['v1/user/view', 'id' => 1], 'v1/u/1', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/view'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
                     [['v1/user/options'], 'v1/u', WebUrlRule::CREATE_STATUS_SUCCESS],
                     [['v1/user/options', 'id' => 42], 'v1/u/42', WebUrlRule::CREATE_STATUS_SUCCESS],
-                    [['v1/user/delete'], false, WebUrlRule::CREATE_STATUS_PARSING_ONLY],
-                    [['v1/user/view'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
+                    [['v1/user/delete', 'id' => 44], 'v1/u/44', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/delete'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
+                    [['v1/user/create'], 'v1/u', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/update', 'id' => 46], 'v1/u/46', WebUrlRule::CREATE_STATUS_SUCCESS],
+                    [['v1/user/update'], false, WebUrlRule::CREATE_STATUS_PARAMS_MISMATCH],
+
                     [['v1/missing/view'], false, WebUrlRule::CREATE_STATUS_ROUTE_MISMATCH],
                 ],
             ],

--- a/tests/framework/web/UrlManagerCreateUrlTest.php
+++ b/tests/framework/web/UrlManagerCreateUrlTest.php
@@ -202,6 +202,7 @@ class UrlManagerCreateUrlTest extends TestCase
             'post/<id:\d+>' => 'post/view',
             'posts' => 'post/index',
             'book/<id:\d+>/<title>' => 'book/view',
+            'POST posts' => 'post/create',
         ];
         $manager = $this->getUrlManager($config, $showScriptName);
 
@@ -235,6 +236,10 @@ class UrlManagerCreateUrlTest extends TestCase
         // match third rule, ensure encoding of params
         $url = $manager->$method(['book/view', 'id' => 1, 'title' => 'sample post']);
         $this->assertEquals("$prefix/book/1/sample+post", $url);
+
+        // match fourth rule, since 2.0.41 non-GET verbs are allowed
+        $url = $manager->$method(['post/create']);
+        $this->assertEquals("$prefix/posts", $url);
     }
 
     /**

--- a/tests/framework/web/UrlManagerParseUrlTest.php
+++ b/tests/framework/web/UrlManagerParseUrlTest.php
@@ -342,7 +342,7 @@ class UrlManagerParseUrlTest extends TestCase
                 ],
             ],
         ], \yii\web\Application::className());
-        $this->assertEquals('/app/post/delete?id=123', $manager->createUrl(['post/delete', 'id' => 123]));
+        $this->assertEquals('/app/post/123', $manager->createUrl(['post/delete', 'id' => 123]));
         $this->destroyApplication();
 
         unset($_SERVER['REQUEST_METHOD']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | only if someone depends on non-GET rule URL to not be created
| Tests pass?   | ✔️
| Fixed issues  | #18487
