### PR TITLE
cast shell_exec to string

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -39,7 +39,7 @@ Yii Framework 2 Change Log
 - Enh #19437: Add support to specify request port by trusted proxies in `\yii\web\Request::getServerPort()` (rhertogh)
 - Bug #19445: Fix caching in `yii\i18n\Formatter::getUnitMessage()` (WinterSilence)
 - Bug #19454: Fix PDO exception code not properly passed to `yii\db\Exception` (Roguyt)
-
+- Bug #19477: cast shell_exec() output to string (schmunk42)
 
 2.0.45 February 11, 2022
 ------------------------

--- a/framework/console/controllers/AssetController.php
+++ b/framework/console/controllers/AssetController.php
@@ -544,7 +544,7 @@ EOD;
         if (is_string($this->cssCompressor)) {
             $tmpFile = $outputFile . '.tmp';
             $this->combineCssFiles($inputFiles, $tmpFile);
-            $this->stdout(shell_exec(strtr($this->cssCompressor, [
+            $this->stdout((string)shell_exec(strtr($this->cssCompressor, [
                 '{from}' => escapeshellarg($tmpFile),
                 '{to}' => escapeshellarg($outputFile),
             ])));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

I get an error (only PHP 8.1), even for a command which runs without (obvious) error.

```
yii asset/compress config/assets.php web/bundles/config.php

[...]

Loading configuration from 'config/assets.php'...
Collecting source bundles information...
Creating output bundle 'frontend':
  Compressing CSS files...

Error: fwrite(): Passing null to parameter #2 ($data) of type string is deprecated
2022-07-21 14:45:17 [-][-][-][error][yii\base\ErrorException:8192] yii\base\ErrorException: fwrite(): Passing null to parameter #2 ($data) of type string is deprecated in /app/vendor/yiisoft/yii2-dev/framework/helpers/BaseConsole.php:792
Stack trace:
#0 [internal function]: yii\base\ErrorHandler->handleError(8192, 'fwrite(): Passi...', '/app/vendor/yii...', 792)
#1 /app/vendor/yiisoft/yii2-dev/framework/helpers/BaseConsole.php(792): fwrite(Resource id #2, NULL)
#2 /app/vendor/yiisoft/yii2-dev/framework/console/Controller.php(306): yii\helpers\BaseConsole::stdout(NULL)
#3 /app/vendor/yiisoft/yii2-dev/framework/console/controllers/AssetController.php(549): yii\console\Controller->stdout(NULL)
#4 /app/vendor/yiisoft/yii2-dev/framework/console/controllers/AssetController.php(373): yii\console\controllers\AssetController->compressCssFiles(Array, '/app/src/../web...')
#5 /app/vendor/yiisoft/yii2-dev/framework/console/controllers/AssetController.php(199): yii\console\controllers\AssetController->buildTarget(Object(yii\web\AssetBundle), 'css', Array)
#6 [internal function]: yii\console\controllers\AssetController->actionCompress('config/assets.p...', 'web/bundles/con...')
#7 /app/vendor/yiisoft/yii2-dev/framework/base/InlineAction.php(57): call_user_func_array(Array, Array)
#8 /app/vendor/yiisoft/yii2-dev/framework/base/Controller.php(178): yii\base\InlineAction->runWithParams(Array)
#9 /app/vendor/yiisoft/yii2-dev/framework/console/Controller.php(182): yii\base\Controller->runAction('compress', Array)
#10 /app/vendor/yiisoft/yii2-dev/framework/base/Module.php(552): yii\console\Controller->runAction('compress', Array)
#11 /app/vendor/yiisoft/yii2-dev/framework/console/Application.php(180): yii\base\Module->runAction('asset/compress', Array)
#12 /app/vendor/yiisoft/yii2-dev/framework/console/Application.php(147): yii\console\Application->runAction('asset/compress', Array)
#13 /app/vendor/yiisoft/yii2-dev/framework/base/Application.php(384): yii\console\Application->handleRequest(Object(yii\console\Request))
#14 /app/src/bin/yii(37): yii\base\Application->run()
#15 {main}
```
