### PR TITLE
Remove methods mset, mget and madd of `yii\caching\Cache`, getHasChanged of `yii\caching\Dependency`

### DIFF
--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -171,23 +171,6 @@ abstract class Cache extends Component implements CacheInterface
      * Some caches (such as memcache, apc) allow retrieving multiple cached values at the same time,
      * which may improve the performance. In case a cache does not support this feature natively,
      * this method will try to simulate it.
-     *
-     * @param string[] $keys list of string keys identifying the cached values
-     * @return array list of cached values corresponding to the specified keys. The array
-     * is returned in terms of (key, value) pairs.
-     * If a value is not cached or expired, the corresponding array value will be false.
-     * @deprecated This method is an alias for [[multiGet()]] and will be removed in 2.1.0.
-     */
-    public function mget($keys)
-    {
-        return $this->multiGet($keys);
-    }
-
-    /**
-     * Retrieves multiple values from cache with the specified keys.
-     * Some caches (such as memcache, apc) allow retrieving multiple cached values at the same time,
-     * which may improve the performance. In case a cache does not support this feature natively,
-     * this method will try to simulate it.
      * @param string[] $keys list of string keys identifying the cached values
      * @return array list of cached values corresponding to the specified keys. The array
      * is returned in terms of (key, value) pairs.
@@ -267,25 +250,6 @@ abstract class Cache extends Component implements CacheInterface
      * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is false.
      * @return array array of failed keys
-     * @deprecated This method is an alias for [[multiSet()]] and will be removed in 2.1.0.
-     */
-    public function mset($items, $duration = null, $dependency = null)
-    {
-        return $this->multiSet($items, $duration, $dependency);
-    }
-
-    /**
-     * Stores multiple items in cache. Each item contains a value identified by a key.
-     * If the cache already contains such a key, the existing value and
-     * expiration time will be replaced with the new ones, respectively.
-     *
-     * @param array $items the items to be cached, as key-value pairs.
-     * @param int|null $duration default duration in seconds before the cache will expire. If not set,
-     * default [[defaultDuration]] value is used.
-     * @param Dependency|null $dependency dependency of the cached items. If the dependency changes,
-     * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
-     * This parameter is ignored if [[serializer]] is false.
-     * @return array array of failed keys
      * @since 2.0.7
      */
     public function multiSet($items, $duration = null, $dependency = null)
@@ -311,23 +275,6 @@ abstract class Cache extends Component implements CacheInterface
         }
 
         return $this->setValues($data, $duration);
-    }
-
-    /**
-     * Stores multiple items in cache. Each item contains a value identified by a key.
-     * If the cache already contains such a key, the existing value and expiration time will be preserved.
-     *
-     * @param array $items the items to be cached, as key-value pairs.
-     * @param int $duration default number of seconds in which the cached values will expire. 0 means never expire.
-     * @param Dependency|null $dependency dependency of the cached items. If the dependency changes,
-     * the corresponding values in the cache will be invalidated when it is fetched via [[get()]].
-     * This parameter is ignored if [[serializer]] is false.
-     * @return array array of failed keys
-     * @deprecated This method is an alias for [[multiAdd()]] and will be removed in 2.1.0.
-     */
-    public function madd($items, $duration = 0, $dependency = null)
-    {
-        return $this->multiAdd($items, $duration, $dependency);
     }
 
     /**

--- a/framework/caching/Dependency.php
+++ b/framework/caching/Dependency.php
@@ -58,17 +58,6 @@ abstract class Dependency extends \yii\base\BaseObject
     }
 
     /**
-     * Returns a value indicating whether the dependency has changed.
-     * @deprecated since version 2.0.11. Will be removed in version 2.1. Use [[isChanged()]] instead.
-     * @param CacheInterface $cache the cache component that is currently evaluating this dependency
-     * @return bool whether the dependency has changed.
-     */
-    public function getHasChanged($cache)
-    {
-        return $this->isChanged($cache);
-    }
-
-    /**
      * Checks whether the dependency is changed.
      * @param CacheInterface $cache the cache component that is currently evaluating this dependency
      * @return bool whether the dependency has changed.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
