### PR TITLE
fix wrong formatted changelog entry which lead to unit test error

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -27,7 +27,7 @@ Yii Framework 2 Change Log
 - Enh #19804: Remove the unnecessary call to `$this->oldAttributes` in `BaseActiveRecord::getDirtyAttributes()` (thiagotalma)
 - Bug #19813: Fix `yii\base\DynamicModel` validation with validators that reference missing attributes (michaelarnauts)
 - Enh #19816: Explicitly pass `$fallbackToMaster` as `true` to `getSlavePdo()` to ensure it is not affected by child class with changed defaults (developedsoftware)
-- Bug #19828 Fix "strtr(): Passing null to parameter #1 ($string) of type string is deprecated" (uaoleg)
+- Bug #19828: Fix "strtr(): Passing null to parameter #1 ($string) of type string is deprecated" (uaoleg)
 - Bug #19720: Fix "zh-HK" locale causing [error][yii\i18n\PhpMessageSource::loadFallbackMessages] The message file for category 'yii' does not exist (uaoleg)
 - Bug #19736: Fix `StringHelper::truncate(null, 10)` causes error Deprecated: mb_strlen(): Passing null to parameter #1 ($string) of type string is deprecated (uaoleg)
 


### PR DESCRIPTION
Fixes this unit test failure:

~~~
1) yiiunit\framework\ChangeLogTest::testContributorLine with data set #23 ('- Bug #19828 Fix "strtr(): Pa...aoleg)')
Failed asserting that '- Bug #19828 Fix "strtr(): Passing null to parameter #1 ($string) of type string is deprecated" (uaoleg)' matches PCRE pattern "/- (Bug|Enh|Chg|New)( #\d+(, #\d+)*)?(\s\(CVE-[\d-]+\))?: .*[^.] \(.+\)$/".
~~~