### PR TITLE
Remove deprecated method `className()` for branch `2.2`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,6 @@ jobs:
         if: matrix.php != '8.1'
         run: vendor/bin/phpunit --exclude-group $PHPUNIT_EXCLUDE_GROUP --colors=always --verbose
 
-
       - name: Upload coverage to Codecov.
         if: matrix.php == '8.1'
         uses: codecov/codecov-action@v3

--- a/composer.lock
+++ b/composer.lock
@@ -11,7 +11,7 @@
             "version": "3.3.11",
             "source": {
                 "type": "git",
-                "url": "git@github.com:RobinHerbots/Inputmask.git",
+                "url": "https://github.com/RobinHerbots/Inputmask.git",
                 "reference": "5e670ad62f50c738388d4dcec78d2888505ad77b"
             },
             "dist": {
@@ -1498,16 +1498,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.9",
+            "version": "9.6.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778"
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a9aceaf20a682aeacf28d582654a1670d8826778",
-                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6d351645c3fe5a30f5e86be6577d946af65a328",
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328",
                 "shasum": ""
             },
             "require": {
@@ -1581,7 +1581,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.9"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.10"
             },
             "funding": [
                 {
@@ -1597,7 +1597,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-11T06:13:56+00:00"
+            "time": "2023-07-10T04:04:23+00:00"
         },
         {
             "name": "psr/cache",

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -974,7 +974,7 @@ Yii Framework 2 Change Log
 - Enh: Added check to `yii\base\Model::formName()` to prevent source path disclosure when form is represented by an anonymous class (silverfire)
 - Chg #15420: Handle OPTIONS request in `yii\filter\Cors` so the preflight check isn't passed trough authentication filters (michaelarnauts, leandrogehlen)
 - Chg #15625: `yii\grid\DataColumn` boolean filter dropdown list values are now in reversed order (bizley)
-- Chg #15633: Deprecated `yii\base\BaseObject::class` in favor of native PHP syntax `::class`, which does not trigger autoloading (brandonkelly)
+- Chg #15633: Deprecated `yii\base\BaseObject::className()` in favor of native PHP syntax `::class`, which does not trigger autoloading (brandonkelly)
 - Chg #15633: Deprecated XCache and Zend data cache support as caching backends (brandonkelly)
 - Chg #15633: Deprecated `yii\BaseYii::powered()` method (brandonkelly)
 - Chg #15633: Added `yii\base\InvalidArgumentException` and deprecated `yii\base\InvalidParamException` (brandonkelly)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -974,7 +974,7 @@ Yii Framework 2 Change Log
 - Enh: Added check to `yii\base\Model::formName()` to prevent source path disclosure when form is represented by an anonymous class (silverfire)
 - Chg #15420: Handle OPTIONS request in `yii\filter\Cors` so the preflight check isn't passed trough authentication filters (michaelarnauts, leandrogehlen)
 - Chg #15625: `yii\grid\DataColumn` boolean filter dropdown list values are now in reversed order (bizley)
-- Chg #15633: Deprecated `yii\base\BaseObject::className()` in favor of native PHP syntax `::class`, which does not trigger autoloading (brandonkelly)
+- Chg #15633: Deprecated `yii\base\BaseObject::class` in favor of native PHP syntax `::class`, which does not trigger autoloading (brandonkelly)
 - Chg #15633: Deprecated XCache and Zend data cache support as caching backends (brandonkelly)
 - Chg #15633: Deprecated `yii\BaseYii::powered()` method (brandonkelly)
 - Chg #15633: Added `yii\base\InvalidArgumentException` and deprecated `yii\base\InvalidParamException` (brandonkelly)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -521,9 +521,8 @@ Upgrade from Yii 2.0.13
 
 * Log targets (like `yii\log\EmailTarget`) are now throwing `yii\log\LogRuntimeException` in case log can not be properly exported.
 
-* You can start preparing your application for Yii 2.1 by doing the following:
+* You can start preparing your application for Yii 2.2 by doing the following:
 
-  - Replace `::class` calls with `::class` (if you’re running PHP 5.5+).
   - Replace usages of `yii\base\InvalidParamException` with `yii\base\InvalidArgumentException`.
   - Replace calls to `Yii::trace()` with `Yii::debug()`.
   - Remove calls to `yii\BaseYii::powered()`.

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -292,7 +292,7 @@ Upgrade from Yii 2.0.34
   public function rules()
   {
       return [
-          ['attribute', 'each', 'rule' => ['exist', 'targetClass' => static::className(), 'targetAttribute' => 'id']],
+          ['attribute', 'each', 'rule' => ['exist', 'targetClass' => static::class, 'targetAttribute' => 'id']],
       ];
   }
   ```
@@ -523,7 +523,7 @@ Upgrade from Yii 2.0.13
 
 * You can start preparing your application for Yii 2.1 by doing the following:
 
-  - Replace `::className()` calls with `::class` (if you’re running PHP 5.5+).
+  - Replace `::class` calls with `::class` (if you’re running PHP 5.5+).
   - Replace usages of `yii\base\InvalidParamException` with `yii\base\InvalidArgumentException`.
   - Replace calls to `Yii::trace()` with `Yii::debug()`.
   - Remove calls to `yii\BaseYii::powered()`.

--- a/framework/base/BaseObject.php
+++ b/framework/base/BaseObject.php
@@ -77,16 +77,6 @@ use Yii;
 class BaseObject implements Configurable
 {
     /**
-     * Returns the fully qualified name of this class.
-     * @return string the fully qualified name of this class.
-     * @deprecated since 2.0.14. On PHP >=5.5, use `::class` instead.
-     */
-    public static function className()
-    {
-        return get_called_class();
-    }
-
-    /**
      * Constructor.
      *
      * The default implementation does two things:

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -102,8 +102,8 @@ class Controller extends Component implements ViewContextInterface
     public function init()
     {
         parent::init();
-        $this->request = Instance::ensure($this->request, Request::className());
-        $this->response = Instance::ensure($this->response, Response::className());
+        $this->request = Instance::ensure($this->request, Request::class);
+        $this->response = Instance::ensure($this->response, Response::class);
     }
 
     /**

--- a/framework/behaviors/SluggableBehavior.php
+++ b/framework/behaviors/SluggableBehavior.php
@@ -243,7 +243,7 @@ class SluggableBehavior extends AttributeBehavior
         /* @var $model BaseActiveRecord */
         $validator = Yii::createObject(array_merge(
             [
-                'class' => UniqueValidator::className(),
+                'class' => UniqueValidator::class,
             ],
             $this->uniqueValidator
         ));

--- a/framework/caching/DbCache.php
+++ b/framework/caching/DbCache.php
@@ -95,7 +95,7 @@ class DbCache extends Cache
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
     }
 
     /**

--- a/framework/caching/DbDependency.php
+++ b/framework/caching/DbDependency.php
@@ -50,7 +50,7 @@ class DbDependency extends Dependency
     protected function generateDependencyData($cache)
     {
         /* @var $db Connection */
-        $db = Instance::ensure($this->db, Connection::className());
+        $db = Instance::ensure($this->db, Connection::class);
         if ($this->sql === null) {
             throw new InvalidConfigException('DbDependency::sql must be set.');
         }

--- a/framework/console/controllers/CacheController.php
+++ b/framework/console/controllers/CacheController.php
@@ -300,6 +300,6 @@ class CacheController extends Controller
      */
     private function canBeFlushed($className)
     {
-        return !is_a($className, ApcCache::className(), true) || PHP_SAPI !== 'cli';
+        return !is_a($className, ApcCache::class, true) || PHP_SAPI !== 'cli';
     }
 }

--- a/framework/console/controllers/FixtureController.php
+++ b/framework/console/controllers/FixtureController.php
@@ -258,7 +258,7 @@ class FixtureController extends Controller
         $fixtureClassNames = [];
 
         foreach ($fixtures as $fixture) {
-            $fixtureClassNames[] = $fixture::className();
+            $fixtureClassNames[] = $fixture::class;
         }
 
         $this->outputList($fixtureClassNames);

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -318,7 +318,7 @@ EOD;
             }
         } elseif ($this->config['format'] === 'db') {
             /** @var Connection $db */
-            $db = Instance::ensure($this->config['db'], Connection::className());
+            $db = Instance::ensure($this->config['db'], Connection::class);
             $sourceMessageTable = isset($this->config['sourceMessageTable']) ? $this->config['sourceMessageTable'] : '{{%source_message}}';
             $messageTable = isset($this->config['messageTable']) ? $this->config['messageTable'] : '{{%message}}';
             $this->saveMessagesToDb(

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -180,7 +180,7 @@ class MigrateController extends BaseMigrateController
     public function beforeAction($action)
     {
         if (parent::beforeAction($action)) {
-            $this->db = Instance::ensure($this->db, Connection::className());
+            $this->db = Instance::ensure($this->db, Connection::class);
             return true;
         }
 
@@ -471,7 +471,7 @@ class MigrateController extends BaseMigrateController
             if ($relatedColumn === null) {
                 $relatedColumn = 'id';
                 try {
-                    $this->db = Instance::ensure($this->db, Connection::className());
+                    $this->db = Instance::ensure($this->db, Connection::class);
                     $relatedTableSchema = $this->db->getTableSchema($relatedTable);
                     if ($relatedTableSchema !== null) {
                         $primaryKeyCount = count($relatedTableSchema->primaryKey);

--- a/framework/data/BaseDataProvider.php
+++ b/framework/data/BaseDataProvider.php
@@ -211,7 +211,7 @@ abstract class BaseDataProvider extends Component implements DataProviderInterfa
     public function setPagination($value)
     {
         if (is_array($value)) {
-            $config = ['class' => Pagination::className()];
+            $config = ['class' => Pagination::class];
             if ($this->id !== null) {
                 $config['pageParam'] = $this->id . '-page';
                 $config['pageSizeParam'] = $this->id . '-per-page';
@@ -252,7 +252,7 @@ abstract class BaseDataProvider extends Component implements DataProviderInterfa
     public function setSort($value)
     {
         if (is_array($value)) {
-            $config = ['class' => Sort::className()];
+            $config = ['class' => Sort::class];
             if ($this->id !== null) {
                 $config['sortParam'] = $this->id . '-sort';
             }

--- a/framework/data/DataFilter.php
+++ b/framework/data/DataFilter.php
@@ -288,7 +288,7 @@ class DataFilter extends Model
         if (!is_object($this->_searchModel) || $this->_searchModel instanceof \Closure) {
             $model = Yii::createObject($this->_searchModel);
             if (!$model instanceof Model) {
-                throw new InvalidConfigException('`' . get_class($this) . '::$searchModel` should be an instance of `' . Model::className() . '` or its DI compatible configuration.');
+                throw new InvalidConfigException('`' . get_class($this) . '::$searchModel` should be an instance of `' . Model::class . '` or its DI compatible configuration.');
             }
             $this->_searchModel = $model;
         }
@@ -302,7 +302,7 @@ class DataFilter extends Model
     public function setSearchModel($model)
     {
         if (is_object($model) && !$model instanceof Model && !$model instanceof \Closure) {
-            throw new InvalidConfigException('`' . get_class($this) . '::$searchModel` should be an instance of `' . Model::className() . '` or its DI compatible configuration.');
+            throw new InvalidConfigException('`' . get_class($this) . '::$searchModel` should be an instance of `' . Model::class . '` or its DI compatible configuration.');
         }
         $this->_searchModel = $model;
     }

--- a/framework/data/SqlDataProvider.php
+++ b/framework/data/SqlDataProvider.php
@@ -96,7 +96,7 @@ class SqlDataProvider extends BaseDataProvider
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
         if ($this->sql === null) {
             throw new InvalidConfigException('The "sql" property must be set.');
         }

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -411,7 +411,7 @@ class ActiveRecord extends BaseActiveRecord
      */
     public static function find()
     {
-        return Yii::createObject(ActiveQuery::className(), [get_called_class()]);
+        return Yii::createObject(ActiveQuery::class, [get_called_class()]);
     }
 
     /**

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -87,7 +87,7 @@ class Migration extends Component implements MigrationInterface
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
         $this->db->getSchema()->refresh();
         $this->db->enableSlaves = false;
     }
@@ -311,7 +311,7 @@ class Migration extends Component implements MigrationInterface
      *
      * If a column is specified with definition only (e.g. 'PRIMARY KEY (name, type)'), it will be directly
      * put into the generated SQL.
-     * 
+     *
      * Example usage:
      * ```php
      * class m200000_000000_create_table_fruits extends \yii\db\Migration
@@ -319,7 +319,7 @@ class Migration extends Component implements MigrationInterface
      *     public function safeUp()
      *     {
      *          $this->createTable('{{%fruits}}', [
-     *              // ...              
+     *              // ...
      *              'column_name double precision null default null',
      * ```
 

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -198,7 +198,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
     public function batch($batchSize = 100, $db = null)
     {
         return Yii::createObject([
-            'class' => BatchQueryResult::className(),
+            'class' => BatchQueryResult::class,
             'query' => $this,
             'batchSize' => $batchSize,
             'db' => $db,
@@ -226,7 +226,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
     public function each($batchSize = 100, $db = null)
     {
         return Yii::createObject([
-            'class' => BatchQueryResult::className(),
+            'class' => BatchQueryResult::class,
             'query' => $this,
             'batchSize' => $batchSize,
             'db' => $db,

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -313,7 +313,7 @@ abstract class Schema extends BaseObject
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**
@@ -328,7 +328,7 @@ abstract class Schema extends BaseObject
      */
     public function createColumnSchemaBuilder($type, $length = null)
     {
-        return Yii::createObject(ColumnSchemaBuilder::className(), [$type, $length]);
+        return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length]);
     }
 
     /**

--- a/framework/db/cubrid/Schema.php
+++ b/framework/db/cubrid/Schema.php
@@ -249,7 +249,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -332,7 +332,7 @@ SQL;
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**
@@ -811,6 +811,6 @@ SQL;
      */
     public function createColumnSchemaBuilder($type, $length = null)
     {
-        return Yii::createObject(ColumnSchemaBuilder::className(), [$type, $length, $this->db]);
+        return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length, $this->db]);
     }
 }

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -222,7 +222,7 @@ SQL;
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**
@@ -472,7 +472,7 @@ SQL;
      */
     public function createColumnSchemaBuilder($type, $length = null)
     {
-        return Yii::createObject(ColumnSchemaBuilder::className(), [$type, $length, $this->db]);
+        return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length, $this->db]);
     }
 
     /**

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -262,7 +262,7 @@ SQL;
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**
@@ -270,7 +270,7 @@ SQL;
      */
     public function createColumnSchemaBuilder($type, $length = null)
     {
-        return Yii::createObject(ColumnSchemaBuilder::className(), [$type, $length]);
+        return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length]);
     }
 
     /**

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -289,7 +289,7 @@ SQL;
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -207,7 +207,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**
@@ -216,7 +216,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     public function createColumnSchemaBuilder($type, $length = null)
     {
-        return Yii::createObject(ColumnSchemaBuilder::className(), [$type, $length]);
+        return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length]);
     }
 
     /**

--- a/framework/filters/AccessControl.php
+++ b/framework/filters/AccessControl.php
@@ -99,7 +99,7 @@ class AccessControl extends ActionFilter
     {
         parent::init();
         if ($this->user !== false) {
-            $this->user = Instance::ensure($this->user, User::className());
+            $this->user = Instance::ensure($this->user, User::class);
         }
         foreach ($this->rules as $i => $rule) {
             if (is_array($rule)) {

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -547,7 +547,7 @@ class GridView extends BaseListView
                 $column = $this->createDataColumn($column);
             } else {
                 $column = Yii::createObject(array_merge([
-                    'class' => $this->dataColumnClass ?: DataColumn::className(),
+                    'class' => $this->dataColumnClass ?: DataColumn::class,
                     'grid' => $this,
                 ], $column));
             }
@@ -572,7 +572,7 @@ class GridView extends BaseListView
         }
 
         return Yii::createObject([
-            'class' => $this->dataColumnClass ?: DataColumn::className(),
+            'class' => $this->dataColumnClass ?: DataColumn::class,
             'grid' => $this,
             'attribute' => $matches[1],
             'format' => isset($matches[3]) ? $matches[3] : 'text',

--- a/framework/i18n/DbMessageSource.php
+++ b/framework/i18n/DbMessageSource.php
@@ -96,7 +96,7 @@ class DbMessageSource extends MessageSource
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
         if ($this->enableCaching) {
             $this->cache = Instance::ensure($this->cache, 'yii\caching\CacheInterface');
         }

--- a/framework/log/DbTarget.php
+++ b/framework/log/DbTarget.php
@@ -53,7 +53,7 @@ class DbTarget extends Target
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
     }
 
     /**

--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -142,7 +142,7 @@ abstract class BaseMailer extends Component implements MailerInterface, ViewCont
     protected function createView(array $config)
     {
         if (!array_key_exists('class', $config)) {
-            $config['class'] = View::className();
+            $config['class'] = View::class;
         }
 
         return Yii::createObject($config);

--- a/framework/mutex/DbMutex.php
+++ b/framework/mutex/DbMutex.php
@@ -37,6 +37,6 @@ abstract class DbMutex extends Mutex
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
     }
 }

--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -119,7 +119,7 @@ class DbManager extends BaseManager
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
         if ($this->cache !== null) {
             $this->cache = Instance::ensure($this->cache, 'yii\caching\CacheInterface');
         }
@@ -449,7 +449,7 @@ class DbManager extends BaseManager
      */
     protected function populateItem($row)
     {
-        $class = $row['type'] == Item::TYPE_PERMISSION ? Permission::className() : Role::className();
+        $class = $row['type'] == Item::TYPE_PERMISSION ? Permission::class : Role::class;
 
         if (!isset($row['data']) || ($data = @unserialize(is_resource($row['data']) ? stream_get_contents($row['data']) : $row['data'])) === false) {
             $data = null;

--- a/framework/rbac/PhpManager.php
+++ b/framework/rbac/PhpManager.php
@@ -724,7 +724,7 @@ class PhpManager extends BaseManager
         $rules = $this->loadFromFile($this->ruleFile);
 
         foreach ($items as $name => $item) {
-            $class = $item['type'] == Item::TYPE_PERMISSION ? Permission::className() : Role::className();
+            $class = $item['type'] == Item::TYPE_PERMISSION ? Permission::class : Role::class;
 
             $this->items[$name] = new $class([
                 'name' => $name,

--- a/framework/rest/Controller.php
+++ b/framework/rest/Controller.php
@@ -49,21 +49,21 @@ class Controller extends \yii\web\Controller
     {
         return [
             'contentNegotiator' => [
-                'class' => ContentNegotiator::className(),
+                'class' => ContentNegotiator::class,
                 'formats' => [
                     'application/json' => Response::FORMAT_JSON,
                     'application/xml' => Response::FORMAT_XML,
                 ],
             ],
             'verbFilter' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => $this->verbs(),
             ],
             'authenticator' => [
-                'class' => CompositeAuth::className(),
+                'class' => CompositeAuth::class,
             ],
             'rateLimiter' => [
-                'class' => RateLimiter::className(),
+                'class' => RateLimiter::class,
             ],
         ];
     }

--- a/framework/rest/IndexAction.php
+++ b/framework/rest/IndexAction.php
@@ -183,7 +183,7 @@ class IndexAction extends Action
         }
 
         return Yii::createObject([
-            'class' => ActiveDataProvider::className(),
+            'class' => ActiveDataProvider::class,
             'query' => $query,
             'pagination' => $pagination,
             'sort' => $sort,

--- a/framework/rest/UrlRule.php
+++ b/framework/rest/UrlRule.php
@@ -233,7 +233,7 @@ class UrlRule extends CompositeUrlRule
                         Yii::debug([
                             'rule' => method_exists($rule, '__toString') ? $rule->__toString() : get_class($rule),
                             'match' => $result !== false,
-                            'parent' => self::className(),
+                            'parent' => self::class,
                         ], __METHOD__);
                     }
                     if ($result !== false) {

--- a/framework/test/DbFixture.php
+++ b/framework/test/DbFixture.php
@@ -38,6 +38,6 @@ abstract class DbFixture extends Fixture
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, BaseObject::className());
+        $this->db = Instance::ensure($this->db, BaseObject::class);
     }
 }

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -189,7 +189,11 @@ class UniqueValidator extends Validator
         /** @var ActiveRecordInterface|\yii\base\BaseObject $targetClass $query */
         $query = $this->prepareQuery($targetClass, $conditions);
 
-        if (!$model instanceof ActiveRecordInterface || $model->getIsNewRecord() || $model::className() !== $targetClass::className()) {
+        if (
+            !$model instanceof ActiveRecordInterface ||
+            $model->getIsNewRecord() ||
+            !$model instanceof $targetClass
+        ) {
             // if current $model isn't in the database yet, then it's OK just to call exists()
             // also there's no need to run check based on primary keys, when $targetClass is not the same as $model's class
             $exists = $query->exists();

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -394,10 +394,10 @@ class AssetManager extends Component
     public function getConverter()
     {
         if ($this->_converter === null) {
-            $this->_converter = Yii::createObject(AssetConverter::className());
+            $this->_converter = Yii::createObject(AssetConverter::class);
         } elseif (is_array($this->_converter) || is_string($this->_converter)) {
             if (is_array($this->_converter) && !isset($this->_converter['class'])) {
-                $this->_converter['class'] = AssetConverter::className();
+                $this->_converter['class'] = AssetConverter::class;
             }
             $this->_converter = Yii::createObject($this->_converter);
         }

--- a/framework/web/CompositeUrlRule.php
+++ b/framework/web/CompositeUrlRule.php
@@ -60,7 +60,7 @@ abstract class CompositeUrlRule extends BaseObject implements UrlRuleInterface
                 Yii::debug([
                     'rule' => method_exists($rule, '__toString') ? $rule->__toString() : get_class($rule),
                     'match' => $result !== false,
-                    'parent' => self::className(),
+                    'parent' => self::class,
                 ], __METHOD__);
             }
             if ($result !== false) {

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -90,7 +90,7 @@ class DbSession extends MultiFieldSession
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
     }
 
     /**

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -178,7 +178,7 @@ class UrlManager extends Component
         if ($this->normalizer !== false) {
             $this->normalizer = Yii::createObject($this->normalizer);
             if (!$this->normalizer instanceof UrlNormalizer) {
-                throw new InvalidConfigException('`' . get_class($this) . '::normalizer` should be an instance of `' . UrlNormalizer::className() . '` or its DI compatible configuration.');
+                throw new InvalidConfigException('`' . get_class($this) . '::normalizer` should be an instance of `' . UrlNormalizer::class . '` or its DI compatible configuration.');
             }
         }
 

--- a/framework/web/UrlRule.php
+++ b/framework/web/UrlRule.php
@@ -195,7 +195,7 @@ class UrlRule extends BaseObject implements UrlRuleInterface
             throw new InvalidConfigException('UrlRule::route must be set.');
         }
         if (is_array($this->normalizer)) {
-            $normalizerConfig = array_merge(['class' => UrlNormalizer::className()], $this->normalizer);
+            $normalizerConfig = array_merge(['class' => UrlNormalizer::class], $this->normalizer);
             $this->normalizer = Yii::createObject($normalizerConfig);
         }
         if ($this->normalizer !== null && $this->normalizer !== false && !$this->normalizer instanceof UrlNormalizer) {

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -521,7 +521,7 @@ class View extends \yii\base\View
             }
         } else {
             $this->getAssetManager()->bundles[$key] = Yii::createObject([
-                'class' => AssetBundle::className(),
+                'class' => AssetBundle::class,
                 'baseUrl' => '',
                 'basePath' => '@webroot',
                 (string)$type => [ArrayHelper::merge([!Url::isRelative($url) ? $url : ltrim($url, '/')], $originalOptions)],

--- a/framework/widgets/BaseListView.php
+++ b/framework/widgets/BaseListView.php
@@ -253,7 +253,7 @@ abstract class BaseListView extends Widget
         }
         /* @var $class LinkPager */
         $pager = $this->pager;
-        $class = ArrayHelper::remove($pager, 'class', LinkPager::className());
+        $class = ArrayHelper::remove($pager, 'class', LinkPager::class);
         $pager['pagination'] = $pagination;
         $pager['view'] = $this->getView();
 
@@ -272,7 +272,7 @@ abstract class BaseListView extends Widget
         }
         /* @var $class LinkSorter */
         $sorter = $this->sorter;
-        $class = ArrayHelper::remove($sorter, 'class', LinkSorter::className());
+        $class = ArrayHelper::remove($sorter, 'class', LinkSorter::class);
         $sorter['sort'] = $sort;
         $sorter['view'] = $this->getView();
 

--- a/tests/data/ar/Alpha.php
+++ b/tests/data/ar/Alpha.php
@@ -20,6 +20,6 @@ class Alpha extends ActiveRecord
 
     public function getBetas()
     {
-        return $this->hasMany(Beta::className(), ['alpha_string_identifier' => 'string_identifier']);
+        return $this->hasMany(Beta::class, ['alpha_string_identifier' => 'string_identifier']);
     }
 }

--- a/tests/data/ar/Beta.php
+++ b/tests/data/ar/Beta.php
@@ -21,6 +21,6 @@ class Beta extends ActiveRecord
 
     public function getAlpha()
     {
-        return $this->hasOne(Alpha::className(), ['string_identifier' => 'alpha_string_identifier']);
+        return $this->hasOne(Alpha::class, ['string_identifier' => 'alpha_string_identifier']);
     }
 }

--- a/tests/data/ar/Category.php
+++ b/tests/data/ar/Category.php
@@ -22,22 +22,22 @@ class Category extends ActiveRecord
 
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['category_id' => 'id']);
+        return $this->hasMany(Item::class, ['category_id' => 'id']);
     }
 
     public function getLimitedItems()
     {
-        return $this->hasMany(Item::className(), ['category_id' => 'id'])
+        return $this->hasMany(Item::class, ['category_id' => 'id'])
             ->onCondition(['item.id' => [1, 2, 3]]);
     }
 
     public function getOrderItems()
     {
-        return $this->hasMany(OrderItem::className(), ['item_id' => 'id'])->via('items');
+        return $this->hasMany(OrderItem::class, ['item_id' => 'id'])->via('items');
     }
 
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['id' => 'order_id'])->via('orderItems');
+        return $this->hasMany(Order::class, ['id' => 'order_id'])->via('orderItems');
     }
 }

--- a/tests/data/ar/Customer.php
+++ b/tests/data/ar/Customer.php
@@ -37,49 +37,49 @@ class Customer extends ActiveRecord
 
     public function getProfile()
     {
-        return $this->hasOne(Profile::className(), ['id' => 'profile_id']);
+        return $this->hasOne(Profile::class, ['id' => 'profile_id']);
     }
 
     public function getOrdersPlain()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+        return $this->hasMany(Order::class, ['customer_id' => 'id']);
     }
 
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])->orderBy('[[id]]');
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])->orderBy('[[id]]');
     }
 
     public function getExpensiveOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])->andWhere('[[total]] > 50')->orderBy('id');
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])->andWhere('[[total]] > 50')->orderBy('id');
     }
 
     public function getOrdersWithItems()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])->with('orderItems');
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])->with('orderItems');
     }
 
     public function getExpensiveOrdersWithNullFK()
     {
-        return $this->hasMany(OrderWithNullFK::className(), ['customer_id' => 'id'])->andWhere('[[total]] > 50')->orderBy('id');
+        return $this->hasMany(OrderWithNullFK::class, ['customer_id' => 'id'])->andWhere('[[total]] > 50')->orderBy('id');
     }
 
     public function getOrdersWithNullFK()
     {
-        return $this->hasMany(OrderWithNullFK::className(), ['customer_id' => 'id'])->orderBy('id');
+        return $this->hasMany(OrderWithNullFK::class, ['customer_id' => 'id'])->orderBy('id');
     }
 
     public function getOrders2()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])->inverseOf('customer2')->orderBy('id');
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])->inverseOf('customer2')->orderBy('id');
     }
 
     // deeply nested table relation
     public function getOrderItems()
     {
         /* @var $rel ActiveQuery */
-        $rel = $this->hasMany(Item::className(), ['id' => 'item_id']);
+        $rel = $this->hasMany(Item::class, ['id' => 'item_id']);
 
         return $rel->viaTable('order_item', ['order_id' => 'id'], function ($q) {
             /* @var $q ActiveQuery */
@@ -89,13 +89,13 @@ class Customer extends ActiveRecord
 
     public function getOrderItems2()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id'])
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id'])
             ->via('orders');
     }
 
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems2');
     }
 

--- a/tests/data/ar/CustomerWithConstructor.php
+++ b/tests/data/ar/CustomerWithConstructor.php
@@ -40,11 +40,11 @@ class CustomerWithConstructor extends ActiveRecord
 
     public static function instantiate($row)
     {
-        return (new \ReflectionClass(static::className()))->newInstanceWithoutConstructor();
+        return (new \ReflectionClass(static::class))->newInstanceWithoutConstructor();
     }
 
     public function getProfile()
     {
-        return $this->hasOne(ProfileWithConstructor::className(), ['id' => 'profile_id']);
+        return $this->hasOne(ProfileWithConstructor::class, ['id' => 'profile_id']);
     }
 }

--- a/tests/data/ar/Department.php
+++ b/tests/data/ar/Department.php
@@ -39,7 +39,7 @@ class Department extends ActiveRecord
     public function getEmployees()
     {
         return $this
-            ->hasMany(Employee::className(), [
+            ->hasMany(Employee::class, [
                 'department_id' => 'id',
             ])
             ->inverseOf('department')

--- a/tests/data/ar/Dossier.php
+++ b/tests/data/ar/Dossier.php
@@ -41,7 +41,7 @@ class Dossier extends ActiveRecord
     public function getEmployee()
     {
         return $this
-            ->hasOne(Employee::className(), [
+            ->hasOne(Employee::class, [
                 'department_id' => 'department_id',
                 'id' => 'employee_id',
             ])

--- a/tests/data/ar/Employee.php
+++ b/tests/data/ar/Employee.php
@@ -55,7 +55,7 @@ class Employee extends ActiveRecord
     public function getDepartment()
     {
         return $this
-            ->hasOne(Department::className(), [
+            ->hasOne(Department::class, [
                 'id' => 'department_id',
             ])
             ->inverseOf('employees')
@@ -70,7 +70,7 @@ class Employee extends ActiveRecord
     public function getDossier()
     {
         return $this
-            ->hasOne(Dossier::className(), [
+            ->hasOne(Dossier::class, [
                 'department_id' => 'department_id',
                 'employee_id' => 'id',
             ])

--- a/tests/data/ar/Item.php
+++ b/tests/data/ar/Item.php
@@ -23,6 +23,6 @@ class Item extends ActiveRecord
 
     public function getCategory()
     {
-        return $this->hasOne(Category::className(), ['id' => 'category_id']);
+        return $this->hasOne(Category::class, ['id' => 'category_id']);
     }
 }

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -34,40 +34,40 @@ class Order extends ActiveRecord
 
     public function getCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 
     public function getCustomerJoinedWithProfile()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id'])
+        return $this->hasOne(Customer::class, ['id' => 'customer_id'])
             ->joinWith('profile');
     }
 
     public function getCustomerJoinedWithProfileIndexOrdered()
     {
-        return $this->hasMany(Customer::className(), ['id' => 'customer_id'])
+        return $this->hasMany(Customer::class, ['id' => 'customer_id'])
             ->joinWith('profile')->orderBy(['profile.description' => SORT_ASC])->indexBy('name');
     }
 
     public function getCustomer2()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id'])->inverseOf('orders2');
+        return $this->hasOne(Customer::class, ['id' => 'customer_id'])->inverseOf('orders2');
     }
 
     public function getOrderItems()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id']);
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id']);
     }
 
     public function getOrderItems2()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id'])
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id'])
             ->indexBy('item_id');
     }
 
     public function getOrderItems3()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id'])
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id'])
             ->indexBy(function ($row) {
                 return $row['order_id'] . '_' . $row['item_id'];
             });
@@ -75,12 +75,12 @@ class Order extends ActiveRecord
 
     public function getOrderItemsWithNullFK()
     {
-        return $this->hasMany(OrderItemWithNullFK::className(), ['order_id' => 'id']);
+        return $this->hasMany(OrderItemWithNullFK::class, ['order_id' => 'id']);
     }
 
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems', function ($q) {
                 // additional query configuration
             })->orderBy('item.id');
@@ -88,7 +88,7 @@ class Order extends ActiveRecord
 
     public function getExpensiveItemsUsingViaWithCallable()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems', function (ActiveQuery $q) {
                 $q->where(['>=', 'subtotal', 10]);
             });
@@ -96,7 +96,7 @@ class Order extends ActiveRecord
 
     public function getCheapItemsUsingViaWithCallable()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems', function (ActiveQuery $q) {
                 $q->where(['<', 'subtotal', 10]);
             });
@@ -104,19 +104,19 @@ class Order extends ActiveRecord
 
     public function getItemsIndexed()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems')->indexBy('id');
     }
 
     public function getItemsWithNullFK()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->viaTable('order_item_with_null_fk', ['order_id' => 'id']);
     }
 
     public function getItemsInOrder1()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems', function ($q) {
                 $q->orderBy(['subtotal' => SORT_ASC]);
             })->orderBy('name');
@@ -124,7 +124,7 @@ class Order extends ActiveRecord
 
     public function getItemsInOrder2()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems', function ($q) {
                 $q->orderBy(['subtotal' => SORT_DESC]);
             })->orderBy('name');
@@ -132,70 +132,70 @@ class Order extends ActiveRecord
 
     public function getBooks()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems')
             ->where(['category_id' => 1]);
     }
 
     public function getBooksWithNullFK()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItemsWithNullFK')
             ->where(['category_id' => 1]);
     }
 
     public function getBooksViaTable()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->viaTable('order_item', ['order_id' => 'id'])
             ->where(['category_id' => 1]);
     }
 
     public function getBooksWithNullFKViaTable()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->viaTable('order_item_with_null_fk', ['order_id' => 'id'])
             ->where(['category_id' => 1]);
     }
 
     public function getBooks2()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->onCondition(['category_id' => 1])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
     public function getBooksExplicit()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->onCondition(['category_id' => 1])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
     public function getBooksExplicitA()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('bo')
+        return $this->hasMany(Item::class, ['id' => 'item_id'])->alias('bo')
             ->onCondition(['bo.category_id' => 1])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
     public function getBookItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('books')
+        return $this->hasMany(Item::class, ['id' => 'item_id'])->alias('books')
             ->onCondition(['books.category_id' => 1])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
     public function getMovieItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('movies')
+        return $this->hasMany(Item::class, ['id' => 'item_id'])->alias('movies')
             ->onCondition(['movies.category_id' => 2])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
     public function getLimitedItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->onCondition(['item.id' => [3, 5]])
             ->via('orderItems');
     }
@@ -228,22 +228,22 @@ class Order extends ActiveRecord
 
     public function getQuantityOrderItems()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id', 'quantity' => 'id']);
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id', 'quantity' => 'id']);
     }
 
     public function getOrderItemsFor8()
     {
-        return $this->hasMany(OrderItemWithNullFK::className(), ['order_id' => 'id'])->andOnCondition(['subtotal' => 8.0]);
+        return $this->hasMany(OrderItemWithNullFK::class, ['order_id' => 'id'])->andOnCondition(['subtotal' => 8.0]);
     }
 
     public function getItemsFor8()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])->via('orderItemsFor8');
+        return $this->hasMany(Item::class, ['id' => 'item_id'])->via('orderItemsFor8');
     }
 
     public function getVirtualCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'virtualCustomerId']);
+        return $this->hasOne(Customer::class, ['id' => 'virtualCustomerId']);
     }
 
 }

--- a/tests/data/ar/OrderItem.php
+++ b/tests/data/ar/OrderItem.php
@@ -30,7 +30,7 @@ class OrderItem extends ActiveRecord
     {
         return [
             'typecast' => [
-                'class' => AttributeTypecastBehavior::className(),
+                'class' => AttributeTypecastBehavior::class,
                 'attributeTypes' => [
                     'order_id' => AttributeTypecastBehavior::TYPE_STRING,
                 ],
@@ -44,23 +44,23 @@ class OrderItem extends ActiveRecord
 
     public function getOrder()
     {
-        return $this->hasOne(Order::className(), ['id' => 'order_id']);
+        return $this->hasOne(Order::class, ['id' => 'order_id']);
     }
 
     public function getItem()
     {
-        return $this->hasOne(Item::className(), ['id' => 'item_id']);
+        return $this->hasOne(Item::class, ['id' => 'item_id']);
     }
 
     // relations used by ::testFindCompositeWithJoin()
     public function getOrderItemCompositeWithJoin()
     {
-        return $this->hasOne(self::className(), ['item_id' => 'item_id', 'order_id' => 'order_id'])
+        return $this->hasOne(self::class, ['item_id' => 'item_id', 'order_id' => 'order_id'])
             ->joinWith('item');
     }
     public function getOrderItemCompositeNoJoin()
     {
-        return $this->hasOne(self::className(), ['item_id' => 'item_id', 'order_id' => 'order_id']);
+        return $this->hasOne(self::class, ['item_id' => 'item_id', 'order_id' => 'order_id']);
     }
 
     public function getCustom()

--- a/tests/data/ar/OrderItemWithConstructor.php
+++ b/tests/data/ar/OrderItemWithConstructor.php
@@ -36,11 +36,11 @@ class OrderItemWithConstructor extends ActiveRecord
 
     public static function instantiate($row)
     {
-        return (new \ReflectionClass(static::className()))->newInstanceWithoutConstructor();
+        return (new \ReflectionClass(static::class))->newInstanceWithoutConstructor();
     }
 
     public function getOrder()
     {
-        return $this->hasOne(OrderWithConstructor::className(), ['id' => 'order_id']);
+        return $this->hasOne(OrderWithConstructor::class, ['id' => 'order_id']);
     }
 }

--- a/tests/data/ar/OrderWithConstructor.php
+++ b/tests/data/ar/OrderWithConstructor.php
@@ -40,22 +40,22 @@ class OrderWithConstructor extends ActiveRecord
 
     public static function instantiate($row)
     {
-        return (new \ReflectionClass(static::className()))->newInstanceWithoutConstructor();
+        return (new \ReflectionClass(static::class))->newInstanceWithoutConstructor();
     }
 
     public function getCustomer()
     {
-        return $this->hasOne(CustomerWithConstructor::className(), ['id' => 'customer_id']);
+        return $this->hasOne(CustomerWithConstructor::class, ['id' => 'customer_id']);
     }
 
     public function getCustomerJoinedWithProfile()
     {
-        return $this->hasOne(CustomerWithConstructor::className(), ['id' => 'customer_id'])
+        return $this->hasOne(CustomerWithConstructor::class, ['id' => 'customer_id'])
             ->joinWith('profile');
     }
 
     public function getOrderItems()
     {
-        return $this->hasMany(OrderItemWithConstructor::className(), ['order_id' => 'id'])->inverseOf('order');
+        return $this->hasMany(OrderItemWithConstructor::class, ['order_id' => 'id'])->inverseOf('order');
     }
 }

--- a/tests/data/ar/ProfileWithConstructor.php
+++ b/tests/data/ar/ProfileWithConstructor.php
@@ -33,6 +33,6 @@ class ProfileWithConstructor extends ActiveRecord
 
     public static function instantiate($row)
     {
-        return (new \ReflectionClass(static::className()))->newInstanceWithoutConstructor();
+        return (new \ReflectionClass(static::class))->newInstanceWithoutConstructor();
     }
 }

--- a/tests/data/console/controllers/fixtures/DependentActiveFixture.php
+++ b/tests/data/console/controllers/fixtures/DependentActiveFixture.php
@@ -20,7 +20,7 @@ class DependentActiveFixture extends ActiveFixture
 
     public function load()
     {
-        FixtureStorage::$activeFixtureSequence[] = self::className();
+        FixtureStorage::$activeFixtureSequence[] = self::class;
         parent::load();
     }
 }

--- a/tests/data/console/controllers/fixtures/FirstIndependentActiveFixture.php
+++ b/tests/data/console/controllers/fixtures/FirstIndependentActiveFixture.php
@@ -15,7 +15,7 @@ class FirstIndependentActiveFixture extends ActiveFixture
 
     public function load()
     {
-        FixtureStorage::$activeFixtureSequence[] = self::className();
+        FixtureStorage::$activeFixtureSequence[] = self::class;
         parent::load();
     }
 }

--- a/tests/data/console/controllers/fixtures/SecondIndependentActiveFixture.php
+++ b/tests/data/console/controllers/fixtures/SecondIndependentActiveFixture.php
@@ -15,7 +15,7 @@ class SecondIndependentActiveFixture extends ActiveFixture
 
     public function load()
     {
-        FixtureStorage::$activeFixtureSequence[] = self::className();
+        FixtureStorage::$activeFixtureSequence[] = self::class;
         parent::load();
     }
 }

--- a/tests/data/controllers/TestController.php
+++ b/tests/data/controllers/TestController.php
@@ -20,7 +20,7 @@ class TestController extends Controller
     {
         return [
             'error' => array_merge([
-                'class' => ErrorAction::className(),
+                'class' => ErrorAction::class,
                 'view' => '@yiiunit/data/views/error.php',
             ], $this->actionConfig),
         ];

--- a/tests/data/validators/models/ValidatorTestMainModel.php
+++ b/tests/data/validators/models/ValidatorTestMainModel.php
@@ -20,6 +20,6 @@ class ValidatorTestMainModel extends ActiveRecord
 
     public function getReferences()
     {
-        return $this->hasMany(ValidatorTestRefModel::className(), ['ref' => 'id']);
+        return $this->hasMany(ValidatorTestRefModel::class, ['ref' => 'id']);
     }
 }

--- a/tests/data/validators/models/ValidatorTestRefModel.php
+++ b/tests/data/validators/models/ValidatorTestRefModel.php
@@ -26,6 +26,6 @@ class ValidatorTestRefModel extends ActiveRecord
 
     public function getMain()
     {
-        return $this->hasOne(ValidatorTestMainModel::className(), ['id' => 'ref']);
+        return $this->hasOne(ValidatorTestMainModel::class, ['id' => 'ref']);
     }
 }

--- a/tests/data/views/widgets/ListView/item.php
+++ b/tests/data/views/widgets/ListView/item.php
@@ -10,4 +10,4 @@
 /* @var $index int */
 /* @var $widget \yii\widgets\ListView */
 
-echo "Item #{$index}: {$model['login']} - Widget: " . $widget->className();
+echo "Item #{$index}: {$model['login']} - Widget: " . $widget::class;

--- a/tests/framework/BaseYiiTest.php
+++ b/tests/framework/BaseYiiTest.php
@@ -80,11 +80,11 @@ class BaseYiiTest extends TestCase
         Yii::$container = new Container();
 
         $qux = Yii::createObject([
-            '__class' => Qux::className(),
+            '__class' => Qux::class,
             'a' => 42,
         ]);
 
-        $this->assertInstanceOf(Qux::className(), $qux);
+        $this->assertInstanceOf(Qux::class, $qux);
         $this->assertSame(42, $qux->a);
     }
 
@@ -131,12 +131,12 @@ class BaseYiiTest extends TestCase
     public function testDi3CompatibilityCreateDependentObject()
     {
         $object = Yii::createObject([
-            '__class' => FooBaz::className(),
-            'fooDependent' => ['__class' => FooDependentSubclass::className()],
+            '__class' => FooBaz::class,
+            'fooDependent' => ['__class' => FooDependentSubclass::class],
         ]);
 
-        $this->assertInstanceOf(FooBaz::className(), $object);
-        $this->assertInstanceOf(FooDependentSubclass::className(), $object->fooDependent);
+        $this->assertInstanceOf(FooBaz::class, $object);
+        $this->assertInstanceOf(FooDependentSubclass::class, $object->fooDependent);
     }
 
     /**
@@ -152,7 +152,7 @@ class BaseYiiTest extends TestCase
 
         BaseYii::setLogger(null);
         $defaultLogger = BaseYii::getLogger();
-        $this->assertInstanceOf(Logger::className(), $defaultLogger);
+        $this->assertInstanceOf(Logger::class, $defaultLogger);
     }
 
     /**

--- a/tests/framework/ar/ActiveRecordTestTrait.php
+++ b/tests/framework/ar/ActiveRecordTestTrait.php
@@ -1115,7 +1115,7 @@ trait ActiveRecordTestTrait
         /* @var $this TestCase|ActiveRecordTestTrait */
 
         $afterFindCalls = [];
-        Event::on(BaseActiveRecord::className(), BaseActiveRecord::EVENT_AFTER_FIND, function ($event) use (&$afterFindCalls) {
+        Event::on(BaseActiveRecord::class, BaseActiveRecord::EVENT_AFTER_FIND, function ($event) use (&$afterFindCalls) {
             /* @var $ar BaseActiveRecord */
             $ar = $event->sender;
             $afterFindCalls[] = [\get_class($ar), $ar->getIsNewRecord(), $ar->getPrimaryKey(), $ar->isRelationPopulated('orders')];
@@ -1160,7 +1160,7 @@ trait ActiveRecordTestTrait
         ], $afterFindCalls);
         $afterFindCalls = [];
 
-        Event::off(BaseActiveRecord::className(), BaseActiveRecord::EVENT_AFTER_FIND);
+        Event::off(BaseActiveRecord::class, BaseActiveRecord::EVENT_AFTER_FIND);
     }
 
     public function testAfterRefresh()
@@ -1170,7 +1170,7 @@ trait ActiveRecordTestTrait
         /* @var $this TestCase|ActiveRecordTestTrait */
 
         $afterRefreshCalls = [];
-        Event::on(BaseActiveRecord::className(), BaseActiveRecord::EVENT_AFTER_REFRESH, function ($event) use (&$afterRefreshCalls) {
+        Event::on(BaseActiveRecord::class, BaseActiveRecord::EVENT_AFTER_REFRESH, function ($event) use (&$afterRefreshCalls) {
             /* @var $ar BaseActiveRecord */
             $ar = $event->sender;
             $afterRefreshCalls[] = [\get_class($ar), $ar->getIsNewRecord(), $ar->getPrimaryKey(), $ar->isRelationPopulated('orders')];
@@ -1181,7 +1181,7 @@ trait ActiveRecordTestTrait
         $customer->refresh();
         $this->assertEquals([[$customerClass, false, 1, false]], $afterRefreshCalls);
         $afterRefreshCalls = [];
-        Event::off(BaseActiveRecord::className(), BaseActiveRecord::EVENT_AFTER_REFRESH);
+        Event::off(BaseActiveRecord::class, BaseActiveRecord::EVENT_AFTER_REFRESH);
     }
 
     public function testFindEmptyInCondition()

--- a/tests/framework/base/ApplicationTest.php
+++ b/tests/framework/base/ApplicationTest.php
@@ -24,13 +24,13 @@ class ApplicationTest extends TestCase
         $this->mockApplication([
             'container' => [
                 'definitions' => [
-                    Dispatcher::className() => DispatcherMock::className(),
+                    Dispatcher::class => DispatcherMock::class,
                 ],
             ],
             'bootstrap' => ['log'],
         ]);
 
-        $this->assertInstanceOf(DispatcherMock::className(), Yii::$app->log);
+        $this->assertInstanceOf(DispatcherMock::class, Yii::$app->log);
     }
 
     public function testBootstrap()
@@ -41,15 +41,15 @@ class ApplicationTest extends TestCase
         $this->mockApplication([
             'components' => [
                 'withoutBootstrapInterface' => [
-                    'class' => Component::className(),
+                    'class' => Component::class,
                 ],
                 'withBootstrapInterface' => [
-                    'class' => BootstrapComponentMock::className(),
+                    'class' => BootstrapComponentMock::class,
                 ],
             ],
             'modules' => [
                 'moduleX' => [
-                    'class' => Module::className(),
+                    'class' => Module::class,
                 ],
             ],
             'bootstrap' => [

--- a/tests/framework/base/BaseObjectTest.php
+++ b/tests/framework/base/BaseObjectTest.php
@@ -135,7 +135,7 @@ class BaseObjectTest extends TestCase
 
     public function testObjectProperty()
     {
-        $this->assertInstanceOf(NewObject::className(), $this->object->object);
+        $this->assertInstanceOf(NewObject::class, $this->object->object);
         $this->assertEquals('object text', $this->object->object->text);
         $this->object->object->text = 'new text';
         $this->assertEquals('new text', $this->object->object->text);
@@ -150,7 +150,7 @@ class BaseObjectTest extends TestCase
     public function testGetClassName()
     {
         $object = $this->object;
-        $this->assertSame(get_class($object), $object::className());
+        $this->assertSame(get_class($object), $object::class);
     }
 
     public function testReadingWriteOnlyProperty()

--- a/tests/framework/base/EventTest.php
+++ b/tests/framework/base/EventTest.php
@@ -32,10 +32,10 @@ class EventTest extends TestCase
 
     public function testOn()
     {
-        Event::on(Post::className(), 'save', function ($event) {
+        Event::on(Post::class, 'save', function ($event) {
             $this->counter += 1;
         });
-        Event::on(ActiveRecord::className(), 'save', function ($event) {
+        Event::on(ActiveRecord::class, 'save', function ($event) {
             $this->counter += 3;
         });
         Event::on('yiiunit\framework\base\SomeInterface', SomeInterface::EVENT_SUPER_EVENT, function ($event) {
@@ -61,33 +61,33 @@ class EventTest extends TestCase
         $handler = function ($event) {
             $this->counter++;
         };
-        $this->assertFalse(Event::hasHandlers(Post::className(), 'save'));
-        Event::on(Post::className(), 'save', $handler);
-        $this->assertTrue(Event::hasHandlers(Post::className(), 'save'));
-        Event::off(Post::className(), 'save', $handler);
-        $this->assertFalse(Event::hasHandlers(Post::className(), 'save'));
+        $this->assertFalse(Event::hasHandlers(Post::class, 'save'));
+        Event::on(Post::class, 'save', $handler);
+        $this->assertTrue(Event::hasHandlers(Post::class, 'save'));
+        Event::off(Post::class, 'save', $handler);
+        $this->assertFalse(Event::hasHandlers(Post::class, 'save'));
     }
 
     public function testHasHandlers()
     {
-        $this->assertFalse(Event::hasHandlers(Post::className(), 'save'));
-        $this->assertFalse(Event::hasHandlers(ActiveRecord::className(), 'save'));
+        $this->assertFalse(Event::hasHandlers(Post::class, 'save'));
+        $this->assertFalse(Event::hasHandlers(ActiveRecord::class, 'save'));
         $this->assertFalse(Event::hasHandlers('yiiunit\framework\base\SomeInterface', SomeInterface::EVENT_SUPER_EVENT));
-        Event::on(Post::className(), 'save', function ($event) {
+        Event::on(Post::class, 'save', function ($event) {
             $this->counter += 1;
         });
         Event::on('yiiunit\framework\base\SomeInterface', SomeInterface::EVENT_SUPER_EVENT, function ($event) {
             $this->counter++;
         });
-        $this->assertTrue(Event::hasHandlers(Post::className(), 'save'));
-        $this->assertFalse(Event::hasHandlers(ActiveRecord::className(), 'save'));
+        $this->assertTrue(Event::hasHandlers(Post::class, 'save'));
+        $this->assertFalse(Event::hasHandlers(ActiveRecord::class, 'save'));
 
-        $this->assertFalse(Event::hasHandlers(User::className(), 'save'));
-        Event::on(ActiveRecord::className(), 'save', function ($event) {
+        $this->assertFalse(Event::hasHandlers(User::class, 'save'));
+        Event::on(ActiveRecord::class, 'save', function ($event) {
             $this->counter += 1;
         });
-        $this->assertTrue(Event::hasHandlers(User::className(), 'save'));
-        $this->assertTrue(Event::hasHandlers(ActiveRecord::className(), 'save'));
+        $this->assertTrue(Event::hasHandlers(User::class, 'save'));
+        $this->assertTrue(Event::hasHandlers(ActiveRecord::class, 'save'));
         $this->assertTrue(Event::hasHandlers('yiiunit\framework\base\SomeInterface', SomeInterface::EVENT_SUPER_EVENT));
     }
 
@@ -125,7 +125,7 @@ class EventTest extends TestCase
 
         // class-level
         $this->assertFalse($triggered);
-        Event::trigger(SomeClass::className(), 'super.test');
+        Event::trigger(SomeClass::class, 'super.test');
         $this->assertTrue($triggered);
     }
 
@@ -142,10 +142,10 @@ class EventTest extends TestCase
 
     public function testOffUnmatchedHandler()
     {
-        $this->assertFalse(Event::hasHandlers(Post::className(), 'afterSave'));
-        Event::on(Post::className(), 'afterSave', [$this, 'bla-bla']);
-        $this->assertFalse(Event::off(Post::className(), 'afterSave', [$this, 'bla-bla-bla']));
-        $this->assertTrue(Event::off(Post::className(), 'afterSave', [$this, 'bla-bla']));
+        $this->assertFalse(Event::hasHandlers(Post::class, 'afterSave'));
+        Event::on(Post::class, 'afterSave', [$this, 'bla-bla']);
+        $this->assertFalse(Event::off(Post::class, 'afterSave', [$this, 'bla-bla-bla']));
+        $this->assertTrue(Event::off(Post::class, 'afterSave', [$this, 'bla-bla']));
     }
 
     /**
@@ -154,7 +154,7 @@ class EventTest extends TestCase
      */
     public function testOnWildcard()
     {
-        Event::on(Post::className(), '*', function ($event) {
+        Event::on(Post::class, '*', function ($event) {
             $this->counter += 1;
         });
         Event::on('*\Post', 'save', function ($event) {
@@ -165,7 +165,7 @@ class EventTest extends TestCase
         $post->save();
         $this->assertEquals(4, $this->counter);
 
-        $this->assertTrue(Event::hasHandlers(Post::className(), 'save'));
+        $this->assertTrue(Event::hasHandlers(Post::class, 'save'));
     }
 
     /**
@@ -177,11 +177,11 @@ class EventTest extends TestCase
         $handler = function ($event) {
             $this->counter++;
         };
-        $this->assertFalse(Event::hasHandlers(Post::className(), 'save'));
+        $this->assertFalse(Event::hasHandlers(Post::class, 'save'));
         Event::on('*\Post', 'save', $handler);
-        $this->assertTrue(Event::hasHandlers(Post::className(), 'save'));
+        $this->assertTrue(Event::hasHandlers(Post::class, 'save'));
         Event::off('*\Post', 'save', $handler);
-        $this->assertFalse(Event::hasHandlers(Post::className(), 'save'));
+        $this->assertFalse(Event::hasHandlers(Post::class, 'save'));
     }
 }
 

--- a/tests/framework/base/ModuleTest.php
+++ b/tests/framework/base/ModuleTest.php
@@ -151,25 +151,25 @@ class ModuleTest extends TestCase
         $module->controllerNamespace = 'yiiunit\framework\base';
 
         $route = 'module-test';
-        $this->assertInstanceOf(ModuleTestController::className(), $module->createControllerByID($route));
+        $this->assertInstanceOf(ModuleTestController::class, $module->createControllerByID($route));
 
         $route = 'module-test-';
-        $this->assertNotInstanceOf(ModuleTestController::className(), $module->createControllerByID($route));
+        $this->assertNotInstanceOf(ModuleTestController::class, $module->createControllerByID($route));
 
         $route = '-module-test';
-        $this->assertNotInstanceOf(ModuleTestController::className(), $module->createControllerByID($route));
+        $this->assertNotInstanceOf(ModuleTestController::class, $module->createControllerByID($route));
 
         $route = 'very-complex-name-test';
-        $this->assertInstanceOf(VeryComplexNameTestController::className(), $module->createControllerByID($route));
+        $this->assertInstanceOf(VeryComplexNameTestController::class, $module->createControllerByID($route));
 
         $route = 'very-complex-name-test--';
-        $this->assertNotInstanceOf(VeryComplexNameTestController::className(), $module->createControllerByID($route));
+        $this->assertNotInstanceOf(VeryComplexNameTestController::class, $module->createControllerByID($route));
 
         $route = '--very-complex-name-test';
-        $this->assertNotInstanceOf(VeryComplexNameTestController::className(), $module->createControllerByID($route));
+        $this->assertNotInstanceOf(VeryComplexNameTestController::class, $module->createControllerByID($route));
 
         $route = 'very---complex---name---test';
-        $this->assertNotInstanceOf(VeryComplexNameTestController::className(), $module->createControllerByID($route));
+        $this->assertNotInstanceOf(VeryComplexNameTestController::class, $module->createControllerByID($route));
     }
 
     public function testCreateController()

--- a/tests/framework/base/WidgetTest.php
+++ b/tests/framework/base/WidgetTest.php
@@ -55,8 +55,8 @@ class WidgetTest extends TestCase
     {
         Yii::$container = new Container();
         Yii::$container->setDefinitions([
-            TestWidgetB::className() => [
-                'class' => TestWidget::className()
+            TestWidgetB::class => [
+                'class' => TestWidget::class
             ]
         ]);
 

--- a/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
@@ -298,7 +298,7 @@ class ActiveRecordAttributeTypecast extends ActiveRecord
     {
         return [
             'attributeTypecast' => [
-                'class' => AttributeTypecastBehavior::className(),
+                'class' => AttributeTypecastBehavior::class,
                 'attributeTypes' => [
                     'name' => AttributeTypecastBehavior::TYPE_STRING,
                     'amount' => AttributeTypecastBehavior::TYPE_INTEGER,

--- a/tests/framework/behaviors/AttributesBehaviorTest.php
+++ b/tests/framework/behaviors/AttributesBehaviorTest.php
@@ -181,7 +181,7 @@ class ActiveRecordWithAttributesBehavior extends ActiveRecord
     {
         return [
             'attributes' => [
-                'class' => AttributesBehavior::className(),
+                'class' => AttributesBehavior::class,
                 'attributes' => [
                     'alias' => [
                         self::EVENT_BEFORE_VALIDATE => function ($event) {

--- a/tests/framework/behaviors/BlameableBehaviorConsoleTest.php
+++ b/tests/framework/behaviors/BlameableBehaviorConsoleTest.php
@@ -59,7 +59,7 @@ class BlameableBehaviorConsoleTest extends TestCase
     {
         $model = new ActiveRecordBlameableConsole([
             'as blameable' => [
-                'class' => BlameableBehavior::className(),
+                'class' => BlameableBehavior::class,
                 'defaultValue' => 2
             ],
         ]);
@@ -88,7 +88,7 @@ class ActiveRecordBlameableConsoleWithDefaultValueClosure extends ActiveRecordBl
     {
         return [
             'blameable' => [
-                'class' => BlameableBehavior::className(),
+                'class' => BlameableBehavior::class,
                 'defaultValue' => function () {
                     return 10 + 1;
                 }
@@ -112,7 +112,7 @@ class ActiveRecordBlameableConsole extends ActiveRecord
     {
         return [
             'blameable' => [
-                'class' => BlameableBehavior::className(),
+                'class' => BlameableBehavior::class,
             ],
         ];
     }

--- a/tests/framework/behaviors/BlameableBehaviorTest.php
+++ b/tests/framework/behaviors/BlameableBehaviorTest.php
@@ -133,7 +133,7 @@ class BlameableBehaviorTest extends TestCase
     {
         $model = new ActiveRecordBlameable([
             'as blameable' => [
-                'class' => BlameableBehavior::className(),
+                'class' => BlameableBehavior::class,
                 'attributes' => [
                     BaseActiveRecord::EVENT_BEFORE_VALIDATE => 'created_by',
                     BaseActiveRecord::EVENT_BEFORE_INSERT => ['created_by', 'updated_by'],
@@ -161,7 +161,7 @@ class BlameableBehaviorTest extends TestCase
 
         $model = new ActiveRecordBlameable([
             'as blameable' => [
-                'class' => BlameableBehavior::className(),
+                'class' => BlameableBehavior::class,
                 'defaultValue' => 2
             ],
         ]);
@@ -193,7 +193,7 @@ class ActiveRecordBlameableWithDefaultValueClosure extends ActiveRecordBlameable
     {
         return [
             'blameable' => [
-                'class' => BlameableBehavior::className(),
+                'class' => BlameableBehavior::class,
                 'defaultValue' => function () {
                     return $this->created_by + 1;
                 }
@@ -217,7 +217,7 @@ class ActiveRecordBlameable extends ActiveRecord
     {
         return [
             'blameable' => [
-                'class' => BlameableBehavior::className(),
+                'class' => BlameableBehavior::class,
             ],
         ];
     }

--- a/tests/framework/behaviors/CacheableWidgetBehaviorTest.php
+++ b/tests/framework/behaviors/CacheableWidgetBehaviorTest.php
@@ -107,8 +107,8 @@ class CacheableWidgetBehaviorTest extends TestCase
      */
     private function initializeWidgetMocks()
     {
-        $this->simpleWidget = $this->getWidgetMock(SimpleCacheableWidget::className());
-        $this->dynamicWidget = $this->getWidgetMock(DynamicCacheableWidget::className());
+        $this->simpleWidget = $this->getWidgetMock(SimpleCacheableWidget::class);
+        $this->dynamicWidget = $this->getWidgetMock(DynamicCacheableWidget::class);
     }
 
     /**

--- a/tests/framework/behaviors/OptimisticLockBehaviorTest.php
+++ b/tests/framework/behaviors/OptimisticLockBehaviorTest.php
@@ -73,7 +73,7 @@ class OptimisticLockBehaviorTest extends TestCase
     public function testUpdateRecordWithinConsoleRequest()
     {
         ActiveRecordLockVersion::$behaviors = [
-            OptimisticLockBehavior::className(),
+            OptimisticLockBehavior::class,
         ];
         $model = new ActiveRecordLockVersion();
         $model->version = 0;
@@ -102,7 +102,7 @@ class OptimisticLockBehaviorTest extends TestCase
         Yii::$app->set('request', $request);
 
         ActiveRecordLockVersion::$behaviors = [
-            OptimisticLockBehavior::className(),
+            OptimisticLockBehavior::class,
         ];
         $model = new ActiveRecordLockVersion();
         $this->assertEquals(true, $model->save(false), 'model is successfully saved');
@@ -134,7 +134,7 @@ class OptimisticLockBehaviorTest extends TestCase
         Yii::$app->set('request', $request);
 
         ActiveRecordLockVersion::$behaviors = [
-            OptimisticLockBehavior::className(),
+            OptimisticLockBehavior::class,
         ];
         $model = new ActiveRecordLockVersion();
         $this->assertEquals(true, $model->save(false), 'model is successfully saved');
@@ -217,7 +217,7 @@ class OptimisticLockBehaviorTest extends TestCase
         Yii::$app->set('request', $request);
 
         ActiveRecordLockVersion::$behaviors = [
-            OptimisticLockBehavior::className(),
+            OptimisticLockBehavior::class,
         ];
         $model = new ActiveRecordLockVersion();
         $this->assertEquals(true, $model->save(false), 'model is successfully saved');

--- a/tests/framework/behaviors/SluggableBehaviorTest.php
+++ b/tests/framework/behaviors/SluggableBehaviorTest.php
@@ -245,7 +245,7 @@ class ActiveRecordSluggable extends ActiveRecord
     {
         return [
             'sluggable' => [
-                'class' => SluggableBehavior::className(),
+                'class' => SluggableBehavior::class,
                 'attribute' => 'name',
             ],
         ];
@@ -266,7 +266,7 @@ class ActiveRecordSluggable extends ActiveRecord
 
     public function getRelated()
     {
-        return $this->hasOne(ActiveRecordRelated::className(), ['id' => 'belongs_to_id']);
+        return $this->hasOne(ActiveRecordRelated::class, ['id' => 'belongs_to_id']);
     }
 }
 
@@ -284,7 +284,7 @@ class ActiveRecordSluggableUnique extends ActiveRecordSluggable
     {
         return [
             'sluggable' => [
-                'class' => SluggableBehavior::className(),
+                'class' => SluggableBehavior::class,
                 'attribute' => 'name',
                 'ensureUnique' => true,
             ],
@@ -298,7 +298,7 @@ class SkipOnEmptySluggableActiveRecord extends ActiveRecordSluggable
     {
         return [
             'sluggable' => [
-                'class' => SluggableBehavior::className(),
+                'class' => SluggableBehavior::class,
                 'attribute' => 'name',
                 'slugAttribute' => 'slug',
                 'ensureUnique' => true,

--- a/tests/framework/behaviors/TimestampBehaviorTest.php
+++ b/tests/framework/behaviors/TimestampBehaviorTest.php
@@ -76,7 +76,7 @@ class TimestampBehaviorTest extends TestCase
         $currentTime = time();
 
         ActiveRecordTimestamp::$behaviors = [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
         ];
         $model = new ActiveRecordTimestamp();
         $model->save(false);
@@ -93,7 +93,7 @@ class TimestampBehaviorTest extends TestCase
         $currentTime = time();
 
         ActiveRecordTimestamp::$behaviors = [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
         ];
         $model = new ActiveRecordTimestamp();
         $model->save(false);
@@ -114,7 +114,7 @@ class TimestampBehaviorTest extends TestCase
     public function testUpdateCleanRecord()
     {
         ActiveRecordTimestamp::$behaviors = [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
         ];
         $model = new ActiveRecordTimestamp();
         $model->save(false);
@@ -186,7 +186,7 @@ class TimestampBehaviorTest extends TestCase
         ActiveRecordTimestamp::$tableName = 'test_auto_timestamp_string';
         ActiveRecordTimestamp::$behaviors = [
             'timestamp' => [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'value' => new Expression("strftime('%Y')"),
             ],
         ];
@@ -199,7 +199,7 @@ class TimestampBehaviorTest extends TestCase
         $model->updated_at = $enforcedTime;
         $model->save(false);
         $this->assertEquals($enforcedTime, $model->created_at, 'Create time has been set on update!');
-        $this->assertInstanceOf(Expression::className(), $model->updated_at);
+        $this->assertInstanceOf(Expression::class, $model->updated_at);
         $model->refresh();
         $this->assertEquals($enforcedTime, $model->created_at, 'Create time has been set on update!');
         $this->assertEquals(date('Y'), $model->updated_at);
@@ -209,7 +209,7 @@ class TimestampBehaviorTest extends TestCase
     {
         ActiveRecordTimestamp::$behaviors = [
             'timestamp' => [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'value' => new Expression("strftime('%Y')"),
             ],
         ];
@@ -224,7 +224,7 @@ class TimestampBehaviorTest extends TestCase
     {
         ActiveRecordTimestamp::$behaviors = [
             'timestamp' => [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'value' => new Expression("strftime('%Y')"),
             ],
         ];

--- a/tests/framework/caching/DependencyTest.php
+++ b/tests/framework/caching/DependencyTest.php
@@ -34,7 +34,7 @@ class DependencyTest extends TestCase
 
     public function testGenerateReusableHash()
     {
-        $dependency = $this->getMockForAbstractClass(Dependency::className());
+        $dependency = $this->getMockForAbstractClass(Dependency::class);
         $dependency->data = 'dummy';
 
         $result = $this->invokeMethod($dependency, 'generateReusableHash');
@@ -44,8 +44,8 @@ class DependencyTest extends TestCase
 
     public function testIsChanged()
     {
-        $dependency = $this->getMockForAbstractClass(Dependency::className());
-        $cache = $this->getMockForAbstractClass(Cache::className());
+        $dependency = $this->getMockForAbstractClass(Dependency::class);
+        $cache = $this->getMockForAbstractClass(Cache::class);
 
         $result = $dependency->isChanged($cache);
         $this->assertFalse($result);

--- a/tests/framework/console/ControllerTest.php
+++ b/tests/framework/console/ControllerTest.php
@@ -126,7 +126,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        \Yii::$container->set(DummyService::className(), function() { throw new \RuntimeException('uh oh'); });
+        \Yii::$container->set(DummyService::class, function() { throw new \RuntimeException('uh oh'); });
 
         $this->expectException(get_class(new RuntimeException()));
         $this->expectExceptionMessage('uh oh');
@@ -144,7 +144,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        \Yii::$container->clear(DummyService::className());
+        \Yii::$container->clear(DummyService::class);
         $this->expectException(get_class(new Exception()));
         $this->expectExceptionMessage('Could not load required service: dummyService');
         $this->controller->bindActionParams($injectionAction, $params);
@@ -161,13 +161,13 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        \Yii::$container->set(DummyService::className(), DummyService::className());
+        \Yii::$container->set(DummyService::class, DummyService::class);
         $args = $this->controller->bindActionParams($injectionAction, $params);
         $this->assertEquals($params['before'], $args[0]);
         $this->assertEquals(\Yii::$app->request, $args[1]);
         $this->assertEquals('Component: yii\console\Request $request', \Yii::$app->requestedParams['request']);
         $this->assertEquals($params['between'], $args[2]);
-        $this->assertInstanceOf(DummyService::className(), $args[3]);
+        $this->assertInstanceOf(DummyService::class, $args[3]);
         $this->assertEquals('Container DI: yiiunit\framework\console\stubs\DummyService $dummyService', \Yii::$app->requestedParams['dummyService']);
         $this->assertNull($args[4]);
         $this->assertEquals('Unavailable service: post', \Yii::$app->requestedParams['post']);
@@ -181,7 +181,7 @@ class ControllerTest extends TestCase
             'basePath' => __DIR__,
         ]));
         $module->set('yii\data\DataProviderInterface', [
-            'class' => \yii\data\ArrayDataProvider::className(),
+            'class' => \yii\data\ArrayDataProvider::class,
         ]);
         // Use the PHP71 controller for this test
         $this->controller = new FakePhp71Controller('fake', $module);
@@ -189,7 +189,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionModuleServiceInjection');
         $args = $this->controller->bindActionParams($injectionAction, []);
-        $this->assertInstanceOf(\yii\data\ArrayDataProvider::className(), $args[0]);
+        $this->assertInstanceOf(\yii\data\ArrayDataProvider::class, $args[0]);
         $this->assertEquals('Module yii\base\Module DI: yii\data\DataProviderInterface $dataProvider', \Yii::$app->requestedParams['dataProvider']);
     }
 

--- a/tests/framework/console/controllers/DbMessageControllerTest.php
+++ b/tests/framework/console/controllers/DbMessageControllerTest.php
@@ -33,7 +33,7 @@ class DbMessageControllerTest extends BaseMessageControllerTest
                 'id' => 'Migrator',
                 'basePath' => '@yiiunit',
                 'controllerMap' => [
-                    'migrate' => EchoMigrateController::className(),
+                    'migrate' => EchoMigrateController::class,
                 ],
                 'components' => [
                     'db' => static::getConnection(),

--- a/tests/framework/console/controllers/FixtureControllerTest.php
+++ b/tests/framework/console/controllers/FixtureControllerTest.php
@@ -237,7 +237,7 @@ class FixtureControllerTest extends DatabaseTestCase
 
         $lastFixture = end(FixtureStorage::$activeFixtureSequence);
 
-        $this->assertEquals(DependentActiveFixture::className(), $lastFixture);
+        $this->assertEquals(DependentActiveFixture::class, $lastFixture);
     }
 }
 

--- a/tests/framework/console/controllers/MigrateControllerTest.php
+++ b/tests/framework/console/controllers/MigrateControllerTest.php
@@ -28,8 +28,8 @@ class MigrateControllerTest extends TestCase
 
     public function setUp(): void
     {
-        $this->migrateControllerClass = EchoMigrateController::className();
-        $this->migrationBaseClass = Migration::className();
+        $this->migrateControllerClass = EchoMigrateController::class;
+        $this->migrationBaseClass = Migration::class;
 
         $this->mockApplication([
             'components' => [

--- a/tests/framework/data/ActiveDataProviderTest.php
+++ b/tests/framework/data/ActiveDataProviderTest.php
@@ -39,9 +39,9 @@ abstract class ActiveDataProviderTest extends DatabaseTestCase
         ]);
         $orders = $provider->getModels();
         $this->assertCount(3, $orders);
-        $this->assertInstanceOf(Order::className(), $orders[0]);
-        $this->assertInstanceOf(Order::className(), $orders[1]);
-        $this->assertInstanceOf(Order::className(), $orders[2]);
+        $this->assertInstanceOf(Order::class, $orders[0]);
+        $this->assertInstanceOf(Order::class, $orders[1]);
+        $this->assertInstanceOf(Order::class, $orders[2]);
         $this->assertEquals([1, 2, 3], $provider->getKeys());
 
         $provider = new ActiveDataProvider([
@@ -63,8 +63,8 @@ abstract class ActiveDataProviderTest extends DatabaseTestCase
         ]);
         $orders = $provider->getModels();
         $this->assertCount(2, $orders);
-        $this->assertInstanceOf(Order::className(), $orders[0]);
-        $this->assertInstanceOf(Order::className(), $orders[1]);
+        $this->assertInstanceOf(Order::class, $orders[0]);
+        $this->assertInstanceOf(Order::class, $orders[1]);
         $this->assertEquals([2, 3], $provider->getKeys());
 
         $provider = new ActiveDataProvider([
@@ -86,9 +86,9 @@ abstract class ActiveDataProviderTest extends DatabaseTestCase
         ]);
         $items = $provider->getModels();
         $this->assertCount(3, $items);
-        $this->assertInstanceOf(Item::className(), $items[0]);
-        $this->assertInstanceOf(item::className(), $items[1]);
-        $this->assertInstanceOf(Item::className(), $items[2]);
+        $this->assertInstanceOf(Item::class, $items[0]);
+        $this->assertInstanceOf(item::class, $items[1]);
+        $this->assertInstanceOf(Item::class, $items[2]);
         $this->assertEquals([3, 4, 5], $provider->getKeys());
 
         $provider = new ActiveDataProvider([
@@ -110,8 +110,8 @@ abstract class ActiveDataProviderTest extends DatabaseTestCase
         ]);
         $items = $provider->getModels();
         $this->assertCount(2, $items);
-        $this->assertInstanceOf(Item::className(), $items[0]);
-        $this->assertInstanceOf(Item::className(), $items[1]);
+        $this->assertInstanceOf(Item::class, $items[0]);
+        $this->assertInstanceOf(Item::class, $items[1]);
 
         $provider = new ActiveDataProvider([
             'query' => $order->getBooks(),

--- a/tests/framework/data/BaseDataProviderTest.php
+++ b/tests/framework/data/BaseDataProviderTest.php
@@ -17,7 +17,7 @@ class BaseDataProviderTest extends TestCase
 {
     public function testGenerateId()
     {
-        $rc = new \ReflectionClass(BaseDataProvider::className());
+        $rc = new \ReflectionClass(BaseDataProvider::class);
         $rp = $rc->getProperty('counter');
         $rp->setAccessible(true);
         $rp->setValue(null);

--- a/tests/framework/data/DataFilterTest.php
+++ b/tests/framework/data/DataFilterTest.php
@@ -34,12 +34,12 @@ class DataFilterTest extends TestCase
         $builder->setSearchModel($model);
         $this->assertSame($model, $builder->getSearchModel());
 
-        $builder->setSearchModel(Singer::className());
+        $builder->setSearchModel(Singer::class);
         $model = $builder->getSearchModel();
         $this->assertTrue($model instanceof Singer);
 
         $builder->setSearchModel([
-            'class' => Singer::className(),
+            'class' => Singer::class,
             'scenario' => 'search',
         ]);
         $model = $builder->getSearchModel();

--- a/tests/framework/db/ActiveQueryModelConnectionTest.php
+++ b/tests/framework/db/ActiveQueryModelConnectionTest.php
@@ -45,7 +45,7 @@ class ActiveQueryModelConnectionTest extends TestCase
         $this->globalConnection->expects($this->never())->method('getQueryBuilder');
         $this->prepareConnectionMock($this->modelConnection);
 
-        $query = new ActiveQuery(ActiveRecord::className());
+        $query = new ActiveQuery(ActiveRecord::class);
         $query->one();
     }
 
@@ -54,7 +54,7 @@ class ActiveQueryModelConnectionTest extends TestCase
         $this->modelConnection->expects($this->never())->method('getQueryBuilder');
         $this->prepareConnectionMock($this->globalConnection);
 
-        $query = new ActiveQuery(DefaultActiveRecord::className());
+        $query = new ActiveQuery(DefaultActiveRecord::class);
         $query->one();
     }
 
@@ -63,7 +63,7 @@ class ActiveQueryModelConnectionTest extends TestCase
         $this->globalConnection->expects($this->never())->method('getQueryBuilder');
         $this->prepareConnectionMock($this->modelConnection);
 
-        $query = new ActiveQuery(ActiveRecord::className());
+        $query = new ActiveQuery(ActiveRecord::class);
         $query->all();
     }
 
@@ -72,7 +72,7 @@ class ActiveQueryModelConnectionTest extends TestCase
         $this->modelConnection->expects($this->never())->method('getQueryBuilder');
         $this->prepareConnectionMock($this->globalConnection);
 
-        $query = new ActiveQuery(DefaultActiveRecord::className());
+        $query = new ActiveQuery(DefaultActiveRecord::class);
         $query->all();
     }
 }

--- a/tests/framework/db/ActiveQueryTest.php
+++ b/tests/framework/db/ActiveQueryTest.php
@@ -34,8 +34,8 @@ abstract class ActiveQueryTest extends DatabaseTestCase
             'on' => ['a' => 'b'],
             'joinWith' => ['dummy relation'],
         ];
-        $query = new ActiveQuery(Customer::className(), $config);
-        $this->assertEquals($query->modelClass, Customer::className());
+        $query = new ActiveQuery(Customer::class, $config);
+        $this->assertEquals($query->modelClass, Customer::class);
         $this->assertEquals($query->on, $config['on']);
         $this->assertEquals($query->joinWith, $config['joinWith']);
     }
@@ -46,10 +46,10 @@ abstract class ActiveQueryTest extends DatabaseTestCase
         $callback = function (\yii\base\Event $event) use ($where) {
             $event->sender->where = $where;
         };
-        Event::on(ActiveQuery::className(), ActiveQuery::EVENT_INIT, $callback);
-        $result = new ActiveQuery(Customer::className());
+        Event::on(ActiveQuery::class, ActiveQuery::EVENT_INIT, $callback);
+        $result = new ActiveQuery(Customer::class);
         $this->assertEquals($where, $result->where);
-        Event::off(ActiveQuery::className(), ActiveQuery::EVENT_INIT, $callback);
+        Event::off(ActiveQuery::class, ActiveQuery::EVENT_INIT, $callback);
     }
 
     /**
@@ -57,7 +57,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testPrepare()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $builder = new QueryBuilder(new Connection());
         $result = $query->prepare($builder);
         $this->assertInstanceOf('yii\db\Query', $result);
@@ -65,7 +65,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testPopulate_EmptyRows()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $rows = [];
         $result = $query->populate([]);
         $this->assertEquals($rows, $result);
@@ -76,7 +76,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testPopulate_FilledRows()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $rows = $query->all();
         $result = $query->populate($rows);
         $this->assertEquals($rows, $result);
@@ -87,7 +87,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testOne()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $query->one();
         $this->assertInstanceOf('yiiunit\data\ar\Customer', $result);
     }
@@ -97,7 +97,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testCreateCommand()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $query->createCommand();
         $this->assertInstanceOf('yii\db\Command', $result);
     }
@@ -107,7 +107,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testQueryScalar()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $this->invokeMethod($query, 'queryScalar', ['name', null]);
         $this->assertEquals('user1', $result);
     }
@@ -117,7 +117,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testJoinWith()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $query->joinWith('profile');
         $this->assertEquals([
             [['profile'], true, 'LEFT JOIN'],
@@ -129,7 +129,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testInnerJoinWith()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $query->innerJoinWith('profile');
         $this->assertEquals([
             [['profile'], true, 'INNER JOIN'],
@@ -138,7 +138,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testBuildJoinWithRemoveDuplicateJoinByTableName()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $query->innerJoinWith('orders')
             ->joinWith('orders.orderItems');
         $this->invokeMethod($query, 'buildJoinWith');
@@ -161,7 +161,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testGetQueryTableName_from_not_set()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $this->invokeMethod($query, 'getTableNameAndAlias');
         $this->assertEquals(['customer', 'customer'], $result);
     }
@@ -169,14 +169,14 @@ abstract class ActiveQueryTest extends DatabaseTestCase
     public function testGetQueryTableName_from_set()
     {
         $options = ['from' => ['alias' => 'customer']];
-        $query = new ActiveQuery(Customer::className(), $options);
+        $query = new ActiveQuery(Customer::class, $options);
         $result = $this->invokeMethod($query, 'getTableNameAndAlias');
         $this->assertEquals(['customer', 'alias'], $result);
     }
 
     public function testOnCondition()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $on = ['active' => true];
         $params = ['a' => 'b'];
         $result = $query->onCondition($on, $params);
@@ -186,7 +186,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testAndOnCondition_on_not_set()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $on = ['active' => true];
         $params = ['a' => 'b'];
         $result = $query->andOnCondition($on, $params);
@@ -197,7 +197,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
     public function testAndOnCondition_on_set()
     {
         $onOld = ['active' => true];
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $query->on = $onOld;
 
         $on = ['active' => true];
@@ -209,7 +209,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testOrOnCondition_on_not_set()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $on = ['active' => true];
         $params = ['a' => 'b'];
         $result = $query->orOnCondition($on, $params);
@@ -220,7 +220,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
     public function testOrOnCondition_on_set()
     {
         $onOld = ['active' => true];
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $query->on = $onOld;
 
         $on = ['active' => true];
@@ -235,15 +235,15 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testViaTable()
     {
-        $query = new ActiveQuery(Customer::className(), ['primaryModel' => new Order()]);
-        $result = $query->viaTable(Profile::className(), ['id' => 'item_id']);
+        $query = new ActiveQuery(Customer::class, ['primaryModel' => new Order()]);
+        $result = $query->viaTable(Profile::class, ['id' => 'item_id']);
         $this->assertInstanceOf('yii\db\ActiveQuery', $result);
         $this->assertInstanceOf('yii\db\ActiveQuery', $result->via);
     }
 
     public function testAlias_not_set()
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $query->alias('alias');
         $this->assertInstanceOf('yii\db\ActiveQuery', $result);
         $this->assertEquals(['alias' => 'customer'], $result->from);
@@ -252,7 +252,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
     public function testAlias_yet_set()
     {
         $aliasOld = ['old'];
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $query->from = $aliasOld;
         $result = $query->alias('alias');
         $this->assertInstanceOf('yii\db\ActiveQuery', $result);
@@ -267,7 +267,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testGetTableNames_notFilledFrom()
     {
-        $query = new ActiveQuery(Profile::className());
+        $query = new ActiveQuery(Profile::class);
 
         $tables = $query->getTablesUsedInFrom();
 
@@ -278,7 +278,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testGetTableNames_wontFillFrom()
     {
-        $query = new ActiveQuery(Profile::className());
+        $query = new ActiveQuery(Profile::class);
         $this->assertEquals($query->from, null);
         $query->getTablesUsedInFrom();
         $this->assertEquals($query->from, null);
@@ -299,8 +299,8 @@ abstract class ActiveQueryTest extends DatabaseTestCase
         $this->assertNotNull($category);
         $orders = $category->orders;
         $this->assertEquals(2, count($orders));
-        $this->assertInstanceOf(Order::className(), $orders[0]);
-        $this->assertInstanceOf(Order::className(), $orders[1]);
+        $this->assertInstanceOf(Order::class, $orders[0]);
+        $this->assertInstanceOf(Order::class, $orders[1]);
         $ids = [$orders[0]->id, $orders[1]->id];
         sort($ids);
         $this->assertEquals([1, 3], $ids);
@@ -309,7 +309,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
         $this->assertNotNull($category);
         $orders = $category->orders;
         $this->assertEquals(1, count($orders));
-        $this->assertInstanceOf(Order::className(), $orders[0]);
+        $this->assertInstanceOf(Order::class, $orders[0]);
         $this->assertEquals(2, $orders[0]->id);
     }
 }

--- a/tests/framework/db/BatchQueryResultTest.php
+++ b/tests/framework/db/BatchQueryResultTest.php
@@ -28,7 +28,7 @@ abstract class BatchQueryResultTest extends DatabaseTestCase
         $query = new Query();
         $query->from('customer')->orderBy('id');
         $result = $query->batch(2, $db);
-        $this->assertInstanceOf(BatchQueryResult::className(), $result);
+        $this->assertInstanceOf(BatchQueryResult::class, $result);
         $this->assertEquals(2, $result->batchSize);
         $this->assertSame($result->query, $query);
 

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -92,7 +92,7 @@ abstract class CommandTest extends DatabaseTestCase
         // query
         $sql = 'SELECT * FROM {{customer}}';
         $reader = $db->createCommand($sql)->query();
-        $this->assertInstanceOf(DataReader::className(), $reader);
+        $this->assertInstanceOf(DataReader::class, $reader);
 
         // queryAll
         $rows = $db->createCommand('SELECT * FROM {{customer}}')->queryAll();

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -221,7 +221,7 @@ abstract class SchemaTest extends DatabaseTestCase
         $schema->db->tablePrefix = $tablePrefix;
         $schema->db->schemaCache = new ArrayCache();
         $noCacheTable = $schema->getTableSchema($tableName, true);
-        $this->assertInstanceOf(TableSchema::className(), $noCacheTable);
+        $this->assertInstanceOf(TableSchema::class, $noCacheTable);
 
         // Compare
         $schema->db->tablePrefix = $testTablePrefix;
@@ -231,14 +231,14 @@ abstract class SchemaTest extends DatabaseTestCase
         $schema->db->tablePrefix = $tablePrefix;
         $schema->refreshTableSchema($tableName);
         $refreshedTable = $schema->getTableSchema($tableName, false);
-        $this->assertInstanceOf(TableSchema::className(), $refreshedTable);
+        $this->assertInstanceOf(TableSchema::class, $refreshedTable);
         $this->assertNotSame($noCacheTable, $refreshedTable);
 
         // Compare
         $schema->db->tablePrefix = $testTablePrefix;
         $schema->refreshTableSchema($testTablePrefix);
         $testRefreshedTable = $schema->getTableSchema($testTableName, false);
-        $this->assertInstanceOf(TableSchema::className(), $testRefreshedTable);
+        $this->assertInstanceOf(TableSchema::class, $testRefreshedTable);
         $this->assertEquals($refreshedTable, $testRefreshedTable);
         $this->assertNotSame($testNoCacheTable, $testRefreshedTable);
     }
@@ -865,7 +865,7 @@ abstract class SchemaTest extends DatabaseTestCase
 
     private function normalizeConstraintPair(Constraint $expectedConstraint, Constraint $actualConstraint)
     {
-        if ($expectedConstraint::className() !== $actualConstraint::className()) {
+        if ($expectedConstraint::class !== $actualConstraint::class) {
             return;
         }
 

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -40,7 +40,7 @@ SQL;
 
         $dt = $schema->columns['dt'];
 
-        $this->assertInstanceOf(Expression::className(), $dt->defaultValue);
+        $this->assertInstanceOf(Expression::class, $dt->defaultValue);
         $this->assertEquals('CURRENT_TIMESTAMP', (string)$dt->defaultValue);
     }
 
@@ -61,11 +61,11 @@ SQL;
         $schema = $this->getConnection()->getTableSchema('current_timestamp_test');
 
         $dt = $schema->columns['dt'];
-        $this->assertInstanceOf(Expression::className(), $dt->defaultValue);
+        $this->assertInstanceOf(Expression::class, $dt->defaultValue);
         $this->assertEquals('CURRENT_TIMESTAMP(2)', (string)$dt->defaultValue);
 
         $ts = $schema->columns['ts'];
-        $this->assertInstanceOf(Expression::className(), $ts->defaultValue);
+        $this->assertInstanceOf(Expression::class, $ts->defaultValue);
         $this->assertEquals('CURRENT_TIMESTAMP(3)', (string)$ts->defaultValue);
     }
 
@@ -116,8 +116,8 @@ SQL;
             'comment' => '',
         ]]);
 
-        $this->assertInstanceOf(ColumnSchema::className(), $column);
-        $this->assertInstanceOf(Expression::className(), $column->defaultValue);
+        $this->assertInstanceOf(ColumnSchema::class, $column);
+        $this->assertInstanceOf(Expression::class, $column->defaultValue);
         $this->assertEquals('CURRENT_TIMESTAMP', $column->defaultValue);
     }
 
@@ -142,7 +142,7 @@ SQL;
             'comment' => '',
         ]]);
 
-        $this->assertInstanceOf(ColumnSchema::className(), $column);
+        $this->assertInstanceOf(ColumnSchema::class, $column);
         $this->assertEquals(NULL, $column->defaultValue);
     }
 

--- a/tests/framework/db/pgsql/ActiveRecordTest.php
+++ b/tests/framework/db/pgsql/ActiveRecordTest.php
@@ -329,7 +329,7 @@ class UserAR extends ActiveRecord
     public function behaviors()
     {
         return [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
         ];
     }
 }

--- a/tests/framework/db/pgsql/ExistValidatorTest.php
+++ b/tests/framework/db/pgsql/ExistValidatorTest.php
@@ -30,7 +30,7 @@ class ExistValidatorTest extends \yiiunit\framework\validators\ExistValidatorTes
         $this->assertFalse($model->hasErrors());
 
         // Different target table
-        $validator = new ExistValidator(['targetClass' => ValidatorTestMainModel::className(), 'targetAttribute' => 'id']);
+        $validator = new ExistValidator(['targetClass' => ValidatorTestMainModel::class, 'targetAttribute' => 'id']);
         $model = ValidatorTestRefModel::findOne(['id' => 1]);
         $validator->validateAttribute($model, 'ref');
         $this->assertFalse($model->hasErrors());

--- a/tests/framework/db/sqlite/ConnectionTest.php
+++ b/tests/framework/db/sqlite/ConnectionTest.php
@@ -58,7 +58,7 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
 
             $db = $this->prepareMasterSlave($masterCount, $slaveCount);
 
-            $this->assertInstanceOf(Connection::className(), $db->getSlave());
+            $this->assertInstanceOf(Connection::class, $db->getSlave());
             $this->assertTrue($db->getSlave()->isActive);
             $this->assertFalse($db->isActive);
 
@@ -70,7 +70,7 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
             $db->createCommand("UPDATE profile SET description='test' WHERE id=1")->execute();
             $this->assertTrue($db->isActive);
             if ($masterCount > 0) {
-                $this->assertInstanceOf(Connection::className(), $db->getMaster());
+                $this->assertInstanceOf(Connection::class, $db->getMaster());
                 $this->assertTrue($db->getMaster()->isActive);
             } else {
                 $this->assertNull($db->getMaster());
@@ -86,7 +86,7 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
             $this->assertFalse($db->isActive);
 
             $customer = Customer::findOne(1);
-            $this->assertInstanceOf(Customer::className(), $customer);
+            $this->assertInstanceOf(Customer::class, $customer);
             $this->assertEquals('user1', $customer->name);
             $this->assertFalse($db->isActive);
 
@@ -94,7 +94,7 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
             $customer->save();
             $this->assertTrue($db->isActive);
             $customer = Customer::findOne(1);
-            $this->assertInstanceOf(Customer::className(), $customer);
+            $this->assertInstanceOf(Customer::class, $customer);
             $this->assertEquals('user1', $customer->name);
             $result = $db->useMaster(function () {
                 return Customer::findOne(1)->name;

--- a/tests/framework/di/InstanceTest.php
+++ b/tests/framework/di/InstanceTest.php
@@ -30,12 +30,12 @@ class InstanceTest extends TestCase
     public function testOf()
     {
         $container = new Container();
-        $className = Component::className();
+        $className = Component::class;
         $instance = Instance::of($className);
 
         $this->assertInstanceOf('\\yii\\di\\Instance', $instance);
-        $this->assertInstanceOf(Component::className(), $instance->get($container));
-        $this->assertInstanceOf(Component::className(), Instance::ensure($instance, $className, $container));
+        $this->assertInstanceOf(Component::class, $instance->get($container));
+        $this->assertInstanceOf(Component::class, Instance::ensure($instance, $className, $container));
         $this->assertNotSame($instance->get($container), Instance::ensure($instance, $className, $container));
     }
 
@@ -47,8 +47,8 @@ class InstanceTest extends TestCase
             'dsn' => 'test',
         ]);
 
-        $this->assertInstanceOf(Connection::className(), Instance::ensure('db', 'yii\db\Connection', $container));
-        $this->assertInstanceOf(Connection::className(), Instance::ensure(new Connection(), 'yii\db\Connection', $container));
+        $this->assertInstanceOf(Connection::class, Instance::ensure('db', 'yii\db\Connection', $container));
+        $this->assertInstanceOf(Connection::class, Instance::ensure(new Connection(), 'yii\db\Connection', $container));
         $this->assertInstanceOf('\\yii\\db\\Connection', Instance::ensure(['class' => 'yii\db\Connection', 'dsn' => 'test'], 'yii\db\Connection', $container));
     }
 
@@ -82,8 +82,8 @@ class InstanceTest extends TestCase
             'dsn' => 'test',
         ]);
 
-        $this->assertInstanceOf(Connection::className(), Instance::ensure('db', null, $container));
-        $this->assertInstanceOf(Connection::className(), Instance::ensure(new Connection(), null, $container));
+        $this->assertInstanceOf(Connection::class, Instance::ensure('db', null, $container));
+        $this->assertInstanceOf(Connection::class, Instance::ensure(new Connection(), null, $container));
         $this->assertInstanceOf('\\yii\\db\\Connection', Instance::ensure(['class' => 'yii\db\Connection', 'dsn' => 'test'], null, $container));
     }
 
@@ -94,9 +94,9 @@ class InstanceTest extends TestCase
             'dsn' => 'test',
         ]);
 
-        $this->assertInstanceOf(Connection::className(), Instance::ensure('db'));
-        $this->assertInstanceOf(Connection::className(), Instance::ensure(new Connection()));
-        $this->assertInstanceOf(Connection::className(), Instance::ensure(['class' => 'yii\db\Connection', 'dsn' => 'test']));
+        $this->assertInstanceOf(Connection::class, Instance::ensure('db'));
+        $this->assertInstanceOf(Connection::class, Instance::ensure(new Connection()));
+        $this->assertInstanceOf(Connection::class, Instance::ensure(['class' => 'yii\db\Connection', 'dsn' => 'test']));
         Yii::$container = new Container();
     }
 
@@ -141,7 +141,7 @@ class InstanceTest extends TestCase
 
         $container = Instance::of('db');
 
-        $this->assertInstanceOf(Connection::className(), $container->get());
+        $this->assertInstanceOf(Connection::class, $container->get());
 
         $this->destroyApplication();
     }
@@ -191,7 +191,7 @@ class InstanceTest extends TestCase
         $this->expectException('yii\base\InvalidConfigException');
         $this->expectExceptionMessage('Invalid data type: yii\db\Connection. yii\base\Widget is expected.');
         Instance::ensure([
-            'class' => Connection::className(),
+            'class' => Connection::class,
         ], 'yii\base\Widget');
     }
 }

--- a/tests/framework/di/ServiceLocatorTest.php
+++ b/tests/framework/di/ServiceLocatorTest.php
@@ -40,7 +40,7 @@ class ServiceLocatorTest extends TestCase
     {
         // anonymous function
         $container = new ServiceLocator();
-        $className = TestClass::className();
+        $className = TestClass::class;
         $container->set($className, function () {
             return new TestClass([
                 'prop1' => 100,
@@ -54,7 +54,7 @@ class ServiceLocatorTest extends TestCase
 
         // static method
         $container = new ServiceLocator();
-        $className = TestClass::className();
+        $className = TestClass::class;
         $container->set($className, [__NAMESPACE__ . '\\Creator', 'create']);
         $object = $container->get($className);
         $this->assertInstanceOf($className, $object);
@@ -65,7 +65,7 @@ class ServiceLocatorTest extends TestCase
     public function testObject()
     {
         $object = new TestClass();
-        $className = TestClass::className();
+        $className = TestClass::class;
         $container = new ServiceLocator();
         $container->set($className, $object);
         $this->assertSame($container->get($className), $object);
@@ -76,16 +76,16 @@ class ServiceLocatorTest extends TestCase
         $config = [
             'components' => [
                 'test' => [
-                    'class' => TestClass::className(),
+                    'class' => TestClass::class,
                 ],
             ],
         ];
 
         // User Defined Config
-        $config['components']['test']['__class'] = TestSubclass::className();
+        $config['components']['test']['__class'] = TestSubclass::class;
 
         $app = new ServiceLocator($config);
-        $this->assertInstanceOf(TestSubclass::className(), $app->get('test'));
+        $this->assertInstanceOf(TestSubclass::class, $app->get('test'));
     }
 
 
@@ -93,7 +93,7 @@ class ServiceLocatorTest extends TestCase
     {
         // with configuration: shared
         $container = new ServiceLocator();
-        $className = TestClass::className();
+        $className = TestClass::class;
         $container->set($className, [
             'class' => $className,
             'prop1' => 10,

--- a/tests/framework/di/stubs/FooBaz.php
+++ b/tests/framework/di/stubs/FooBaz.php
@@ -18,7 +18,7 @@ class FooBaz extends \yii\base\BaseObject
     public function init()
     {
         // default config usually used by Yii
-        $dependentConfig = array_merge(['class' => FooDependent::className()], $this->fooDependent);
+        $dependentConfig = array_merge(['class' => FooDependent::class], $this->fooDependent);
         $this->fooDependent = \Yii::createObject($dependentConfig);
     }
 }

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -55,7 +55,7 @@ class AccessRuleTest extends \yiiunit\TestCase
     protected function mockUser($userid = null)
     {
         $user = new User([
-            'identityClass' => UserIdentity::className(),
+            'identityClass' => UserIdentity::class,
             'enableAutoLogin' => false,
         ]);
         if ($userid !== null) {
@@ -336,7 +336,7 @@ class AccessRuleTest extends \yiiunit\TestCase
     {
         $action = $this->mockAction();
         $user = $this->getMockBuilder('\yii\web\User')->getMock();
-        $user->identityCLass = UserIdentity::className();
+        $user->identityCLass = UserIdentity::class;
 
         $rule = new AccessRule([
             'allow' => true,

--- a/tests/framework/filters/PageCacheTest.php
+++ b/tests/framework/filters/PageCacheTest.php
@@ -422,7 +422,7 @@ class PageCacheTest extends TestCase
                 'cache' => $cache = new ArrayCache(),
                 'view' => new View(),
                 'dependency' => [
-                    'class' => ExpressionDependency::className(),
+                    'class' => ExpressionDependency::class,
                     'expression' => 'Yii::$app->params[\'dependency\']',
                 ],
             ]);

--- a/tests/framework/filters/RateLimiterTest.php
+++ b/tests/framework/filters/RateLimiterTest.php
@@ -47,7 +47,7 @@ class RateLimiterTest extends TestCase
     {
         $rateLimiter = new RateLimiter();
 
-        $this->assertInstanceOf(Request::className(), $rateLimiter->request);
+        $this->assertInstanceOf(Request::class, $rateLimiter->request);
     }
 
     public function testInitFilledResponse()
@@ -61,7 +61,7 @@ class RateLimiterTest extends TestCase
     {
         $rateLimiter = new RateLimiter();
 
-        $this->assertInstanceOf(Response::className(), $rateLimiter->response);
+        $this->assertInstanceOf(Response::class, $rateLimiter->response);
     }
 
     public function testBeforeActionUserInstanceOfRateLimitInterface()
@@ -90,7 +90,7 @@ class RateLimiterTest extends TestCase
 
     public function testBeforeActionEmptyUser()
     {
-        $user = new User(['identityClass' => RateLimit::className()]);
+        $user = new User(['identityClass' => RateLimit::class]);
         Yii::$app->set('user', $user);
         $rateLimiter = new RateLimiter();
 
@@ -157,13 +157,13 @@ class RateLimiterTest extends TestCase
     {
         $rateLimiter = new RateLimiter();
         $rateLimiter->user = function($action) {
-            return new User(['identityClass' => RateLimit::className()]);
+            return new User(['identityClass' => RateLimit::class]);
         };
         $rateLimiter->beforeAction('test');
 
         // testing the evaluation of user closure, which in this case returns not the expect object and therefore
         // the log message "does not implement RateLimitInterface" is expected.
-        $this->assertInstanceOf(User::className(), $rateLimiter->user);
+        $this->assertInstanceOf(User::class, $rateLimiter->user);
         $this->assertContains('Rate limit skipped: "user" does not implement RateLimitInterface.', Yii::getLogger()->messages);
     }
 }

--- a/tests/framework/filters/auth/AuthMethodTest.php
+++ b/tests/framework/filters/auth/AuthMethodTest.php
@@ -23,7 +23,7 @@ class AuthMethodTest extends TestCase
         $this->mockWebApplication([
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ]);
@@ -36,7 +36,7 @@ class AuthMethodTest extends TestCase
      */
     protected function createFilter($authenticateCallback)
     {
-        $filter = $this->getMockBuilder(AuthMethod::className())
+        $filter = $this->getMockBuilder(AuthMethod::class)
             ->setMethods(['authenticate'])
             ->getMock();
         $filter->method('authenticate')->willReturnCallback($authenticateCallback);
@@ -71,7 +71,7 @@ class AuthMethodTest extends TestCase
 
     public function testIsOptional()
     {
-        $reflection = new \ReflectionClass(AuthMethod::className());
+        $reflection = new \ReflectionClass(AuthMethod::class);
         $method = $reflection->getMethod('isOptional');
         $method->setAccessible(true);
 

--- a/tests/framework/grid/DataColumnTest.php
+++ b/tests/framework/grid/DataColumnTest.php
@@ -33,7 +33,7 @@ class DataColumnTest extends \yiiunit\TestCase
             'dataProvider' => new ArrayDataProvider([
                 'allModels' => [],
                 'totalCount' => 0,
-                'modelClass' => Order::className(),
+                'modelClass' => Order::class,
             ]),
             'columns' => ['customer_id', 'total'],
         ]);

--- a/tests/framework/grid/GridViewTest.php
+++ b/tests/framework/grid/GridViewTest.php
@@ -96,7 +96,7 @@ class GridViewTest extends \yiiunit\TestCase
         $this->assertCount(count($row), $columns);
 
         foreach ($columns as $index => $column) {
-            $this->assertInstanceOf(DataColumn::className(), $column);
+            $this->assertInstanceOf(DataColumn::class, $column);
             $this->assertArrayHasKey($column->attribute, $row);
         }
 
@@ -117,7 +117,7 @@ class GridViewTest extends \yiiunit\TestCase
         $this->assertCount(count($row) - 2, $columns);
 
         foreach ($columns as $index => $column) {
-            $this->assertInstanceOf(DataColumn::className(), $column);
+            $this->assertInstanceOf(DataColumn::class, $column);
             $this->assertArrayHasKey($column->attribute, $row);
             $this->assertNotEquals('relation', $column->attribute);
             $this->assertNotEquals('otherRelation', $column->attribute);

--- a/tests/framework/grid/RadiobuttonColumnTest.php
+++ b/tests/framework/grid/RadiobuttonColumnTest.php
@@ -91,7 +91,7 @@ class RadiobuttonColumnTest extends TestCase
             'options' => ['id' => 'radio-gridview'],
             'columns' => [
                 [
-                    'class' => RadioButtonColumn::className(),
+                    'class' => RadioButtonColumn::class,
                     'radioOptions' => function ($model) {
                         return [
                             'value' => $model['value'],

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -56,7 +56,7 @@ class ArrayHelperTest extends TestCase
             '_content' => 'test',
             'length' => 4,
         ], ArrayHelper::toArray($object, [
-            $object::className() => [
+            $object::class => [
                 'id', 'secret',
                 '_content' => 'content',
                 'length' => function ($post) {
@@ -85,13 +85,13 @@ class ArrayHelperTest extends TestCase
                 'id_plus_1' => 124,
             ],
         ], ArrayHelper::toArray($object, [
-            $object::className() => [
+            $object::class => [
                 'id', 'subObject',
                 'id_plus_1' => function ($post) {
                     return $post->id + 1;
                 },
             ],
-            $subObject::className() => [
+            $subObject::class => [
                 'id',
                 'id_plus_1' => function ($post) {
                     return $post->id + 1;
@@ -107,7 +107,7 @@ class ArrayHelperTest extends TestCase
                 'id_plus_1' => 124,
             ],
         ], ArrayHelper::toArray($object, [
-            $subObject::className() => [
+            $subObject::class => [
                 'id',
                 'id_plus_1' => function ($post) {
                     return $post->id + 1;

--- a/tests/framework/helpers/UrlTest.php
+++ b/tests/framework/helpers/UrlTest.php
@@ -41,7 +41,7 @@ class UrlTest extends TestCase
                     'hostInfo' => 'http://example.com/',
                 ],
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ], '\yii\web\Application');

--- a/tests/framework/i18n/DbMessageSourceTest.php
+++ b/tests/framework/i18n/DbMessageSourceTest.php
@@ -45,7 +45,7 @@ class DbMessageSourceTest extends I18NTest
 
     private function getMessageSourceClass()
     {
-        return DbMessageSource::className();
+        return DbMessageSource::class;
     }
 
     protected static function runConsoleAction($route, $params = [])
@@ -55,7 +55,7 @@ class DbMessageSourceTest extends I18NTest
                 'id' => 'Migrator',
                 'basePath' => '@yiiunit',
                 'controllerMap' => [
-                    'migrate' => EchoMigrateController::className(),
+                    'migrate' => EchoMigrateController::class,
                 ],
                 'components' => [
                     'db' => static::getConnection(),
@@ -147,13 +147,13 @@ class DbMessageSourceTest extends I18NTest
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
 
-        Event::on(DbMessageSource::className(), DbMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {});
+        Event::on(DbMessageSource::class, DbMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {});
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
-        Event::off(DbMessageSource::className(), DbMessageSource::EVENT_MISSING_TRANSLATION);
+        Event::off(DbMessageSource::class, DbMessageSource::EVENT_MISSING_TRANSLATION);
 
-        Event::on(DbMessageSource::className(), DbMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
+        Event::on(DbMessageSource::class, DbMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
             if ($event->message == 'New missing translation message.') {
                 $event->translatedMessage = 'TRANSLATION MISSING HERE!';
             }
@@ -163,7 +163,7 @@ class DbMessageSourceTest extends I18NTest
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('TRANSLATION MISSING HERE!', $this->i18n->translate('test', 'New missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
-        Event::off(DbMessageSource::className(), DbMessageSource::EVENT_MISSING_TRANSLATION);
+        Event::off(DbMessageSource::class, DbMessageSource::EVENT_MISSING_TRANSLATION);
     }
 
 

--- a/tests/framework/i18n/I18NTest.php
+++ b/tests/framework/i18n/I18NTest.php
@@ -46,7 +46,7 @@ class I18NTest extends TestCase
 
     private function getMessageSourceClass()
     {
-        return PhpMessageSource::className();
+        return PhpMessageSource::class;
     }
 
     public function testTranslate()
@@ -208,13 +208,13 @@ class I18NTest extends TestCase
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
 
-        Event::on(PhpMessageSource::className(), PhpMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {});
+        Event::on(PhpMessageSource::class, PhpMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {});
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
-        Event::off(PhpMessageSource::className(), PhpMessageSource::EVENT_MISSING_TRANSLATION);
+        Event::off(PhpMessageSource::class, PhpMessageSource::EVENT_MISSING_TRANSLATION);
 
-        Event::on(PhpMessageSource::className(), PhpMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
+        Event::on(PhpMessageSource::class, PhpMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
             if ($event->message == 'New missing translation message.') {
                 $event->translatedMessage = 'TRANSLATION MISSING HERE!';
             }
@@ -224,7 +224,7 @@ class I18NTest extends TestCase
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('TRANSLATION MISSING HERE!', $this->i18n->translate('test', 'New missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
-        Event::off(PhpMessageSource::className(), PhpMessageSource::EVENT_MISSING_TRANSLATION);
+        Event::off(PhpMessageSource::class, PhpMessageSource::EVENT_MISSING_TRANSLATION);
     }
 
     public static function sourceLanguageDataProvider()

--- a/tests/framework/log/DbTargetTest.php
+++ b/tests/framework/log/DbTargetTest.php
@@ -37,7 +37,7 @@ abstract class DbTargetTest extends TestCase
                 'id' => 'Migrator',
                 'basePath' => '@yiiunit',
                 'controllerMap' => [
-                    'migrate' => EchoMigrateController::className(),
+                    'migrate' => EchoMigrateController::class,
                 ],
                 'components' => [
                     'db' => static::getConnection(),

--- a/tests/framework/mutex/FileMutexTest.php
+++ b/tests/framework/mutex/FileMutexTest.php
@@ -27,7 +27,7 @@ class FileMutexTest extends TestCase
     protected function createMutex()
     {
         return \Yii::createObject([
-            'class' => FileMutex::className(),
+            'class' => FileMutex::class,
             'mutexPath' => '@yiiunit/runtime/mutex',
         ]);
     }

--- a/tests/framework/mutex/MysqlMutexTest.php
+++ b/tests/framework/mutex/MysqlMutexTest.php
@@ -32,7 +32,7 @@ class MysqlMutexTest extends DatabaseTestCase
     protected function createMutex($additionalParams = [])
     {
         return \Yii::createObject(array_merge([
-            'class' => MysqlMutex::className(),
+            'class' => MysqlMutex::class,
             'db' => $this->getConnection(),
         ], $additionalParams));
     }

--- a/tests/framework/mutex/PgsqlMutexTest.php
+++ b/tests/framework/mutex/PgsqlMutexTest.php
@@ -30,7 +30,7 @@ class PgsqlMutexTest extends DatabaseTestCase
     protected function createMutex()
     {
         return \Yii::createObject([
-            'class' => PgsqlMutex::className(),
+            'class' => PgsqlMutex::class,
             'db' => $this->getConnection(),
         ]);
     }

--- a/tests/framework/mutex/RetryAcquireTraitTest.php
+++ b/tests/framework/mutex/RetryAcquireTraitTest.php
@@ -89,7 +89,7 @@ class RetryAcquireTraitTest extends TestCase
     {
         return Yii::createObject(
             [
-                'class' => DumbMutex::className(),
+                'class' => DumbMutex::class,
             ]
         );
     }

--- a/tests/framework/rbac/DbManagerTestCase.php
+++ b/tests/framework/rbac/DbManagerTestCase.php
@@ -57,7 +57,7 @@ abstract class DbManagerTestCase extends ManagerTestCase
                 'id' => 'Migrator',
                 'basePath' => '@yiiunit',
                 'controllerMap' => [
-                    'migrate' => EchoMigrateController::className(),
+                    'migrate' => EchoMigrateController::class,
                 ],
                 'components' => [
                     'db' => static::createConnection(),
@@ -201,7 +201,7 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
         if ($isValid) {
             $this->assertTrue(isset($permissions['createPost']));
-            $this->assertInstanceOf(Permission::className(), $permissions['createPost']);
+            $this->assertInstanceOf(Permission::class, $permissions['createPost']);
         } else {
             $this->assertEmpty($permissions);
         }
@@ -221,7 +221,7 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
         if ($isValid) {
             $this->assertTrue(isset($roles['Author']));
-            $this->assertInstanceOf(Role::className(), $roles['Author']);
+            $this->assertInstanceOf(Role::class, $roles['Author']);
         } else {
             $this->assertEmpty($roles);
         }
@@ -272,7 +272,7 @@ abstract class DbManagerTestCase extends ManagerTestCase
         $assignment = $this->auth->getAssignment('createPost', $searchUserId);
 
         if ($isValid) {
-            $this->assertInstanceOf(Assignment::className(), $assignment);
+            $this->assertInstanceOf(Assignment::class, $assignment);
             $this->assertEquals($userId, $assignment->userId);
         } else {
             $this->assertEmpty($assignment);
@@ -293,8 +293,8 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
         if ($isValid) {
             $this->assertNotEmpty($assignments);
-            $this->assertInstanceOf(Assignment::className(), $assignments['createPost']);
-            $this->assertInstanceOf(Assignment::className(), $assignments['updatePost']);
+            $this->assertInstanceOf(Assignment::class, $assignments['createPost']);
+            $this->assertInstanceOf(Assignment::class, $assignments['updatePost']);
         } else {
             $this->assertEmpty($assignments);
         }

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -32,7 +32,7 @@ abstract class ManagerTestCase extends TestCase
     public function testCreateRole()
     {
         $role = $this->auth->createRole('admin');
-        $this->assertInstanceOf(Role::className(), $role);
+        $this->assertInstanceOf(Role::class, $role);
         $this->assertEquals(Item::TYPE_ROLE, $role->type);
         $this->assertEquals('admin', $role->name);
     }
@@ -40,7 +40,7 @@ abstract class ManagerTestCase extends TestCase
     public function testCreatePermission()
     {
         $permission = $this->auth->createPermission('edit post');
-        $this->assertInstanceOf(Permission::className(), $permission);
+        $this->assertInstanceOf(Permission::class, $permission);
         $this->assertEquals(Item::TYPE_PERMISSION, $permission->type);
         $this->assertEquals('edit post', $permission->name);
     }
@@ -275,7 +275,7 @@ abstract class ManagerTestCase extends TestCase
         $expectedPermissions = ['createPost', 'updatePost', 'readPost', 'updateAnyPost'];
         $this->assertEquals(count($expectedPermissions), count($permissions));
         foreach ($expectedPermissions as $permissionName) {
-            $this->assertInstanceOf(Permission::className(), $permissions[$permissionName]);
+            $this->assertInstanceOf(Permission::class, $permissions[$permissionName]);
         }
     }
 
@@ -286,7 +286,7 @@ abstract class ManagerTestCase extends TestCase
         $expectedPermissions = ['deletePost', 'createPost', 'updatePost', 'readPost'];
         $this->assertEquals(count($expectedPermissions), count($permissions));
         foreach ($expectedPermissions as $permissionName) {
-            $this->assertInstanceOf(Permission::className(), $permissions[$permissionName]);
+            $this->assertInstanceOf(Permission::class, $permissions[$permissionName]);
         }
     }
 
@@ -316,15 +316,15 @@ abstract class ManagerTestCase extends TestCase
         $this->auth->assign($reader, 123);
 
         $roles = $this->auth->getRolesByUser('reader A');
-        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertInstanceOf(Role::class, reset($roles));
         $this->assertEquals($roles['reader']->name, 'reader');
 
         $roles = $this->auth->getRolesByUser(0);
-        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertInstanceOf(Role::class, reset($roles));
         $this->assertEquals($roles['reader']->name, 'reader');
 
         $roles = $this->auth->getRolesByUser(123);
-        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertInstanceOf(Role::class, reset($roles));
         $this->assertEquals($roles['reader']->name, 'reader');
 
         $this->assertContains('myDefaultRole', array_keys($roles));
@@ -336,12 +336,12 @@ abstract class ManagerTestCase extends TestCase
 
         $roles = $this->auth->getChildRoles('withoutChildren');
         $this->assertCount(1, $roles);
-        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertInstanceOf(Role::class, reset($roles));
         $this->assertSame(reset($roles)->name, 'withoutChildren');
 
         $roles = $this->auth->getChildRoles('reader');
         $this->assertCount(1, $roles);
-        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertInstanceOf(Role::class, reset($roles));
         $this->assertSame(reset($roles)->name, 'reader');
 
         $roles = $this->auth->getChildRoles('author');
@@ -613,7 +613,7 @@ abstract class ManagerTestCase extends TestCase
 
         /** @var ActionRule $rule */
         $rule = $this->auth->getRule('action_rule');
-        $this->assertInstanceOf(ActionRule::className(), $rule);
+        $this->assertInstanceOf(ActionRule::class, $rule);
     }
 
     public function testDefaultRolesWithClosureReturningNonArrayValue()

--- a/tests/framework/rest/IndexActionTest.php
+++ b/tests/framework/rest/IndexActionTest.php
@@ -28,7 +28,7 @@ class IndexActionTest extends TestCase
                     'dsn' => 'sqlite::memory:',
                 ],
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ]);
@@ -45,11 +45,11 @@ class IndexActionTest extends TestCase
         Yii::$app->controller = new RestController(
             'rest',
             new Module('rest'), [
-            'modelClass' => IndexActionModel::className(),
+            'modelClass' => IndexActionModel::class,
             'actions' => [
                 'index' => [
-                    'class' => IndexAction::className(),
-                    'modelClass' => IndexActionModel::className(),
+                    'class' => IndexAction::class,
+                    'modelClass' => IndexActionModel::class,
                     'prepareSearchQuery' => function ($query, $requestParams) use (&$sql) {
                         $this->assertTrue($query instanceof Query);
                         $sql = $query->createCommand()->getRawSql();
@@ -90,11 +90,11 @@ class IndexActionTest extends TestCase
         $controller = new RestController(
             'rest',
             new Module('rest'), [
-            'modelClass' => IndexActionModel::className(),
+            'modelClass' => IndexActionModel::class,
             'actions' => [
                 'index' => [
-                    'class' => IndexAction::className(),
-                    'modelClass' => IndexActionModel::className(),
+                    'class' => IndexAction::class,
+                    'modelClass' => IndexActionModel::class,
                     'pagination' => $pagination,
                     'sort' => $sort,
                 ],

--- a/tests/framework/test/ActiveFixtureTest.php
+++ b/tests/framework/test/ActiveFixtureTest.php
@@ -42,7 +42,7 @@ class ActiveFixtureTest extends DatabaseTestCase
         $test->setUp();
         $fixture = $test->getFixture('customers');
 
-        $this->assertEquals(CustomerFixture::className(), get_class($fixture));
+        $this->assertEquals(CustomerFixture::class, get_class($fixture));
         $this->assertCount(2, $fixture);
         $this->assertEquals(1, $fixture['customer1']['id']);
         $this->assertEquals('customer1@example.com', $fixture['customer1']['email']);
@@ -61,7 +61,7 @@ class ActiveFixtureTest extends DatabaseTestCase
         $test->setUp();
         $fixture = $test->getFixture('customers');
 
-        $this->assertEquals(Customer::className(), get_class($fixture->getModel('customer1')));
+        $this->assertEquals(Customer::class, get_class($fixture->getModel('customer1')));
         $this->assertEquals(1, $fixture->getModel('customer1')->id);
         $this->assertEquals('customer1@example.com', $fixture->getModel('customer1')->email);
         $this->assertEquals(1, $fixture['customer1']['profile_id']);
@@ -220,7 +220,7 @@ class CustomerDbTestCase extends BaseDbTestCase
     public function fixtures()
     {
         return [
-            'customers' => CustomerFixture::className(),
+            'customers' => CustomerFixture::class,
         ];
     }
 }
@@ -230,7 +230,7 @@ class CustomDirectoryDbTestCase extends BaseDbTestCase
     public function fixtures()
     {
         return [
-            'customers' => CustomDirectoryFixture::className(),
+            'customers' => CustomDirectoryFixture::class,
         ];
     }
 }
@@ -241,7 +241,7 @@ class DataPathDbTestCase extends BaseDbTestCase
     {
         return [
             'customers' => [
-                'class' => CustomDirectoryFixture::className(),
+                'class' => CustomDirectoryFixture::class,
                 'dataFile' => '@app/framework/test/data/customer.php'
             ]
         ];
@@ -254,7 +254,7 @@ class TruncateTestCase extends BaseDbTestCase
     {
         return [
             'animals' => [
-                'class' => AnimalFixture::className(),
+                'class' => AnimalFixture::class,
             ]
         ];
     }

--- a/tests/framework/test/FixtureTest.php
+++ b/tests/framework/test/FixtureTest.php
@@ -110,41 +110,41 @@ class MyTestCase
         switch ($this->scenario) {
             case 0: return [];
             case 1: return [
-                'fixture1' => Fixture1::className(),
+                'fixture1' => Fixture1::class,
             ];
             case 2: return [
-                'fixture2' => Fixture2::className(),
+                'fixture2' => Fixture2::class,
             ];
             case 3: return [
-                'fixture3' => Fixture3::className(),
+                'fixture3' => Fixture3::class,
             ];
             case 4: return [
-                'fixture1' => Fixture1::className(),
-                'fixture2' => Fixture2::className(),
+                'fixture1' => Fixture1::class,
+                'fixture2' => Fixture2::class,
             ];
             case 5: return [
-                'fixture2' => Fixture2::className(),
-                'fixture3' => Fixture3::className(),
+                'fixture2' => Fixture2::class,
+                'fixture3' => Fixture3::class,
             ];
             case 6: return [
-                'fixture1' => Fixture1::className(),
-                'fixture3' => Fixture3::className(),
+                'fixture1' => Fixture1::class,
+                'fixture3' => Fixture3::class,
             ];
             case 7: return [
-                'fixture1' => Fixture1::className(),
-                'fixture2' => Fixture2::className(),
-                'fixture3' => Fixture3::className(),
+                'fixture1' => Fixture1::class,
+                'fixture2' => Fixture2::class,
+                'fixture3' => Fixture3::class,
             ];
             case 8: return [
-                'fixture4' => Fixture4::className(),
+                'fixture4' => Fixture4::class,
             ];
             case 9: return [
-                'fixture5' => Fixture5::className(),
-                'fixture4' => Fixture4::className(),
+                'fixture5' => Fixture5::class,
+                'fixture4' => Fixture4::class,
             ];
             case 10: return [
-                'fixture3a' => Fixture3::className(), // duplicate fixtures may occur two fixtures depend on the same fixture.
-                'fixture3b' => Fixture3::className(),
+                'fixture3a' => Fixture3::class, // duplicate fixtures may occur two fixtures depend on the same fixture.
+                'fixture3b' => Fixture3::class,
             ];
             default: return [];
         }

--- a/tests/framework/validators/ExistValidatorTest.php
+++ b/tests/framework/validators/ExistValidatorTest.php
@@ -40,7 +40,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
         }
         // combine to save the time creating a new db-fixture set (likely ~5 sec)
         try {
-            $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::className()]);
+            $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::class]);
             $val->validate('ref');
             $this->fail('Exception should have been thrown at this time');
         } catch (Exception $e) {
@@ -51,7 +51,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
 
     public function testValidateValue()
     {
-        $val = new ExistValidator(['targetClass' => ValidatorTestRefModel::className(), 'targetAttribute' => 'id']);
+        $val = new ExistValidator(['targetClass' => ValidatorTestRefModel::class, 'targetAttribute' => 'id']);
         $this->assertTrue($val->validate(2));
         $this->assertTrue($val->validate(5));
         $this->assertFalse($val->validate(99));
@@ -61,12 +61,12 @@ abstract class ExistValidatorTest extends DatabaseTestCase
     public function testValidateAttribute()
     {
         // existing value on different table
-        $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::className(), 'targetAttribute' => 'id']);
+        $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::class, 'targetAttribute' => 'id']);
         $m = ValidatorTestRefModel::findOne(['id' => 1]);
         $val->validateAttribute($m, 'ref');
         $this->assertFalse($m->hasErrors());
         // non-existing value on different table
-        $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::className(), 'targetAttribute' => 'id']);
+        $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::class, 'targetAttribute' => 'id']);
         $m = ValidatorTestRefModel::findOne(['id' => 6]);
         $val->validateAttribute($m, 'ref');
         $this->assertTrue($m->hasErrors('ref'));
@@ -138,7 +138,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
     public function testValidateCompositeKeys()
     {
         $val = new ExistValidator([
-            'targetClass' => OrderItem::className(),
+            'targetClass' => OrderItem::class,
             'targetAttribute' => ['order_id', 'item_id'],
         ]);
         // validate old record
@@ -158,7 +158,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
         $this->assertTrue($m->hasErrors('order_id'));
 
         $val = new ExistValidator([
-            'targetClass' => OrderItem::className(),
+            'targetClass' => OrderItem::class,
             'targetAttribute' => ['id' => 'order_id'],
         ]);
         // validate old record
@@ -187,7 +187,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
         OrderItem::$tableName = '{{%order_item}}';
 
         $val = new ExistValidator([
-            'targetClass' => OrderItem::className(),
+            'targetClass' => OrderItem::class,
             'targetAttribute' => ['id' => 'order_id'],
         ]);
 
@@ -205,7 +205,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
     public function testExpresionInAttributeColumnName()
     {
         $val = new ExistValidator([
-           'targetClass' => OrderItem::className(),
+           'targetClass' => OrderItem::class,
            'targetAttribute' => ['id' => 'COALESCE([[order_id]], 0)'],
        ]);
 

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -127,7 +127,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
 
     public function testValidateAttributeOfNonARModel()
     {
-        $val = new UniqueValidator(['targetClass' => ValidatorTestRefModel::className(), 'targetAttribute' => 'ref']);
+        $val = new UniqueValidator(['targetClass' => ValidatorTestRefModel::class, 'targetAttribute' => 'ref']);
         $m = FakedValidationModel::createWithAttributes(['attr_1' => 5, 'attr_2' => 1313]);
         $val->validateAttribute($m, 'attr_1');
         $this->assertTrue($m->hasErrors('attr_1'));
@@ -137,7 +137,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
 
     public function testValidateNonDatabaseAttribute()
     {
-        $val = new UniqueValidator(['targetClass' => ValidatorTestRefModel::className(), 'targetAttribute' => 'ref']);
+        $val = new UniqueValidator(['targetClass' => ValidatorTestRefModel::class, 'targetAttribute' => 'ref']);
         /** @var ValidatorTestMainModel $m */
         $m = ValidatorTestMainModel::findOne(1);
         $val->validateAttribute($m, 'testMainVal');
@@ -159,7 +159,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
     public function testValidateCompositeKeys()
     {
         $val = new UniqueValidator([
-            'targetClass' => OrderItem::className(),
+            'targetClass' => OrderItem::class,
             'targetAttribute' => ['order_id', 'item_id'],
         ]);
         // validate old record
@@ -182,7 +182,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $this->assertFalse($m->hasErrors('order_id'));
 
         $val = new UniqueValidator([
-            'targetClass' => OrderItem::className(),
+            'targetClass' => OrderItem::class,
             'targetAttribute' => ['id' => 'order_id'],
         ]);
         // validate old record
@@ -214,7 +214,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
     {
         // Check whether "Description" and "name" aren't equal
         $val = new UniqueValidator([
-            'targetClass' => Customer::className(),
+            'targetClass' => Customer::class,
             'targetAttribute' => ['description' => 'name'],
         ]);
 
@@ -362,11 +362,11 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
 
     public function testGetTargetClassWithFilledTargetClassProperty()
     {
-        $validator = new UniqueValidator(['targetClass' => Profile::className()]);
+        $validator = new UniqueValidator(['targetClass' => Profile::class]);
         $model = new FakedValidationModel();
         $actualTargetClass = $this->invokeMethod($validator, 'getTargetClass', [$model]);
 
-        $this->assertEquals(Profile::className(), $actualTargetClass);
+        $this->assertEquals(Profile::class, $actualTargetClass);
     }
 
     public function testGetTargetClassWithNotFilledTargetClassProperty()
@@ -375,7 +375,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $model = new FakedValidationModel();
         $actualTargetClass = $this->invokeMethod($validator, 'getTargetClass', [$model]);
 
-        $this->assertEquals(FakedValidationModel::className(), $actualTargetClass);
+        $this->assertEquals(FakedValidationModel::class, $actualTargetClass);
     }
 
     public function testPrepareQuery()

--- a/tests/framework/validators/ValidatorTest.php
+++ b/tests/framework/validators/ValidatorTest.php
@@ -47,9 +47,9 @@ class ValidatorTest extends TestCase
         $model = FakedValidationModel::createWithAttributes(['attr_test1' => 'abc', 'attr_test2' => '2013']);
         /* @var $numberVal NumberValidator */
         $numberVal = TestValidator::createValidator('number', $model, ['attr_test1']);
-        $this->assertInstanceOf(NumberValidator::className(), $numberVal);
+        $this->assertInstanceOf(NumberValidator::class, $numberVal);
         $numberVal = TestValidator::createValidator('integer', $model, ['attr_test2']);
-        $this->assertInstanceOf(NumberValidator::className(), $numberVal);
+        $this->assertInstanceOf(NumberValidator::class, $numberVal);
         $this->assertTrue($numberVal->integerOnly);
         $val = TestValidator::createValidator(
             'boolean',
@@ -57,7 +57,7 @@ class ValidatorTest extends TestCase
             ['attr_test1', 'attr_test2'],
             ['on' => ['a', 'b']]
         );
-        $this->assertInstanceOf(BooleanValidator::className(), $val);
+        $this->assertInstanceOf(BooleanValidator::class, $val);
         $this->assertSame(['a', 'b'], $val->on);
         $this->assertSame(['attr_test1', 'attr_test2'], $val->attributes);
         $val = TestValidator::createValidator(
@@ -66,11 +66,11 @@ class ValidatorTest extends TestCase
             ['attr_test1', 'attr_test2'],
             ['on' => ['a', 'b'], 'except' => ['c', 'd', 'e']]
         );
-        $this->assertInstanceOf(BooleanValidator::className(), $val);
+        $this->assertInstanceOf(BooleanValidator::class, $val);
         $this->assertSame(['a', 'b'], $val->on);
         $this->assertSame(['c', 'd', 'e'], $val->except);
         $val = TestValidator::createValidator('inlineVal', $model, ['val_attr_a'], ['params' => ['foo' => 'bar']]);
-        $this->assertInstanceOf(InlineValidator::className(), $val);
+        $this->assertInstanceOf(InlineValidator::class, $val);
         $this->assertSame('inlineVal', $val->method[1]);
         $this->assertSame(['foo' => 'bar'], $val->params);
     }
@@ -84,7 +84,7 @@ class ValidatorTest extends TestCase
 
         $validator = TestValidator::createValidator('required', $model, ['firstAttribute']);
 
-        $this->assertInstanceOf(RequiredValidator::className(), $validator);
+        $this->assertInstanceOf(RequiredValidator::class, $validator);
     }
 
     public function testValidateAttributes()
@@ -193,7 +193,7 @@ class ValidatorTest extends TestCase
     public function testValidateValue()
     {
         $this->expectException('yii\base\NotSupportedException');
-        $this->expectExceptionMessage(TestValidator::className() . ' does not support validateValue().');
+        $this->expectExceptionMessage(TestValidator::class . ' does not support validateValue().');
         $val = new TestValidator();
         $val->validate('abc');
     }
@@ -212,7 +212,7 @@ class ValidatorTest extends TestCase
         $this->assertEquals('val_attr_a', $args[0]);
         $this->assertEquals('a', $args[3]);
         $this->assertEquals(['foo' => 'bar'], $args[1]);
-        $this->assertInstanceOf(InlineValidator::className(), $args[2]);
+        $this->assertInstanceOf(InlineValidator::class, $args[2]);
     }
 
     public function testClientValidateAttribute()
@@ -233,7 +233,7 @@ class ValidatorTest extends TestCase
         $this->assertCount(5, $args);
         $this->assertEquals('val_attr_a', $args[0]);
         $this->assertEquals(['foo' => 'bar'], $args[1]);
-        $this->assertInstanceOf(InlineValidator::className(), $args[2]);
+        $this->assertInstanceOf(InlineValidator::class, $args[2]);
     }
 
     public function testIsActive()
@@ -319,7 +319,7 @@ class ValidatorTest extends TestCase
     {
         $model = new DynamicModel();
         $model->defineAttribute(1);
-        $model->addRule([1], SafeValidator::className());
+        $model->addRule([1], SafeValidator::class);
 
         $this->assertNull($model->{1});
         $this->assertTrue($model->validate([1]));

--- a/tests/framework/web/AssetBundleTest.php
+++ b/tests/framework/web/AssetBundleTest.php
@@ -230,7 +230,7 @@ class AssetBundleTest extends \yiiunit\TestCase
         TestSimpleAsset::register($view);
         $this->assertCount(1, $view->assetBundles);
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestSimpleAsset', $view->assetBundles);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestSimpleAsset']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestSimpleAsset']);
 
         $expected = <<<'EOF'
 123<script src="/js/jquery.js"></script>4
@@ -248,9 +248,9 @@ EOF;
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetBundle', $view->assetBundles);
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetLevel3', $view->assetBundles);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3']);
 
         $expected = <<<'EOF'
 1<link href="/files/cssFile.css" rel="stylesheet">23<script src="/js/jquery.js"></script>
@@ -296,9 +296,9 @@ EOF;
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetLevel3', $view->assetBundles);
 
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3']);
 
         $this->assertArrayHasKey('position', $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']->jsOptions);
         $this->assertEquals($pos, $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']->jsOptions['position']);
@@ -384,7 +384,7 @@ EOF;
         TestSimpleAsset::register($view);
         $this->assertCount(1, $view->assetBundles);
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestSimpleAsset', $view->assetBundles);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestSimpleAsset']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestSimpleAsset']);
         // register TestJqueryAsset which also has the jquery.js
         TestJqueryAsset::register($view);
 

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -88,7 +88,7 @@ class ControllerTest extends TestCase
             'basePath' => __DIR__,
             'container' => [
                 'definitions' => [
-                    \yiiunit\framework\web\stubs\ModelBindingStub::className() => [ \yiiunit\framework\web\stubs\ModelBindingStub::className() , "build"],
+                    \yiiunit\framework\web\stubs\ModelBindingStub::class => [ \yiiunit\framework\web\stubs\ModelBindingStub::class , "build"],
                 ]
             ],
             'components' => [
@@ -99,7 +99,7 @@ class ControllerTest extends TestCase
                 ],
             ],
         ]));
-        Yii::$container->set(VendorImage::className(), VendorImage::className());
+        Yii::$container->set(VendorImage::class, VendorImage::class);
         $this->mockWebApplication(['controller' => $this->controller]);
         $injectionAction = new InlineAction('injection', $this->controller, 'actionModelBindingInjection');
         $this->expectException(get_class(new NotFoundHttpException("Not Found Item.")));
@@ -126,7 +126,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        Yii::$container->set(VendorImage::className(), function() { throw new \RuntimeException('uh oh'); });
+        Yii::$container->set(VendorImage::class, function() { throw new \RuntimeException('uh oh'); });
 
         $this->expectException(get_class(new RuntimeException()));
         $this->expectExceptionMessage('uh oh');
@@ -151,7 +151,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        Yii::$container->clear(VendorImage::className());
+        Yii::$container->clear(VendorImage::class);
         $this->expectException(get_class(new ServerErrorHttpException()));
         $this->expectExceptionMessage('Could not load required service: vendorImage');
         $this->controller->bindActionParams($injectionAction, $params);
@@ -174,13 +174,13 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        Yii::$container->set(VendorImage::className(), VendorImage::className());
+        Yii::$container->set(VendorImage::class, VendorImage::class);
         $args = $this->controller->bindActionParams($injectionAction, $params);
         $this->assertEquals($params['before'], $args[0]);
         $this->assertEquals(Yii::$app->request, $args[1]);
         $this->assertEquals('Component: yii\web\Request $request', Yii::$app->requestedParams['request']);
         $this->assertEquals($params['between'], $args[2]);
-        $this->assertInstanceOf(VendorImage::className(), $args[3]);
+        $this->assertInstanceOf(VendorImage::class, $args[3]);
         $this->assertEquals('Container DI: yiiunit\framework\web\stubs\VendorImage $vendorImage', Yii::$app->requestedParams['vendorImage']);
         $this->assertNull($args[4]);
         $this->assertEquals('Unavailable service: post', Yii::$app->requestedParams['post']);
@@ -201,7 +201,7 @@ class ControllerTest extends TestCase
             ],
         ]));
         $module->set('yii\data\DataProviderInterface', [
-            'class' => \yii\data\ArrayDataProvider::className(),
+            'class' => \yii\data\ArrayDataProvider::class,
         ]);
         // Use the PHP71 controller for this test
         $this->controller = new FakePhp71Controller('fake', $module);
@@ -209,7 +209,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionModuleServiceInjection');
         $args = $this->controller->bindActionParams($injectionAction, []);
-        $this->assertInstanceOf(\yii\data\ArrayDataProvider::className(), $args[0]);
+        $this->assertInstanceOf(\yii\data\ArrayDataProvider::class, $args[0]);
         $this->assertEquals('Module yii\base\Module DI: yii\data\DataProviderInterface $dataProvider', Yii::$app->requestedParams['dataProvider']);
     }
 

--- a/tests/framework/web/ErrorHandlerTest.php
+++ b/tests/framework/web/ErrorHandlerTest.php
@@ -75,7 +75,7 @@ Exception: yii\web\NotFoundHttpException', $out);
         $handler->traceLine = '<a href="netbeans://open?file={file}&line={line}">{html}</a>';
         $file = \yii\BaseYii::getAlias('@yii/web/Application.php');
 
-        $out = $handler->renderCallStackItem($file, 63, \yii\web\Application::className(), null, null, null);
+        $out = $handler->renderCallStackItem($file, 63, \yii\web\Application::class, null, null, null);
 
         $this->assertStringContainsString('<a href="netbeans://open?file=' . $file . '&line=63">', $out);
     }

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -33,7 +33,7 @@ class ResponseTest extends \yiiunit\TestCase
         $this->mockWebApplication([
             'components' => [
                 'request' => [
-                    'class' => TestRequestComponent::className(),
+                    'class' => TestRequestComponent::class,
                 ],
             ],
         ]);

--- a/tests/framework/web/UploadedFileTest.php
+++ b/tests/framework/web/UploadedFileTest.php
@@ -70,8 +70,8 @@ class UploadedFileTest extends TestCase
         $productImage = UploadedFile::getInstance(new ModelStub(), 'prod_image');
         $vendorImage = VendorImage::getInstance(new ModelStub(), 'vendor_image');
 
-        $this->assertInstanceOf(UploadedFile::className(), $productImage);
-        $this->assertInstanceOf(VendorImage::className(), $vendorImage);
+        $this->assertInstanceOf(UploadedFile::class, $productImage);
+        $this->assertInstanceOf(VendorImage::class, $vendorImage);
     }
 
     public function testGetInstances()
@@ -80,11 +80,11 @@ class UploadedFileTest extends TestCase
         $vendorImages = VendorImage::getInstances(new ModelStub(), 'vendor_images');
 
         foreach ($productImages as $productImage) {
-            $this->assertInstanceOf(UploadedFile::className(), $productImage);
+            $this->assertInstanceOf(UploadedFile::class, $productImage);
         }
 
         foreach ($vendorImages as $vendorImage) {
-            $this->assertInstanceOf(VendorImage::className(), $vendorImage);
+            $this->assertInstanceOf(VendorImage::class, $vendorImage);
         }
     }
 

--- a/tests/framework/web/UrlManagerCreateUrlTest.php
+++ b/tests/framework/web/UrlManagerCreateUrlTest.php
@@ -761,12 +761,12 @@ class UrlManagerCreateUrlTest extends TestCase
         /* @var $rules CachedUrlRule[] */
         $rules = [
             Yii::createObject([
-                'class' => CachedUrlRule::className(),
+                'class' => CachedUrlRule::class,
                 'route' => 'user/show',
                 'pattern' => 'user/<name:[\w-]+>',
             ]),
             Yii::createObject([
-                'class' => CachedUrlRule::className(),
+                'class' => CachedUrlRule::class,
                 'route' => '<controller>/<action>',
                 'pattern' => '<controller:\w+>/<action:\w+>',
             ]),
@@ -808,12 +808,12 @@ class UrlManagerCreateUrlTest extends TestCase
         /* @var $rules CachedUrlRule[] */
         $rules = [
             Yii::createObject([
-                'class' => CachedUrlRule::className(),
+                'class' => CachedUrlRule::class,
                 'route' => 'user/show',
                 'pattern' => 'user/<name:[\w-]+>',
             ]),
             Yii::createObject([
-                'class' => CachedUrlRule::className(),
+                'class' => CachedUrlRule::class,
                 'route' => '<controller>/<action>',
                 'pattern' => '<controller:\w+>/<action:\w+>',
             ]),
@@ -841,7 +841,7 @@ class UrlManagerCreateUrlTest extends TestCase
     {
         $this->mockWebApplication([
             'components' => [
-                'cache' => ArrayCache::className(),
+                'cache' => ArrayCache::class,
             ],
         ]);
         $urlManager = $this->getUrlManager([
@@ -854,7 +854,7 @@ class UrlManagerCreateUrlTest extends TestCase
         $cachedUrlManager = $this->getUrlManager([
             'cache' => 'cache',
             'ruleConfig' => [
-                'class' => CachedUrlRule::className(),
+                'class' => CachedUrlRule::class,
             ],
             'rules' => [
                 '/' => 'site/index',
@@ -862,15 +862,15 @@ class UrlManagerCreateUrlTest extends TestCase
         ]);
 
         $this->assertNotEquals($urlManager->rules, $cachedUrlManager->rules);
-        $this->assertInstanceOf(UrlRule::className(), $urlManager->rules[0]);
-        $this->assertInstanceOf(CachedUrlRule::className(), $cachedUrlManager->rules[0]);
+        $this->assertInstanceOf(UrlRule::class, $urlManager->rules[0]);
+        $this->assertInstanceOf(CachedUrlRule::class, $cachedUrlManager->rules[0]);
     }
 
     public function testNotEnsuringCacheForEmptyRuleset()
     {
         $this->mockWebApplication([
             'components' => [
-                'cache' => ArrayCache::className(),
+                'cache' => ArrayCache::class,
             ],
         ]);
         // no rules - don't ensure cache
@@ -884,6 +884,6 @@ class UrlManagerCreateUrlTest extends TestCase
             'cache' => 'cache',
             'rules' => ['/' => 'site/index'],
         ]);
-        $this->assertInstanceOf(ArrayCache::className(), $urlManager->cache);
+        $this->assertInstanceOf(ArrayCache::class, $urlManager->cache);
     }
 }

--- a/tests/framework/web/UrlManagerParseUrlTest.php
+++ b/tests/framework/web/UrlManagerParseUrlTest.php
@@ -344,7 +344,7 @@ class UrlManagerParseUrlTest extends TestCase
                     'baseUrl' => '/app',
                 ],
             ],
-        ], \yii\web\Application::className());
+        ], \yii\web\Application::class);
         $this->assertEquals('/app/post/123', $manager->createUrl(['post/delete', 'id' => 123]));
         $this->destroyApplication();
 

--- a/tests/framework/web/UrlRuleTest.php
+++ b/tests/framework/web/UrlRuleTest.php
@@ -71,7 +71,7 @@ class UrlRuleTest extends TestCase
     {
         $manager = new UrlManager([
             'cache' => null,
-            'normalizer' => UrlNormalizer::className(),
+            'normalizer' => UrlNormalizer::class,
         ]);
         $request = new Request(['hostInfo' => 'http://en.example.com']);
         $suites = $this->getTestsForParseRequest();
@@ -100,7 +100,7 @@ class UrlRuleTest extends TestCase
         $manager = new UrlManager([
             'cache' => null,
             'normalizer' => [
-                'class' => UrlNormalizer::className(),
+                'class' => UrlNormalizer::class,
                 'action' => UrlNormalizer::ACTION_REDIRECT_PERMANENT,
             ],
         ]);
@@ -129,7 +129,7 @@ class UrlRuleTest extends TestCase
         $manager = new UrlManager([
             'cache' => null,
             'normalizer' => [
-                'class' => UrlNormalizer::className(),
+                'class' => UrlNormalizer::class,
                 'action' => UrlNormalizer::ACTION_REDIRECT_TEMPORARY,
             ],
         ]);
@@ -158,7 +158,7 @@ class UrlRuleTest extends TestCase
         $manager = new UrlManager([
             'cache' => null,
             'normalizer' => [
-                'class' => UrlNormalizer::className(),
+                'class' => UrlNormalizer::class,
                 'action' => UrlNormalizer::ACTION_NOT_FOUND,
             ],
         ]);
@@ -186,7 +186,7 @@ class UrlRuleTest extends TestCase
         $manager = new UrlManager([
             'cache' => null,
             'normalizer' => [
-                'class' => UrlNormalizer::className(),
+                'class' => UrlNormalizer::class,
                 'action' => null,
             ],
         ]);
@@ -215,7 +215,7 @@ class UrlRuleTest extends TestCase
         $manager = new UrlManager([
             'cache' => null,
             'normalizer' => [
-                'class' => UrlNormalizer::className(),
+                'class' => UrlNormalizer::class,
                 'action' => $normalizerAction,
             ],
         ]);

--- a/tests/framework/web/UserTest.php
+++ b/tests/framework/web/UserTest.php
@@ -50,11 +50,11 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                     'authTimeout' => 10,
                 ],
                 'authManager' => [
-                    'class' => PhpManager::className(),
+                    'class' => PhpManager::class,
                     'itemFile' => '@runtime/user_test_rbac_items.php',
                     'assignmentFile' => '@runtime/user_test_rbac_assignments.php',
                     'ruleFile' => '@runtime/user_test_rbac_rules.php',
@@ -104,16 +104,16 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                     'authTimeout' => 10,
                     'enableAutoLogin' => true,
                     'autoRenewCookie' => false,
                 ],
                 'response' => [
-                    'class' => MockResponse::className(),
+                    'class' => MockResponse::class,
                 ],
                 'request' => [
-                    'class' => MockRequest::className(),
+                    'class' => MockRequest::class,
                 ],
             ],
         ];
@@ -156,14 +156,14 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                     'enableAutoLogin' => true,
                 ],
                 'response' => [
-                    'class' => MockResponse::className(),
+                    'class' => MockResponse::class,
                 ],
                 'request' => [
-                    'class' => MockRequest::className(),
+                    'class' => MockRequest::class,
                 ],
             ],
         ];
@@ -220,10 +220,10 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
                 'authManager' => [
-                    'class' => PhpManager::className(),
+                    'class' => PhpManager::class,
                     'itemFile' => '@runtime/user_test_rbac_items.php',
                     'assignmentFile' => '@runtime/user_test_rbac_assignments.php',
                     'ruleFile' => '@runtime/user_test_rbac_rules.php',
@@ -346,10 +346,10 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
                 'authManager' => [
-                    'class' => PhpManager::className(),
+                    'class' => PhpManager::class,
                     'itemFile' => '@runtime/user_test_rbac_items.php',
                     'assignmentFile' => '@runtime/user_test_rbac_assignments.php',
                     'ruleFile' => '@runtime/user_test_rbac_rules.php',
@@ -369,37 +369,37 @@ class UserTest extends TestCase
         $this->mockWebApplication([
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
-                    'accessChecker' => AccessChecker::className()
+                    'identityClass' => UserIdentity::class,
+                    'accessChecker' => AccessChecker::class
                 ]
             ],
         ]);
-        $this->assertInstanceOf(AccessChecker::className(), Yii::$app->user->accessChecker);
+        $this->assertInstanceOf(AccessChecker::class, Yii::$app->user->accessChecker);
 
         $this->mockWebApplication([
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                     'accessChecker' => [
-                        'class' => AccessChecker::className(),
+                        'class' => AccessChecker::class,
                     ],
                 ],
             ],
         ]);
-        $this->assertInstanceOf(AccessChecker::className(), Yii::$app->user->accessChecker);
+        $this->assertInstanceOf(AccessChecker::class, Yii::$app->user->accessChecker);
 
         $this->mockWebApplication([
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                     'accessChecker' => 'accessChecker',
                 ],
                 'accessChecker' => [
-                    'class' => AccessChecker::className(),
+                    'class' => AccessChecker::class,
                 ]
             ],
         ]);
-        $this->assertInstanceOf(AccessChecker::className(), Yii::$app->user->accessChecker);
+        $this->assertInstanceOf(AccessChecker::class, Yii::$app->user->accessChecker);
     }
 
     public function testGetIdentityException()
@@ -411,7 +411,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => ExceptionIdentity::className(),
+                    'identityClass' => ExceptionIdentity::class,
                 ],
                 'session' => $session,
             ],
@@ -436,10 +436,10 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
                 'authManager' => [
-                    'class' => PhpManager::className(),
+                    'class' => PhpManager::class,
                     'itemFile' => '@runtime/user_test_rbac_items.php',
                     'assignmentFile' => '@runtime/user_test_rbac_assignments.php',
                     'ruleFile' => '@runtime/user_test_rbac_rules.php',
@@ -459,7 +459,7 @@ class UserTest extends TestCase
         $this->assertFalse(Yii::$app->user->can('doSomething'));
 
         Yii::$app->user->setIdentity(UserIdentity::findIdentity('user1'));
-        $this->assertInstanceOf(UserIdentity::className(), Yii::$app->user->identity);
+        $this->assertInstanceOf(UserIdentity::class, Yii::$app->user->identity);
         $this->assertTrue(Yii::$app->user->can('doSomething'));
 
         Yii::$app->user->setIdentity(null);
@@ -475,7 +475,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ];
@@ -492,7 +492,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ];
@@ -511,7 +511,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ];
@@ -531,7 +531,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ];
@@ -551,7 +551,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ];

--- a/tests/framework/web/ViewTest.php
+++ b/tests/framework/web/ViewTest.php
@@ -116,7 +116,7 @@ class ViewTest extends TestCase
                     'scriptUrl' => '/baseUrl/index.php',
                 ],
                 'cache' => [
-                    'class' => FileCache::className(),
+                    'class' => FileCache::class,
                 ],
             ],
         ]);

--- a/tests/framework/web/session/AbstractDbSessionTest.php
+++ b/tests/framework/web/session/AbstractDbSessionTest.php
@@ -60,7 +60,7 @@ abstract class AbstractDbSessionTest extends TestCase
         $config = $databases[$driverAvailable];
 
         $result = [
-            'class' => Connection::className(),
+            'class' => Connection::class,
             'dsn' => $config['dsn'],
         ];
 
@@ -271,11 +271,11 @@ abstract class AbstractDbSessionTest extends TestCase
 
     public function testInitUseStrictMode()
     {
-        $this->initStrictModeTest(DbSession::className());
+        $this->initStrictModeTest(DbSession::class);
     }
 
     public function testUseStrictMode()
     {
-        $this->useStrictModeTest(DbSession::className());
+        $this->useStrictModeTest(DbSession::class);
     }
 }

--- a/tests/framework/web/session/CacheSessionTest.php
+++ b/tests/framework/web/session/CacheSessionTest.php
@@ -56,11 +56,11 @@ class CacheSessionTest extends \yiiunit\TestCase
 
     public function testInitUseStrictMode()
     {
-        $this->initStrictModeTest(CacheSession::className());
+        $this->initStrictModeTest(CacheSession::class);
     }
 
     public function testUseStrictMode()
     {
-        $this->useStrictModeTest(CacheSession::className());
+        $this->useStrictModeTest(CacheSession::class);
     }
 }

--- a/tests/framework/web/session/SessionTest.php
+++ b/tests/framework/web/session/SessionTest.php
@@ -94,7 +94,7 @@ class SessionTest extends TestCase
 
     public function testInitUseStrictMode()
     {
-        $this->initStrictModeTest(Session::className());
+        $this->initStrictModeTest(Session::class);
     }
 
     public function testUseStrictMode()
@@ -109,6 +109,6 @@ class SessionTest extends TestCase
             }
         }
 
-        $this->useStrictModeTest(Session::className());
+        $this->useStrictModeTest(Session::class);
     }
 }

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -600,8 +600,8 @@ EOD;
 
     public function testWidget()
     {
-        $this->activeField->widget(TestInputWidget::className());
-        $this->assertEquals('Render: ' . TestInputWidget::className(), $this->activeField->parts['{input}']);
+        $this->activeField->widget(TestInputWidget::class);
+        $this->assertEquals('Render: ' . TestInputWidget::class, $this->activeField->parts['{input}']);
         $widget = TestInputWidget::$lastInstance;
 
         $this->assertSame($this->activeField->model, $widget->model);
@@ -609,7 +609,7 @@ EOD;
         $this->assertSame($this->activeField->form->view, $widget->view);
         $this->assertSame($this->activeField, $widget->field);
 
-        $this->activeField->widget(TestInputWidget::className(), ['options' => ['id' => 'test-id']]);
+        $this->activeField->widget(TestInputWidget::class, ['options' => ['id' => 'test-id']]);
         $this->assertEquals('test-id', $this->activeField->labelOptions['for']);
     }
 
@@ -618,7 +618,7 @@ EOD;
         $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
         $this->activeField->model->addError('attributeName', 'error');
 
-        $this->activeField->widget(TestInputWidget::className());
+        $this->activeField->widget(TestInputWidget::class);
         $widget = TestInputWidget::$lastInstance;
         $expectedOptions = [
             'class' => 'form-control has-error',
@@ -628,7 +628,7 @@ EOD;
         $this->assertEquals($expectedOptions, $widget->options);
 
         $this->activeField->inputOptions = [];
-        $this->activeField->widget(TestInputWidget::className());
+        $this->activeField->widget(TestInputWidget::class);
         $widget = TestInputWidget::$lastInstance;
         $expectedOptions = [
             'class' => 'has-error',
@@ -672,7 +672,7 @@ HTML;
 
     public function testInputOptionsTransferToWidget()
     {
-        $widget = $this->activeField->widget(TestMaskedInput::className(), [
+        $widget = $this->activeField->widget(TestMaskedInput::class, [
             'mask' => '999-999-9999',
             'options' => ['placeholder' => 'pholder_direct'],
         ]);
@@ -680,14 +680,14 @@ HTML;
 
         // transfer options from ActiveField to widget
         $this->activeField->inputOptions = ['placeholder' => 'pholder_input'];
-        $widget = $this->activeField->widget(TestMaskedInput::className(), [
+        $widget = $this->activeField->widget(TestMaskedInput::class, [
             'mask' => '999-999-9999',
         ]);
         $this->assertStringContainsString('placeholder="pholder_input"', (string) $widget);
 
         // set both AF and widget options (second one takes precedence)
         $this->activeField->inputOptions = ['placeholder' => 'pholder_both_input'];
-        $widget = $this->activeField->widget(TestMaskedInput::className(), [
+        $widget = $this->activeField->widget(TestMaskedInput::class, [
             'mask' => '999-999-9999',
             'options' => ['placeholder' => 'pholder_both_direct']
         ]);

--- a/tests/framework/widgets/ActiveFormTest.php
+++ b/tests/framework/widgets/ActiveFormTest.php
@@ -116,7 +116,7 @@ HTML
         $model = new DynamicModel(['name']);
         $model->addRule(['name'], 'required');
 
-        $view = $this->getMockBuilder(View::className())->getMock();
+        $view = $this->getMockBuilder(View::class)->getMock();
         $view->method('registerJs')->with($this->matches("jQuery('#w0').yiiActiveForm([], {\"validateOnSubmit\":false});"));
         $view->method('registerAssetBundle')->willReturn(true);
 

--- a/tests/framework/widgets/FragmentCacheTest.php
+++ b/tests/framework/widgets/FragmentCacheTest.php
@@ -22,7 +22,7 @@ class FragmentCacheTest extends \yiiunit\TestCase
         parent::setUp();
         $this->mockWebApplication();
         Yii::$app->set('cache', [
-            'class' => ArrayCache::className(),
+            'class' => ArrayCache::class,
         ]);
     }
 

--- a/tests/framework/widgets/ListViewTest.php
+++ b/tests/framework/widgets/ListViewTest.php
@@ -134,7 +134,7 @@ HTML
             ],
             [
                 function ($model, $key, $index, $widget) {
-                    return "Item #{$index}: {$model['login']} - Widget: " . $widget->className();
+                    return "Item #{$index}: {$model['login']} - Widget: " . $widget::class;
                 },
                 '<div id="w0" class="list-view"><div class="summary">Showing <b>1-3</b> of <b>3</b> items.</div>
 <div data-key="0">Item #0: silverfire - Widget: yii\widgets\ListView</div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
