### PR TITLE
Fixes comparison completly  in `BaseHtml::renderSelectOptions()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Bug #19508: Fix wrong selection for boolean attributes in GridView (alnidok)
 - Bug #19517: Fix regression in `CompositeAuth::authenticate()` introduced in #19418 (WinterSilence)
 - Bug #19537: Fix default expression detection for MariaDB `date` and `time` columns (bizley)
+- Bug #19577: Fix comparasion in `BaseHtml::renderSelectOptions()` (WinterSilence)
 
 
 2.0.46 August 18, 2022

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1871,8 +1871,9 @@ class BaseHtml
      */
     public static function renderSelectOptions($selection, $items, &$tagOptions = [])
     {
-        if (ArrayHelper::isTraversable($selection)) {
-            $selection = array_map('strval', ArrayHelper::toArray($selection));
+        $multipleSelection = $selection !== null && ArrayHelper::isTraversable($selection);
+        if ($multipleSelection) {
+            $selection = ArrayHelper::toArray($selection);
         }
 
         $lines = [];
@@ -1915,20 +1916,16 @@ class BaseHtml
                 if (!array_key_exists('selected', $attrs)) {
                     if ($selection === null) {
                         $attrs['selected'] = false;
-                    } elseif (ArrayHelper::isTraversable($selection)) {
-                        if (!$strict && (is_int($key) || is_float($key))) {
-                            // to prevent error at comparing with an object
-                            $key = (string) $key;
-                        }
-                        $attrs['selected'] = ArrayHelper::isIn($key, $selection, $strict);
-                    } elseif ($strict) {
-                        $attrs['selected'] = $selection === $key;
                     } else {
-                        if (is_int($key) || is_float($key)) {
-                            // to prevent error at comparing with an object
+                            // to prevent error at comparing with an object(s)
+                        if (!$strict && (is_int($key) || is_float($key))) {
                             $key = (string) $key;
                         }
-                        $attrs['selected'] = $selection == $key;
+                        $attrs['selected'] = ArrayHelper::isIn(
+                            $key,
+                            $multipleSelection ? $selection : [$selection],
+                            $strict
+                        );
                     }
                 }
                 $text = $encode ? static::encode($value) : $value;

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1913,9 +1913,23 @@ class BaseHtml
                 $attrs = isset($options[$key]) ? $options[$key] : [];
                 $attrs['value'] = (string) $key;
                 if (!array_key_exists('selected', $attrs)) {
-                    $attrs['selected'] = $selection !== null &&
-                        (!ArrayHelper::isTraversable($selection) && ($strict ? !strcmp($key, $selection) : $selection == $key)
-                        || ArrayHelper::isTraversable($selection) && ArrayHelper::isIn((string)$key, $selection, $strict));
+                    if ($selection === null) {
+                        $attrs['selected'] = false;
+                    } elseif (ArrayHelper::isTraversable($selection)) {
+                        if (!$strict && (is_int($key) || is_float($key))) {
+                            // to prevent error at comparing with an object
+                            $key = (string) $key;
+                        }
+                        $attrs['selected'] = ArrayHelper::isIn($key, $selection, $strict);
+                    } elseif ($strict) {
+                        $attrs['selected'] = $selection === $key;
+                    } else {
+                        if (is_int($key) || is_float($key)) {
+                            // to prevent error at comparing with an object
+                            $key = (string) $key;
+                        }
+                        $attrs['selected'] = $selection == $key;
+                    }
                 }
                 $text = $encode ? static::encode($value) : $value;
                 if ($encodeSpaces) {

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1917,7 +1917,7 @@ class BaseHtml
                     if ($selection === null) {
                         $attrs['selected'] = false;
                     } else {
-                            // to prevent error at comparing with an object(s)
+                        // to prevent error at comparing with an object(s)
                         if (!$strict && (is_int($key) || is_float($key))) {
                             $key = (string) $key;
                         }

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1085,7 +1085,7 @@ EOD;
         $data = ['1' => '1', '1.1' => '1.1', '1.10' => '1.10'];
         $attributes = ['strict' => true];
         $this->assertEqualsWithoutLE($expected, Html::renderSelectOptions(['1.1'], $data, $attributes));
-        $attributes = ['strict' => true];
+        $attributes = ['strict' => false];
         $this->assertEqualsWithoutLE($expected, Html::renderSelectOptions([1.1], $data, $attributes));
 
         $expected = <<<'EOD'

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1085,7 +1085,7 @@ EOD;
         $data = ['1' => '1', '1.1' => '1.1', '1.10' => '1.10'];
         $attributes = ['strict' => true];
         $this->assertEqualsWithoutLE($expected, Html::renderSelectOptions(['1.1'], $data, $attributes));
-        $attributes = ['strict' => false];
+        $attributes = ['strict' => true];
         $this->assertEqualsWithoutLE($expected, Html::renderSelectOptions([1.1], $data, $attributes));
 
         $expected = <<<'EOD'


### PR DESCRIPTION
Current `BaseHtml::renderSelectOptions()` behavior is incorrect:
- multiple selection: always converts `$selection` and `$key` to strings
- single selection: converts `$selection` and `$key` to strings at strict comparation (`strcmp()`)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #19522
