### PR TITLE
Fix wrong example in `BaseMigrateController`

### DIFF
--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -632,7 +632,7 @@ abstract class BaseMigrateController extends Controller
      * For example:
      *
      * ```
-     * yii migrate/create 'app\\migrations\\createUserTable'
+     * yii migrate/create app\\migrations\\createUserTable
      * ```
      *
      * In case [[migrationPath]] is not set and no namespace is provided, the first entry of [[migrationNamespaces]] will be used.


### PR DESCRIPTION
~~~bash
>yii migrate/create 'app\\migrations\\CreateCarMarksTable'
Yii Migration Tool (based on Yii v2.0.43)

Error: The migration name should contain letters, digits, underscore and/or backslash characters only.
~~~

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
