### PR TITLE
add `_REQUEST_BODY` when set request parse the log file _POST is empty data

### DIFF
--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -178,7 +178,7 @@ abstract class Target extends Component
         foreach ($context as $key => $value) {
             $result[] = "\${$key} = " . VarDumper::dumpAsString($value);
         }
-
+        $result['_REQUEST_BODY'] = Yii::$app->request->getBodyParams();
         return implode("\n\n", $result);
     }
 


### PR DESCRIPTION
add _REQUEST_BODY when set request parse the log file _POST is empty data

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
