### PR TITLE
Make `Migration->printException()` overridable

### DIFF
--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -162,7 +162,7 @@ class Migration extends Component implements MigrationInterface
     /**
      * @param \Throwable $e
      */
-    private function printException($e)
+    protected function printException($e)
     {
         echo 'Exception: ' . $e->getMessage() . ' (' . $e->getFile() . ':' . $e->getLine() . ")\n";
         echo $e->getTraceAsString() . "\n";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
