### PR TITLE
- Bugfix: ArrayHelper::getValue() with Objects ignores default-value

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,7 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #19243: Handle `finfo_open` for tar.xz as `application/octet-stream` on PHP 8.1 (longthanhtran)
 - Bug #19235: Fix return type compatibility of `yii\web\SessionIterator` class methods for PHP 8.1 (virtual-designer)
-
+- Bug #19266: Fix ArrayHelper::getValue() with Objects ignores default-value (HenryVolkmer)
 
 2.0.45 February 11, 2022
 ------------------------

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -199,7 +199,7 @@ class BaseArrayHelper
         }
 
         if (is_object($array) && property_exists($array, $key)) {
-            return $array->$key;
+            return $array->$key ?? $default;
         }
 
         if (static::keyExists($key, $array)) {
@@ -218,7 +218,7 @@ class BaseArrayHelper
             // this is expected to fail if the property does not exist, or __get() is not implemented
             // it is not reliably possible to check whether a property is accessible beforehand
             try {
-                return $array->$key;
+                return $array->$key ? $array->$key : $default;
             } catch (\Exception $e) {
                 if ($array instanceof ArrayAccess) {
                     return $default;

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -822,6 +822,16 @@ class ArrayHelperTest extends TestCase
         $this->assertEquals(23, ArrayHelper::getValue($object, 'id'));
     }
 
+    public function testDefaultValueObjects()
+    {
+        $object = new Post1();
+        $object->title = null;
+        $this->assertEquals('default value', ArrayHelper::getValue($object, 'title','default value'));
+
+        $object = new Post2(['content' => null]);
+        $this->assertEquals('default value', ArrayHelper::getValue($object, 'content','default value'));
+    }
+
     public function testGetValueNonexistingProperties1()
     {
         if (PHP_VERSION_ID < 80000) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

@see changes in ArrayHelper UnitTest
