### PR TITLE
Fix types

### DIFF
--- a/framework/BaseYii.php
+++ b/framework/BaseYii.php
@@ -203,7 +203,7 @@ class BaseYii
      * @param string $alias the alias name (e.g. "@yii"). It must start with a '@' character.
      * It may contain the forward-slash '/' which serves as a boundary character when performing
      * alias translation by [[getAlias()]].
-     * @param string $path the path corresponding to the alias. If this is null, the alias will
+     * @param string|null $path the path corresponding to the alias. If this is null, the alias will
      * be removed. Trailing '/' and '\' characters will be trimmed. This can be
      *
      * - a directory or a file path (e.g. `/tmp`, `/tmp/main.txt`)
@@ -528,7 +528,7 @@ class BaseYii
      * @param string $category the message category.
      * @param string $message the message to be translated.
      * @param array $params the parameters that will be used to replace the corresponding placeholders in the message.
-     * @param string $language the language code (e.g. `en-US`, `en`). If this is null, the current
+     * @param string|null $language the language code (e.g. `en-US`, `en`). If this is null, the current
      * [[\yii\base\Application::language|application language]] will be used.
      * @return string the translated message.
      */

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -126,7 +126,7 @@ abstract class Application extends Module
      */
     public $requestedRoute;
     /**
-     * @var Action the requested Action. If null, it means the request cannot be resolved into an action.
+     * @var Action|null the requested Action. If null, it means the request cannot be resolved into an action.
      */
     public $requestedAction;
     /**
@@ -517,7 +517,7 @@ abstract class Application extends Module
 
     /**
      * Returns the cache component.
-     * @return \yii\caching\CacheInterface the cache application component. Null if the component is not enabled.
+     * @return \yii\caching\CacheInterface|null the cache application component. Null if the component is not enabled.
      */
     public function getCache()
     {
@@ -643,7 +643,7 @@ abstract class Application extends Module
      * This method replaces the `exit()` function by ensuring the application life cycle is completed
      * before terminating the application.
      * @param int $status the exit status (value 0 means normal exit while other values mean abnormal exit).
-     * @param Response $response the response to be sent. If not set, the default application [[response]] component will be used.
+     * @param Response|null $response the response to be sent. If not set, the default application [[response]] component will be used.
      * @throws ExitException if the application is in testing mode
      */
     public function end($status = 0, $response = null)

--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -544,7 +544,7 @@ class Component extends BaseObject
      * wildcard will be removed, while handlers registered with plain names matching this wildcard will remain.
      *
      * @param string $name event name
-     * @param callable $handler the event handler to be removed.
+     * @param callable|null $handler the event handler to be removed.
      * If it is null, all handlers attached to the named event will be removed.
      * @return bool if a handler is found and detached
      * @see on()
@@ -645,7 +645,7 @@ class Component extends BaseObject
     /**
      * Returns the named behavior object.
      * @param string $name the behavior name
-     * @return null|Behavior the behavior object, or null if the behavior does not exist
+     * @return Behavior|null the behavior object, or null if the behavior does not exist
      */
     public function getBehavior($name)
     {
@@ -703,7 +703,7 @@ class Component extends BaseObject
      * Detaches a behavior from the component.
      * The behavior's [[Behavior::detach()]] method will be invoked.
      * @param string $name the behavior's name.
-     * @return null|Behavior the detached behavior. Null if the behavior does not exist.
+     * @return Behavior|null the detached behavior. Null if the behavior does not exist.
      */
     public function detachBehavior($name)
     {

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -51,7 +51,7 @@ class Controller extends Component implements ViewContextInterface
      */
     public $defaultAction = 'index';
     /**
-     * @var null|string|false the name of the layout to be applied to this controller's views.
+     * @var string|null|false the name of the layout to be applied to this controller's views.
      * This property mainly affects the behavior of [[render()]].
      * Defaults to null, meaning the actual layout value should inherit that from [[module]]'s layout value.
      * If false, no layout will be applied.

--- a/framework/base/ErrorException.php
+++ b/framework/base/ErrorException.php
@@ -38,7 +38,7 @@ class ErrorException extends \ErrorException
      * @param int $severity [optional]
      * @param string $filename [optional]
      * @param int $lineno [optional]
-     * @param \Throwable|\Exception $previous [optional]
+     * @param \Throwable|\Exception|null $previous [optional]
      */
     public function __construct($message = '', $code = 0, $severity = 1, $filename = __FILE__, $lineno = __LINE__, $previous = null)
     {

--- a/framework/base/Event.php
+++ b/framework/base/Event.php
@@ -34,7 +34,7 @@ class Event extends BaseObject
      */
     public $name;
     /**
-     * @var object the sender of this event. If not set, this property will be
+     * @var object|null the sender of this event. If not set, this property will be
      * set as the object whose `trigger()` method is called.
      * This property may also be a `null` when this event is a
      * class-level event which is triggered in a static context.
@@ -130,7 +130,7 @@ class Event extends BaseObject
      *
      * @param string $class the fully qualified class name from which the event handler needs to be detached.
      * @param string $name the event name.
-     * @param callable $handler the event handler to be removed.
+     * @param callable|null $handler the event handler to be removed.
      * If it is `null`, all handlers attached to the named event will be removed.
      * @return bool whether a handler is found and detached.
      * @see on()
@@ -257,7 +257,7 @@ class Event extends BaseObject
      * for the specified class and all its parent classes.
      * @param string|object $class the object or the fully qualified class name specifying the class-level event.
      * @param string $name the event name.
-     * @param Event $event the event parameter. If not set, a default [[Event]] object will be created.
+     * @param Event|null $event the event parameter. If not set, a default [[Event]] object will be created.
      */
     public static function trigger($class, $name, $event = null)
     {

--- a/framework/base/ExitException.php
+++ b/framework/base/ExitException.php
@@ -28,7 +28,7 @@ class ExitException extends \Exception
      * @param int $status the exit status code
      * @param string $message error message
      * @param int $code error code
-     * @param \Throwable|\Exception $previous The previous exception used for the exception chaining.
+     * @param \Throwable|\Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($status = 0, $message = null, $code = 0, $previous = null)
     {

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -151,7 +151,7 @@ class Module extends ServiceLocator
     /**
      * Constructor.
      * @param string $id the ID of this module.
-     * @param Module $parent the parent module (if any).
+     * @param Module|null $parent the parent module (if any).
      * @param array $config name-value pairs that will be used to initialize the object properties.
      */
     public function __construct($id, $parent = null, $config = [])

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -146,7 +146,7 @@ class Security extends Component
      * to hash input or output data.
      * @param string $data the data to encrypt
      * @param string $inputKey the input to use for encryption and authentication
-     * @param string $info optional context and application specific information, see [[hkdf()]]
+     * @param string|null $info optional context and application specific information, see [[hkdf()]]
      * @return string the encrypted data as byte string
      * @see decryptByKey()
      * @see encryptByPassword()
@@ -172,7 +172,7 @@ class Security extends Component
      * Verifies and decrypts data encrypted with [[encryptByKey()]].
      * @param string $data the encrypted data to decrypt
      * @param string $inputKey the input to use for encryption and authentication
-     * @param string $info optional context and application specific information, see [[hkdf()]]
+     * @param string|null $info optional context and application specific information, see [[hkdf()]]
      * @return bool|string the decrypted data or false on authentication failure
      * @see encryptByKey()
      */
@@ -286,8 +286,8 @@ class Security extends Component
      * Recommend use one of the SHA-2 hash algorithms: sha224, sha256, sha384 or sha512.
      * @param string $algo a hash algorithm supported by `hash_hmac()`, e.g. 'SHA-256'
      * @param string $inputKey the source key
-     * @param string $salt the random salt
-     * @param string $info optional info to bind the derived key material to application-
+     * @param string|null $salt the random salt
+     * @param string|null $info optional info to bind the derived key material to application-
      * and context-specific information, e.g. a user ID or API version, see
      * [RFC 5869](https://tools.ietf.org/html/rfc5869)
      * @param int $length length of the output key in bytes. If 0, the output key is
@@ -529,7 +529,7 @@ class Security extends Component
      * ```
      *
      * @param string $password The password to be hashed.
-     * @param int $cost Cost parameter used by the Blowfish hash algorithm.
+     * @param int|null $cost Cost parameter used by the Blowfish hash algorithm.
      * The higher the value of cost,
      * the longer it takes to generate the hash and to verify a password against it. Higher cost
      * therefore slows down a brute-force attack. For best protection against brute-force attacks,

--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -54,7 +54,7 @@ class View extends Component implements DynamicContentAwareInterface
      */
     public $params = [];
     /**
-     * @var array a list of available renderers indexed by their corresponding supported file extensions.
+     * @var array|null a list of available renderers indexed by their corresponding supported file extensions.
      * Each renderer may be a view renderer object or the configuration for creating the renderer object.
      * For example, the following configuration enables both Smarty and Twig view renderers:
      *
@@ -74,7 +74,7 @@ class View extends Component implements DynamicContentAwareInterface
      */
     public $defaultExtension = 'php';
     /**
-     * @var Theme|array|string the theme object or the configuration for creating the theme object.
+     * @var Theme|array|string|null the theme object or the configuration for creating the theme object.
      * If not set, it means theming is not enabled.
      */
     public $theme;
@@ -142,7 +142,7 @@ class View extends Component implements DynamicContentAwareInterface
      *
      * @param string $view the view name.
      * @param array $params the parameters (name-value pairs) that will be extracted and made available in the view file.
-     * @param object $context the context to be assigned to the view and can later be accessed via [[context]]
+     * @param object|null $context the context to be assigned to the view and can later be accessed via [[context]]
      * in the view. If the context implements [[ViewContextInterface]], it may also be used to locate
      * the view file corresponding to a relative view name.
      * @return string the rendering result
@@ -160,7 +160,7 @@ class View extends Component implements DynamicContentAwareInterface
      * Finds the view file based on the given view name.
      * @param string $view the view name or the [path alias](guide:concept-aliases) of the view file. Please refer to [[render()]]
      * on how to specify this parameter.
-     * @param object $context the context to be assigned to the view and can later be accessed via [[context]]
+     * @param object|null $context the context to be assigned to the view and can later be accessed via [[context]]
      * in the view. If the context implements [[ViewContextInterface]], it may also be used to locate
      * the view file corresponding to a relative view name.
      * @return string the view file path. Note that the file may not exist.
@@ -215,7 +215,7 @@ class View extends Component implements DynamicContentAwareInterface
      *
      * @param string $viewFile the view file. This can be either an absolute file path or an alias of it.
      * @param array $params the parameters (name-value pairs) that will be extracted and made available in the view file.
-     * @param object $context the context that the view should use for rendering the view. If null,
+     * @param object|null $context the context that the view should use for rendering the view. If null,
      * existing [[context]] will be used.
      * @return string the rendering result
      * @throws ViewNotFoundException if the view file does not exist

--- a/framework/behaviors/AttributeTypecastBehavior.php
+++ b/framework/behaviors/AttributeTypecastBehavior.php
@@ -214,7 +214,7 @@ class AttributeTypecastBehavior extends Behavior
 
     /**
      * Typecast owner attributes according to [[attributeTypes]].
-     * @param array $attributeNames list of attribute names that should be type-casted.
+     * @param array|null $attributeNames list of attribute names that should be type-casted.
      * If this parameter is empty, it means any attribute listed in the [[attributeTypes]]
      * should be type-casted.
      */

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -62,7 +62,7 @@ abstract class Cache extends Component implements CacheInterface
      */
     public $keyPrefix;
     /**
-     * @var null|array|false the functions used to serialize and unserialize cached data. Defaults to null, meaning
+     * @var array|null|false the functions used to serialize and unserialize cached data. Defaults to null, meaning
      * using the default PHP `serialize()` and `unserialize()` functions. If you want to use some more efficient
      * serializer (e.g. [igbinary](https://pecl.php.net/package/igbinary)), you may configure this property with
      * a two-element array. The first element specifies the serialization function, and the second the deserialization
@@ -229,9 +229,9 @@ abstract class Cache extends Component implements CacheInterface
      * @param mixed $key a key identifying the value to be cached. This can be a simple string or
      * a complex data structure consisting of factors representing the key.
      * @param mixed $value the value to be cached
-     * @param int $duration default duration in seconds before the cache will expire. If not set,
+     * @param int|null $duration default duration in seconds before the cache will expire. If not set,
      * default [[defaultDuration]] value is used.
-     * @param Dependency $dependency dependency of the cached item. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached item. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return bool whether the value is successfully stored into cache
@@ -261,9 +261,9 @@ abstract class Cache extends Component implements CacheInterface
      * expiration time will be replaced with the new ones, respectively.
      *
      * @param array $items the items to be cached, as key-value pairs.
-     * @param int $duration default duration in seconds before the cache will expire. If not set,
+     * @param int|null $duration default duration in seconds before the cache will expire. If not set,
      * default [[defaultDuration]] value is used.
-     * @param Dependency $dependency dependency of the cached items. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached items. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return array array of failed keys
@@ -280,9 +280,9 @@ abstract class Cache extends Component implements CacheInterface
      * expiration time will be replaced with the new ones, respectively.
      *
      * @param array $items the items to be cached, as key-value pairs.
-     * @param int $duration default duration in seconds before the cache will expire. If not set,
+     * @param int|null $duration default duration in seconds before the cache will expire. If not set,
      * default [[defaultDuration]] value is used.
-     * @param Dependency $dependency dependency of the cached items. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached items. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return array array of failed keys
@@ -319,7 +319,7 @@ abstract class Cache extends Component implements CacheInterface
      *
      * @param array $items the items to be cached, as key-value pairs.
      * @param int $duration default number of seconds in which the cached values will expire. 0 means never expire.
-     * @param Dependency $dependency dependency of the cached items. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached items. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return array array of failed keys
@@ -336,7 +336,7 @@ abstract class Cache extends Component implements CacheInterface
      *
      * @param array $items the items to be cached, as key-value pairs.
      * @param int $duration default number of seconds in which the cached values will expire. 0 means never expire.
-     * @param Dependency $dependency dependency of the cached items. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached items. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return array array of failed keys
@@ -370,7 +370,7 @@ abstract class Cache extends Component implements CacheInterface
      * a complex data structure consisting of factors representing the key.
      * @param mixed $value the value to be cached
      * @param int $duration the number of seconds in which the cached value will expire. 0 means never expire.
-     * @param Dependency $dependency dependency of the cached item. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached item. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return bool whether the value is successfully stored into cache
@@ -590,9 +590,9 @@ abstract class Cache extends Component implements CacheInterface
      * If you use $callable that can return `false`, then keep in mind that [[getOrSet()]] may work inefficiently
      * because the [[yii\caching\Cache::get()]] method uses `false` return value to indicate the data item is not found
      * in the cache. Thus, caching of `false` value will lead to unnecessary internal calls.
-     * @param int $duration default duration in seconds before the cache will expire. If not set,
+     * @param int|null $duration default duration in seconds before the cache will expire. If not set,
      * [[defaultDuration]] value will be used.
-     * @param Dependency $dependency dependency of the cached item. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached item. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is `false`.
      * @return mixed result of $callable execution

--- a/framework/caching/CacheInterface.php
+++ b/framework/caching/CacheInterface.php
@@ -97,9 +97,9 @@ interface CacheInterface extends \ArrayAccess
      * @param mixed $key a key identifying the value to be cached. This can be a simple string or
      * a complex data structure consisting of factors representing the key.
      * @param mixed $value the value to be cached
-     * @param int $duration default duration in seconds before the cache will expire. If not set,
+     * @param int|null $duration default duration in seconds before the cache will expire. If not set,
      * default [[defaultDuration]] value is used.
-     * @param Dependency $dependency dependency of the cached item. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached item. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return bool whether the value is successfully stored into cache
@@ -112,9 +112,9 @@ interface CacheInterface extends \ArrayAccess
      * expiration time will be replaced with the new ones, respectively.
      *
      * @param array $items the items to be cached, as key-value pairs.
-     * @param int $duration default duration in seconds before the cache will expire. If not set,
+     * @param int|null $duration default duration in seconds before the cache will expire. If not set,
      * default [[defaultDuration]] value is used.
-     * @param Dependency $dependency dependency of the cached items. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached items. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return array array of failed keys
@@ -128,7 +128,7 @@ interface CacheInterface extends \ArrayAccess
      * a complex data structure consisting of factors representing the key.
      * @param mixed $value the value to be cached
      * @param int $duration the number of seconds in which the cached value will expire. 0 means never expire.
-     * @param Dependency $dependency dependency of the cached item. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached item. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return bool whether the value is successfully stored into cache
@@ -141,7 +141,7 @@ interface CacheInterface extends \ArrayAccess
      *
      * @param array $items the items to be cached, as key-value pairs.
      * @param int $duration default number of seconds in which the cached values will expire. 0 means never expire.
-     * @param Dependency $dependency dependency of the cached items. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached items. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return array array of failed keys
@@ -182,9 +182,9 @@ interface CacheInterface extends \ArrayAccess
      * a complex data structure consisting of factors representing the key.
      * @param callable|\Closure $callable the callable or closure that will be used to generate a value to be cached.
      * In case $callable returns `false`, the value will not be cached.
-     * @param int $duration default duration in seconds before the cache will expire. If not set,
+     * @param int|null $duration default duration in seconds before the cache will expire. If not set,
      * [[defaultDuration]] value will be used.
-     * @param Dependency $dependency dependency of the cached item. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached item. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is `false`.
      * @return mixed result of $callable execution

--- a/framework/console/Application.php
+++ b/framework/console/Application.php
@@ -170,7 +170,7 @@ class Application extends \yii\base\Application
      *
      * @param string $route the route that specifies the action.
      * @param array $params the parameters to be passed to the action
-     * @return int|Response the result of the action. This can be either an exit code or Response object.
+     * @return int|Response|null the result of the action. This can be either an exit code or Response object.
      * Exit code 0 means normal, and other values mean abnormal. Exit code of `null` is treated as `0` as well.
      * @throws Exception if the route is invalid
      */

--- a/framework/console/UnknownCommandException.php
+++ b/framework/console/UnknownCommandException.php
@@ -34,7 +34,7 @@ class UnknownCommandException extends Exception
      * @param string $route the route of the command that could not be found.
      * @param Application $application the console application instance involved.
      * @param int $code the Exception code.
-     * @param \Exception $previous the previous exception used for the exception chaining.
+     * @param \Exception|null $previous the previous exception used for the exception chaining.
      */
     public function __construct($route, $application, $code = 0, \Exception $previous = null)
     {

--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -992,7 +992,7 @@ abstract class BaseMigrateController extends Controller
 
     /**
      * Returns the migration history.
-     * @param int $limit the maximum number of records in the history to be returned. `null` for "no limit".
+     * @param int|null $limit the maximum number of records in the history to be returned. `null` for "no limit".
      * @return array the migration history
      */
     abstract protected function getMigrationHistory($limit);

--- a/framework/console/controllers/HelpController.php
+++ b/framework/console/controllers/HelpController.php
@@ -41,7 +41,7 @@ class HelpController extends Controller
      * Displays available commands or the detailed information
      * about a particular command.
      *
-     * @param string $command The name of the command to show help about.
+     * @param string|null $command The name of the command to show help about.
      * If not provided, all available commands will be displayed.
      * @return int the exit status
      * @throws Exception if the command for help is unknown

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -286,7 +286,7 @@ EOD;
      * This command will search through source code files and extract
      * messages that need to be translated in different languages.
      *
-     * @param string $configFile the path or alias of the configuration file.
+     * @param string|null $configFile the path or alias of the configuration file.
      * You may use the "yii message/config" command to generate
      * this file and then customize it for your needs.
      * @throws Exception on failure.

--- a/framework/data/DataFilter.php
+++ b/framework/data/DataFilter.php
@@ -613,7 +613,7 @@ class DataFilter extends Model
      * Validates operator condition.
      * @param string $operator raw operator control keyword.
      * @param mixed $condition attribute condition.
-     * @param string $attribute attribute name.
+     * @param string|null $attribute attribute name.
      */
     protected function validateOperatorCondition($operator, $condition, $attribute = null)
     {

--- a/framework/data/Pagination.php
+++ b/framework/data/Pagination.php
@@ -250,7 +250,7 @@ class Pagination extends BaseObject implements Linkable
      * Creates the URL suitable for pagination with the specified page number.
      * This method is mainly called by pagers when creating URLs used to perform pagination.
      * @param int $page the zero-based page number that the URL should point to.
-     * @param int $pageSize the number of items on each page. If not set, the value of [[pageSize]] will be used.
+     * @param int|null $pageSize the number of items on each page. If not set, the value of [[pageSize]] will be used.
      * @param bool $absolute whether to create an absolute URL. Defaults to `false`.
      * @return string the created URL
      * @see params
@@ -339,7 +339,7 @@ class Pagination extends BaseObject implements Linkable
      * Returns the value of the specified query parameter.
      * This method returns the named parameter value from [[params]]. Null is returned if the value does not exist.
      * @param string $name the parameter name
-     * @param string $defaultValue the value to be returned when the specified parameter does not exist in [[params]].
+     * @param string|null $defaultValue the value to be returned when the specified parameter does not exist in [[params]].
      * @return string|null the parameter value
      */
     protected function getQueryParam($name, $defaultValue = null)

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -124,7 +124,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 
     /**
      * Executes query and returns all results as an array.
-     * @param Connection $db the DB connection used to create the DB command.
+     * @param Connection|null $db the DB connection used to create the DB command.
      * If null, the DB connection returned by [[modelClass]] will be used.
      * @return array|ActiveRecord[] the query results. If the query results in nothing, an empty array will be returned.
      */
@@ -778,7 +778,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      * @param array $link the link between the junction table and the table associated with [[primaryModel]].
      * The keys of the array represent the columns in the junction table, and the values represent the columns
      * in the [[primaryModel]] table.
-     * @param callable $callable a PHP callback for customizing the relation associated with the junction table.
+     * @param callable|null $callable a PHP callback for customizing the relation associated with the junction table.
      * Its signature should be `function($query)`, where `$query` is the query to be customized.
      * @return $this the query object itself
      * @throws InvalidConfigException when query is not initialized properly

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -81,12 +81,12 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     const EVENT_INIT = 'init';
 
     /**
-     * @var string the SQL statement to be executed for retrieving AR records.
+     * @var string|null the SQL statement to be executed for retrieving AR records.
      * This is set by [[ActiveRecord::findBySql()]].
      */
     public $sql;
     /**
-     * @var string|array the join condition to be used when this query is used in a relational context.
+     * @var string|array|null the join condition to be used when this query is used in a relational context.
      * The condition will be used in the ON part when [[ActiveQuery::joinWith()]] is called.
      * Otherwise, the condition will be used in the WHERE part of a query.
      * Please refer to [[Query::where()]] on how to specify this parameter.
@@ -94,7 +94,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     public $on;
     /**
-     * @var array a list of relations that this query should be joined with
+     * @var array|null a list of relations that this query should be joined with
      */
     public $joinWith;
 

--- a/framework/db/ActiveQueryInterface.php
+++ b/framework/db/ActiveQueryInterface.php
@@ -31,7 +31,7 @@ interface ActiveQueryInterface extends QueryInterface
 
     /**
      * Executes query and returns a single row of result.
-     * @param Connection $db the DB connection used to create the DB command.
+     * @param Connection|null $db the DB connection used to create the DB command.
      * If `null`, the DB connection returned by [[ActiveQueryTrait::$modelClass|modelClass]] will be used.
      * @return ActiveRecordInterface|array|null a single row of query result. Depending on the setting of [[asArray]],
      * the query result may be either an array or an ActiveRecord object. `null` will be returned
@@ -92,7 +92,7 @@ interface ActiveQueryInterface extends QueryInterface
     /**
      * Specifies the relation associated with the junction table for use in relational query.
      * @param string $relationName the relation name. This refers to a relation declared in the [[ActiveRelationTrait::primaryModel|primaryModel]] of the relation.
-     * @param callable $callable a PHP callback for customizing the relation associated with the junction table.
+     * @param callable|null $callable a PHP callback for customizing the relation associated with the junction table.
      * Its signature should be `function($query)`, where `$query` is the query to be customized.
      * @return $this the relation object itself.
      */

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -392,7 +392,7 @@ class ActiveRecord extends BaseActiveRecord
      *
      * For a large set of models you might consider using [[ActiveQuery::each()]] to keep memory usage within limits.
      *
-     * @param string|array $condition the conditions that will be put in the WHERE part of the DELETE SQL.
+     * @param string|array|null $condition the conditions that will be put in the WHERE part of the DELETE SQL.
      * Please refer to [[Query::where()]] on how to specify this parameter.
      * @param array $params the parameters (name => value) to be bound to the query.
      * @return int the number of rows deleted
@@ -554,7 +554,7 @@ class ActiveRecord extends BaseActiveRecord
      * @param bool $runValidation whether to perform validation (calling [[validate()]])
      * before saving the record. Defaults to `true`. If the validation fails, the record
      * will not be saved to the database and this method will return `false`.
-     * @param array $attributes list of attributes that need to be saved. Defaults to `null`,
+     * @param array|null $attributes list of attributes that need to be saved. Defaults to `null`,
      * meaning all attributes that are loaded from DB will be saved.
      * @return bool whether the attributes are valid and the record is inserted successfully.
      * @throws \Exception in case insert failed.
@@ -591,7 +591,7 @@ class ActiveRecord extends BaseActiveRecord
 
     /**
      * Inserts an ActiveRecord into DB without considering transaction.
-     * @param array $attributes list of attributes that need to be saved. Defaults to `null`,
+     * @param array|null $attributes list of attributes that need to be saved. Defaults to `null`,
      * meaning all attributes that are loaded from DB will be saved.
      * @return bool whether the record is inserted successfully.
      */
@@ -661,7 +661,7 @@ class ActiveRecord extends BaseActiveRecord
      * @param bool $runValidation whether to perform validation (calling [[validate()]])
      * before saving the record. Defaults to `true`. If the validation fails, the record
      * will not be saved to the database and this method will return `false`.
-     * @param array $attributeNames list of attributes that need to be saved. Defaults to `null`,
+     * @param array|null $attributeNames list of attributes that need to be saved. Defaults to `null`,
      * meaning all attributes that are loaded from DB will be saved.
      * @return int|false the number of rows affected, or false if validation fails
      * or [[beforeSave()]] stops the updating process.

--- a/framework/db/ActiveRecordInterface.php
+++ b/framework/db/ActiveRecordInterface.php
@@ -310,7 +310,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      * Customer::deleteAll([status = 3]);
      * ```
      *
-     * @param array $condition the condition that matches the records that should get deleted.
+     * @param array|null $condition the condition that matches the records that should get deleted.
      * Please refer to [[QueryInterface::where()]] on how to specify this parameter.
      * An empty condition will match all records.
      * @return int the number of rows deleted
@@ -335,7 +335,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      * @param bool $runValidation whether to perform validation (calling [[\yii\base\Model::validate()|validate()]])
      * before saving the record. Defaults to `true`. If the validation fails, the record
      * will not be saved to the database and this method will return `false`.
-     * @param array $attributeNames list of attribute names that need to be saved. Defaults to `null`,
+     * @param array|null $attributeNames list of attribute names that need to be saved. Defaults to `null`,
      * meaning all attributes that are loaded from DB will be saved.
      * @return bool whether the saving succeeded (i.e. no validation errors occurred).
      */
@@ -356,7 +356,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      * @param bool $runValidation whether to perform validation (calling [[\yii\base\Model::validate()|validate()]])
      * before saving the record. Defaults to `true`. If the validation fails, the record
      * will not be saved to the database and this method will return `false`.
-     * @param array $attributes list of attributes that need to be saved. Defaults to `null`,
+     * @param array|null $attributes list of attributes that need to be saved. Defaults to `null`,
      * meaning all attributes that are loaded from DB will be saved.
      * @return bool whether the attributes are valid and the record is inserted successfully.
      */
@@ -377,7 +377,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      * @param bool $runValidation whether to perform validation (calling [[\yii\base\Model::validate()|validate()]])
      * before saving the record. Defaults to `true`. If the validation fails, the record
      * will not be saved to the database and this method will return `false`.
-     * @param array $attributeNames list of attributes that need to be saved. Defaults to `null`,
+     * @param array|null $attributeNames list of attributes that need to be saved. Defaults to `null`,
      * meaning all attributes that are loaded from DB will be saved.
      * @return int|bool the number of rows affected, or `false` if validation fails
      * or updating process is stopped for other reasons.

--- a/framework/db/ActiveRecordInterface.php
+++ b/framework/db/ActiveRecordInterface.php
@@ -79,9 +79,6 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      * @param bool $asArray whether to return the primary key value as an array. If true,
      * the return value will be an array with column name as key and column value as value.
      * If this is `false` (default), a scalar value will be returned for non-composite primary key.
-     * @property mixed The old primary key value. An array (column name => column value) is
-     * returned if the primary key is composite. A string is returned otherwise (`null` will be
-     * returned if the key value is `null`).
      * @return mixed the old primary key value. An array (column name => column value) is returned if the primary key
      * is composite or `$asArray` is true. A string is returned otherwise (`null` will be returned if
      * the key value is `null`).

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -98,7 +98,7 @@ trait ActiveRelationTrait
      * ```
      *
      * @param string $relationName the relation name. This refers to a relation declared in [[primaryModel]].
-     * @param callable $callable a PHP callback for customizing the relation associated with the junction table.
+     * @param callable|null $callable a PHP callback for customizing the relation associated with the junction table.
      * Its signature should be `function($query)`, where `$query` is the query to be customized.
      * @return $this the relation object itself.
      */
@@ -391,8 +391,8 @@ trait ActiveRelationTrait
     /**
      * @param array $models
      * @param array $link
-     * @param array $viaModels
-     * @param null|self $viaQuery
+     * @param array|null $viaModels
+     * @param self|null $viaQuery
      * @param bool $checkMultiple
      * @return array
      */

--- a/framework/db/ArrayExpression.php
+++ b/framework/db/ArrayExpression.php
@@ -28,7 +28,7 @@ use yii\base\InvalidConfigException;
 class ArrayExpression implements ExpressionInterface, \ArrayAccess, \Countable, \IteratorAggregate
 {
     /**
-     * @var null|string the type of the array elements. Defaults to `null` which means the type is
+     * @var string|null the type of the array elements. Defaults to `null` which means the type is
      * not explicitly specified.
      *
      * Note that in case when type is not specified explicitly and DBMS can not guess it from the context,
@@ -68,7 +68,7 @@ class ArrayExpression implements ExpressionInterface, \ArrayAccess, \Countable, 
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getType()
     {

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1110,9 +1110,6 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * @param bool $asArray whether to return the primary key value as an array. If `true`,
      * the return value will be an array with column names as keys and column values as values.
      * Note that for composite primary keys, an array will always be returned regardless of this parameter value.
-     * @property mixed The primary key value. An array (column name => column value) is returned if
-     * the primary key is composite. A string is returned otherwise (null will be returned if
-     * the key value is null).
      * @return mixed the primary key value. An array (column name => column value) is returned if the primary key
      * is composite or `$asArray` is `true`. A string is returned otherwise (null will be returned if
      * the key value is null).
@@ -1140,9 +1137,6 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * @param bool $asArray whether to return the primary key value as an array. If `true`,
      * the return value will be an array with column name as key and column value as value.
      * If this is `false` (default), a scalar value will be returned for non-composite primary key.
-     * @property mixed The old primary key value. An array (column name => column value) is
-     * returned if the primary key is composite. A string is returned otherwise (null will be
-     * returned if the key value is null).
      * @return mixed the old primary key value. An array (column name => column value) is returned if the primary key
      * is composite or `$asArray` is `true`. A string is returned otherwise (null will be returned if
      * the key value is null).

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -196,7 +196,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * Customer::deleteAll('status = 3');
      * ```
      *
-     * @param string|array $condition the conditions that will be put in the WHERE part of the DELETE SQL.
+     * @param string|array|null $condition the conditions that will be put in the WHERE part of the DELETE SQL.
      * Please refer to [[Query::where()]] on how to specify this parameter.
      * @return int the number of rows deleted
      * @throws NotSupportedException if not overridden.
@@ -229,7 +229,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      *    and implement necessary business logic (e.g. merging the changes, prompting stated data)
      *    to resolve the conflict.
      *
-     * @return string the column name that stores the lock version of a table row.
+     * @return string|null the column name that stores the lock version of a table row.
      * If `null` is returned (default implemented), optimistic locking will not be supported.
      */
     public function optimisticLock()
@@ -666,7 +666,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * @param bool $runValidation whether to perform validation (calling [[validate()]])
      * before saving the record. Defaults to `true`. If the validation fails, the record
      * will not be saved to the database and this method will return `false`.
-     * @param array $attributeNames list of attribute names that need to be saved. Defaults to null,
+     * @param array|null $attributeNames list of attribute names that need to be saved. Defaults to null,
      * meaning all attributes that are loaded from DB will be saved.
      * @return bool whether the saving succeeded (i.e. no validation errors occurred).
      */
@@ -723,7 +723,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * @param bool $runValidation whether to perform validation (calling [[validate()]])
      * before saving the record. Defaults to `true`. If the validation fails, the record
      * will not be saved to the database and this method will return `false`.
-     * @param array $attributeNames list of attribute names that need to be saved. Defaults to null,
+     * @param array|null $attributeNames list of attribute names that need to be saved. Defaults to null,
      * meaning all attributes that are loaded from DB will be saved.
      * @return int|false the number of rows affected, or `false` if validation fails
      * or [[beforeSave()]] stops the updating process.
@@ -783,7 +783,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
 
     /**
      * @see update()
-     * @param array $attributes attributes to update
+     * @param array|null $attributes attributes to update
      * @return int|false the number of rows affected, or false if [[beforeSave()]] stops the updating process.
      * @throws StaleObjectException
      */
@@ -1225,7 +1225,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * It can be declared in either the Active Record class itself or one of its behaviors.
      * @param string $name the relation name, e.g. `orders` for a relation defined via `getOrders()` method (case-sensitive).
      * @param bool $throwException whether to throw exception if the relation does not exist.
-     * @return ActiveQueryInterface|ActiveQuery the relational query object. If the relation does not exist
+     * @return ActiveQueryInterface|ActiveQuery|null the relational query object. If the relation does not exist
      * and `$throwException` is `false`, `null` will be returned.
      * @throws InvalidArgumentException if the named relation does not exist.
      */

--- a/framework/db/BatchQueryResult.php
+++ b/framework/db/BatchQueryResult.php
@@ -43,7 +43,7 @@ class BatchQueryResult extends Component implements \Iterator
     const EVENT_FINISH = 'finish';
 
     /**
-     * @var Connection the DB connection to be used when performing batch query.
+     * @var Connection|null the DB connection to be used when performing batch query.
      * If null, the "db" application component will be used.
      */
     public $db;

--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -124,8 +124,8 @@ class ColumnSchemaBuilder extends BaseObject
      * Create a column schema builder instance giving the type and value precision.
      *
      * @param string $type type of the column. See [[$type]].
-     * @param int|string|array $length length or precision of the column. See [[$length]].
-     * @param \yii\db\Connection $db the current database connection. See [[$db]].
+     * @param int|string|array|null $length length or precision of the column. See [[$length]].
+     * @param \yii\db\Connection|null $db the current database connection. See [[$db]].
      * @param array $config name-value pairs that will be used to initialize the object properties
      */
     public function __construct($type, $length = null, $db = null, $config = [])

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -103,7 +103,7 @@ class Command extends Component
      */
     private $_refreshTableName;
     /**
-     * @var string|false|null the isolation level to use for this transaction.
+     * @var string|null|false the isolation level to use for this transaction.
      * See [[Transaction::begin()]] for details.
      */
     private $_isolationLevel = false;
@@ -116,10 +116,10 @@ class Command extends Component
 
     /**
      * Enables query cache for this command.
-     * @param int $duration the number of seconds that query result of this command can remain valid in the cache.
+     * @param int|null $duration the number of seconds that query result of this command can remain valid in the cache.
      * If this is not set, the value of [[Connection::queryCacheDuration]] will be used instead.
      * Use 0 to indicate that the cached data will never expire.
-     * @param \yii\caching\Dependency $dependency the cache dependency associated with the cached query result.
+     * @param \yii\caching\Dependency|null $dependency the cache dependency associated with the cached query result.
      * @return $this the command object itself
      */
     public function cache($duration = null, $dependency = null)
@@ -237,7 +237,7 @@ class Command extends Component
      * this may improve performance.
      * For SQL statement with binding parameters, this method is invoked
      * automatically.
-     * @param bool $forRead whether this method is called for a read query. If null, it means
+     * @param bool|null $forRead whether this method is called for a read query. If null, it means
      * the SQL statement should be used to determine whether it is for read or write.
      * @throws Exception if there is any DB error
      */
@@ -292,8 +292,8 @@ class Command extends Component
      * the form `:name`. For a prepared statement using question mark
      * placeholders, this will be the 1-indexed position of the parameter.
      * @param mixed $value the PHP variable to bind to the SQL statement parameter (passed by reference)
-     * @param int $dataType SQL data type of the parameter. If null, the type is determined by the PHP type of the value.
-     * @param int $length length of the data type
+     * @param int|null $dataType SQL data type of the parameter. If null, the type is determined by the PHP type of the value.
+     * @param int|null $length length of the data type
      * @param mixed $driverOptions the driver-specific options
      * @return $this the current command being executed
      * @see https://www.php.net/manual/en/function.PDOStatement-bindParam.php
@@ -336,7 +336,7 @@ class Command extends Component
      * the form `:name`. For a prepared statement using question mark
      * placeholders, this will be the 1-indexed position of the parameter.
      * @param mixed $value The value to bind to the parameter
-     * @param int $dataType SQL data type of the parameter. If null, the type is determined by the PHP type of the value.
+     * @param int|null $dataType SQL data type of the parameter. If null, the type is determined by the PHP type of the value.
      * @return $this the current command being executed
      * @see https://www.php.net/manual/en/function.PDOStatement-bindValue.php
      */
@@ -399,7 +399,7 @@ class Command extends Component
 
     /**
      * Executes the SQL statement and returns ALL rows at once.
-     * @param int $fetchMode the result fetch mode. Please refer to [PHP manual](https://www.php.net/manual/en/function.PDOStatement-setFetchMode.php)
+     * @param int|null $fetchMode the result fetch mode. Please refer to [PHP manual](https://www.php.net/manual/en/function.PDOStatement-setFetchMode.php)
      * for valid fetch modes. If this parameter is null, the value set in [[fetchMode]] will be used.
      * @return array all rows of the query result. Each array element is an array representing a row of data.
      * An empty array is returned if the query results in nothing.
@@ -413,7 +413,7 @@ class Command extends Component
     /**
      * Executes the SQL statement and returns the first row of the result.
      * This method is best used when only the first row of result is needed for a query.
-     * @param int $fetchMode the result fetch mode. Please refer to [PHP manual](https://www.php.net/manual/en/pdostatement.setfetchmode.php)
+     * @param int|null $fetchMode the result fetch mode. Please refer to [PHP manual](https://www.php.net/manual/en/pdostatement.setfetchmode.php)
      * for valid fetch modes. If this parameter is null, the value set in [[fetchMode]] will be used.
      * @return array|false the first row (in terms of an array) of the query result. False is returned if the query
      * results in nothing.
@@ -641,7 +641,7 @@ class Command extends Component
      *
      * @param string $table the name of the table to be created. The name will be properly quoted by the method.
      * @param array $columns the columns (name => definition) in the new table.
-     * @param string $options additional SQL fragment that will be appended to the generated SQL.
+     * @param string|null $options additional SQL fragment that will be appended to the generated SQL.
      * @return $this the command object itself
      */
     public function createTable($table, $columns, $options = null)
@@ -783,8 +783,8 @@ class Command extends Component
      * @param string|array $columns the name of the column to that the constraint will be added on. If there are multiple columns, separate them with commas.
      * @param string $refTable the table that the foreign key references to.
      * @param string|array $refColumns the name of the column that the foreign key references to. If there are multiple columns, separate them with commas.
-     * @param string $delete the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
-     * @param string $update the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
+     * @param string|null $delete the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
+     * @param string|null $update the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
      * @return $this the command object itself
      */
     public function addForeignKey($name, $table, $columns, $refTable, $refColumns, $delete = null, $update = null)
@@ -1136,7 +1136,7 @@ class Command extends Component
     /**
      * Performs the actual DB query of a SQL statement.
      * @param string $method method of PDOStatement to be called
-     * @param int $fetchMode the result fetch mode. Please refer to [PHP manual](https://www.php.net/manual/en/function.PDOStatement-setFetchMode.php)
+     * @param int|null $fetchMode the result fetch mode. Please refer to [PHP manual](https://www.php.net/manual/en/function.PDOStatement-setFetchMode.php)
      * for valid fetch modes. If this parameter is null, the value set in [[fetchMode]] will be used.
      * @return mixed the method execution result
      * @throws Exception if the query causes any problem

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -162,11 +162,11 @@ class Connection extends Component
      */
     public $dsn;
     /**
-     * @var string the username for establishing DB connection. Defaults to `null` meaning no username to use.
+     * @var string|null the username for establishing DB connection. Defaults to `null` meaning no username to use.
      */
     public $username;
     /**
-     * @var string the password for establishing DB connection. Defaults to `null` meaning no password to use.
+     * @var string|null the password for establishing DB connection. Defaults to `null` meaning no password to use.
      */
     public $password;
     /**
@@ -177,7 +177,7 @@ class Connection extends Component
      */
     public $attributes;
     /**
-     * @var PDO the PHP PDO instance associated with this DB connection.
+     * @var PDO|null the PHP PDO instance associated with this DB connection.
      * This property is mainly managed by [[open()]] and [[close()]] methods.
      * When a DB connection is active, this property will represent a PDO instance;
      * otherwise, it will be null.
@@ -236,7 +236,7 @@ class Connection extends Component
      */
     public $queryCache = 'cache';
     /**
-     * @var string the charset used for database connection. The property is only used
+     * @var string|null the charset used for database connection. The property is only used
      * for MySQL, PostgreSQL and CUBRID databases. Defaults to null, meaning using default charset
      * as configured by the database.
      *
@@ -248,7 +248,7 @@ class Connection extends Component
      */
     public $charset;
     /**
-     * @var bool whether to turn on prepare emulation. Defaults to false, meaning PDO
+     * @var bool|null whether to turn on prepare emulation. Defaults to false, meaning PDO
      * will use the native prepare support if available. For some databases (such as MySQL),
      * this may need to be set true so that PDO can emulate the prepare support to bypass
      * the buggy native prepare support.
@@ -492,10 +492,10 @@ class Connection extends Component
      *
      * @param callable $callable a PHP callable that contains DB queries which will make use of query cache.
      * The signature of the callable is `function (Connection $db)`.
-     * @param int $duration the number of seconds that query results can remain valid in the cache. If this is
+     * @param int|null $duration the number of seconds that query results can remain valid in the cache. If this is
      * not set, the value of [[queryCacheDuration]] will be used instead.
      * Use 0 to indicate that the cached data will never expire.
-     * @param \yii\caching\Dependency $dependency the cache dependency associated with the cached query results.
+     * @param \yii\caching\Dependency|null $dependency the cache dependency associated with the cached query results.
      * @return mixed the return result of the callable
      * @throws \Exception if there is any exception during query
      * @see enableQueryCache
@@ -562,9 +562,9 @@ class Connection extends Component
     /**
      * Returns the current query cache information.
      * This method is used internally by [[Command]].
-     * @param int $duration the preferred caching duration. If null, it will be ignored.
-     * @param \yii\caching\Dependency $dependency the preferred caching dependency. If null, it will be ignored.
-     * @return array the current query cache information, or null if query cache is not enabled.
+     * @param int|null $duration the preferred caching duration. If null, it will be ignored.
+     * @param \yii\caching\Dependency|null $dependency the preferred caching dependency. If null, it will be ignored.
+     * @return array|null the current query cache information, or null if query cache is not enabled.
      * @internal
      */
     public function getQueryCacheInfo($duration, $dependency)
@@ -752,7 +752,7 @@ class Connection extends Component
 
     /**
      * Creates a command for execution.
-     * @param string $sql the SQL statement to be executed
+     * @param string|null $sql the SQL statement to be executed
      * @param array $params the parameters to be bound to the SQL statement
      * @return Command the DB command
      */
@@ -1043,7 +1043,7 @@ class Connection extends Component
      * When [[enableSlaves]] is true, one of the slaves will be used for read queries, and its PDO instance
      * will be returned by this method.
      * @param bool $fallbackToMaster whether to return a master PDO in case none of the slave connections is available.
-     * @return PDO the PDO instance for the currently active slave connection. `null` is returned if no slave connection
+     * @return PDO|null the PDO instance for the currently active slave connection. `null` is returned if no slave connection
      * is available and `$fallbackToMaster` is false.
      */
     public function getSlavePdo($fallbackToMaster = true)
@@ -1071,7 +1071,7 @@ class Connection extends Component
      * Returns the currently active slave connection.
      * If this method is called for the first time, it will try to open a slave connection when [[enableSlaves]] is true.
      * @param bool $fallbackToMaster whether to return a master connection in case there is no slave connection available.
-     * @return Connection the currently active slave connection. `null` is returned if there is no slave available and
+     * @return Connection|null the currently active slave connection. `null` is returned if there is no slave available and
      * `$fallbackToMaster` is false.
      */
     public function getSlave($fallbackToMaster = true)
@@ -1090,7 +1090,7 @@ class Connection extends Component
     /**
      * Returns the currently active master connection.
      * If this method is called for the first time, it will try to open a master connection.
-     * @return Connection the currently active master connection. `null` is returned if there is no master available.
+     * @return Connection|null the currently active master connection. `null` is returned if there is no master available.
      * @since 2.0.11
      */
     public function getMaster()
@@ -1152,7 +1152,7 @@ class Connection extends Component
      *
      * @param array $pool the list of connection configurations in the server pool
      * @param array $sharedConfig the configuration common to those given in `$pool`.
-     * @return Connection the opened DB connection, or `null` if no server is available
+     * @return Connection|null the opened DB connection, or `null` if no server is available
      * @throws InvalidConfigException if a configuration does not specify "dsn"
      * @see openFromPoolSequentially
      */
@@ -1179,7 +1179,7 @@ class Connection extends Component
      *
      * @param array $pool the list of connection configurations in the server pool
      * @param array $sharedConfig the configuration common to those given in `$pool`.
-     * @return Connection the opened DB connection, or `null` if no server is available
+     * @return Connection|null the opened DB connection, or `null` if no server is available
      * @throws InvalidConfigException if a configuration does not specify "dsn"
      * @since 2.0.11
      * @see openFromPool

--- a/framework/db/DataReader.php
+++ b/framework/db/DataReader.php
@@ -79,7 +79,7 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
      * in the result set. If using the column name, be aware that the name
      * should match the case of the column, as returned by the driver.
      * @param mixed $value Name of the PHP variable to which the column will be bound.
-     * @param int $dataType Data type of the parameter
+     * @param int|null $dataType Data type of the parameter
      * @see https://www.php.net/manual/en/function.PDOStatement-bindColumn.php
      */
     public function bindColumn($column, &$value, $dataType = null)

--- a/framework/db/Exception.php
+++ b/framework/db/Exception.php
@@ -27,7 +27,7 @@ class Exception extends \yii\base\Exception
      * @param string $message PDO error message
      * @param array $errorInfo PDO error info
      * @param string $code PDO error code
-     * @param \Throwable|\Exception $previous The previous exception used for the exception chaining.
+     * @param \Throwable|\Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message, $errorInfo = [], $code = '', $previous = null)
     {

--- a/framework/db/JsonExpression.php
+++ b/framework/db/JsonExpression.php
@@ -69,7 +69,7 @@ class JsonExpression implements ExpressionInterface, \JsonSerializable
     }
 
     /**
-     * @return null|string the type of JSON
+     * @return string|null the type of JSON
      * @see type
      */
     public function getType()

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -314,7 +314,7 @@ class Migration extends Component implements MigrationInterface
      *
      * @param string $table the name of the table to be created. The name will be properly quoted by the method.
      * @param array $columns the columns (name => definition) in the new table.
-     * @param string $options additional SQL fragment that will be appended to the generated SQL.
+     * @param string|null $options additional SQL fragment that will be appended to the generated SQL.
      */
     public function createTable($table, $columns, $options = null)
     {
@@ -457,8 +457,8 @@ class Migration extends Component implements MigrationInterface
      * @param string|array $columns the name of the column to that the constraint will be added on. If there are multiple columns, separate them with commas or use an array.
      * @param string $refTable the table that the foreign key references to.
      * @param string|array $refColumns the name of the column that the foreign key references to. If there are multiple columns, separate them with commas or use an array.
-     * @param string $delete the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
-     * @param string $update the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
+     * @param string|null $delete the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
+     * @param string|null $update the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
      */
     public function addForeignKey($name, $table, $columns, $refTable, $refColumns, $delete = null, $update = null)
     {

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -261,7 +261,6 @@ class Migration extends Component implements MigrationInterface
      * If `true` is passed, the column data will be updated to match the insert column data.
      * If `false` is passed, no update will be performed if the column data already exists.
      * @param array $params the parameters to be bound to the command.
-     * @return $this the command object itself.
      * @since 2.0.14
      */
     public function upsert($table, $insertColumns, $updateColumns = true, $params = [])

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -191,7 +191,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      * ```
      *
      * @param int $batchSize the number of records to be fetched in each batch.
-     * @param Connection $db the database connection. If not set, the "db" application component will be used.
+     * @param Connection|null $db the database connection. If not set, the "db" application component will be used.
      * @return BatchQueryResult the batch query result. It implements the [[\Iterator]] interface
      * and can be traversed to retrieve the data in batches.
      */
@@ -219,7 +219,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      * ```
      *
      * @param int $batchSize the number of records to be fetched in each batch.
-     * @param Connection $db the database connection. If not set, the "db" application component will be used.
+     * @param Connection|null $db the database connection. If not set, the "db" application component will be used.
      * @return BatchQueryResult the batch query result. It implements the [[\Iterator]] interface
      * and can be traversed to retrieve the data in batches.
      */
@@ -290,7 +290,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
     /**
      * Returns the query result as a scalar value.
      * The value returned will be the first column in the first row of the query results.
-     * @param Connection $db the database connection used to generate the SQL statement.
+     * @param Connection|null $db the database connection used to generate the SQL statement.
      * If this parameter is not given, the `db` application component will be used.
      * @return string|int|null|false the value of the first column in the first row of the query result.
      * False is returned if the query result is empty.
@@ -372,7 +372,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      * Returns the sum of the specified column values.
      * @param string $q the column name or expression.
      * Make sure you properly [quote](guide:db-dao#quoting-table-and-column-names) column names in the expression.
-     * @param Connection $db the database connection used to generate the SQL statement.
+     * @param Connection|null $db the database connection used to generate the SQL statement.
      * If this parameter is not given, the `db` application component will be used.
      * @return mixed the sum of the specified column values.
      */
@@ -389,7 +389,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      * Returns the average of the specified column values.
      * @param string $q the column name or expression.
      * Make sure you properly [quote](guide:db-dao#quoting-table-and-column-names) column names in the expression.
-     * @param Connection $db the database connection used to generate the SQL statement.
+     * @param Connection|null $db the database connection used to generate the SQL statement.
      * If this parameter is not given, the `db` application component will be used.
      * @return mixed the average of the specified column values.
      */
@@ -633,7 +633,7 @@ PATTERN;
      * Starting from version 2.0.1, you may also select sub-queries as columns by specifying each such column
      * as a `Query` instance representing the sub-query.
      *
-     * @param string $option additional option that should be appended to the 'SELECT' keyword. For example,
+     * @param string|null $option additional option that should be appended to the 'SELECT' keyword. For example,
      * in MySQL, the option 'SQL_CALC_FOUND_ROWS' can be used.
      * @return $this the query object itself
      */
@@ -1324,7 +1324,7 @@ PATTERN;
      * Use a negative number to indicate that query cache should not be used.
      * Use boolean `true` to indicate that [[Connection::queryCacheDuration]] should be used.
      * Defaults to `true`.
-     * @param \yii\caching\Dependency $dependency the cache dependency associated with the cached result.
+     * @param \yii\caching\Dependency|null $dependency the cache dependency associated with the cached result.
      * @return $this the Query object itself
      * @since 2.0.14
      */

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -53,13 +53,13 @@ class Query extends Component implements QueryInterface, ExpressionInterface
     use QueryTrait;
 
     /**
-     * @var array the columns being selected. For example, `['id', 'name']`.
+     * @var array|null the columns being selected. For example, `['id', 'name']`.
      * This is used to construct the SELECT clause in a SQL statement. If not set, it means selecting all columns.
      * @see select()
      */
     public $select;
     /**
-     * @var string additional option that should be appended to the 'SELECT' keyword. For example,
+     * @var string|null additional option that should be appended to the 'SELECT' keyword. For example,
      * in MySQL, the option 'SQL_CALC_FOUND_ROWS' can be used.
      */
     public $selectOption;
@@ -67,20 +67,20 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      * @var bool whether to select distinct rows of data only. If this is set true,
      * the SELECT clause would be changed to SELECT DISTINCT.
      */
-    public $distinct;
+    public $distinct = false;
     /**
-     * @var array the table(s) to be selected from. For example, `['user', 'post']`.
+     * @var array|null the table(s) to be selected from. For example, `['user', 'post']`.
      * This is used to construct the FROM clause in a SQL statement.
      * @see from()
      */
     public $from;
     /**
-     * @var array how to group the query results. For example, `['company', 'department']`.
+     * @var array|null how to group the query results. For example, `['company', 'department']`.
      * This is used to construct the GROUP BY clause in a SQL statement.
      */
     public $groupBy;
     /**
-     * @var array how to join with other tables. Each array element represents the specification
+     * @var array|null how to join with other tables. Each array element represents the specification
      * of one join which has the following structure:
      *
      * ```php
@@ -98,12 +98,12 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      */
     public $join;
     /**
-     * @var string|array|ExpressionInterface the condition to be applied in the GROUP BY clause.
+     * @var string|array|ExpressionInterface|null the condition to be applied in the GROUP BY clause.
      * It can be either a string or an array. Please refer to [[where()]] on how to specify the condition.
      */
     public $having;
     /**
-     * @var array this is used to construct the UNION clause(s) in a SQL statement.
+     * @var array|null this is used to construct the UNION clause(s) in a SQL statement.
      * Each array element is an array of the following structure:
      *
      * - `query`: either a string or a [[Query]] object representing a query
@@ -111,7 +111,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      */
     public $union;
     /**
-     * @var array this is used to construct the WITH section in a SQL query.
+     * @var array|null this is used to construct the WITH section in a SQL query.
      * Each array element is an array of the following structure:
      *
      * - `query`: either a string or a [[Query]] object representing a query
@@ -122,12 +122,12 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      */
     public $withQueries;
     /**
-     * @var array list of query parameter values indexed by parameter placeholders.
+     * @var array|null list of query parameter values indexed by parameter placeholders.
      * For example, `[':name' => 'Dan', ':age' => 31]`.
      */
     public $params = [];
     /**
-     * @var int|true the default number of seconds that query results can remain valid in cache.
+     * @var int|bool|null the default number of seconds that query results can remain valid in cache.
      * Use 0 to indicate that the cached data will never expire.
      * Use a negative number to indicate that query cache should not be used.
      * Use boolean `true` to indicate that [[Connection::queryCacheDuration]] should be used.
@@ -136,7 +136,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      */
     public $queryCacheDuration;
     /**
-     * @var \yii\caching\Dependency the dependency to be associated with the cached query result for this query
+     * @var \yii\caching\Dependency|null the dependency to be associated with the cached query result for this query
      * @see cache()
      * @since 2.0.14
      */

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -710,7 +710,7 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * @param string $table the name of the table to be created. The name will be properly quoted by the method.
      * @param array $columns the columns (name => definition) in the new table.
-     * @param string $options additional SQL fragment that will be appended to the generated SQL.
+     * @param string|null $options additional SQL fragment that will be appended to the generated SQL.
      * @return string the SQL statement for creating a new DB table.
      */
     public function createTable($table, $columns, $options = null)
@@ -863,8 +863,8 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param string $refTable the table that the foreign key references to.
      * @param string|array $refColumns the name of the column that the foreign key references to.
      * If there are multiple columns, separate them with commas or use an array to represent them.
-     * @param string $delete the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
-     * @param string $update the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
+     * @param string|null $delete the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
+     * @param string|null $update the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
      * @return string the SQL statement for adding a foreign key constraint to an existing table.
      */
     public function addForeignKey($name, $table, $columns, $refTable, $refColumns, $delete = null, $update = null)
@@ -1035,7 +1035,7 @@ class QueryBuilder extends \yii\base\BaseObject
      * The sequence will be reset such that the primary key of the next new row inserted
      * will have the specified value or the maximum existing value +1.
      * @param string $table the name of the table whose primary key sequence will be reset
-     * @param array|string $value the value for the primary key of the next new row inserted. If this is not set,
+     * @param array|string|null $value the value for the primary key of the next new row inserted. If this is not set,
      * the next new row's primary key will have the maximum existing value +1.
      * @return string the SQL statement for resetting sequence
      * @throws NotSupportedException if this is not supported by the underlying DBMS
@@ -1051,7 +1051,7 @@ class QueryBuilder extends \yii\base\BaseObject
      * The sequence is reset such that the primary key of the next new row inserted
      * will have the specified value or the maximum existing value +1.
      * @param string $table the name of the table whose primary key sequence is reset
-     * @param array|string $value the value for the primary key of the next new row inserted. If this is not set,
+     * @param array|string|null $value the value for the primary key of the next new row inserted. If this is not set,
      * the next new row's primary key will have the maximum existing value +1.
      * @throws NotSupportedException if this is not supported by the underlying DBMS
      * @since 2.0.16
@@ -1228,7 +1228,7 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param array $columns
      * @param array $params the binding parameters to be populated
      * @param bool $distinct
-     * @param string $selectOption
+     * @param string|null $selectOption
      * @return string the SELECT clause built from [[Query::$select]].
      */
     public function buildSelect($columns, &$params, $distinct = false, $selectOption = null)

--- a/framework/db/QueryInterface.php
+++ b/framework/db/QueryInterface.php
@@ -24,7 +24,7 @@ interface QueryInterface
 {
     /**
      * Executes the query and returns all results as an array.
-     * @param Connection $db the database connection used to execute the query.
+     * @param Connection|null $db the database connection used to execute the query.
      * If this parameter is not given, the `db` application component will be used.
      * @return array the query results. If the query results in nothing, an empty array will be returned.
      */
@@ -32,7 +32,7 @@ interface QueryInterface
 
     /**
      * Executes the query and returns a single row of result.
-     * @param Connection $db the database connection used to execute the query.
+     * @param Connection|null $db the database connection used to execute the query.
      * If this parameter is not given, the `db` application component will be used.
      * @return array|bool the first row (in terms of an array) of the query result. False is returned if the query
      * results in nothing.

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -322,7 +322,7 @@ abstract class Schema extends BaseObject
      * This method may be overridden by child classes to create a DBMS-specific column schema builder.
      *
      * @param string $type type of the column. See [[ColumnSchemaBuilder::$type]].
-     * @param int|string|array $length length or precision of the column. See [[ColumnSchemaBuilder::$length]].
+     * @param int|string|array|null $length length or precision of the column. See [[ColumnSchemaBuilder::$length]].
      * @return ColumnSchemaBuilder column schema builder instance
      * @since 2.0.6
      */

--- a/framework/db/SchemaBuilderTrait.php
+++ b/framework/db/SchemaBuilderTrait.php
@@ -41,7 +41,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a primary key column.
-     * @param int $length column size or precision definition.
+     * @param int|null $length column size or precision definition.
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -53,7 +53,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a big primary key column.
-     * @param int $length column size or precision definition.
+     * @param int|null $length column size or precision definition.
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -65,7 +65,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a char column.
-     * @param int $length column size definition i.e. the maximum string length.
+     * @param int|null $length column size definition i.e. the maximum string length.
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.8
@@ -77,7 +77,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a string column.
-     * @param int $length column size definition i.e. the maximum string length.
+     * @param int|null $length column size definition i.e. the maximum string length.
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -99,7 +99,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a tinyint column. If tinyint is not supported by the DBMS, smallint will be used.
-     * @param int $length column size or precision definition.
+     * @param int|null $length column size or precision definition.
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.14
@@ -111,7 +111,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a smallint column.
-     * @param int $length column size or precision definition.
+     * @param int|null $length column size or precision definition.
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -123,7 +123,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates an integer column.
-     * @param int $length column size or precision definition.
+     * @param int|null $length column size or precision definition.
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -135,7 +135,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a bigint column.
-     * @param int $length column size or precision definition.
+     * @param int|null $length column size or precision definition.
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -147,7 +147,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a float column.
-     * @param int $precision column value precision. First parameter passed to the column type, e.g. FLOAT(precision).
+     * @param int|null $precision column value precision. First parameter passed to the column type, e.g. FLOAT(precision).
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -159,7 +159,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a double column.
-     * @param int $precision column value precision. First parameter passed to the column type, e.g. DOUBLE(precision).
+     * @param int|null $precision column value precision. First parameter passed to the column type, e.g. DOUBLE(precision).
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -171,10 +171,10 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a decimal column.
-     * @param int $precision column value precision, which is usually the total number of digits.
+     * @param int|null $precision column value precision, which is usually the total number of digits.
      * First parameter passed to the column type, e.g. DECIMAL(precision, scale).
      * This parameter will be ignored if not supported by the DBMS.
-     * @param int $scale column value scale, which is usually the number of digits after the decimal point.
+     * @param int|null $scale column value scale, which is usually the number of digits after the decimal point.
      * Second parameter passed to the column type, e.g. DECIMAL(precision, scale).
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
@@ -195,7 +195,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a datetime column.
-     * @param int $precision column value precision. First parameter passed to the column type, e.g. DATETIME(precision).
+     * @param int|null $precision column value precision. First parameter passed to the column type, e.g. DATETIME(precision).
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -207,7 +207,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a timestamp column.
-     * @param int $precision column value precision. First parameter passed to the column type, e.g. TIMESTAMP(precision).
+     * @param int|null $precision column value precision. First parameter passed to the column type, e.g. TIMESTAMP(precision).
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -219,7 +219,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a time column.
-     * @param int $precision column value precision. First parameter passed to the column type, e.g. TIME(precision).
+     * @param int|null $precision column value precision. First parameter passed to the column type, e.g. TIME(precision).
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -241,7 +241,7 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a binary column.
-     * @param int $length column size or precision definition.
+     * @param int|null $length column size or precision definition.
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.
      * @since 2.0.6
@@ -263,10 +263,10 @@ trait SchemaBuilderTrait
 
     /**
      * Creates a money column.
-     * @param int $precision column value precision, which is usually the total number of digits.
+     * @param int|null $precision column value precision, which is usually the total number of digits.
      * First parameter passed to the column type, e.g. DECIMAL(precision, scale).
      * This parameter will be ignored if not supported by the DBMS.
-     * @param int $scale column value scale, which is usually the number of digits after the decimal point.
+     * @param int|null $scale column value scale, which is usually the number of digits after the decimal point.
      * Second parameter passed to the column type, e.g. DECIMAL(precision, scale).
      * This parameter will be ignored if not supported by the DBMS.
      * @return ColumnSchemaBuilder the column instance which can be further customized.

--- a/framework/db/TableSchema.php
+++ b/framework/db/TableSchema.php
@@ -39,7 +39,7 @@ class TableSchema extends BaseObject
      */
     public $primaryKey = [];
     /**
-     * @var string sequence name for the primary key. Null if no sequence.
+     * @var string|null sequence name for the primary key. Null if no sequence.
      */
     public $sequenceName;
     /**

--- a/framework/db/conditions/LikeCondition.php
+++ b/framework/db/conditions/LikeCondition.php
@@ -18,7 +18,7 @@ use yii\base\InvalidArgumentException;
 class LikeCondition extends SimpleCondition
 {
     /**
-     * @var array|false map of chars to their replacements, false if characters should not be escaped
+     * @var array|null|false map of chars to their replacements, false if characters should not be escaped
      * or either null or empty array if escaping is condition builder responsibility.
      * By default it's set to `null`.
      */

--- a/framework/db/cubrid/QueryBuilder.php
+++ b/framework/db/cubrid/QueryBuilder.php
@@ -263,7 +263,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      *
      * @param string $table table name
      * @param string $column column name
-     * @return null|string the column definition
+     * @return string|null the column definition
      * @throws Exception in case when table does not contain column
      * @since 2.0.8
      */

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -293,7 +293,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
       * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
       * @param string $table the table to be commented or whose column is to be commented. The table name will be
       * properly quoted by the method.
-      * @param string $column optional. The name of the column to be commented. If empty, the command will add the
+      * @param string|null $column optional. The name of the column to be commented. If empty, the command will add the
       * comment to the table instead. The column name will be properly quoted by the method.
       * @return string the SQL statement for adding a comment.
       * @throws InvalidArgumentException if the table does not exist.
@@ -359,7 +359,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      *
      * @param string $table the table that will have the comment removed or whose column will have the comment removed.
      * The table name will be properly quoted by the method.
-     * @param string $column optional. The name of the column whose comment will be removed. If empty, the command
+     * @param string|null $column optional. The name of the column whose comment will be removed. If empty, the command
      * will remove the comment from the table instead. The column name will be properly quoted by the method.
      * @return string the SQL statement for removing the comment.
      * @throws InvalidArgumentException if the table does not exist.
@@ -415,7 +415,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
     /**
      * Returns an array of column names given model name.
      *
-     * @param string $modelClass name of the model class
+     * @param string|null $modelClass name of the model class
      * @return array|null array of column names
      */
     protected function getAllColumnNames($modelClass = null)

--- a/framework/db/mssql/TableSchema.php
+++ b/framework/db/mssql/TableSchema.php
@@ -16,7 +16,7 @@ namespace yii\db\mssql;
 class TableSchema extends \yii\db\TableSchema
 {
     /**
-     * @var string name of the catalog (database) that this table belongs to.
+     * @var string|null name of the catalog (database) that this table belongs to.
      * Defaults to null, meaning no catalog (or the current database).
      */
     public $catalogName;

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -357,7 +357,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      *
      * @param string $table table name
      * @param string $column column name
-     * @return null|string the column definition
+     * @return string|null the column definition
      * @throws Exception in case when table does not contain column
      */
     private function getColumnDefinition($table, $column)

--- a/framework/db/oci/conditions/InConditionBuilder.php
+++ b/framework/db/oci/conditions/InConditionBuilder.php
@@ -39,7 +39,7 @@ class InConditionBuilder extends \yii\db\conditions\InConditionBuilder
      *
      * @param ExpressionInterface|InCondition $condition the expression to be built.
      * @param array $params the binding parameters.
-     * @return null|string null when split is not required. Otherwise - built SQL condition.
+     * @return string|null null when split is not required. Otherwise - built SQL condition.
      */
     protected function splitCondition(InCondition $condition, &$params)
     {

--- a/framework/db/pgsql/ArrayParser.php
+++ b/framework/db/pgsql/ArrayParser.php
@@ -80,7 +80,7 @@ class ArrayParser
      *
      * @param string $value
      * @param int $i parse starting position
-     * @return null|string
+     * @return string|null
      */
     private function parseString($value, &$i)
     {

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -290,8 +290,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * @param string $refTable the table that the foreign key references to.
      * @param string|array $refColumns the name of the column that the foreign key references to.
      * If there are multiple columns, separate them with commas or use an array to represent them.
-     * @param string $delete the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
-     * @param string $update the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
+     * @param string|null $delete the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
+     * @param string|null $update the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
      * @return string the SQL statement for adding a foreign key constraint to an existing table.
      * @throws NotSupportedException this is not supported by SQLite
      */

--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -579,7 +579,7 @@ class Container extends Component
     /**
      * Resolves dependencies by replacing them with the actual object instances.
      * @param array $dependencies the dependencies
-     * @param ReflectionClass $reflection the class reflection associated with the dependencies
+     * @param ReflectionClass|null $reflection the class reflection associated with the dependencies
      * @return array the resolved dependencies
      * @throws InvalidConfigException if a dependency cannot be resolved or if a dependency cannot be fulfilled.
      */

--- a/framework/di/Instance.php
+++ b/framework/di/Instance.php
@@ -111,8 +111,8 @@ class Instance
      * You may specify a reference in terms of a component ID or an Instance object.
      * Starting from version 2.0.2, you may also pass in a configuration array for creating the object.
      * If the "class" value is not specified in the configuration array, it will use the value of `$type`.
-     * @param string $type the class/interface name to be checked. If null, type check will not be performed.
-     * @param ServiceLocator|Container $container the container. This will be passed to [[get()]].
+     * @param string|null $type the class/interface name to be checked. If null, type check will not be performed.
+     * @param ServiceLocator|Container|null $container the container. This will be passed to [[get()]].
      * @return object the object referenced by the Instance, or `$reference` itself if it is an object.
      * @throws InvalidConfigException if the reference is invalid
      */
@@ -159,7 +159,7 @@ class Instance
 
     /**
      * Returns the actual object referenced by this Instance object.
-     * @param ServiceLocator|Container $container the container used to locate the referenced object.
+     * @param ServiceLocator|Container|null $container the container used to locate the referenced object.
      * If null, the method will first try `Yii::$app` then `Yii::$container`.
      * @return object the actual object referenced by this Instance object.
      */

--- a/framework/filters/HttpCache.php
+++ b/framework/filters/HttpCache.php
@@ -86,12 +86,12 @@ class HttpCache extends ActionFilter
      */
     public $params;
     /**
-     * @var string the value of the `Cache-Control` HTTP header. If null, the header will not be sent.
+     * @var string|null the value of the `Cache-Control` HTTP header. If null, the header will not be sent.
      * @see http://tools.ietf.org/html/rfc2616#section-14.9
      */
     public $cacheControlHeader = 'public, max-age=3600';
     /**
-     * @var string the name of the cache limiter to be set when [session_cache_limiter()](https://www.php.net/manual/en/function.session-cache-limiter.php)
+     * @var string|null the name of the cache limiter to be set when [session_cache_limiter()](https://www.php.net/manual/en/function.session-cache-limiter.php)
      * is called. The default value is an empty string, meaning turning off automatic sending of cache headers entirely.
      * You may set this property to be `public`, `private`, `private_no_expire`, and `nocache`.
      * Please refer to [session_cache_limiter()](https://www.php.net/manual/en/function.session-cache-limiter.php)
@@ -158,9 +158,9 @@ class HttpCache extends ActionFilter
     /**
      * Validates if the HTTP cache contains valid content.
      * If both Last-Modified and ETag are null, returns false.
-     * @param int $lastModified the calculated Last-Modified value in terms of a UNIX timestamp.
+     * @param int|null $lastModified the calculated Last-Modified value in terms of a UNIX timestamp.
      * If null, the Last-Modified header will not be validated.
-     * @param string $etag the calculated ETag value. If null, the ETag header will not be validated.
+     * @param string|null $etag the calculated ETag value. If null, the ETag header will not be validated.
      * @return bool whether the HTTP cache is still valid.
      */
     protected function validateCache($lastModified, $etag)

--- a/framework/filters/auth/AuthInterface.php
+++ b/framework/filters/auth/AuthInterface.php
@@ -26,7 +26,7 @@ interface AuthInterface
      * @param User $user
      * @param Request $request
      * @param Response $response
-     * @return IdentityInterface the authenticated user identity. If authentication information is not provided, null will be returned.
+     * @return IdentityInterface|null the authenticated user identity. If authentication information is not provided, null will be returned.
      * @throws UnauthorizedHttpException if authentication information is provided but is invalid.
      */
     public function authenticate($user, $request, $response);

--- a/framework/grid/Column.php
+++ b/framework/grid/Column.php
@@ -26,7 +26,7 @@ class Column extends BaseObject
      */
     public $grid;
     /**
-     * @var null|string the header cell content. Note that it will not be HTML-encoded.
+     * @var string|null the header cell content. Note that it will not be HTML-encoded.
      */
     public $header;
     /**

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -585,7 +585,7 @@ class BaseArrayHelper
      * @param array $array
      * @param string|\Closure $from
      * @param string|\Closure $to
-     * @param string|\Closure $group
+     * @param string|\Closure|null $group
      * @return array
      */
     public static function map($array, $from, $to, $group = null)
@@ -697,7 +697,7 @@ class BaseArrayHelper
      * @param array $data data to be encoded
      * @param bool $valuesOnly whether to encode array values only. If false,
      * both the array keys and array values will be encoded.
-     * @param string $charset the charset that the data is using. If not set,
+     * @param string|null $charset the charset that the data is using. If not set,
      * [[\yii\base\Application::charset]] will be used.
      * @return array the encoded data
      * @see https://www.php.net/manual/en/function.htmlspecialchars.php

--- a/framework/helpers/BaseConsole.php
+++ b/framework/helpers/BaseConsole.php
@@ -807,7 +807,7 @@ class BaseConsole
      * Asks the user for input. Ends when the user types a carriage return (PHP_EOL). Optionally, It also provides a
      * prompt.
      *
-     * @param string $prompt the prompt to display before waiting for input (optional)
+     * @param string|null $prompt the prompt to display before waiting for input (optional)
      * @return string the user's input
      */
     public static function input($prompt = null)
@@ -822,7 +822,7 @@ class BaseConsole
     /**
      * Prints text to STDOUT appended with a carriage return (PHP_EOL).
      *
-     * @param string $string the text to print
+     * @param string|null $string the text to print
      * @return int|bool number of bytes printed or false on error.
      */
     public static function output($string = null)
@@ -833,7 +833,7 @@ class BaseConsole
     /**
      * Prints text to STDERR appended with a carriage return (PHP_EOL).
      *
-     * @param string $string the text to print
+     * @param string|null $string the text to print
      * @return int|bool number of bytes printed or false on error.
      */
     public static function error($string = null)
@@ -998,7 +998,7 @@ class BaseConsole
      * @param int $total the total value of items that are to be done.
      * @param string $prefix an optional string to display before the progress bar.
      * Default to empty string which results in no prefix to be displayed.
-     * @param int|float|bool $width optional width of the progressbar. This can be an integer representing
+     * @param int|float|bool|null $width optional width of the progressbar. This can be an integer representing
      * the number of characters to display for the progress bar or a float between 0 and 1 representing the
      * percentage of screen with the progress bar may take. It can also be set to false to disable the
      * bar and only show progress information like percent, number of items and ETA.
@@ -1024,7 +1024,7 @@ class BaseConsole
      *
      * @param int $done the number of items that are completed.
      * @param int $total the total value of items that are to be done.
-     * @param string $prefix an optional string to display before the progress bar.
+     * @param string|null $prefix an optional string to display before the progress bar.
      * Defaults to null meaning the prefix specified by [[startProgress()]] will be used.
      * If prefix is specified it will update the prefix that will be used by later calls.
      * @see startProgress

--- a/framework/helpers/BaseFormatConverter.php
+++ b/framework/helpers/BaseFormatConverter.php
@@ -96,7 +96,7 @@ class BaseFormatConverter
      *
      * @param string $pattern date format pattern in ICU format.
      * @param string $type 'date', 'time', or 'datetime'.
-     * @param string $locale the locale to use for converting ICU short patterns `short`, `medium`, `long` and `full`.
+     * @param string|null $locale the locale to use for converting ICU short patterns `short`, `medium`, `long` and `full`.
      * If not given, `Yii::$app->language` will be used.
      * @return string The converted date format pattern.
      */
@@ -353,7 +353,7 @@ class BaseFormatConverter
      *
      * @param string $pattern date format pattern in ICU format.
      * @param string $type 'date', 'time', or 'datetime'.
-     * @param string $locale the locale to use for converting ICU short patterns `short`, `medium`, `long` and `full`.
+     * @param string|null $locale the locale to use for converting ICU short patterns `short`, `medium`, `long` and `full`.
      * If not given, `Yii::$app->language` will be used.
      * @return string The converted date format pattern.
      */

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -572,7 +572,7 @@ class BaseHtml
 
     /**
      * Generates an input button.
-     * @param string $label the value attribute. If it is null, the value attribute will not be generated.
+     * @param string|null $label the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as
      * the attributes of the resulting tag. The values will be HTML-encoded using [[encode()]].
      * If a value is null, the corresponding attribute will not be rendered.
@@ -592,7 +592,7 @@ class BaseHtml
      * Be careful when naming form elements such as submit buttons. According to the [jQuery documentation](https://api.jquery.com/submit/) there
      * are some reserved names that can cause conflicts, e.g. `submit`, `length`, or `method`.
      *
-     * @param string $label the value attribute. If it is null, the value attribute will not be generated.
+     * @param string|null $label the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as
      * the attributes of the resulting tag. The values will be HTML-encoded using [[encode()]].
      * If a value is null, the corresponding attribute will not be rendered.
@@ -608,7 +608,7 @@ class BaseHtml
 
     /**
      * Generates a reset input button.
-     * @param string $label the value attribute. If it is null, the value attribute will not be generated.
+     * @param string|null $label the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the attributes of the button tag. The values will be HTML-encoded using [[encode()]].
      * Attributes whose value is null will be ignored and not put in the tag returned.
      * See [[renderTagAttributes()]] for details on how attributes are being rendered.

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -506,7 +506,7 @@ class BaseInflector
      * of the helper.
      *
      * @param string $string input string
-     * @param string|\Transliterator $transliterator either a [[\Transliterator]] or a string
+     * @param string|\Transliterator|null $transliterator either a [[\Transliterator]] or a string
      * from which a [[\Transliterator]] can be built.
      * @return string
      * @since 2.0.7 this method is public.
@@ -586,8 +586,8 @@ class BaseInflector
      * ```
      *
      * @param array $words the words to be converted into an string
-     * @param string $twoWordsConnector the string connecting words when there are only two
-     * @param string $lastWordConnector the string connecting the last two words. If this is null, it will
+     * @param string|null $twoWordsConnector the string connecting words when there are only two
+     * @param string|null $lastWordConnector the string connecting the last two words. If this is null, it will
      * take the value of `$twoWordsConnector`.
      * @param string $connector the string connecting words other than those connected by
      * $lastWordConnector and $twoWordsConnector

--- a/framework/helpers/BaseMarkdown.php
+++ b/framework/helpers/BaseMarkdown.php
@@ -54,7 +54,7 @@ class BaseMarkdown
      * Converts markdown into HTML.
      *
      * @param string $markdown the markdown text to parse
-     * @param string $flavor the markdown flavor to use. See [[$flavors]] for available values.
+     * @param string|null $flavor the markdown flavor to use. See [[$flavors]] for available values.
      * Defaults to [[$defaultFlavor]], if not set.
      * @return string the parsed HTML output
      * @throws InvalidArgumentException when an undefined flavor is given.
@@ -72,7 +72,7 @@ class BaseMarkdown
      * This can be useful for parsing small comments or description lines.
      *
      * @param string $markdown the markdown text to parse
-     * @param string $flavor the markdown flavor to use. See [[$flavors]] for available values.
+     * @param string|null $flavor the markdown flavor to use. See [[$flavors]] for available values.
      * Defaults to [[$defaultFlavor]], if not set.
      * @return string the parsed HTML output
      * @throws InvalidArgumentException when an undefined flavor is given.

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -38,7 +38,7 @@ class BaseStringHelper
      *
      * @param string $string the input string. Must be one character or longer.
      * @param int $start the starting position
-     * @param int $length the desired portion length. If not specified or `null`, there will be
+     * @param int|null $length the desired portion length. If not specified or `null`, there will be
      * no limit on length i.e. the output will be until the end of the string.
      * @return string the extracted part of string, or FALSE on failure or an empty string.
      * @see https://www.php.net/manual/en/function.substr.php
@@ -111,7 +111,7 @@ class BaseStringHelper
      * @param string $string The string to truncate.
      * @param int $length How many characters from original string to include into truncated string.
      * @param string $suffix String to append to the end of truncated string.
-     * @param string $encoding The charset to use, defaults to charset currently used by application.
+     * @param string|null $encoding The charset to use, defaults to charset currently used by application.
      * @param bool $asHtml Whether to treat the string being truncated as HTML and preserve proper HTML tags.
      * This parameter is available since version 2.0.1.
      * @return string the truncated string.

--- a/framework/helpers/BaseUrl.php
+++ b/framework/helpers/BaseUrl.php
@@ -290,7 +290,7 @@ class BaseUrl
      *
      * @param string|array $url the URL to remember. Please refer to [[to()]] for acceptable formats.
      * If this parameter is not specified, the currently requested URL will be used.
-     * @param string $name the name associated with the URL to be remembered. This can be used
+     * @param string|null $name the name associated with the URL to be remembered. This can be used
      * later by [[previous()]]. If not set, [[\yii\web\User::setReturnUrl()]] will be used with passed URL.
      * @see previous()
      * @see \yii\web\User::setReturnUrl()
@@ -309,7 +309,7 @@ class BaseUrl
     /**
      * Returns the URL previously [[remember()|remembered]].
      *
-     * @param string $name the named associated with the URL that was remembered previously.
+     * @param string|null $name the named associated with the URL that was remembered previously.
      * If not set, [[\yii\web\User::getReturnUrl()]] will be used to obtain remembered URL.
      * @return string|null the URL previously remembered. Null is returned if no URL was remembered with the given name
      * and `$name` is not specified.

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -1636,7 +1636,7 @@ class Formatter extends Component
     /**
      * @param string $unitType one of [[UNIT_WEIGHT]], [[UNIT_LENGTH]]
      * @param string $unitFormat one of [[FORMAT_WIDTH_SHORT]], [[FORMAT_WIDTH_LONG]]
-     * @param string $system either [[UNIT_SYSTEM_METRIC]] or [[UNIT_SYSTEM_IMPERIAL]]. When `null`, property [[systemOfUnits]] will be used.
+     * @param string|null $system either [[UNIT_SYSTEM_METRIC]] or [[UNIT_SYSTEM_IMPERIAL]]. When `null`, property [[systemOfUnits]] will be used.
      * @param int $position internal position of size unit
      * @return string
      * @throws InvalidConfigException when INTL is not installed or does not contain required information

--- a/framework/i18n/GettextMoFile.php
+++ b/framework/i18n/GettextMoFile.php
@@ -250,7 +250,7 @@ class GettextMoFile extends GettextFile
      * Reads a string.
      * @param resource $fileHandle file handle
      * @param int $length of the string
-     * @param int $offset of the string in the file. If null, it reads from the current position.
+     * @param int|null $offset of the string in the file. If null, it reads from the current position.
      * @return string the result
      */
     protected function readString($fileHandle, $length, $offset = null)

--- a/framework/i18n/Locale.php
+++ b/framework/i18n/Locale.php
@@ -46,7 +46,7 @@ class Locale extends Component
     /**
      * Returns a currency symbol
      *
-     * @param string $currencyCode the 3-letter ISO 4217 currency code to get symbol for. If null,
+     * @param string|null $currencyCode the 3-letter ISO 4217 currency code to get symbol for. If null,
      * method will attempt using currency code from [[locale]].
      * @return string
      */

--- a/framework/i18n/MissingTranslationEvent.php
+++ b/framework/i18n/MissingTranslationEvent.php
@@ -23,7 +23,7 @@ class MissingTranslationEvent extends Event
      */
     public $message;
     /**
-     * @var string the translated message. An event handler may overwrite this property
+     * @var string|null the translated message. An event handler may overwrite this property
      * with a translated version of [[message]] if possible. If not set (null), it means the message is not translated.
      */
     public $translatedMessage;

--- a/framework/log/SyslogTarget.php
+++ b/framework/log/SyslogTarget.php
@@ -27,7 +27,7 @@ class SyslogTarget extends Target
      */
     public $facility = LOG_USER;
     /**
-     * @var int openlog options. This is a bitfield passed as the `$option` parameter to [openlog()](https://www.php.net/openlog).
+     * @var int|null openlog options. This is a bitfield passed as the `$option` parameter to [openlog()](https://www.php.net/openlog).
      * Defaults to `null` which means to use the default options `LOG_ODELAY | LOG_PID`.
      * @see https://www.php.net/openlog for available options.
      * @since 2.0.11

--- a/framework/mail/BaseMessage.php
+++ b/framework/mail/BaseMessage.php
@@ -25,7 +25,7 @@ use yii\base\ErrorHandler;
 abstract class BaseMessage extends BaseObject implements MessageInterface
 {
     /**
-     * @var MailerInterface the mailer instance that created this message.
+     * @var MailerInterface|null the mailer instance that created this message.
      * For independently created messages this is `null`.
      */
     public $mailer;
@@ -33,7 +33,7 @@ abstract class BaseMessage extends BaseObject implements MessageInterface
 
     /**
      * Sends this email message.
-     * @param MailerInterface $mailer the mailer that should be used to send this message.
+     * @param MailerInterface|null $mailer the mailer that should be used to send this message.
      * If no mailer is given it will first check if [[mailer]] is set and if not,
      * the "mailer" application component will be used instead.
      * @return bool whether this message is sent successfully.

--- a/framework/mail/MessageInterface.php
+++ b/framework/mail/MessageInterface.php
@@ -204,7 +204,7 @@ interface MessageInterface
 
     /**
      * Sends this email message.
-     * @param MailerInterface $mailer the mailer that should be used to send this message.
+     * @param MailerInterface|null $mailer the mailer that should be used to send this message.
      * If null, the "mailer" application component will be used instead.
      * @return bool whether this message is sent successfully.
      */

--- a/framework/rbac/ManagerInterface.php
+++ b/framework/rbac/ManagerInterface.php
@@ -60,7 +60,7 @@ interface ManagerInterface extends CheckAccessInterface
     /**
      * Returns the named role.
      * @param string $name the role name.
-     * @return null|Role the role corresponding to the specified name. Null is returned if no such role.
+     * @return Role|null the role corresponding to the specified name. Null is returned if no such role.
      */
     public function getRole($name);
 
@@ -91,7 +91,7 @@ interface ManagerInterface extends CheckAccessInterface
     /**
      * Returns the named permission.
      * @param string $name the permission name.
-     * @return null|Permission the permission corresponding to the specified name. Null is returned if no such permission.
+     * @return Permission|null the permission corresponding to the specified name. Null is returned if no such permission.
      */
     public function getPermission($name);
 
@@ -118,7 +118,7 @@ interface ManagerInterface extends CheckAccessInterface
     /**
      * Returns the rule of the specified name.
      * @param string $name the rule name
-     * @return null|Rule the rule object, or null if the specified name does not correspond to a rule.
+     * @return Rule|null the rule object, or null if the specified name does not correspond to a rule.
      */
     public function getRule($name);
 
@@ -208,7 +208,7 @@ interface ManagerInterface extends CheckAccessInterface
      * Returns the assignment information regarding a role and a user.
      * @param string $roleName the role name
      * @param string|int $userId the user ID (see [[\yii\web\User::id]])
-     * @return null|Assignment the assignment information. Null is returned if
+     * @return Assignment|null the assignment information. Null is returned if
      * the role is not assigned to the user.
      */
     public function getAssignment($roleName, $userId);

--- a/framework/requirements/YiiRequirementChecker.php
+++ b/framework/requirements/YiiRequirementChecker.php
@@ -295,9 +295,9 @@ class YiiRequirementChecker
      * This method includes the view file as a PHP script
      * and captures the display result if required.
      * @param string $_viewFile_ view file
-     * @param array $_data_ data to be extracted and made available to the view file
+     * @param array|null $_data_ data to be extracted and made available to the view file
      * @param bool $_return_ whether the rendering result should be returned as a string
-     * @return string the rendering result. Null if the rendering result is not required.
+     * @return string|null the rendering result. Null if the rendering result is not required.
      */
     function renderViewFile($_viewFile_, $_data_ = null, $_return_ = false)
     {

--- a/framework/rest/ActiveController.php
+++ b/framework/rest/ActiveController.php
@@ -127,7 +127,7 @@ class ActiveController extends Controller
      * If the user does not have access, a [[ForbiddenHttpException]] should be thrown.
      *
      * @param string $action the ID of the action to be executed
-     * @param object $model the model to be accessed. If null, it means no specific model is being accessed.
+     * @param object|null $model the model to be accessed. If null, it means no specific model is being accessed.
      * @param array $params additional parameters
      * @throws ForbiddenHttpException if the user does not have access
      */

--- a/framework/rest/OptionsAction.php
+++ b/framework/rest/OptionsAction.php
@@ -31,7 +31,7 @@ class OptionsAction extends \yii\base\Action
 
     /**
      * Responds to the OPTIONS request.
-     * @param string $id
+     * @param string|null $id
      */
     public function run($id = null)
     {

--- a/framework/test/BaseActiveFixture.php
+++ b/framework/test/BaseActiveFixture.php
@@ -42,7 +42,7 @@ abstract class BaseActiveFixture extends DbFixture implements \IteratorAggregate
      * Returns the AR model by the specified model name.
      * A model name is the key of the corresponding data row in [[data]].
      * @param string $name the model name.
-     * @return null|\yii\db\ActiveRecord the AR model, or null if the model cannot be found in the database
+     * @return \yii\db\ActiveRecord|null the AR model, or null if the model cannot be found in the database
      * @throws \yii\base\InvalidConfigException if [[modelClass]] is not set.
      */
     public function getModel($name)

--- a/framework/test/FixtureTrait.php
+++ b/framework/test/FixtureTrait.php
@@ -79,7 +79,7 @@ trait FixtureTrait
     /**
      * Loads the specified fixtures.
      * This method will call [[Fixture::load()]] for every fixture object.
-     * @param Fixture[] $fixtures the fixtures to be loaded. If this parameter is not specified,
+     * @param Fixture[]|null $fixtures the fixtures to be loaded. If this parameter is not specified,
      * the return value of [[getFixtures()]] will be used.
      */
     public function loadFixtures($fixtures = null)
@@ -103,7 +103,7 @@ trait FixtureTrait
     /**
      * Unloads the specified fixtures.
      * This method will call [[Fixture::unload()]] for every fixture object.
-     * @param Fixture[] $fixtures the fixtures to be loaded. If this parameter is not specified,
+     * @param Fixture[]|null $fixtures the fixtures to be loaded. If this parameter is not specified,
      * the return value of [[getFixtures()]] will be used.
      */
     public function unloadFixtures($fixtures = null)
@@ -151,7 +151,7 @@ trait FixtureTrait
     /**
      * Returns the named fixture.
      * @param string $name the fixture name. This can be either the fixture alias name, or the class name if the alias is not used.
-     * @return Fixture the fixture object, or null if the named fixture does not exist.
+     * @return Fixture|null the fixture object, or null if the named fixture does not exist.
      */
     public function getFixture($name)
     {

--- a/framework/validators/DateValidator.php
+++ b/framework/validators/DateValidator.php
@@ -119,7 +119,7 @@ class DateValidator extends Validator
      */
     public $timeZone;
     /**
-     * @var string the name of the attribute to receive the parsing result.
+     * @var string|null the name of the attribute to receive the parsing result.
      * When this property is not null and the validation is successful, the named attribute will
      * receive the parsing result.
      *
@@ -160,7 +160,7 @@ class DateValidator extends Validator
      */
     public $timestampAttributeTimeZone = 'UTC';
     /**
-     * @var int|string upper limit of the date. Defaults to null, meaning no upper limit.
+     * @var int|string|null upper limit of the date. Defaults to null, meaning no upper limit.
      * This can be a unix timestamp or a string representing a date time value.
      * If this property is a string, [[format]] will be used to parse it.
      * @see tooBig for the customized message used when the date is too big.
@@ -168,7 +168,7 @@ class DateValidator extends Validator
      */
     public $max;
     /**
-     * @var int|string lower limit of the date. Defaults to null, meaning no lower limit.
+     * @var int|string|null lower limit of the date. Defaults to null, meaning no lower limit.
      * This can be a unix timestamp or a string representing a date time value.
      * If this property is a string, [[format]] will be used to parse it.
      * @see tooSmall for the customized message used when the date is too small.
@@ -186,13 +186,13 @@ class DateValidator extends Validator
      */
     public $tooSmall;
     /**
-     * @var string user friendly value of upper limit to display in the error message.
+     * @var string|null user friendly value of upper limit to display in the error message.
      * If this property is null, the value of [[max]] will be used (before parsing).
      * @since 2.0.4
      */
     public $maxString;
     /**
-     * @var string user friendly value of lower limit to display in the error message.
+     * @var string|null user friendly value of lower limit to display in the error message.
      * If this property is null, the value of [[min]] will be used (before parsing).
      * @since 2.0.4
      */

--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -308,7 +308,7 @@ class ExistValidator extends Validator
      * Returns conditions with alias.
      * @param ActiveQuery $query
      * @param array $conditions array of condition, keys to be modified
-     * @param null|string $alias set empty string for no apply alias. Set null for apply primary table alias
+     * @param string|null $alias set empty string for no apply alias. Set null for apply primary table alias
      * @return array
      */
     private function applyTableAlias($query, $conditions, $alias = null)

--- a/framework/validators/FileValidator.php
+++ b/framework/validators/FileValidator.php
@@ -28,7 +28,7 @@ use yii\web\UploadedFile;
 class FileValidator extends Validator
 {
     /**
-     * @var array|string a list of file name extensions that are allowed to be uploaded.
+     * @var array|string|null a list of file name extensions that are allowed to be uploaded.
      * This can be either an array or a string consisting of file extension names
      * separated by space or comma (e.g. "gif, jpg").
      * Extension names are case-insensitive. Defaults to null, meaning all file name
@@ -42,7 +42,7 @@ class FileValidator extends Validator
      */
     public $checkExtensionByMimeType = true;
     /**
-     * @var array|string a list of file MIME types that are allowed to be uploaded.
+     * @var array|string|null a list of file MIME types that are allowed to be uploaded.
      * This can be either an array or a string consisting of file MIME types
      * separated by space or comma (e.g. "text/plain, image/png").
      * The mask with the special character `*` can be used to match groups of mime types.
@@ -52,13 +52,13 @@ class FileValidator extends Validator
      */
     public $mimeTypes;
     /**
-     * @var int the minimum number of bytes required for the uploaded file.
+     * @var int|null the minimum number of bytes required for the uploaded file.
      * Defaults to null, meaning no limit.
      * @see tooSmall for the customized message for a file that is too small.
      */
     public $minSize;
     /**
-     * @var int the maximum number of bytes required for the uploaded file.
+     * @var int|null the maximum number of bytes required for the uploaded file.
      * Defaults to null, meaning no limit.
      * Note, the size limit is also affected by `upload_max_filesize` and `post_max_size` INI setting
      * and the 'MAX_FILE_SIZE' hidden field value. See [[getSizeLimit()]] for details.

--- a/framework/validators/ImageValidator.php
+++ b/framework/validators/ImageValidator.php
@@ -27,25 +27,25 @@ class ImageValidator extends FileValidator
      */
     public $notImage;
     /**
-     * @var int the minimum width in pixels.
+     * @var int|null the minimum width in pixels.
      * Defaults to null, meaning no limit.
      * @see underWidth for the customized message used when image width is too small.
      */
     public $minWidth;
     /**
-     * @var int the maximum width in pixels.
+     * @var int|null the maximum width in pixels.
      * Defaults to null, meaning no limit.
      * @see overWidth for the customized message used when image width is too big.
      */
     public $maxWidth;
     /**
-     * @var int the minimum height in pixels.
+     * @var int|null the minimum height in pixels.
      * Defaults to null, meaning no limit.
      * @see underHeight for the customized message used when image height is too small.
      */
     public $minHeight;
     /**
-     * @var int the maximum width in pixels.
+     * @var int|null the maximum width in pixels.
      * Defaults to null, meaning no limit.
      * @see overHeight for the customized message used when image height is too big.
      */

--- a/framework/validators/IpValidator.php
+++ b/framework/validators/IpValidator.php
@@ -86,7 +86,7 @@ class IpValidator extends Validator
      */
     public $ipv4 = true;
     /**
-     * @var bool whether the address can be an IP with CIDR subnet, like `192.168.10.0/24`.
+     * @var bool|null whether the address can be an IP with CIDR subnet, like `192.168.10.0/24`.
      * The following values are possible:
      *
      * - `false` - the address must not have a subnet (default).

--- a/framework/validators/NumberValidator.php
+++ b/framework/validators/NumberValidator.php
@@ -34,12 +34,12 @@ class NumberValidator extends Validator
      */
     public $integerOnly = false;
     /**
-     * @var int|float upper limit of the number. Defaults to null, meaning no upper limit.
+     * @var int|float|null upper limit of the number. Defaults to null, meaning no upper limit.
      * @see tooBig for the customized message used when the number is too big.
      */
     public $max;
     /**
-     * @var int|float lower limit of the number. Defaults to null, meaning no lower limit.
+     * @var int|float|null lower limit of the number. Defaults to null, meaning no lower limit.
      * @see tooSmall for the customized message used when the number is too small.
      */
     public $min;

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -309,7 +309,7 @@ class UniqueValidator extends Validator
      * Returns conditions with alias.
      * @param ActiveQuery $query
      * @param array $conditions array of condition, keys to be modified
-     * @param null|string $alias set empty string for no apply alias. Set null for apply primary table alias
+     * @param string|null $alias set empty string for no apply alias. Set null for apply primary table alias
      * @return array
      */
     private function applyTableAlias($query, $conditions, $alias = null)

--- a/framework/validators/UrlValidator.php
+++ b/framework/validators/UrlValidator.php
@@ -35,7 +35,7 @@ class UrlValidator extends Validator
      */
     public $validSchemes = ['http', 'https'];
     /**
-     * @var string the default URI scheme. If the input doesn't contain the scheme part, the default
+     * @var string|null the default URI scheme. If the input doesn't contain the scheme part, the default
      * scheme will be prepended to it (thus changing the input). Defaults to null, meaning a URL must
      * contain the scheme part.
      */

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -132,7 +132,7 @@ class Validator extends Component
      */
     public $skipOnError = true;
     /**
-     * @var bool whether this validation rule should be skipped if the attribute value
+     * @var bool|null whether this validation rule should be skipped if the attribute value
      * is null or an empty string. This property is used only when validating [[yii\base\Model]].
      */
     public $skipOnEmpty = true;
@@ -271,7 +271,7 @@ class Validator extends Component
      * - If this is a string or an array, the intersection of [[getAttributeNames()]]
      *   and the specified attributes will be returned.
      *
-     * @return array list of attribute names.
+     * @return array|null list of attribute names.
      * @since 2.0.16
      */
     public function getValidationAttributes($attributes = null)
@@ -313,7 +313,7 @@ class Validator extends Component
      * Validates a given value.
      * You may use this method to validate a value out of the context of a data model.
      * @param mixed $value the data value to be validated.
-     * @param string $error the error message to be returned, if the validation fails.
+     * @param string|null $error the error message to be returned, if the validation fails.
      * @return bool whether the data is valid.
      */
     public function validate($value, &$error = null)

--- a/framework/web/Application.php
+++ b/framework/web/Application.php
@@ -33,7 +33,7 @@ class Application extends \yii\base\Application
      */
     public $defaultRoute = 'site';
     /**
-     * @var array the configuration specifying a controller action which should handle
+     * @var array|null the configuration specifying a controller action which should handle
      * all user requests. This is mainly used when the application is in maintenance mode
      * and needs to handle all incoming requests via a single action.
      * The configuration is an array whose first element specifies the route of the action.

--- a/framework/web/BadRequestHttpException.php
+++ b/framework/web/BadRequestHttpException.php
@@ -23,7 +23,7 @@ class BadRequestHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
      * @param \Throwable|null $previous The previous exception used for the exception chaining.
      */

--- a/framework/web/CompositeUrlRule.php
+++ b/framework/web/CompositeUrlRule.php
@@ -130,7 +130,7 @@ abstract class CompositeUrlRule extends BaseObject implements UrlRuleInterface
      * For multiple rules statuses will be combined by bitwise `or` operator
      * (e.g. `UrlRule::CREATE_STATUS_PARSING_ONLY | UrlRule::CREATE_STATUS_PARAMS_MISMATCH`).
      *
-     * @return null|int Status of the URL creation after the last [[createUrl()]] call. `null` if rule does not provide
+     * @return int|null Status of the URL creation after the last [[createUrl()]] call. `null` if rule does not provide
      * info about create status.
      * @see createStatus
      * @see https://www.php.net/manual/en/language.operators.bitwise.php

--- a/framework/web/ConflictHttpException.php
+++ b/framework/web/ConflictHttpException.php
@@ -18,9 +18,9 @@ class ConflictHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -290,7 +290,7 @@ class Controller extends \yii\base\Controller
      *
      * For this function to work you have to [[User::setReturnUrl()|set the return URL]] in appropriate places before.
      *
-     * @param string|array $defaultUrl the default return URL in case it was not set previously.
+     * @param string|array|null $defaultUrl the default return URL in case it was not set previously.
      * If this is null and the return URL was not set previously, [[Application::homeUrl]] will be redirected to.
      * Please refer to [[User::setReturnUrl()]] on accepted format of the URL.
      * @return Response the current response object

--- a/framework/web/CookieCollection.php
+++ b/framework/web/CookieCollection.php
@@ -212,7 +212,7 @@ class CookieCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * It is implicitly called when you use something like `$cookie = $collection[$name];`.
      * This is equivalent to [[get()]].
      * @param string $name the cookie name
-     * @return Cookie the cookie with the specified name, null if the named cookie does not exist.
+     * @return Cookie|null the cookie with the specified name, null if the named cookie does not exist.
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($name)

--- a/framework/web/ErrorAction.php
+++ b/framework/web/ErrorAction.php
@@ -67,7 +67,7 @@ class ErrorAction extends Action
      */
     public $defaultMessage;
     /**
-     * @var string|false|null the name of the layout to be applied to this error action view.
+     * @var string|null|false the name of the layout to be applied to this error action view.
      * If not set, the layout configured in the controller will be used.
      * @see \yii\base\Controller::$layout
      * @since 2.0.14

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -39,7 +39,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
      */
     public $maxTraceSourceLines = 13;
     /**
-     * @var string the route (e.g. `site/error`) to the controller action that will be used
+     * @var string|null the route (e.g. `site/error`) to the controller action that will be used
      * to display external errors. Inside the action, it can retrieve the error information
      * using `Yii::$app->errorHandler->exception`. This property defaults to null, meaning ErrorHandler
      * will handle the error display.

--- a/framework/web/ForbiddenHttpException.php
+++ b/framework/web/ForbiddenHttpException.php
@@ -23,9 +23,9 @@ class ForbiddenHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/GoneHttpException.php
+++ b/framework/web/GoneHttpException.php
@@ -23,9 +23,9 @@ class GoneHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/HeaderCollection.php
+++ b/framework/web/HeaderCollection.php
@@ -227,7 +227,7 @@ class HeaderCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * It is implicitly called when you use something like `$header = $collection[$name];`.
      * This is equivalent to [[get()]].
      * @param string $name the header name
-     * @return string the header value with the specified name, null if the named header does not exist.
+     * @return string|null the header value with the specified name, null if the named header does not exist.
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($name)

--- a/framework/web/HttpException.php
+++ b/framework/web/HttpException.php
@@ -38,7 +38,7 @@ class HttpException extends UserException
     /**
      * Constructor.
      * @param int $status HTTP status code, such as 404, 500, etc.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
      * @param \Throwable|null $previous The previous exception used for the exception chaining.
      */

--- a/framework/web/MethodNotAllowedHttpException.php
+++ b/framework/web/MethodNotAllowedHttpException.php
@@ -18,9 +18,9 @@ class MethodNotAllowedHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/MultiFieldSession.php
+++ b/framework/web/MultiFieldSession.php
@@ -89,8 +89,8 @@ abstract class MultiFieldSession extends Session
 
     /**
      * Composes storage field set for session writing.
-     * @param string $id Optional session id
-     * @param string $data Optional session data
+     * @param string|null $id Optional session id
+     * @param string|null $data Optional session data
      * @return array storage fields
      */
     protected function composeFields($id = null, $data = null)

--- a/framework/web/NotAcceptableHttpException.php
+++ b/framework/web/NotAcceptableHttpException.php
@@ -22,9 +22,9 @@ class NotAcceptableHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/NotFoundHttpException.php
+++ b/framework/web/NotFoundHttpException.php
@@ -18,9 +18,9 @@ class NotFoundHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/RangeNotSatisfiableHttpException.php
+++ b/framework/web/RangeNotSatisfiableHttpException.php
@@ -24,9 +24,9 @@ class RangeNotSatisfiableHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -1108,7 +1108,7 @@ class Request extends \yii\base\Request
 
     /**
      * Returns the server name.
-     * @return string server name, null if not available
+     * @return string|null server name, null if not available
      */
     public function getServerName()
     {
@@ -1750,7 +1750,7 @@ class Request extends \yii\base\Request
 
     /**
      * Loads the CSRF token from cookie or session.
-     * @return string the CSRF token loaded from cookie or session. Null is returned if the cookie or session
+     * @return string|null the CSRF token loaded from cookie or session. Null is returned if the cookie or session
      * does not have CSRF token.
      */
     protected function loadCsrfToken()
@@ -1780,7 +1780,7 @@ class Request extends \yii\base\Request
     }
 
     /**
-     * @return string the CSRF token sent via [[CSRF_HEADER]] by browser. Null is returned if no such header is sent.
+     * @return string|null the CSRF token sent via [[CSRF_HEADER]] by browser. Null is returned if no such header is sent.
      */
     public function getCsrfTokenFromHeader()
     {
@@ -1813,7 +1813,7 @@ class Request extends \yii\base\Request
      * Note that the method will NOT perform CSRF validation if [[enableCsrfValidation]] is false or the HTTP method
      * is among GET, HEAD or OPTIONS.
      *
-     * @param string $clientSuppliedToken the user-provided CSRF token to be validated. If null, the token will be retrieved from
+     * @param string|null $clientSuppliedToken the user-provided CSRF token to be validated. If null, the token will be retrieved from
      * the [[csrfParam]] POST field or HTTP header.
      * This parameter is available since version 2.0.4.
      * @return bool whether CSRF token is valid. If [[enableCsrfValidation]] is false, this method will return true.

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -273,7 +273,7 @@ class Response extends \yii\base\Response
      * Sets the response status code.
      * This method will set the corresponding status text if `$text` is null.
      * @param int $value the status code
-     * @param string $text the status text. If not set, it will be set automatically based on the status code.
+     * @param string|null $text the status text. If not set, it will be set automatically based on the status code.
      * @throws InvalidArgumentException if the status code is invalid.
      * @return $this the response object itself
      */
@@ -499,7 +499,7 @@ class Response extends \yii\base\Response
      * ```
      *
      * @param string $filePath the path of the file to be sent.
-     * @param string $attachmentName the file name shown to the user. If null, it will be determined from `$filePath`.
+     * @param string|null $attachmentName the file name shown to the user. If null, it will be determined from `$filePath`.
      * @param array $options additional options for sending the file. The following options are supported:
      *
      *  - `mimeType`: the MIME type of the content. If not set, it will be guessed based on `$filePath`
@@ -634,10 +634,10 @@ class Response extends \yii\base\Response
     /**
      * Sets a default set of HTTP headers for file downloading purpose.
      * @param string $attachmentName the attachment file name
-     * @param string $mimeType the MIME type for the response. If null, `Content-Type` header will NOT be set.
+     * @param string|null $mimeType the MIME type for the response. If null, `Content-Type` header will NOT be set.
      * @param bool $inline whether the browser should open the file within the browser window. Defaults to false,
      * meaning a download dialog will pop up.
-     * @param int $contentLength the byte length of the file being downloaded. If null, `Content-Length` header will NOT be set.
+     * @param int|null $contentLength the byte length of the file being downloaded. If null, `Content-Length` header will NOT be set.
      * @return $this the response object itself
      */
     public function setDownloadHeaders($attachmentName, $mimeType = null, $inline = false, $contentLength = null)
@@ -743,7 +743,7 @@ class Response extends \yii\base\Response
      * ```
      *
      * @param string $filePath file name with full path
-     * @param string $attachmentName file name shown to the user. If null, it will be determined from `$filePath`.
+     * @param string|null $attachmentName file name shown to the user. If null, it will be determined from `$filePath`.
      * @param array $options additional options for sending the file. The following options are supported:
      *
      *  - `mimeType`: the MIME type of the content. If not set, it will be guessed based on `$filePath`

--- a/framework/web/ServerErrorHttpException.php
+++ b/framework/web/ServerErrorHttpException.php
@@ -18,9 +18,9 @@ class ServerErrorHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/TooManyRequestsHttpException.php
+++ b/framework/web/TooManyRequestsHttpException.php
@@ -22,9 +22,9 @@ class TooManyRequestsHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/UnauthorizedHttpException.php
+++ b/framework/web/UnauthorizedHttpException.php
@@ -25,9 +25,9 @@ class UnauthorizedHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/UnprocessableEntityHttpException.php
+++ b/framework/web/UnprocessableEntityHttpException.php
@@ -24,9 +24,9 @@ class UnprocessableEntityHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/UnsupportedMediaTypeHttpException.php
+++ b/framework/web/UnsupportedMediaTypeHttpException.php
@@ -23,9 +23,9 @@ class UnsupportedMediaTypeHttpException extends HttpException
 {
     /**
      * Constructor.
-     * @param string $message error message
+     * @param string|null $message error message
      * @param int $code error code
-     * @param \Exception $previous The previous exception used for the exception chaining.
+     * @param \Exception|null $previous The previous exception used for the exception chaining.
      */
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/UploadedFile.php
+++ b/framework/web/UploadedFile.php
@@ -59,7 +59,7 @@ class UploadedFile extends BaseObject
     public $error;
     /**
      * @var string|null The full path as submitted by the browser. Note this value does not always
-     * contain a real directory structure, and cannot be trusted. Available as of PHP 8.1. 
+     * contain a real directory structure, and cannot be trusted. Available as of PHP 8.1.
      * @since 2.0.46
      */
     public $fullPath;
@@ -103,7 +103,7 @@ class UploadedFile extends BaseObject
      * @param \yii\base\Model $model the data model
      * @param string $attribute the attribute name. The attribute name may contain array indexes.
      * For example, '[1]file' for tabular file uploading; and 'file[1]' for an element in a file array.
-     * @return null|UploadedFile the instance of the uploaded file.
+     * @return UploadedFile|null the instance of the uploaded file.
      * Null is returned if no file is uploaded for the specified model attribute.
      * @see getInstanceByName()
      */
@@ -131,7 +131,7 @@ class UploadedFile extends BaseObject
      * Returns an uploaded file according to the given file input name.
      * The name can be a plain string or a string like an array element (e.g. 'Post[imageFile]', or 'Post[0][imageFile]').
      * @param string $name the name of the file input field.
-     * @return null|UploadedFile the instance of the uploaded file.
+     * @return UploadedFile|null the instance of the uploaded file.
      * Null is returned if no file is uploaded for the specified name.
      */
     public static function getInstanceByName($name)

--- a/framework/web/UrlNormalizerRedirectException.php
+++ b/framework/web/UrlNormalizerRedirectException.php
@@ -38,9 +38,9 @@ class UrlNormalizerRedirectException extends \yii\base\Exception
      * @param int $statusCode HTTP status code used for redirection
      * @param bool|string $scheme the URI scheme to use in the generated URL for redirection.
      * This will be used as second parameter for [[\yii\helpers\Url::to()]]
-     * @param string $message the error message
+     * @param string|null $message the error message
      * @param int $code the error code
-     * @param \Exception $previous the previous exception used for the exception chaining
+     * @param \Exception|null $previous the previous exception used for the exception chaining
      */
     public function __construct($url, $statusCode = 302, $scheme = false, $message = null, $code = 0, \Exception $previous = null)
     {

--- a/framework/web/UrlRule.php
+++ b/framework/web/UrlRule.php
@@ -541,7 +541,7 @@ class UrlRule extends BaseObject implements UrlRuleInterface
     /**
      * Returns status of the URL creation after the last [[createUrl()]] call.
      *
-     * @return null|int Status of the URL creation after the last [[createUrl()]] call. `null` if rule does not provide
+     * @return int|null Status of the URL creation after the last [[createUrl()]] call. `null` if rule does not provide
      * info about create status.
      * @see createStatus
      * @since 2.0.12

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -80,7 +80,7 @@ class User extends Component
      */
     public $enableSession = true;
     /**
-     * @var string|array the URL for login when [[loginRequired()]] is called.
+     * @var string|array|null the URL for login when [[loginRequired()]] is called.
      * If an array is given, [[UrlManager::createUrl()]] will be called to create the corresponding URL.
      * The first element of the array should be the route to the login action, and the rest of
      * the name-value pairs are GET parameters used to construct the login URL. For example,
@@ -368,7 +368,7 @@ class User extends Component
 
     /**
      * Returns a value that uniquely represents the user.
-     * @return string|int the unique identifier for the user. If `null`, it means the user is a guest.
+     * @return string|int|null the unique identifier for the user. If `null`, it means the user is a guest.
      * @see getIdentity()
      */
     public function getId()
@@ -384,7 +384,7 @@ class User extends Component
      * This method reads the return URL from the session. It is usually used by the login action which
      * may call this method to redirect the browser to where it goes after successful authentication.
      *
-     * @param string|array $defaultUrl the default return URL in case it was not set previously.
+     * @param string|array|null $defaultUrl the default return URL in case it was not set previously.
      * If this is null and the return URL was not set previously, [[Application::homeUrl]] will be redirected to.
      * Please refer to [[setReturnUrl()]] on accepted format of the URL.
      * @return string the URL that the user should be redirected to after login.

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -202,7 +202,7 @@ class View extends \yii\base\View
      *
      * @param string $view the view name. Please refer to [[render()]] on how to specify this parameter.
      * @param array $params the parameters (name-value pairs) that will be extracted and made available in the view file.
-     * @param object $context the context that the view should use for rendering the view. If null,
+     * @param object|null $context the context that the view should use for rendering the view. If null,
      * existing [[context]] will be used.
      * @return string the rendering result
      * @see render()
@@ -336,7 +336,7 @@ class View extends \yii\base\View
      * will result in the meta tag `<meta name="description" content="This website is about funny raccoons.">`.
      *
      * @param array $options the HTML attributes for the meta tag.
-     * @param string $key the key that identifies the meta tag. If two meta tags are registered
+     * @param string|null $key the key that identifies the meta tag. If two meta tags are registered
      * with the same key, the latter will overwrite the former. If this is null, the new meta tag
      * will be appended to the existing ones.
      */
@@ -386,7 +386,7 @@ class View extends \yii\base\View
      * has more options for this kind of link tag.
      *
      * @param array $options the HTML attributes for the link tag.
-     * @param string $key the key that identifies the link tag. If two link tags are registered
+     * @param string|null $key the key that identifies the link tag. If two link tags are registered
      * with the same key, the latter will overwrite the former. If this is null, the new link tag
      * will be appended to the existing ones.
      */
@@ -403,7 +403,7 @@ class View extends \yii\base\View
      * Registers a CSS code block.
      * @param string $css the content of the CSS code block to be registered
      * @param array $options the HTML attributes for the `<style>`-tag.
-     * @param string $key the key that identifies the CSS code block. If null, it will use
+     * @param string|null $key the key that identifies the CSS code block. If null, it will use
      * $css as the key. If two CSS code blocks are registered with the same key, the latter
      * will overwrite the former.
      */
@@ -427,7 +427,7 @@ class View extends \yii\base\View
      * - `depends`: array, specifies the names of the asset bundles that this CSS file depends on.
      * - `appendTimestamp`: bool whether to append a timestamp to the URL.
      *
-     * @param string $key the key that identifies the CSS script file. If null, it will use
+     * @param string|null $key the key that identifies the CSS script file. If null, it will use
      * $url as the key. If two CSS files are registered with the same key, the latter
      * will overwrite the former.
      * @throws InvalidConfigException
@@ -451,7 +451,7 @@ class View extends \yii\base\View
      * - [[POS_READY]]: enclosed within jQuery(document).ready(). This is the default value.
      *   Note that by using this position, the method will automatically register the jQuery js file.
      *
-     * @param string $key the key that identifies the JS code block. If null, it will use
+     * @param string|null $key the key that identifies the JS code block. If null, it will use
      * $js as the key. If two JS code blocks are registered with the same key, the latter
      * will overwrite the former.
      */
@@ -475,7 +475,7 @@ class View extends \yii\base\View
      * - `depends`: array, specifies the names of the asset bundles that this CSS file depends on.
      * - `appendTimestamp`: bool whether to append a timestamp to the URL.
      *
-     * @param string $key the key that identifies the JS script file. If null, it will use
+     * @param string|null $key the key that identifies the JS script file. If null, it will use
      * $url as the key. If two JS files are registered with the same key at the same position, the latter
      * will overwrite the former. Note that position option takes precedence, thus files registered with the same key,
      * but different position option will not override each other.
@@ -550,7 +550,7 @@ class View extends \yii\base\View
      *
      * Please refer to [[Html::jsFile()]] for other supported options.
      *
-     * @param string $key the key that identifies the JS script file. If null, it will use
+     * @param string|null $key the key that identifies the JS script file. If null, it will use
      * $url as the key. If two JS files are registered with the same key at the same position, the latter
      * will overwrite the former. Note that position option takes precedence, thus files registered with the same key,
      * but different position option will not override each other.

--- a/framework/web/XmlResponseFormatter.php
+++ b/framework/web/XmlResponseFormatter.php
@@ -37,7 +37,7 @@ class XmlResponseFormatter extends Component implements ResponseFormatterInterfa
      */
     public $encoding;
     /**
-     * @var string|string[]|false the name of the root element. If set to false, null or is empty then no root tag
+     * @var string|string[]|null|false the name of the root element. If set to false, null or is empty then no root tag
      * should be added.
      *
      * Since 2.0.44 URI namespace could be specified by passing `[namespace, tag name]` array.

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -187,7 +187,7 @@ class ActiveField extends Component
      * Renders the whole field.
      * This method will generate the label, error tag, input tag and hint tag (if any), and
      * assemble them into HTML according to [[template]].
-     * @param string|callable $content the content within the field container.
+     * @param string|callable|null $content the content within the field container.
      * If `null` (not set), the default methods will be called to generate the label, error tag and input tag,
      * and use them as the content.
      * If a callable, it will be called to generate the content. The signature of the callable should be:
@@ -264,10 +264,10 @@ class ActiveField extends Component
 
     /**
      * Generates a label tag for [[attribute]].
-     * @param null|string|false $label the label to use. If `null`, the label will be generated via [[Model::getAttributeLabel()]].
+     * @param string|null|false $label the label to use. If `null`, the label will be generated via [[Model::getAttributeLabel()]].
      * If `false`, the generated field will not contain the label part.
      * Note that this will NOT be [[Html::encode()|encoded]].
-     * @param null|array $options the tag options in terms of name-value pairs. It will be merged with [[labelOptions]].
+     * @param array|null $options the tag options in terms of name-value pairs. It will be merged with [[labelOptions]].
      * The options will be rendered as the attributes of the resulting tag. The values will be HTML-encoded
      * using [[Html::encode()]]. If a value is `null`, the corresponding attribute will not be rendered.
      * @return $this the field object itself.
@@ -323,7 +323,7 @@ class ActiveField extends Component
 
     /**
      * Renders the hint tag.
-     * @param string|bool $content the hint content.
+     * @param string|bool|null $content the hint content.
      * If `null`, the hint will be generated via [[Model::getAttributeHint()]].
      * If `false`, the generated field will not contain the hint part.
      * Note that this will NOT be [[Html::encode()|encoded]].

--- a/framework/widgets/Menu.php
+++ b/framework/widgets/Menu.php
@@ -141,12 +141,12 @@ class Menu extends Widget
      */
     public $options = [];
     /**
-     * @var string the CSS class that will be assigned to the first item in the main menu or each submenu.
+     * @var string|null the CSS class that will be assigned to the first item in the main menu or each submenu.
      * Defaults to null, meaning no such CSS class will be assigned.
      */
     public $firstItemCssClass;
     /**
-     * @var string the CSS class that will be assigned to the last item in the main menu or each submenu.
+     * @var string|null the CSS class that will be assigned to the last item in the main menu or each submenu.
      * Defaults to null, meaning no such CSS class will be assigned.
      */
     public $lastItemCssClass;

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -21,7 +21,7 @@ abstract class QueryTest extends DatabaseTestCase
         $query = new Query();
         $query->select('*');
         $this->assertEquals(['*' => '*'], $query->select);
-        $this->assertNull($query->distinct);
+        $this->assertFalse($query->distinct);
         $this->assertNull($query->selectOption);
 
         $query = new Query();


### PR DESCRIPTION
This updates several `@var`/`@param`/`@return` tags to include `null` where it was missing, based on the following description, or default param values.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
