### PR TITLE
New methods: BaseActiveRecord::loadRelations() and BaseActiveRecord::loadRelationsFor().

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.50 under development
 ------------------------
 
-- no changes in this release.
+- Enh #12743: Added new methods `BaseActiveRecord::loadRelations()` and `BaseActiveRecord::loadRelationsFor()` to eager load related models for existing primary model instances (PowerGamer1)
 
 
 2.0.49.2 October 12, 2023

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1787,4 +1787,57 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
 
         return $newValue !== $oldValue;
     }
+
+    /**
+     * Eager loads related models for the already loaded primary models.
+     *
+     * Helps to reduce the number of queries performed against database if some related models are only used
+     * when a specific condition is met. For example:
+     *
+     * ```php
+     * $customers = Customer::find()->where(['country_id' => 123])->all();
+     * if (Yii:app()->getUser()->getIdentity()->canAccessOrders()) {
+     *     Customer::loadRelationsFor($customers, 'orders.items');
+     * }
+     * ```
+     *
+     * @param array|ActiveRecordInterface[] $models array of primary models. Each model should have the same type and can be:
+     * - an active record instance;
+     * - active record instance represented by array (i.e. active record was loaded using [[ActiveQuery::asArray()]]).
+     * @param string|array $relationNames the names of the relations of primary models to be loaded from database. See [[ActiveQueryInterface::with()]] on how to specify this argument.
+     * @param bool $asArray whether to load each related model as an array or an object (if the relation itself does not specify that).
+     * @since 2.0.49
+     */
+    public static function loadRelationsFor(&$models, $relationNames, $asArray = false)
+    {
+        // ActiveQueryTrait::findWith() called below assumes $models array is non-empty.
+        if (empty($models)) {
+            return;
+        }
+
+        static::find()->asArray($asArray)->findWith((array)$relationNames, $models);
+    }
+
+    /**
+     * Eager loads related models for the already loaded primary model.
+     *
+     * Helps to reduce the number of queries performed against database if some related models are only used
+     * when a specific condition is met. For example:
+     *
+     * ```php
+     * $customer = Customer::find()->where(['id' => 123])->one();
+     * if (Yii:app()->getUser()->getIdentity()->canAccessOrders()) {
+     *     $customer->loadRelations('orders.items');
+     * }
+     * ```
+     *
+     * @param string|array $relationNames the names of the relations of this model to be loaded from database. See [[ActiveQueryInterface::with()]] on how to specify this argument.
+     * @param bool $asArray whether to load each relation as an array or an object (if the relation itself does not specify that).
+     * @since 2.0.49
+     */
+    public function loadRelations($relationNames, $asArray = false)
+    {
+        $models = [$this];
+        static::loadRelationsFor($models, $relationNames, $asArray);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #11000, #12743

Equivalent of https://laravel.com/docs/10.x/eloquent-relationships#lazy-eager-loading in Eloquent ORM.

Should be mentioned in Yii2 guide.
