### PR TITLE
Fix return of `BaseHtml::getAttributeValue`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Enh #18783: Add `XmlResponseFormatter::$objectTagToLowercase` option to lowercase object tags (WinterSilence, samdark)
 - Bug #18845: Fix duplicating `id` in `MigrateController::addDefaultPrimaryKey()` (WinterSilence, samdark)
 - Bug #17119: Fix `yii\caching\Cache::multiSet()` to use `yii\caching\Cache::$defaultDuration` when no duration is passed (OscarBarrett)
+- Bug #18863: Fix fix return of `BaseHtml::getAttributeValue()` (dicrtarasov, WinterSilence)
 
 
 2.0.43 August 09, 2021

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,7 +13,7 @@ Yii Framework 2 Change Log
 - Enh #18783: Add `XmlResponseFormatter::$objectTagToLowercase` option to lowercase object tags (WinterSilence, samdark)
 - Bug #18845: Fix duplicating `id` in `MigrateController::addDefaultPrimaryKey()` (WinterSilence, samdark)
 - Bug #17119: Fix `yii\caching\Cache::multiSet()` to use `yii\caching\Cache::$defaultDuration` when no duration is passed (OscarBarrett)
-- Bug #18863: Fix fix return of `BaseHtml::getAttributeValue()` (dicrtarasov, WinterSilence)
+- Bug #18863: Fix return of `BaseHtml::getAttributeValue()` (dicrtarasov, WinterSilence)
 
 
 2.0.43 August 09, 2021

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2236,7 +2236,7 @@ class BaseHtml
      *
      * @param Model $model the model object
      * @param string $attribute the attribute name or expression
-     * @return string|array the corresponding attribute value
+     * @return string|null the corresponding attribute value
      * @throws InvalidArgumentException if the attribute name contains non-word characters.
      */
     public static function getAttributeValue($model, $attribute)
@@ -2260,17 +2260,14 @@ class BaseHtml
         if (is_array($value)) {
             foreach ($value as $i => $v) {
                 if ($v instanceof ActiveRecordInterface) {
-                    $v = $v->getPrimaryKey(false);
-                    $value[$i] = is_array($v) ? json_encode($v) : $v;
+                    $value[$i] = $v->getPrimaryKey();
                 }
             }
         } elseif ($value instanceof ActiveRecordInterface) {
-            $value = $value->getPrimaryKey(false);
-
-            return is_array($value) ? json_encode($value) : $value;
+            $value = $value->getPrimaryKey();
         }
 
-        return $value;
+        return is_array($value) ? Json::encode($value) : ($value === null ? null : (string) $value);
     }
 
     /**

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1895,7 +1895,7 @@ EOD;
             $activeRecord,
         ];
 
-        $expected = [1];
+        $expected = '[1]';
         $actual = Html::getAttributeValue($model, 'types');
         $this->assertSame($expected, $actual);
     }

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1887,7 +1887,7 @@ EOD;
         $activeRecord->method('getPrimaryKey')->willReturn(1);
         $model->types = $activeRecord;
 
-        $expected = 1;
+        $expected = '1';
         $actual = Html::getAttributeValue($model, 'types');
         $this->assertSame($expected, $actual);
 


### PR DESCRIPTION
Similar to freezed #18831 + test fix + update changelog

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18831
