### PR TITLE
fix(Validation): Changed FilterValidator's fallback value (#19238)

### DIFF
--- a/framework/validators/FilterValidator.php
+++ b/framework/validators/FilterValidator.php
@@ -75,7 +75,7 @@ class FilterValidator extends Validator
     {
         $value = $model->$attribute;
         if (!$this->skipOnArray || !is_array($value)) {
-            $value = isset($value) ? $value : '';
+            $value = isset($value) ? $value : null;
             $model->$attribute = call_user_func($this->filter, $value);
         }
     }


### PR DESCRIPTION
Fallback value now is null instead of empty string
(which was added in 2.0.45 and breaks bc),
just like it was in previous versions.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19238
