### PR TITLE
Add generic typing to `createObject()`

### DIFF
--- a/framework/BaseYii.php
+++ b/framework/BaseYii.php
@@ -326,7 +326,8 @@ class BaseYii
      * Using [[\yii\di\Container|dependency injection container]], this method can also identify
      * dependent objects, instantiate them and inject them into the newly created object.
      *
-     * @param string|array|callable $type the object type. This can be specified in one of the following forms:
+     * @template T
+     * @param class-string<T>|array{class: class-string<T>}|callable(): T $type the object type. This can be specified in one of the following forms:
      *
      * - a string: representing the class name of the object to be created
      * - a configuration array: the array must contain a `class` element which is treated as the object class,
@@ -335,7 +336,7 @@ class BaseYii
      *   The callable should return a new instance of the object being created.
      *
      * @param array $params the constructor parameters
-     * @return object the created object
+     * @return T the created object
      * @throws InvalidConfigException if the configuration is invalid.
      * @see \yii\di\Container
      */

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -27,6 +27,7 @@ Yii Framework 2 Change Log
 - Bug #18913: Add filename validation for `MessageSource::getMessageFilePath()` (uaoleg)
 - Bug #18909: Fix bug with binding default action parameters for controllers (bizley)
 - Bug #18955: Check `yiisoft/yii2-swiftmailer` before using as default mailer in `yii\base\Application` (WinterSilence)
+- Enh #18976: Add generic typing to `Yii::createObject()` (brandonkelly)
 
 
 2.0.43 August 09, 2021


### PR DESCRIPTION
This PR enhances the `Yii::createObject()` docblock types with generics, which give code introspection tools like PhpStorm and PHPStan better insight into what will be returned by the method.

With this change, both PHPStan and PhpStorm will now be smart enough to know that `$entry` in the following example is going to be an object of type `craft\elements\Entry`:

```php
$entry = Yii::createObject('craft\elements\Entry');
```

PHPStan would also be able to understand the following examples:

```php
$entry = Yii::createObject(function(): Entry {
    return new 'craft\elements\Entry';
});

$entry = Yii::createObject([
    'class' => 'craft\elements\Entry',
    // ...
]);
```

Resources:

- [Generics in PHP using PHPDocs](https://phpstan.org/blog/generics-in-php-using-phpdocs) (PHPStan)
- [PHPDoc Types: class-string](https://phpstan.org/writing-php-code/phpdoc-types#class-string) (PHPStan)
- [PhpStorm 2021.2: Support for generics](https://blog.jetbrains.com/phpstorm/2021/07/phpstorm-2021-2-release/#generics) (PhpStorm)

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
