### PR TITLE
Bower is deprecated since 2017, we should use npm instead

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -23,7 +23,7 @@ jobs:
         run: composer update $DEFAULT_COMPOSER_FLAGS
 
       - name: Install JQuery `3.6.*@stable` for tests.
-        run: composer require "bower-asset/jquery:3.6.*@stable"
+        run: composer require "npm-asset/jquery:3.6.*@stable"
 
       - name: Install node.js.
         uses: actions/setup-node@v1

--- a/composer.json
+++ b/composer.json
@@ -75,10 +75,10 @@
         "yiisoft/yii2-composer": "~2.0.4",
         "ezyang/htmlpurifier": "^4.6",
         "cebe/markdown": "~1.0.0 | ~1.1.0 | ~1.2.0",
-        "bower-asset/jquery": "3.7.*@stable | 3.6.*@stable | 3.5.*@stable | 3.4.*@stable | 3.3.*@stable | 3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
-        "bower-asset/inputmask": "^5.0.8 ",
-        "bower-asset/punycode": "^2.2",
-        "bower-asset/yii2-pjax": "~2.0.1"
+        "npm-asset/jquery": "3.7.*@stable | 3.6.*@stable | 3.5.*@stable | 3.4.*@stable | 3.3.*@stable | 3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
+        "npm-asset/inputmask": "^5.0.8 ",
+        "npm-asset/punycode": "^2.2",
+        "npm-asset/yii2-pjax": "~2.0.1"
     },
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "^0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,83 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7269257cc9e1f2b37d4e30c637bb226b",
+    "content-hash": "c1ab83d0eb50d7867b2af1a1966534ad",
     "packages": [
-        {
-            "name": "bower-asset/inputmask",
-            "version": "5.0.8",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:RobinHerbots/Inputmask.git",
-                "reference": "e0f39e0c93569c6b494c3a57edef2c59313a6b64"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/RobinHerbots/Inputmask/zipball/e0f39e0c93569c6b494c3a57edef2c59313a6b64",
-                "reference": "e0f39e0c93569c6b494c3a57edef2c59313a6b64"
-            },
-            "require": {
-                "bower-asset/jquery": ">=1.7"
-            },
-            "type": "bower-asset",
-            "license": [
-                "http://opensource.org/licenses/mit-license.php"
-            ]
-        },
-        {
-            "name": "bower-asset/jquery",
-            "version": "3.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jquery/jquery-dist.git",
-                "reference": "fde1f76e2799dd877c176abde0ec836553246991"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/jquery/jquery-dist/zipball/fde1f76e2799dd877c176abde0ec836553246991",
-                "reference": "fde1f76e2799dd877c176abde0ec836553246991"
-            },
-            "type": "bower-asset",
-            "license": [
-                "MIT"
-            ]
-        },
-        {
-            "name": "bower-asset/punycode",
-            "version": "v2.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mathiasbynens/punycode.js.git",
-                "reference": "9e1b2cda98d215d3a73fcbfe93c62e021f4ba768"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mathiasbynens/punycode.js/zipball/9e1b2cda98d215d3a73fcbfe93c62e021f4ba768",
-                "reference": "9e1b2cda98d215d3a73fcbfe93c62e021f4ba768"
-            },
-            "type": "bower-asset"
-        },
-        {
-            "name": "bower-asset/yii2-pjax",
-            "version": "2.0.8",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:yiisoft/jquery-pjax.git",
-                "reference": "a9298d57da63d14a950f1b94366a864bc62264fb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/jquery-pjax/zipball/a9298d57da63d14a950f1b94366a864bc62264fb",
-                "reference": "a9298d57da63d14a950f1b94366a864bc62264fb"
-            },
-            "require": {
-                "bower-asset/jquery": ">=1.8"
-            },
-            "type": "bower-asset",
-            "license": [
-                "MIT"
-            ]
-        },
         {
             "name": "cebe/markdown",
             "version": "1.2.1",
@@ -205,6 +130,51 @@
                 "source": "https://github.com/ezyang/htmlpurifier/tree/v4.17.0"
             },
             "time": "2023-11-17T15:01:25+00:00"
