### PR TITLE
fix Exception\Throwable order

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -335,9 +335,9 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
     {
         try {
             return $this->__get($name) !== null;
-        } catch (\Throwable $t) {
+        } catch (\Exception $t) {
             return false;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return false;
         }
     }

--- a/framework/log/DbTarget.php
+++ b/framework/log/DbTarget.php
@@ -78,7 +78,7 @@ class DbTarget extends Target
             list($text, $level, $category, $timestamp) = $message;
             if (!is_string($text)) {
                 // exceptions may not be serializable if in the call stack somewhere is a Closure
-                if ($text instanceof \Throwable || $text instanceof \Exception) {
+                if ($text instanceof \Exception || $text instanceof \Throwable) {
                     $text = (string) $text;
                 } else {
                     $text = VarDumper::export($text);

--- a/framework/log/SyslogTarget.php
+++ b/framework/log/SyslogTarget.php
@@ -84,7 +84,7 @@ class SyslogTarget extends Target
         $level = Logger::getLevelName($level);
         if (!is_string($text)) {
             // exceptions may not be serializable if in the call stack somewhere is a Closure
-            if ($text instanceof \Throwable || $text instanceof \Exception) {
+            if ($text instanceof \Exception || $text instanceof \Throwable) {
                 $text = (string) $text;
             } else {
                 $text = VarDumper::export($text);

--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -296,7 +296,7 @@ abstract class Target extends Component
         $level = Logger::getLevelName($level);
         if (!is_string($text)) {
             // exceptions may not be serializable if in the call stack somewhere is a Closure
-            if ($text instanceof \Throwable || $text instanceof \Exception) {
+            if ($text instanceof \Exception || $text instanceof \Throwable) {
                 $text = (string) $text;
             } else {
                 $text = VarDumper::export($text);


### PR DESCRIPTION
Fix order of Throwable/Exception for PHP 5.x, where Throwable in unknown class, so Exception must be firt in code.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
