### PR TITLE
Get rid of deprecation warnings for trim() [PHP8.3]

### DIFF
--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -413,7 +413,7 @@ class UrlManager extends Component
         $anchor = isset($params['#']) ? '#' . $params['#'] : '';
         unset($params['#'], $params[$this->routeParam]);
 
-        $route = trim($params[0], '/');
+        $route = trim(isset($params[0]) ? $params[0] : '', '/');
         unset($params[0]);
 
         $baseUrl = $this->showScriptName || !$this->enablePrettyUrl ? $this->getScriptUrl() : $this->getBaseUrl();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | [Issue:Fix tests for 8.3](https://github.com/yiisoft/yii2-authclient/issues/380), [PR:Fix warnings](https://github.com/yiisoft/yii2-authclient/pull/383)
