### PR TITLE
Added example with hyphen in action ID

### DIFF
--- a/framework/filters/VerbFilter.php
+++ b/framework/filters/VerbFilter.php
@@ -57,6 +57,8 @@ class VerbFilter extends Behavior
      * You can use `'*'` to stand for all actions. When an action is explicitly
      * specified, it takes precedence over the specification given by `'*'`.
      *
+     * @see https://www.yiiframework.com/doc/guide/2.0/en/structure-controllers#action-ids
+     *
      * For example,
      *
      * ```php
@@ -64,6 +66,7 @@ class VerbFilter extends Behavior
      *   'create' => ['GET', 'POST'],
      *   'update' => ['GET', 'PUT', 'POST'],
      *   'delete' => ['POST', 'DELETE'],
+     *   'author-comment' => ['POST', 'DELETE'],
      *   '*' => ['GET'],
      * ]
      * ```


### PR DESCRIPTION
Also added link to guide on actions - don't know if you have a better way than providing a static URL... And maybe it should be moved to the class description?

(Added the example because I didn't know whether the action had to be specified as `authorComment` or `author-comment`)