### PR TITLE
Update BaseStringHelper.php

### DIFF
--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -330,7 +330,11 @@ class BaseStringHelper
      */
     public static function countWords($string)
     {
-        return count(preg_split('/\s+/u', $string, 0, PREG_SPLIT_NO_EMPTY));
+        $keywords = preg_split('/\s+/u', $string, 0, PREG_SPLIT_NO_EMPTY);
+        if ($keywords !== false) {
+            return count($keywords);
+        }
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Exception 'TypeError' with message 'count(): Argument #1 ($value) must be of type Countable|array, bool given'

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
