### PR TITLE
PHPStan level 0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         run: composer req --dev phpstan/phpstan
         if: matrix.php == '8.0'
       - name: PHPStan analysis with PHP 8.0
-        run: vendor/bin/phpstan analyse framework -c phpstan.neon
+        run: vendor/bin/phpstan analyse framework -c phpstan.neon --no-progress
         if: matrix.php == '8.0'
       - name: PHPUnit tests for PHP 7.1
         run: vendor/bin/phpunit --verbose --coverage-clover=coverage.clover --exclude-group $PHPUNIT_EXCLUDE_GROUP --colors=always

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,15 +60,21 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install dependencies
         run: composer update $DEFAULT_COMPOSER_FLAGS
-      - name: PHP Unit tests for PHP 7.1
+      - name: Install PHPStan for PHP 8.0
+        run: composer req --dev phpstan/phpstan
+        if: matrix.php == '8.0'
+      - name: PHPStan analysis with PHP 8.0
+        run: vendor/bin/phpstan analyse framework -c phpstan.neon
+        if: matrix.php == '8.0'
+      - name: PHPUnit tests for PHP 7.1
         run: vendor/bin/phpunit --verbose --coverage-clover=coverage.clover --exclude-group $PHPUNIT_EXCLUDE_GROUP --colors=always
         if: matrix.php == '7.1'
-      - name: PHP Unit tests for PHP >= 7.2
+      - name: PHPUnit tests for PHP >= 7.2
         run: vendor/bin/phpunit --verbose --exclude-group $PHPUNIT_EXCLUDE_GROUP --colors=always
         env:
           PHPUNIT_EXCLUDE_GROUP: mssql,oci,wincache,xcache,zenddata,cubrid
         if: matrix.php >= '7.2'
-      - name: PHP Unit tests for PHP <= 7.0
+      - name: PHPUnit tests for PHP <= 7.0
         run: vendor/bin/phpunit --verbose --exclude-group $PHPUNIT_EXCLUDE_GROUP --colors=always
         if: matrix.php <= '7.0'
       - name: Code coverage

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "cweagans/composer-patches": "^1.7",
         "phpunit/phpunit": "4.8.34",
         "cebe/indent": "~1.0.2",
-        "friendsofphp/php-cs-fixer": "~2.2.3",
+        "friendsofphp/php-cs-fixer": "^2.2",
         "johnkary/phpunit-speedtrap": "^1.0"
     },
     "repositories": [
@@ -102,9 +102,6 @@
             "yii\\": "framework/",
             "yii\\cs\\": "cs/src/"
         }
