### PR TITLE
Fixed typo in di container guide

### DIFF
--- a/docs/guide-fr/concept-di-container.md
+++ b/docs/guide-fr/concept-di-container.md
@@ -410,7 +410,7 @@ $container->setDefinitions([
     ]
 ]);
 
-$reader = $container->get('app\storage\DocumentsReader); 
+$reader = $container->get('app\storage\DocumentsReader'); 
 // Se comporte exactement comme l'exemple précédent
 ```
 

--- a/docs/guide-ja/concept-di-container.md
+++ b/docs/guide-ja/concept-di-container.md
@@ -448,7 +448,7 @@ $container->setDefinitions([
     }
 ]);
 
-$reader = $container->get('app\storage\DocumentsReader); 
+$reader = $container->get('app\storage\DocumentsReader'); 
 // 構成情報に書かれている依存とともに DocumentReader オブジェクトが生成されます
 ```
 
@@ -481,7 +481,7 @@ $container->setDefinitions([
     ]
 ]);
 
-$reader = $container->get('app\storage\DocumentsReader); 
+$reader = $container->get('app\storage\DocumentsReader'); 
 // 前の例と全く同じオブジェクトが生成されます
 ```
 

--- a/docs/guide-zh-CN/concept-di-container.md
+++ b/docs/guide-zh-CN/concept-di-container.md
@@ -427,7 +427,7 @@ $container->setDefinitions([
     }
 ]);
 
-$reader = $container->get('app\storage\DocumentsReader); 
+$reader = $container->get('app\storage\DocumentsReader'); 
 // 将按照配置中的描述创建 DocumentReader 对象及其依赖关系
 ```
 
@@ -465,7 +465,7 @@ $container->setDefinitions([
     ]
 ]);
 
-$reader = $container->get('app\storage\DocumentsReader); 
+$reader = $container->get('app\storage\DocumentsReader'); 
 // 将与前面示例中的行为完全相同。
 ```
 

--- a/docs/guide/concept-di-container.md
+++ b/docs/guide/concept-di-container.md
@@ -484,7 +484,7 @@ $container->setDefinitions([
     ]
 ]);
 
-$reader = $container->get('app\storage\DocumentsReader); 
+$reader = $container->get('app\storage\DocumentsReader'); 
 // Will behave exactly the same as in the previous example.
 ```
 


### PR DESCRIPTION
DI container guide was missing ending quotation mark in few places.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -
