### PR TITLE
Correct note about html encoded items in radio/checkboxlist

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1745,7 +1745,6 @@ class BaseHtml
      * about attribute expression.
      * @param array $items the data item used to generate the checkboxes.
      * The array keys are the checkbox values, and the array values are the corresponding labels.
-     * Note that the labels will NOT be HTML-encoded, while the values will.
      * @param array $options options (name => config) for the checkbox list container tag.
      * The following options are specially handled:
      *
@@ -1787,7 +1786,6 @@ class BaseHtml
      * about attribute expression.
      * @param array $items the data item used to generate the radio buttons.
      * The array keys are the radio values, and the array values are the corresponding labels.
-     * Note that the labels will NOT be HTML-encoded, while the values will.
      * @param array $options options (name => config) for the radio button list container tag.
      * The following options are specially handled:
      *
@@ -1829,7 +1827,6 @@ class BaseHtml
      * about attribute expression.
      * @param array $items the data item used to generate the input fields.
      * The array keys are the input values, and the array values are the corresponding labels.
-     * Note that the labels will NOT be HTML-encoded, while the values will.
      * @param array $options options (name => config) for the input list. The supported special options
      * depend on the input type specified by `$type`.
      * @return string the generated input list


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

The documentation for BaseHtml activeRadioList, activeCheckboxList and activeListbox incorrectly states that labels are not html encoded, while they are.

This seems like a leftover from https://github.com/yiisoft/yii2/commit/d87afeb496b3f75431192e1a1c9250e22a5363f7 when label encoding was added by default for checkboxlist and radiolist.