-    },
-    "config": {
-        "platform": {"php": "5.4"}
     },
     "bin": [
         "framework/yii"

--- a/framework/base/DynamicModel.php
+++ b/framework/base/DynamicModel.php
@@ -220,7 +220,7 @@ class DynamicModel extends Model
     public static function validateData(array $data, $rules = [])
     {
         /* @var $model DynamicModel */
-        $model = new static($data);
+        $model = new static($data); /** @phpstan-ignore-line */
         if (!empty($rules)) {
             $validators = $model->getValidators();
             foreach ($rules as $rule) {

--- a/framework/base/Event.php
+++ b/framework/base/Event.php
@@ -274,6 +274,7 @@ class Event extends BaseObject
         }
 
         if ($event === null) {
+            /** @phpstan-ignore-next-line */
             $event = new static();
         }
         $event->handled = false;

--- a/framework/base/Widget.php
+++ b/framework/base/Widget.php
@@ -211,7 +211,7 @@ class Widget extends Component implements ViewContextInterface
 
     /**
      * Executes the widget.
-     * @return string the result of widget execution to be outputted.
+     * @return string|void the result of widget execution to be outputted.
      */
     public function run()
     {

--- a/framework/caching/XCache.php
+++ b/framework/caching/XCache.php
@@ -101,6 +101,7 @@ class XCache extends Cache
     protected function flushValues()
     {
         for ($i = 0, $max = xcache_count(XC_TYPE_VAR); $i < $max; $i++) {
+            /** @phpstan-ignore-next-line */
             if (xcache_clear_cache(XC_TYPE_VAR, $i) === false) {
                 return false;
             }

--- a/framework/console/controllers/CacheController.php
+++ b/framework/console/controllers/CacheController.php
@@ -166,8 +166,10 @@ class CacheController extends Controller
             $schema = $connection->getSchema();
             $schema->refresh();
             $this->stdout("Schema cache for component \"$db\", was flushed.\n\n", Console::FG_GREEN);
+            return ExitCode::OK;
         } catch (\Exception $e) {
             $this->stdout($e->getMessage() . "\n\n", Console::FG_RED);
+            return ExitCode::UNSPECIFIED_ERROR;
         }
     }
 

--- a/framework/console/controllers/FixtureController.php
+++ b/framework/console/controllers/FixtureController.php
@@ -231,6 +231,8 @@ class FixtureController extends Controller
 
         $this->unloadFixtures($this->createFixtures($fixtures));
         $this->notifyUnloaded($fixtures);
+
+        return ExitCode::OK;
     }
 
     /**

--- a/framework/console/controllers/HelpController.php
+++ b/framework/console/controllers/HelpController.php
@@ -43,7 +43,6 @@ class HelpController extends Controller
      *
      * @param string $command The name of the command to show help about.
      * If not provided, all available commands will be displayed.
-     * @return int the exit status
      * @throws Exception if the command for help is unknown
      */
     public function actionIndex($command = null)

--- a/framework/console/controllers/ServeController.php
+++ b/framework/console/controllers/ServeController.php
@@ -47,7 +47,7 @@ class ServeController extends Controller
      *
      * @param string $address address to serve on. Either "host" or "host:port".
      *
-     * @return int
+     * @return int|void
      */
     public function actionIndex($address = 'localhost')
     {
@@ -55,7 +55,7 @@ class ServeController extends Controller
         $router = $this->router !== null ? Yii::getAlias($this->router) : null;
 
         if (strpos($address, ':') === false) {
-            $address = $address . ':' . $this->port;
+            $address .= ':' . $this->port;
         }
 
         if (!is_dir($documentRoot)) {

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1210,6 +1210,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public static function instantiate($row)
     {
+        /** @phpstan-ignore-next-line */
         return new static();
     }
 

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -261,7 +261,6 @@ class Migration extends Component implements MigrationInterface
      * If `true` is passed, the column data will be updated to match the insert column data.
      * If `false` is passed, no update will be performed if the column data already exists.
      * @param array $params the parameters to be bound to the command.
-     * @return $this the command object itself.
      * @since 2.0.14
      */
     public function upsert($table, $insertColumns, $updateColumns = true, $params = [])

--- a/framework/db/conditions/BetweenColumnsCondition.php
+++ b/framework/db/conditions/BetweenColumnsCondition.php
@@ -116,6 +116,7 @@ class BetweenColumnsCondition implements ConditionInterface
             throw new InvalidArgumentException("Operator '$operator' requires three operands.");
         }
 
+        /** @phpstan-ignore-next-line */
         return new static($operands[0], $operator, $operands[1], $operands[2]);
     }
 }

--- a/framework/db/conditions/BetweenCondition.php
+++ b/framework/db/conditions/BetweenCondition.php
@@ -93,6 +93,7 @@ class BetweenCondition implements ConditionInterface
             throw new InvalidArgumentException("Operator '$operator' requires three operands.");
         }
 
+        /** @phpstan-ignore-next-line */
         return new static($operands[0], $operator, $operands[1], $operands[2]);
     }
 }

--- a/framework/db/conditions/ConjunctionCondition.php
+++ b/framework/db/conditions/ConjunctionCondition.php
@@ -48,6 +48,7 @@ abstract class ConjunctionCondition implements ConditionInterface
      */
     public static function fromArrayDefinition($operator, $operands)
     {
+        /** @phpstan-ignore-next-line */
         return new static($operands);
     }
 }

