### PR TITLE
Fix an invalid phpDoc annotation of DataProviderInterface::getSort()

### DIFF
--- a/framework/data/DataProviderInterface.php
+++ b/framework/data/DataProviderInterface.php
@@ -61,7 +61,7 @@ interface DataProviderInterface
     public function getKeys();
 
     /**
-     * @return Sort the sorting object. If this is false, it means the sorting is disabled.
+     * @return Sort|false the sorting object. If this is false, it means the sorting is disabled.
      */
     public function getSort();
 


### PR DESCRIPTION
Fix an invalid phpDoc annotation of DataProviderInterface::getSort()

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
