### PR TITLE
use getTargetClass in function checkTargetAttributeExistence

### DIFF
--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -169,7 +169,7 @@ class ExistValidator extends Validator
             $conditions[] = $params;
         }
 
-        $targetClass = $this->targetClass === null ? get_class($model) : $this->targetClass;
+        $targetClass = $this->getTargetClass($model);
         $query = $this->createQuery($targetClass, $conditions);
 
         if (!$this->valueExists($targetClass, $query, $model->$attribute)) {


### PR DESCRIPTION
found this small modification interesting, to subtract redundancy, and also facilitate modification of `checkTargetAttributeExistence`, when you only want to change `getTargetClass `.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
