### PR TITLE
Support for MySQL ANSI/ANSI_QUOTES modes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,7 +16,7 @@ Yii Framework 2 Change Log
 - Bug #18480: Transactions are not committed using the dblib driver (bbrunekreeft)
 - Enh #18493: Faster request parsing for REST UrlRule with prefix handling (bizley)
 - Enh #18487: Allow creating URLs for non-GET-verb rules (bizley)
-- Bug #8750: Fix MySQL support when running in `ANSI`/`ANSI_QUOTES` modes (brandonkelly)  
+- Bug #8750: Fix MySQL support when running in `ANSI`/`ANSI_QUOTES` modes (brandonkelly)
 
 
 2.0.40 December 23, 2020

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #18480: Transactions are not committed using the dblib driver (bbrunekreeft)
 - Enh #18493: Faster request parsing for REST UrlRule with prefix handling (bizley)
 - Enh #18487: Allow creating URLs for non-GET-verb rules (bizley)
+- Bug #8750: Fix MySQL support when running in `ANSI`/`ANSI_QUOTES` modes (brandonkelly)  
 
 
 2.0.40 December 23, 2020

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -90,7 +90,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
             $row = array_values($row);
             $sql = $row[1];
         }
-        if (preg_match_all('/^\s*`(.*?)`\s+(.*?),?$/m', $sql, $matches)) {
+        if (preg_match_all('/^\s*[`"](.*?)[`"]\s+(.*?),?$/m', $sql, $matches)) {
             foreach ($matches[1] as $i => $c) {
                 if ($c === $oldName) {
                     return "ALTER TABLE $quotedTable CHANGE "
@@ -373,7 +373,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
             $row = array_values($row);
             $sql = $row[1];
         }
-        if (preg_match_all('/^\s*`(.*?)`\s+(.*?),?$/m', $sql, $matches)) {
+        if (preg_match_all('/^\s*[`"](.*?)[`"]\s+(.*?),?$/m', $sql, $matches)) {
             foreach ($matches[1] as $i => $c) {
                 if ($c === $column) {
                     return $matches[2][$i];

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -413,9 +413,9 @@ SQL;
             $regexp = '/FOREIGN KEY\s+\(([^\)]+)\)\s+REFERENCES\s+([^\(^\s]+)\s*\(([^\)]+)\)/mi';
             if (preg_match_all($regexp, $sql, $matches, PREG_SET_ORDER)) {
                 foreach ($matches as $match) {
-                    $fks = array_map('trim', explode(',', str_replace('`', '', $match[1])));
-                    $pks = array_map('trim', explode(',', str_replace('`', '', $match[3])));
-                    $constraint = [str_replace('`', '', $match[2])];
+                    $fks = array_map('trim', explode(',', str_replace(['`', '"'], '', $match[1])));
+                    $pks = array_map('trim', explode(',', str_replace(['`', '"'], '', $match[3])));
+                    $constraint = [str_replace(['`', '"'], '', $match[2])];
                     foreach ($fks as $k => $name) {
                         $constraint[$name] = $pks[$k];
                     }
@@ -446,11 +446,11 @@ SQL;
         $sql = $this->getCreateTableSql($table);
         $uniqueIndexes = [];
 
-        $regexp = '/UNIQUE KEY\s+\`(.+)\`\s*\((\`.+\`)+\)/mi';
+        $regexp = '/UNIQUE KEY\s+[`"](.+)[`"]\s*\(([`"].+[`"])+\)/mi';
         if (preg_match_all($regexp, $sql, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $indexName = $match[1];
-                $indexColumns = array_map('trim', explode('`,`', trim($match[2], '`')));
+                $indexColumns = array_map('trim', preg_split('/[`"],[`"]/', trim($match[2], '`"')));
                 $uniqueIndexes[$indexName] = $indexColumns;
             }
         }


### PR DESCRIPTION
This PR adds support for MySQL’s `ANSI` and `ANSI_QUOTES` modes, by checking for `"` characters in addition to <code>\`</code> whenever parsing the results of a `SHOW CREATE TABLE` command.

`ANSI_QUOTES` is enabled by default on DigitalOcean for MySQL 8, so it would be great to get this pulled in.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #8750
