### PR TITLE
Implement StringHelper::mask Method

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,8 @@ Yii Framework 2 Change Log
 - Bug #20002: Fixed superfluous query on HEAD request in serializer (xicond)
 - Enh #12743: Added new methods `BaseActiveRecord::loadRelations()` and `BaseActiveRecord::loadRelationsFor()` to eager load related models for existing primary model instances (PowerGamer1)
 - Enh #20030: Improve performance of handling `ErrorHandler::$memoryReserveSize` (antonshevelev, rob006)
+- Enh #20032: Added `mask` method for string masking with multibyte support (salehhashemi1992)
+
 
 2.0.49.2 October 12, 2023
 -------------------------

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -507,23 +507,23 @@ class BaseStringHelper
      *                   This can be a positive or negative integer.
      *                   Positive values count from the beginning,
      *                   negative values count from the end of the string.
-     * @param int $offset The length of the section to be masked.
+     * @param int $length The length of the section to be masked.
      *                    The masking will start from the $start position
-     *                    and continue for $offset characters.
+     *                    and continue for $length characters.
      * @param string $mask The character to use for masking. The default is '*'.
      * @return string The masked string.
      */
-    public static function mask($string, $start, $offset, $mask = '*') {
-        $length = mb_strlen($string, 'UTF-8');
+    public static function mask($string, $start, $length, $mask = '*') {
+        $strLength = mb_strlen($string, 'UTF-8');
 
         // Return original string if start position is out of bounds
-        if ($start >= $length || $start < -$length) {
+        if ($start >= $strLength || $start < -$strLength) {
             return $string;
         }
 
         $masked = mb_substr($string, 0, $start, 'UTF-8');
-        $masked .= str_repeat($mask, abs($offset));
-        $masked .= mb_substr($string, $start + abs($offset), null, 'UTF-8');
+        $masked .= str_repeat($mask, abs($length));
+        $masked .= mb_substr($string, $start + abs($length), null, 'UTF-8');
 
         return $masked;
     }

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -503,23 +503,27 @@ class BaseStringHelper
      * This method is multibyte-safe.
      *
      * @param string $string The input string.
-     * @param int $start The starting position from where to mask.
-     * @param int $end The ending position up to which to mask. Negative value counts from the end.
-     * @param string $maskChar The character to use for masking. Default is '*'.
+     * @param int $start The starting position from where to begin masking.
+     *                   This can be a positive or negative integer.
+     *                   Positive values count from the beginning,
+     *                   negative values count from the end of the string.
+     * @param int $offset The length of the section to be masked.
+     *                    The masking will start from the $start position
+     *                    and continue for $offset characters.
+     * @param string $mask The character to use for masking. The default is '*'.
      * @return string The masked string.
      */
-    public static function mask($string, $start, $end, $maskChar = '*') {
+    public static function mask($string, $start, $offset, $mask = '*') {
         $length = mb_strlen($string, 'UTF-8');
 
-        // If both $start and $end are zero, we want the entire string masked
-        if ($start === 0 && $end === 0) {
-            return str_repeat($maskChar, $length);
+        // Return original string if start position is out of bounds
+        if ($start >= $length || $start < -$length) {
+            return $string;
         }
 
-        // Create the masked string
         $masked = mb_substr($string, 0, $start, 'UTF-8');
-        $masked .= str_repeat($maskChar, $length - ($start + abs($end)));
-        $masked .= mb_substr($string, $end, null, 'UTF-8');
+        $masked .= str_repeat($mask, abs($offset));
+        $masked .= mb_substr($string, $start + abs($offset), null, 'UTF-8');
 
         return $masked;
     }

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -497,4 +497,30 @@ class BaseStringHelper
 
         return implode('', $parts);
     }
+
+    /**
+     * Masks a portion of a string with a repeated character.
+     * This method is multibyte-safe.
+     *
+     * @param string $string The input string.
+     * @param int $start The starting position from where to mask.
+     * @param int $end The ending position up to which to mask. Negative value counts from the end.
+     * @param string $maskChar The character to use for masking. Default is '*'.
+     * @return string The masked string.
+     */
+    public static function mask($string, $start, $end, $maskChar = '*') {
+        $length = mb_strlen($string, 'UTF-8');
+
+        // If both $start and $end are zero, we want the entire string masked
+        if ($start === 0 && $end === 0) {
+            return str_repeat($maskChar, $length);
+        }
+
+        // Create the masked string
+        $masked = mb_substr($string, 0, $start, 'UTF-8');
+        $masked .= str_repeat($maskChar, $length - ($start + abs($end)));
+        $masked .= mb_substr($string, $end, null, 'UTF-8');
+
+        return $masked;
+    }
 }

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -475,28 +475,35 @@ class StringHelperTest extends TestCase
         ];
     }
 
