### PR TITLE
Fix problem with not available `on` property

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.43 under development
 ------------------------
 
-- no changes in this release.
+- Bug #18634: Fix `yii\db\BaseActiveRecord::unlink()` and `unlinkAll()` to omit condition for `on` property when it doesn't exist (bizley)
 
 
 2.0.42 May 05, 2021

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -1,8 +1,8 @@
 Yii Framework 2 Change Log
 ==========================
 
-2.0.43 under development
-------------------------
+2.0.42.1 under development
+--------------------------
 
 - Bug #18634: Fix `yii\db\BaseActiveRecord::unlink()` and `unlinkAll()` to omit condition for `on` property when it doesn't exist (bizley)
 

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1413,7 +1413,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
             foreach (array_keys($columns) as $a) {
                 $nulls[$a] = null;
             }
-            if ($viaRelation->on !== null) {
+            if (property_exists($viaRelation, 'on') && $viaRelation->on !== null) {
                 $columns = ['and', $columns, $viaRelation->on];
             }
             if (is_array($relation->via)) {
@@ -1513,7 +1513,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
             if (!empty($viaRelation->where)) {
                 $condition = ['and', $condition, $viaRelation->where];
             }
-            if (!empty($viaRelation->on)) {
+            if (property_exists($viaRelation, 'on') && !empty($viaRelation->on)) {
                 $condition = ['and', $condition, $viaRelation->on];
             }
             if (is_array($relation->via)) {
@@ -1550,7 +1550,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
                 if (!empty($relation->where)) {
                     $condition = ['and', $condition, $relation->where];
                 }
-                if (!empty($relation->on)) {
+                if (property_exists($relation, 'on') && !empty($relation->on)) {
                     $condition = ['and', $condition, $relation->on];
                 }
                 if ($delete) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | https://github.com/yiisoft/yii2-elasticsearch/pull/304

I think this is the least problematic solution to the error that can pop up in the current Yii packages like Elasticsearch, Redis, Sphinx. At the same time it looks like `unlink` method is not really prepared for the objects different than core's ActiveQuery (in spite of claiming it can be anything implementing ActiveQueryInterface) but changing it now in every mentioned package would be  worse IMO.