### PR TITLE
BC break: Calling a method unnecessarily

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -24,6 +24,7 @@ Yii Framework 2 Change Log
 - Bug #19770: Fix `yii\mutex\MysqlMutex` `keyPrefix` expression param binding (kamarton)
 - Enh #19794: Add caching in `yii\web\Request` for `getUserIP()` and `getSecureForwardedHeaderTrustedParts()` (rhertogh)
 - Bug #19795: Fix `yii\web\Response::redirect()` to prevent setting headers with URL containing new line character (bizley)
+- Enh #19804: Change `$this->oldAttributes` to `$this->_oldAttributes` to avoid calling a method unnecessarily (thiagotalma)
 
 2.0.47 November 18, 2022
 ------------------------

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1762,7 +1762,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     private function isAttributeDirty($attribute, $value)
     {
-        $old_attribute = $this->_oldAttributes[$attribute];
+        $old_attribute = $this->_oldAttributes === null || !array_key_exists($attribute, $this->_oldAttributes) ? [] : $this->_oldAttributes[$attribute];
         if (is_array($value) && is_array($this->_oldAttributes[$attribute])) {
             $value = ArrayHelper::recursiveSort($value);
             $old_attribute = ArrayHelper::recursiveSort($old_attribute);

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1762,8 +1762,8 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     private function isAttributeDirty($attribute, $value)
     {
-        $old_attribute = $this->oldAttributes[$attribute];
-        if (is_array($value) && is_array($this->oldAttributes[$attribute])) {
+        $old_attribute = $this->_oldAttributes[$attribute];
+        if (is_array($value) && is_array($this->_oldAttributes[$attribute])) {
             $value = ArrayHelper::recursiveSort($value);
             $old_attribute = ArrayHelper::recursiveSort($old_attribute);
         }


### PR DESCRIPTION
Making an indirect call to the `$this->getOldAttributes()` method caused my code to break. I understand that the correct thing would be to reference `$this->_oldAttributes`.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19272
