### PR TITLE
fix error #19019  default sort error on mongodb dataProvider

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.44 under development
 ------------------------
 
+- Bug #19019 : Fix default sort error on mongodb dataProvider 
 - Bug #18798: Fix `StringHelper::dirname()` when passing string with a trailing slash (perlexed)
 - Enh #18328: Raise warning when trying to register a file after `View::endPage()` has been called (perlexed)
 - Enh #18812: Added error messages and optimized "error" methods in `yii\helpers\BaseJson` (WinterSilence, samdark)

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -228,8 +228,8 @@ class Sort extends BaseObject
         $attributeOrders = $this->getAttributeOrders($recalculate);
         $orders = [];
         foreach ($attributeOrders as $attribute => $direction) {
-            $definition = $this->attributes[$attribute];
-            $columns = $definition[$direction === SORT_ASC ? 'asc' : 'desc'];
+            $definition = $this->attributes[$attribute]??'_id ';
+            $columns = $definition[$direction === SORT_ASC ? 'asc' : 'desc'] ?? 'asc';
             if (is_array($columns) || $columns instanceof \Traversable) {
                 foreach ($columns as $name => $dir) {
                     $orders[$name] = $dir;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
