### PR TITLE
Removed unnecessary nullcheck in access control

### DIFF
--- a/framework/filters/AccessControl.php
+++ b/framework/filters/AccessControl.php
@@ -125,8 +125,6 @@ class AccessControl extends ActionFilter
             } elseif ($allow === false) {
                 if (isset($rule->denyCallback)) {
                     call_user_func($rule->denyCallback, $rule, $action);
-                } elseif ($this->denyCallback !== null) {
-                    call_user_func($this->denyCallback, $rule, $action);
                 } else {
                     $this->denyAccess($user);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |

isset() also checks null. Therefore elseif is unnecessary.
