### PR TITLE
Refine Persian Coding Standards Documentation in core-code-style File

### DIFF
--- a/docs/internals-fa/core-code-style.md
+++ b/docs/internals-fa/core-code-style.md
@@ -1,49 +1,52 @@
 رعایت اصول و سبک کدنویسی فریمورک Yii2
 ===============================
-<p dir='rtl' align='right'>
-سبک کدنویسی که در نسخه 2 فریمورک و extension های رسمی استفاده میشه دارای اصول، قواعد و قانون های خودش هست. پس اگر تصمیم دارید چیزی به هسته اضافه کنید باید این قواعد رو در نظر بگیرید حتی در غیر این صورت هم رعایت این موارد خالی از لطف نیست و توصیه میکنم این کارُ انجام بدین. در حالی که میتونید راحت باشید، شما مجبور به رعایت این سبک در application خودتون نیستید...
+<p dir='rtl'>
+سبک کدنویسی که در نسخه 2 فریمورک و extension های رسمی استفاده میشه دارای اصول، قواعد و قانون های خودش هست. پس اگر تصمیم دارید چیزی به هسته اضافه کنید باید این قواعد رو در نظر بگیرید حتی در غیر این صورت هم رعایت این موارد خالی از لطف نیست و توصیه می‌کنم این کارو انجام بدین.
+
+البته که نیاز نیست حتما این موارد رو در برنامه‌های خودتون رعایت کنید و می تونید در این مورد راحت باشید...
 </p>
-<p dir='rtl' align='right'>
-میتونید برای دریافت پیکره بندی CodeSniffer اینجا رو مطالعه کنید: https://github.com/yiisoft/yii2-coding-standards
+<p dir='rtl'>
+می‌تونید برای دریافت پیکربندی CodeSniffer اینجا رو مطالعه کنید: https://github.com/yiisoft/yii2-coding-standards
 </p>
 
 ## 1. نگاه کلی
-<p dir='rtl' align='right'>
-به طور کلی ما از سبک PSR-2 استفاده میکنیم و هر چیزی که در این سبک وجود داره اینجا هم هست.
-(https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)</p>
+<p dir='rtl'>
+به طور کلی ما از سبک کدنویسی PSR-2 پیروی می‌کنیم:
 
-<p dir='rtl' align='right'> در فایل ها باید از برچسب های php?> و =?> استفاده شود.</p>
-<p dir='rtl' align='right'> در پایان هر فایل باید یک خط جدید(newline) داشته باشید.</p>
-<p dir='rtl' align='right'> encoding فایل برای کد های php باید UTF-8 without BOM باشد.</p>
-<p dir='rtl' align='right'>  به جای tab از 4 فضای خالی(space) استفاده کنید.</p>
-<p dir='rtl' align='right'> نام کلاس ها باید به صورت StudlyCaps تعریف شوند.</p>
-<p dir='rtl' align='right'> ثابت های داخل کلاس تماما باید با حروف بزرگ و گاهی با جداکننده "_" تعریف شوند.</p>
-<p dir='rtl' align='right'> نام متد ها و پراپرتی ها باید به صورت camelCase تعریف شوند.</p>
-<p dir='rtl' align='right'> پراپرتی های خصوصی(private) باید با "_" شروع شوند.</p>
-<p dir='rtl' align='right'> همیشه از elseif جای else if استفاده کنید.</p>
+https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md</p>
 
-## 2. فایل ها
+<p dir='rtl'> در فایل‌ها باید از برچسب‌های php?> و =?> استفاده شود.</p>
+<p dir='rtl'> در پایان هر فایل باید یک خط جدید (newline) داشته باشید.</p>
+<p dir='rtl'> encoding فایل برای کدهای php باید UTF-8 without BOM باشد.</p>
+<p dir='rtl'>  به جای tab از 4 فضای خالی (space) استفاده کنید.</p>
+<p dir='rtl'> نام کلاس‌ها باید به صورت StudlyCaps تعریف شوند.</p>
+<p dir='rtl'> ثابت‌های داخل کلاس تماما باید با حروف بزرگ و گاهی با جداکننده "_" تعریف شوند.</p>
+<p dir='rtl'> نام متدها و پراپرتی‌ها باید به صورت camelCase تعریف شوند.</p>
+<p dir='rtl'> پراپرتی‌های خصوصی (private) باید با "_" شروع شوند.</p>
+<p dir='rtl'> همیشه از elseif جای else if استفاده کنید.</p>
 
