### PR TITLE
Fix Container::resolveCallableDependencies() unable to handle union t…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Bug #19187: Fix `yii\filters\PageCache` to store original headers names instead of normalized ones (bizley)
 - Bug #19191: Change `\Exception` to `\Throwable` in `BadRequestHttpException` and `HttpException` (Dmitrijlin)
 - Bug #19204: Support numbers in Inflector::camel2words (longthanhtran)
+- Bug #19004: Container::resolveCallableDependencies() unable to handle union types (sartor)
 
 
 2.0.44 December 30, 2021

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,7 +12,7 @@ Yii Framework 2 Change Log
 - Bug #19187: Fix `yii\filters\PageCache` to store original headers names instead of normalized ones (bizley)
 - Bug #19191: Change `\Exception` to `\Throwable` in `BadRequestHttpException` and `HttpException` (Dmitrijlin)
 - Bug #19204: Support numbers in Inflector::camel2words (longthanhtran)
-- Bug #19004: Container::resolveCallableDependencies() unable to handle union types (sartor)
+- Bug #19004: Container::resolveCallableDependencies() unable to handle union and intersection types (sartor)
 
 
 2.0.44 December 30, 2021

--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -665,7 +665,21 @@ class Container extends Component
 
             if (PHP_VERSION_ID >= 80000) {
                 $class = $param->getType();
-                $isClass = $class !== null && !$param->getType()->isBuiltin();
+                if ($class instanceof \ReflectionUnionType) {
+                    $isClass = false;
+                    foreach ($class->getTypes() as $type) {
+                        if (!$type->isBuiltin()) {
+                            $class = $type;
+                            $isClass = true;
+                            break;
+                        }
+                    }
+                } elseif ($class instanceof \ReflectionIntersectionType) {
+                    throw new InvalidConfigException("Unable to resolve intersection types yet"); // TODO: decide strategy how to
+                } else {
+                    $isClass = $class !== null && !$class->isBuiltin();
+                }
+
             } else {
                 $class = $param->getClass();
                 $isClass = $class !== null;

--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -665,7 +665,7 @@ class Container extends Component
 
             if (PHP_VERSION_ID >= 80000) {
                 $class = $param->getType();
-                if ($class instanceof \ReflectionUnionType) {
+                if ($class instanceof \ReflectionUnionType || (PHP_VERSION_ID >= 80100 && $class instanceof \ReflectionIntersectionType)) {
                     $isClass = false;
                     foreach ($class->getTypes() as $type) {
                         if (!$type->isBuiltin()) {
@@ -674,8 +674,6 @@ class Container extends Component
                             break;
                         }
                     }
-                } elseif ($class instanceof \ReflectionIntersectionType) {
-                    throw new InvalidConfigException("Unable to resolve intersection types yet"); // TODO: decide strategy how to
                 } else {
                     $isClass = $class !== null && !$class->isBuiltin();
                 }

--- a/tests/framework/di/ContainerTest.php
+++ b/tests/framework/di/ContainerTest.php
@@ -24,11 +24,11 @@ use yiiunit\framework\di\stubs\Foo;
 use yiiunit\framework\di\stubs\FooProperty;
 use yiiunit\framework\di\stubs\Kappa;
 use yiiunit\framework\di\stubs\Qux;
+use yiiunit\framework\di\stubs\QuxAnother;
 use yiiunit\framework\di\stubs\QuxInterface;
 use yiiunit\framework\di\stubs\QuxFactory;
 use yiiunit\framework\di\stubs\UnionTypeNotNull;
 use yiiunit\framework\di\stubs\UnionTypeNull;
-use yiiunit\framework\di\stubs\StaticMethodsWithComplexTypes;
 use yiiunit\framework\di\stubs\UnionTypeWithClass;
 use yiiunit\framework\di\stubs\Zeta;
 use yiiunit\TestCase;
@@ -685,8 +685,11 @@ class ContainerTest extends TestCase
         $this->mockApplication([
             'components' => [
                 Beta::className(),
-                'yiiunit\framework\di\stubs\QuxInterface' => Qux::className(),
             ],
+        ]);
+
+        Yii::$container->set('yiiunit\framework\di\stubs\QuxInterface', [
+            'class' => Qux::className(),
         ]);
 
         $className = 'yiiunit\framework\di\stubs\StaticMethodsWithComplexTypes';
@@ -702,5 +705,25 @@ class ContainerTest extends TestCase
 
         $params = Yii::$container->resolveCallableDependencies([$className, 'withQuxAndBetaUnion']);
         $this->assertInstanceOf(Qux::classname(), $params[0]);
+    }
+
+    public function testResolveCallableDependenciesIntersectionTypes()
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Can not be tested on PHP < 8.1');
+            return;
+        }
+
+        Yii::$container->set('yiiunit\framework\di\stubs\QuxInterface', [
+            'class' => Qux::className(),
+        ]);
+
+        $className = 'yiiunit\framework\di\stubs\StaticMethodsWithComplexTypes';
+
+        $params = Yii::$container->resolveCallableDependencies([$className, 'withQuxInterfaceAndQuxAnotherIntersection']);
+        $this->assertInstanceOf(Qux::classname(), $params[0]);
+
+        $params = Yii::$container->resolveCallableDependencies([$className, 'withQuxAnotherAndQuxInterfaceIntersection']);
+        $this->assertInstanceOf(QuxAnother::classname(), $params[0]);
     }
 }

