### PR TITLE
Added support for string and DateTimeInterface as Cookie::$expire

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Bug #19868: Added whitespace sanitation for tests, due to updates in ICU 72 (schmunk42)
 - Enh #19884: Added support Enums in Query Builder (sk1t0n)
 - Bug #19906: Fixed multiline strings in the `\yii\console\widgets\Table` widget (rhertogh)
+- Enh #19920: Broadened the accepted type of `Cookie::$expire` from `int` to `int|string|null` (rhertogh)
 
 
 2.0.48.1 May 24, 2023

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,7 +14,7 @@ Yii Framework 2 Change Log
 - Bug #19868: Added whitespace sanitation for tests, due to updates in ICU 72 (schmunk42)
 - Enh #19884: Added support Enums in Query Builder (sk1t0n)
 - Bug #19906: Fixed multiline strings in the `\yii\console\widgets\Table` widget (rhertogh)
-- Enh #19920: Broadened the accepted type of `Cookie::$expire` from `int` to `int|string|null` (rhertogh)
+- Enh #19920: Broadened the accepted type of `Cookie::$expire` from `int` to `int|string|\DateTimeInterface|null` (rhertogh)
 
 
 2.0.48.1 May 24, 2023

--- a/framework/web/Cookie.php
+++ b/framework/web/Cookie.php
@@ -57,7 +57,7 @@ class Cookie extends \yii\base\BaseObject
      */
     public $domain = '';
     /**
-     * @var int|string|null the timestamp or date at which the cookie expires. This is the server timestamp.
+     * @var int|string|\DateTimeInterface|null the timestamp or date at which the cookie expires. This is the server timestamp.
      * Defaults to 0, meaning "until the browser is closed" (the same applies to `null`).
      */
     public $expire = 0;

--- a/framework/web/Cookie.php
+++ b/framework/web/Cookie.php
@@ -57,7 +57,7 @@ class Cookie extends \yii\base\BaseObject
      */
     public $domain = '';
     /**
-     * @var int the timestamp at which the cookie expires. This is the server timestamp.
+     * @var int|string|null the timestamp or date at which the cookie expires. This is the server timestamp.
      * Defaults to 0, meaning "until the browser is closed".
      */
     public $expire = 0;

--- a/framework/web/Cookie.php
+++ b/framework/web/Cookie.php
@@ -58,7 +58,7 @@ class Cookie extends \yii\base\BaseObject
     public $domain = '';
     /**
      * @var int|string|null the timestamp or date at which the cookie expires. This is the server timestamp.
-     * Defaults to 0, meaning "until the browser is closed".
+     * Defaults to 0, meaning "until the browser is closed" (the same applies to `null`).
      */
     public $expire = 0;
     /**

--- a/framework/web/CookieCollection.php
+++ b/framework/web/CookieCollection.php
@@ -116,7 +116,12 @@ class CookieCollection extends BaseObject implements \IteratorAggregate, \ArrayA
             && ($this->_cookies[$name]->expire === null
                 || $this->_cookies[$name]->expire === 0
                 || (
-                    is_string($this->_cookies[$name]->expire) && strtotime($this->_cookies[$name]->expire) >= time()
+                    (is_string($this->_cookies[$name]->expire) && strtotime($this->_cookies[$name]->expire) >= time())
+                    || (
+                        interface_exists('\DateTimeInterface')
+                        && $this->_cookies[$name]->expire instanceof \DateTimeInterface
+                        && $this->_cookies[$name]->expire->getTimestamp() >= time()
+                    )
                     || $this->_cookies[$name]->expire >= time()
                 )
             );

--- a/framework/web/CookieCollection.php
+++ b/framework/web/CookieCollection.php
@@ -51,7 +51,7 @@ class CookieCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * Returns an iterator for traversing the cookies in the collection.
      * This method is required by the SPL interface [[\IteratorAggregate]].
      * It will be implicitly called when you use `foreach` to traverse the collection.
-     * @return ArrayIterator an iterator for traversing the cookies in the collection.
+     * @return ArrayIterator<string, Cookie> an iterator for traversing the cookies in the collection.
      */
     #[\ReturnTypeWillChange]
     public function getIterator()
