### PR TITLE
Fix ActiveRecord::attributes()

### DIFF
--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -470,7 +470,7 @@ class ActiveRecord extends BaseActiveRecord
      */
     public function attributes()
     {
-        return array_keys(static::getTableSchema()->columns);
+        return static::getTableSchema()->getColumnNames();
     }
 
     /**


### PR DESCRIPTION
`ActiveRecord::attributes()` call `TableSchema::getColumnNames()` instead duplicate his code

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
