### PR TITLE
Switch from swiftmailer to symfonymailer in examples & tutorials

### DIFF
--- a/docs/guide/concept-configurations.md
+++ b/docs/guide/concept-configurations.md
@@ -103,7 +103,7 @@ $config = [
             'class' => 'yii\caching\FileCache',
         ],
         'mailer' => [
-            'class' => 'yii\swiftmailer\Mailer',
+            'class' => 'yii\symfonymailer\Mailer',
         ],
         'log' => [
             'class' => 'yii\log\Dispatcher',
@@ -207,7 +207,7 @@ return [
         'class' => 'yii\caching\FileCache',
     ],
     'mailer' => [
-        'class' => 'yii\swiftmailer\Mailer',
+        'class' => 'yii\symfonymailer\Mailer',
     ],
     'log' => [
         'class' => 'yii\log\Dispatcher',

--- a/docs/guide/concept-di-container.md
+++ b/docs/guide/concept-di-container.md
@@ -163,7 +163,7 @@ $container->set('yii\db\Connection');
 // register an interface
 // When a class depends on the interface, the corresponding class
 // will be instantiated as the dependent object
-$container->set('yii\mail\MailInterface', 'yii\swiftmailer\Mailer');
+$container->set('yii\mail\MailInterface', 'yii\symfonymailer\Mailer');
 
 // register an alias name. You can use $container->get('foo')
 // to create an instance of Connection

--- a/docs/guide/structure-extensions.md
+++ b/docs/guide/structure-extensions.md
@@ -434,8 +434,8 @@ registered on [Packagist](https://packagist.org/) and can be easily installed as
 - [yiisoft/yii2-sphinx](https://www.yiiframework.com/extension/yiisoft/yii2-sphinx):
   provides the support for using [Sphinx](https://sphinxsearch.com/). It includes features such as basic query,
   Active Record, code generation, etc.
-- [yiisoft/yii2-swiftmailer](https://www.yiiframework.com/extension/yiisoft/yii2-swiftmailer):
-  provides email sending features based on [swiftmailer](https://swiftmailer.symfony.com/).
+- [yiisoft/yii2-symfonymailer](https://www.yiiframework.com/extension/yiisoft/yii2-symfonymailer):
+  provides email sending features based on [Symfony Mailer](https://symfony.com/doc/current/mailer.html).
 - [yiisoft/yii2-twig](https://www.yiiframework.com/extension/yiisoft/yii2-twig):
   provides a template engine based on [Twig](https://twig.symfony.com/).
 

--- a/docs/guide/tutorial-mailing.md
+++ b/docs/guide/tutorial-mailing.md
@@ -8,7 +8,7 @@ only the content composition functionality and basic interface. Actual mail send
 be provided by the extension, because different projects may require its different implementation and
 it usually depends on the external services and libraries.
 
-For the most common cases you can use [yii2-swiftmailer](https://www.yiiframework.com/extension/yiisoft/yii2-swiftmailer) official extension.
+For the most common cases you can use [yii2-symfonymailer](https://www.yiiframework.com/extension/yiisoft/yii2-symfonymailer) official extension.
 
 
 Configuration
@@ -22,16 +22,11 @@ return [
     //....
     'components' => [
         'mailer' => [
-            'class' => 'yii\swiftmailer\Mailer',
+            'class' => 'yii\symfonymailer\Mailer',
             'useFileTransport' => false,
             'transport' => [
-                'class' => 'Swift_SmtpTransport',
-                'encryption' => 'tls',
-                'host' => 'your_mail_server_host',
-                'port' => 'your_smtp_port',
-                'username' => 'your_username',
-                'password' => 'your_password',
-            ],             
+                'dsn' => 'smtp://user:pass@smtp.example.com:465',
+            ],
         ],
     ],
 ];


### PR DESCRIPTION
Let stop mentioning Swiftmailer now that it's not maintained anymore.

@samdark Could you publish the `yiisoft/yii2-symfonymailer` on the website extensions page? https://www.yiiframework.com/extensions/create