### PR TITLE
Fix mb_ucwords when a word ends with 0

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -19,6 +19,7 @@ Yii Framework 2 Change Log
 - Bug #18880: Fix `yii\helpers\ArrayHelper::toArray()` for `DateTime` objects in PHP >= 7.4 (rhertogh)
 - Bug #18883: Fix `yii\web\HeaderCollection::fromArray()` now ensures lower case keys (rhertogh)
 - Bug #18886: Fix default return of `yii\db\Migration::safeUp()` and `yii\db\Migration::safeDown()` (WinterSilence)
+- Bug #18898: Fix `yii\helpers\Inflector::camel2words()` to work with words ending with 0 (michaelarnauts)
 
 
 2.0.43 August 09, 2021

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -48,7 +48,7 @@ class BaseStringHelper
         if ($length === null) {
             $length = static::byteLength($string);
         }
- 
+
         return mb_substr($string, $start, $length, '8bit');
     }
 
@@ -71,7 +71,7 @@ class BaseStringHelper
         if ($len > 0 && mb_substr($path, -$len) === $suffix) {
             $path = mb_substr($path, 0, -$len);
         }
- 
+
         $path = rtrim(str_replace('\\', '/', $path), '/');
         $pos = mb_strrpos($path, '/');
         if ($pos !== false) {
@@ -468,7 +468,7 @@ class BaseStringHelper
         }
 
         $parts = preg_split('/(\s+[^\w]+\s+|^[^\w]+\s+|\s+)/u', $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
-        $ucfirstEven = !trim(mb_substr($parts[0], -1, 1, $encoding));
+        $ucfirstEven = (trim(mb_substr($parts[0], -1, 1, $encoding)) === '');
         foreach ($parts as $key => $value) {
             $isEven = (bool)($key % 2);
             if ($ucfirstEven === $isEven) {

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -468,7 +468,7 @@ class BaseStringHelper
         }
 
         $parts = preg_split('/(\s+[^\w]+\s+|^[^\w]+\s+|\s+)/u', $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
-        $ucfirstEven = (trim(mb_substr($parts[0], -1, 1, $encoding)) === '');
+        $ucfirstEven = trim(mb_substr($parts[0], -1, 1, $encoding)) === '';
         foreach ($parts as $key => $value) {
             $isEven = (bool)($key % 2);
             if ($ucfirstEven === $isEven) {

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -438,6 +438,8 @@ class StringHelperTest extends TestCase
             ['0', '0'],
             [null, ''],
             ['здесь我 multibyte我 строка', 'Здесь我 Multibyte我 Строка'],
+            ['p0 upload', 'P0 Upload'],
+            ['p5 upload', 'P5 Upload'],
         ];
     }
 


### PR DESCRIPTION
This fixes the regression indicated in issue #18898

The `$ucfirstEven = !trim(mb_substr($parts[0], -1, 1, $encoding));` lines checks the last character, and see if this is falsy. This was probably meant to check for an empty string, but `'0'` is also falsy.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #18898

@WinterSilence @brandonkelly
