### PR TITLE
Explicity pass $fallbackToMaster to getSlavePdo()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -25,7 +25,7 @@ Yii Framework 2 Change Log
 - Enh #19794: Add caching in `yii\web\Request` for `getUserIP()` and `getSecureForwardedHeaderTrustedParts()` (rhertogh)
 - Bug #19795: Fix `yii\web\Response::redirect()` to prevent setting headers with URL containing new line character (bizley)
 - Enh #19804: Remove the unnecessary call to `$this->oldAttributes` in `BaseActiveRecord::getDirtyAttributes()` (thiagotalma)
-- Enh #19816: Explicitly pass $fallbackToMaster as true to getSlavePdo() to ensure it is not affected by child class with changed defaults
+- Enh #19816: Explicitly pass `$fallbackToMaster` as `true` to `getSlavePdo()` to ensure it is not affected by child class with changed defaults (developedsoftware)
 
 2.0.47 November 18, 2022
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -25,6 +25,7 @@ Yii Framework 2 Change Log
 - Enh #19794: Add caching in `yii\web\Request` for `getUserIP()` and `getSecureForwardedHeaderTrustedParts()` (rhertogh)
 - Bug #19795: Fix `yii\web\Response::redirect()` to prevent setting headers with URL containing new line character (bizley)
 - Enh #19804: Remove the unnecessary call to `$this->oldAttributes` in `BaseActiveRecord::getDirtyAttributes()` (thiagotalma)
+- Enh #19816: Explicitly pass $fallbackToMaster as true to getSlavePdo() to ensure it is not affected by child class with changed defaults
 
 2.0.47 November 18, 2022
 ------------------------

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -258,7 +258,7 @@ class Command extends Component
             $forRead = false;
         }
         if ($forRead || $forRead === null && $this->db->getSchema()->isReadQuery($sql)) {
-            $pdo = $this->db->getSlavePdo();
+            $pdo = $this->db->getSlavePdo(true);
         } else {
             $pdo = $this->db->getMasterPdo();
         }

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -1013,7 +1013,7 @@ class Connection extends Component
             if (($pos = strpos((string)$this->dsn, ':')) !== false) {
                 $this->_driverName = strtolower(substr($this->dsn, 0, $pos));
             } else {
-                $this->_driverName = strtolower($this->getSlavePdo()->getAttribute(PDO::ATTR_DRIVER_NAME));
+                $this->_driverName = strtolower($this->getSlavePdo(true)->getAttribute(PDO::ATTR_DRIVER_NAME));
             }
         }
 

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -458,7 +458,7 @@ abstract class Schema extends BaseObject
             return $str;
         }
 
