### PR TITLE
Hotfix as jquery.inputmask.bundle.js net::ERR_ABORTED 404 (Not Found)…

### DIFF
--- a/framework/widgets/MaskedInputAsset.php
+++ b/framework/widgets/MaskedInputAsset.php
@@ -21,7 +21,7 @@ class MaskedInputAsset extends AssetBundle
 {
     public $sourcePath = '@bower/inputmask/dist';
     public $js = [
-        'jquery.inputmask.bundle.js',
+        'jquery.inputmask.min.js',
     ];
     public $depends = [
         'yii\web\YiiAsset',


### PR DESCRIPTION
 jquery.inputmask.bundle.js seems like not registered. Use jquery.inputmask.min.js instead.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Fixed issues  |  jquery.inputmask.bundle.js not registered, use  jquery.inputmask.min.js
