### PR TITLE
Update start-forms.md

### DIFF
--- a/docs/guide-es/start-forms.md
+++ b/docs/guide-es/start-forms.md
@@ -72,7 +72,7 @@ namespace app\controllers;
 
 use Yii;
 use yii\web\Controller;
-use app\models\EntryForm;
+use frontend\models\EntryForm;
 
 class SiteController extends Controller
 {


### PR DESCRIPTION
I am new to YII, but following the examples to learn, I think there is a mistake.

On line 75, 
use app\models\EntryForm;

It should be replaced by
use frontend\models\EntryForm;

Because otherwise it generates an error

Unable to find 'app\models\EntryForm' 
or 
Class 'frontend\controllers\EntryForm' not found

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
