### PR TITLE
fix bodyParams return value for psalm

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -37,7 +37,7 @@ use yii\validators\IpValidator;
  * @property-read string|null $authUser The username sent via HTTP authentication, `null` if the username is
  * not given.
  * @property string $baseUrl The relative URL for the application.
- * @property array|object $bodyParams The request parameters given in the request body. Note that the type of
+ * @property array $bodyParams The request parameters given in the request body. Note that the type of
  * this property differs in getter and setter. See [[getBodyParams()]] and [[setBodyParams()]] for details.
  * @property-read string $contentType Request content-type. Empty string is returned if this information is
  * not available.
@@ -548,7 +548,7 @@ class Request extends \yii\base\Request
      * Request parameters are determined using the parsers configured in [[parsers]] property.
      * If no parsers are configured for the current [[contentType]] it uses the PHP function `mb_parse_str()`
      * to parse the [[rawBody|request body]].
-     * @return array|object the request parameters given in the request body.
+     * @return array the request parameters given in the request body.
      * @throws \yii\base\InvalidConfigException if a registered parser does not implement the [[RequestParserInterface]].
      * @see getMethod()
      * @see getBodyParam()


### PR DESCRIPTION
because the value of yii\web\Request::$_bodyParams is never an object

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | 

Since I updated to a psalm 4.23, I get a lot of errors like this:

```
ERROR: PossiblyInvalidArgument - controllers/UrlNodesController.php:351:22 - Argument 1 of models\UrlNode::load expects array<array-key, mixed>, possibly different type array<array-key, mixed>|mixed|object provided (see https://psalm.dev/092)
        $model->load(Yii::$app->getRequest()->getBodyParams(), '');

```

I checked the `\yii\web\Request` class and I think the return value cannot be an object.