### PR TITLE
Cache: use defaultDuration for multiSet when no duration is provided

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Enh #18762: Added `yii\helpers\Json::$keepObjectType` and `yii\web\JsonResponseFormatter::$keepObjectType` in order to avoid changing zero-indexed objects to array in `yii\helpers\Json::encode()` (zebraf1)
 - Enh #18783: Add support for URI namespaced tags in `XmlResponseFormatter` (WinterSilence, samdark)
 - Enh #18783: Add `XmlResponseFormatter::$objectTagToLowercase` option to lowercase object tags (WinterSilence, samdark)
+- Bug #17119: Fix `yii\caching\Cache::multiSet()` to use `yii\caching\Cache::$defaultDuration` when no duration is passed (OscarBarrett)
 
 
 2.0.43 August 09, 2021

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -68,6 +68,7 @@ Upgrade from Yii 2.0.43
         ],
       ],
       ```
+* `yii\caching\Cache::multiSet()` now uses the default cache duration (`yii\caching\Cache::$defaultDuration`) when no duration is provided. A duration of 0 should be explicitly passed if items should not expire.
 
 Upgrade from Yii 2.0.42
 -----------------------

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -261,14 +261,15 @@ abstract class Cache extends Component implements CacheInterface
      * expiration time will be replaced with the new ones, respectively.
      *
      * @param array $items the items to be cached, as key-value pairs.
-     * @param int $duration default number of seconds in which the cached values will expire. 0 means never expire.
+     * @param int $duration default duration in seconds before the cache will expire. If not set,
+     * default [[defaultDuration]] value is used.
      * @param Dependency $dependency dependency of the cached items. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return array array of failed keys
      * @deprecated This method is an alias for [[multiSet()]] and will be removed in 2.1.0.
      */
-    public function mset($items, $duration = 0, $dependency = null)
+    public function mset($items, $duration = null, $dependency = null)
     {
         return $this->multiSet($items, $duration, $dependency);
     }
@@ -279,15 +280,20 @@ abstract class Cache extends Component implements CacheInterface
      * expiration time will be replaced with the new ones, respectively.
      *
      * @param array $items the items to be cached, as key-value pairs.
-     * @param int $duration default number of seconds in which the cached values will expire. 0 means never expire.
+     * @param int $duration default duration in seconds before the cache will expire. If not set,
+     * default [[defaultDuration]] value is used.
      * @param Dependency $dependency dependency of the cached items. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return array array of failed keys
      * @since 2.0.7
      */
-    public function multiSet($items, $duration = 0, $dependency = null)
+    public function multiSet($items, $duration = null, $dependency = null)
     {
+        if ($duration === null) {
+            $duration = $this->defaultDuration;
+        }
+
         if ($dependency !== null && $this->serializer !== false) {
             $dependency->evaluateDependency($this);
         }

--- a/framework/caching/CacheInterface.php
+++ b/framework/caching/CacheInterface.php
@@ -112,13 +112,14 @@ interface CacheInterface extends \ArrayAccess
      * expiration time will be replaced with the new ones, respectively.
      *
      * @param array $items the items to be cached, as key-value pairs.
-     * @param int $duration default number of seconds in which the cached values will expire. 0 means never expire.
+     * @param int $duration default duration in seconds before the cache will expire. If not set,
+     * default [[defaultDuration]] value is used.
      * @param Dependency $dependency dependency of the cached items. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return array array of failed keys
      */
-    public function multiSet($items, $duration = 0, $dependency = null);
+    public function multiSet($items, $duration = null, $dependency = null);
 
     /**
      * Stores a value identified by a key into cache if the cache does not contain this key.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17119

This PR addresses an inconsistency between `set` and `multiSet`: `set` has a default duration of null (which falls back to `$defaultDuration`) whereas `multiSet` currently has a default duration of 0 (no expiry).

[multiSet was added 6 years ago](), while [set was updated to use the  default duration 5 years ago](https://github.com/yiisoft/yii2/commit/9a1c168939a5534c9dc8c881c6933b616ecc5de3).

As per #17119, TagDependencies do not expire as they are set using `multiSet`. As such, this PR makes the set commands in `Cache` more consistent, and as a result allows TagDependencies to expire using the default cache duration.