### PR TITLE
Fix #19467: Revert changes in `Inflector::camel2words()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.46 under development
 ------------------------
 
+- Bug #19467: Revert changes in `Inflector::camel2words()` introduced in #19204 (samdark)
 - Bug #19471: Enable console commands on hostings with disabled `exec()` function (WinterSilence, lubosdz)
 - Bug #19469: Fix a virtual relation not working because of new isset checks in `\yii\db\ActiveRelationTrait` (wvanheumen)
 - Bug #19380: Fix PHP 8.1 passing non string to trim() in `yii\db\Query` (wa1kb0y)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -51,6 +51,12 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to follow the instructions
 for both A and B.
 
+Upgrade from Yii 2.0.45
+-----------------------
+
+* Changes in `Inflector::camel2words()` introduced in 2.0.45 were reverted so it works as in pre-2.0.45. If you need
+  2.0.45 behavior, [introduce your own method](https://github.com/yiisoft/yii2/pull/19495/files).
+
 Upgrade from Yii 2.0.44
 -----------------------
 

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -388,7 +388,7 @@ class BaseInflector
         }
         // Add a space before any uppercase letter preceded by a lowercase letter (xY => x Y)
         // and any uppercase letter preceded by an uppercase letter and followed by a lowercase letter (XYz => X Yz)
-        $label = preg_replace('/(?<=\p{Ll})\p{Lu}|(?<=[\p{L}\d])\p{Lu}(?=\p{Ll})|(\d+)/u', ' \0', $name);
+        $label = preg_replace('/(?<=\p{Ll})\p{Lu}|(?<=\p{L})\p{Lu}(?=\p{Ll})/u', ' \0', $name);
 
         $label = mb_strtolower(trim(str_replace(['-', '_', '.'], ' ', $label)), self::encoding());
 

--- a/tests/framework/helpers/InflectorTest.php
+++ b/tests/framework/helpers/InflectorTest.php
@@ -121,9 +121,6 @@ class InflectorTest extends TestCase
         $this->assertEquals('Foo Bar', Inflector::camel2words('foo BAR'));
         $this->assertEquals('Foo Bar', Inflector::camel2words('Foo Bar'));
         $this->assertEquals('Foo Bar', Inflector::camel2words('FOO BAR'));
-        $this->assertEquals('Order 4 Other Phones', Inflector::camel2words('Order4OtherPhones'));
-        $this->assertEquals('I Have 23 Dogs', Inflector::camel2words('IHave23Dogs'));
-        $this->assertEquals('Con Chó Cười 34 Lần', Inflector::camel2words('ConChóCười34Lần'));
     }
 
     public function testCamel2id()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #19467, #19204
