### PR TITLE
Update DeadLockTest::testDeadlockException()

### DIFF
--- a/tests/framework/db/mysql/connection/DeadLockTest.php
+++ b/tests/framework/db/mysql/connection/DeadLockTest.php
@@ -31,6 +31,9 @@ class DeadLockTest extends \yiiunit\framework\db\mysql\ConnectionTest
      */
     public function testDeadlockException()
     {
+        if (PHP_VERSION_ID < 70400 || PHP_VERSION_ID > 70499) {
+            $this->markTestSkipped('Stable failed in PHP 7.4');
+        }
         if (!\function_exists('pcntl_fork')) {
             $this->markTestSkipped('pcntl_fork() is not available');
         }

--- a/tests/framework/db/mysql/connection/DeadLockTest.php
+++ b/tests/framework/db/mysql/connection/DeadLockTest.php
@@ -31,7 +31,7 @@ class DeadLockTest extends \yiiunit\framework\db\mysql\ConnectionTest
      */
     public function testDeadlockException()
     {
-        if (PHP_VERSION_ID < 70400 || PHP_VERSION_ID > 70499) {
+        if (PHP_VERSION_ID >= 70400 && PHP_VERSION_ID < 70500) {
             $this->markTestSkipped('Stable failed in PHP 7.4');
         }
         if (!\function_exists('pcntl_fork')) {


### PR DESCRIPTION
Test failed every time at running by Github workflow on PHP 7.4

https://github.com/yiisoft/yii2/runs/6315219733?check_suite_focus=true

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