@@ -113,7 +113,13 @@ class CookieCollection extends BaseObject implements \IteratorAggregate, \ArrayA
     public function has($name)
     {
         return isset($this->_cookies[$name]) && $this->_cookies[$name]->value !== ''
-            && ($this->_cookies[$name]->expire === null || $this->_cookies[$name]->expire === 0 || $this->_cookies[$name]->expire >= time());
+            && ($this->_cookies[$name]->expire === null
+                || $this->_cookies[$name]->expire === 0
+                || (
+                    is_string($this->_cookies[$name]->expire) && strtotime($this->_cookies[$name]->expire) >= time()
+                    || $this->_cookies[$name]->expire >= time()
+                )
+            );
     }
 
     /**
@@ -174,7 +180,7 @@ class CookieCollection extends BaseObject implements \IteratorAggregate, \ArrayA
 
     /**
      * Returns the collection as a PHP array.
-     * @return array the array representation of the collection.
+     * @return Cookie[] the array representation of the collection.
      * The array keys are cookie names, and the array values are the corresponding cookie objects.
      */
     public function toArray()

--- a/framework/web/CookieCollection.php
+++ b/framework/web/CookieCollection.php
@@ -118,7 +118,7 @@ class CookieCollection extends BaseObject implements \IteratorAggregate, \ArrayA
                 || (
                     (is_string($this->_cookies[$name]->expire) && strtotime($this->_cookies[$name]->expire) >= time())
                     || (
-                        interface_exists('\DateTimeInterface')
+                        interface_exists('\\DateTimeInterface')
                         && $this->_cookies[$name]->expire instanceof \DateTimeInterface
                         && $this->_cookies[$name]->expire->getTimestamp() >= time()
                     )

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -401,12 +401,19 @@ class Response extends \yii\base\Response
         }
         foreach ($this->getCookies() as $cookie) {
             $value = $cookie->value;
-            if ($cookie->expire != 1 && isset($validationKey)) {
+            $expire = $cookie->expire;
+            if (is_string($expire)) {
+                $expire = strtotime($expire);
+            }
+            if ($expire === null || $expire === false) {
+                $expire = 0;
+            }
+            if ($expire != 1 && isset($validationKey)) {
                 $value = Yii::$app->getSecurity()->hashData(serialize([$cookie->name, $value]), $validationKey);
             }
             if (PHP_VERSION_ID >= 70300) {
                 setcookie($cookie->name, $value, [
-                    'expires' => $cookie->expire,
+                    'expires' => $expire,
                     'path' => $cookie->path,
                     'domain' => $cookie->domain,
                     'secure' => $cookie->secure,
@@ -420,7 +427,7 @@ class Response extends \yii\base\Response
                 if (!is_null($cookie->sameSite)) {
                     $cookiePath .= '; samesite=' . $cookie->sameSite;
                 }
-                setcookie($cookie->name, $value, $cookie->expire, $cookiePath, $cookie->domain, $cookie->secure, $cookie->httpOnly);
+                setcookie($cookie->name, $value, $expire, $cookiePath, $cookie->domain, $cookie->secure, $cookie->httpOnly);
             }
         }
     }

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -404,6 +404,8 @@ class Response extends \yii\base\Response
             $expire = $cookie->expire;
             if (is_string($expire)) {
                 $expire = strtotime($expire);
+            } elseif (interface_exists('\\DateTimeInterface') && $expire instanceof \DateTimeInterface) {
+                $expire = $expire->getTimestamp();
             }
             if ($expire === null || $expire === false) {
                 $expire = 0;

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -470,7 +470,7 @@ class ResponseTest extends \yiiunit\TestCase
             if ($name === null) {
                 throw new \Exception('Could not determine cookie name for header "' . $header . '".');
             }
-            $cookies = array_merge_recursive($cookies, [$name => $params]);
+            $cookies[$name] = $params;
         }
 
         return $cookies;

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -380,21 +380,100 @@ class ResponseTest extends \yiiunit\TestCase
         );
     }
 
