### PR TITLE
Update FilterValidator.php

### DIFF
--- a/framework/validators/FilterValidator.php
+++ b/framework/validators/FilterValidator.php
@@ -77,7 +77,7 @@ class FilterValidator extends Validator
     public function validateAttribute($model, $attribute)
     {
         $value = $model->$attribute;
-        if (!$this->skipOnArray || !is_array($value)) {
+        if ((!$this->skipOnArray || !is_array($value)) && $value !== null) {
             $model->$attribute = call_user_func($this->filter, $value);
         }
     }


### PR DESCRIPTION
PHP Deprecated Warning 'yii\base\ErrorException' with message 'trim(): Passing null to parameter #1 ($string) of type string is deprecated'

in /app/shop.box/vendor/yiisoft/yii2/validators/FilterValidator.php:81

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |
