### PR TITLE
Fix BaseArrayHelper::htmlDecode()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -26,6 +26,7 @@ Yii Framework 2 Change Log
 - Bug #19237: Fix OCI PHP 8.1 passing `null` to trim() (longthanhtran)
 - Bug #19312: Fix PHP 8.1 error when passing null to `yii\helpers\BaseInflector` (WinterSilence)
 - Bug #19368: Fix PHP 8.1 error when `$fileMimeType` is `null` in `yii\validators\FileValidator::validateMimeType()` (bizley)
+- Bug #19386: Fix recursive calling `yii\helpers\BaseArrayHelper::htmlDecode()` (WinterSilence)
 
 
 2.0.45 February 11, 2022

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -733,7 +733,7 @@ class BaseArrayHelper
      *
      * @param array $data data to be decoded
      * @param bool $valuesOnly whether to decode array values only. If `false`,
-     * both the array keys and array values will be decoded.
+     * then both the array keys and array values will be decoded.
      * @return array the decoded data
      * @see https://www.php.net/manual/en/function.htmlspecialchars-decode.php
      */

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -732,7 +732,7 @@ class BaseArrayHelper
      * Only string values will be decoded.
      *
      * @param array $data data to be decoded
-     * @param bool $valuesOnly whether to decode array values only. If false,
+     * @param bool $valuesOnly whether to decode array values only. If `false`,
      * both the array keys and array values will be decoded.
      * @return array the decoded data
      * @see https://www.php.net/manual/en/function.htmlspecialchars-decode.php
@@ -742,10 +742,10 @@ class BaseArrayHelper
         $d = [];
         foreach ($data as $key => $value) {
             if (!$valuesOnly && is_string($key)) {
-                $key = htmlspecialchars_decode($key, ENT_QUOTES);
+                $key = htmlspecialchars_decode($key, ENT_QUOTES | ENT_SUBSTITUTE);
             }
             if (is_string($value)) {
-                $d[$key] = htmlspecialchars_decode($value, ENT_QUOTES);
+                $d[$key] = htmlspecialchars_decode($value, ENT_QUOTES | ENT_SUBSTITUTE);
             } elseif (is_array($value)) {
                 $d[$key] = static::htmlDecode($value, $valuesOnly);
             } else {

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -726,9 +726,11 @@ class BaseArrayHelper
 
     /**
      * Decodes HTML entities into the corresponding characters in an array of strings.
+     *
      * Only array values will be decoded by default.
      * If a value is an array, this method will also decode it recursively.
      * Only string values will be decoded.
+     *
      * @param array $data data to be decoded
      * @param bool $valuesOnly whether to decode array values only. If false,
      * both the array keys and array values will be decoded.
@@ -745,7 +747,7 @@ class BaseArrayHelper
             if (is_string($value)) {
                 $d[$key] = htmlspecialchars_decode($value, ENT_QUOTES);
             } elseif (is_array($value)) {
-                $d[$key] = static::htmlDecode($value);
+                $d[$key] = static::htmlDecode($value, $valuesOnly);
             } else {
                 $d[$key] = $value;
             }

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -1208,6 +1208,7 @@ class ArrayHelperTest extends TestCase
             'cde' => false,
             3 => 'blank',
             [
+                '<>' => 'a<>b',
                 '<a>' => '<a href="index.php?a=1&b=2">link</a>',
                 '23' => true,
             ],

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -1184,6 +1184,7 @@ class ArrayHelperTest extends TestCase
             'cde' => false,
             3 => 'blank',
             [
+                '<>' => 'a&lt;&gt;b',
                 '&lt;a&gt;' => '&lt;a href=&quot;index.php?a=1&amp;b=2&quot;&gt;link&lt;/a&gt;',
                 '23' => true,
             ],
@@ -1195,6 +1196,7 @@ class ArrayHelperTest extends TestCase
             'cde' => false,
             3 => 'blank',
             [
+                '<>' => 'a<>b',
                 '&lt;a&gt;' => '<a href="index.php?a=1&b=2">link</a>',
                 '23' => true,
             ],

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -1184,30 +1184,33 @@ class ArrayHelperTest extends TestCase
             'cde' => false,
             3 => 'blank',
             [
-                '<>' => 'a&lt;&gt;b',
+                '&lt;a&gt;' => '&lt;a href=&quot;index.php?a=1&amp;b=2&quot;&gt;link&lt;/a&gt;',
                 '23' => true,
             ],
         ];
-        $this->assertEquals([
+
+        $expected = [
             'abc' => '123',
             '&lt;' => '>',
             'cde' => false,
             3 => 'blank',
             [
-                '<>' => 'a<>b',
+                '&lt;a&gt;' => '<a href="index.php?a=1&b=2">link</a>',
                 '23' => true,
             ],
-        ], ArrayHelper::htmlDecode($array));
-        $this->assertEquals([
+        ];
+        $this->assertEquals($expected, ArrayHelper::htmlDecode($array));
+        $expected = [
             'abc' => '123',
             '<' => '>',
             'cde' => false,
             3 => 'blank',
             [
-                '<>' => 'a<>b',
+                '<a>' => '<a href="index.php?a=1&b=2">link</a>',
                 '23' => true,
             ],
-        ], ArrayHelper::htmlDecode($array, false));
+        ];
+        $this->assertEquals($expected, ArrayHelper::htmlDecode($array, false));
     }
 
     public function testIsIn()


### PR DESCRIPTION
Add missed second argument on recursive calling.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
