### PR TITLE
Reduce memory copy in "afterRender" event

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,6 +15,7 @@ Yii Framework 2 Change Log
 - Bug #18845: Fix duplicating `id` in `MigrateController::addDefaultPrimaryKey()` (WinterSilence, samdark)
 - Bug #17119: Fix `yii\caching\Cache::multiSet()` to use `yii\caching\Cache::$defaultDuration` when no duration is passed (OscarBarrett)
 - Bug #18842: Fix `yii\base\Controller::bindInjectedParams()` to not throw error when argument of `ReflectionUnionType` type is passed (bizley)
+- Enh #18858: Reduce memory copy in `yii\base\View::afterRender` method (LeoOnTheEarth)
 
 
 2.0.43 August 09, 2021

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -15,7 +15,7 @@ Yii Framework 2 Change Log
 - Bug #18845: Fix duplicating `id` in `MigrateController::addDefaultPrimaryKey()` (WinterSilence, samdark)
 - Bug #17119: Fix `yii\caching\Cache::multiSet()` to use `yii\caching\Cache::$defaultDuration` when no duration is passed (OscarBarrett)
 - Bug #18842: Fix `yii\base\Controller::bindInjectedParams()` to not throw error when argument of `ReflectionUnionType` type is passed (bizley)
-- Enh #18858: Reduce memory copy in `yii\base\View::afterRender` method (LeoOnTheEarth)
+- Enh #18858: Reduce memory usage in `yii\base\View::afterRender` method (LeoOnTheEarth)
 - Bug #18880: Fix `yii\helpers\ArrayHelper::toArray()` for `DateTime` objects in PHP >= 7.4 (rhertogh)
 
 

--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -316,10 +316,10 @@ class View extends Component implements DynamicContentAwareInterface
             $event = new ViewEvent([
                 'viewFile' => $viewFile,
                 'params' => $params,
-                'output' => $output,
             ]);
+            $event->output =& $output;
+
             $this->trigger(self::EVENT_AFTER_RENDER, $event);
-            $output = $event->output;
         }
     }
 

--- a/tests/framework/base/ViewTest.php
+++ b/tests/framework/base/ViewTest.php
@@ -97,4 +97,22 @@ PHP
 
         $this->assertSame($subViewContent, $view->render('@testviews/base'));
     }
+
+    public function testAfterRender()
+    {
+        $view = new View();
+        $filename = 'path/to/file';
+        $params = ['search' => 'simple', 'replace' => 'new'];
+        $output = 'This is a simple rendered output. (filename)';
+        $expectedOutput = 'This is a new rendered output. (path/to/file)';
+
+        $view->on(View::EVENT_AFTER_RENDER, function (ViewEvent $event) {
+            $event->output = str_replace($event->params['search'], $event->params['replace'], $event->output);
+            $event->output = str_replace('filename', $event->viewFile, $event->output);
+        });
+
+        $view->afterRender($filename, $params, $output);
+
+        $this->assertSame($expectedOutput, $output);
+    }
 }


### PR DESCRIPTION
Since `$output` parameter is already a reference, we could assign to `ViewEvent::$output` property directly with the reference of `$output` parameter. Then we can reduce some memory.

I found it when my `$event->output` is very large, the memory usage is wired with this line: `$output = $event->output;`, it does some unnecessary memory copy.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
