### PR TITLE
Remove unnecessary SQL updates in the database on attributes typecast (#17194)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.48 under development
 ------------------------
-
+- Bug #17194: Fix unnecessary SQL updates in the database on attributes typecast via `yii\behaviors\AttributeTypecastBehavior` (aivchen)
 - Bug #19693: Fix db/Command not caching `NULL` result with scalar fetchMode (Arkeins)
 - Enh #15376: Added cache usage for `yii2\rbac\DbManager::getRolesByUser()` (manchenkoff)
 - Enh #9740: Usage of DI instead of new keyword in Schemas (manchenkoff)

--- a/framework/behaviors/AttributeTypecastBehavior.php
+++ b/framework/behaviors/AttributeTypecastBehavior.php
@@ -366,9 +366,6 @@ class AttributeTypecastBehavior extends Behavior
         $this->resetOldAttributes();
     }
 
-    /**
-     * @return void
-     */
     private function resetOldAttributes()
     {
         if ($this->attributeTypes === null) {

--- a/framework/behaviors/AttributeTypecastBehavior.php
+++ b/framework/behaviors/AttributeTypecastBehavior.php
@@ -362,5 +362,23 @@ class AttributeTypecastBehavior extends Behavior
     public function afterFind($event)
     {
         $this->typecastAttributes();
+
+        $this->resetOldAttributes();
+    }
+
+    /**
+     * @return void
+     */
+    private function resetOldAttributes()
+    {
+        if ($this->attributeTypes === null) {
+            return;
+        }
+
+        $attributes = array_keys($this->attributeTypes);
+
+        foreach ($attributes as $attribute) {
+            $this->owner->setOldAttribute($attribute, $this->owner->{$attribute});
+        }
     }
 }

--- a/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
@@ -129,8 +129,6 @@ class AttributeTypecastBehaviorTest extends TestCase
 
     /**
      * @see https://github.com/yiisoft/yii2/issues/17194
-     *
-     * @return void
      */
     public function testDirtyAttributesAreEmptyAfterFind()
     {

--- a/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
@@ -128,6 +128,26 @@ class AttributeTypecastBehaviorTest extends TestCase
     }
 
     /**
+     * @see https://github.com/yiisoft/yii2/issues/17194
+     *
+     * @return void
+     */
+    public function testDirtyAttributesAreEmptyAfterFind()
+    {
+        $model = new ActiveRecordAttributeTypecast();
+        $model->name = 123;
+        $model->amount = '58';
+        $model->price = '100.8';
+        $model->isActive = 1;
+        $model->callback = 'foo';
+        $model->save(false);
+
+        $model = ActiveRecordAttributeTypecast::find()->one();
+
+        $this->assertEmpty($model->getDirtyAttributes());
+    }
+
+    /**
      * @depends testTypecast
      */
     public function testAfterValidateEvent()


### PR DESCRIPTION
We need to set old attributes to their current values to avoid useless SQL updates.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #17194
