### PR TITLE
Add method `BaseHtml::getInputIdByName()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #18650: Refactor `framework/assets/yii.activeForm.js` arrow function into traditional function for IE11 compatibility (marcovtwout)
 - Enh #18628: Added strings "software", and "hardware" to `$specials` array in `yii\helpers\BaseInflector` (kjusupov)
+- Enh #18653: Added method `yii\helpers\BaseHtml::getInputIdByName()` (WinterSilence)
 
 
 2.0.42.1 May 06, 2021

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2307,20 +2307,32 @@ class BaseHtml
     }
 
     /**
+     * Converts input name to ID.
+     *
+     * For example, if `$name` is `Post[content]`, this method will return `post-content`.
+     *
+     * @param string $name the input name
+     * @return string the generated input ID
+     */
+    public static function getInputIdByName($name)
+    {
+        $charset = Yii::$app ? Yii::$app->charset : 'UTF-8';
+        $name = mb_strtolower($name, $charset);
+        return str_replace(['[]', '][', '[', ']', ' ', '.'], ['', '-', '-', '', '-', '-'], $name);
+    }
+
+    /**
      * Generates an appropriate input ID for the specified attribute name or expression.
      *
-     * This method converts the result [[getInputName()]] into a valid input ID.
-     * For example, if [[getInputName()]] returns `Post[content]`, this method will return `post-content`.
      * @param Model $model the model object
      * @param string $attribute the attribute name or expression. See [[getAttributeName()]] for explanation of attribute expression.
-     * @return string the generated input ID
+     * @return string the generated input ID.
      * @throws InvalidArgumentException if the attribute name contains non-word characters.
      */
     public static function getInputId($model, $attribute)
     {
-        $charset = Yii::$app ? Yii::$app->charset : 'UTF-8';
-        $name = mb_strtolower(static::getInputName($model, $attribute), $charset);
-        return str_replace(['[]', '][', '[', ']', ' ', '.'], ['', '-', '-', '', '-', '-'], $name);
+        $name = static::getInputName($model, $attribute);
+        return static::getInputIdByName($name);
     }
 
     /**

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2313,6 +2313,7 @@ class BaseHtml
      *
      * @param string $name the input name
      * @return string the generated input ID
+     * @since 2.0.43
      */
     public static function getInputIdByName($name)
     {

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2318,7 +2318,7 @@ class BaseHtml
     {
         $charset = Yii::$app ? Yii::$app->charset : 'UTF-8';
         $name = mb_strtolower($name, $charset);
-        return str_replace(['[]', '][', '[', ']', ' ', '.'], ['', '-', '-', '', '-', '-'], $name);
+        return str_replace(['[]', '][', '[', ']', ' ', '.', '--'], ['', '-', '-', '', '-', '-', '-'], $name);
     }
 
     /**

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1944,11 +1944,14 @@ EOD;
     }
 
     /**
-     * @dataProvider testGetInputIdDataProvider
+     * @dataProvider testGetInputIdByNameDataProvider
      */
     public function testGetInputIdByName($attributeName, $inputIdExpected)
     {
-        $inputIdActual = Html::getInputIdByName($attributeName);
+        $model = new DynamicModel();
+        $model->defineAttribute($attributeName);
+        $inputNameActual = Html::getInputName($model, $attributeName);
+        $inputIdActual = Html::getInputIdByName($inputNameActual);
 
         $this->assertSame($inputIdExpected, $inputIdActual);
     }
@@ -2051,6 +2054,45 @@ HTML;
     }
 
     public function testGetInputIdDataProvider()
+    {
+        return [
+            [
+                'foo',
+                'dynamicmodel-foo',
+            ],
+            [
+                'FooBar',
+                'dynamicmodel-foobar',
+            ],
+            [
+                'Foo_Bar',
+                'dynamicmodel-foo_bar',
+            ],
+            [
+                'foo[]',
+                'dynamicmodel-foo',
+            ],
+            [
+                'foo[bar][baz]',
+                'dynamicmodel-foo-bar-baz',
+            ],
+
+            [
+                'foo.bar',
+                'dynamicmodel-foo-bar',
+            ],
+            [
+                'bild_groß_dateiname',
+                'dynamicmodel-bild_groß_dateiname',
+            ],
+            [
+                'ФуБарБаз',
+                'dynamicmodel-фубарбаз',
+            ],
+        ];
+    }
+
+    public function testGetInputIdByNameDataProvider()
     {
         return [
             [

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1943,6 +1943,16 @@ EOD;
         $this->assertSame($inputIdExpected, $inputIdActual);
     }
 
+    /**
+     * @dataProvider testGetInputIdDataProvider
+     */
+    public function testGetInputIdByName($attributeName, $inputIdExpected)
+    {
+        $inputIdActual = Html::getInputIdByName($attributeName);
+
+        $this->assertSame($inputIdExpected, $inputIdActual);
+    }
+
     public function testEscapeJsRegularExpression()
     {
         $expected = '/[a-z0-9-]+/';


### PR DESCRIPTION
Move converting input name to ID in method `getInputIdByName()`.
This method is usefull for widgets not used models and custom formatters: https://github.com/yiisoft/yii2/blob/7e323ba07ce3d0d15c7ad7e9f8e5361faec17335/framework/helpers/BaseHtml.php#L980

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
