### PR TITLE
Fix validation on missing attributes in DynamicModel

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -25,7 +25,7 @@ Yii Framework 2 Change Log
 - Enh #19794: Add caching in `yii\web\Request` for `getUserIP()` and `getSecureForwardedHeaderTrustedParts()` (rhertogh)
 - Bug #19795: Fix `yii\web\Response::redirect()` to prevent setting headers with URL containing new line character (bizley)
 - Enh #19804: Remove the unnecessary call to `$this->oldAttributes` in `BaseActiveRecord::getDirtyAttributes()` (thiagotalma)
-- Enh #19813: Fix `yii\base\DynamicModel` validation with validators that reference missing attributes (michaelarnauts)
+- Bug #19813: Fix `yii\base\DynamicModel` validation with validators that reference missing attributes (michaelarnauts)
 
 2.0.47 November 18, 2022
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -25,6 +25,7 @@ Yii Framework 2 Change Log
 - Enh #19794: Add caching in `yii\web\Request` for `getUserIP()` and `getSecureForwardedHeaderTrustedParts()` (rhertogh)
 - Bug #19795: Fix `yii\web\Response::redirect()` to prevent setting headers with URL containing new line character (bizley)
 - Enh #19804: Remove the unnecessary call to `$this->oldAttributes` in `BaseActiveRecord::getDirtyAttributes()` (thiagotalma)
+- Enh #19813: Fix `yii\base\DynamicModel` validation with validators that reference missing attributes (michaelarnauts)
 
 2.0.47 November 18, 2022
 ------------------------

--- a/framework/base/DynamicModel.php
+++ b/framework/base/DynamicModel.php
@@ -201,6 +201,7 @@ class DynamicModel extends Model
         }
 
         $validators->append($validator);
+        $this->defineAttributesByValidator($validator);
 
         return $this;
     }
@@ -223,9 +224,11 @@ class DynamicModel extends Model
             foreach ($rules as $rule) {
                 if ($rule instanceof Validator) {
                     $validators->append($rule);
+                    $model->defineAttributesByValidator($rule);
                 } elseif (is_array($rule) && isset($rule[0], $rule[1])) { // attributes, validator type
                     $validator = Validator::createValidator($rule[1], $model, (array)$rule[0], array_slice($rule, 2));
                     $validators->append($validator);
+                    $model->defineAttributesByValidator($validator);
                 } else {
                     throw new InvalidConfigException('Invalid validation rule: a rule must specify both attribute names and validator type.');
                 }
@@ -235,6 +238,19 @@ class DynamicModel extends Model
         $model->validate();
 
         return $model;
+    }
+
+    /**
+     * Define the attributes that applies to the specified Validator.
+     * @param Validator $validator the validator whose attributes are to be defined.
+     */
+    private function defineAttributesByValidator($validator)
+    {
+        foreach ($validator->getAttributeNames() as $attribute) {
+            if (!$this->hasAttribute($attribute)) {
+                $this->defineAttribute($attribute);
+            }
+        }
     }
 
     /**

--- a/tests/framework/base/DynamicModelTest.php
+++ b/tests/framework/base/DynamicModelTest.php
@@ -37,6 +37,20 @@ class DynamicModelTest extends TestCase
         $this->assertTrue($model->hasErrors('age'));
     }
 
+    public function testValidateDataWithPostData()
+    {
+        $post = [
+            'name' => 'long name',
+        ];
+        $model = DynamicModel::validateData($post, [
+            [['email', 'name'], 'required'],
+            ['age', 'default', 'value' => 18],
+        ]);
+        $this->assertTrue($model->hasErrors());
+        $this->assertTrue($model->hasErrors('email'));
+        $this->assertEquals(18, $model->age);
+    }
+
     public function testAddRule()
     {
         $model = new DynamicModel();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️ (not sure)
| Fixed issues  | #19811 

See #19811 for an explanation.

DynamicModel is made for validating dynamic data. It doesn't make sense to expect that all the attributes are there, since that's exactly what we are trying to validate.