+        },
+        {
+            "name": "npm-asset/inputmask",
+            "version": "5.0.8",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.8.tgz"
+            },
+            "type": "npm-asset",
+            "license": [
+                "MIT"
+            ]
+        },
+        {
+            "name": "npm-asset/jquery",
+            "version": "3.7.1",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz"
+            },
+            "type": "npm-asset",
+            "license": [
+                "MIT"
+            ]
+        },
+        {
+            "name": "npm-asset/punycode",
+            "version": "2.3.1",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
+            },
+            "type": "npm-asset",
+            "license": [
+                "MIT"
+            ]
+        },
+        {
+            "name": "npm-asset/yii2-pjax",
+            "version": "2.0.8",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/yii2-pjax/-/yii2-pjax-2.0.8.tgz"
+            },
+            "type": "npm-asset"
         },
         {
             "name": "yiisoft/yii2-composer",
@@ -2353,7 +2323,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "bower-asset/jquery": 0
+        "npm-asset/jquery": 0
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Chg #19902: Remove support for CUBRID (mtangoo)
 - Chg #19891: Remove XCache and ZendDataCache support (mtangoo)
+- Enh #20135: Remove Bower dependency and use minified JS on production (razvanphp)
 
 
 2.0.50 under development

--- a/framework/composer.json
+++ b/framework/composer.json
@@ -70,11 +70,17 @@
         "yiisoft/yii2-composer": "~2.0.4",
         "ezyang/htmlpurifier": "^4.6",
         "cebe/markdown": "~1.0.0 | ~1.1.0 | ~1.2.0",
-        "bower-asset/jquery": "3.7.*@stable | 3.6.*@stable | 3.5.*@stable | 3.4.*@stable | 3.3.*@stable | 3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
-        "bower-asset/inputmask": "^5.0.8 ",
-        "bower-asset/punycode": "^2.2",
-        "bower-asset/yii2-pjax": "~2.0.1"
+        "npm-asset/jquery": "3.7.*@stable | 3.6.*@stable | 3.5.*@stable | 3.4.*@stable | 3.3.*@stable | 3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
+        "npm-asset/inputmask": "^5.0.8 ",
+        "npm-asset/punycode": "^2.2",
+        "npm-asset/yii2-pjax": "~2.0.1"
     },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
+        }
+    ],
     "autoload": {
         "psr-4": {"yii\\": ""}
     },
@@ -84,6 +90,11 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.0.x-dev"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true
         }
     }
 }

--- a/framework/validators/PunycodeAsset.php
+++ b/framework/validators/PunycodeAsset.php
@@ -18,7 +18,7 @@ use yii\web\AssetBundle;
  */
 class PunycodeAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/punycode';
+    public $sourcePath = '@npm/punycode';
     public $js = [
         'punycode.js',
     ];

--- a/framework/web/JqueryAsset.php
+++ b/framework/web/JqueryAsset.php
@@ -16,8 +16,8 @@ namespace yii\web;
  */
 class JqueryAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/jquery/dist';
+    public $sourcePath = '@npm/jquery/dist';
     public $js = [
-        'jquery.js',
+        YII_ENV_DEV ? 'jquery.js' : 'jquery.min.js'
     ];
 }

--- a/framework/widgets/MaskedInputAsset.php
+++ b/framework/widgets/MaskedInputAsset.php
@@ -20,9 +20,9 @@ use yii\web\AssetBundle;
  */
 class MaskedInputAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/inputmask/dist';
