### PR TITLE
Fix tests scrutinizer.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -35,7 +35,7 @@ build:
 
       services:
         db-mysql:
-          image: mysql:8.0
+          image: mysql:5.7
 
           # Define any additional environment variables that are needed by the service.
           env:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

The mysql deacklock tests fails in the latest version of mysql, i'm investigating what the changes are, that make the test fail, in scrutinizer, i changed from 8.0 to 5.7, as well as the general action build to do the static analysis and calculate the coverage code, in the mysql test that we have for version 8:latets we can use 8.0.28 which does not fail, while we investigate the error, if so, let me know and I will change it.
