### PR TITLE
Update FilterValidator.php

### DIFF
--- a/framework/validators/FilterValidator.php
+++ b/framework/validators/FilterValidator.php
@@ -77,6 +77,10 @@ class FilterValidator extends Validator
     public function validateAttribute($model, $attribute)
     {
         $value = $model->$attribute;
+        if ($this->filter === 'trim') {
+            $value = (string)$model->$attribute;
+        }
+
         if (!$this->skipOnArray || !is_array($value)) {
             $model->$attribute = call_user_func($this->filter, $value);
         }


### PR DESCRIPTION
fixing: trim(): Passing null to parameter 1 ($string) of type string is deprecated on PHP 8.2

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |
