### PR TITLE
Fixed a bug with the yii serve command and a custom router

### DIFF
--- a/framework/console/controllers/ServeController.php
+++ b/framework/console/controllers/ServeController.php
@@ -80,7 +80,7 @@ class ServeController extends Controller
         }
         $this->stdout("Quit the server with CTRL-C or COMMAND-C.\n");
 
-        passthru('"' . PHP_BINARY . '"' . " -S {$address} -t \"{$documentRoot}\" $router");
+        passthru('"' . PHP_BINARY . '"' . " -S {$address} -t \"{$documentRoot}\" \"$router\"");
     }
 
     /**


### PR DESCRIPTION
If you supply a custom router and the path has a space in it, things break.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20005 
