### PR TITLE
Fix TableTest namespace

### DIFF
--- a/tests/framework/console/widgets/TableTest.php
+++ b/tests/framework/console/widgets/TableTest.php
@@ -5,7 +5,7 @@
  * @license http://www.yiiframework.com/license/
  */
 
-namespace yiiunit\framework\console;
+namespace yiiunit\framework\console\widgets;
 
 use yii\console\widgets\Table;
 use yii\helpers\Console;


### PR DESCRIPTION
Fixes a warning when Composer 2 is dumping the autoloader:

> Class yiiunit\framework\console\TableTest located in ./tests/framework/console/widgets/TableTest.php does not comply with psr-4 autoloading standard. Skipping.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