-<p dir='rtl' align='right'> در فایل ها باید از برچسب های php?> و =?> استفاده کرد نه از ?> .</p>
-<p dir='rtl' align='right'> در انتهای فایل های php نباید از تگ <? استفاده کنید.</p>
-<p dir='rtl' align='right'>  در انتهای هر خط نباید space وجود داشته باشد</p>
-<p dir='rtl' align='right'> پسوند فایل هایی که شامل کد php هستند باید php. باشد.</p>
-<p dir='rtl' align='right'> encoding فایل برای کد های php باید UTF-8 without BOM باشد.</p>
+## 2. فایل‌ها
+
+<p dir='rtl'> در فایل‌ها باید از برچسب های php?> و =?> استفاده کرد نه از ?> .</p>
+<p dir='rtl'> در انتهای فایل‌های php نباید از تگ ?> استفاده کنید.</p>
+<p dir='rtl'>  در انتهای هر خط نباید space وجود داشته باشد.</p>
+<p dir='rtl'> پسوند فایل‌هایی که شامل کد php هستند باید php. باشد.</p>
+<p dir='rtl'> encoding فایل برای کدهای php باید UTF-8 without BOM باشد.</p>
 
 
-## 3. نام کلاس ها
-<p dir='rtl' align='right'>
-نام کلاس ها باید به صورت StudlyCaps تعریف شوند. به عنوان مثال, `Controller`, `Model`.</p>
+## 3. نام کلاس‌ها
+<p dir='rtl'>
+نام کلاس‌ها باید به صورت StudlyCaps تعریف شوند. به عنوان مثال، `Controller` و `Model`.</p>
 
-## 4. کلاس ها
+## 4. کلاس‌ها
 
-<p dir='rtl' align='right'> نام کلاس ها باید به صورت CamelCase تعریف شوند.</p>
-<p dir='rtl' align='right'> آکولاد باز باید در خط بعدی، زیر نام کلاس نوشته شود.</p>
-<p dir='rtl' align='right'> تمام کلاس ها باید بلاک مستندات مطابق استاندارد PHPDoc داشته باشند.</p>
-<p dir='rtl' align='right'> برای تمام کد های داخل کلاس باید با 4 space فاصله ایجاد کنید.</p>
- <p dir='rtl' align='right'> فقط یک کلاس داخل هر فایل php باید موجود باشد.</p>
-<p dir='rtl' align='right'> تمام کلاس ها باید namespaced داشته باشند.</p>
-<p dir='rtl' align='right'> نام کلاس باید معال نام فایل و namespace باید مطابق مسیر آن باشد.</p>
+<p dir='rtl'> نام کلاس‌ها باید به صورت CamelCase تعریف شوند.</p>
+<p dir='rtl'> آکولاد باز باید در خط بعدی، زیر نام کلاس نوشته شود.</p>
+<p dir='rtl'> تمام کلاس‌ها باید بلاک مستندات مطابق استاندارد PHPDoc داشته باشند.</p>
+<p dir='rtl'> برای تمام کدهای داخل کلاس باید با 4 space فاصله ایجاد کنید.</p>
+ <p dir='rtl'> فقط یک کلاس داخل هر فایل php باید موجود باشد.</p>
+<p dir='rtl'> تمام کلاس‌ها باید namespaced داشته باشند.</p>
+<p dir='rtl'> نام کلاس باید معادل نام فایل و namespace باید مطابق مسیر آن باشد.</p>
 
 ```php
 /**
@@ -55,9 +58,9 @@ class MyClass extends \yii\base\BaseObject implements MyInterface
 }
 ```
 
-### 4.1. ثابت ها
-<p dir='rtl' align='right'>
-ثابت های داخل کلاس تماما باید با حروف بزرگ و گاهی با جداکننده "_" تعریف شوند.<p>
+### 4.1. ثابت‌ها
+<p dir='rtl'>
+ثابت‌های داخل کلاس تماما باید با حروف بزرگ و گاهی با جداکننده "_" تعریف شوند.<p>
 
 ```php
 <?php
@@ -67,15 +70,15 @@ class Foo
     const DATE_APPROVED = '2012-06-01';
 }
 ```
-### 4.2. پراپرتی ها
+### 4.2. پراپرتی‌ها
 
