### PR TITLE
Fix `\yii\rest\CreateAction::run()`

### DIFF
--- a/framework/rest/CreateAction.php
+++ b/framework/rest/CreateAction.php
@@ -49,9 +49,9 @@ class CreateAction extends Action
             'scenario' => $this->scenario,
         ]);
 
-        $model->load($this->controller->getRequest()->getBodyParams(), '');
+        $model->load($this->controller->request->getBodyParams(), '');
         if ($model->save()) {
-            $response = $this->controller->getResponse();
+            $response = $this->controller->response;
             $response->setStatusCode(201);
             $id = implode(',', array_values($model->getPrimaryKey(true)));
             $response->getHeaders()->set('Location', Url::toRoute([$this->viewAction, 'id' => $id], true));

--- a/framework/rest/CreateAction.php
+++ b/framework/rest/CreateAction.php
@@ -43,14 +43,15 @@ class CreateAction extends Action
             call_user_func($this->checkAccess, $this->id);
         }
 
-        /* @var $model \yii\db\ActiveRecord */
-        $model = new $this->modelClass([
+        /** @var \yii\db\ActiveRecordInterface $model */
+        $model = Yii::createObject([
+            'class' => $this->modelClass,
             'scenario' => $this->scenario,
         ]);
 
-        $model->load(Yii::$app->getRequest()->getBodyParams(), '');
+        $model->load($this->controller->getRequest()->getBodyParams(), '');
         if ($model->save()) {
-            $response = Yii::$app->getResponse();
+            $response = $this->controller->getResponse();
             $response->setStatusCode(201);
             $id = implode(',', array_values($model->getPrimaryKey(true)));
             $response->getHeaders()->set('Location', Url::toRoute([$this->viewAction, 'id' => $id], true));


### PR DESCRIPTION
Use `Yii::createObject()` to import configuration added by service locator.
Use response/request defined in parent controller

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
