### PR TITLE
Execute tests/bootstrap.php via autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,11 @@
             "yii\\cs\\": "cs/src/"
         }
     },
+    "autoload-dev": {
+        "files": [
+            "tests/bootstrap.php"
+        ]
+    },
     "config": {
         "platform": {"php": "5.4"}
     },


### PR DESCRIPTION
The contributing guide [states](https://github.com/yiisoft/yii2/blob/master/docs/internals/git-workflow.md#unit-tests):

> You can execute unit tests by running `phpunit` in the repo root directory. If you do not have phpunit installed globally you can run `php vendor/bin/phpunit` or `vendor/bin/phpunit.bat` in case of execution from the Windows OS.

I’m finding this to not be true, because `tests/bootstrap.php` is not executed when you try this, so several things don’t get set up properly for the tests to be able to run.

With this change, when the yii2 repo is Composer-installed directly, `tests/bootstrap.php` will get executed on each request before PHPUnit is run.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
