### PR TITLE
Fix #17241 ActiveField::widget() input options

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.41 under development
 ------------------------
 
+- Bug #17241: Fix `ActiveField()::widget()` to use configured input options (yugaego)
 - Enh #18483: Add `yii\log\Logger::$dbEventNames` that allows specifying event names used to get statistical results (profiling) of DB queries (atiline)
 - Enh #18455: Add ability to use separate attributes for data model and filter model of `yii\grid\GridView` in `yii\grid\DataColumn` (PowerGamer1)
 - Enh #18447: Do not use `getLastInsertID` to get PK from insert query to lower collision probability for concurrent inserts (darkdef)

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -775,19 +775,19 @@ class ActiveField extends Component
         $config['attribute'] = $this->attribute;
         $config['view'] = $this->form->getView();
         if (is_subclass_of($class, 'yii\widgets\InputWidget')) {
-            foreach ($this->inputOptions as $key => $value) {
-                if (!isset($config['options'][$key])) {
-                    $config['options'][$key] = $value;
-                }
-            }
+            $classOptions = (new \ReflectionClass($class))->getDefaultProperties();
+            $classOptions = is_null($classOptions['options']) ? [] : $classOptions['options'];
+
+            $definitions = \Yii::$container->getDefinitions();
+            $diOptions = (isset($definitions[$class]['options'])) ? $definitions[$class]['options'] : [];
+
+            $fieldOptions = isset($config['options']) ? $config['options'] : [];
+            $config['options'] = array_merge($classOptions, $diOptions, $this->inputOptions, $fieldOptions);
+
             $config['field'] = $this;
-            if (!isset($config['options'])) {
-                $config['options'] = [];
-            }
             if ($this->form->validationStateOn === ActiveForm::VALIDATION_STATE_ON_INPUT) {
                 $this->addErrorClassIfNeeded($config['options']);
             }
-
             $this->addAriaAttributes($config['options']);
             $this->adjustLabelFor($config['options']);
         }

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -555,6 +555,18 @@ EOD;
 
     public function testWidgetOptions()
     {
+        $this->activeField->widget(TestInputWidget::className());
+        $widget = TestInputWidget::$lastInstance;
+        $this->assertArraySubset(['data-default' => 'value'], $widget->options);
+
+        $this->activeField->widget(TestInputWidget::className(), ['options' => ['data-default' => 'another']]);
+        $widget = TestInputWidget::$lastInstance;
+        $this->assertArraySubset(['data-default' => 'another'], $widget->options);
+
+        $this->activeField->widget(TestInputWidget::className(), ['options' => ['data-toggle' => 'toggle']]);
+        $widget = TestInputWidget::$lastInstance;
+        $this->assertArraySubset(['data-toggle' => 'toggle', 'data-default' => 'value'], $widget->options);
+
         $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
         $this->activeField->model->addError('attributeName', 'error');
 
@@ -564,6 +576,7 @@ EOD;
             'class' => 'form-control has-error',
             'aria-invalid' => 'true',
             'id' => 'activefieldtestmodel-attributename',
+            'data-default' => 'value'
         ];
         $this->assertEquals($expectedOptions, $widget->options);
 
@@ -574,6 +587,7 @@ EOD;
             'class' => 'has-error',
             'aria-invalid' => 'true',
             'id' => 'activefieldtestmodel-attributename',
+            'data-default' => 'value'
         ];
         $this->assertEquals($expectedOptions, $widget->options);
     }
@@ -705,6 +719,8 @@ class TestInputWidget extends InputWidget
      * @var static
      */
     public static $lastInstance;
+
+    public $options = ['data-default' => 'value'];
 
     public function init()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️
| Fixed issues  | #17241

The issue is rooted in having several points of control over a widget's input attributes. The points of control - the ones I am aware of - are listed below in order of precedence, from lowest to highest:

1. subInputWidget::options class property default value.
2. subInputWidget::options DI container configuration.
3. ActiveField::inputOptions.
4. ActiveField::widget(,$config['options']).

The first two were used before Yii 2.0.17 and prevented from the load by #16681 and #17299 fixes.

