### PR TITLE
Update deprecated isArray() method in Controller.php

### DIFF
--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -133,7 +133,7 @@ class Controller extends \yii\base\Controller
                 if (PHP_VERSION_ID >= 80000) {
                     $isArray = ($type = $param->getType()) instanceof \ReflectionNamedType && $type->getName() === 'array';
                 } else {
-                    $isArray = $param->isArray();
+                    $isArray = $param->getType() && $param->getType()->getName() === 'array';
                 }
                 if ($isArray) {
                     $params[$name] = (array)$params[$name];

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -129,12 +129,9 @@ class Controller extends \yii\base\Controller
         foreach ($method->getParameters() as $param) {
             $name = $param->getName();
             if (array_key_exists($name, $params)) {
-                $isValid = true;
-                if (PHP_VERSION_ID >= 80000) {
-                    $isArray = ($type = $param->getType()) instanceof \ReflectionNamedType && $type->getName() === 'array';
-                } else {
-                    $isArray = $param->getType() && $param->getType()->getName() === 'array';
-                }
+                $isValid = true;                
+                $isArray = ($type = $param->getType()) instanceof \ReflectionNamedType && $type->getName() === 'array';
+                
                 if ($isArray) {
                     $params[$name] = (array)$params[$name];
                 } elseif (is_array($params[$name])) {


### PR DESCRIPTION
Update deprecated ReflectionParameter::isArray() method.
Reference (PHP 8): https://php.watch/versions/8.0/deprecated-reflectionparameter-methods


| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | N/A

**Description:**

This pull request addresses the deprecation warning related to the `ReflectionParameter::isArray()` method in PHP 8. Instead of using the deprecated method, the code now utilizes `$param->getType() && $param->getType()->getName() === 'array'` to achieve the same functionality.

**Changes Made:**

- Replaced deprecated `ReflectionParameter::isArray()` method with `$param->getType() && $param->getType()->getName() === 'array'`.

**Additional Notes:**

- The changes are made in accordance with the recommendations for PHP 8 compatibility.
- No backward compatibility breaks are introduced.
- No new features or bug fixes are included in this pull request.

Please review and merge as appropriate. Thank you!