-<p dir='rtl' align='right'> از کلید واژه های public، protected و private استفاده کنید.</p>
-<p dir='rtl' align='right'> پراپرتی های public و protected باید در بالای کلاس و قبل از متد ها تعریف شوند. private هم همینطور اما ممکن هست کاهی قبل از متدی که با آن مرتبط هست آورده شود.</p>
-<p dir='rtl' align='right'> ترتیب تعریف پراپرتی ها باید به صورت اول public، دوم protected و سپس private باشد! هیچ قانون سختی برای رعایت این مورد نیست...</p>
-<p dir='rtl' align='right'> برای خوانایی بهتر میتونید از خط خالی بین گروه های public، protected و private استفاده کنید.
-<p dir='rtl' align='right'> متغییر های private باید مثل varName_$ باشند.</p>
-<p dir='rtl' align='right'> اعضای عمومی داخل کلاس باید به صورت camelCase تعریف شوند.(حرف اول کوچک، با CamelCase فرق میکنه).</p>
-<p dir='rtl' align='right'> بهتره از نام هایی مثل i$ و j$ استفاده نکنید.</p>
+<p dir='rtl'> از کلید واژه های public ،protected و private استفاده کنید.</p>
+<p dir='rtl'> پراپرتی‌های public و protected باید در بالای کلاس و قبل از متدها تعریف شوند. private هم همینطور اما ممکن هست گاهی قبل از متدی که با آن مرتبط هست آورده شود.</p>
+<p dir='rtl'> ترتیب تعریف پراپرتی‌ها باید به صورت اول public، دوم protected و سپس private باشد! کار بسیار ساده‌ایست :)</p>
+<p dir='rtl'> برای خوانایی بهتر می‌تونید از خط خالی بین گروه‌های public، protected و private استفاده کنید.
+<p dir='rtl'> متغیر های private باید مثل varName_$ باشند.</p>
+<p dir='rtl'> اعضای عمومی داخل کلاس باید به صورت camelCase تعریف شوند. (حرف اول کوچک، با CamelCase فرق میکنه)</p>
+<p dir='rtl'> بهتره از نام‌هایی مثل i$ و j$ استفاده نکنید.</p>
 
 ```php
 <?php
@@ -96,12 +99,12 @@ class Foo
 }
 ```
 
-### 4.3. متد ها
+### 4.3. متدها
 
-<p dir='rtl' align='right'> توابع و متد ها باید camelCase باشند.</p>
-<p dir='rtl' align='right'> نام باید هدف رو نشون بده.</p>
-<p dir='rtl' align='right'> از کلید واژه های public، protected و private استفاده کنید.</p>
-<p dir='rtl' align='right'> آکولاد باز باید در خط بعدی یعنی زیر نام متد قرار بگیره.</p>
+<p dir='rtl'> توابع و متدها باید camelCase باشند.</p>
+<p dir='rtl'> نام باید هدف رو نشون بده.</p>
+<p dir='rtl'> از کلید واژه های public، protected و private استفاده کنید.</p>
+<p dir='rtl'> آکولاد باز باید در خط بعدی یعنی زیر نام متد قرار بگیره.</p>
 
 ```php
 /**
@@ -120,14 +123,14 @@ class Foo
 }
 ```
 
-### 4.4 بلوک های PHPDoc
+### 4.4 بلوک‌های PHPDoc
 
