### PR TITLE
fix passing null to non-nullable parameter deprecation in PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,9 +118,13 @@
             "phpunit/phpunit-mock-objects": {
                 "Fix PHP 7 and 8 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_mock_objects.patch"
             },
+            "phpunit/php-file-iterator": {
+                "Fix PHP 8.1 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_path_file_iterator.patch"
+            },
             "phpunit/phpunit": {
                 "Fix PHP 7 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_php7.patch",
-                "Fix PHP 8 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_php8.patch"
+                "Fix PHP 8 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_php8.patch",
+                "Fix PHP 8.1 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_php81.patch"
             }
         }
     }

--- a/framework/base/ArrayAccessTrait.php
+++ b/framework/base/ArrayAccessTrait.php
@@ -26,6 +26,7 @@ trait ArrayAccessTrait
      * It will be implicitly called when you use `foreach` to traverse the collection.
      * @return \ArrayIterator an iterator for traversing the cookies in the collection.
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->data);
@@ -36,6 +37,7 @@ trait ArrayAccessTrait
      * This method is required by Countable interface.
      * @return int number of data elements.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);
@@ -46,6 +48,7 @@ trait ArrayAccessTrait
      * @param mixed $offset the offset to check on
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->data[$offset]);
@@ -56,6 +59,7 @@ trait ArrayAccessTrait
      * @param int $offset the offset to retrieve element.
      * @return mixed the element at the offset, null if no element is found at the offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->data[$offset]) ? $this->data[$offset] : null;
@@ -66,6 +70,7 @@ trait ArrayAccessTrait
      * @param int $offset the offset to set element
      * @param mixed $item the element value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $item)
     {
         $this->data[$offset] = $item;
@@ -75,6 +80,7 @@ trait ArrayAccessTrait
      * This method is required by the interface [[\ArrayAccess]].
      * @param mixed $offset the offset to unset element
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->data[$offset]);

--- a/framework/db/ArrayExpression.php
+++ b/framework/db/ArrayExpression.php
@@ -104,6 +104,7 @@ class ArrayExpression implements ExpressionInterface, \ArrayAccess, \Countable, 
      * The return value will be casted to boolean if non-boolean was returned.
      * @since 2.0.14
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->value[$offset]);
@@ -119,6 +120,7 @@ class ArrayExpression implements ExpressionInterface, \ArrayAccess, \Countable, 
      * @return mixed Can return all value types.
      * @since 2.0.14
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->value[$offset];
@@ -137,6 +139,7 @@ class ArrayExpression implements ExpressionInterface, \ArrayAccess, \Countable, 
      * @return void
      * @since 2.0.14
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->value[$offset] = $value;
@@ -152,6 +155,7 @@ class ArrayExpression implements ExpressionInterface, \ArrayAccess, \Countable, 
      * @return void
      * @since 2.0.14
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->value[$offset]);
@@ -167,6 +171,7 @@ class ArrayExpression implements ExpressionInterface, \ArrayAccess, \Countable, 
      * The return value is cast to an integer.
      * @since 2.0.14
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->value);
@@ -181,6 +186,7 @@ class ArrayExpression implements ExpressionInterface, \ArrayAccess, \Countable, 
      * @since 2.0.14.1
      * @throws InvalidConfigException when ArrayExpression contains QueryInterface object
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $value = $this->getValue();

