### PR TITLE
Improve check on loading cached file if the file not found

### DIFF
--- a/framework/caching/FileCache.php
+++ b/framework/caching/FileCache.php
@@ -110,7 +110,7 @@ class FileCache extends Cache
     {
         $cacheFile = $this->getCacheFile($key);
 
-        if (@filemtime($cacheFile) > time()) {
+        if (file_exists($cacheFile) && @filemtime($cacheFile) > time()) {
             $fp = @fopen($cacheFile, 'r');
             if ($fp !== false) {
                 @flock($fp, LOCK_SH);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Improvement?    | ✔️
| Breaks BC?    | ❌

This fixes annoying errors in debug mode when attempting to load from cache non-existing file (filecache only). Adding simple check whether the file exists fixes the issue.