+    public $sourcePath = '@npm/inputmask/dist';
     public $js = [
-        'jquery.inputmask.js',
+        YII_ENV_DEV ? 'jquery.inputmask.js' : 'jquery.inputmask.min.js',
     ];
     public $depends = [
         'yii\web\YiiAsset',

--- a/framework/widgets/PjaxAsset.php
+++ b/framework/widgets/PjaxAsset.php
@@ -18,7 +18,7 @@ use yii\web\AssetBundle;
  */
 class PjaxAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/yii2-pjax';
+    public $sourcePath = '@npm/yii2-pjax';
     public $js = [
         'jquery.pjax.js',
     ];

--- a/tests/js/tests/yii.activeForm.test.js
+++ b/tests/js/tests/yii.activeForm.test.js
@@ -8,7 +8,7 @@ var vm = require('vm');
 describe('yii.activeForm', function () {
     var yiiActiveFormPath = 'framework/assets/yii.activeForm.js';
     var yiiPath = 'framework/assets/yii.js';
-    var jQueryPath = 'vendor/bower-asset/jquery/dist/jquery.js';
+    var jQueryPath = 'vendor/npm-asset/jquery/dist/jquery.js';
     var $;
     var $activeForm;
 

--- a/tests/js/tests/yii.captcha.test.js
+++ b/tests/js/tests/yii.captcha.test.js
@@ -8,7 +8,7 @@ var vm = require('vm');
 
 describe('yii.captcha', function () {
     var yiiCaptchaPath = 'framework/assets/yii.captcha.js';
-    var jQueryPath = 'vendor/bower-asset/jquery/dist/jquery.js';
+    var jQueryPath = 'vendor/npm-asset/jquery/dist/jquery.js';
     var $;
     var $captcha;
     var settings = {

--- a/tests/js/tests/yii.gridView.test.js
+++ b/tests/js/tests/yii.gridView.test.js
@@ -9,7 +9,7 @@ var vm = require('vm');
 describe('yii.gridView', function () {
     var yiiGridViewPath = 'framework/assets/yii.gridView.js';
     var yiiPath = 'framework/assets/yii.js';
-    var jQueryPath = 'vendor/bower-asset/jquery/dist/jquery.js';
+    var jQueryPath = 'vendor/npm-asset/jquery/dist/jquery.js';
     var $;
     var $gridView;
     var settings = {

--- a/tests/js/tests/yii.test.js
+++ b/tests/js/tests/yii.test.js
@@ -20,8 +20,8 @@ var StringUtils = {
 
 describe('yii', function () {
     var yiiPath = 'framework/assets/yii.js';
-    var jQueryPath = 'vendor/bower-asset/jquery/dist/jquery.js';
-    var pjaxPath = 'vendor/bower-asset/yii2-pjax/jquery.pjax.js';
+    var jQueryPath = 'vendor/npm-asset/jquery/dist/jquery.js';
+    var pjaxPath = 'vendor/npm-asset/yii2-pjax/jquery.pjax.js';
     var sandbox;
     var $;
     var yii;

--- a/tests/js/tests/yii.validation.test.js
+++ b/tests/js/tests/yii.validation.test.js
@@ -18,7 +18,7 @@ var StringUtils = {
 };
 
 var jsdom = require('mocha-jsdom');
-var punycode = require('../../../vendor/bower-asset/punycode/punycode');
+var punycode = require('../../../vendor/npm-asset/punycode/punycode');
 
 var fs = require('fs');
 var vm = require('vm');
@@ -76,7 +76,7 @@ describe('yii.validation', function () {
     }
 
     jsdom({
-        src: fs.readFileSync('vendor/bower-asset/jquery/dist/jquery.js', 'utf-8')
+        src: fs.readFileSync('vendor/npm-asset/jquery/dist/jquery.js', 'utf-8')
     });
 
     before(function () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

https://bower.io/blog/2017/how-to-migrate-away-from-bower/
https://www.yiiframework.com/wiki/785/use-minified-version-of-jqueryasset-bootstrapasset-and-all-default-assets - @robregonm