-<p dir='rtl' align='right'> برای متد ها باید مستندات بنویسید(PHPDoc).</p>
-<p dir='rtl' align='right'> در PHPDoc نوع param@, var@, property@ و return@ باید مشخص شود(bool, int, string, array یا null).</p>
-<p dir='rtl' align='right'> برای تایپ آرایه در PHPDoc از []ClassName استفاده کنید.</p>
-<p dir='rtl' align='right'> خط اول PHPDoc باید هدف یک متد رو شرح بده.</p>
-<p dir='rtl' align='right'> اگر متد ها چیزی رو بررسی میکنن مثل isActive بخش PHPDoc رو باید با عبارت Checks whether شروع کنید.</p>
-<p dir='rtl' align='right'> return@ در PHPDoc  یاید دقیقا مشخص کنه چی بازگردانده میشود.</p>
+<p dir='rtl'> برای متدها باید مستندات بنویسید (PHPDoc).</p>
+<p dir='rtl'> در PHPDoc نوع param@ ،var@ ،property@ و return@ باید مشخص شود (bool, int, string, array یا null).</p>
+<p dir='rtl'> برای تایپ آرایه در PHPDoc از []ClassName استفاده کنید.</p>
+<p dir='rtl'> خط اول PHPDoc باید هدف یک متد رو شرح بده.</p>
+<p dir='rtl'> اگر متدها چیزی رو بررسی میکنن مثل isActive بخش PHPDoc رو باید با عبارت Checks whether شروع کنید.</p>
+<p dir='rtl'> return@ در PHPDoc  یاید دقیقا مشخص کنه چی بازگردانده میشه.</p>
 
 ```php
 /**
@@ -146,14 +149,14 @@ class Foo
 
 ### 4.5 Constructors
 
-<p dir='rtl' align='right'> `__construct` باید به جای استایل PHP 4 constructors استفاده شود.</p>
+<p dir='rtl'> `__construct` باید به جای استایل PHP 4 constructors استفاده شود.</p>
 
 ## 5 PHP
 
-### 5.1 نوع ها
+### 5.1 نوع‌ها
 
-<p dir='rtl' align='right'> تمام انواع و مقادیر باید با حروف کوچک نوشته شوند مثل true, false, null و array.</p>
-<p dir='rtl' align='right'> تغییر نوع یک متغییر خیلی بده، به این مثال توجه کنید:</p>
+<p dir='rtl'> تمام انواع و مقادیر باید با حروف کوچک نوشته شوند مثل true ،false ،null و array.</p>
+<p dir='rtl'> تغییر نوع یک متغیر خیلی بده، به این مثال توجه کنید:</p>
 
 
 ```php
@@ -164,22 +167,22 @@ public function save(Transaction $transaction, $argument2 = 100)
 }
 ```
 
-### 5.2 رشته ها
+### 5.2 رشته‌ها
 
-<p dir='rtl' align='right'> اگر رشته ی شما شامل متغییر های دیگه این نیست از تک کوتیشن جای دابل کوتیشن استفاده کنید.</p>
+<p dir='rtl'> اگر رشته‌ی شما شامل متغیرهای دیگه‌ای نیست از تک‌کوتیشن جای دابل‌کوتیشن استفاده کنید.</p>
 
 ```php
 $str = 'Like this.';
 ```
 
-<p dir='rtl' align='right'> دو روش زیر مناسب برای جایگزینی هستند:</p>
+<p dir='rtl'> دو روش زیر مناسب برای جایگزینی هستند:</p>
 
 ```php
 $str1 = "Hello $username!";
 $str2 = "Hello {$username}!";
 ```
-<p dir='rtl' align='right'>
-حالت زی مجاز نیست:</p>
+<p dir='rtl'>
+حالت زیر مجاز نیست:</p>
 
 ```php
 $str3 = "Hello ${username}!";
@@ -187,13 +190,13 @@ $str3 = "Hello ${username}!";
 
 #### الحاق
 
-<p dir='rtl' align='right'> برای الحاق قبل و بعد کاراکتر dot فاصله بذارید</p>
+<p dir='rtl'> برای الحاق قبل و بعد کاراکتر dot فاصله بذارید:</p>
 
 ```php
 $name = 'Yii' . ' Framework';
 ```
 
-<p dir='rtl' align='right'> و اگر رشته ی شما بلند بود میتونید اینطور عمل کنید:</p>
+<p dir='rtl'> و اگر رشته ی شما بلند بود می‌تونید اینطور عمل کنید:</p>
 
 ```php
 $sql = "SELECT *"
@@ -201,11 +204,11 @@ $sql = "SELECT *"
     . "WHERE `id` = 121 ";
 ```
 
-### 5.3 آرایه ها
+### 5.3 آرایه‌ها
 
