### PR TITLE
Added `jfif` to mimeTypes.php

### DIFF
--- a/framework/helpers/mimeTypes.php
+++ b/framework/helpers/mimeTypes.php
@@ -355,6 +355,7 @@ $mimeTypes = [
     'jam' => 'application/vnd.jam',
     'jar' => 'application/java-archive',
     'java' => 'text/x-java-source',
+    'jfif' => 'image/jpeg',
     'jisp' => 'application/vnd.jisp',
     'jlt' => 'application/vnd.hp-jlyt',
     'jnlp' => 'application/x-java-jnlp-file',

--- a/tests/framework/helpers/MimeTest.php
+++ b/tests/framework/helpers/MimeTest.php
@@ -385,6 +385,7 @@ class MimeTest extends TestCase
                 'jam' => 'application/vnd.jam',
                 'jar' => 'application/java-archive',
                 'java' => 'text/x-java-source',
+                'jfif' => 'image/jpeg',
                 'jisp' => 'application/vnd.jisp',
                 'jlt' => 'application/vnd.hp-jlyt',
                 'jnlp' => 'application/x-java-jnlp-file',


### PR DESCRIPTION
Added the 'image/jpeg' mime type for `.jfif` files (https://en.wikipedia.org/wiki/JPEG_File_Interchange_Format)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
