### PR TITLE
Fix "passing null to parameter #1 ($string) of type string is deprecated"

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Bug #19508: Fix wrong selection for boolean attributes in GridView (alnidok)
 - Bug #19517: Fix regression in `CompositeAuth::authenticate()` introduced in #19418 (WinterSilence)
 - Bug #19537: Fix default expression detection for MariaDB `date` and `time` columns (bizley)
+- Bug #19533: Fix "passing null to parameter #1 ($string) of type string is deprecated" (samdark)
 
 
 2.0.46 August 18, 2022

--- a/framework/validators/FilterValidator.php
+++ b/framework/validators/FilterValidator.php
@@ -78,7 +78,7 @@ class FilterValidator extends Validator
     {
         $value = $model->$attribute;
         if (!$this->skipOnArray || !is_array($value)) {
-            $model->$attribute = call_user_func($this->filter, $value);
+            $model->$attribute = call_user_func((string)$this->filter, $value);
         }
     }
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19533