### PR TITLE
Remove deprecated method `setMethod()` in tests.

### DIFF
--- a/tests/framework/BaseYiiTest.php
+++ b/tests/framework/BaseYiiTest.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework;
 
 use Yii;
+use yii\base\InvalidConfigException;
 use yii\BaseYii;
 use yii\di\Container;
 use yii\log\Logger;
@@ -90,20 +91,16 @@ class BaseYiiTest extends TestCase
         // Test passing in of normal params combined with DI params.
         $this->assertTrue(Yii::createObject(fn(Singer $singer, $a) => $a === 'a', ['a']));
 
-
         $singer = new Singer();
         $singer->firstName = 'Bob';
         $this->assertTrue(Yii::createObject(fn(Singer $singer, $a) => $singer->firstName === 'Bob', [$singer, 'a']));
-
-
         $this->assertTrue(Yii::createObject(fn(Singer $singer, $a = 3) => true));
-
         $this->assertTrue(Yii::createObject(new CallableClass()));
     }
 
     public function testCreateObjectEmptyArrayException(): void
     {
-        $this->expectException('yii\base\InvalidConfigException');
+        $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Object configuration must be an array containing a "class" or "__class" element.');
 
         Yii::createObject([]);
@@ -111,7 +108,7 @@ class BaseYiiTest extends TestCase
 
     public function testCreateObjectInvalidConfigException(): void
     {
-        $this->expectException('yii\base\InvalidConfigException');
+        $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Unsupported configuration type: ' . gettype(null));
 
         Yii::createObject(null);
@@ -154,9 +151,9 @@ class BaseYiiTest extends TestCase
      */
     public function testLog(): void
     {
-        $logger = $this->getMockBuilder('yii\\log\\Logger')
-            ->setMethods(['log'])
-            ->getMock();
+        $logger = $this->createMock(Logger::class);
+        $logger->onlyMethods(['log']);
+
         BaseYii::setLogger($logger);
 
         $logger->expects($this->exactly(6))

--- a/tests/framework/behaviors/CacheableWidgetBehaviorTest.php
+++ b/tests/framework/behaviors/CacheableWidgetBehaviorTest.php
@@ -2,9 +2,10 @@
 
 namespace yiiunit\framework\behaviors;
 
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use yii\base\Widget;
 use yii\behaviors\CacheableWidgetBehavior;
+use yii\caching\ArrayCache;
 use yiiunit\TestCase;
 
 /**
@@ -17,17 +18,13 @@ class CacheableWidgetBehaviorTest extends TestCase
 {
     /**
      * Default-initialized simple cacheable widget mock.
-     *
-     * @var PHPUnit_Framework_MockObject_MockObject|SimpleCacheableWidget|CacheableWidgetBehavior
      */
-    private $simpleWidget;
+    private MockObject|SimpleCacheableWidget|CacheableWidgetBehavior|null $simpleWidget = null;
 
     /**
      * Default-initialized dynamic cacheable widget mock.
-     *
-     * @var PHPUnit_Framework_MockObject_MockObject|DynamicCacheableWidget|CacheableWidgetBehavior
      */
-    private $dynamicWidget;
+    private MockObject|SimpleCacheableWidget|CacheableWidgetBehavior|null $dynamicWidget = null;
 
     /**
      * {@inheritdoc}
@@ -91,7 +88,7 @@ class CacheableWidgetBehaviorTest extends TestCase
         $this->mockApplication([
             'components' => [
                 'cache' => [
-                    'class' => '\yii\caching\ArrayCache',
+                    'class' => ArrayCache::class,
                 ],
             ],
             'params' => [
@@ -113,18 +110,14 @@ class CacheableWidgetBehaviorTest extends TestCase
 
     /**
      * Returns a widget mock.
-     * @param $widgetClass
-     * @return PHPUnit_Framework_MockObject_MockObject
      */
-    private function getWidgetMock(string $widgetClass)
+    private function getWidgetMock(string $widgetClass): MockObject
     {
-        $widgetMock = $this->getMockBuilder($widgetClass)
-            ->setMethods(['run'])
+        return $this->getMockBuilder($widgetClass)
+            ->onlyMethods(['run'])
             ->enableOriginalConstructor()
             ->enableProxyingToOriginalMethods()
             ->getMock();
-
-        return $widgetMock;
     }
 }
 
@@ -159,7 +152,7 @@ class BaseCacheableWidget extends Widget
     public function behaviors()
     {
         return [
-            'cacheable' => 'yii\behaviors\CacheableWidgetBehavior',
+            'cacheable' => CacheableWidgetBehavior::class,
         ];
     }
 }

--- a/tests/framework/console/controllers/AssetControllerTest.php
+++ b/tests/framework/console/controllers/AssetControllerTest.php
@@ -7,8 +7,11 @@
 
 namespace yiiunit\framework\console\controllers;
 
+use Exception;
 use Yii;
+use yii\base\Module;
 use yii\console\controllers\AssetController;
+use yii\console\Exception as ConsoleException;
 use yii\helpers\ArrayHelper;
 use yii\helpers\FileHelper;
 use yii\helpers\StringHelper;
@@ -26,11 +29,11 @@ class AssetControllerTest extends TestCase
     /**
      * @var string path for the test files.
      */
-    protected $testFilePath = '';
+    protected string $testFilePath = '';
     /**
      * @var string test assets path.
      */
-    protected $testAssetsBasePath = '';
+    protected string $testAssetsBasePath = '';
 
     public function setUp(): void
     {
@@ -72,8 +75,8 @@ class AssetControllerTest extends TestCase
      */
     protected function createAssetController()
     {
-        $module = $this->getMockBuilder('yii\\base\\Module')
-            ->setMethods(['fake'])
+        $module = $this->getMockBuilder(Module::class)
+            ->addMethods(['fake'])
             ->setConstructorArgs(['console'])
             ->getMock();
         $assetController = new AssetControllerMock('asset', $module);
@@ -456,7 +459,7 @@ EOL;
 
         // Assert :
         $expectedExceptionMessage = ": {$namespace}\AssetA -> {$namespace}\AssetB -> {$namespace}\AssetC -> {$namespace}\AssetA";
-        $this->expectException('yii\console\Exception');
+        $this->expectException(ConsoleException::class);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
         // When :

--- a/tests/framework/console/controllers/BaseMessageControllerTest.php
+++ b/tests/framework/console/controllers/BaseMessageControllerTest.php
@@ -8,7 +8,9 @@
 namespace yiiunit\framework\console\controllers;
 
 use Yii;
+use yii\base\Module;
 use yii\console\controllers\MessageController;
+use yii\console\Exception;
 use yii\helpers\FileHelper;
 use yii\helpers\VarDumper;
 use yiiunit\TestCase;
@@ -61,8 +63,8 @@ abstract class BaseMessageControllerTest extends TestCase
      */
     protected function createMessageController()
     {
-        $module = $this->getMockBuilder('yii\\base\\Module')
-            ->setMethods(['fake'])
+        $module = $this->getMockBuilder(Module::class)
+            ->addMethods(['fake'])
             ->setConstructorArgs(['console'])
             ->getMock();
         $messageController = new MessageControllerMock('message', $module);
@@ -162,7 +164,7 @@ abstract class BaseMessageControllerTest extends TestCase
 
     public function testConfigFileNotExist(): void
     {
-        $this->expectException('yii\\console\\Exception');
+        $this->expectException(Exception::class);
         $this->runMessageControllerAction('extract', ['not_existing_file.php']);
     }
 

--- a/tests/framework/console/controllers/HelpControllerTest.php
+++ b/tests/framework/console/controllers/HelpControllerTest.php
@@ -7,6 +7,7 @@
 
 namespace yiiunit\framework\console\controllers;
 
+use yii\base\Module;
 use yii\console\controllers\HelpController;
 use yii\helpers\Console;
 use yiiunit\TestCase;
@@ -32,8 +33,8 @@ class HelpControllerTest extends TestCase
      */
     protected function createController()
     {
-        $module = $this->getMockBuilder('yii\\base\\Module')
-            ->setMethods(['fake'])
+        $module = $this->getMockBuilder(Module::class)
+            ->addMethods(['fake'])
             ->setConstructorArgs(['console'])
             ->getMock();
         return new BufferedHelpController('help', $module);

--- a/tests/framework/console/controllers/MigrateControllerTestTrait.php
+++ b/tests/framework/console/controllers/MigrateControllerTestTrait.php
@@ -8,6 +8,7 @@
 namespace yiiunit\framework\console\controllers;
 
 use Yii;
+use yii\base\Module;
 use yii\console\controllers\BaseMigrateController;
 use yii\console\ExitCode;
 use yii\helpers\FileHelper;
@@ -78,8 +79,8 @@ trait MigrateControllerTestTrait
      */
     protected function createMigrateController(array $config = [])
     {
-        $module = $this->getMockBuilder('yii\\base\\Module')
-            ->setMethods(['fake'])
+        $module = $this->getMockBuilder(Module::class)
+            ->addMethods(['fake'])
             ->setConstructorArgs(['console'])
             ->getMock();
         $class = $this->migrateControllerClass;

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -10,7 +10,9 @@ namespace yiiunit\framework\filters;
 use Closure;
 use Yii;
 use yii\base\Action;
+use yii\base\InvalidConfigException;
 use yii\filters\AccessRule;
+use yii\rbac\BaseManager;
 use yii\web\Controller;
 use yii\web\Request;
 use yii\web\User;
@@ -33,26 +35,16 @@ class AccessRuleTest extends \yiiunit\TestCase
         $this->mockWebApplication();
     }
 
-    /**
-     * @param string $method
-     * @return Request
-     */
-    protected function mockRequest($method = 'GET')
+    protected function mockRequest(string $method = 'GET'): Request
     {
         /** @var Request $request */
-        $request = $this->getMockBuilder('\yii\web\Request')
-            ->setMethods(['getMethod'])
-            ->getMock();
+        $request = $this->createPartialMock(Request::class, ['getMethod']);
         $request->method('getMethod')->willReturn($method);
 
         return $request;
     }
 
-    /**
-     * @param string $userid optional user id
-     * @return User
-     */
-    protected function mockUser($userid = null)
+    protected function mockUser(string $userid = null): User
     {
         $user = new User([
             'identityClass' => UserIdentity::class,
@@ -65,19 +57,13 @@ class AccessRuleTest extends \yiiunit\TestCase
         return $user;
     }
 
-    /**
-     * @return Action
-     */
-    protected function mockAction()
+    protected function mockAction(): Action
     {
         $controller = new Controller('site', Yii::$app);
         return new Action('test', $controller);
     }
 
-    /**
-     * @return \yii\rbac\BaseManager
-     */
-    protected function mockAuthManager()
+    protected function mockAuthManager(): BaseManager
     {
         $auth = new MockAuthManager();
         // add "createPost" permission
@@ -302,7 +288,7 @@ class AccessRuleTest extends \yiiunit\TestCase
             'roles' => ['@'],
         ]);
 
-        $this->expectException('yii\base\InvalidConfigException');
+        $this->expectException(InvalidConfigException::class);
         $rule->allows($action, false, $request);
     }
 
@@ -335,7 +321,7 @@ class AccessRuleTest extends \yiiunit\TestCase
     public function testMatchRolesAndPermissions(): void
     {
         $action = $this->mockAction();
-        $user = $this->getMockBuilder('\yii\web\User')->getMock();
+        $user = $this->createMock('\yii\web\User');
         $user->identityCLass = UserIdentity::class;
 
         $rule = new AccessRule([

--- a/tests/framework/filters/AjaxFilterTest.php
+++ b/tests/framework/filters/AjaxFilterTest.php
@@ -10,6 +10,7 @@ namespace yiiunit\framework\filters;
 use Yii;
 use yii\base\Action;
 use yii\filters\AjaxFilter;
+use yii\web\BadRequestHttpException;
 use yii\web\Controller;
 use yii\web\Request;
 use yiiunit\TestCase;
@@ -19,16 +20,10 @@ use yiiunit\TestCase;
  */
 class AjaxFilterTest extends TestCase
 {
-    /**
-     * @param bool $isAjax
-     * @return Request
-     */
-    protected function mockRequest($isAjax)
+    protected function mockRequest(bool $isAjax = false): Request
     {
         /** @var Request $request */
-        $request = $this->getMockBuilder('\yii\web\Request')
-            ->setMethods(['getIsAjax'])
-            ->getMock();
+        $request = $this->createPartialMock(Request::class, ['getIsAjax']);
         $request->method('getIsAjax')->willReturn($isAjax);
 
         return $request;
@@ -45,7 +40,7 @@ class AjaxFilterTest extends TestCase
         $this->assertTrue($filter->beforeAction($action));
 
         $filter->request = $this->mockRequest(false);
-        $this->expectException('yii\web\BadRequestHttpException');
+        $this->expectException(BadRequestHttpException::class);
         $filter->beforeAction($action);
     }
 }

--- a/tests/framework/filters/auth/AuthMethodTest.php
+++ b/tests/framework/filters/auth/AuthMethodTest.php
@@ -11,6 +11,7 @@ use Yii;
 use yii\base\Action;
 use yii\filters\auth\AuthMethod;
 use yii\web\Controller;
+use yii\web\UnauthorizedHttpException;
 use yiiunit\framework\filters\stubs\UserIdentity;
 use yiiunit\TestCase;
 
@@ -36,9 +37,7 @@ class AuthMethodTest extends TestCase
      */
     protected function createFilter($authenticateCallback)
     {
-        $filter = $this->getMockBuilder(AuthMethod::class)
-            ->setMethods(['authenticate'])
-            ->getMock();
+        $filter = $this->createPartialMock(AuthMethod::class, ['authenticate']);
         $filter->method('authenticate')->willReturnCallback($authenticateCallback);
 
         return $filter;
@@ -65,7 +64,7 @@ class AuthMethodTest extends TestCase
         $this->assertTrue($filter->beforeAction($action));
 
         $filter = $this->createFilter(fn() => null);
-        $this->expectException('yii\web\UnauthorizedHttpException');
+        $this->expectException(UnauthorizedHttpException::class);
         $this->assertTrue($filter->beforeAction($action));
     }
 

--- a/tests/framework/log/DispatcherTest.php
+++ b/tests/framework/log/DispatcherTest.php
@@ -23,6 +23,7 @@ namespace yiiunit\framework\log {
     use yii\base\UserException;
     use yii\log\Dispatcher;
     use yii\log\Logger;
+    use yii\log\Target;
     use yiiunit\TestCase;
 
     /**
@@ -154,9 +155,7 @@ namespace yiiunit\framework\log {
          */
         public function testDispatchWithDisabledTarget(): void
         {
-            $target = $this->getMockBuilder('yii\\log\\Target')
-                ->setMethods(['collect'])
-                ->getMockForAbstractClass();
+            $target = $this->createPartialMock(Target::class, ['collect', 'export']);
 
             $target->expects($this->never())->method($this->anything());
             $target->enabled = false;
@@ -170,9 +169,7 @@ namespace yiiunit\framework\log {
          */
         public function testDispatchWithSuccessTargetCollect(): void
         {
-            $target = $this->getMockBuilder('yii\\log\\Target')
-                ->setMethods(['collect'])
-                ->getMockForAbstractClass();
+            $target = $this->createPartialMock(Target::class, ['collect', 'export']);
 
             $target->expects($this->once())
                 ->method('collect')
@@ -191,13 +188,8 @@ namespace yiiunit\framework\log {
         public function testDispatchWithFakeTarget2ThrowExceptionWhenCollect(): void
         {
             static::$microtimeIsMocked = true;
-            $target1 = $this->getMockBuilder('yii\\log\\Target')
-                ->setMethods(['collect'])
-                ->getMockForAbstractClass();
-
-            $target2 = $this->getMockBuilder('yii\\log\\Target')
-                ->setMethods(['collect'])
-                ->getMockForAbstractClass();
+            $target1 = $this->createPartialMock(Target::class, ['collect', 'export']);
+            $target2 = $this->createPartialMock(Target::class, ['collect', 'export']);
 
             $target1->expects($this->exactly(2))
                 ->method('collect')

--- a/tests/framework/log/EmailTargetTest.php
+++ b/tests/framework/log/EmailTargetTest.php
@@ -8,6 +8,8 @@
 namespace yiiunit\framework\log;
 
 use yii\log\EmailTarget;
+use yii\mail\BaseMailer;
+use yii\mail\BaseMessage;
 use yiiunit\TestCase;
 
 /**
@@ -27,9 +29,7 @@ class EmailTargetTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->mailer = $this->getMockBuilder('yii\\mail\\BaseMailer')
-            ->setMethods(['compose'])
-            ->getMockForAbstractClass();
+        $this->mailer = $this->createPartialMock(BaseMailer::class, ['compose', 'sendMessage']);
     }
 
     /**
@@ -63,8 +63,8 @@ class EmailTargetTest extends TestCase
         $messages = [$message1, $message2];
         $textBody = wordwrap(implode("\n", [$message1[0], $message2[0]]), 70);
 
-        $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
-            ->setMethods(['setTextBody', 'send', 'setSubject'])
+        $message = $this->getMockBuilder(BaseMessage::class)
+            ->onlyMethods(['setTextBody', 'send', 'setSubject'])
             ->getMockForAbstractClass();
         $message->method('send')->willReturn(true);
 
@@ -75,7 +75,7 @@ class EmailTargetTest extends TestCase
         $message->expects($this->once())->method('setSubject')->with($this->equalTo('Hello world'));
 
         $mailTarget = $this->getMockBuilder('yii\\log\\EmailTarget')
-            ->setMethods(['formatMessage'])
+            ->onlyMethods(['formatMessage'])
             ->setConstructorArgs([
                 [
                     'mailer' => $this->mailer,
@@ -108,8 +108,8 @@ class EmailTargetTest extends TestCase
         $messages = [$message1, $message2];
         $textBody = wordwrap(implode("\n", [$message1[0], $message2[0]]), 70);
 
-        $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
-            ->setMethods(['setTextBody', 'send', 'setSubject'])
+        $message = $this->getMockBuilder(BaseMessage::class)
+            ->onlyMethods(['setTextBody', 'send', 'setSubject'])
             ->getMockForAbstractClass();
         $message->method('send')->willReturn(true);
 
@@ -119,8 +119,8 @@ class EmailTargetTest extends TestCase
         $message->expects($this->once())->method('send')->with($this->equalTo($this->mailer));
         $message->expects($this->once())->method('setSubject')->with($this->equalTo('Application Log'));
 
-        $mailTarget = $this->getMockBuilder('yii\\log\\EmailTarget')
-            ->setMethods(['formatMessage'])
+        $mailTarget = $this->getMockBuilder(EmailTarget::class)
+            ->onlyMethods(['formatMessage'])
             ->setConstructorArgs([
                 [
                     'mailer' => $this->mailer,
@@ -148,13 +148,13 @@ class EmailTargetTest extends TestCase
      */
     public function testExportWithSendFailure(): void
     {
-        $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
-            ->setMethods(['send'])
+        $message = $this->getMockBuilder(BaseMessage::class)
+            ->onlyMethods(['send'])
             ->getMockForAbstractClass();
         $message->method('send')->willReturn(false);
         $this->mailer->expects($this->once())->method('compose')->willReturn($message);
         $mailTarget = $this->getMockBuilder('yii\\log\\EmailTarget')
-            ->setMethods(['formatMessage'])
+            ->onlyMethods(['formatMessage'])
             ->setConstructorArgs([
                 [
                     'mailer' => $this->mailer,

--- a/tests/framework/log/LoggerTest.php
+++ b/tests/framework/log/LoggerTest.php
@@ -30,7 +30,7 @@ class LoggerTest extends TestCase
     {
         $this->logger = new Logger();
         $this->dispatcher = $this->getMockBuilder('yii\log\Dispatcher')
-            ->setMethods(['dispatch'])
+            ->onlyMethods(['dispatch'])
             ->getMock();
     }
 
@@ -85,10 +85,9 @@ class LoggerTest extends TestCase
      */
     public function testLogWithFlush(): void
     {
-        /* @var $logger Logger|\PHPUnit_Framework_MockObject_MockObject */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['flush'])
-            ->getMock();
+        /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $logger  */
+        $logger = $this->createPartialMock(Logger::class, ['flush']);
+
         $logger->flushInterval = 1;
         $logger->expects($this->exactly(1))->method('flush');
         $logger->log('test1', Logger::LEVEL_INFO);
@@ -149,10 +148,9 @@ class LoggerTest extends TestCase
             ['duration' => 30],
         ];
 
-        /* @var $logger Logger|\PHPUnit_Framework_MockObject_MockObject */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['getProfiling'])
-            ->getMock();
+        /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $logger  */
+        $logger = $this->createPartialMock(Logger::class, ['getProfiling']);
+
         $logger->method('getProfiling')->willReturn($timings);
         $logger->expects($this->once())
             ->method('getProfiling')
@@ -343,10 +341,9 @@ class LoggerTest extends TestCase
     {
         $messages = ['anyData'];
         $returnValue = 'return value';
+
         /* @var $logger Logger|\PHPUnit_Framework_MockObject_MockObject */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
         $logger->method('calculateTimings')->willReturn($returnValue);
@@ -371,9 +368,7 @@ class LoggerTest extends TestCase
             ],
         ];
         /* @var $logger Logger|\PHPUnit_Framework_MockObject_MockObject */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
         $logger->method('calculateTimings')->willReturn($returnValue);
@@ -411,9 +406,7 @@ class LoggerTest extends TestCase
          * Matched by category name
          */
         /* @var $logger Logger|\PHPUnit_Framework_MockObject_MockObject */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
         $logger->method('calculateTimings')->willReturn($returnValue);
@@ -424,9 +417,7 @@ class LoggerTest extends TestCase
          * Matched by prefix
          */
         /* @var $logger Logger|\PHPUnit_Framework_MockObject_MockObject */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
         $logger->method('calculateTimings')->willReturn($returnValue);
@@ -473,9 +464,7 @@ class LoggerTest extends TestCase
          * Exclude by category name
          */
         /* @var $logger Logger|\PHPUnit_Framework_MockObject_MockObject */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
         $logger->method('calculateTimings')->willReturn($returnValue);
@@ -486,9 +475,7 @@ class LoggerTest extends TestCase
          * Exclude by category prefix
          */
         /* @var $logger Logger|\PHPUnit_Framework_MockObject_MockObject */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
         $logger->method('calculateTimings')->willReturn($returnValue);

--- a/tests/framework/log/SyslogTargetTest.php
+++ b/tests/framework/log/SyslogTargetTest.php
@@ -25,9 +25,10 @@ namespace yii\log {
 
 namespace yiiunit\framework\log {
 
-    use PHPUnit_Framework_MockObject_MockObject;
+    use PHPUnit\Framework\MockObject\MockObject;
     use yii\helpers\VarDumper;
     use yii\log\Logger;
+    use yii\log\SyslogTarget;
     use yiiunit\TestCase;
 
     /**
@@ -45,7 +46,7 @@ namespace yiiunit\framework\log {
         public static $functions = [];
 
         /**
-         * @var PHPUnit_Framework_MockObject_MockObject
+         * @var MockObject
          */
         protected $syslogTarget;
 
@@ -54,9 +55,7 @@ namespace yiiunit\framework\log {
          */
         protected function setUp(): void
         {
-            $this->syslogTarget = $this->getMockBuilder('yii\\log\\SyslogTarget')
-                ->setMethods(['getMessagePrefix'])
-                ->getMock();
+            $this->syslogTarget = $this->createPartialMock(SyslogTarget::class, ['getMessagePrefix']);
         }
 
         /**
@@ -76,8 +75,10 @@ namespace yiiunit\framework\log {
                 ['profile begin message', Logger::LEVEL_PROFILE_BEGIN],
                 ['profile end message', Logger::LEVEL_PROFILE_END],
             ];
-            $syslogTarget = $this->getMockBuilder('yii\\log\\SyslogTarget')
-                ->setMethods(['openlog', 'syslog', 'formatMessage', 'closelog'])
+
+            $syslogTarget = $this->getMockBuilder(SyslogTarget::class)
+                ->addMethods(['openlog', 'syslog', 'closelog'])
+                ->onlyMethods(['formatMessage'])
                 ->getMock();
 
             $syslogTarget->identity = $identity;
@@ -152,9 +153,11 @@ namespace yiiunit\framework\log {
          */
         public function testFailedExport(): void
         {
-            $syslogTarget = $this->getMockBuilder('yii\\log\\SyslogTarget')
-                ->setMethods(['openlog', 'syslog', 'formatMessage', 'closelog'])
+            $syslogTarget = $this->getMockBuilder(SyslogTarget::class)
+                ->addMethods(['openlog', 'syslog', 'closelog'])
+                ->onlyMethods(['formatMessage'])
                 ->getMock();
+
             $syslogTarget->method('syslog')->willReturn(false);
 
             $syslogTarget->identity = 'identity string';

--- a/tests/framework/log/TargetTest.php
+++ b/tests/framework/log/TargetTest.php
@@ -7,6 +7,7 @@
 
 namespace yiiunit\framework\log;
 
+use yii\base\InvalidConfigException;
 use yii\log\Dispatcher;
 use yii\log\Logger;
 use yii\log\Target;
@@ -149,7 +150,7 @@ class TargetTest extends TestCase
         $target->setLevels(['trace']);
         $this->assertEquals(Logger::LEVEL_TRACE, $target->getLevels());
 
-        $this->expectException('yii\\base\\InvalidConfigException');
+        $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Unrecognized level: unknown level');
         $target->setLevels(['info', 'unknown level']);
     }
@@ -168,7 +169,7 @@ class TargetTest extends TestCase
         $target->setLevels(Logger::LEVEL_TRACE);
         $this->assertEquals(Logger::LEVEL_TRACE, $target->getLevels());
 
-        $this->expectException('yii\\base\\InvalidConfigException');
+        $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Incorrect 128 value');
         $target->setLevels(128);
     }
@@ -235,9 +236,8 @@ class TargetTest extends TestCase
 
     public function testBreakProfilingWithFlushWithProfilingDisabled(): void
     {
-        $dispatcher = $this->getMockBuilder('yii\log\Dispatcher')
-            ->setMethods(['dispatch'])
-            ->getMock();
+        $dispatcher = $this->createPartialMock(Dispatcher::class, ['dispatch']);
+
         $dispatcher->expects($this->once())->method('dispatch')->with($this->callback(fn($messages) => count($messages) === 2
             && $messages[0][0] === 'token.a'
             && $messages[0][1] == Logger::LEVEL_PROFILE_BEGIN
@@ -255,9 +255,8 @@ class TargetTest extends TestCase
 
     public function testNotBreakProfilingWithFlushWithProfilingEnabled(): void
     {
-        $dispatcher = $this->getMockBuilder('yii\log\Dispatcher')
-            ->setMethods(['dispatch'])
-            ->getMock();
+        $dispatcher = $this->createPartialMock(Dispatcher::class, ['dispatch']);
+
         $dispatcher->expects($this->exactly(2))->method('dispatch')->withConsecutive(
             [
                 $this->callback(fn($messages) => count($messages) === 1 && $messages[0][0] === 'info'),
@@ -286,9 +285,8 @@ class TargetTest extends TestCase
 
     public function testFlushingWithProfilingEnabledAndOverflow(): void
     {
-        $dispatcher = $this->getMockBuilder('yii\log\Dispatcher')
-            ->setMethods(['dispatch'])
-            ->getMock();
+        $dispatcher = $this->createPartialMock(Dispatcher::class, ['dispatch']);
+
         $dispatcher->expects($this->exactly(3))->method('dispatch')->withConsecutive(
             [
                 $this->callback(fn($messages) => count($messages) === 2

--- a/tests/framework/mail/BaseMailerTest.php
+++ b/tests/framework/mail/BaseMailerTest.php
@@ -295,9 +295,8 @@ TEXT
     {
         $message = new Message();
 
-        $mailerMock = $this->getMockBuilder('yiiunit\framework\mail\Mailer')
-            ->setMethods(['beforeSend', 'afterSend'])
-            ->getMock();
+        $mailerMock = $this->createPartialMock(Mailer::class, ['beforeSend', 'afterSend']);
+
         $mailerMock->expects($this->once())->method('beforeSend')->with($message)->will($this->returnValue(true));
         $mailerMock->expects($this->once())->method('afterSend')->with($message, true);
         $mailerMock->send($message);

--- a/tests/framework/web/UrlManagerParseUrlTest.php
+++ b/tests/framework/web/UrlManagerParseUrlTest.php
@@ -416,9 +416,7 @@ class UrlManagerParseUrlTest extends TestCase
 
     public function testRulesCacheIsUsed(): void
     {
-        $arrayCache = $this->getMockBuilder('yii\caching\ArrayCache')
-            ->setMethods(['get', 'set'])
-            ->getMock();
+        $arrayCache = $this->createPartialMock(ArrayCache::class, ['get', 'set']);
 
         $manager = $this->getUrlManager([
             'rules' => ['post/<id:\d+>' => 'post/view'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
