### PR TITLE
Add method `className()`, don't break `BC` third party extensions.

### DIFF
--- a/framework/base/BaseObject.php
+++ b/framework/base/BaseObject.php
@@ -282,4 +282,14 @@ class BaseObject implements Configurable
     {
         return method_exists($this, $name);
     }
+
+    /**
+     * Returns the fully qualified name of this class.
+     *
+     * @return string the fully qualified name of this class.
+     */
+    public static function className(): string
+    {
+        return static::class;
+    }
 }

--- a/tests/framework/base/BaseObjectTest.php
+++ b/tests/framework/base/BaseObjectTest.php
@@ -159,6 +159,11 @@ class BaseObjectTest extends TestCase
         $this->expectExceptionMessage('Getting write-only property: yiiunit\framework\base\NewObject::writeOnly');
         $this->object->writeOnly;
     }
+
+    public function testClassName(): void
+    {
+        $this->assertSame(NewObject::class, $this->object::className());
+    }
 }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

View comment: https://github.com/yiisoft/yii2/pull/19894#issuecomment-1639886321
