### PR TITLE
Removed copying of non-existing test files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,7 @@ FROM ${DOCKER_YII2_PHP_IMAGE}
 # Project source-code
 WORKDIR /project
 ADD composer.* /project/
-# Apply testing patches
-ADD tests/phpunit_mock_objects.patch /project/tests/phpunit_mock_objects.patch
-ADD tests/phpunit_getopt.patch /project/tests/phpunit_getopt.patch
-# Install packgaes
+# Install packages
 RUN /usr/local/bin/composer install --prefer-dist
 ADD ./ /project
 ENV PATH /project/vendor/bin:${PATH}


### PR DESCRIPTION
Tests patches are now loaded via URL (https://github.com/yiisoft/yii2/pull/18356).

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | Incompatibility introduced by #18356
