### PR TITLE
Add caching for getUserIP and getSecureForwardedHeaderTrustedParts

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -22,6 +22,7 @@ Yii Framework 2 Change Log
 - Bug #19731: Fix `yii\data\Sort` to generate proper link when multisort is on and attribute has a default sort order set (bizley)
 - Bug #19735: Fix `yii\validators\NumberValidator` to use programmable message for the value validation (bizley)
 - Bug #19770: Fix `yii\mutex\MysqlMutex` `keyPrefix` expression param binding (kamarton)
+- Enh #19794: Add caching in `yii\web\Request` for `getUserIP()` and `getSecureForwardedHeaderTrustedParts()` (rhertogh)
 
 2.0.47 November 18, 2022
 ------------------------

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -1231,7 +1231,9 @@ class Request extends \yii\base\Request
     {
         if ($this->_ip === null) {
             $this->_ip = $this->getUserIpFromIpHeaders();
-            $this->_ip = $this->_ip === null ? $this->getRemoteIP() : $this->_ip;
+            if ($this->_ip === null) {
+                $this->_ip = $this->getRemoteIP();
+            }
         }
 
         return $this->_ip;

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -1220,6 +1220,8 @@ class Request extends \yii\base\Request
         return null;
     }
 
+    private $_ip = null;
+
     /**
      * Returns the user IP address.
      * The IP is determined using headers and / or `$_SERVER` variables.
@@ -1227,8 +1229,12 @@ class Request extends \yii\base\Request
      */
     public function getUserIP()
     {
-        $ip = $this->getUserIpFromIpHeaders();
-        return $ip === null ? $this->getRemoteIP() : $ip;
+        if ($this->_ip === null) {
+            $this->_ip = $this->getUserIpFromIpHeaders();
+            $this->_ip = $this->_ip === null ? $this->getRemoteIP() : $this->_ip;
+        }
+
+        return $this->_ip;
     }
 
     /**
@@ -1902,6 +1908,8 @@ class Request extends \yii\base\Request
         return null;
     }
 
+    private $_secureForwardedHeaderTrustedParts;
+
     /**
      * Gets only trusted `Forwarded` header parts
      *
@@ -1911,6 +1919,10 @@ class Request extends \yii\base\Request
      */
     protected function getSecureForwardedHeaderTrustedParts()
     {
+        if ($this->_secureForwardedHeaderTrustedParts !== null) {
+            return $this->_secureForwardedHeaderTrustedParts;
+        }
+
         $validator = $this->getIpValidator();
         $trustedHosts = [];
         foreach ($this->trustedHosts as $trustedCidr => $trustedCidrOrHeaders) {
@@ -1921,9 +1933,14 @@ class Request extends \yii\base\Request
         }
         $validator->setRanges($trustedHosts);
 
-        return array_filter($this->getSecureForwardedHeaderParts(), function ($headerPart) use ($validator) {
-            return isset($headerPart['for']) ? !$validator->validate($headerPart['for']) : true;
-        });
+        $this->_secureForwardedHeaderTrustedParts = array_filter(
+            $this->getSecureForwardedHeaderParts(),
+            function ($headerPart) use ($validator) {
+                return isset($headerPart['for']) ? !$validator->validate($headerPart['for']) : true;
+            }
+        );
+
+        return $this->_secureForwardedHeaderTrustedParts;
     }
 
     private $_secureForwardedHeaderParts;

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -422,17 +422,18 @@ class AccessRuleTest extends \yiiunit\TestCase
     {
         $action = $this->mockAction();
         $user = false;
-        $request = $this->mockRequest();
 
         $rule = new AccessRule();
 
         // by default match all IPs
+        $request = $this->mockRequest();
         $rule->allow = true;
         $this->assertTrue($rule->allows($action, $user, $request));
         $rule->allow = false;
         $this->assertFalse($rule->allows($action, $user, $request));
 
         // empty IPs = match all IPs
+        $request = $this->mockRequest();
         $rule->ips = [];
         $rule->allow = true;
         $this->assertTrue($rule->allows($action, $user, $request));
@@ -441,6 +442,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // match, one IP
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $request = $this->mockRequest();
         $rule->ips = ['127.0.0.1'];
         $rule->allow = true;
         $this->assertTrue($rule->allows($action, $user, $request));
@@ -449,6 +451,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // no match, one IP
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $request = $this->mockRequest();
         $rule->ips = ['192.168.0.1'];
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
@@ -457,12 +460,14 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // no partial match, one IP
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $request = $this->mockRequest();
         $rule->ips = ['127.0.0.10'];
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
         $rule->allow = false;
         $this->assertNull($rule->allows($action, $user, $request));
         $_SERVER['REMOTE_ADDR'] = '127.0.0.10';
+        $request = $this->mockRequest();
         $rule->ips = ['127.0.0.1'];
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
@@ -471,6 +476,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // match, one IP IPv6
         $_SERVER['REMOTE_ADDR'] = '::1';
+        $request = $this->mockRequest();
         $rule->ips = ['::1'];
         $rule->allow = true;
         $this->assertTrue($rule->allows($action, $user, $request));
@@ -479,6 +485,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // no match, one IP IPv6
         $_SERVER['REMOTE_ADDR'] = '::1';
+        $request = $this->mockRequest();
         $rule->ips = ['dead::beaf::1'];
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
@@ -487,12 +494,14 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // no partial match, one IP IPv6
         $_SERVER['REMOTE_ADDR'] = '::1';
+        $request = $this->mockRequest();
         $rule->ips = ['::123'];
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
         $rule->allow = false;
         $this->assertNull($rule->allows($action, $user, $request));
         $_SERVER['REMOTE_ADDR'] = '::123';
+        $request = $this->mockRequest();
         $rule->ips = ['::1'];
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
@@ -501,6 +510,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // undefined IP
         $_SERVER['REMOTE_ADDR'] = null;
+        $request = $this->mockRequest();
         $rule->ips = ['192.168.*'];
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
@@ -512,12 +522,12 @@ class AccessRuleTest extends \yiiunit\TestCase
     {
         $action = $this->mockAction();
         $user = false;
-        $request = $this->mockRequest();
 
         $rule = new AccessRule();
 
         // no match
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $request = $this->mockRequest();
         $rule->ips = ['192.168.*'];
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
@@ -526,6 +536,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // match
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $request = $this->mockRequest();
         $rule->ips = ['127.0.*'];
         $rule->allow = true;
         $this->assertTrue($rule->allows($action, $user, $request));
@@ -534,6 +545,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // match, IPv6
         $_SERVER['REMOTE_ADDR'] = '2a01:4f8:120:7202::2';
+        $request = $this->mockRequest();
         $rule->ips = ['2a01:4f8:120:*'];
         $rule->allow = true;
         $this->assertTrue($rule->allows($action, $user, $request));
@@ -542,6 +554,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // no match, IPv6
         $_SERVER['REMOTE_ADDR'] = '::1';
+        $request = $this->mockRequest();
         $rule->ips = ['2a01:4f8:120:*'];
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
@@ -553,12 +566,12 @@ class AccessRuleTest extends \yiiunit\TestCase
     {
         $action = $this->mockAction();
         $user = false;
-        $request = $this->mockRequest();
 
         $rule = new AccessRule();
 
         // no match
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $request = $this->mockRequest();
         $rule->ips = ['127.0.0.32/27'];
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));
@@ -567,6 +580,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // match
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $request = $this->mockRequest();
         $rule->ips = ['127.0.0.1/27'];
         $rule->allow = true;
         $this->assertTrue($rule->allows($action, $user, $request));
@@ -575,6 +589,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // match, IPv6
         $_SERVER['REMOTE_ADDR'] = '2a01:4f8:120:7202::2';
+        $request = $this->mockRequest();
         $rule->ips = ['2a01:4f8:120:7202::2/127'];
         $rule->allow = true;
         $this->assertTrue($rule->allows($action, $user, $request));
@@ -583,6 +598,7 @@ class AccessRuleTest extends \yiiunit\TestCase
 
         // no match, IPv6
         $_SERVER['REMOTE_ADDR'] = '2a01:4f8:120:7202::ffff';
+        $request = $this->mockRequest();
         $rule->ips = ['2a01:4f8:120:7202::2/123'];
         $rule->allow = true;
         $this->assertNull($rule->allows($action, $user, $request));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Many function in the `yii\web\Request` are cached in private properties. This PR adds the same functionality for the `getUserIP`  and `getSecureForwardedHeaderTrustedParts` functions.
This greatly improves performance when a lot of `trustedHosts` are set (e.g. when using CloudFlare or AWS CloudFront).

Before:
![image](https://user-images.githubusercontent.com/1292337/228071184-47b822bb-edb3-46df-8b8f-f5b3ed56a673.png)

After:
![image](https://user-images.githubusercontent.com/1292337/228071324-627225a6-8c92-4138-aefb-509bcf5dc769.png)
