### PR TITLE
Docs: Wrong operator format

### DIFF
--- a/docs/guide/db-query-builder.md
+++ b/docs/guide/db-query-builder.md
@@ -879,10 +879,10 @@ Using the operator format, it would look like the following:
 ```php
 [
     'and',
-    '>', 'posts', $minLimit,
-    '>', 'comments', $minLimit,
-    '>', 'reactions', $minLimit,
-    '>', 'subscriptions', $minLimit
+    ['>', 'posts', $minLimit],
+    ['>', 'comments', $minLimit],
+    ['>', 'reactions', $minLimit],
+    ['>', 'subscriptions', $minLimit]
 ]
 ```
 


### PR DESCRIPTION
Based on the docs and mainly my experience with Yii, I believe the "and" operator format here is wrong. The condition parts which the "and" separates have to be each in an array, otherwise the where() doesn't know where the condition starts and where ends.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
