### PR TITLE
Fix required branch not specified

### DIFF
--- a/docs/internals/git-workflow.md
+++ b/docs/internals/git-workflow.md
@@ -111,7 +111,7 @@ review your suggestion, and provide appropriate feedback along the way.
 ### 2. Pull the latest code from the main Yii branch
 
 ```
-git pull upstream
+git pull upstream master
 ```
 
 You should start at this point for every new contribution to make sure you are working on the latest code.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

The `git pull upstream` command mentioned in the Git workflow internal docs aborts with the message:

```
You asked to pull from the remote 'upstream', but did not specify                             
a branch. Because this is not the default configured remote                                   
for your current branch, you must specify a branch on the command line.
```