### PR TITLE
Change \Exception to \Throwable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "yiisoft/yii2": "self.version"
     },
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=5.4.0",
         "ext-mbstring": "*",
         "ext-ctype": "*",
         "lib-pcre": "*",

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "yiisoft/yii2": "self.version"
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.0.0",
         "ext-mbstring": "*",
         "ext-ctype": "*",
         "lib-pcre": "*",

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #19148: Fix undefined array key errors in `yii\db\ActiveRelationTrait` (stevekr)
 - Bug #19041: Fix PHP 8.1 issues (longthanhtran, samdark, pamparam83, sartor, githubjeka)
 - Enh #19171: Added `$pagination` and `$sort` to `\yii\rest\IndexAction` for easy configuration (rhertogh)
+- Bug #19191: Change `\Exception` to `\Throwable` in `BadRequestHttpException` and `HttpException` (Dmitrijlin)
 
 
 2.0.44 December 30, 2021

--- a/framework/web/BadRequestHttpException.php
+++ b/framework/web/BadRequestHttpException.php
@@ -27,7 +27,7 @@ class BadRequestHttpException extends HttpException
      * @param int $code error code
      * @param \Throwable|null $previous The previous exception used for the exception chaining.
      */
-    public function __construct($message = null, $code = 0, \Throwable $previous = null)
+    public function __construct($message = null, $code = 0, $previous = null)
     {
         parent::__construct(400, $message, $code, $previous);
     }

--- a/framework/web/BadRequestHttpException.php
+++ b/framework/web/BadRequestHttpException.php
@@ -25,9 +25,9 @@ class BadRequestHttpException extends HttpException
      * Constructor.
      * @param string $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Throwable|null $previous The previous exception used for the exception chaining.
      */
-    public function __construct($message = null, $code = 0, \Exception $previous = null)
+    public function __construct($message = null, $code = 0, \Throwable $previous = null)
     {
         parent::__construct(400, $message, $code, $previous);
     }

--- a/framework/web/HttpException.php
+++ b/framework/web/HttpException.php
@@ -40,9 +40,9 @@ class HttpException extends UserException
      * @param int $status HTTP status code, such as 404, 500, etc.
      * @param string $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Throwable|null $previous The previous exception used for the exception chaining.
      */
-    public function __construct($status, $message = null, $code = 0, \Exception $previous = null)
+    public function __construct($status, $message = null, $code = 0, \Throwable $previous = null)
     {
         $this->statusCode = $status;
         parent::__construct((string)$message, $code, $previous);

--- a/framework/web/HttpException.php
+++ b/framework/web/HttpException.php
@@ -42,7 +42,7 @@ class HttpException extends UserException
      * @param int $code error code
      * @param \Throwable|null $previous The previous exception used for the exception chaining.
      */
-    public function __construct($status, $message = null, $code = 0, \Throwable $previous = null)
+    public function __construct($status, $message = null, $code = 0, $previous = null)
     {
         $this->statusCode = $status;
         parent::__construct((string)$message, $code, $previous);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #19191 
I've added Throwable interface to parameters in BadRequestHttpException and HttpException. There are problem with version of PHP. Throwable was added at PHP 7.0, so for that pull request required minimum version of PHP is 7.0
