### PR TITLE
Do not duplicate log messages

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.50 under development
 ------------------------
 
+- Bug #19984: Do not duplicate log messages in memory (lubosdz)
 - Bug #19925: Improved PHP version check when handling MIME types (schmunk42)
 - Bug #19940: File Log writer without newline (terabytesoftw)
 - Bug #19951: Removed unneeded MIME file tests (schmunk42)

--- a/framework/log/FileTarget.php
+++ b/framework/log/FileTarget.php
@@ -107,9 +107,8 @@ class FileTarget extends Target
     public function export()
     {
         $text = implode("\n", array_map([$this, 'formatMessage'], $this->messages)) . "\n";
-        $trimmedText = trim($text);
 
-        if (empty($trimmedText)) {
+        if (!trim($text)) {
             return; // No messages to export, so we exit the function early
         }
 

--- a/framework/log/FileTarget.php
+++ b/framework/log/FileTarget.php
@@ -108,7 +108,7 @@ class FileTarget extends Target
     {
         $text = implode("\n", array_map([$this, 'formatMessage'], $this->messages)) . "\n";
 
-        if (!trim($text)) {
+        if (trim($text) === '') {
             return; // No messages to export, so we exit the function early
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

There was missing EOL introduced in #16208, then fixed in #19940, but still there is redundant variable `$trimmedText` which duplicates in memory log messages possibly exhausting memory on large logs. This PR is only cleanup to remove it.
