### PR TITLE
(#13105) Add yiiActiveForm validate_only property for skipping form a…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.44 under development
 ------------------------
-
+- Enh #13105: Add yiiActiveForm validate_only property for skipping form auto-submission (ptolomaues)
 - Bug #18798: Fix `StringHelper::dirname()` when passing string with a trailing slash (perlexed)
 - Enh #18328: Raise warning when trying to register a file after `View::endPage()` has been called (perlexed)
 - Enh #18812: Added error messages and optimized "error" methods in `yii\helpers\BaseJson` (WinterSilence, samdark)

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -218,6 +218,7 @@
                     attributes: attributes,
                     submitting: false,
                     validated: false,
+                    validate_only: false, // validate without auto submitting
                     options: getFormOptions($form)
                 });
 
@@ -754,12 +755,14 @@
                 data.submitting = false;
             } else {
                 data.validated = true;
-                if (data.submitObject) {
-                    applyButtonOptions($form, data.submitObject);
-                }
-                $form.submit();
-                if (data.submitObject) {
-                    restoreButtonOptions($form);
+                if (!data.validate_only) {
+                    if (data.submitObject) {
+                        applyButtonOptions($form, data.submitObject);
+                    }
+                    $form.submit();
+                    if (data.submitObject) {
+                        restoreButtonOptions($form);
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
#13105

    JS validation example:
    
    form = $('#someForm');
    form.data('yiiActiveForm').validate_only = true;
    form.one('afterValidate', afterValidateEvent);
    form.yiiActiveForm('validate', true); //run validation
    
    function afterValidateEvent() {
        if ($('#someForm').find('.has-error').length) {
           // Validation failed
        }
         // Validation successed
    }