### PR TITLE
Fixes a virtual relation not working because of new isset checks

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.46 under development
 ------------------------
 
+- Bug #19469: Fix a virtual relation not working because of new isset checks in `\yii\db\ActiveRelationTrait` (wvanheumen)
 - Bug #19380: Fix PHP 8.1 passing non string to trim() in `yii\db\Query` (wa1kb0y)
 - Bug #19272: Fix bug in dirty attributes check on multidimensional array (speedplli)
 - Bug #19349: Fix PHP 8.1 error when attribute and label of `yii\grid\DataColumn` are empty (githubjeka)

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -528,7 +528,7 @@ trait ActiveRelationTrait
             // single key
             $attribute = reset($this->link);
             foreach ($models as $model) {
-                $value = isset($model[$attribute]) ? $model[$attribute] : null;
+                $value = isset($model[$attribute]) || property_exists($model, $attribute) ? $model[$attribute] : null;
                 if ($value !== null) {
                     if (is_array($value)) {
                         $values = array_merge($values, $value);
@@ -586,7 +586,7 @@ trait ActiveRelationTrait
     {
         $key = [];
         foreach ($attributes as $attribute) {
-            if (isset($model[$attribute])) {
+            if (isset($model[$attribute]) || property_exists($model, $attribute)) {
                 $key[] = $this->normalizeModelKey($model[$attribute]);
             }
         }

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -528,7 +528,7 @@ trait ActiveRelationTrait
             // single key
             $attribute = reset($this->link);
             foreach ($models as $model) {
-                $value = isset($model[$attribute]) || property_exists($model, $attribute) ? $model[$attribute] : null;
+                $value = isset($model[$attribute]) || (is_object($model) && property_exists($model, $attribute)) ? $model[$attribute] : null;
                 if ($value !== null) {
                     if (is_array($value)) {
                         $values = array_merge($values, $value);
@@ -586,7 +586,7 @@ trait ActiveRelationTrait
     {
         $key = [];
         foreach ($attributes as $attribute) {
-            if (isset($model[$attribute]) || property_exists($model, $attribute)) {
+            if (isset($model[$attribute]) || (is_object($model) && property_exists($model, $attribute))) {
                 $key[] = $this->normalizeModelKey($model[$attribute]);
             }
         }

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -25,6 +25,8 @@ class Order extends ActiveRecord
 {
     public static $tableName;
 
+    public $virtualCustomerId = null;
+
     public static function tableName()
     {
         return static::$tableName ?: 'order';
@@ -238,4 +240,10 @@ class Order extends ActiveRecord
     {
         return $this->hasMany(Item::className(), ['id' => 'item_id'])->via('orderItemsFor8');
     }
+
+    public function getVirtualCustomer()
+    {
+        return $this->hasOne(Customer::className(), ['id' => 'virtualCustomerId']);
+    }
+
 }

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -2159,4 +2159,15 @@ abstract class ActiveRecordTest extends DatabaseTestCase
             'item_id' => null,
         ]));
     }
+
+    public function testVirtualRelation()
+    {
+        /* @var $orderClass ActiveRecordInterface */
+        $orderClass = $this->getOrderClass();
+        $order = $orderClass::findOne(2);
+        $order->virtualCustomerId = $order->customer_id;
+
+        $this->assertNotNull($order->virtualCustomer);
+    }
+
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

2.0.45 has new check to prevent warnings, but fail because object are interpreted as arrays.

```
$object = new ArModel();
$object->virtualField = 1;
var_dump(isset($object['virtualField'])); #result: false
var_dump($object['virtualField']); #result:  1
```

Seems to only happen if the AR model does not have the fields in the attributes array. Therefor, called it a virtual relation.

Added a test that fails on 2.0.45, success on 2.0.44
