### PR TITLE
fix SchemaTest::testColumnSchema() for MySql <5.7

### DIFF
--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -121,9 +121,9 @@ SQL;
 
     public function getExpectedColumns()
     {
-        $version = $this->getConnection()->pdo->getAttribute(\PDO::ATTR_SERVER_VERSION);
+        $version = $this->getConnection()->getSchema()->getServerVersion();
 
-        return array_merge(
+        $columns = array_merge(
             parent::getExpectedColumns(),
             [
                 'int_col' => [
@@ -176,5 +176,13 @@ SQL;
                 ],
             ]
         );
+
+        if (version_compare($version, '5.7', '<')) {
+            $columns['json_col']['type'] = 'text';
+            $columns['json_col']['dbType'] = 'longtext';
+            $columns['json_col']['phpType'] = 'string';
+        }
+
+        return $columns;
     }
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Is bugfix?       | ✔
| New feature?     | ❌
| Breaks BC?       | ❌
| Tests pass?      | ✔

### What steps will reproduce the problem?
| Q                | A
| ---------------- | ---
| Yii version      | >=2.0.14
| MySql version    | <5.7

`phpunit tests/framework/db/mysql/SchemaTest.php --filter testColumnSchema`

### What is the expected result?
Test passed.

### What do you get instead?
> There was 1 failure:

> dbType of column json_col does not match. type is text, dbType is longtext.
Failed asserting that two strings are identical.
Expected :json
Actual   :longtext