### PR TITLE
Fixed PhpDoc in Migration.php (revert #18886)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -20,7 +20,6 @@ Yii Framework 2 Change Log
 - Enh #18858: Reduce memory usage in `yii\base\View::afterRender` method (LeoOnTheEarth)
 - Bug #18880: Fix `yii\helpers\ArrayHelper::toArray()` for `DateTime` objects in PHP >= 7.4 (rhertogh)
 - Bug #18883: Fix `yii\web\HeaderCollection::fromArray()` now ensures lower case keys (rhertogh)
-- Bug #18886: Fix default return of `yii\db\Migration::safeUp()` and `yii\db\Migration::safeDown()` (WinterSilence)
 - Enh #18899: Replace usages of `strpos` with `strncmp` and remove redundant usage of `array_merge` and `array_values` (AlexGx)
 - Bug #18898: Fix `yii\helpers\Inflector::camel2words()` to work with words ending with 0 (michaelarnauts)
 - Enh #18904: Improve Captcha client-side validation (hexkir)
@@ -29,6 +28,7 @@ Yii Framework 2 Change Log
 - Bug #18955: Check `yiisoft/yii2-swiftmailer` before using as default mailer in `yii\base\Application` (WinterSilence)
 - Bug #18988: Fix default value of `yii\console\controllers\MessageController::$translator` (WinterSilence)
 - Bug #18993: Load defaults by `attributes()` in `yii\db\ActiveRecord::loadDefaultValues()` (WinterSilence)
+- Bug #19021: Fix return type in PhpDoc `yii\db\Migration` functions `up()`, `down()`, `safeUp()` and `safeDown()` (WinterSilence, rhertogh)
 
 
 2.0.43 August 09, 2021

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -104,7 +104,7 @@ class Migration extends Component implements MigrationInterface
     /**
      * This method contains the logic to be executed when applying this migration.
      * Child classes may override this method to provide actual migration logic.
-     * @return false|mixed return a false value to indicate the migration fails
+     * @return false|void|mixed return a false value to indicate the migration fails
      * and should not proceed further. All other return values mean the migration succeeds.
      */
     public function up()
@@ -133,7 +133,7 @@ class Migration extends Component implements MigrationInterface
      * This method contains the logic to be executed when removing this migration.
      * The default implementation throws an exception indicating the migration cannot be removed.
      * Child classes may override this method if the corresponding migrations can be removed.
-     * @return false|mixed return a false value to indicate the migration fails
+     * @return false|void|mixed return a false value to indicate the migration fails
      * and should not proceed further. All other return values mean the migration succeeds.
      */
     public function down()
@@ -177,7 +177,7 @@ class Migration extends Component implements MigrationInterface
      * Note: Not all DBMS support transactions. And some DB queries cannot be put into a transaction. For some examples,
      * please refer to [implicit commit](http://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html).
      *
-     * @return false|mixed return a false value to indicate the migration fails
+     * @return false|void|mixed return a false value to indicate the migration fails
      * and should not proceed further. All other return values mean the migration succeeds.
      */
     public function safeUp()
@@ -194,7 +194,7 @@ class Migration extends Component implements MigrationInterface
      * Note: Not all DBMS support transactions. And some DB queries cannot be put into a transaction. For some examples,
      * please refer to [implicit commit](http://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html).
      *
-     * @return false|mixed return a false value to indicate the migration fails
+     * @return false|void|mixed return a false value to indicate the migration fails
      * and should not proceed further. All other return values mean the migration succeeds.
      */
     public function safeDown()

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -104,7 +104,7 @@ class Migration extends Component implements MigrationInterface
     /**
      * This method contains the logic to be executed when applying this migration.
      * Child classes may override this method to provide actual migration logic.
-     * @return bool return a false value to indicate the migration fails
+     * @return false|mixed return a false value to indicate the migration fails
      * and should not proceed further. All other return values mean the migration succeeds.
      */
     public function up()
@@ -133,7 +133,7 @@ class Migration extends Component implements MigrationInterface
      * This method contains the logic to be executed when removing this migration.
      * The default implementation throws an exception indicating the migration cannot be removed.
      * Child classes may override this method if the corresponding migrations can be removed.
-     * @return bool return a false value to indicate the migration fails
+     * @return false|mixed return a false value to indicate the migration fails
      * and should not proceed further. All other return values mean the migration succeeds.
      */
     public function down()
@@ -177,12 +177,11 @@ class Migration extends Component implements MigrationInterface
      * Note: Not all DBMS support transactions. And some DB queries cannot be put into a transaction. For some examples,
      * please refer to [implicit commit](http://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html).
      *
-     * @return bool return a false value to indicate the migration fails
+     * @return false|mixed return a false value to indicate the migration fails
      * and should not proceed further. All other return values mean the migration succeeds.
      */
     public function safeUp()
     {
-        return true;
     }
 
     /**
@@ -195,12 +194,11 @@ class Migration extends Component implements MigrationInterface
      * Note: Not all DBMS support transactions. And some DB queries cannot be put into a transaction. For some examples,
      * please refer to [implicit commit](http://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html).
      *
-     * @return bool return a false value to indicate the migration fails
+     * @return false|mixed return a false value to indicate the migration fails
      * and should not proceed further. All other return values mean the migration succeeds.
      */
     public function safeDown()
     {
-        return true;
     }
 
     /**


### PR DESCRIPTION
Fixed the return type of `up()`, `down()`, `safeUp()` and `safeDown()` functions to match the described behavior.
The current implementation checks for `false`, "all other return values mean the migration succeeds".
This PR also reverts #18886 since it was a code fix for what was documentation error.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #18886
