### PR TITLE
Resolve issue #19204

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Enh #19171: Added `$pagination` and `$sort` to `\yii\rest\IndexAction` for easy configuration (rhertogh)
 - Bug #19187: Fix `yii\filters\PageCache` to store original headers names instead of normalized ones (bizley)
 - Bug #19191: Change `\Exception` to `\Throwable` in `BadRequestHttpException` and `HttpException` (Dmitrijlin)
+- Bug #19204: Support numbers in Inflector::camel2words (longthanhtran)
 
 
 2.0.44 December 30, 2021

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -373,7 +373,7 @@ class BaseInflector
     {
         // Add a space before any uppercase letter preceded by a lowercase letter (xY => x Y)
         // and any uppercase letter preceded by an uppercase letter and followed by a lowercase letter (XYz => X Yz)
-        $label = preg_replace('/(?<=\p{Ll})\p{Lu}|(?<=\p{L})\p{Lu}(?=\p{Ll})/u', ' \0', $name);
+        $label = preg_replace('/(?<=\p{Ll})\p{Lu}|(?<=[\p{L}\d])\p{Lu}(?=\p{Ll})|(\d+)/u', ' \0', $name);
 
         $label = mb_strtolower(trim(str_replace(['-', '_', '.'], ' ', $label)), self::encoding());
 

--- a/tests/framework/helpers/InflectorTest.php
+++ b/tests/framework/helpers/InflectorTest.php
@@ -121,6 +121,9 @@ class InflectorTest extends TestCase
         $this->assertEquals('Foo Bar', Inflector::camel2words('foo BAR'));
         $this->assertEquals('Foo Bar', Inflector::camel2words('Foo Bar'));
         $this->assertEquals('Foo Bar', Inflector::camel2words('FOO BAR'));
+        $this->assertEquals('Order 4 Other Phones', Inflector::camel2words('Order4OtherPhones'));
+        $this->assertEquals('I Have 23 Dogs', Inflector::camel2words('IHave23Dogs'));
+        $this->assertEquals('Con Chó Cười 34 Lần', Inflector::camel2words('ConChóCười34Lần'));
     }
 
     public function testCamel2id()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19204 

The PR to support number(s) in CamelCase string, such as `Order4OtherPhones` to `Order 4 Other Phones` per issue [19204](https://github.com/yiisoft/yii2/issues/19204)