--- a/framework/db/conditions/ExistsCondition.php
+++ b/framework/db/conditions/ExistsCondition.php
@@ -49,6 +49,7 @@ class ExistsCondition implements ConditionInterface
             throw new InvalidArgumentException('Subquery for EXISTS operator must be a Query object.');
         }
 
+        /** @phpstan-ignore-next-line */
         return new static($operator, $operands[0]);
     }
 

--- a/framework/db/conditions/HashCondition.php
+++ b/framework/db/conditions/HashCondition.php
@@ -44,6 +44,7 @@ class HashCondition implements ConditionInterface
      */
     public static function fromArrayDefinition($operator, $operands)
     {
+        /** @phpstan-ignore-next-line */
         return new static($operands);
     }
 }

--- a/framework/db/conditions/InCondition.php
+++ b/framework/db/conditions/InCondition.php
@@ -84,6 +84,7 @@ class InCondition implements ConditionInterface
             throw new InvalidArgumentException("Operator '$operator' requires two operands.");
         }
 
+        /** @phpstan-ignore-next-line */
         return new static($operands[0], $operator, $operands[1]);
     }
 }

--- a/framework/db/conditions/LikeCondition.php
+++ b/framework/db/conditions/LikeCondition.php
@@ -68,6 +68,7 @@ class LikeCondition extends SimpleCondition
             throw new InvalidArgumentException("Operator '$operator' requires two operands.");
         }
 
+        /** @phpstan-ignore-next-line */
         $condition = new static($operands[0], $operator, $operands[1]);
         if (isset($operands[2])) {
             $condition->escapingReplacements = $operands[2];

--- a/framework/db/conditions/NotCondition.php
+++ b/framework/db/conditions/NotCondition.php
@@ -51,6 +51,7 @@ class NotCondition implements ConditionInterface
             throw new InvalidArgumentException("Operator '$operator' requires exactly one operand.");
         }
 
+        /** @phpstan-ignore-next-line */
         return new static(array_shift($operands));
     }
 }

--- a/framework/db/conditions/SimpleCondition.php
+++ b/framework/db/conditions/SimpleCondition.php
@@ -79,6 +79,7 @@ class SimpleCondition implements ConditionInterface
             throw new InvalidArgumentException("Operator '$operator' requires two operands.");
         }
 
+        /** @phpstan-ignore-next-line */
         return new static($operands[0], $operator, $operands[1]);
     }
 }