-<p dir='rtl' align='right'> برای تعریف آرایه ها از نحوه ی کوتاه اون یعنی [] استفاده کنید.</p>
-<p dir='rtl' align='right'> از ایندکس منفی در آرایه ها استفاده نکنید.</p>
-<p dir='rtl' align='right'> روش های زیر قابل قبول و مناسب هستند:</p>
+<p dir='rtl'> برای تعریف آرایه‌ها از ساختار کوتاه اون یعنی [] استفاده کنید.</p>
+<p dir='rtl'> از ایندکس منفی در آرایه‌ها استفاده نکنید.</p>
+<p dir='rtl'> روش‌های زیر قابل قبول و مناسب هستند:</p>
 
 ```php
 $arr = [3, 14, 15, 'Yii', 'Framework'];
@@ -228,10 +231,10 @@ $config = [
 
 ### 5.4 دستورات کنترلی
 
-<p dir='rtl' align='right'> در دستورات کنترلی قبل و بعد پرانتز space بذارید.</p>
-<p dir='rtl' align='right'> آکولاد باز در همان خط دستور قرار میگیرد.</p>
-<p dir='rtl' align='right'> آکولاد بسته در خط جدید.</p>
-<p dir='rtl' align='right'> برای دستورات یک خطی همیشه از پرانتز استفاده کنید.</p>
+<p dir='rtl'> در دستورات کنترلی قبل و بعد پرانتز space بذارید.</p>
+<p dir='rtl'> آکولاد باز در همان خط دستور قرار میگیرد.</p>
+<p dir='rtl'> آکولاد بسته در خط جدید.</p>
+<p dir='rtl'> برای دستورات یک خطی همیشه از پرانتز استفاده کنید.</p>
 
 ```php
 if ($event === null) {
@@ -248,7 +251,7 @@ if (!$model && null === $event)
     throw new Exception('test');
 ```
 
-<p dir='rtl' align='right'>بعد از return از else استفاده نکنید</p>
+<p dir='rtl'>بعد از return از else استفاده نکنید:</p>
 
 ```php
 $result = $this->getResult();
@@ -258,7 +261,7 @@ if (empty($result)) {
     // process result
 }
 ```
-<p dir='rtl' align='right'>اینطوری بهتره</p>
+<p dir='rtl'>اینطوری بهتره:</p>
 
 
 ```php
@@ -272,8 +275,8 @@ if (empty($result)) {
 
 #### switch
 
-<p dir='rtl' align='right'> از فرمت زیر برای switch استفاده کنید
-</p>
+<p dir='rtl'> از فرمت زیر برای switch استفاده کنید:</p>
+
 ```php
 switch ($this->phpType) {
     case 'string':
@@ -291,9 +294,9 @@ switch ($this->phpType) {
 }
 ```
 
-### 5.5 function calls
+### 5.5 صدا زدن فانکشن‌ها
 
-<p dir='rtl' align='right'>روش مناسب صدا زدن توابع همراه با پارامتر ها هم اینطور صحیحه</p>
+<p dir='rtl'>روش مناسب صدا زدن فانکشن‌ها همراه با پارامتر هم به این صورته:</p>
 
 ```php
 doIt(2, 3);
@@ -308,7 +311,7 @@ doIt('a', [
 
 ### 5.6  تعریف Anonymous functions (lambda)
 
-<p dir='rtl' align='right'> در توابع بی نام بین function/use فضای خالی(space) بذارید.</p>
+<p dir='rtl'> در توابع بی نام بین function/use فضای خالی (space) بذارید:</p>
 
 ```php
 // good
@@ -328,14 +331,14 @@ $mul = array_reduce($numbers, function($r, $x) use($n) {
 });
 ```
 
-مستند نویسی 
+مستند نویسی
 -------------
 
-<p dir='rtl' align='right'> [phpDoc](https://phpdoc.org/) رو بخونید و موارد اونُ رعایت کنید.</p>
-<p dir='rtl' align='right'> کد بدون مستندات مجاز نیست.</p>
-<p dir='rtl' align='right'> تمام کلاس ها باید شامل بلاک مستندات در ابتدای فایل باشند.</p>
-<p dir='rtl' align='right'> نیازی به نوشتن return@ ندارید اگر متد شما اگر چیزی را برنمیگرداند.</p>
-<p dir='rtl' align='right'> به مثال های زیر توجه کنید:</p>
+<p dir='rtl'> https://phpdoc.org رو بخونید و موارد اون رو رعایت کنید.</p>
+<p dir='rtl'> کد بدون مستندات مجاز نیست.</p>
+<p dir='rtl'> تمام کلاس‌ها باید شامل بلاک مستندات در ابتدای فایل باشند.</p>
+<p dir='rtl'> نیازی به نوشتن return@ ندارید اگر متد شما چیزی برنمی‌گرداند.</p>
+<p dir='rtl'> به مثال‌های زیر توجه کنید:</p>
 
   ```php
     <?php
@@ -386,43 +389,42 @@ class Component extends \yii\base\BaseObject
  * For example,
  *
  * ```
- * $component->getEventHandlers($eventName)->insertAt(0, $eventHandler);
- * ```
- *
- * @param string $name the event name
- * @return Vector list of attached event handlers for the event
- * @throws Exception if the event is not defined
- */
-public function getEventHandlers($name)
-{
-    if (!isset($this->_e[$name])) {
-        $this->_e[$name] = new Vector;
-    }
-    $this->ensureBehaviors();
-    return $this->_e[$name];
-}
+* $component->getEventHandlers($eventName)->insertAt(0, $eventHandler);
+* ```
+*
+* @param string $name the event name
+* @return Vector list of attached event handlers for the event
+* @throws Exception if the event is not defined
+  */
+  public function getEventHandlers($name)
+  {
+  if (!isset($this->_e[$name])) {
+  $this->_e[$name] = new Vector;
+  }
+  $this->ensureBehaviors();
+  return $this->_e[$name];
+  }
 ```
 
 #### نظرات
 
-<p dir='rtl' align='right'> از // برای کامنت گذاری استفاده کنید نه از #.</p>
-<p dir='rtl' align='right'> در خطوطی که کامنت گذاشتین نباید کد بنویسید، یعنی اون خط برای اون کامنت باید باشه.</p>
+<p dir='rtl'> از // برای کامنت گذاری استفاده کنید نه از #.</p>
+<p dir='rtl'> در خطوطی که کامنت گذاشتین نباید کد بنویسید، یعنی اون خط برای اون کامنت باید باشه.</p>
 
 قوانین بیشتر
 ----------------
 
-<p dir='rtl' align='right'> تا جایی که میتونید از تابع empty به جای === استفاده کنید.</p>
-<p dir='rtl' align='right'> اگر شرایط تو در تویی در کد شما وجود نداره return زود هنگام یا ساده تر بگم return وسط متد مشکلی نخواهد داشت.</p>
-<p dir='rtl' align='right'> همیشه از static جای self به جز موارد زیر استفاده کنید:</p>
-<p dir='rtl' align='right'>1) دسترسی به ثابت ها باید با self انجام بشه.</p>
-<p dir='rtl' align='right'>2) دسترسی به پراپرتی های خصوصی باید با self انجام بشه.</p>
-<p dir='rtl' align='right'>3) مجاز به استفاده از self برای صدا زدن توابع در مواقعی مثل فراخوانی بازگشتی هستید.</p>
+<p dir='rtl'> تا جایی که می‌تونید از تابع empty به جای === استفاده کنید.</p>
+<p dir='rtl'> اگر شرایط تو در تویی در کد شما وجود نداره return زود هنگام یا ساده تر بگم return وسط متد مشکلی نخواهد داشت.</p>
+<p dir='rtl'> همیشه از static جای self به جز موارد زیر استفاده کنید:</p>
+<p dir='rtl'>1) دسترسی به ثابت‌ها باید با self انجام بشه.</p>
+<p dir='rtl'>2) دسترسی به پراپرتی‌های خصوصی باید با self انجام بشه.</p>
+<p dir='rtl'>3) مجاز به استفاده از self برای صدا زدن توابع در مواقعی مثل فراخوانی بازگشتی هستید.</p>
 
 
-namespace ها
+نیم‌اسپیس‌ها
 ----------------
