### PR TITLE
Empty fields exclusion in safe attributes of Model

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.47 under development
 ------------------------
 
-- no changes in this release.
+- Bug #15557: Fix empty fields exclusion in safe attributes of `yii\base\Model` (manchenkoff)
 
 
 2.0.46 August 18, 2022

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -790,7 +790,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
         }
         $attributes = [];
         foreach ($scenarios[$scenario] as $attribute) {
-            if (mb_strlen($attribute) !== 0 && strncmp($attribute, '!', 1) !== 0 && !in_array('!' . $attribute, $scenarios[$scenario])) {
+            if (strlen($attribute) !== 0 && strncmp($attribute, '!', 1) !== 0 && !in_array('!' . $attribute, $scenarios[$scenario])) {
                 $attributes[] = $attribute;
             }
         }

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -790,7 +790,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
         }
         $attributes = [];
         foreach ($scenarios[$scenario] as $attribute) {
-            if (strncmp($attribute, '!', 1) !== 0 && !in_array('!' . $attribute, $scenarios[$scenario])) {
+            if (mb_strlen($attribute) !== 0 && strncmp($attribute, '!', 1) !== 0 && !in_array('!' . $attribute, $scenarios[$scenario])) {
                 $attributes[] = $attribute;
             }
         }

--- a/tests/framework/base/ModelTest.php
+++ b/tests/framework/base/ModelTest.php
@@ -7,6 +7,7 @@
 
 namespace yiiunit\framework\base;
 
+use yii\base\DynamicModel;
 use yii\base\Model;
 use yiiunit\data\base\InvalidRulesModel;
 use yiiunit\data\base\RulesModel;
@@ -512,6 +513,15 @@ class ModelTest extends TestCase
         $this->expectExceptionMessage('The "formName()" method should be explicitly defined for anonymous models');
 
         $model->formName();
+    }
+
+    public function testExcludeEmptyAttributesFromSafe()
+    {
+        $model = new DynamicModel(['' => 'emptyFieldValue']);
+        $model->addRule('', 'safe');
+
+        $this->assertEquals([], $model->safeAttributes());
+        $this->assertEquals([''], $model->attributes());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #15557 

This change will exclude empty fields like `['' => 'value']` from safe attributes.