### PR TITLE
Fix autoload in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,8 +99,14 @@
     },
     "autoload": {
         "psr-4": {
-            "yii\\": "framework/",
-            "yii\\cs\\": "cs/src/"
+            "yii\\": "framework/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "yii\\cs\\": "cs/src/",
+            "yii\\build\\": "build/",
+            "yiiunit\\": "tests/"
         }
     },
     "config": {


### PR DESCRIPTION
Move `yii\cs\`  into `autoload-dev` and add  `tests/` and `build/` namespaces

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
