### PR TITLE
Change property visibility to allow more flexibility for apps

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,8 @@ Yii Framework 2 Change Log
 
 - Enh #9740: Usage of DI instead of new keyword in Schemas (manchenkoff)
 - Enh #19689: Remove empty elements from the `class` array in `yii\helpers\BaseHtml::renderTagAttributes()` to prevent unwanted spaces (MoritzLost)
+- Chg #19696: Change visibility of `yii\web\View::isPageEnded` to `protected` (lubosdz, samdark)
+
 
 2.0.47 November 18, 2022
 ------------------------

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -138,7 +138,7 @@ class View extends \yii\base\View
      * @var bool
      * @since 2.0.44
      */
-    protected $_isPageEnded = false;
+    protected $isPageEnded = false;
 
 
     /**

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -181,7 +181,7 @@ class View extends \yii\base\View
     {
         $this->trigger(self::EVENT_END_PAGE);
 
-        $this->_isPageEnded = true;
+        $this->isPageEnded = true;
 
         $content = ob_get_clean();
 
@@ -499,7 +499,7 @@ class View extends \yii\base\View
         }
         $appendTimestamp = ArrayHelper::remove($options, 'appendTimestamp', $assetManagerAppendTimestamp);
 
-        if ($this->_isPageEnded) {
+        if ($this->isPageEnded) {
             Yii::warning('You\'re trying to register a file after View::endPage() has been called.');
         }
 

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -132,11 +132,13 @@ class View extends \yii\base\View
     public $jsFiles = [];
 
     private $_assetManager;
+
     /**
      * Whether [[endPage()]] has been called and all files have been registered
      * @var bool
+     * @since 2.0.44
      */
-    private $_isPageEnded = false;
+    protected $_isPageEnded = false;
 
 
     /**
@@ -498,7 +500,7 @@ class View extends \yii\base\View
         $appendTimestamp = ArrayHelper::remove($options, 'appendTimestamp', $assetManagerAppendTimestamp);
 
         if ($this->_isPageEnded) {
-            Yii::warning('You\'re trying to register a file after View::endPage() has been called');
+            Yii::warning('You\'re trying to register a file after View::endPage() has been called.');
         }
 
         if (empty($depends)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | introduced by #18975, fixes #19696

Commit #18975 throws warning when reusing the `View` object more than once in a single request. This unfortunately ignores possible legit use cases. For example in one our app we have CMS admin, which requires in first step fetching & parsing View output from the page being edited (find placeholders) and then in returned view (2. View usage) display editable areas. Since 2.0.44 our logger is bloated with warnings `You\'re trying to register a file after View::endBody() has been called`. Since the property has been assigned `private`, there is no way to allow overriding behavior in an application e.g. for specific controllers only.

This commit alleviates aforementioned issue by changing property visibility from `private` to `protected`.