### PR TITLE
Catch unserialize() errors

### DIFF
--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -135,7 +135,13 @@ abstract class Cache extends Component implements CacheInterface
         if ($value === false || $this->serializer === false) {
             return $value;
         } elseif ($this->serializer === null) {
-            $value = unserialize((string)$value);
+            try {
+                $value = unserialize((string)$value);
+            } catch (\Exception $e) {
+                return false;
+            } catch (\Throwable $e) {
+                return false;
+            }
         } else {
             $value = call_user_func($this->serializer[1], $value);
         }


### PR DESCRIPTION
Catches any exceptions/errors that could be thrown by `unserialize()` when retrieving cache data, e.g. if the cache file has become corrupted.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
