### PR TITLE
fix $descriptor | yiisoft\yii2\web\AssetConverter.php

### DIFF
--- a/framework/web/AssetConverter.php
+++ b/framework/web/AssetConverter.php
@@ -95,8 +95,8 @@ class AssetConverter extends Component implements AssetConverterInterface
             '{to}' => escapeshellarg("$basePath/$result"),
         ]);
         $descriptor = [
-            1 => ['pipe', 'w'],
-            2 => ['pipe', 'w'],
+            1 => ["pipe", "r"],
+            2 => ["pipe", "w"],
         ];
         $pipes = [];
         $proc = proc_open($command, $descriptor, $pipes, $basePath);

--- a/framework/web/AssetConverter.php
+++ b/framework/web/AssetConverter.php
@@ -95,13 +95,13 @@ class AssetConverter extends Component implements AssetConverterInterface
             '{to}' => escapeshellarg("$basePath/$result"),
         ]);
         $descriptor = [
-            1 => ["pipe", "r"],
-            2 => ["pipe", "w"],
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
         ];
         $pipes = [];
         $proc = proc_open($command, $descriptor, $pipes, $basePath);
-        $stdout = stream_get_contents($pipes[1]);
-        $stderr = stream_get_contents($pipes[2]);
+        $stdout = stream_get_contents($pipes[0]);
+        $stderr = stream_get_contents($pipes[1]);
         foreach ($pipes as $pipe) {
             fclose($pipe);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | -

All pipes as 'w' are causing an infinite loading and just stop if restart Apache. The sass command works perfectly, but website never finish loading

```
$descriptor = [
    1 => ['pipe', 'w'],
    2 => ['pipe', 'w'],
];

...

$stdout = stream_get_contents($pipes[1]);
$stderr = stream_get_contents($pipes[2]);
```

This fix the error

```
$descriptor = [
    0 => ['pipe', 'r'],
    1 => ['pipe', 'w'],
];

...

$stdout = stream_get_contents($pipes[0]);
$stderr = stream_get_contents($pipes[1]);
```