### PR TITLE
Fix typo in "Configurable" class description codesnippet

### DIFF
--- a/framework/base/Configurable.php
+++ b/framework/base/Configurable.php
@@ -15,7 +15,7 @@ namespace yii\base;
  * like the following:
  *
  * ```php
- * public function __constructor($param1, $param2, ..., $config = [])
+ * public function __construct($param1, $param2, ..., $config = [])
  * ```
  *
  * That is, the last parameter of the constructor must accept a configuration array.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | 
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

Just a typo in a code snippet