-    /**
-     * @param string $string
-     * @param int $start
-     * @param int $end
-     * @param string $maskChar
-     * @param string $expectedResult
-     * @dataProvider dataProviderMask
-     */
-    public function testMask($string, $start, $end, $maskChar, $expectedResult)
+    public function testMask()
     {
-        $this->assertSame($expectedResult, StringHelper::mask($string, $start, $end, $maskChar));
-    }
+        // Standard masking
+        $this->assertSame('12******90', StringHelper::mask('1234567890', 2, 6));
+        $this->assertSame('a********j', StringHelper::mask('abcdefghij', 1, 8));
+        $this->assertSame('*************', StringHelper::mask('Hello, World!', 0, 13));
+        $this->assertSame('************!', StringHelper::mask('Hello, World!', 0, 12));
+        $this->assertSame('Hello, *orld!', StringHelper::mask('Hello, World!', 7, 1));
+        $this->assertSame('Saleh Hashemi', StringHelper::mask('Saleh Hashemi', 0, 0));
 
-    public function dataProviderMask()
-    {
-        return [
-            ['1234567890', 2, -2, '*', '12******90'],
-            ['abcdefghij', 1, -1, '*', 'a********j'],
-            ['Hello, World!', 0, 0, '*', '*************'],
-            ['Hello, World!', 0, -1, '*', '************!'],
-            ['Hello, World!', 7, -5, '*', 'Hello, *orld!'],
-            ['1234567890', 0, 0, '#', '##########'],
-        ];
+        // Different Mask Character
+        $this->assertSame('12######90', StringHelper::mask('1234567890', 2, 6, '#'));
+
+        // Positions outside the string
+        $this->assertSame('1234567890', StringHelper::mask('1234567890', 20, 6));
+        $this->assertSame('1234567890', StringHelper::mask('1234567890', -20, 6));
+
+        // Negative values for start
+        $this->assertSame('1234****90', StringHelper::mask('1234567890', -6, 4));
+
+        // type-related edge case
+        $this->assertSame('1234****90', StringHelper::mask(1234567890, -6, 4));
+
+        // Multibyte characters
+        $this->assertSame('你**', StringHelper::mask('你好吗', 1, 2));
+        $this->assertSame('你好吗', StringHelper::mask('你好吗', 4, 2));
+
+        // Special characters
+        $this->assertSame('em**l@email.com', StringHelper::mask('email@email.com', 2, 2));
+        $this->assertSame('******email.com', StringHelper::mask('email@email.com', 0, 6));
     }
 }

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -474,4 +474,29 @@ class StringHelperTest extends TestCase
             ['', ''],
         ];
     }
+
+    /**
+     * @param string $string
+     * @param int $start
+     * @param int $end
+     * @param string $maskChar
+     * @param string $expectedResult
+     * @dataProvider dataProviderMask
+     */
+    public function testMask($string, $start, $end, $maskChar, $expectedResult)
+    {
+        $this->assertSame($expectedResult, StringHelper::mask($string, $start, $end, $maskChar));
+    }
+
+    public function dataProviderMask()
+    {
+        return [
+            ['1234567890', 2, -2, '*', '12******90'],
+            ['abcdefghij', 1, -1, '*', 'a********j'],
+            ['Hello, World!', 0, 0, '*', '*************'],
+            ['Hello, World!', 0, -1, '*', '************!'],
+            ['Hello, World!', 7, -5, '*', 'Hello, *orld!'],
+            ['1234567890', 0, 0, '#', '##########'],
+        ];
+    }
 }


### PR DESCRIPTION
Introduce `mask` method in the `StringHelper` class. 

This method is particularly useful for hiding parts of sensitive information like email addresses or phone numbers and so on.
Tests are included

## Usage
```php
$result = StringHelper::mask("1234567890", 2, 6); // Output will be "12******90"
```


