### PR TITLE
Update `FilterValidator::validateAttribute()`

### DIFF
--- a/framework/validators/FilterValidator.php
+++ b/framework/validators/FilterValidator.php
@@ -75,7 +75,9 @@ class FilterValidator extends Validator
     {
         $value = $model->$attribute;
         if (!$this->skipOnArray || !is_array($value)) {
-            $value = isset($value) ? $value : '';
+            if ($this->filter === 'trim' && $value === null) {
+                $value = '';
+            }
             $model->$attribute = call_user_func($this->filter, $value);
         }
     }


### PR DESCRIPTION
Revert changes by #19041. Converts nulled value when using 'trim' filter to keep BC (declared in `Validator::$builtInValidators`).

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #19238
