### PR TITLE
Fix ErrorHandler::htmlEncode()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #18650: Refactor `framework/assets/yii.activeForm.js` arrow function into traditional function for IE11 compatibility (marcovtwout)
-- Bug #18749: Fix `yii\web\ErrorHandler::encodeHtml()` to support strings with invalid UTF symbols (vjik)  
+- Bug #18749: Fix `yii\web\ErrorHandler::encodeHtml()` to support strings with invalid UTF symbols (vjik)
 - Enh #18724: Allow jQuery 3.6 to be installed (marcovtwout)
 - Enh #18628: Added strings "software", and "hardware" to `$specials` array in `yii\helpers\BaseInflector` (kjusupov)
 - Enh #18653: Added method `yii\helpers\BaseHtml::getInputIdByName()` (WinterSilence)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #18650: Refactor `framework/assets/yii.activeForm.js` arrow function into traditional function for IE11 compatibility (marcovtwout)
+- Bug #18749: Fix `yii\web\ErrorHandler::encodeHtml()` to support strings with invalid UTF symbols (vjik)  
 - Enh #18724: Allow jQuery 3.6 to be installed (marcovtwout)
 - Enh #18628: Added strings "software", and "hardware" to `$specials` array in `yii\helpers\BaseInflector` (kjusupov)
 - Enh #18653: Added method `yii\helpers\BaseHtml::getInputIdByName()` (WinterSilence)

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -180,7 +180,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
      */
     public function htmlEncode($text)
     {
-        return htmlspecialchars($text, ENT_NOQUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+        return htmlspecialchars($text, ENT_NOQUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
     }
 
     /**

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -180,7 +180,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
      */
     public function htmlEncode($text)
     {
-        return htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+        return htmlspecialchars($text, ENT_NOQUOTES | ENT_SUBSTITUTE | ENT_HTML5);
     }
 
     /**

--- a/tests/framework/web/ErrorHandlerTest.php
+++ b/tests/framework/web/ErrorHandlerTest.php
@@ -79,6 +79,46 @@ Exception: yii\web\NotFoundHttpException', $out);
 
         $this->assertContains('<a href="netbeans://open?file=' . $file . '&line=63">', $out);
     }
+
+    public function dataHtmlEncode()
+    {
+        return [
+            [
+                "a \t=<>&\"'\x80\u{20bd}`\u{000a}\u{000c}\u{0000}",
+                "a \t=&lt;&gt;&amp;\"'�₽`\n\u{000c}\u{0000}",
+            ],
+            [
+                '<b>test</b>',
+                '&lt;b&gt;test&lt;/b&gt;',
+            ],
+            [
+                '"hello"',
+                '"hello"',
+            ],
+            [
+                "'hello world'",
+                "'hello world'",
+            ],
+            [
+                'Chip&amp;Dale',
+                'Chip&amp;amp;Dale',
+            ],
+            [
+                "\t\$x=24;",
+                "\t\$x=24;",
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataHtmlEncode
+     */
+    public function testHtmlEncode($text, $expected)
+    {
+        $handler = Yii::$app->getErrorHandler();
+
+        $this->assertSame($expected, $handler->htmlEncode($text));
+    }
 }
 
 class ErrorHandler extends \yii\web\ErrorHandler

--- a/tests/framework/web/ErrorHandlerTest.php
+++ b/tests/framework/web/ErrorHandlerTest.php
@@ -84,8 +84,8 @@ Exception: yii\web\NotFoundHttpException', $out);
     {
         return [
             [
-                "a \t=<>&\"'\x80\u{20bd}`\u{000a}\u{000c}\u{0000}",
-                "a \t=&lt;&gt;&amp;\"'�₽`\n\u{000c}\u{0000}",
+                "a \t=<>&\"'\x80`\n",
+                "a \t=&lt;&gt;&amp;\"'�`\n",
             ],
             [
                 '<b>test</b>',
@@ -116,6 +116,21 @@ Exception: yii\web\NotFoundHttpException', $out);
     public function testHtmlEncode($text, $expected)
     {
         $handler = Yii::$app->getErrorHandler();
+
+        $this->assertSame($expected, $handler->htmlEncode($text));
+    }
+
+    public function testHtmlEncodeWithUnicodeSequence()
+    {
+        if (PHP_VERSION_ID < 70000) {
+            $this->markTestSkipped('Can not be tested on PHP < 7.0');
+            return;
+        }
+
+        $handler = Yii::$app->getErrorHandler();
+
+        $text = "a \t=<>&\"'\x80\u{20bd}`\u{000a}\u{000c}\u{0000}";
+        $expected = "a \t=&lt;&gt;&amp;\"'�₽`\n\u{000c}\u{0000}";
 
         $this->assertSame($expected, $handler->htmlEncode($text));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️/❌
| Fixed issues  | -

When error message contain invalid utf symbols method `ErrorHandler::htmlEncode()` returned empty string. This PR fixed this bug.
