### PR TITLE
Fix bug #19235

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - no changes in this release.
-- Bug #19235: Fix return type compatibility `yii\web\SessionIterator` methods for PHP 8.1
+- Bug #19235: Fix return type compatibility of `yii\web\SessionIterator` class methods for PHP 8.1
 
 2.0.45 February 11, 2022
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - no changes in this release.
-
+- Bug #19235: Fix return type compatibility `yii\web\SessionIterator` methods for PHP 8.1
 
 2.0.45 February 11, 2022
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - no changes in this release.
-- Bug #19235: Fix return type compatibility of `yii\web\SessionIterator` class methods for PHP 8.1
+- Bug #19235: Fix return type compatibility of `yii\web\SessionIterator` class methods for PHP 8.1 (virtual-designer)
 
 2.0.45 February 11, 2022
 ------------------------

--- a/framework/web/SessionIterator.php
+++ b/framework/web/SessionIterator.php
@@ -37,6 +37,7 @@ class SessionIterator implements \Iterator
      * Rewinds internal array pointer.
      * This method is required by the interface [[\Iterator]].
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->_key = reset($this->_keys);
@@ -47,6 +48,7 @@ class SessionIterator implements \Iterator
      * This method is required by the interface [[\Iterator]].
      * @return mixed the key of the current array element
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->_key;
@@ -57,6 +59,7 @@ class SessionIterator implements \Iterator
      * This method is required by the interface [[\Iterator]].
      * @return mixed the current array element
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return isset($_SESSION[$this->_key]) ? $_SESSION[$this->_key] : null;
@@ -66,6 +69,7 @@ class SessionIterator implements \Iterator
      * Moves the internal pointer to the next array element.
      * This method is required by the interface [[\Iterator]].
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         do {
@@ -78,6 +82,7 @@ class SessionIterator implements \Iterator
      * This method is required by the interface [[\Iterator]].
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->_key !== false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | #19235<!-- comma-separated list of tickets # fixed by the PR, if any -->

Fixed issue #19235:  PHP 8.1 Throws an error: `Uncaught yii\base\ErrorException: Return type of yii\web\SessionIterator::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`

(To the reviewers, I'm new to open-source contribution, so if you notice something wrong, please feel free to notify me.)