### PR TITLE
strtr(): Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -27,7 +27,7 @@ Yii Framework 2 Change Log
 - Enh #19804: Remove the unnecessary call to `$this->oldAttributes` in `BaseActiveRecord::getDirtyAttributes()` (thiagotalma)
 - Bug #19813: Fix `yii\base\DynamicModel` validation with validators that reference missing attributes (michaelarnauts)
 - Enh #19816: Explicitly pass `$fallbackToMaster` as `true` to `getSlavePdo()` to ensure it is not affected by child class with changed defaults (developedsoftware)
-- Bug #19828 strtr(): Passing null to parameter #1 ($string) of type string is deprecated
+- Bug #19828 Fix "strtr(): Passing null to parameter #1 ($string) of type string is deprecated" (uaoleg)
 
 2.0.47 November 18, 2022
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -27,6 +27,7 @@ Yii Framework 2 Change Log
 - Enh #19804: Remove the unnecessary call to `$this->oldAttributes` in `BaseActiveRecord::getDirtyAttributes()` (thiagotalma)
 - Bug #19813: Fix `yii\base\DynamicModel` validation with validators that reference missing attributes (michaelarnauts)
 - Enh #19816: Explicitly pass `$fallbackToMaster` as `true` to `getSlavePdo()` to ensure it is not affected by child class with changed defaults (developedsoftware)
+- Bug #19828 strtr(): Passing null to parameter #1 ($string) of type string is deprecated
 
 2.0.47 November 18, 2022
 ------------------------

--- a/framework/db/conditions/LikeConditionBuilder.php
+++ b/framework/db/conditions/LikeConditionBuilder.php
@@ -77,8 +77,10 @@ class LikeConditionBuilder implements ExpressionBuilderInterface
         foreach ($values as $value) {
             if ($value instanceof ExpressionInterface) {
                 $phName = $this->queryBuilder->buildExpression($value, $params);
+            } elseif (empty($value)) {
+                $phName = $this->queryBuilder->bindParam('%%', $params);
             } else {
-                $phName = $this->queryBuilder->bindParam(empty($escape) || $value === null ? $value : ('%' . strtr($value, $escape) . '%'), $params);
+                $phName = $this->queryBuilder->bindParam(empty($escape) ? $value : ('%' . strtr($value, $escape) . '%'), $params);
             }
             $parts[] = "{$column} {$operator} {$phName}{$escapeSql}";
         }

--- a/framework/db/conditions/LikeConditionBuilder.php
+++ b/framework/db/conditions/LikeConditionBuilder.php
@@ -78,7 +78,7 @@ class LikeConditionBuilder implements ExpressionBuilderInterface
             if ($value instanceof ExpressionInterface) {
                 $phName = $this->queryBuilder->buildExpression($value, $params);
             } else {
-                $phName = $this->queryBuilder->bindParam(empty($escape) ? $value : ('%' . strtr($value, $escape) . '%'), $params);
+                $phName = $this->queryBuilder->bindParam(empty($escape) || empty($value) ? $value : ('%' . strtr($value, $escape) . '%'), $params);
             }
             $parts[] = "{$column} {$operator} {$phName}{$escapeSql}";
         }

--- a/framework/db/conditions/LikeConditionBuilder.php
+++ b/framework/db/conditions/LikeConditionBuilder.php
@@ -78,7 +78,7 @@ class LikeConditionBuilder implements ExpressionBuilderInterface
             if ($value instanceof ExpressionInterface) {
                 $phName = $this->queryBuilder->buildExpression($value, $params);
             } else {
-                $phName = $this->queryBuilder->bindParam(empty($escape) || is_null($value) ? $value : ('%' . strtr($value, $escape) . '%'), $params);
+                $phName = $this->queryBuilder->bindParam(empty($escape) || $value === null ? $value : ('%' . strtr($value, $escape) . '%'), $params);
             }
             $parts[] = "{$column} {$operator} {$phName}{$escapeSql}";
         }

--- a/framework/db/conditions/LikeConditionBuilder.php
+++ b/framework/db/conditions/LikeConditionBuilder.php
@@ -78,7 +78,7 @@ class LikeConditionBuilder implements ExpressionBuilderInterface
             if ($value instanceof ExpressionInterface) {
                 $phName = $this->queryBuilder->buildExpression($value, $params);
             } else {
-                $phName = $this->queryBuilder->bindParam(empty($escape) || empty($value) ? $value : ('%' . strtr($value, $escape) . '%'), $params);
+                $phName = $this->queryBuilder->bindParam(empty($escape) || is_null($value) ? $value : ('%' . strtr($value, $escape) . '%'), $params);
             }
             $parts[] = "{$column} {$operator} {$phName}{$escapeSql}";
         }

--- a/framework/db/conditions/LikeConditionBuilder.php
+++ b/framework/db/conditions/LikeConditionBuilder.php
@@ -77,10 +77,8 @@ class LikeConditionBuilder implements ExpressionBuilderInterface
         foreach ($values as $value) {
             if ($value instanceof ExpressionInterface) {
                 $phName = $this->queryBuilder->buildExpression($value, $params);
-            } elseif (empty($value)) {
-                $phName = $this->queryBuilder->bindParam('%%', $params);
             } else {
-                $phName = $this->queryBuilder->bindParam(empty($escape) ? $value : ('%' . strtr($value, $escape) . '%'), $params);
+                $phName = $this->queryBuilder->bindParam(empty($escape) ? $value : ('%' . strtr((string)$value, $escape) . '%'), $params);
             }
             $parts[] = "{$column} {$operator} {$phName}{$escapeSql}";
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19684
