### PR TITLE
Set the default  to an array

### DIFF
--- a/framework/base/ActionFilter.php
+++ b/framework/base/ActionFilter.php
@@ -36,7 +36,7 @@ class ActionFilter extends Behavior
      *
      * @see except
      */
-    public $only;
+    public $only = [];
     /**
      * @var array list of action IDs that this filter should not apply to.
      * @see only


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | ❌
======================
In fact, `$only` and `$except` have the same meaning, but when looking at the source code, if you do not notice the comments above the variable, it is very easy to interfere.

