### PR TITLE
Allows router to be aliased

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -19,6 +19,7 @@ Yii Framework 2 Change Log
 - Bug #18648: Fix `yii\web\Request` to properly handle HTTP Basic Auth headers (olegbaturin)
 - Enh #18726: Added `yii\helpers\Json::$prettyPrint` (rhertogh)
 - Enh #18734: Added `yii\validators\EmailValidator::$enableLocalIDN` (brandonkelly)
+- Enh #18656: Added ability for `yii serve`'s `--router` param to take an alias (markhuot)
 
 
 2.0.42.1 May 06, 2021

--- a/framework/console/controllers/ServeController.php
+++ b/framework/console/controllers/ServeController.php
@@ -52,6 +52,7 @@ class ServeController extends Controller
     public function actionIndex($address = 'localhost')
     {
         $documentRoot = Yii::getAlias($this->docroot);
+        $router = Yii::getAlias($this->router);
 
         if (strpos($address, ':') === false) {
             $address = $address . ':' . $this->port;
@@ -67,19 +68,19 @@ class ServeController extends Controller
             return self::EXIT_CODE_ADDRESS_TAKEN_BY_ANOTHER_PROCESS;
         }
 
-        if ($this->router !== null && !file_exists($this->router)) {
-            $this->stdout("Routing file \"$this->router\" does not exist.\n", Console::FG_RED);
+        if ($this->router !== null && !file_exists($router)) {
+            $this->stdout("Routing file \"$router\" does not exist.\n", Console::FG_RED);
             return self::EXIT_CODE_NO_ROUTING_FILE;
         }
 
         $this->stdout("Server started on http://{$address}/\n");
         $this->stdout("Document root is \"{$documentRoot}\"\n");
         if ($this->router) {
-            $this->stdout("Routing file is \"$this->router\"\n");
+            $this->stdout("Routing file is \"$router\"\n");
         }
         $this->stdout("Quit the server with CTRL-C or COMMAND-C.\n");
 
-        passthru('"' . PHP_BINARY . '"' . " -S {$address} -t \"{$documentRoot}\" $this->router");
+        passthru('"' . PHP_BINARY . '"' . " -S {$address} -t \"{$documentRoot}\" $router");
     }
 
     /**

--- a/framework/console/controllers/ServeController.php
+++ b/framework/console/controllers/ServeController.php
@@ -36,7 +36,7 @@ class ServeController extends Controller
      */
     public $docroot = '@app/web';
     /**
-     * @var string path to router script.
+     * @var string path or [path alias](guide:concept-aliases) to router script.
      * See https://secure.php.net/manual/en/features.commandline.webserver.php
      */
     public $router;
@@ -52,7 +52,7 @@ class ServeController extends Controller
     public function actionIndex($address = 'localhost')
     {
         $documentRoot = Yii::getAlias($this->docroot);
-        $router = Yii::getAlias($this->router);
+        $router = $this->router !== null ? Yii::getAlias($this->router) : null;
 
         if (strpos($address, ':') === false) {
             $address = $address . ':' . $this->port;


### PR DESCRIPTION
This allows the `yii serve` command to accept an aliased router (as the document root is). An example of this could be routing to your `@app/web/index.php` file.

One use case for this is that, by default, `yii serve` will not route `.json` files through your router by default. However, if you use `yii serve --router="@app/web/index.php"` it will force all requests through the router, which will send `.json` requests through your application.

This is not a BC break because it does not change the default functionality (although I would argue we should make `$this->router = "@app/web/index.php";`). Instead it just supports that functionality for people who need it.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | n/a

Note, this is a second PR after initial conversation over in https://github.com/yiisoft/yii2/pull/18656 because I messed up the merge and fudged the history. Instead of force pushing to get things back in line I started a new branch off `master` and am now opening this new PR. Sorry.

All feedback from the previous PR has been addressed, documentation has been updated, null values have been checked.
