### PR TITLE
ActiveRelationTrait: strictly checking attributes, update related PHPDoc's

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.46 under development
 ------------------------
 
-- no changes in this release.
+- Enh #19236: Added `yii\db\ActiveRelationTrait::isModelAttribute()` to checking AR attributes strictly (WinterSilence)
 
 
 2.0.45 February 11, 2022

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -292,7 +292,7 @@ trait ActiveRelationTrait
             $keys = null;
             if ($this->multiple && count($link) === 1) {
                 $primaryModelKey = reset($link);
-                $keys = isset($primaryModel[$primaryModelKey]) ? $primaryModel[$primaryModelKey] : null;
+                $keys = $this->isModelAttribute($primaryModel, $primaryModelKey) ? $primaryModel[$primaryModelKey] : null;
             }
             if (is_array($keys)) {
                 $value = [];
@@ -324,6 +324,21 @@ trait ActiveRelationTrait
         }
 
         return $models;
+    }
+
+    /**
+     * @param ActiveRecordInterface|array $model the AR instance or an array of attributes
+     * @param string $attribute the attribute name to test
+     * @return bool
+     * @since 2.0.45
+     */
+    protected function isModelAttribute($model, $attribute)
+    {
+        if ($model instanceof ActiveRecordInterface) {
+            return $model->hasAttribute($attribute);
+        }
+
+        return array_key_exists($attribute, $model);
     }
 
     /**
@@ -515,7 +530,7 @@ trait ActiveRelationTrait
     }
 
     /**
-     * @param array $models
+     * @param ActiveRecordInterface[]|array[] $models
      */
     private function filterByModels($models)
     {
@@ -528,7 +543,7 @@ trait ActiveRelationTrait
             // single key
             $attribute = reset($this->link);
             foreach ($models as $model) {
-                $value = isset($model[$attribute]) ? $model[$attribute] : null;
+                $value = $this->isModelAttribute($model, $attribute) ? $model[$attribute] : null;
                 if ($value !== null) {
                     if (is_array($value)) {
                         $values = array_merge($values, $value);
@@ -586,7 +601,7 @@ trait ActiveRelationTrait
     {
         $key = [];
         foreach ($attributes as $attribute) {
-            if (isset($model[$attribute])) {
+            if ($this->isModelAttribute($model, $attribute)) {
                 $key[] = $this->normalizeModelKey($model[$attribute]);
             }
         }

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -327,10 +327,15 @@ trait ActiveRelationTrait
     }
 
     /**
-     * @param ActiveRecordInterface|array $model the AR instance or an array of attributes
-     * @param string $attribute the attribute name to test
+     * Checks if the given attribute exists in the model or in an array of model attributes.
+     *
+     * > Note: An attributes of an ActiveRecord model represents the values of a particular column in database table.
+     * > You should NOT redeclare any of the attributes!
+     *
+     * @param ActiveRecordInterface|array $model the ActiveRecord instance or an array of model attributes
+     * @param string $attribute the attribute name to check
      * @return bool
-     * @since 2.0.45
+     * @since 2.0.46
      */
     protected function isModelAttribute($model, $attribute)
     {


### PR DESCRIPTION
- Adds  and integrate inner method `isModelAttribute()` to strict checking attributes to stop undocumented using any public/magic properties(via getter) as AR attributes.
- Extends related PHPDoc's,

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

Blocking undocumented using is BC or not? semi...
