### PR TITLE
Improve reflection param/return types in console\Controller

### DIFF
--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -680,7 +680,7 @@ class Controller extends \yii\base\Controller
 
     /**
      * @param Action $action
-     * @return \ReflectionMethod
+     * @return \ReflectionFunctionAbstract
      */
     protected function getActionMethodReflection($action)
     {
@@ -697,7 +697,7 @@ class Controller extends \yii\base\Controller
 
     /**
      * Parses the comment block into tags.
-     * @param \Reflector $reflection the comment block
+     * @param \ReflectionClass|\ReflectionProperty|\ReflectionFunctionAbstract $reflection the comment block
      * @return array the parsed tags
      */
     protected function parseDocCommentTags($reflection)
@@ -725,7 +725,7 @@ class Controller extends \yii\base\Controller
     /**
      * Returns the first line of docblock.
      *
-     * @param \Reflector $reflection
+     * @param \ReflectionClass|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
      * @return string
      */
     protected function parseDocCommentSummary($reflection)
@@ -741,7 +741,7 @@ class Controller extends \yii\base\Controller
     /**
      * Returns full description from the docblock.
      *
-     * @param \Reflector $reflection
+     * @param \ReflectionClass|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
      * @return string
      */
     protected function parseDocCommentDetail($reflection)


### PR DESCRIPTION
This clarifies exactly which reflection classes `yii\console\Controller::parseDocCommentTags()`, `parseDocCommentSummary()`, and `parseDocCommentDetail()` should accept for their `$reflection` param, since `getdocComment()` isn’t actually implemented by the base `Reflection` class.

(It’s implemented separately for [ReflectionClass](https://www.php.net/manual/en/reflectionclass.getdoccomment.php), [ReflectionProperty](https://www.php.net/manual/en/reflectionproperty.getdoccomment.php), and [ReflectionFunctionAbstract](https://www.php.net/manual/en/reflectionfunctionabstract.getdoccomment.php).)

The `@return` type for `getActionMethodReflection()` was also changed, from `ReflectionMethod` to `ReflectionFunctionAbstract`, making room for subclasses to return a `ReflectionFunction` object.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
