### PR TITLE
default strict=true for gridview filter (#19508)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.47 under development
 ------------------------
 
-- no changes in this release.
+- Bug #19508: Fix wrong selection for boolean attributes in GridView (alnidok)
 
 
 2.0.46 August 18, 2022

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -216,10 +216,10 @@ class DataColumn extends Column
                 $error = '';
             }
             if (is_array($this->filter)) {
-                $options = array_merge(['prompt' => ''], $this->filterInputOptions);
+                $options = array_merge(['prompt' => '', 'strict' => true], $this->filterInputOptions);
                 return Html::activeDropDownList($model, $this->filterAttribute, $this->filter, $options) . $error;
             } elseif ($this->format === 'boolean') {
-                $options = array_merge(['prompt' => ''], $this->filterInputOptions);
+                $options = array_merge(['prompt' => '', 'strict' => true], $this->filterInputOptions);
                 return Html::activeDropDownList($model, $this->filterAttribute, [
                     1 => $this->grid->formatter->booleanFormat[1],
                     0 => $this->grid->formatter->booleanFormat[0],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/yii2/issues/19508

Gridview filter behavior was changed https://github.com/yiisoft/yii2/issues/19508 after merge PR https://github.com/yiisoft/yii2/pull/19331

https://github.com/yiisoft/yii2/blob/340666010a1292b62d7b348ead579b3d95a2cfd9/framework/helpers/BaseHtml.php#L1917
because `strict=false` by default
https://github.com/yiisoft/yii2/blob/340666010a1292b62d7b348ead579b3d95a2cfd9/framework/helpers/BaseHtml.php#L1881

---

It means that we should add this code for every boolean column or numeric column with allowable value=0 (ie statuses)
```php
'filterInputOptions' => [
    'class' => 'form-control',
    'strict' => true,
],
```

I think that it is a bug and **strict should be true by default for GridView filters**.
This PR do it.