### PR TITLE
Small fixes in `yii\helpers\BaseStringHelper`

### DIFF
--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -72,7 +72,7 @@ class BaseStringHelper
             $path = mb_substr($path, 0, -$len);
         }
  
-        $path = rtrim(str_replace('\\', '/', $path), '/\\');
+        $path = rtrim(str_replace('\\', '/', $path), '/');
         $pos = mb_strrpos($path, '/');
         if ($pos !== false) {
             return mb_substr($path, $pos + 1);
@@ -92,8 +92,7 @@ class BaseStringHelper
      */
     public static function dirname($path)
     {
-        $path = str_replace('\\', '/', $path);
-        $pos = mb_strrpos($path, '/');
+        $pos = mb_strrpos(str_replace('\\', '/', $path), '/');
         if ($pos !== false) {
             return mb_substr($path, 0, $pos);
         }

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -156,7 +156,7 @@ class BaseStringHelper
      * Truncate a string while preserving the HTML.
      *
      * @param string $string The string to truncate
-     * @param int $count Thr counter
+     * @param int $count The counter
      * @param string $suffix String to append to the end of the truncated string.
      * @param string|bool $encoding Encoding flag or charset.
      * @return string

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -72,7 +72,7 @@ class BaseStringHelper
             $path = mb_substr($path, 0, -$len);
         }
  
-        $path = rtrim(str_replace('\\', '/', $path), '/');
+        $path = rtrim(str_replace('\\', '/', $path), '\/');
         $pos = mb_strrpos($path, '/');
         if ($pos !== false) {
             return mb_substr($path, $pos + 1);

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -72,7 +72,7 @@ class BaseStringHelper
             $path = mb_substr($path, 0, -$len);
         }
  
-        $path = rtrim(str_replace('\\', '/', $path), '\/');
+        $path = rtrim(str_replace('\\', '/', $path), '/\\');
         $pos = mb_strrpos($path, '/');
         if ($pos !== false) {
             return mb_substr($path, $pos + 1);

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -230,11 +230,12 @@ class BaseStringHelper
         }
         if ($caseSensitive) {
             return strncmp($string, $with, $bytes) === 0;
-
         }
-        $encoding = Yii::$app ? Yii::$app->charset : 'UTF-8';
 
-        return mb_strtolower(mb_substr($string, 0, $bytes, '8bit'), $encoding) === mb_strtolower($with, $encoding);
+        $encoding = Yii::$app ? Yii::$app->charset : 'UTF-8';
+        $string = static::byteSubstr($string, 0, $bytes);
+
+        return mb_strtolower($string, $encoding) === mb_strtolower($with, $encoding);
     }
 
     /**
@@ -261,8 +262,9 @@ class BaseStringHelper
         }
 
         $encoding = Yii::$app ? Yii::$app->charset : 'UTF-8';
-        $substr = mb_substr($string, -$bytes, static::byteLength($string), '8bit');
-        return mb_strtolower($substr, $encoding) === mb_strtolower($with, $encoding);
+        $string = static::byteSubstr($string, -$bytes);
+
+        return mb_strtolower($string, $encoding) === mb_strtolower($with, $encoding);
     }
 
     /**

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -92,7 +92,7 @@ class BaseStringHelper
      */
     public static function dirname($path)
     {
-        $path = rtrim(str_replace('\\', '/', $path), '/');
+        $path = str_replace('\\', '/', $path);
         $pos = mb_strrpos($path, '/');
         if ($pos !== false) {
             return mb_substr($path, 0, $pos);

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -48,6 +48,7 @@ class BaseStringHelper
         if ($length === null) {
             $length = static::byteLength($string);
         }
+ 
         return mb_substr($string, $start, $length, '8bit');
     }
 

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -45,8 +45,8 @@ class BaseStringHelper
      */
     public static function byteSubstr($string, $start, $length = null)
     {
-        if ($length !== null) {
-            $length = static::byteLength($length);
+        if ($length === null) {
+            $length = static::byteLength($string);
         }
         return mb_substr($string, $start, $length, '8bit');
     }
@@ -232,6 +232,7 @@ class BaseStringHelper
 
         }
         $encoding = Yii::$app ? Yii::$app->charset : 'UTF-8';
+
         return mb_strtolower(mb_substr($string, 0, $bytes, '8bit'), $encoding) === mb_strtolower($with, $encoding);
     }
 

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -23,6 +23,7 @@ class BaseStringHelper
     /**
      * Returns the number of bytes in the given string.
      * This method ensures the string is treated as a byte array by using `mb_strlen()`.
+     *
      * @param string $string the string being measured for length
      * @return int the number of bytes in the given string.
      */
