### PR TITLE
Fix profiling with short flush interval

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -20,6 +20,7 @@ Yii Framework 2 Change Log
 - Enh #18726: Added `yii\helpers\Json::$prettyPrint` (rhertogh)
 - Enh #18734: Added `yii\validators\EmailValidator::$enableLocalIDN` (brandonkelly)
 - Enh #18656: Added ability for `yii serve`'s `--router` param to take an alias (markhuot)
+- Bug #18274: Fix `yii\log\Logger` to calculate profile timings no matter the value of the flush interval (bizley)
 
 
 2.0.42.1 May 06, 2021

--- a/framework/log/Logger.php
+++ b/framework/log/Logger.php
@@ -108,7 +108,7 @@ class Logger extends Component
      */
     public $traceLevel = 0;
     /**
-     * @var Dispatcher the message dispatcher
+     * @var Dispatcher the message dispatcher.
      */
     public $dispatcher;
     /**
@@ -116,6 +116,13 @@ class Logger extends Component
      * @since 2.0.41
      */
     public $dbEventNames = ['yii\db\Command::query', 'yii\db\Command::execute'];
+
+    /**
+     * @var array of profiling related messages.
+     * Structure of a log message is the same as in [[$messages]].
+     * @since 2.0.43
+     */
+    protected $profileMessages = [];
 
 
     /**
@@ -162,7 +169,11 @@ class Logger extends Component
                 }
             }
         }
-        $this->messages[] = [$message, $level, $category, $time, $traces, memory_get_usage()];
+        $data = [$message, $level, $category, $time, $traces, memory_get_usage()];
+        $this->messages[] = $data;
+        if ($level == self::LEVEL_PROFILE_BEGIN || $level == self::LEVEL_PROFILE_END) {
+            $this->profileMessages[] = $data;
+        }
         if ($this->flushInterval > 0 && count($this->messages) >= $this->flushInterval) {
             $this->flush();
         }
@@ -213,7 +224,7 @@ class Logger extends Component
      */
     public function getProfiling($categories = [], $excludeCategories = [])
     {
-        $timings = $this->calculateTimings($this->messages);
+        $timings = $this->calculateTimings($this->profileMessages);
         if (empty($categories) && empty($excludeCategories)) {
             return $timings;
         }

--- a/tests/framework/log/TargetTest.php
+++ b/tests/framework/log/TargetTest.php
@@ -236,6 +236,26 @@ class TargetTest extends TestCase
         $this->assertCount(6, static::$messages[0]);
         $this->assertCount(6, static::$messages[1]);
     }
+
+    public function testBreakProfilingWithFlush()
+    {
+        $logger = new Logger();
+        new Dispatcher([
+            'logger' => $logger,
+            'targets' => [new TestTarget()],
+            'flushInterval' => 2,
+        ]);
+
+        $logger->log('token.a', Logger::LEVEL_PROFILE_BEGIN, 'category');
+        $logger->log('info', Logger::LEVEL_INFO, 'category');
+        $logger->log('token.a', Logger::LEVEL_PROFILE_END, 'category');
+
+        $timings = $logger->getProfiling(['category']);
+
+        self::assertCount(1, $timings);
+        self::assertArrayHasKey('info', $timings[0]);
+        self::assertArrayHasKey('category', $timings[0]);
+    }
 }
 
 class TestTarget extends Target


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18274

It uses test from #18291

The obvious downside of this is that in case of many, many profiling messages script can go oom but I think it is not something to be worried about.
