### PR TITLE
Mark client-side scripts as safe to use for browsers (#20087)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -21,6 +21,7 @@ Yii Framework 2 Change Log
 - Enh #20032: Added `yii\helpers\BaseStringHelper::mask()` method for string masking with multibyte support (salehhashemi1992)
 - Enh #20034: Added `yii\helpers\BaseStringHelper::findBetween()` to retrieve a substring that lies between two strings (salehhashemi1992)
 - Bug #20083: Fix deprecated warning implicit conversion from float (skepticspriggan)
+- Enh #20087: Add custom attributes to script tags (skepticspriggan)
 - Enh #20121: Added `yiisoft/yii2-coding-standards` to composer `require-dev` and lint code to comply with PSR12 (razvanphp)
 - Enh #20134: Raise minimum `PHP` version to `7.3` (@terabytesoftw)
 - Bug #20141: Update `ezyang/htmlpurifier` dependency to version `4.17` (@terabytesoftw)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -220,6 +220,11 @@ class BaseHtml
      */
     public static function script($content, $options = [])
     {
+        $view = Yii::$app->getView();
+        if ($view instanceof \yii\web\View && !empty($view->scriptOptions)) {
+            $options = array_merge($view->scriptOptions, $options);
+        }
+
         return static::tag('script', $content, $options);
     }
 

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -132,6 +132,7 @@ class View extends \yii\base\View
      */
     public $jsFiles = [];
     /**
+     * @since 2.0.50
      * @var array the script tag options.
      */
     public $scriptOptions = [];

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -131,6 +131,10 @@ class View extends \yii\base\View
      * @see registerJsFile()
      */
     public $jsFiles = [];
+    /**
+     * @var array the script tag options.
+     */
+    public $scriptOptions = [];
 
     private $_assetManager;
 

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -90,6 +90,21 @@ class HtmlTest extends TestCase
         $this->assertEquals("<script type=\"text/js\">{$content}</script>", Html::script($content, ['type' => 'text/js']));
     }
 
+    public function testScriptCustomAttribute()
+    {
+        $nonce = Yii::$app->security->generateRandomString();
+        $this->mockApplication([
+            'components' => [
+                'view' => [
+                    'class' => 'yii\web\View',
+                    'scriptOptions' => ['nonce' => $nonce],
+                ],
+            ],
+        ]);
+        $content = 'a <>';
+        $this->assertEquals("<script nonce=\"{$nonce}\">{$content}</script>", Html::script($content));
+    }
+
     public function testCssFile()
     {
         $this->assertEquals('<link href="http://example.com" rel="stylesheet">', Html::cssFile('http://example.com'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #20087 

The important choices made and the reasons why are summarized below. I'm open to suggestions for improvements.

**What attribute should be added to the script tag?**

_Only the nonce_

- Nonce use-case is easy to find in the API docs
- Less flexible

_Custom attributes_

- Nonce use-case is easy to find if explained in the general docs
- More flexible

### Solution 1 -- Only the nonce

This section assumes only the nonce is added.

**Where should the nonce script attribute be added?**

_In the BaseHtml helper_

Set the nonce attribute in all script tags via `yii\helpers\BaseHtml::script()` when it exists. This is similar to how the hidden CSRF token input is added to all forms via `yii\helpers\BaseHtml::beginForm()`. 

Adding it at a low level ensures all script tags are whitelisted and makes it easier to maintain.

**How should the nonce be called?**

_From a function in the Response component_

```php
$nonce = Yii::$app->response->getCspNonce();
```

**Where should the nonce be set?**

_In the application configuration_

```php
'components' => [
    'response' => [
        'class' => 'yii\web\Response',
        'cspNonce' => $nonce,
    ],
],
```

### Solution 2 -- Custom attributes

Set custom script attributes centrally in web.php:

```php
'components' => [
    'view' => [
        'class' => 'yii\web\View',
        'scriptOptions' => ['nonce' => $nonce],
    ],
],
```

Updates required to make this work:

- Add the variable `jsOptions` to `yii\web\View`.
- Load the default options from `jsOptions` inside `yii\helpers\Html::script()`.