### PR TITLE
Update PHPDoc of `\yii\console\Controller`

### DIFF
--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -28,12 +28,9 @@ use yii\helpers\Inflector;
  * where `<route>` is a route to a controller action and the params will be populated as properties of a command.
  * See [[options()]] for details.
  *
- * @property-read string $help This property is read-only.
- * @property-read string $helpSummary This property is read-only.
- * @property-read array $passedOptionValues The properties corresponding to the passed options. This property
- * is read-only.
- * @property-read array $passedOptions The names of the options passed during execution. This property is
- * read-only.
+ * @property-read string $helpSummary The one-line short summary describing this controller.
+ * @property-read array $passedOptionValues The properties corresponding to the passed options.
+ * @property-read array $passedOptions The names of the options passed during execution.
  * @property Request $request
  * @property Response $response
  *


### PR DESCRIPTION
Removes redundant description "This property is read-only." for  `@property-read` tags
Remove tag `@property-read string $help` because class have public property with same name

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