--- a/framework/db/cubrid/Schema.php
+++ b/framework/db/cubrid/Schema.php
@@ -92,6 +92,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
     protected function findTableNames($schema = '')
     {
         $pdo = $this->db->getSlavePdo();
+        /** @phpstan-ignore-next-line */
         $tables = $pdo->cubrid_schema(\PDO::CUBRID_SCH_TABLE);
         $tableNames = [];
         foreach ($tables as $table) {
@@ -110,7 +111,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
     protected function loadTableSchema($name)
     {
         $pdo = $this->db->getSlavePdo();
-
+        /** @phpstan-ignore-next-line */
         $tableInfo = $pdo->cubrid_schema(\PDO::CUBRID_SCH_TABLE, $name);
 
         if (!isset($tableInfo[0]['NAME'])) {
@@ -127,7 +128,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
             $column = $this->loadColumnSchema($info);
             $table->columns[$column->name] = $column;
         }
-
+        /** @phpstan-ignore-next-line */
         $primaryKeys = $pdo->cubrid_schema(\PDO::CUBRID_SCH_PRIMARY_KEY, $table->name);
         foreach ($primaryKeys as $key) {
             $column = $table->columns[$key['ATTR_NAME']];
@@ -137,7 +138,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
                 $table->sequenceName = '';
             }
         }
-
+        /** @phpstan-ignore-next-line */
         $foreignKeys = $pdo->cubrid_schema(\PDO::CUBRID_SCH_IMPORTED_KEYS, $table->name);
         foreach ($foreignKeys as $key) {
             if (isset($table->foreignKeys[$key['FK_NAME']])) {
@@ -158,6 +159,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     protected function loadTablePrimaryKey($tableName)
     {
+        /** @phpstan-ignore-next-line */
         $primaryKey = $this->db->getSlavePdo()->cubrid_schema(\PDO::CUBRID_SCH_PRIMARY_KEY, $tableName);
         if (empty($primaryKey)) {
             return null;
@@ -181,7 +183,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
             2 => 'NO ACTION',
             3 => 'SET NULL',
         ];
-
+        /** @phpstan-ignore-next-line */
         $foreignKeys = $this->db->getSlavePdo()->cubrid_schema(\PDO::CUBRID_SCH_IMPORTED_KEYS, $tableName);
         $foreignKeys = ArrayHelper::index($foreignKeys, null, 'FK_NAME');
         ArrayHelper::multisort($foreignKeys, 'KEY_SEQ', SORT_ASC, SORT_NUMERIC);
@@ -385,6 +387,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     private function loadTableConstraints($tableName, $returnType)
     {
+        /** @phpstan-ignore-next-line */
         $constraints = $this->db->getSlavePdo()->cubrid_schema(\PDO::CUBRID_SCH_CONSTRAINT, $tableName);
         $constraints = ArrayHelper::index($constraints, null, ['TYPE', 'NAME']);
         ArrayHelper::multisort($constraints, 'KEY_ORDER', SORT_ASC, SORT_NUMERIC);

--- a/framework/di/Instance.php
+++ b/framework/di/Instance.php
@@ -85,6 +85,7 @@ class Instance
      */
     public static function of($id, $optional = false)
     {
+        /** @phpstan-ignore-next-line */
         return new static($id, $optional);
     }
 
@@ -135,6 +136,7 @@ class Instance
         }
 
         if (is_string($reference)) {
+            /** @phpstan-ignore-next-line */
             $reference = new static($reference);
         } elseif ($type === null || $reference instanceof $type) {
             return $reference;

--- a/framework/requirements/YiiRequirementChecker.php
+++ b/framework/requirements/YiiRequirementChecker.php
@@ -297,7 +297,7 @@ class YiiRequirementChecker
      * @param string $_viewFile_ view file
      * @param array $_data_ data to be extracted and made available to the view file
      * @param bool $_return_ whether the rendering result should be returned as a string
-     * @return string the rendering result. Null if the rendering result is not required.
+     * @return string|void the rendering result. Null if the rendering result is not required.
      */
     function renderViewFile($_viewFile_, $_data_ = null, $_return_ = false)
     {

--- a/framework/web/UploadedFile.php
+++ b/framework/web/UploadedFile.php
@@ -127,6 +127,7 @@ class UploadedFile extends BaseObject
     public static function getInstanceByName($name)
     {
         $files = self::loadFiles();
+        /** @phpstan-ignore-next-line */
         return isset($files[$name]) ? new static($files[$name]) : null;
     }
 
@@ -143,11 +144,13 @@ class UploadedFile extends BaseObject
     {
         $files = self::loadFiles();
         if (isset($files[$name])) {
+            /** @phpstan-ignore-next-line */
             return [new static($files[$name])];
         }
         $results = [];
         foreach ($files as $key => $file) {
             if (strpos($key, "{$name}[") === 0) {
+                /** @phpstan-ignore-next-line */
                 $results[] = new static($file);
             }
         }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 0
+    excludePaths:
+        analyseAndScan:
+            - framework/base/Object.php


### PR DESCRIPTION
This is an attempt to introduce static analysis to Yii 2 with well known and widely used PHPStan package (level 0 for the good start).
Few things were required:
- composer's config.platform was removed in order to install PHPStan (it requires PHP 7|8)
- composer's constraint for friendsofphp/php-cs-fixer was changed to `^2.2` because of the above removal.

As we can see even with level 0 it proves to show some things to be fixed, like missing returns. To keep everything as it was before I've added `ignore` comments for the lines with `new static` (PHPStan correctly throws warnings there, see https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static ).

If we want to keep it I would be happy to increase the level as high as possible while keeping Yii 2 compatible with PHP 5.4.