### PR TITLE
2.0.48 bug: AttributeTypecastBehavior::resetOldAttributes() causes "class has no attribute named" InvalidArgumentException

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -1,8 +1,8 @@
 Yii Framework 2 Change Log
 ==========================
 
-2.0.48.2 June 4, 2023
----------------------
+2.0.49 under development
+------------------------
 
 - Bug #19857: Fix AttributeTypecastBehavior::resetOldAttributes() causes "class has no attribute named" InvalidArgumentException (uaoleg)
 - Bug #18859: Fix `yii\web\Controller::bindInjectedParams()` to not throw error when argument of `ReflectionUnionType` type is passed (bizley)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -1,11 +1,10 @@
 Yii Framework 2 Change Log
 ==========================
 
-2.0.49 under development
-------------------------
+2.0.48.2 June 4, 2023
+---------------------
 
-- Bug #18859: Fix `yii\web\Controller::bindInjectedParams()` to not throw error when argument of `ReflectionUnionType` type is passed (bizley)
-- Enh #19841: Allow jQuery 3.7 to be installed (wouter90)
+- Bug #19857: Fix AttributeTypecastBehavior::resetOldAttributes() causes "class has no attribute named" InvalidArgumentException (uaoleg)
 
 
 2.0.48.1 May 24, 2023

--- a/framework/behaviors/AttributeTypecastBehavior.php
+++ b/framework/behaviors/AttributeTypecastBehavior.php
@@ -366,7 +366,10 @@ class AttributeTypecastBehavior extends Behavior
         $this->resetOldAttributes();
     }
 
-    private function resetOldAttributes()
+    /**
+     * Resets the old values of the named attributes.
+     */
+    protected function resetOldAttributes()
     {
         if ($this->attributeTypes === null) {
             return;
@@ -375,7 +378,9 @@ class AttributeTypecastBehavior extends Behavior
         $attributes = array_keys($this->attributeTypes);
 
         foreach ($attributes as $attribute) {
-            $this->owner->setOldAttribute($attribute, $this->owner->{$attribute});
+            if ($this->owner->canSetOldAttribute($attribute)) {
+                $this->owner->setOldAttribute($attribute, $this->owner->{$attribute});
+            }
         }
     }
 }

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -576,11 +576,22 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function setOldAttribute($name, $value)
     {
-        if (isset($this->_oldAttributes[$name]) || $this->hasAttribute($name)) {
+        if ($this->canSetOldAttribute($name)) {
             $this->_oldAttributes[$name] = $value;
         } else {
             throw new InvalidArgumentException(get_class($this) . ' has no attribute named "' . $name . '".');
         }
+    }
+
+    /**
+     * Returns if the old named attribute can be set.
+     * @param string $name the attribute name
+     * @return bool whether the old attribute can be set
+     * @see setOldAttribute()
+     */
+    public function canSetOldAttribute($name): bool
+    {
+        return (isset($this->_oldAttributes[$name]) || $this->hasAttribute($name));
     }
 
     /**

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -589,7 +589,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * @return bool whether the old attribute can be set
      * @see setOldAttribute()
      */
-    public function canSetOldAttribute($name): bool
+    public function canSetOldAttribute($name)
     {
         return (isset($this->_oldAttributes[$name]) || $this->hasAttribute($name));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19856
