### PR TITLE
Docs: fix typo: input tabular data: remove unnecessary "-1"

### DIFF
--- a/docs/guide/input-tabular-input.md
+++ b/docs/guide/input-tabular-input.md
@@ -92,7 +92,7 @@ public function actionCreate()
 {
     $settings = [];
     if ($this->request->isPost) {
-        $count = count($this->request->post($setting->tableName())) - 1;
+        $count = count($this->request->post($setting->tableName()));
         for ($i = 0; $i < $count; $i++) {
             $settings[$i] = new Setting();
         }


### PR DESCRIPTION
Before the change, with this input:
```
$_POST = [
    'Setting' => [
        0 => ['value' => 'value0'],
        1 => ['value' => 'value1'],
    ]
];
```
contents of $settings would be created as follows:
```
$settings = [
    Setting(value='value0'),
];
```
after the change it will be:
```
$settings = [
    Setting(value='value0'),
    Setting(value='value1'),
];
```

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | None