### PR TITLE
Fix MySQL mutex sometimes allows acquiring of the same locknames

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -23,7 +23,7 @@ Yii Framework 2 Change Log
 - Bug #18898: Fix `yii\helpers\Inflector::camel2words()` to work with words ending with 0 (michaelarnauts)
 - Enh #18904: Improve Captcha client-side validation (hexkir)
 - Bug #18913: Add filename validation for `MessageSource::getMessageFilePath()` (uaoleg)
-
+- Bug #18877: MySQL mutex sometimes allows acquiring of the same locknames (alexjeen, raphaelts3)
 
 2.0.43 August 09, 2021
 ----------------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | https://github.com/yiisoft/yii2/issues/18877

Since @alexjeen hasn't answered about pull requesting the fix for the bug, I've taken the liberty of pull requesting his solution with a small code arrangement that I think improves overall readability. 
I've included both of us in the changelog because I think it's the more sensate thing to do, but let me know if I should change it.