### PR TITLE
Increase scrollbar width for Windows Terminal

### DIFF
--- a/framework/console/widgets/Table.php
+++ b/framework/console/widgets/Table.php
@@ -49,7 +49,7 @@ use yii\helpers\Console;
 class Table extends Widget
 {
     const DEFAULT_CONSOLE_SCREEN_WIDTH = 120;
-    const CONSOLE_SCROLLBAR_OFFSET = 3;
+    const CONSOLE_SCROLLBAR_OFFSET = 4;
     const CHAR_TOP = 'top';
     const CHAR_TOP_MID = 'top-mid';
     const CHAR_TOP_LEFT = 'top-left';


### PR DESCRIPTION
Table layout is broken on following configuration:

Ubuntu on WSL2
Windows 10
Windows Terminal

When table row does not fit to screen width on terminal, table borders are broken.

| Q             | A
| ------------- | ---
| Is bugfix?    | Yes
| New feature?  | No
| Breaks BC?    | No
| Tests pass?   | Should pass
| Fixed issues  | -