--- a/tests/framework/di/ContainerTest.php
+++ b/tests/framework/di/ContainerTest.php
@@ -692,7 +692,7 @@ class ContainerTest extends TestCase
             'class' => Qux::className(),
         ]);
 
-        $className = 'yiiunit\framework\di\stubs\StaticMethodsWithComplexTypes';
+        $className = 'yiiunit\framework\di\stubs\StaticMethodsWithUnionTypes';
 
         $params = Yii::$container->resolveCallableDependencies([$className, 'withBetaUnion']);
         $this->assertInstanceOf(Beta::classname(), $params[0]);
@@ -718,7 +718,7 @@ class ContainerTest extends TestCase
             'class' => Qux::className(),
         ]);
 
-        $className = 'yiiunit\framework\di\stubs\StaticMethodsWithComplexTypes';
+        $className = 'yiiunit\framework\di\stubs\StaticMethodsWithIntersectionTypes';
 
         $params = Yii::$container->resolveCallableDependencies([$className, 'withQuxInterfaceAndQuxAnotherIntersection']);
         $this->assertInstanceOf(Qux::classname(), $params[0]);

--- a/tests/framework/di/ContainerTest.php
+++ b/tests/framework/di/ContainerTest.php
@@ -28,6 +28,7 @@ use yiiunit\framework\di\stubs\QuxInterface;
 use yiiunit\framework\di\stubs\QuxFactory;
 use yiiunit\framework\di\stubs\UnionTypeNotNull;
 use yiiunit\framework\di\stubs\UnionTypeNull;
+use yiiunit\framework\di\stubs\StaticMethodsWithComplexTypes;
 use yiiunit\framework\di\stubs\UnionTypeWithClass;
 use yiiunit\framework\di\stubs\Zeta;
 use yiiunit\TestCase;
@@ -672,5 +673,32 @@ class ContainerTest extends TestCase
 
         $this->expectException('TypeError');
         (new Container())->get(UnionTypeNotNull::className());
+    }
+
+    public function testResolveCallableDependenciesUnionTypes()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('Can not be tested on PHP < 8.0');
+            return;
+        }
+
+        $this->mockApplication([
+            'components' => [
+                Beta::className(),
+                'yiiunit\framework\di\stubs\QuxInterface' => Qux::className(),
+            ],
+        ]);
+
+        $params = Yii::$container->resolveCallableDependencies([StaticMethodsWithComplexTypes::class, 'withBetaUnion']);
+        $this->assertInstanceOf(Beta::classname(), $params[0]);
+
+        $params = Yii::$container->resolveCallableDependencies([StaticMethodsWithComplexTypes::class, 'withBetaUnionInverse']);
+        $this->assertInstanceOf(Beta::classname(), $params[0]);
+
+        $params = Yii::$container->resolveCallableDependencies([StaticMethodsWithComplexTypes::class, 'withBetaAndQuxUnion']);
+        $this->assertInstanceOf(Beta::classname(), $params[0]);
+
+        $params = Yii::$container->resolveCallableDependencies([StaticMethodsWithComplexTypes::class, 'withQuxAndBetaUnion']);
+        $this->assertInstanceOf(Qux::classname(), $params[0]);
     }
 }

--- a/tests/framework/di/ContainerTest.php
+++ b/tests/framework/di/ContainerTest.php
@@ -689,16 +689,18 @@ class ContainerTest extends TestCase
             ],
         ]);
 
-        $params = Yii::$container->resolveCallableDependencies([StaticMethodsWithComplexTypes::class, 'withBetaUnion']);
+        $className = 'yiiunit\framework\di\stubs\StaticMethodsWithComplexTypes';
+
+        $params = Yii::$container->resolveCallableDependencies([$className, 'withBetaUnion']);
         $this->assertInstanceOf(Beta::classname(), $params[0]);
 
