### PR TITLE
Resolve - Error in migration createTable (and possible other) method when DB data type has more than one word

### DIFF
--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -642,13 +642,12 @@ class Command extends Component
      * 
      * Example usage:
      * ```php
-     * class m200000_000000_create_table_fruits extends \yii\db\Migration
-     * {
-     *     public function safeUp()
-     *     {
-     *          $this->createTable('{{%fruits}}', [
-     *              // ...              
-     *              'column_name double precision null default null',
+     * Yii::$app->db->createCommand()->createTable('post', [
+     *     'id' => 'pk',
+     *     'title' => 'string',
+     *     'text' => 'text',
+     *     'column_name double precision null default null',
+     * ]);                   
      * ```
      *
      * @param string $table the name of the table to be created. The name will be properly quoted by the method.

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -631,13 +631,25 @@ class Command extends Component
      *
      * The columns in the new table should be specified as name-definition pairs (e.g. 'name' => 'string'),
      * where name stands for a column name which will be properly quoted by the method, and definition
-     * stands for the column type which can contain an abstract DB type.
+     * stands for the column type which must contain an abstract DB type. 
+     * 
      * The method [[QueryBuilder::getColumnType()]] will be called
      * to convert the abstract column types to physical ones. For example, `string` will be converted
      * as `varchar(255)`, and `string not null` becomes `varchar(255) not null`.
      *
      * If a column is specified with definition only (e.g. 'PRIMARY KEY (name, type)'), it will be directly
      * inserted into the generated SQL.
+     * 
+     * Example usage:
+     * ```php
+     * class m200000_000000_create_table_fruits extends \yii\db\Migration
+     * {
+     *     public function safeUp()
+     *     {
+     *          $this->createTable('{{%fruits}}', [
+     *              // ...              
+     *              'column_name double precision null default null',
+     * ```
      *
      * @param string $table the name of the table to be created. The name will be properly quoted by the method.
      * @param array $columns the columns (name => definition) in the new table.

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -305,12 +305,24 @@ class Migration extends Component implements MigrationInterface
      *
      * The columns in the new  table should be specified as name-definition pairs (e.g. 'name' => 'string'),
      * where name stands for a column name which will be properly quoted by the method, and definition
-     * stands for the column type which can contain an abstract DB type.
+     * stands for the column type which must contain an abstract DB type.
      *
      * The [[QueryBuilder::getColumnType()]] method will be invoked to convert any abstract type into a physical one.
      *
      * If a column is specified with definition only (e.g. 'PRIMARY KEY (name, type)'), it will be directly
      * put into the generated SQL.
+     * 
+     * Example usage:
+     * ```php
+     * class m200000_000000_create_table_fruits extends \yii\db\Migration
+     * {
+     *     public function safeUp()
+     *     {
+     *          $this->createTable('{{%fruits}}', [
+     *              // ...              
+     *              'column_name double precision null default null',
+     * ```
+
      *
      * @param string $table the name of the table to be created. The name will be properly quoted by the method.
      * @param array $columns the columns (name => definition) in the new table.

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -692,7 +692,7 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * The columns in the new table should be specified as name-definition pairs (e.g. 'name' => 'string'),
      * where name stands for a column name which will be properly quoted by the method, and definition
-     * stands for the column type which can contain an abstract DB type.
+     * stands for the column type which must contain an abstract DB type.
      * The [[getColumnType()]] method will be invoked to convert any abstract type into a physical one.
      *
      * If a column is specified with definition only (e.g. 'PRIMARY KEY (name, type)'), it will be directly
@@ -705,6 +705,7 @@ class QueryBuilder extends \yii\base\BaseObject
      *  'id' => 'pk',
      *  'name' => 'string',
      *  'age' => 'integer',
+     *  'column_name double precision null default null', # definition only example
      * ]);
      * ```
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️and ❌!
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/yii2/issues/19759
