### PR TITLE
Fixed \yiiunit\framework\helpers\JsonTest::testEncode() for PHP 5.4

### DIFF
--- a/tests/framework/helpers/JsonTest.php
+++ b/tests/framework/helpers/JsonTest.php
@@ -96,14 +96,15 @@ class JsonTest extends TestCase
         $data->data = (object) null;
         $this->assertSame('{}', Json::encode($data));
 
-        // Generator
-        $data = function () {
-            foreach (['a' => 1, 'b' => 2] as $name  => $value) {
-                yield $name => $value;
-            }
-        };
-
-        $this->assertSame('{"a":1,"b":2}', Json::encode($data()));
+        // Generator (Only supported since PHP 5.5)
+        if (PHP_VERSION_ID >= 50500) {
+            $data = function () {
+                foreach (['a' => 1, 'b' => 2] as $name => $value) {
+                    yield $name => $value;
+                }
+            };
+            $this->assertSame('{"a":1,"b":2}', Json::encode($data()));
+        }
     }
 
     public function testHtmlEncode()

--- a/tests/framework/helpers/JsonTest.php
+++ b/tests/framework/helpers/JsonTest.php
@@ -98,11 +98,14 @@ class JsonTest extends TestCase
 
         // Generator (Only supported since PHP 5.5)
         if (PHP_VERSION_ID >= 50500) {
-            $data = function () {
-                foreach (['a' => 1, 'b' => 2] as $name => $value) {
-                    yield $name => $value;
-                }
-            };
+            $data = eval(<<<'PHP'
+                return function () {
+                    foreach (['a' => 1, 'b' => 2] as $name => $value) {
+                        yield $name => $value;
+                    }
+                };
+PHP
+            );
             $this->assertSame('{"a":1,"b":2}', Json::encode($data()));
         }
     }


### PR DESCRIPTION
'\Generator' is only supported since PHP 5.5

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | Fixed unit test for #19777, #19796