-        $params = Yii::$container->resolveCallableDependencies([StaticMethodsWithComplexTypes::class, 'withBetaUnionInverse']);
+        $params = Yii::$container->resolveCallableDependencies([$className, 'withBetaUnionInverse']);
         $this->assertInstanceOf(Beta::classname(), $params[0]);
 
-        $params = Yii::$container->resolveCallableDependencies([StaticMethodsWithComplexTypes::class, 'withBetaAndQuxUnion']);
+        $params = Yii::$container->resolveCallableDependencies([$className, 'withBetaAndQuxUnion']);
         $this->assertInstanceOf(Beta::classname(), $params[0]);
 
-        $params = Yii::$container->resolveCallableDependencies([StaticMethodsWithComplexTypes::class, 'withQuxAndBetaUnion']);
+        $params = Yii::$container->resolveCallableDependencies([$className, 'withQuxAndBetaUnion']);
         $this->assertInstanceOf(Qux::classname(), $params[0]);
     }
 }

--- a/tests/framework/di/stubs/QuxAnother.php
+++ b/tests/framework/di/stubs/QuxAnother.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\di\stubs;
+
+use yii\base\BaseObject;
+
+class QuxAnother extends BaseObject implements QuxInterface
+{
+    public function quxMethod()
+    {
+    }
+}

--- a/tests/framework/di/stubs/StaticMethodsWithComplexTypes.php
+++ b/tests/framework/di/stubs/StaticMethodsWithComplexTypes.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace yiiunit\framework\di\stubs;
+
+class StaticMethodsWithComplexTypes
+{
+    public static function withBetaUnion(string | Beta $beta)
+    {
+    }
+
+    public static function withBetaUnionInverse(Beta | string $beta)
+    {
+    }
+
+    public static function withBetaAndQuxUnion(Beta | Qux $betaOrQux)
+    {
+    }
+
+    public static function withQuxAndBetaUnion(Qux | Beta $betaOrQux)
+    {
+    }
+}

--- a/tests/framework/di/stubs/StaticMethodsWithComplexTypes.php
+++ b/tests/framework/di/stubs/StaticMethodsWithComplexTypes.php
@@ -12,11 +12,19 @@ class StaticMethodsWithComplexTypes
     {
     }
 
-    public static function withBetaAndQuxUnion(Beta | Qux $betaOrQux)
+    public static function withBetaAndQuxUnion(Beta | QuxInterface $betaOrQux)
     {
     }
 
-    public static function withQuxAndBetaUnion(Qux | Beta $betaOrQux)
+    public static function withQuxAndBetaUnion(QuxInterface | Beta $betaOrQux)
+    {
+    }
+
+    public static function withQuxInterfaceAndQuxAnotherIntersection(QuxInterface & QuxAnother $Qux)
+    {
+    }
+
+    public static function withQuxAnotherAndQuxInterfaceIntersection(QuxAnother & QuxInterface $Qux)
     {
     }
 }

--- a/tests/framework/di/stubs/StaticMethodsWithIntersectionTypes.php
+++ b/tests/framework/di/stubs/StaticMethodsWithIntersectionTypes.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace yiiunit\framework\di\stubs;
+
+// Syntax valid only for PHP 8.1+
+class StaticMethodsWithIntersectionTypes
+{
+    public static function withQuxInterfaceAndQuxAnotherIntersection(QuxInterface & QuxAnother $Qux)
+    {
+    }
+
+    public static function withQuxAnotherAndQuxInterfaceIntersection(QuxAnother & QuxInterface $Qux)
+    {
+    }
+}

--- a/tests/framework/di/stubs/StaticMethodsWithUnionTypes.php
+++ b/tests/framework/di/stubs/StaticMethodsWithUnionTypes.php
@@ -2,7 +2,8 @@
 
 namespace yiiunit\framework\di\stubs;
 
-class StaticMethodsWithComplexTypes
+// Syntax valid only for PHP 8.0+
+class StaticMethodsWithUnionTypes
 {
     public static function withBetaUnion(string | Beta $beta)
     {
@@ -17,14 +18,6 @@ class StaticMethodsWithComplexTypes
     }
 
     public static function withQuxAndBetaUnion(QuxInterface | Beta $betaOrQux)
-    {
-    }
-
-    public static function withQuxInterfaceAndQuxAnotherIntersection(QuxInterface & QuxAnother $Qux)
-    {
-    }
-
-    public static function withQuxAnotherAndQuxInterfaceIntersection(QuxAnother & QuxInterface $Qux)
     {
     }
 }


### PR DESCRIPTION
…ypes

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | [19004](https://github.com/yiisoft/yii2/issues/19004)

Container::resolveCallableDependencies() can be used now with union types in arguments
If more than one interfaces can satisfy type rule, than first one will be used