### PR TITLE
Update AccessRule.php

### DIFF
--- a/framework/filters/AccessRule.php
+++ b/framework/filters/AccessRule.php
@@ -242,9 +242,7 @@ class AccessRule extends Component
                     return true;
                 }
             } else {
-                if (!isset($roleParams)) {
-                    $roleParams = !is_array($this->roleParams) && is_callable($this->roleParams) ? call_user_func($this->roleParams, $this) : $this->roleParams;
-                }
+                $roleParams = !is_array($this->roleParams) && is_callable($this->roleParams) ? call_user_func($this->roleParams, $this) : $this->roleParams;
                 if ($user->can($item, $roleParams)) {
                     return true;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

`$roleParams` is always empty, there is no need to use `isset` statement
