### PR TITLE
Allow jQuery 3.7 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "yiisoft/yii2-composer": "~2.0.4",
         "ezyang/htmlpurifier": "^4.6",
         "cebe/markdown": "~1.0.0 | ~1.1.0 | ~1.2.0",
-        "bower-asset/jquery": "3.6.*@stable | 3.5.*@stable | 3.4.*@stable | 3.3.*@stable | 3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
+        "bower-asset/jquery": "3.7.*@stable | 3.6.*@stable | 3.5.*@stable | 3.4.*@stable | 3.3.*@stable | 3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
         "bower-asset/inputmask": "~3.2.2 | ~3.3.5",
         "bower-asset/punycode": "1.3.*",
         "bower-asset/yii2-pjax": "~2.0.1",

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.49 under development
 ------------------------
 
-- no changes in this release. 
+- Enh #19841: Allow jQuery 3.7 to be installed (wouter90) 
 
 
 2.0.48 May 22, 2023

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.49 under development
 ------------------------
 
-- Enh #19841: Allow jQuery 3.7 to be installed (wouter90) 
+- Enh #19841: Allow jQuery 3.7 to be installed (wouter90)
 
 
 2.0.48 May 22, 2023

--- a/framework/composer.json
+++ b/framework/composer.json
@@ -70,7 +70,7 @@
         "yiisoft/yii2-composer": "~2.0.4",
         "ezyang/htmlpurifier": "^4.6",
         "cebe/markdown": "~1.0.0 | ~1.1.0 | ~1.2.0",
-        "bower-asset/jquery": "3.6.*@stable | 3.5.*@stable | 3.4.*@stable | 3.3.*@stable | 3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
+        "bower-asset/jquery": "3.7.*@stable | 3.6.*@stable | 3.5.*@stable | 3.4.*@stable | 3.3.*@stable | 3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
         "bower-asset/inputmask": "~3.2.2 | ~3.3.5",
         "bower-asset/punycode": "1.3.*",
         "bower-asset/yii2-pjax": "~2.0.1",


### PR DESCRIPTION
See https://blog.jquery.com/2023/05/11/jquery-3-7-0-released-staying-in-order/

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #19841
