### PR TITLE
Fix #18832 - Inflector::camel2words() adding extra spaces

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 
 - Enh #18826: Add ability to turn the sorting off for a clicked column in GridView with multisort (ditibal)
 - Bug #18646: Remove stale identity data from session if `IdentityInterface::findIdentity()` returns `null` (mikehaertl)
+- Bug #18832: Fix `Inflector::camel2words()` adding extra spaces (brandonkelly)
 
 
 2.0.43 August 09, 2021

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -371,11 +371,11 @@ class BaseInflector
      */
     public static function camel2words($name, $ucwords = true)
     {
-        $label = mb_strtolower(trim(str_replace([
-            '-',
-            '_',
-            '.',
-        ], ' ', preg_replace('/(?<!\p{Lu})(\p{Lu})|(\p{Lu})(?=\p{Ll})/u', ' \0', $name))), self::encoding());
+        // Add a space before any uppercase letter preceded by a lowercase letter (xY => x Y)
+        // and any uppercase letter preceded by an uppercase letter and followed by a lowercase letter (XYz => X Yz)
+        $label = preg_replace('/(?<=\p{Ll})\p{Lu}|(?<=\p{L})\p{Lu}(?=\p{Ll})/u', ' \0', $name);
+
+        $label = mb_strtolower(trim(str_replace(['-', '_', '.'], ' ', $label)), self::encoding());
 
         return $ucwords ? StringHelper::mb_ucwords($label, self::encoding()) : $label;
     }

--- a/tests/framework/helpers/InflectorTest.php
+++ b/tests/framework/helpers/InflectorTest.php
@@ -117,6 +117,10 @@ class InflectorTest extends TestCase
         $this->assertEquals('Generate Csrf', Inflector::camel2words('generateCSRF'));
         $this->assertEquals('Generate Csrf Token', Inflector::camel2words('generateCSRFToken'));
         $this->assertEquals('Csrf Token Generator', Inflector::camel2words('CSRFTokenGenerator'));
+        $this->assertEquals('Foo Bar', Inflector::camel2words('foo bar'));
+        $this->assertEquals('Foo Bar', Inflector::camel2words('foo BAR'));
+        $this->assertEquals('Foo Bar', Inflector::camel2words('Foo Bar'));
+        $this->assertEquals('Foo Bar', Inflector::camel2words('FOO BAR'));
     }
 
     public function testCamel2id()


### PR DESCRIPTION
This PR fixes #18832 introduced in 2.0.43, by updating the `preg_replace()` call in `Inflecwor::camel2words()` to only add spaces before uppercase characters followed by lowercase characters, _if they aren’t preceded by another letter_.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18832
