### PR TITLE
Resolve #19130

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Bug #19191: Change `\Exception` to `\Throwable` in `BadRequestHttpException` and `HttpException` (Dmitrijlin)
 - Bug #19204: Support numbers in Inflector::camel2words (longthanhtran)
 - Bug #19047: Fix deprecated preg_match() passing null parameters #2 in db\mysql\Schema.php (longthanhtran)
+- Bug #19130: Fix DbSession breaks in some case (longthanhtran)
 
 
 2.0.44 December 30, 2021

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -151,11 +151,6 @@ class DbSession extends MultiFieldSession
                     ->insert($this->sessionTable, $row)
                     ->execute();
             }
-        } else {
-            // shouldn't reach here normally
-            $this->db->createCommand()
-                ->insert($this->sessionTable, $this->composeFields($newID, ''))
-                ->execute();
         }
     }
 

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -140,7 +140,7 @@ class DbSession extends MultiFieldSession
                ->queryOne();
         });
 
-        if ($row !== false) {
+        if ($row !== false && $this->getIsActive()) {
             if ($deleteOldSession) {
                 $this->db->createCommand()
                     ->update($this->sessionTable, ['id' => $newID], ['id' => $oldID])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19130 

The PR resolves issue #19130, the DbSession's regenerateID should follow Session's regenerateID signature to do nothing if no active sessionID exists.