### PR TITLE
Implement StringHelper::findBetween Method

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Enh #20030: Improve performance of handling `ErrorHandler::$memoryReserveSize` (antonshevelev, rob006)
 - Enh #20042: Add empty array check to `ActiveQueryTrait::findWith()` (renkas)
 - Enh #20032: Added `mask` method for string masking with multibyte support (salehhashemi1992)
+- Enh #20034: Added `findBetween` to retrieve a substring that lies between two strings (salehhashemi1992)
 
 
 2.0.49.2 October 12, 2023

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,8 +13,8 @@ Yii Framework 2 Change Log
 - Enh #12743: Added new methods `BaseActiveRecord::loadRelations()` and `BaseActiveRecord::loadRelationsFor()` to eager load related models for existing primary model instances (PowerGamer1)
 - Enh #20030: Improve performance of handling `ErrorHandler::$memoryReserveSize` (antonshevelev, rob006)
 - Enh #20042: Add empty array check to `ActiveQueryTrait::findWith()` (renkas)
-- Enh #20032: Added `mask` method for string masking with multibyte support (salehhashemi1992)
-- Enh #20034: Added `findBetween` to retrieve a substring that lies between two strings (salehhashemi1992)
+- Enh #20032: Added `yii\helpers\BaseStringHelper::mask()` method for string masking with multibyte support (salehhashemi1992)
+- Enh #20034: Added `yii\helpers\BaseStringHelper::findBetween()` to retrieve a substring that lies between two strings (salehhashemi1992)
 
 
 2.0.49.2 October 12, 2023

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -527,4 +527,32 @@ class BaseStringHelper
 
         return $masked;
     }
+
+    /**
+     * Returns the portion of the string that lies between the first occurrence of the start string
+     * and the last occurrence of the end string after that.
+     *
+     * @param string $string The input string.
+     * @param string $start The string marking the start of the portion to extract.
+     * @param string $end The string marking the end of the portion to extract.
+     * @return string The portion of the string between the first occurrence of start and the last occurrence of end.
+     */
+    public static function findBetween($string, $start, $end)
+    {
+        $startPos = mb_strpos($string, $start);
+
+        if ($startPos === false) {
+            return '';
+        }
+
+        // Cut the string from the start position
+        $subString = mb_substr($string, $startPos + mb_strlen($start));
+        $endPos = mb_strrpos($subString, $end);
+
+        if ($endPos === false) {
+            return '';
+        }
+
+        return mb_substr($subString, 0, $endPos);
+    }
 }

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -535,14 +535,15 @@ class BaseStringHelper
      * @param string $string The input string.
      * @param string $start The string marking the start of the portion to extract.
      * @param string $end The string marking the end of the portion to extract.
-     * @return string The portion of the string between the first occurrence of start and the last occurrence of end.
+     * @return string|null The portion of the string between the first occurrence of
+     * start and the last occurrence of end, or null if either start or end cannot be found.
      */
     public static function findBetween($string, $start, $end)
     {
         $startPos = mb_strpos($string, $start);
 
         if ($startPos === false) {
-            return '';
+            return null;
         }
 
         // Cut the string from the start position
@@ -550,7 +551,7 @@ class BaseStringHelper
         $endPos = mb_strrpos($subString, $end);
 
         if ($endPos === false) {
-            return '';
+            return null;
         }
 
         return mb_substr($subString, 0, $endPos);

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -506,4 +506,30 @@ class StringHelperTest extends TestCase
         $this->assertSame('em**l@email.com', StringHelper::mask('email@email.com', 2, 2));
         $this->assertSame('******email.com', StringHelper::mask('email@email.com', 0, 6));
     }
+
+    /**
+     * @param string $string
+     * @param string $start
+     * @param string $end
+     * @param string $expectedResult
+     * @dataProvider dataProviderFindBetween
+     */
+    public function testFindBetween($string, $start, $end, $expectedResult)
+    {
+        $this->assertSame($expectedResult, StringHelper::findBetween($string, $start, $end));
+    }
+
+    public function dataProviderFindBetween()
+    {
+        return [
+            ['hello world hello', 'hello ', ' world', ''],  // end before start
+            ['This is a sample string', 'is ', ' string', 'is a sample'],  // normal case
+            ['startendstart', 'start', 'end', ''],  // end before start
+            ['startmiddleend', 'start', 'end', 'middle'],  // normal case
+            ['startend', 'start', 'end', ''],  // end immediately follows start
+            ['multiple start start end end', 'start ', ' end', 'start end'],  // multiple starts and ends
+            ['', 'start', 'end', ''],  // empty string
+            ['no delimiters here', 'start', 'end', ''],  // no start and end
+        ];
+    }
 }

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -522,14 +522,18 @@ class StringHelperTest extends TestCase
     public function dataProviderFindBetween()
     {
         return [
-            ['hello world hello', 'hello ', ' world', ''],  // end before start
-            ['This is a sample string', 'is ', ' string', 'is a sample'],  // normal case
+            ['hello world hello', ' hello', ' world', null],  // end before start
+            ['This is a sample string', ' is ', ' string', 'a sample'],  // normal case
             ['startendstart', 'start', 'end', ''],  // end before start
             ['startmiddleend', 'start', 'end', 'middle'],  // normal case
             ['startend', 'start', 'end', ''],  // end immediately follows start
             ['multiple start start end end', 'start ', ' end', 'start end'],  // multiple starts and ends
-            ['', 'start', 'end', ''],  // empty string
-            ['no delimiters here', 'start', 'end', ''],  // no start and end
+            ['', 'start', 'end', null],  // empty string
+            ['no delimiters here', 'start', 'end', null],  // no start and end
+            ['start only', 'start', 'end', null], // start found but no end
+            ['end only', 'start', 'end', null], // end found but no start
+            ['spécial !@#$%^&*()', 'spé', '&*()', 'cial !@#$%^'],  // Special characters
+            ['من صالح هاشمی هستم', 'من ', ' هستم', 'صالح هاشمی'], // other languages
         ];
     }
 }


### PR DESCRIPTION
Implement the `findBetween` method in the `StringHelper` class. 

This method retrieves a substring that lies between the first occurrence of a specified start string and the last occurrence of a specified end string in the input string.

Tests are included.

### Usage
```php
$htmlContent = "<div class='content'>Hello World</div>";
$content = StringHelper::findBetween($htmlContent, "<div class='content'>", "</div>");
```
```php
$logData = "INFO: Start --- debug data --- End";
$debugData = StringHelper::findBetween($logData, "Start ---", "--- End");
```
```php
$htmlData = "<html><body><a href="https://example.com">Link</a></body></html>";
$link= StringHelper::findBetween($htmlData, '<a href="', '">');
```


