### PR TITLE
Fix `ArrayAccess` implementation in `yii\base\Model`

### DIFF
--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -10,6 +10,7 @@ namespace yii\base;
 use ArrayAccess;
 use ArrayIterator;
 use ArrayObject;
+use Countable;
 use IteratorAggregate;
 use ReflectionClass;
 use Yii;
@@ -55,9 +56,8 @@ use yii\validators\Validator;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-class Model extends Component implements StaticInstanceInterface, IteratorAggregate, ArrayAccess, Arrayable
+class Model extends Component implements StaticInstanceInterface, IteratorAggregate, ArrayAccess, Arrayable, Countable
 {
-    use ArrayableTrait;
     use StaticInstanceTrait;
 
     /**
@@ -1006,7 +1006,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      * Returns whether there is an element at the specified offset.
      * This method is required by the SPL interface [[\ArrayAccess]].
      * It is implicitly called when you use something like `isset($model[$offset])`.
-     * @param mixed $offset the offset to check on.
+     * @param string $offset the offset to check on.
      * @return bool whether or not an offset exists.
      */
     public function offsetExists($offset)
@@ -1018,7 +1018,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      * Returns the element at the specified offset.
      * This method is required by the SPL interface [[\ArrayAccess]].
      * It is implicitly called when you use something like `$value = $model[$offset];`.
-     * @param mixed $offset the offset to retrieve element.
+     * @param string $offset the offset to retrieve element.
      * @return mixed the element at the offset, null if no element is found at the offset
      */
     public function offsetGet($offset)
@@ -1029,23 +1029,34 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
     /**
      * Sets the element at the specified offset.
      * This method is required by the SPL interface [[\ArrayAccess]].
-     * It is implicitly called when you use something like `$model[$offset] = $item;`.
-     * @param int $offset the offset to set element
-     * @param mixed $item the element value
+     * It is implicitly called when you use something like `$model[$offset] = $value;`.
+     * @param string $offset the offset to set element
+     * @param mixed $value the element value
      */
-    public function offsetSet($offset, $item)
+    public function offsetSet($offset, $value)
     {
-        $this->$offset = $item;
+        $this->$offset = $value;
     }
 
     /**
      * Sets the element value at the specified offset to null.
      * This method is required by the SPL interface [[\ArrayAccess]].
      * It is implicitly called when you use something like `unset($model[$offset])`.
-     * @param mixed $offset the offset to unset element
+     * @param string $offset the offset to unset element
      */
     public function offsetUnset($offset)
     {
         $this->$offset = null;
+    }
+
+    /**
+     * Returns number of attributes.
+     * This method is required by the SPL interface [[\Countable]].
+     * It is implicitly called when you use something like `count($model)`.
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->attributes());
     }
 }

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -58,6 +58,7 @@ use yii\validators\Validator;
  */
 class Model extends Component implements StaticInstanceInterface, IteratorAggregate, ArrayAccess, Arrayable, Countable
 {
+    use ArrayableTrait;
     use StaticInstanceTrait;
 
     /**


### PR DESCRIPTION
Improve `ArrayAccess`  implementation: fix parameter name in `offsetSet()`, fix `$offset` type in PhpDoc's

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
