### PR TITLE
Option to pass callable as key prefix

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Bug #19508: Fix wrong selection for boolean attributes in GridView (alnidok)
 - Bug #19517: Fix regression in `CompositeAuth::authenticate()` introduced in #19418 (WinterSilence)
 - Bug #19537: Fix default expression detection for MariaDB `date` and `time` columns (bizley)
+- Enh #19584: `yii\caching\Cache` allows closure for `$keyPrefix` in order to generate more dynamic globale cache prefixes (nadar)
 
 
 2.0.46 August 18, 2022

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -54,11 +54,14 @@ use yii\helpers\StringHelper;
 abstract class Cache extends Component implements CacheInterface
 {
     /**
-     * @var string a string prefixed to every cache key so that it is unique globally in the whole cache storage.
+     * @var string|callable A string prefixed to every cache key so that it is unique globally in the whole cache storage.
      * It is recommended that you set a unique cache key prefix for each application if the same cache
      * storage is being used by different applications.
      *
      * To ensure interoperability, only alphanumeric characters should be used.
+     *
+     * since 2.0.X its allowed to use a closure function, this can be usefull when working with environment variables or
+     * any other environment depending cache prefix.
      */
     public $keyPrefix;
     /**
@@ -117,8 +120,10 @@ abstract class Cache extends Component implements CacheInterface
 
             $key = md5($serializedKey);
         }
+        
+        $prefix = is_callable($this->keyPrefix) ? call_user_func($this->keyPrefix, $key, $this) : $this->keyPrefix;
 
-        return $this->keyPrefix . $key;
+        return $prefix . $key;
     }
 
     /**

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -60,8 +60,8 @@ abstract class Cache extends Component implements CacheInterface
      *
      * To ensure interoperability, only alphanumeric characters should be used.
      *
-     * Since 2.0.47 its allowed to use a closure function, this can be usefull when working with environment variables or
-     * any dynamic calculated cache key. Keep in mind to use alphanumeric characters:
+     * Since 2.0.47 its allowed to use a closure function, this can be useful when working with environment variables or
+     * any dynamic calculated cache prefx. Keep in mind to use alphanumeric characters as mentioned above:
      *
      * ```php
      * 'cache' => [

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -60,8 +60,17 @@ abstract class Cache extends Component implements CacheInterface
      *
      * To ensure interoperability, only alphanumeric characters should be used.
      *
-     * since 2.0.X its allowed to use a closure function, this can be usefull when working with environment variables or
-     * any other environment depending cache prefix.
+     * Since 2.0.47 its allowed to use a closure function, this can be usefull when working with environment variables or
+     * any dynamic calculated cache key. Keep in mind to use alphanumeric characters:
+     *
+     * ```php
+     * 'cache' => [
+     *     'class' => 'yii\caching\FileCache',
+     *     'keyPrefix' => function() {
+     *         return YII_ENV;
+     *     }
+     * ]
+     * ```
      */
     public $keyPrefix;
     /**
@@ -121,7 +130,7 @@ abstract class Cache extends Component implements CacheInterface
             $key = md5($serializedKey);
         }
         
-        $prefix = is_callable($this->keyPrefix) ? call_user_func($this->keyPrefix, $key, $this) : $this->keyPrefix;
+        $prefix = is_callable($this->keyPrefix) ? call_user_func($this->keyPrefix, $this) : $this->keyPrefix;
 
         return $prefix . $key;
     }

--- a/tests/framework/caching/FileCacheTest.php
+++ b/tests/framework/caching/FileCacheTest.php
@@ -86,28 +86,10 @@ class FileCacheTest extends CacheTestCase
     public function testCallableKeyPrefix()
     {
         $time = time();
-        $key = uniqid('uid-cache_');
         $cache = $this->getCacheInstance();
-        $cache->flush();
-
-        $cache->directoryLevel = 1;
         $cache->keyPrefix = function() use ($time) { return 'dynamicprefix'.$time; };
-        $normalizeKey = $cache->buildKey($key);
-        $expectedDirectoryName = substr($normalizeKey, 6, 2);
-
-        $value = \time();
-
-        $refClass = new \ReflectionClass($cache);
-
-        $refMethodGetCacheFile = $refClass->getMethod('getCacheFile');
-        $refMethodGetCacheFile->setAccessible(true);
-        $refMethodGet = $refClass->getMethod('get');
-        $refMethodSet = $refClass->getMethod('set');
-
-        $cacheFile = $refMethodGetCacheFile->invoke($cache, $normalizeKey);
-
-        $this->assertTrue($refMethodSet->invoke($cache, $key, $value));
-        $this->assertContains('dynamicprefix'.$time, basename($cacheFile));
+        
+        $this->assertSame('dynamicprefix'.$time.'barfoo', $cache->buildKey('barfoo'));
     }
 
     public function testCacheRenewalOnDifferentOwnership()


### PR DESCRIPTION
There are different reason where cache key should be evaluated dynamically in the config, for example something like this:

```php
'cache' => [
            'class' => 'yii\redis\Cache',
            'redis' => 'redis',
            'keyPrefix' => function() {
                return getenv('SERVER_ENV') ?: 'defaultprefix';
             }
],
```

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Let me know if this is acceptable, so i will add some more phpdocs and changelog.
