### PR TITLE
Fixed adding new css class to previously added CSS class key for bug …

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.48 under development
 ------------------------
 
-- Bug #19012: Fixed adding new css class to previously added CSS class key (lawgiver00)
+- Bug #19012: Fixed adding new CSS class to previously added CSS class key (lawgiver00)
 - Enh #9740: Usage of DI instead of new keyword in Schemas (manchenkoff)
 - Enh #19689: Remove empty elements from the `class` array in `yii\helpers\BaseHtml::renderTagAttributes()` to prevent unwanted spaces (MoritzLost)
 - Chg #19696: Change visibility of `yii\web\View::isPageEnded` to `protected` (lubosdz, samdark)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.48 under development
 ------------------------
 
+- Bug #19012: Fixed adding new css class to previously added CSS class key (lawgiver00)
 - Enh #9740: Usage of DI instead of new keyword in Schemas (manchenkoff)
 - Enh #19689: Remove empty elements from the `class` array in `yii\helpers\BaseHtml::renderTagAttributes()` to prevent unwanted spaces (MoritzLost)
 - Chg #19696: Change visibility of `yii\web\View::isPageEnded` to `protected` (lubosdz, samdark)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2078,8 +2078,8 @@ class BaseHtml
         foreach ($additionalClasses as $key => $class) {
             if (is_int($key) && !in_array($class, $existingClasses)) {
                 $existingClasses[] = $class;
-            } else if(isset($existingClasses[$key])) {
-                $existingClasses[$key] = implode(' ', array_merge(explode(' ',$existingClasses[$key]),[$class]));
+            } elseif (isset($existingClasses[$key])) {
+                $existingClasses[$key] = implode(' ', array_merge(explode(' ', $existingClasses[$key]), [$class]));
             } elseif (!isset($existingClasses[$key])) {
                 $existingClasses[$key] = $class;
             }

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2078,6 +2078,8 @@ class BaseHtml
         foreach ($additionalClasses as $key => $class) {
             if (is_int($key) && !in_array($class, $existingClasses)) {
                 $existingClasses[] = $class;
+            } else if(isset($existingClasses[$key])) {
+                $existingClasses[$key] = implode(' ', array_merge(explode(' ',$existingClasses[$key]),[$class]));
             } elseif (!isset($existingClasses[$key])) {
                 $existingClasses[$key] = $class;
             }


### PR DESCRIPTION
…#19012

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | Fixes #19012, if you tried to add another class to an already existing key as described in the dumentation for addCssClass it would ignore any attempt except for the first one. This fix find the key and adds the additional classes as originally intended.
