### PR TITLE
Fix result & optimize `BaseJson::decode()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -1,6 +1,12 @@
 Yii Framework 2 Change Log
 ==========================
 
+2.0.44 under development
+------------------------
+
+- Bug #18813: Fix returned value for empty string, passing stringable object is allow in `yii\helpers\BaseJson::decode()` (WinterSilence)
+
+
 2.0.43 under development
 ------------------------
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.44 under development
 ------------------------
 
-- Bug #18813: Fix returned value for empty string, passing stringable object is allow in `yii\helpers\BaseJson::decode()` (WinterSilence)
+- Enh #18813: Allow passing stringable object to `yii\helpers\BaseJson::decode()` (WinterSilence)
 
 
 2.0.43 under development

--- a/framework/helpers/BaseJson.php
+++ b/framework/helpers/BaseJson.php
@@ -124,7 +124,7 @@ class BaseJson
             throw new InvalidArgumentException('Invalid JSON data.');
         }
 
-        $decode = json_decode((string) $json, (bool) $asArray);
+        $decode = json_decode($json, (bool) $asArray);
         static::handleJsonError(json_last_error());
 
         return $decode;

--- a/framework/helpers/BaseJson.php
+++ b/framework/helpers/BaseJson.php
@@ -105,19 +105,26 @@ class BaseJson
 
     /**
      * Decodes the given JSON string into a PHP data structure.
+     *
      * @param string $json the JSON string to be decoded
-     * @param bool $asArray whether to return objects in terms of associative arrays.
+     * @param bool $asArray whether to return objects in terms of associative arrays
      * @return mixed the PHP data
      * @throws InvalidArgumentException if there is any decoding error
      */
     public static function decode($json, $asArray = true)
     {
-        if (is_array($json)) {
-            throw new InvalidArgumentException('Invalid JSON data.');
-        } elseif ($json === null || $json === '') {
+        if ($json === null) {
             return null;
         }
-        $decode = json_decode((string) $json, $asArray);
+        if ($json === '') {
+            return '';
+        }
+
+        if (is_array($json) || (is_object($json) && !method_exists($json, '__toString'))) {
+            throw new InvalidArgumentException('Invalid JSON data.');
+        }
+
+        $decode = json_decode((string) $json, (bool) $asArray);
         static::handleJsonError(json_last_error());
 
         return $decode;

--- a/framework/helpers/BaseJson.php
+++ b/framework/helpers/BaseJson.php
@@ -113,11 +113,8 @@ class BaseJson
      */
     public static function decode($json, $asArray = true)
     {
-        if ($json === null) {
+        if ($json === null || $json === '') {
             return null;
-        }
-        if ($json === '') {
-            return '';
         }
 
         if (is_array($json) || (is_object($json) && !method_exists($json, '__toString'))) {

--- a/tests/framework/helpers/JsonTest.php
+++ b/tests/framework/helpers/JsonTest.php
@@ -156,10 +156,11 @@ class JsonTest extends TestCase
 
     public function testDecode()
     {
-        // empty value
+        // empty values
         $json = '';
-        $actual = Json::decode($json);
-        $this->assertNull($actual);
+        $this->assertSame('', Json::decode($json));
+        $json = null;
+        $this->assertNull(Json::decode($json));
 
         // basic data decoding
         $json = '"1"';

--- a/tests/framework/helpers/JsonTest.php
+++ b/tests/framework/helpers/JsonTest.php
@@ -158,7 +158,7 @@ class JsonTest extends TestCase
     {
         // empty values
         $json = '';
-        $this->assertSame('', Json::decode($json));
+        $this->assertNull(Json::decode($json));
         $json = null;
         $this->assertNull(Json::decode($json));
 


### PR DESCRIPTION
- Fix result: if `$json` is empty string method return empty string
- Fix type validation for parameter `$json`: given argument can be stringable object
- Normalize arguments passed to `json_decode()`

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | 
