### PR TITLE
Changed git:// protocol to https:// in git-workflow.md

### DIFF
--- a/docs/internals/git-workflow.md
+++ b/docs/internals/git-workflow.md
@@ -28,7 +28,7 @@ then you must [setup your Git installation to work with GitHub](https://help.git
 Change to the directory where you cloned Yii, normally, "yii2". Then enter the following command:
 
 ```
-git remote add upstream git://github.com/yiisoft/yii2.git
+git remote add upstream https://github.com/yiisoft/yii2.git
 ```
 
 ### 3. Prepare the testing environment <span id="prepare-the-test-environment"></span>
@@ -232,7 +232,7 @@ Doing so will save travis from commencing testruns on changes that are not cover
 
 ```
 git clone git@github.com:YOUR-GITHUB-USERNAME/yii2.git
-git remote add upstream git://github.com/yiisoft/yii2.git
+git remote add upstream https://github.com/yiisoft/yii2.git
 ```
 
 ```


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer supported. Updated git-workflow.md (https://github.com/yiisoft/yii2/blob/master/docs/internals/git-workflow.md) to use https instead, since error could make really hard for github novice users to contribute.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
