### PR TITLE
Use `self` to access private method in `BaseFormatConverter`

### DIFF
--- a/framework/helpers/BaseFormatConverter.php
+++ b/framework/helpers/BaseFormatConverter.php
@@ -103,7 +103,7 @@ class BaseFormatConverter
     {
         if (isset(self::$_icuShortFormats[$pattern])) {
             if (extension_loaded('intl')) {
-                $pattern = static::createFormatter($locale, $type, $pattern);
+                $pattern = self::createFormatter($locale, $type, $pattern);
             } else {
                 return static::$phpFallbackDatePatterns[$pattern][$type];
             }
@@ -347,7 +347,7 @@ class BaseFormatConverter
     {
         if (isset(self::$_icuShortFormats[$pattern])) {
             if (extension_loaded('intl')) {
-                $pattern = static::createFormatter($locale, $type, $pattern);
+                $pattern = self::createFormatter($locale, $type, $pattern);
             } else {
                 return static::$juiFallbackDatePatterns[$pattern][$type];
             }


### PR DESCRIPTION
Addition to https://github.com/yiisoft/yii2/pull/20014 - using `self` ensures that PHP won't use method with the same name in child class.