### PR TITLE
Use the correct db if strict mode is used in DbSession fixes #18574

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Enh #18534: Added `prepareSearchQuery` property in `yii\rest\IndexAction` (programmis)
+- Bug #18574: Fix `yii\web\DbSession` to use the correct db if strict mode is used (Mignar)
 - Bug #17479: Fix `yii\grid\ActionColumn` to render icons when no glyphicons are available (simialbi)
 - Bug #18544: Fix `yii\validators\NumberValidator` to disallow values with whitespaces (bizley)
 - Bug #18552: Fix `yii\data\SqlDataProvider` to properly handle SQL with `ORDER BY` clause (bizley)

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -104,7 +104,7 @@ class DbSession extends MultiFieldSession
     {
         if ($this->getUseStrictMode()) {
             $id = $this->getId();
-            if (!$this->getReadQuery($id)->exists()) {
+            if (!$this->getReadQuery($id)->exists($this->db)) {
                 //This session id does not exist, mark it for forced regeneration
                 $this->_forceRegenerateId = $id;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18574 
