### PR TITLE
Fix: PHP 8.2 accessing (unused) dynamic property $breadcrumbs is depr…

### DIFF
--- a/tests/framework/widgets/LinkSorterTest.php
+++ b/tests/framework/widgets/LinkSorterTest.php
@@ -8,7 +8,6 @@
 namespace yiiunit\framework\widgets;
 
 use yii\data\ActiveDataProvider;
-use yii\widgets\Breadcrumbs;
 use yii\widgets\LinkSorter;
 use yii\widgets\ListView;
 use yiiunit\data\ar\ActiveRecord;
@@ -28,7 +27,6 @@ class LinkSorterTest extends DatabaseTestCase
         parent::setUp();
         ActiveRecord::$db = $this->getConnection();
         $this->mockWebApplication();
-        $this->breadcrumbs = new Breadcrumbs();
     }
 
     public function testLabelsSimple()


### PR DESCRIPTION
…ecated in LinkSorterTest.php

This property was never used in the test and I believe was copied into the setup method for the test when the file was originally created using the same setup as the BreadcrumbsTest which is the only other test with the same chunk of code.  I removed the reference to the dynamic attribute and the associated use statement, and that test now passes successfully.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
