### PR TITLE
Remove deprecated constants `CSRF_MASK_LENGTH`.

### DIFF
--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -94,11 +94,6 @@ class Request extends \yii\base\Request
      * The name of the HTTP header for sending CSRF token.
      */
     const CSRF_HEADER = 'X-CSRF-Token';
-    /**
-     * The length of the CSRF token mask.
-     * @deprecated since 2.0.12. The mask length is now equal to the token length.
-     */
-    const CSRF_MASK_LENGTH = 8;
 
     /**
      * @var bool whether to enable CSRF (Cross-Site Request Forgery) validation. Defaults to true.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
