### PR TITLE
Update BaseArrayHelper.php

### DIFF
--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -532,6 +532,9 @@ class BaseArrayHelper
     public static function getColumn($array, $name, $keepKeys = true)
     {
         $result = [];
+        if(!is_array($array)) {
+            return $result;   
+        }
         if ($keepKeys) {
             foreach ($array as $k => $element) {
                 $result[$k] = static::getValue($element, $name);

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -670,6 +670,9 @@ class ArrayHelperTest extends TestCase
             return $element['data'];
         }, false);
         $this->assertEquals(['abc', 'def'], $result);
+        
+        $result = ArrayHelper::getColumn(null,'aaa');
+        $this->assertEquals($result, []);
     }
 
     public function testMap()


### PR DESCRIPTION
Fix if $array = null;
example 
$column = ArrayHelper::getColumn(null,'test');
will throw Error: Invalid argument supplied for foreach()

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ?
| Fixed issues   |  #18691
