### PR TITLE
Update composer.json

### DIFF
--- a/framework/composer.json
+++ b/framework/composer.json
@@ -77,6 +77,7 @@
         "paragonie/random_compat": ">=1"
     },
     "autoload": {
+        "psr-0": {"Yii": ""},
         "psr-4": {"yii\\": ""}
     },
     "bin": [


### PR DESCRIPTION
> The PSR-0 style is not limited to namespace declarations only but may be specified right down to the class level. This can be useful for libraries with only one class in the global namespace.

https://getcomposer.org/doc/04-schema.md#psr-0

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
