### PR TITLE
Revert "Do not use $this to call static method"

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -22,7 +22,6 @@ Yii Framework 2 Change Log
 - Bug #18593: Fix setting the `maxlength` attribute for `Html::activeInput()` and `Html::activeTextArea()` based on `length` parameter of validator (BSCheshir)
 - Bug #18592: Fix `yii\db\Command::getRawSql()` to not replace query params in invalid places (sartor)
 - Bug #18590: Fix `yii\web\UrlManager` to instantiate cache only when it's actually needed (bizley)
-- Bug #18613: Do not call static methods non-statically in `BaseActiveRecord` (samdark)
 
 2.0.41.1 March 04, 2021
 -----------------------

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1121,7 +1121,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function getPrimaryKey($asArray = false)
     {
-        $keys = static::primaryKey();
+        $keys = $this->primaryKey();
         if (!$asArray && count($keys) === 1) {
             return isset($this->_attributes[$keys[0]]) ? $this->_attributes[$keys[0]] : null;
         }
@@ -1152,7 +1152,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function getOldPrimaryKey($asArray = false)
     {
-        $keys = static::primaryKey();
+        $keys = $this->primaryKey();
         if (empty($keys)) {
             throw new Exception(get_class($this) . ' does not have a primary key. You should either define a primary key for the corresponding table or override the primaryKey() method.');
         }


### PR DESCRIPTION
Reverts yiisoft/yii2#18614 because method `primaryKey` not exists in `BaseActiveRecord`. We must define `abstract static public function primaryKey();` in class `BaseActiveRecord` because `ActiveRecord` defined it as **static** to keep BC. 