### PR TITLE
Add Missing Tests for convertExceptionToString and convertExceptionToArray methods

### DIFF
--- a/tests/framework/web/ErrorHandlerTest.php
+++ b/tests/framework/web/ErrorHandlerTest.php
@@ -42,6 +42,49 @@ Message: This message is displayed to end user
 Exception: yii\web\NotFoundHttpException', $out);
     }
 
+    public function testFormatRaw()
+    {
+        Yii::$app->response->format = yii\web\Response::FORMAT_RAW;
+
+        /** @var ErrorHandler $handler */
+        $handler = Yii::$app->getErrorHandler();
+
+        ob_start(); // suppress response output
+        $this->invokeMethod($handler, 'renderException', [new \Exception('Test Exception')]);
+        $out = ob_get_clean();
+
+        $this->assertcontains('Test Exception', $out);
+
+        $this->assertTrue(is_string(Yii::$app->response->data));
+        $this->assertcontains("Exception 'Exception' with message 'Test Exception'", Yii::$app->response->data);
+    }
+
+    public function testFormatXml()
+    {
+        Yii::$app->response->format = yii\web\Response::FORMAT_XML;
+
+        /** @var ErrorHandler $handler */
+        $handler = Yii::$app->getErrorHandler();
+
+        ob_start(); // suppress response output
+        $this->invokeMethod($handler, 'renderException', [new \Exception('Test Exception')]);
+        $out = ob_get_clean();
+
+        $this->assertcontains('Test Exception', $out);
+
+        $outArray = Yii::$app->response->data;
+
+        $this->assertTrue(is_array(Yii::$app->response->data));
+
+        $this->assertEquals('Exception', $outArray['name']);
+        $this->assertEquals('Test Exception', $outArray['message']);
+        $this->assertArrayHasKey('code', $outArray);
+        $this->assertEquals('Exception', $outArray['type']);
+        $this->assertContains('ErrorHandlerTest.php', $outArray['file']);
+        $this->assertArrayHasKey('stack-trace', $outArray);
+        $this->assertArrayHasKey('line', $outArray);
+    }
+
     public function testClearAssetFilesInErrorView()
     {
         Yii::$app->getView()->registerJsFile('somefile.js');


### PR DESCRIPTION
Fill the testing gaps for the convertExceptionToString and convertExceptionToArray methods in the ErrorHandler class to enhance code coverage.