### PR TITLE
Fix #19743: Non-associative array values in AR weren't considered dirty when reordered

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.48 under development
 ------------------------
 
+- Bug #19743: Non-associative array values in AR weren't considered dirty when reordered (samdark)
 - Enh #19766: Add support for PHP generators to JSON helper (vladis84)
 - Bug #19683: Updated `framework\mimeType.php` to the actual value. Fix typo in `build/controllers/MimeTypeController.php` (DeryabinSergey)
 - Bug #19705: Add binary and other data type to `$typeMap` list for MySQL (sohelahmed7)

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1763,7 +1763,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     private function isValueDifferent($newValue, $oldValue)
     {
-        if (is_array($newValue) && is_array($oldValue)) {
+        if (is_array($newValue) && is_array($oldValue) && !ArrayHelper::isAssociative($oldValue)) {
             $newValue = ArrayHelper::recursiveSort($newValue);
             $oldValue = ArrayHelper::recursiveSort($oldValue);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19743