-    public function testSameSiteCookie()
+    /**
+     * @dataProvider cookiesTestProvider
+     */
+    public function testCookies($cookieConfig, $expected)
     {
         $response = new Response();
-        $response->cookies->add(new Cookie([
-            'name'     => 'test',
-            'value'    => 'testValue',
-            'sameSite' => Cookie::SAME_SITE_STRICT,
-        ]));
+        $response->cookies->add(new Cookie(array_merge(
+            [
+                'name'     => 'test',
+                'value'    => 'testValue',
+            ],
+            $cookieConfig
+        )));
 
         ob_start();
         $response->send();
         $content = ob_get_clean();
 
-        // Only way to test is that it doesn't create any errors
-        $this->assertEquals('', $content);
+        $cookies = $this->parseHeaderCookies();
+        if ($cookies === false) {
+            // Unable to resolve cookies, only way to test is that it doesn't create any errors
+            $this->assertEquals('', $content);
+        } else {
+            $testCookie = $cookies['test'];
+            $actual = array_intersect_key($testCookie, $expected);
+            ksort($actual);
+            ksort($expected);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    public function cookiesTestProvider()
+    {
+        $expireInt = time() + 3600;
+        $expireString = date('D, d-M-Y H:i:s', $expireInt) . ' GMT';
+        return [
+            'same-site' => [
+                ['sameSite' => Cookie::SAME_SITE_STRICT],
+                ['samesite' => Cookie::SAME_SITE_STRICT],
+            ],
+            'expire-as-int' => [
+                ['expire' => $expireInt],
+                ['expires' => $expireString],
+            ],
+            'expire-as-string' => [
+                ['expire' => $expireString],
+                ['expires' => $expireString],
+            ],
+        ];
+    }
+
+    /**
+     * Tries to parse cookies set in the response headers.
+     * When running PHP on the CLI headers are not available (the `headers_list()` function always returns an
+     * empty array). If possible use xDebug: http://xdebug.org/docs/all_functions#xdebug_get_headers
+     * @param $name
+     * @return array|false
+     */
+    protected function parseHeaderCookies() {
+
+        if (!function_exists('xdebug_get_headers')) {
+            return false;
+        }
+
+        $cookies = [];
+        foreach(xdebug_get_headers() as $header) {
+            if (strpos($header, 'Set-Cookie: ') !== 0) {
+                continue;
+            }
+
+            $name = null;
+            $params = [];
+            $pairs = explode(';', substr($header, 12));
+            foreach ($pairs as  $index => $pair) {
+                $pair = trim($pair);
+                if (strpos($pair, '=') === false) {
+                    $params[strtolower($pair)] = true;
+                } else {
+                    list($paramName, $paramValue) = explode('=', $pair, 2);
+                    if ($index === 0) {
+                        $name = $paramName;
+                        $params['value'] = urldecode($paramValue);
+                    } else {
+                        $params[strtolower($paramName)] = urldecode($paramValue);
+                    }
+                }
+            }
+            if ($name === null) {
+                throw new \Exception('Could not determine cookie name for header "' . $header . '".');
+            }
+            $cookies = array_merge_recursive($cookies, [$name => $params]);
+        }
+
+        return $cookies;
     }
 
     /**

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -415,7 +415,8 @@ class ResponseTest extends \yiiunit\TestCase
     {
         $expireInt = time() + 3600;
         $expireString = date('D, d-M-Y H:i:s', $expireInt) . ' GMT';
-        return [
+
+        $testCases = [
             'same-site' => [
                 ['sameSite' => Cookie::SAME_SITE_STRICT],
                 ['samesite' => Cookie::SAME_SITE_STRICT],
@@ -428,7 +429,20 @@ class ResponseTest extends \yiiunit\TestCase
                 ['expire' => $expireString],
                 ['expires' => $expireString],
             ],
+            'expire-as-date_time' => [
+                ['expire' => new \DateTime('@' . $expireInt)],
+                ['expires' => $expireString],
+            ],
         ];
+
+        if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
+            $testCases['expire-as-date_time_immutable'] = [
+                ['expire' => new \DateTimeImmutable('@' . $expireInt)],
+                ['expires' => $expireString],
+            ];
+        }
+
+        return $testCases;
     }
 
     /**

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -429,17 +429,19 @@ class ResponseTest extends \yiiunit\TestCase
                 ['expire' => $expireString],
                 ['expires' => $expireString],
             ],
-            'expire-as-date_time' => [
-                ['expire' => new \DateTime('@' . $expireInt)],
-                ['expires' => $expireString],
-            ],
         ];
 
         if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
-            $testCases['expire-as-date_time_immutable'] = [
-                ['expire' => new \DateTimeImmutable('@' . $expireInt)],
-                ['expires' => $expireString],
-            ];
+            $testCases = array_merge($testCases, [
+                'expire-as-date_time' => [
+                    ['expire' => new \DateTime('@' . $expireInt)],
+                    ['expires' => $expireString],
+                ],
+                'expire-as-date_time_immutable' => [
+                    ['expire' => new \DateTimeImmutable('@' . $expireInt)],
+                    ['expires' => $expireString],
+                ],
+            ]);
         }
 
         return $testCases;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | -
| Fixed issues  | #19917

The `\yii\httpclient\Response::parseCookie()` function sets the `Cookie::$expire` as string.
This PR broadens the accepted types for `Cookie::$expire` from `int` to `int|string|null`.
