### PR TITLE
Add snake Method to String Helpers

### DIFF
--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -497,4 +497,20 @@ class BaseStringHelper
 
         return implode('', $parts);
     }
+
+    /**
+     * Convert a string to snake case.
+     *
+     * @param string $string the input string
+     * @return string snake cased string
+     */
+    public static function snake($string)
+    {
+        if (!ctype_lower($string)) {
+            $string = preg_replace('/\s+/u', '', ucwords($string));
+            $string = mb_strtolower(preg_replace('/(.)(?=[A-Z])/u', '$1_', $string), 'UTF-8');
+        }
+
+        return $string;
+    }
 }

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -474,4 +474,28 @@ class StringHelperTest extends TestCase
             ['', ''],
         ];
     }
+
+    /**
+     * Data provider for testToSnakeCase
+     */
+    public function dataProviderSnake()
+    {
+        return [
+            ['hello_world', 'HelloWorld'],
+            ['hello_world', 'helloWorld'],
+            ['hello_world', 'hello_world'],
+            ['h_e_l_l_o__w_o_r_l_d', 'HELLO_WORLD'],
+            ['hello_world', 'hello world'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderSnake
+     * @param string $expected
+     * @param string $string
+     */
+    public function testToSnakeCase($expected, $string)
+    {
+        $this->assertSame($expected, StringHelper::snake($string));
+    }
 }


### PR DESCRIPTION
Introduce a new method `snake`, to the `BaseStringHelper` class. This method converts a given string into snake_case.
Usage:
```php
$convertedString = StringHelper::snake('helloWorld'); // hello_world
```
Unit tests are also included