### PR TITLE
suppress "Array to string conversion" error caused by rendering input element with non-string form value

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -559,7 +559,7 @@ class BaseHtml
             $options['type'] = $type;
         }
         $options['name'] = $name;
-        $options['value'] = $value === null ? null : (string) $value;
+        $options['value'] = $value === null ? null : @(string) $value;
         return static::tag('input', '', $options);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |

## Issue

The code below result in "Array to string conversion" NOTICE error in PHP 7.x and WARNING error in PHP8.
As Yii2's search model is often used to load data from query parameter, malignant visitor can easily cause Internal Server Error that would be logged and bother system admins.

```php
error_reporting(E_ALL);
$m = new class extends \yii\base\Model
{
    public $hoge;
    public function formName()
    {
        return 'f';
    }

    public function rules()
    {
        return [['hoge', 'string']];
    }
};
$m->load([$m->formName() => ['hoge' => []]]);
$m->validate(); // validator is ineffective in preventing error in next line
echo \yii\helpers\Html::activeInput('text', $m, 'hoge'); // error occurs here
```

## Measures

Simply suppress error.
