### PR TITLE
Update `\yii\base\ErrorHandler`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -28,6 +28,7 @@ Yii Framework 2 Change Log
 - Bug #19368: Fix PHP 8.1 error when `$fileMimeType` is `null` in `yii\validators\FileValidator::validateMimeType()` (bizley)
 - Enh #19384: Normalize `setBodyParams()` and `getBodyParam()` in `yii\web\Request` (WinterSilence, albertborsos)
 - Bug #19386: Fix recursive calling `yii\helpers\BaseArrayHelper::htmlDecode()` (WinterSilence)
+- Bug #19402: Add shutdown event and fix working directory in `yii\base\ErrorHandler` (WinterSilence)
 
 
 2.0.45 February 11, 2022

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -27,9 +27,6 @@ use yii\web\HttpException;
 abstract class ErrorHandler extends Component
 {
     /**
-     * @event the shutdown handler
-     */
-    /**
      * @event Event an event that is triggered when the handler is called by shutdown function via [[handleFatalError()]].
      * @since 2.0.46
      */

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -281,11 +281,11 @@ abstract class ErrorHandler extends Component
     {
         unset($this->_memoryReserve);
 
-        if (isset($this->_workingDirector)) {
+        if (isset($this->_workingDirectory)) {
             // fix working directory for some Web servers e.g. Apache
             chdir($this->_workingDirectory);
             // flush memory
-            unset($this->_workingDirector);
+            unset($this->_workingDirectory);
         }
 
         // load ErrorException manually here because autoloading them will not work
@@ -320,7 +320,7 @@ abstract class ErrorHandler extends Component
             }
 
             $this->trigger(static::EVENT_SHUTDOWN);
-            
+
             exit(1);
         }
     }

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -97,7 +97,7 @@ abstract class ErrorHandler extends Component
                 $this->_memoryReserve = str_pad('x', $this->memoryReserveSize -1);
             }
             // to restore working directory in shutdown handler
-            if (PHP_SAPI, !== 'cli') {
+            if (PHP_SAPI !== 'cli') {
                 $this->_workingDirectory = getcwd();
             }
             register_shutdown_function([$this, 'handleFatalError']);

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -275,10 +275,11 @@ abstract class ErrorHandler extends Component
      */
     public function handleFatalError()
     {
-        $this->_memoryReserve = null;
-
         // fix working directory for some Web servers e.g. Apache
         chdir($this->_workingDirector);
+        // flush memory
+        $this->_workingDirector = null;
+        $this->_memoryReserve = null;
 
         // load ErrorException manually here because autoloading them will not work
         // when error occurs while autoloading a class
@@ -295,6 +296,7 @@ abstract class ErrorHandler extends Component
                 $exception = new ErrorException($error['message'], $error['type'], $error['type'], $error['file'], $error['line']);
             }
             $this->exception = $exception;
+            unset($error);
 
             $this->logException($exception);
 

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -276,7 +276,7 @@ abstract class ErrorHandler extends Component
     public function handleFatalError()
     {
         // fix working directory for some Web servers e.g. Apache
-        chdir($this->_workingDirector);
+        chdir($this->_workingDirectory);
         // flush memory
         $this->_workingDirector = null;
         $this->_memoryReserve = null;

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -277,10 +277,8 @@ abstract class ErrorHandler extends Component
     {
         $this->_memoryReserve = null;
 
-        // fix working directory for some Web servers
-        if (!in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
-            chdir($this->_workingDirector);
-        }
+        // fix working directory for some Web servers e.g. Apache
+        chdir($this->_workingDirector);
 
         // load ErrorException manually here because autoloading them will not work
         // when error occurs while autoloading a class

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -94,7 +94,7 @@ abstract class ErrorHandler extends Component
                 set_error_handler([$this, 'handleError']);
             }
             if ($this->memoryReserveSize > 0) {
-                $this->_memoryReserve = str_pad('x', $this->memoryReserveSize -1);
+                $this->_memoryReserve = str_pad('', $this->memoryReserveSize, 'x');
             }
             // to restore working directory in shutdown handler
             if (PHP_SAPI !== 'cli') {


### PR DESCRIPTION
1. Adds property `_workingDirectory` to restore current working directory in shutdown handler:
> `register_shutdown_function()`:
> Working directory of the script can change inside the shutdown function under some Web servers, e.g. Apache.
2. Adds event to call user's handler on application shutdown

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
