### PR TITLE
Remove deprecated methods to `DbMessageSource::class`.

### DIFF
--- a/framework/i18n/DbMessageSource.php
+++ b/framework/i18n/DbMessageSource.php
@@ -40,12 +40,6 @@ use yii\helpers\ArrayHelper;
 class DbMessageSource extends MessageSource
 {
     /**
-     * Prefix which would be used when generating cache key.
-     * @deprecated This constant has never been used and will be removed in 2.1.0.
-     */
-    const CACHE_KEY_PREFIX = 'DbMessageSource';
-
-    /**
      * @var Connection|array|string the DB connection object or the application component ID of the DB connection.
      *
      * After the DbMessageSource object is created, if you want to change this property, you should only assign


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

