### PR TITLE
Correctly parse boolean keywords (e.g. used in SQLite) in `\yii\db\ColumnSchema::typecast()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Bug #13920: Fixed erroneous validation for specific cases (tim-fischer-maschinensucher)
 - Bug #19927: Fixed `console\controllers\MessageController` when saving translations to database: fixed FK error when adding new string and language at the same time, checking/regenerating all missing messages and dropping messages for unused languages (atrandafir)
 - Bug #20002: Fixed superfluous query on HEAD request in serializer (xicond)
+- Bug #20122: Fixed parsing of boolean keywords (e.g. used in SQLite) in `\yii\db\ColumnSchema::typecast()` (rhertogh)
 - Enh #12743: Added new methods `BaseActiveRecord::loadRelations()` and `BaseActiveRecord::loadRelationsFor()` to eager load related models for existing primary model instances (PowerGamer1)
 - Enh #20030: Improve performance of handling `ErrorHandler::$memoryReserveSize` (antonshevelev, rob006)
 - Enh #20042: Add empty array check to `ActiveQueryTrait::findWith()` (renkas)

--- a/framework/db/ColumnSchema.php
+++ b/framework/db/ColumnSchema.php
@@ -174,7 +174,7 @@ class ColumnSchema extends BaseObject
             case 'boolean':
                 // treating a 0 bit value as false too
                 // https://github.com/yiisoft/yii2/issues/9006
-                return (bool) $value && $value !== "\0";
+                return (bool) $value && $value !== "\0" && strtolower($value) !== 'false';
             case 'double':
                 return (float) $value;
         }

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -545,6 +545,39 @@ abstract class SchemaTest extends DatabaseTestCase
         $this->assertSame('', $columnSchema->dbTypecast(''));
     }
 
+    /**
+     * @dataProvider columnSchemaDbTypecastBooleanPhpTypeProvider
+     * @param mixed $value
+     * @param bool $expected
+     */
+    public function testColumnSchemaDbTypecastBooleanPhpType($value, $expected)
+    {
+        $columnSchema = new ColumnSchema(['phpType' => Schema::TYPE_BOOLEAN]);
+        $this->assertSame($expected, $columnSchema->dbTypecast($value));
+    }
+
+    public function columnSchemaDbTypecastBooleanPhpTypeProvider()
+    {
+        return [
+            [1, true],
+            [0, false],
+            ['1', true],
+            ['0', false],
+
+            // https://github.com/yiisoft/yii2/issues/9006
+            ["\1", true],
+            ["\0", false],
+
+            // https://github.com/yiisoft/yii2/pull/20122
+            ['TRUE', true],
+            ['FALSE', false],
+            ['true', true],
+            ['false', false],
+            ['True', true],
+            ['False', false],
+        ];
+    }
+
     public function testFindUniqueIndexes()
     {
         if ($this->driverName === 'sqlsrv') {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

SQLite uses keywords `TRUE` and `FALSE` for boolean values ([https://www.sqlite.org/datatype3.html](https://www.sqlite.org/datatype3.html#:~:text=2.1.%20Boolean%20Datatype)).

When creating a column with a default value of `false` this keyword is returned literally when getting the table definition. E.g.:
`\Yii::$app->db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_BOOLEAN)->defaultValue(false)`.

When this string is pared it always results in a `true` value (in PHP `var_dump((bool)'false');` results in `bool(true)`).
This PR fixes the boolean parsing by ensuring the value is not the (case insensitive) string 'false'.
