### PR TITLE
Update `LikeCondition::setEscapingReplacements()` phpdoc

### DIFF
--- a/framework/db/conditions/LikeCondition.php
+++ b/framework/db/conditions/LikeCondition.php
@@ -18,8 +18,8 @@ use yii\base\InvalidArgumentException;
 class LikeCondition extends SimpleCondition
 {
     /**
-     * @var array|null|false map of chars to their replacements, false if characters should not be escaped
-     * or either null or empty array if escaping is condition builder responsibility.
+     * @var array|null|false map of chars to their replacements, `false` if characters should not be escaped
+     * or either `null` or empty array if escaping is condition builder responsibility.
      * By default it's set to `null`.
      */
     protected $escapingReplacements;
@@ -40,9 +40,10 @@ class LikeCondition extends SimpleCondition
     /**
      * This method allows to specify how to escape special characters in the value(s).
      *
-     * @param array an array of mappings from the special characters to their escaped counterparts.
-     * You may use `false` or an empty array to indicate the values are already escaped and no escape
-     * should be applied. Note that when using an escape mapping (or the third operand is not provided),
+     * @param array|null|false an array of mappings from the special characters to their escaped counterparts.
+     * You may use `false` to indicate the values are already escaped and no escape should be applied,
+     * or either `null` or empty array if escaping is condition builder responsibility. 
+     * Note that when using an escape mapping (or the third operand is not provided),
      * the values will be automatically enclosed within a pair of percentage characters.
      */
     public function setEscapingReplacements($escapingReplacements)
@@ -51,7 +52,7 @@ class LikeCondition extends SimpleCondition
     }
 
     /**
-     * @return array|false
+     * @return array|null|false
      */
     public function getEscapingReplacements()
     {


### PR DESCRIPTION
This PR makes description consistent with `$escapingReplacements` and actual behavior in builder:
https://github.com/yiisoft/yii2/blob/4e7aac710f189e4cac6570088b5443b34d6ca0e9/framework/db/conditions/LikeConditionBuilder.php#L55