### PR TITLE
Remove unnecessary type

### DIFF
--- a/framework/BaseYii.php
+++ b/framework/BaseYii.php
@@ -68,7 +68,7 @@ class BaseYii
      */
     public static $classMap = [];
     /**
-     * @var \yii\console\Application|\yii\web\Application|\yii\base\Application the application instance
+     * @var \yii\console\Application|\yii\web\Application the application instance
      */
     public static $app;
     /**


### PR DESCRIPTION
Because Web and Console application extend Base application there is no need to specify it.

Actually, PHPStan narrows this to _just_ BaseApplication because it is the only consistent type of the three so you lose Web and Console Application type hints.

See, https://phpstan.org/r/d21fb99f-c436-480b-99c2-32df35ec07fa

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | Fixes PHPStan's ability to reason about the `Yii::$app` static property