@@ -34,6 +35,7 @@ class BaseStringHelper
     /**
      * Returns the portion of string specified by the start and length parameters.
      * This method ensures the string is treated as a byte array by using `mb_substr()`.
+     *
      * @param string $string the input string. Must be one character or longer.
      * @param int $start the starting position
      * @param int $length the desired portion length. If not specified or `null`, there will be
@@ -43,7 +45,10 @@ class BaseStringHelper
      */
     public static function byteSubstr($string, $start, $length = null)
     {
-        return mb_substr($string, $start, $length === null ? mb_strlen($string, '8bit') : $length, '8bit');
+        if ($length !== null) {
+            $length = static::byteLength($length);
+        }
+        return mb_substr($string, $start, $length, '8bit');
     }
 
     /**
@@ -61,11 +66,14 @@ class BaseStringHelper
      */
     public static function basename($path, $suffix = '')
     {
-        if (($len = mb_strlen($suffix)) > 0 && mb_substr($path, -$len) === $suffix) {
+        $len = mb_strlen($suffix);
+        if ($len > 0 && mb_substr($path, -$len) === $suffix) {
             $path = mb_substr($path, 0, -$len);
         }
-        $path = rtrim(str_replace('\\', '/', $path), '/\\');
-        if (($pos = mb_strrpos($path, '/')) !== false) {
+ 
+        $path = rtrim(str_replace('\\', '/', $path), '/');
+        $pos = mb_strrpos($path, '/');
+        if ($pos !== false) {
             return mb_substr($path, $pos + 1);
         }
 
@@ -83,7 +91,8 @@ class BaseStringHelper
      */
     public static function dirname($path)
     {
-        $pos = mb_strrpos(str_replace('\\', '/', $path), '/');
+        $path = rtrim(str_replace('\\', '/', $path), '/');
+        $pos = mb_strrpos($path, '/');
         if ($pos !== false) {
             return mb_substr($path, 0, $pos);
         }
@@ -146,9 +155,9 @@ class BaseStringHelper
      * Truncate a string while preserving the HTML.
      *
      * @param string $string The string to truncate
-     * @param int $count
+     * @param int $count Thr counter
      * @param string $suffix String to append to the end of the truncated string.
-     * @param string|bool $encoding
+     * @param string|bool $encoding Encoding flag or charset.
      * @return string
      * @since 2.0.1
      */
@@ -205,12 +214,12 @@ class BaseStringHelper
     }
 
     /**
-     * Check if given string starts with specified substring.
-     * Binary and multibyte safe.
+     * Check if given string starts with specified substring. Binary and multibyte safe.
      *
      * @param string $string Input string
      * @param string $with Part to search inside the $string
-     * @param bool $caseSensitive Case sensitive search. Default is true. When case sensitive is enabled, $with must exactly match the starting of the string in order to get a true value.
+     * @param bool $caseSensitive Case sensitive search. Default is true. When case sensitive is enabled, `$with` must
+     * exactly match the starting of the string in order to get a true value.
      * @return bool Returns true if first input starts with second input, false otherwise
      */
     public static function startsWith($string, $with, $caseSensitive = true)
@@ -227,12 +236,12 @@ class BaseStringHelper
     }
 
     /**
-     * Check if given string ends with specified substring.
-     * Binary and multibyte safe.
+     * Check if given string ends with specified substring. Binary and multibyte safe.
      *
      * @param string $string Input string to check
-     * @param string $with Part to search inside of the $string.
-     * @param bool $caseSensitive Case sensitive search. Default is true. When case sensitive is enabled, $with must exactly match the ending of the string in order to get a true value.
+     * @param string $with Part to search inside of the `$string`.
+     * @param bool $caseSensitive Case sensitive search. Default is true. When case sensitive is enabled, `$with` must
+     * exactly match the ending of the string in order to get a true value.
      * @return bool Returns true if first input ends with second input, false otherwise
      */
     public static function endsWith($string, $with, $caseSensitive = true)
@@ -241,7 +250,7 @@ class BaseStringHelper
             return true;
         }
         if ($caseSensitive) {
-            // Warning check, see https://secure.php.net/manual/en/function.substr-compare.php#refsect1-function.substr-compare-returnvalues
+            // Warning check, see https://php.net/substr-compare#refsect1-function.substr-compare-returnvalues
             if (static::byteLength($string) < $bytes) {
                 return false;
             }
@@ -250,7 +259,8 @@ class BaseStringHelper
         }
 
         $encoding = Yii::$app ? Yii::$app->charset : 'UTF-8';
-        return mb_strtolower(mb_substr($string, -$bytes, mb_strlen($string, '8bit'), '8bit'), $encoding) === mb_strtolower($with, $encoding);
+        $substr = mb_substr($string, -$bytes, static::byteLength($string), '8bit');
+        return mb_strtolower($substr, $encoding) === mb_strtolower($with, $encoding);
     }
 
     /**
@@ -291,10 +301,10 @@ class BaseStringHelper
 
     /**
      * Counts words in a string.
-     * @since 2.0.8
      *
-     * @param string $string
+     * @param string $string the text to calculate
      * @return int
+     * @since 2.0.8
      */
     public static function countWords($string)
     {
@@ -304,13 +314,14 @@ class BaseStringHelper
     /**
      * Returns string representation of number value with replaced commas to dots, if decimal point
      * of current locale is comma.
-     * @param int|float|string $value
+     *
+     * @param int|float|string $value the value to normalize.
      * @return string
      * @since 2.0.11
      */
     public static function normalizeNumber($value)
     {
-        $value = (string)$value;
+        $value = (string) $value;
 
         $localeInfo = localeconv();
         $decimalSeparator = isset($localeInfo['decimal_point']) ? $localeInfo['decimal_point'] : null;
@@ -328,9 +339,9 @@ class BaseStringHelper
      * > Note: Base 64 padding `=` may be at the end of the returned string.
      * > `=` is not transparent to URL encoding.
      *
-     * @see https://tools.ietf.org/html/rfc4648#page-7
      * @param string $input the string to encode.
      * @return string encoded string.
+     * @see https://tools.ietf.org/html/rfc4648#page-7
      * @since 2.0.12
      */
     public static function base64UrlEncode($input)
@@ -341,9 +352,9 @@ class BaseStringHelper
     /**
      * Decodes "Base 64 Encoding with URL and Filename Safe Alphabet" (RFC 4648).
      *
-     * @see https://tools.ietf.org/html/rfc4648#page-7
      * @param string $input encoded string.
      * @return string decoded string.
+     * @see https://tools.ietf.org/html/rfc4648#page-7
      * @since 2.0.12
      */
     public static function base64UrlDecode($input)
@@ -353,8 +364,8 @@ class BaseStringHelper
 
     /**
      * Safely casts a float to string independent of the current locale.
-     *
      * The decimal separator will always be `.`.
+     *
      * @param float|int $number a floating point number or integer.
      * @return string the string representation of the number.
      * @since 2.0.13
@@ -369,6 +380,7 @@ class BaseStringHelper
     /**
      * Checks if the passed string would match the given shell wildcard pattern.
      * This function emulates [[fnmatch()]], which may be unavailable at certain environment, using PCRE.
+     *
      * @param string $pattern the shell wildcard pattern.
      * @param string $string the tested string.
      * @param array $options options for matching. Valid options are:


### PR DESCRIPTION
- Update and format PhpDoc's
- Format code to more readable
- Replace similar code to `byteSubstr()` and `byteLength()` 

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
