### PR TITLE
Delay exit in error handler

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -28,6 +28,7 @@ Yii Framework 2 Change Log
 - Bug #19368: Fix PHP 8.1 error when `$fileMimeType` is `null` in `yii\validators\FileValidator::validateMimeType()` (bizley)
 - Enh #19384: Normalize `setBodyParams()` and `getBodyParam()` in `yii\web\Request` (WinterSilence, albertborsos)
 - Bug #19386: Fix recursive calling `yii\helpers\BaseArrayHelper::htmlDecode()` (WinterSilence)
+- Enh #19401: Delay `exit(1)` in `yii\base\ErrorHandler::handleFatalError` (arrilot)
 - Bug #19402: Add shutdown event and fix working directory in `yii\base\ErrorHandler` (WinterSilence)
 - Enh #19416: Update and improve configurations for `yii\console\controllers\MessageController` (WinterSilence)
 - Bug #19403: Fix types in `yii\web\SessionIterator` (WinterSilence)

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -321,6 +321,7 @@ abstract class ErrorHandler extends Component
 
             $this->trigger(static::EVENT_SHUTDOWN);
 
+            // ensure it is called after user-defined shutdown functions
             register_shutdown_function(function() {
                 exit(1);
             });

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -292,7 +292,11 @@ abstract class ErrorHandler extends Component
             if (defined('HHVM_VERSION')) {
                 flush();
             }
-            exit(1);
+
+            register_shutdown_function(function() {
+                exit(1);
+            });
+
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌ i suppose it's not likely that anyone relies on the current behavior

Our use case is the following. We want to collect prometheus metrics regarding http requests and console commands - rps, duration, number of errors, timeouts e.t.c.
The way we do it is via register_shutdown_function in a filter attached to route or application.
The problem is that ErrorHandler gets on the road.
Error handler registers its own `register_shutdown_function callback and when a fatal error occurs (e.g. a request exceeds max_execution_time) calls exit(1) in the end of it.
As a result no other `register_shutdown_function` callbacks registered in userland have a chance to be invoked and we lose all the metrics for this request.
It is also worth noting that errorHandler is registered in Yii Application very early during request lifecycle that makes things even worse. 

This is by no mean a new issue. It was raised at least [one](https://github.com/yiisoft/yii2/issues/9769), [two](https://github.com/yiisoft/yii2/issues/6637) times

In the last issue Cebe said "If you have any alternative fixes in mind, feel free to do a suggestion" so here we go.

The idea was taken from Yii's logger - https://github.com/yiisoft/yii2/blob/master/framework/log/Logger.php#L135
According to php docs "Shutdown functions may also call register_shutdown_function() themselves to add a shutdown function to the end of the queue."
By moving exit(1) to the end shutdown callbacks queue we preserve the final exit code and leave a room for developers' own callbacks to be executed.





