### PR TITLE
Check-all checkbox should be unchecked on page load when GridView have no rows

### DIFF
--- a/framework/assets/yii.gridView.js
+++ b/framework/assets/yii.gridView.js
@@ -198,7 +198,9 @@
                 $grid.find(checkAllInput + (all ? ":not(:checked)" : ":checked")).prop('checked', all).change();
             };
             initEventHandler($grid, 'checkRow', 'click.yiiGridView', "#" + id + " " + inputs, handler);
-            handler(); // Ensure "check all" checkbox is checked on page load if all data row checkboxes are initially checked.
+            if($grid.find(inputs).length) {
+                handler(); // Ensure "check all" checkbox is checked on page load if all data row checkboxes are initially checked.
+            }
         },
 
         getSelectedRows: function () {


### PR DESCRIPTION
This PR fixes the following regression introduced by my fix #18867.

After #18867 the check-all checkbox is (incorrectly) checked on page load when GridView have no rows. Before #18867 it was (correctly) unchecked. 

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