-        if (mb_stripos($this->db->dsn, 'odbc:') === false && ($value = $this->db->getSlavePdo()->quote($str)) !== false) {
+        if (mb_stripos($this->db->dsn, 'odbc:') === false && ($value = $this->db->getSlavePdo(true)->quote($str)) !== false) {
             return $value;
         }
 

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -695,7 +695,7 @@ abstract class Schema extends BaseObject
     public function getServerVersion()
     {
         if ($this->_serverVersion === null) {
-            $this->_serverVersion = $this->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+            $this->_serverVersion = $this->db->getSlavePdo(true)->getAttribute(\PDO::ATTR_SERVER_VERSION);
         }
         return $this->_serverVersion;
     }
@@ -809,7 +809,7 @@ abstract class Schema extends BaseObject
      */
     protected function normalizePdoRowKeyCase(array $row, $multiple)
     {
-        if ($this->db->getSlavePdo()->getAttribute(\PDO::ATTR_CASE) !== \PDO::CASE_UPPER) {
+        if ($this->db->getSlavePdo(true)->getAttribute(\PDO::ATTR_CASE) !== \PDO::CASE_UPPER) {
             return $row;
         }
 

--- a/framework/db/cubrid/Schema.php
+++ b/framework/db/cubrid/Schema.php
@@ -92,7 +92,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     protected function findTableNames($schema = '')
     {
-        $pdo = $this->db->getSlavePdo();
+        $pdo = $this->db->getSlavePdo(true);
         $tables = $pdo->cubrid_schema(\PDO::CUBRID_SCH_TABLE);
         $tableNames = [];
         foreach ($tables as $table) {
@@ -110,7 +110,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     protected function loadTableSchema($name)
     {
-        $pdo = $this->db->getSlavePdo();
+        $pdo = $this->db->getSlavePdo(true);
 
         $tableInfo = $pdo->cubrid_schema(\PDO::CUBRID_SCH_TABLE, $name);
 
@@ -159,7 +159,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     protected function loadTablePrimaryKey($tableName)
     {
-        $primaryKey = $this->db->getSlavePdo()->cubrid_schema(\PDO::CUBRID_SCH_PRIMARY_KEY, $tableName);
+        $primaryKey = $this->db->getSlavePdo(true)->cubrid_schema(\PDO::CUBRID_SCH_PRIMARY_KEY, $tableName);
         if (empty($primaryKey)) {
             return null;
         }
@@ -183,7 +183,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
             3 => 'SET NULL',
         ];
 
-        $foreignKeys = $this->db->getSlavePdo()->cubrid_schema(\PDO::CUBRID_SCH_IMPORTED_KEYS, $tableName);
+        $foreignKeys = $this->db->getSlavePdo(true)->cubrid_schema(\PDO::CUBRID_SCH_IMPORTED_KEYS, $tableName);
         $foreignKeys = ArrayHelper::index($foreignKeys, null, 'FK_NAME');
         ArrayHelper::multisort($foreignKeys, 'KEY_SEQ', SORT_ASC, SORT_NUMERIC);
         $result = [];
@@ -386,7 +386,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     private function loadTableConstraints($tableName, $returnType)
     {
-        $constraints = $this->db->getSlavePdo()->cubrid_schema(\PDO::CUBRID_SCH_CONSTRAINT, $tableName);
+        $constraints = $this->db->getSlavePdo(true)->cubrid_schema(\PDO::CUBRID_SCH_CONSTRAINT, $tableName);
         $constraints = ArrayHelper::index($constraints, null, ['TYPE', 'NAME']);
         ArrayHelper::multisort($constraints, 'KEY_ORDER', SORT_ASC, SORT_NUMERIC);
         $result = [

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -410,7 +410,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
         $version = $cache ? $cache->get($key) : null;
         if (!$version) {
-            $version = $this->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+            $version = $this->db->getSlavePdo(true)->getAttribute(\PDO::ATTR_SERVER_VERSION);
             if ($cache) {
                 $cache->set($key, $version, $this->db->schemaCacheDuration);
             }

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -484,7 +484,7 @@ SQL;
     protected function isOldMysql()
     {
         if ($this->_oldMysql === null) {
-            $version = $this->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+            $version = $this->db->getSlavePdo(true)->getAttribute(\PDO::ATTR_SERVER_VERSION);
             $this->_oldMysql = version_compare($version, '5.1', '<=');
         }
 

--- a/tests/framework/db/ConnectionTest.php
+++ b/tests/framework/db/ConnectionTest.php
@@ -469,7 +469,7 @@ abstract class ConnectionTest extends DatabaseTestCase
 
 
     /**
-     * Test whether slave connection is recovered when call getSlavePdo() after close().
+     * Test whether slave connection is recovered when call getSlavePdo(true) after close().
      *
      * @see https://github.com/yiisoft/yii2/issues/14165
      */

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -757,7 +757,7 @@ abstract class SchemaTest extends DatabaseTestCase
         }
 
         $connection = $this->getConnection(false);
-        $connection->getSlavePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
+        $connection->getSlavePdo(true)->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
         $constraints = $connection->getSchema()->{'getTable' . ucfirst($type)}($tableName, true);
         $this->assertMetadataEquals($expected, $constraints);
     }
@@ -775,7 +775,7 @@ abstract class SchemaTest extends DatabaseTestCase
         }
 
         $connection = $this->getConnection(false);
-        $connection->getSlavePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
+        $connection->getSlavePdo(true)->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
         $constraints = $connection->getSchema()->{'getTable' . ucfirst($type)}($tableName, true);
         $this->assertMetadataEquals($expected, $constraints);
     }

--- a/tests/framework/db/cubrid/QueryBuilderTest.php
+++ b/tests/framework/db/cubrid/QueryBuilderTest.php
@@ -57,7 +57,7 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
 
     public function testCommentColumn()
     {
-        $version = $this->getQueryBuilder(false)->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+        $version = $this->getQueryBuilder(false)->db->getSlavePdo(true)->getAttribute(\PDO::ATTR_SERVER_VERSION);
         if (version_compare($version, '10.0', '<')) {
             $this->markTestSkipped('Comments on columns are supported starting with CUBRID 10.0.');
             return;

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -125,7 +125,7 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
         /**
          * @link https://github.com/yiisoft/yii2/issues/14367
          */
-        $mysqlVersion = $this->getDb()->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+        $mysqlVersion = $this->getDb()->getSlavePdo(true)->getAttribute(\PDO::ATTR_SERVER_VERSION);
         $supportsFractionalSeconds = version_compare($mysqlVersion,'5.6.4', '>=');
         if ($supportsFractionalSeconds) {
             $expectedValues = [


### PR DESCRIPTION
So when $fallbackToMaster is overriden or changed to false we do not get an exception

Call to a member function quote() on null
![Screenshot 2023-04-19 at 13 21 15](https://user-images.githubusercontent.com/19648131/233073215-f70136d9-eab4-4861-816c-3e1971f556a5.png)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19812
