### PR TITLE
StringHelper::dirname() fixed for trailing slash

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.44 under development
 ------------------------
 
+- Bug #18798: Fixed `StringHelper::dirname()` when passed string with trailing slash (perlexed) 
 - Enh #18812: Added error messages and optimized "error" methods in `yii\helpers\BaseJson` (WinterSilence, samdark)
 - Chg #18823: Rollback changes #18806 in `yii\validators\ExistValidator::checkTargetRelationExistence()` (WinterSilence)
 - Enh #18826: Add ability to turn the sorting off for a clicked column in GridView with multisort (ditibal)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.44 under development
 ------------------------
 
-- Bug #18798: Fixed `StringHelper::dirname()` when passed string with trailing slash (perlexed) 
+- Bug #18798: Fix `StringHelper::dirname()` when passing string with a trailing slash (perlexed)
 - Enh #18812: Added error messages and optimized "error" methods in `yii\helpers\BaseJson` (WinterSilence, samdark)
 - Chg #18823: Rollback changes #18806 in `yii\validators\ExistValidator::checkTargetRelationExistence()` (WinterSilence)
 - Enh #18826: Add ability to turn the sorting off for a clicked column in GridView with multisort (ditibal)

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -92,9 +92,14 @@ class BaseStringHelper
      */
     public static function dirname($path)
     {
-        $pos = mb_strrpos(str_replace('\\', '/', $path), '/');
-        if ($pos !== false) {
-            return mb_substr($path, 0, $pos);
+        $normalizedPath = rtrim(
+            str_replace('\\', '/', $path),
+            '/',
+        );
+        $separatorPosition = mb_strrpos($normalizedPath, '/');
+
+        if ($separatorPosition !== false) {
+            return mb_substr($path, 0, $separatorPosition);
         }
 
         return '';

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -94,7 +94,7 @@ class BaseStringHelper
     {
         $normalizedPath = rtrim(
             str_replace('\\', '/', $path),
-            '/',
+            '/'
         );
         $separatorPosition = mb_strrpos($normalizedPath, '/');
 

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -452,4 +452,26 @@ class StringHelperTest extends TestCase
     {
         $this->assertSame($expectedResult, StringHelper::mb_ucwords($string));
     }
+
+    /**
+     * @param string $string
+     * @param string $expectedResult
+     * @dataProvider dataProviderDirname
+     */
+    public function testDirname($string, $expectedResult)
+    {
+        $this->assertSame($expectedResult, StringHelper::dirname($string));
+    }
+
+    public function dataProviderDirname()
+    {
+        return [
+            ['\\foo\\bar\\test', '\foo\bar'],
+            ['\\foo/bar\\test', '\foo/bar'],
+            ['\\foo\\bar\\test\\', '\foo\bar'],
+            ['foo/bar/test', 'foo/bar'],
+            ['foo', ''],
+            ['', ''],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/yii2/issues/18798
