### PR TITLE
FIX: trim() Passing null to parameter to rest/UrlRule

### DIFF
--- a/framework/rest/UrlRule.php
+++ b/framework/rest/UrlRule.php
@@ -158,7 +158,7 @@ class UrlRule extends CompositeUrlRule
         }
         $this->controller = $controllers;
 
-        $this->prefix = ($this->prefix !== null) ? trim($this->prefix, '/') : null;
+        $this->prefix = trim((string)$this->prefix, '/');
 
         parent::init();
     }

--- a/framework/rest/UrlRule.php
+++ b/framework/rest/UrlRule.php
@@ -62,7 +62,7 @@ use yii\web\UrlRuleInterface;
 class UrlRule extends CompositeUrlRule
 {
     /**
-     * @var string the common prefix string shared by all patterns.
+     * @var string|null the common prefix string shared by all patterns.
      */
     public $prefix;
     /**
@@ -158,7 +158,7 @@ class UrlRule extends CompositeUrlRule
         }
         $this->controller = $controllers;
 
-        $this->prefix = trim($this->prefix, '/');
+        $this->prefix = ($this->prefix !== null) ? trim($this->prefix, '/') : null;
 
         parent::init();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19041 