--- a/framework/db/BatchQueryResult.php
+++ b/framework/db/BatchQueryResult.php
@@ -114,6 +114,7 @@ class BatchQueryResult extends Component implements \Iterator
      * Resets the iterator to the initial state.
      * This method is required by the interface [[\Iterator]].
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->reset();
@@ -124,6 +125,7 @@ class BatchQueryResult extends Component implements \Iterator
      * Moves the internal pointer to the next dataset.
      * This method is required by the interface [[\Iterator]].
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if ($this->_batch === null || !$this->each || $this->each && next($this->_batch) === false) {
@@ -197,6 +199,7 @@ class BatchQueryResult extends Component implements \Iterator
      * This method is required by the interface [[\Iterator]].
      * @return int the index of the current row.
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->_key;
@@ -207,6 +210,7 @@ class BatchQueryResult extends Component implements \Iterator
      * This method is required by the interface [[\Iterator]].
      * @return mixed the current dataset.
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_value;
@@ -217,6 +221,7 @@ class BatchQueryResult extends Component implements \Iterator
      * This method is required by the interface [[\Iterator]].
      * @return bool whether there is a valid dataset at the current position.
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return !empty($this->_batch);

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -1006,7 +1006,7 @@ class Connection extends Component
     public function getDriverName()
     {
         if ($this->_driverName === null) {
-            if (($pos = strpos($this->dsn, ':')) !== false) {
+            if (($pos = strpos(isset($this->dsn) ? $this->dsn : '', ':')) !== false) {
                 $this->_driverName = strtolower(substr($this->dsn, 0, $pos));
             } else {
                 $this->_driverName = strtolower($this->getSlavePdo()->getAttribute(PDO::ATTR_DRIVER_NAME));

--- a/framework/db/DataReader.php
+++ b/framework/db/DataReader.php
@@ -196,6 +196,7 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
      * In this case, use "SELECT COUNT(*) FROM tableName" to obtain the number of rows.
      * @return int number of rows contained in the result.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->getRowCount();
@@ -216,6 +217,7 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
      * This method is required by the interface [[\Iterator]].
      * @throws InvalidCallException if this method is invoked twice
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         if ($this->_index < 0) {
@@ -231,6 +233,7 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
      * This method is required by the interface [[\Iterator]].
      * @return int the index of the current row.
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->_index;
@@ -241,6 +244,7 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
      * This method is required by the interface [[\Iterator]].
      * @return mixed the current row.
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_row;
@@ -250,6 +254,7 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
      * Moves the internal pointer to the next row.
      * This method is required by the interface [[\Iterator]].
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->_row = $this->_statement->fetch();
@@ -261,6 +266,7 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
      * This method is required by the interface [[\Iterator]].
      * @return bool whether there is a row of data at current position.
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->_row !== false;

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -921,7 +921,7 @@ PATTERN;
      */
     public function andFilterCompare($name, $value, $defaultOperator = '=')
     {
-        if (preg_match('/^(<>|>=|>|<=|<|=)/', $value, $matches)) {
+        if (preg_match('/^(<>|>=|>|<=|<|=)/', isset($value) ? $value : "", $matches)) {
             $operator = $matches[1];
             $value = substr($value, strlen($operator));
         } else {

--- a/framework/db/SqlToken.php
+++ b/framework/db/SqlToken.php
@@ -84,6 +84,7 @@ class SqlToken extends BaseObject implements \ArrayAccess
      * @param int $offset child token offset.
      * @return bool whether the token exists.
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_children[$this->calculateOffset($offset)]);
@@ -96,6 +97,7 @@ class SqlToken extends BaseObject implements \ArrayAccess
      * @param int $offset child token offset.
      * @return SqlToken|null the child token at the specified offset, `null` if there's no token.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $offset = $this->calculateOffset($offset);
@@ -109,6 +111,7 @@ class SqlToken extends BaseObject implements \ArrayAccess
      * @param int|null $offset child token offset.
      * @param SqlToken $token token to be added.
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $token)
     {
         $token->parent = $this;
@@ -126,6 +129,7 @@ class SqlToken extends BaseObject implements \ArrayAccess
      * It is implicitly called when you use something like `unset($token[$offset])`.
      * @param int $offset child token offset.
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $offset = $this->calculateOffset($offset);

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -297,7 +297,7 @@ SQL;
                 && preg_match('/^current_timestamp(?:\(([0-9]*)\))?$/i', $info['default'], $matches)) {
                 $column->defaultValue = new Expression('CURRENT_TIMESTAMP' . (!empty($matches[1]) ? '(' . $matches[1] . ')' : ''));
             } elseif (isset($type) && $type === 'bit') {
-                $column->defaultValue = bindec(trim($info['default'], 'b\''));
+                $column->defaultValue = bindec(trim(isset($info['default']) ? $info['default'] : '', 'b\''));
             } else {
                 $column->defaultValue = $column->phpTypecast($info['default']);
             }

--- a/framework/i18n/PhpMessageSource.php
+++ b/framework/i18n/PhpMessageSource.php
@@ -72,7 +72,7 @@ class PhpMessageSource extends MessageSource
         $messageFile = $this->getMessageFilePath($category, $language);
         $messages = $this->loadMessagesFromFile($messageFile);
 
-        $fallbackLanguage = substr($language, 0, 2);
+        $fallbackLanguage = substr(isset($language) ? $language : '', 0, 2);
         $fallbackSourceLanguage = substr($this->sourceLanguage, 0, 2);
 
         if ($fallbackLanguage !== '' && $language !== $fallbackLanguage) {

--- a/framework/web/HeaderCollection.php
+++ b/framework/web/HeaderCollection.php
@@ -34,6 +34,7 @@ class HeaderCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * It will be implicitly called when you use `foreach` to traverse the collection.
      * @return \ArrayIterator an iterator for traversing the headers in the collection.
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->_headers);

--- a/framework/web/HeaderCollection.php
+++ b/framework/web/HeaderCollection.php
@@ -191,6 +191,7 @@ class HeaderCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * @param string $name the header name
      * @return bool whether the named header exists
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($name)
     {
         return $this->has($name);

--- a/framework/web/HeaderCollection.php
+++ b/framework/web/HeaderCollection.php
@@ -46,6 +46,7 @@ class HeaderCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * It will be implicitly called when you use `count($collection)`.
      * @return int the number of headers in the collection.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->getCount();
@@ -55,6 +56,7 @@ class HeaderCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * Returns the number of headers in the collection.
      * @return int the number of headers in the collection.
      */
+    #[\ReturnTypeWillChange]
     public function getCount()
     {
         return count($this->_headers);

--- a/framework/web/HeaderCollection.php
+++ b/framework/web/HeaderCollection.php
@@ -205,6 +205,7 @@ class HeaderCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * @param string $name the header name
      * @return string the header value with the specified name, null if the named header does not exist.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($name)
     {
         return $this->get($name);
@@ -218,6 +219,7 @@ class HeaderCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * @param string $name the header name
      * @param string $value the header value to be added
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($name, $value)
     {
         $this->set($name, $value);
@@ -230,6 +232,7 @@ class HeaderCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * This is equivalent to [[remove()]].
      * @param string $name the header name
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($name)
     {
         $this->remove($name);

--- a/framework/web/HttpException.php
+++ b/framework/web/HttpException.php
@@ -45,7 +45,7 @@ class HttpException extends UserException
     public function __construct($status, $message = null, $code = 0, \Exception $previous = null)
     {
         $this->statusCode = $status;
-        parent::__construct($message, $code, $previous);
+        parent::__construct(isset($message) ? $message : '', $code, $previous);
     }
 
     /**

--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -662,6 +662,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      * This method is required by the interface [[\IteratorAggregate]].
      * @return SessionIterator an iterator for traversing the session variables.
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $this->open();
@@ -683,6 +684,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      * This method is required by [[\Countable]] interface.
      * @return int number of items in the session.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->getCount();
@@ -964,6 +966,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      * @param int|string $offset the offset to check on
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $this->open();
@@ -976,6 +979,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      * @param int|string $offset the offset to retrieve element.
      * @return mixed the element at the offset, null if no element is found at the offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $this->open();
@@ -988,6 +992,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      * @param int|string $offset the offset to set element
      * @param mixed $item the element value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $item)
     {
         $this->open();
@@ -998,6 +1003,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      * This method is required by the interface [[\ArrayAccess]].
      * @param int|string $offset the offset to unset element
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->open();

--- a/tests/data/base/TraversableObject.php
+++ b/tests/data/base/TraversableObject.php
@@ -28,6 +28,7 @@ class TraversableObject implements \Iterator, \Countable
      * @throws \Exception
      * @since 5.1.0
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         throw new \Exception('Count called on object that should only be traversed.');
@@ -36,6 +37,7 @@ class TraversableObject implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->data[$this->position];
@@ -44,6 +46,7 @@ class TraversableObject implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->position++;
@@ -52,6 +55,7 @@ class TraversableObject implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
@@ -60,6 +64,7 @@ class TraversableObject implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return array_key_exists($this->position, $this->data);
@@ -68,6 +73,7 @@ class TraversableObject implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -1477,6 +1477,7 @@ class ArrayAccessibleObject implements ArrayAccess
         $this->container = $container;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1486,16 +1487,19 @@ class ArrayAccessibleObject implements ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->container);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->container[$offset] : null;
@@ -1519,26 +1523,31 @@ class TraversableArrayAccessibleObject extends ArrayAccessibleObject implements 
         return array_key_exists($keyIndex, $keys) ? $keys[$keyIndex] : false;
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->offsetGet($this->getContainerKey($this->position));
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->getContainerKey($this->position);
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->position;
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         $key = $this->getContainerKey($this->position);

--- a/tests/framework/rest/SerializerTest.php
+++ b/tests/framework/rest/SerializerTest.php
@@ -540,6 +540,7 @@ class TestModel3 extends Model implements \JsonSerializable
         return static::$extraFields;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getAttributes();
@@ -550,6 +551,7 @@ class TestModel4 implements \JsonSerializable
     public $field5 = 'test5';
     public $field6 = 'test6';
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | [19093](https://github.com/yiisoft/yii2/issues/19093)
