### PR TITLE
EmailValidator::$enableLocalIDN

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Bug #18678: Fix `yii\caching\DbCache` to use configured cache table name instead of the default one in case of MSSQL varbinary column type detection (aidanbek)
 - Enh #18695: Added `yii\web\Cookie::SAME_SITE_NONE` constant (rhertogh)
 - Enh #18726: Added `yii\helpers\Json::$prettyPrint` (rhertogh)
+- Enh #18734: Added `yii\validators\EmailValidator::$enableLocalIDN` (brandonkelly)
 
 
 2.0.42.1 May 06, 2021

--- a/framework/validators/EmailValidator.php
+++ b/framework/validators/EmailValidator.php
@@ -63,6 +63,12 @@ class EmailValidator extends Validator
      * otherwise an exception would be thrown.
      */
     public $enableIDN = false;
+    /**
+     * @var bool whether [[enableIDN]] should apply to the local part of the email (left side
+     * of the `@`). Only applies if [[enableIDN]] is `true`.
+     * @since 2.0.43
+     */
+    public $enableLocalIDN = true;
 
 
     /**
@@ -90,7 +96,9 @@ class EmailValidator extends Validator
             $valid = false;
         } else {
             if ($this->enableIDN) {
-                $matches['local'] = $this->idnToAsciiWithFallback($matches['local']);
+                if ($this->enableLocalIDN) {
+                    $matches['local'] = $this->idnToAsciiWithFallback($matches['local']);
+                }
                 $matches['domain'] = $this->idnToAscii($matches['domain']);
                 $value = $matches['name'] . $matches['open'] . $matches['local'] . '@' . $matches['domain'] . $matches['close'];
             }


### PR DESCRIPTION
This adds a new `$enableLocalIDN` property to EmailValidater, giving applications the ability to opt out of allowing non-ASCII characters in the local part of an email.

It defaults to `true` to maintain the previous behavior.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18734
