### PR TITLE
Optimize ActiveRecord::loadDefaultValues()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -28,6 +28,7 @@ Yii Framework 2 Change Log
 - Bug #18909: Fix bug with binding default action parameters for controllers (bizley)
 - Bug #18955: Check `yiisoft/yii2-swiftmailer` before using as default mailer in `yii\base\Application` (WinterSilence)
 - Bug #18988: Fix default value of `yii\console\controllers\MessageController::$translator` (WinterSilence)
+- Bug #18993: Load defaults by `attributes()` in `yii\db\ActiveRecord::loadDefaultValues()` (WinterSilence)
 
 
 2.0.43 August 09, 2021

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -117,9 +117,11 @@ class ActiveRecord extends BaseActiveRecord
     {
         $columns = static::getTableSchema()->columns;
         foreach ($this->attributes() as $name) {
-            $defaultValue = $columns[$name]->defaultValue;
-            if ($defaultValue !== null && (!$skipIfSet || $this->getAttribute($name) === null)) {
-                $this->setAttribute($name, $defaultValue);
+            if (isset($columns[$name])) {
+                $defaultValue = $columns[$name]->defaultValue;
+                if ($defaultValue !== null && (!$skipIfSet || $this->getAttribute($name) === null)) {
+                    $this->setAttribute($name, $defaultValue);
+                }
             }
         }
 

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -115,9 +115,11 @@ class ActiveRecord extends BaseActiveRecord
      */
     public function loadDefaultValues($skipIfSet = true)
     {
-        foreach (static::getTableSchema()->columns as $column) {
-            if ($column->defaultValue !== null && (!$skipIfSet || $this->{$column->name} === null)) {
-                $this->{$column->name} = $column->defaultValue;
+        $columns = static::getTableSchema()->columns;
+        foreach ($this->attributes() as $name) {
+            $defaultValue = $columns[$name]->defaultValue;
+            if ($defaultValue !== null && (!$skipIfSet || $this->getAttribute($name) === null)) {
+                $this->setAttribute($name, $defaultValue);
             }
         }
 

--- a/tests/data/ar/CroppedType.php
+++ b/tests/data/ar/CroppedType.php
@@ -13,7 +13,7 @@ namespace yiiunit\data\ar;
  * @property int $int_col
  * @property int $int_col2 DEFAULT 1
  */
-class СroppedType extends ActiveRecord
+class CroppedType extends ActiveRecord
 {
     /**
      * @inheritDoc

--- a/tests/data/ar/СroppedType.php
+++ b/tests/data/ar/СroppedType.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar;
+
+/**
+ * Model representing 2 columns from "type" table.
+ *
+ * @property int $int_col
+ * @property int $int_col2 DEFAULT 1
+ */
+class СroppedType extends ActiveRecord
+{
+    /**
+     * @inheritDoc
+     */
+    public static function tableName()
+    {
+        return '{{%type}}';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function attributes()
+    {
+        return ['int_col', 'int_col2'];
+    }
+}

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1345,6 +1345,11 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals(33.22, $model->numeric_col);
         $this->assertEquals(true, $model->bool_col2);
 
+        // cropped model with 2 attributes/columns
+        $model = new CroppedType();
+        $model->loadDefaultValues();
+        $this->assertEquals(['int_col' => null, 'int_col2' => 1], $model->toArray());
+        
         if ($this instanceof CubridActiveRecordTest) {
             // cubrid has non-standard timestamp representation
             $this->assertEquals('12:00:00 AM 01/01/2002', $model->time);

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1349,7 +1349,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         // Cropped model with 2 attributes/columns
         $model = new CroppedType();
         $model->loadDefaultValues();
-        $this->assertEquals(['int_col' => null, 'int_col2' => 1], $model->toArray());
+        $this->assertEquals(['int_col2' => 1], $model->toArray());
         
         if ($this instanceof CubridActiveRecordTest) {
             // cubrid has non-standard timestamp representation

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1346,7 +1346,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals(33.22, $model->numeric_col);
         $this->assertEquals(true, $model->bool_col2);
 
-        // cropped model with 2 attributes/columns
+        // Cropped model with 2 attributes/columns
         $model = new CroppedType();
         $model->loadDefaultValues();
         $this->assertEquals(['int_col' => null, 'int_col2' => 1], $model->toArray());

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1345,12 +1345,6 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals(1.23, $model->float_col2);
         $this->assertEquals(33.22, $model->numeric_col);
         $this->assertEquals(true, $model->bool_col2);
-
-        // Cropped model with 2 attributes/columns
-        $model = new CroppedType();
-        $model->loadDefaultValues();
-        $this->assertEquals(['int_col2' => 1], $model->toArray());
-        
         if ($this instanceof CubridActiveRecordTest) {
             // cubrid has non-standard timestamp representation
             $this->assertEquals('12:00:00 AM 01/01/2002', $model->time);
@@ -1360,15 +1354,18 @@ abstract class ActiveRecordTest extends DatabaseTestCase
 
         $model = new Type();
         $model->char_col2 = 'not something';
-
         $model->loadDefaultValues();
         $this->assertEquals('not something', $model->char_col2);
 
         $model = new Type();
         $model->char_col2 = 'not something';
-
         $model->loadDefaultValues(false);
         $this->assertEquals('something', $model->char_col2);
+        
+        // Cropped model with 2 attributes/columns
+        $model = new CroppedType();
+        $model->loadDefaultValues();
+        $this->assertEquals(['int_col2' => 1], $model->toArray());
     }
 
     public function testUnlinkAllViaTable()

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -35,6 +35,7 @@ use yiiunit\data\ar\OrderWithNullFK;
 use yiiunit\data\ar\Profile;
 use yiiunit\data\ar\ProfileWithConstructor;
 use yiiunit\data\ar\Type;
+use yiiunit\data\ar\CroppedType;
 use yiiunit\framework\ar\ActiveRecordTestTrait;
 use yiiunit\framework\db\cubrid\ActiveRecordTest as CubridActiveRecordTest;
 use yiiunit\TestCase;


### PR DESCRIPTION
Iterate `attributes()` instead `getTableSchema()->columns` because `attributes()` can be overridden in user's models and return not all columns
Use `getAttribute()`/`setAttribute()` instead magic properties

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
