### PR TITLE
Prevent trailing or duplicate spaces in class attribute

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Enh #9740: Usage of DI instead of new keyword in Schemas (manchenkoff)
-
+- Enh #19689: Remove empty elements from the `class` array in `yii\helpers\BaseHtml::renderTagAttributes()` to prevent unwanted spaces (MoritzLost)
 
 2.0.47 November 18, 2022
 ------------------------

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2017,7 +2017,7 @@ class BaseHtml
                         $value = explode(' ', implode(' ', $value));
                         $value = array_unique($value);
                     }
-                    $html .= " $name=\"" . static::encode(implode(' ', $value)) . '"';
+                    $html .= " $name=\"" . static::encode(implode(' ', array_filter($value))) . '"';
                 } elseif ($name === 'style') {
                     if (empty($value)) {
                         continue;

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1210,6 +1210,7 @@ EOD;
         $this->assertEquals(' name="test" value="1&lt;&gt;"', Html::renderTagAttributes(['name' => 'test', 'empty' => null, 'value' => '1<>']));
         $this->assertEquals(' checked disabled', Html::renderTagAttributes(['checked' => true, 'disabled' => true, 'hidden' => false]));
         $this->assertEquals(' class="first second"', Html::renderTagAttributes(['class' => ['first', 'second']]));
+        $this->assertEquals(' class="first second"', Html::renderTagAttributes(['class' => ['first', null, 'second', '']]));
         Html::$normalizeClassAttribute = true;
         $this->assertEquals(' class="first second"', Html::renderTagAttributes(['class' => ['first second', 'first']]));
         $this->assertEquals('', Html::renderTagAttributes(['class' => []]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

This is a tiny, backwards-compatible improvement to the `BaseHtml::renderTagAttributes` method. It removes empty elements from the classes array for the `class` attribute, preventing duplicate or trailing whitespaces in the generated HTML.

```php
<div <?= BaseHtml::renderTagAttributes(['class' => [
    'my-custom-element',
    $someCondition ? 'my-custom-element--modifier' : null,
]]) ?>></div>
```

If `$someCondition` is false, this will result in the output:

```html
<div class="my-custom-element "></div>
```

Notice the extra space at the end of the attribute. This is pretty common if you're using this function in Twig templates, where you can omit the last part of the ternary operator.

By filtering out empty elements from the array of classes before joining it, you instead get this:

```html
<div class="my-custom-element"></div>
```

Which is much nicer to look at.