### PR TITLE
Optimize findBetween method (remove calling function mb_substr())

### DIFF
--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -546,14 +546,13 @@ class BaseStringHelper
             return null;
         }
 
-        // Cut the string from the start position
-        $subString = mb_substr($string, $startPos + mb_strlen($start));
-        $endPos = mb_strrpos($subString, $end);
+        $startPos += mb_strlen($start);
+        $endPos = mb_strrpos($string, $end, $startPos);
 
         if ($endPos === false) {
             return null;
         }
 
-        return mb_substr($subString, 0, $endPos);
+        return mb_substr($string, $startPos, $endPos - $startPos);
     }
 }


### PR DESCRIPTION
Utilising `mb_strrpos` with an offset instead of calling the `mb_substr()` Call.