### PR TITLE
Fix error summary always visible with CSP header (#19691)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #17181: Improved `BaseUrl::isRelative($url)` performance (sammousa, bizley, rob006)
 - Bug #17191: Fixed `BaseUrl::isRelative($url)` method in `yii\helpers\BaseUrl` (ggh2e3)
 - Bug #18469: Fixed `Link::serialize(array $links)` method in `yii\web\Link` (ggh2e3)
+- Bug #19691: Fix error summary always visible with CSP header (skepticspriggan)
 - Bug #20040: Fix type `boolean` in `MSSQL` (terabytesoftw)
 - Bug #20005: Fix `yii\console\controllers\ServeController` to specify the router script (terabytesoftw)
 - Bug #19060: Fix `yii\widgets\Menu` bug when using Closure for active item and adding additional tests in `tests\framework\widgets\MenuTest` (atrandafir)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,7 +7,7 @@ Yii Framework 2 Change Log
 - Bug #17181: Improved `BaseUrl::isRelative($url)` performance (sammousa, bizley, rob006)
 - Bug #17191: Fixed `BaseUrl::isRelative($url)` method in `yii\helpers\BaseUrl` (ggh2e3)
 - Bug #18469: Fixed `Link::serialize(array $links)` method in `yii\web\Link` (ggh2e3)
-- Bug #19691: Fix error summary always visible with CSP header (skepticspriggan)
+- Bug #19691: Allow using custom class to style error summary (skepticspriggan)
 - Bug #20040: Fix type `boolean` in `MSSQL` (terabytesoftw)
 - Bug #20005: Fix `yii\console\controllers\ServeController` to specify the router script (terabytesoftw)
 - Bug #19060: Fix `yii\widgets\Menu` bug when using Closure for active item and adding additional tests in `tests\framework\widgets\MenuTest` (atrandafir)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1260,6 +1260,7 @@ class BaseHtml
      * - showAllErrors: boolean, if set to true every error message for each attribute will be shown otherwise
      *   only the first error message for each attribute will be shown. Defaults to `false`.
      *   Option is available since 2.0.10.
+     * - emptyClass: string, the class name that is added to an empty summary.
      *
      * The rest of the options will be rendered as the attributes of the container tag.
      *
@@ -1271,12 +1272,17 @@ class BaseHtml
         $footer = ArrayHelper::remove($options, 'footer', '');
         $encode = ArrayHelper::remove($options, 'encode', true);
         $showAllErrors = ArrayHelper::remove($options, 'showAllErrors', false);
+        $emptyClass = ArrayHelper::remove($options, 'emptyClass', null);
         unset($options['header']);
         $lines = self::collectErrors($models, $encode, $showAllErrors);
         if (empty($lines)) {
             // still render the placeholder for client-side validation use
             $content = '<ul></ul>';
-            $options['style'] = isset($options['style']) ? rtrim($options['style'], ';') . '; display:none' : 'display:none';
+            if($emptyClass !== null) {
+                $options['class'] = $emptyClass;
+            } else {
+                $options['style'] = isset($options['style']) ? rtrim($options['style'], ';') . '; display:none' : 'display:none';
+            }
         } else {
             $content = '<ul><li>' . implode("</li>\n<li>", $lines) . '</li></ul>';
         }

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1278,7 +1278,7 @@ class BaseHtml
         if (empty($lines)) {
             // still render the placeholder for client-side validation use
             $content = '<ul></ul>';
-            if($emptyClass !== null) {
+            if ($emptyClass !== null) {
                 $options['class'] = $emptyClass;
             } else {
                 $options['style'] = isset($options['style']) ? rtrim($options['style'], ';') . '; display:none' : 'display:none';

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1672,6 +1672,11 @@ EOD;
                     $model->addError('name', 'Error message. Here are even more chars: ""');
                 },
             ],
+            [
+                'empty_class',
+                ['emptyClass' => 'd-none'],
+                '<div class="d-none"><p>Please fix the following errors:</p><ul></ul></div>',
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19691 

The issue is fixed by allowing the user to specify a HTML class for an empty error summary. The CSS style corresponding to the class can be set locally in the user's project.