### PR TITLE
(Docs) Fixed preview for $prepareSearchQuery

### DIFF
--- a/framework/rest/IndexAction.php
+++ b/framework/rest/IndexAction.php
@@ -46,8 +46,8 @@ class IndexAction extends Action
      */
     public $prepareDataProvider;
     /**
-     * @var callable a PHP callable that will be called to prepare query in prepareDataProvider
-     * Should return $query
+     * @var callable a PHP callable that will be called to prepare query in prepareDataProvider.
+     * Should return $query.
      * For example:
      *
      * ```php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

https://www.yiiframework.com/doc/api/2.0/yii-rest-indexaction#$prepareDataProvider-detail

**Expected:** "a PHP callable that will be called to prepare query in prepareDataProvider"

**Actual:**

![Screenshot 2021-12-02 at 20-18-47 IndexAction, yii rest IndexAction](https://user-images.githubusercontent.com/8326201/144439602-7a5c7ae2-b32d-405f-80b2-059af3a0a02f.png)