-<p dir='rtl' align='right'> از حرف کوچک استفاده کنید.</p>
-<p dir='rtl' align='right'> از فرم جمع اسم ها برای نشان دادن یک شی استفاده کنید مثل validators.</p>
-<p dir='rtl' align='right'> از فرم منفرد اسم ها برای قابلیت ها و امکانات استفاده کنید مثل web.</p>
-<p dir='rtl' align='right'> بهتره فضای نام تک کلمه ای باشه در غیر این صورت از camelCase استفاده کنید.</p>
-
+<p dir='rtl'> از حرف کوچک استفاده کنید.</p>
+<p dir='rtl'> از فرم جمع اسم‌ها برای نشان دادن یک شی استفاده کنید مثل validators.</p>
+<p dir='rtl'> از فرم مفرد اسم‌ها برای قابلیت‌ها و امکانات استفاده کنید مثل web.</p>
+<p dir='rtl'> بهتره فضای نام تک‌کلمه‌ای باشه در غیر این صورت از camelCase استفاده کنید.</p>


### PR DESCRIPTION
Fix various linguistic and stylistic issues in the Persian `core-code-style` documentation, ensuring a clearer and more comprehensible guideline. 

- typo errors
- punctuations
- semantic clarifications
- remove extra `align='right'`
- ...