### PR TITLE
Connection class for ActiveDataProvider

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #18544: Fix `yii\validators\NumberValidator` to disallow values with whitespaces (bizley)
 - Bug #18552: Fix bug with `yii\data\SqlDataProvider` not properly handling SQL with `ORDER BY` clause (bizley)
+- Bug #18557: Fix `yii\data\ActiveDataProvider` to handle DB connection configuration of different type than just `yii\db\Connection` (bizley)
 
 
 2.0.41.1 March 04, 2021

--- a/framework/data/ActiveDataProvider.php
+++ b/framework/data/ActiveDataProvider.php
@@ -77,12 +77,6 @@ class ActiveDataProvider extends BaseDataProvider
      * Starting from version 2.0.2, this can also be a configuration array for creating the object.
      */
     public $db;
-    /**
-     * @var string the DB connection class name appropriate for this ActiveDataProvider.
-     * Extending classes should replace it to match their connection class.
-     * @since 2.0.42
-     */
-    public $connectionClass = 'yii\db\Connection';
 
 
     /**
@@ -94,7 +88,7 @@ class ActiveDataProvider extends BaseDataProvider
     {
         parent::init();
         if ($this->db !== null) {
-            $this->db = Instance::ensure($this->db, $this->connectionClass);
+            $this->db = Instance::ensure($this->db);
         }
     }
 

--- a/framework/data/ActiveDataProvider.php
+++ b/framework/data/ActiveDataProvider.php
@@ -77,6 +77,12 @@ class ActiveDataProvider extends BaseDataProvider
      * Starting from version 2.0.2, this can also be a configuration array for creating the object.
      */
     public $db;
+    /**
+     * @var string the DB connection class name appropriate for this ActiveDataProvider.
+     * Extending classes should replace it to match their connection class.
+     * @since 2.0.42
+     */
+    public $connectionClass = 'yii\db\Connection';
 
 
     /**
@@ -88,7 +94,7 @@ class ActiveDataProvider extends BaseDataProvider
     {
         parent::init();
         if ($this->db !== null) {
-            $this->db = Instance::ensure($this->db, Connection::className());
+            $this->db = Instance::ensure($this->db, $this->connectionClass);
         }
     }
 

--- a/tests/framework/data/ActiveDataProviderTest.php
+++ b/tests/framework/data/ActiveDataProviderTest.php
@@ -198,4 +198,22 @@ abstract class ActiveDataProviderTest extends DatabaseTestCase
 
         $this->assertEquals(0, $pagination->getPageCount());
     }
+
+    /**
+     * https://github.com/yiisoft/yii2/issues/18557
+     */
+    public function testConnectionClassInit()
+    {
+        $provider = new ActiveDataProvider([
+            'db' => 'yiiunit\framework\data\FakeConnection',
+            'connectionClass' => 'yiiunit\framework\data\FakeConnection',
+        ]);
+
+        $this->assertInstanceOf('yiiunit\framework\data\FakeConnection', $provider->db);
+
+        $this->expectException('yii\base\InvalidConfigException');
+        new ActiveDataProvider(['db' => 'yiiunit\framework\data\FakeConnection']);
+    }
 }
+
+class FakeConnection {}

--- a/tests/framework/data/ActiveDataProviderTest.php
+++ b/tests/framework/data/ActiveDataProviderTest.php
@@ -198,22 +198,4 @@ abstract class ActiveDataProviderTest extends DatabaseTestCase
 
         $this->assertEquals(0, $pagination->getPageCount());
     }
-
-    /**
-     * https://github.com/yiisoft/yii2/issues/18557
-     */
-    public function testConnectionClassInit()
-    {
-        $provider = new ActiveDataProvider([
-            'db' => 'yiiunit\framework\data\FakeConnection',
-            'connectionClass' => 'yiiunit\framework\data\FakeConnection',
-        ]);
-
-        $this->assertInstanceOf('yiiunit\framework\data\FakeConnection', $provider->db);
-
-        $this->expectException('yii\base\InvalidConfigException');
-        new ActiveDataProvider(['db' => 'yiiunit\framework\data\FakeConnection']);
-    }
 }
-
-class FakeConnection {}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18557 

This fixes regression introduced in #18476 - at the same time to not lose the advantage of using `ensure` for the connection configuration I propose adding new property `connectionClass` that providers extending `ActiveDataProvider` can set to their appropriate connection.

Changes in the following packages are required as well:
- [x] `yii2-elasticsearch`
- [x] `yii2-sphinx`
- [x] `yii2-redis` (only tests)
- [x] `yii2-mongodb` (only tests)

I will add the required changes if this PR is merged.