### PR TITLE
Added PHPDoc type hinting for request and response properties of yii\base\Controller derived classes

### DIFF
--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -28,6 +28,7 @@ use yii\helpers\Inflector;
  * where `<route>` is a route to a controller action and the params will be populated as properties of a command.
  * See [[options()]] for details.
  *
+ * @property Response|array|string response The response.
  * @property-read string $help
  * @property-read string $helpSummary
  * @property-read array $passedOptionValues The properties corresponding to the passed options.

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -17,6 +17,8 @@ use yii\helpers\Url;
  *
  * For more details and usage information on Controller, see the [guide article on controllers](guide:structure-controllers).
  *
+ * @property Response|array|string response The response.
+ *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | See below

```PHP
class MyController extends \yii\web\Controller
{
	public function f()
	{
		$this->request->cookieValidationKey = '123';
		$this->response->content = '123';
	}
}
```
In the example above the IDE (like PHPStorm) will rightfully complain that `$this->request` is of class `yii\base\Response` and does not have a member `cookieValidationKey`. Same for response. This PR provides correct type hinting for IDE in PHPDoc comments.