### PR TITLE
fix: PHP 8.1 mb_stripos() deprecated

### DIFF
--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -458,7 +458,7 @@ abstract class Schema extends BaseObject
             return $str;
         }
 
-        if (mb_stripos($this->db->dsn, 'odbc:') === false && ($value = $this->db->getSlavePdo()->quote($str)) !== false) {
+        if (mb_stripos((string)$this->db->dsn, 'odbc:') === false && ($value = $this->db->getSlavePdo()->quote($str)) !== false) {
             return $value;
         }
 


### PR DESCRIPTION
method quoteValue() in framework/db/Schema.php

``mb_stripos(): Passing null to parameter #1 ($haystack) of type string is deprecated``

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
