### PR TITLE
Do not reset retryHandler when yii\db\Command::reset() called

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -20,6 +20,7 @@ Yii Framework 2 Change Log
 - Bug #19670: Fix Error null check PHP 8.1 `yii\rbac\DbManager` (samuelexyz)
 - Bug #19520: Fix for TIMESTAMP & ROWVERSION columns in MSSQL insert query (darkdef)
 - Bug #19581: Fix regression in `CompositeAuth` introduced in #19418 (SamMousa, WinterSilence, samdark)
+- Chg #17811: Do not reset `retryHandler` when `yii\db\Command::reset()` called (erickskrauch)
 
 
 2.0.46 August 18, 2022

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -1324,6 +1324,5 @@ class Command extends Component
         $this->params = [];
         $this->_refreshTableName = null;
         $this->_isolationLevel = false;
-        $this->_retryHandler = null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #17811

Logically, this PR violates backward compatibility. But so far this functionality was nowhere described and was of little use on real projects because almost any operation with `Command` or `Query` was done by calling `setSql()`, which called `reset()` method inside, which sets `_errorHandler` to `null`. So I don't think it's so much a change as more of a design bug fix.

Should I mention this functionality in the docs? I could only find this functionality by reading the source code.

I also wanted to reflect these changes in the tests, but found that the behavior with resetting the field when `reset()` was called was not covered with tests.