### PR TITLE
PHP 8.1 trim(): Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Enh #19689: Remove empty elements from the `class` array in `yii\helpers\BaseHtml::renderTagAttributes()` to prevent unwanted spaces (MoritzLost)
 - Chg #19696: Change visibility of `yii\web\View::isPageEnded` to `protected` (lubosdz, samdark)
 - Bug #19712: Cast shell_exec() output to string for jsCompressor (impayru)
+- Bug: PHP 8.1 compatibility fix for `$query->orderBy(null)`
 
 2.0.47 November 18, 2022
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,7 +14,7 @@ Yii Framework 2 Change Log
 - Enh #19689: Remove empty elements from the `class` array in `yii\helpers\BaseHtml::renderTagAttributes()` to prevent unwanted spaces (MoritzLost)
 - Chg #19696: Change visibility of `yii\web\View::isPageEnded` to `protected` (lubosdz, samdark)
 - Bug #19712: Cast shell_exec() output to string for jsCompressor (impayru)
-- Bug: PHP 8.1 compatibility fix for `$query->orderBy(null)`
+- Bug #19734: PHP 8.1 compatibility fix for `$query->orderBy(null)` (uaoleg)
 - Bug #19731: Fix `yii\data\Sort` to generate proper link when multisort is on and attribute has a default sort order set (bizley)
 
 2.0.47 November 18, 2022

--- a/framework/db/QueryTrait.php
+++ b/framework/db/QueryTrait.php
@@ -305,7 +305,7 @@ trait QueryTrait
 
     /**
      * Sets the ORDER BY part of the query.
-     * @param string|array|ExpressionInterface $columns the columns (and the directions) to be ordered by.
+     * @param string|array|ExpressionInterface|null $columns the columns (and the directions) to be ordered by.
      * Columns can be specified in either a string (e.g. `"id ASC, name DESC"`) or an array
      * (e.g. `['id' => SORT_ASC, 'name' => SORT_DESC]`).
      *
@@ -358,12 +358,14 @@ trait QueryTrait
     /**
      * Normalizes format of ORDER BY data.
      *
-     * @param array|string|ExpressionInterface $columns the columns value to normalize. See [[orderBy]] and [[addOrderBy]].
+     * @param array|string|ExpressionInterface|null $columns the columns value to normalize. See [[orderBy]] and [[addOrderBy]].
      * @return array
      */
     protected function normalizeOrderBy($columns)
     {
-        if ($columns instanceof ExpressionInterface) {
+        if (empty($columns)) {
+            return [];
+        } elseif ($columns instanceof ExpressionInterface) {
             return [$columns];
         } elseif (is_array($columns)) {
             return $columns;


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

