### PR TITLE
fix return of BaseHtml::getAttributeValue

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2245,13 +2245,13 @@ class BaseHtml
             throw new InvalidArgumentException('Attribute name must contain word characters only.');
         }
         $attribute = $matches[2];
-        $value = $model->$attribute;
+        $value = $model->{$attribute};
         if ($matches[3] !== '') {
             foreach (explode('][', trim($matches[3], '[]')) as $id) {
                 if ((is_array($value) || $value instanceof \ArrayAccess) && isset($value[$id])) {
                     $value = $value[$id];
                 } else {
-                    return null;
+                    return '';
                 }
             }
         }
@@ -2260,17 +2260,17 @@ class BaseHtml
         if (is_array($value)) {
             foreach ($value as $i => $v) {
                 if ($v instanceof ActiveRecordInterface) {
-                    $v = $v->getPrimaryKey(false);
+                    $v = $v->getPrimaryKey();
                     $value[$i] = is_array($v) ? json_encode($v) : $v;
                 }
             }
         } elseif ($value instanceof ActiveRecordInterface) {
-            $value = $value->getPrimaryKey(false);
+            $value = $value->getPrimaryKey();
 
-            return is_array($value) ? json_encode($value) : $value;
+            return is_array($value) ? json_encode($value) :(string)$value;
         }
 
-        return $value;
+        return (string)$value;
     }
 
     /**


### PR DESCRIPTION
Return type of BaseHtml::getAttributeValue expected to be `string|array`, but actually returned `null|array|mixed`.
Typecast required.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #18829 
