### PR TITLE
Add tests for uncovered lines in DbDependency

### DIFF
--- a/tests/framework/caching/DbDependencyTest.php
+++ b/tests/framework/caching/DbDependencyTest.php
@@ -21,7 +21,6 @@ class DbDependencyTest extends DatabaseTestCase
      */
     protected $driverName = 'sqlite';
 
-
     /**
      * {@inheritdoc}
      */
@@ -39,10 +38,13 @@ class DbDependencyTest extends DatabaseTestCase
         $db->createCommand()->insert('dependency_item', ['value' => 'initial'])->execute();
     }
 
-    public function testIsChanged()
+    public function testQueryOneIsExecutedWhenQueryCacheEnabled()
     {
         $db = $this->getConnection(false);
         $cache = new ArrayCache();
+
+        // Enable the query cache
+        $db->enableQueryCache = true;
 
         $dependency = new DbDependency();
         $dependency->db = $db;
@@ -55,5 +57,40 @@ class DbDependencyTest extends DatabaseTestCase
         $db->createCommand()->insert('dependency_item', ['value' => 'new'])->execute();
 
         $this->assertTrue($dependency->isChanged($cache));
+    }
+
+    public function testQueryOneIsExecutedWhenQueryCacheDisabled()
+    {
+        $db = $this->getConnection(false);
+        $cache = new ArrayCache();
+
+        // Disable the query cache
+        $db->enableQueryCache = false;
+
+        $dependency = new DbDependency();
+        $dependency->db = $db;
+        $dependency->sql = 'SELECT [[id]] FROM {{dependency_item}} ORDER BY [[id]] DESC LIMIT 1';
+        $dependency->reusable = false;
+
+        $dependency->evaluateDependency($cache);
+        $this->assertFalse($dependency->isChanged($cache));
+
+        $db->createCommand()->insert('dependency_item', ['value' => 'new'])->execute();
+
+        $this->assertTrue($dependency->isChanged($cache));
+    }
+
+    public function testMissingSqlThrowsException()
+    {
+        $this->expectException('\yii\base\InvalidConfigException');
+
+        $db = $this->getConnection(false);
+        $cache = new ArrayCache();
+
+        $dependency = new DbDependency();
+        $dependency->db = $db;
+        $dependency->sql = null;
+
+        $dependency->evaluateDependency($cache);
     }
 }


### PR DESCRIPTION
Add additional test cases to cover lines in the `DbDependency` class that were previously not tested.