### PR TITLE
End fenced code block

### DIFF
--- a/framework/db/ActiveRecordInterface.php
+++ b/framework/db/ActiveRecordInterface.php
@@ -144,6 +144,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      * // Use where() to ignore the default condition
      * // SELECT FROM customer WHERE age>30
      * $customers = Customer::find()->where('age>30')->all();
+     * ```
      *
      * @return ActiveQueryInterface the newly created [[ActiveQueryInterface]] instance.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | None


Adds a closing set of backticks for a code block that resulted in improperly formatted IDE hints. Discovered while reviewing the output of an automated [class reference](https://docs.craftcms.com/api/v4/craft-db-activerecord.html#method-find) tool.