### PR TITLE
Fix file uploader, test typed attributes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -29,6 +29,7 @@ Yii Framework 2 Change Log
 - Bug #20141: Update `ezyang/htmlpurifier` dependency to version `4.17` (@terabytesoftw)
 - Bug #19817: Add MySQL Query `addCheck()` and `dropCheck()` (@bobonov)
 - Bug #20165: Adjust pretty name of closures for PHP 8.4 compatibility (@staabm)
+- Bug #19855: Fixed `yii\validators\FileValidator` to not limit some of its rules only to array attribute (bizley)
 
 2.0.49.2 October 12, 2023
 -------------------------

--- a/framework/validators/FileValidator.php
+++ b/framework/validators/FileValidator.php
@@ -208,40 +208,23 @@ class FileValidator extends Validator
      */
     public function validateAttribute($model, $attribute)
     {
-        if ($this->maxFiles != 1 || $this->minFiles > 1) {
-            $rawFiles = $model->$attribute;
-            if (!is_array($rawFiles)) {
-                $this->addError($model, $attribute, $this->uploadRequired);
+        $files = $this->filterFiles((array) $model->$attribute);
+        $filesCount = count($files);
+        if ($filesCount === 0) {
+            $this->addError($model, $attribute, $this->uploadRequired);
 
-                return;
-            }
+            return;
+        }
 
-            $files = $this->filterFiles($rawFiles);
-            $model->$attribute = $files;
+        if ($this->maxFiles && $filesCount > $this->maxFiles) {
+            $this->addError($model, $attribute, $this->tooMany, ['limit' => $this->maxFiles]);
+        }
+        if ($this->minFiles && $this->minFiles > $filesCount) {
+            $this->addError($model, $attribute, $this->tooFew, ['limit' => $this->minFiles]);
+        }
 
-            if (empty($files)) {
-                $this->addError($model, $attribute, $this->uploadRequired);
-
-                return;
-            }
-
-            $filesCount = count($files);
-            if ($this->maxFiles && $filesCount > $this->maxFiles) {
-                $this->addError($model, $attribute, $this->tooMany, ['limit' => $this->maxFiles]);
-            }
-
-            if ($this->minFiles && $this->minFiles > $filesCount) {
-                $this->addError($model, $attribute, $this->tooFew, ['limit' => $this->minFiles]);
-            }
-
-            foreach ($files as $file) {
-                $result = $this->validateValue($file);
-                if (!empty($result)) {
-                    $this->addError($model, $attribute, $result[0], $result[1]);
-                }
-            }
-        } else {
-            $result = $this->validateValue($model->$attribute);
+        foreach ($files as $file) {
+            $result = $this->validateValue($file);
             if (!empty($result)) {
                 $this->addError($model, $attribute, $result[0], $result[1]);
             }

--- a/framework/validators/FileValidator.php
+++ b/framework/validators/FileValidator.php
@@ -208,18 +208,18 @@ class FileValidator extends Validator
      */
     public function validateAttribute($model, $attribute)
     {
-        $files = $this->filterFiles((array) $model->$attribute);
+        $files = $this->filterFiles(is_array($model->$attribute) ? $model->$attribute : [$model->$attribute]);
         $filesCount = count($files);
-        if ($filesCount === 0) {
+        if ($filesCount === 0 && $this->minFiles > 0) {
             $this->addError($model, $attribute, $this->uploadRequired);
 
             return;
         }
 
-        if ($this->maxFiles && $filesCount > $this->maxFiles) {
+        if ($this->maxFiles > 0 && $filesCount > $this->maxFiles) {
             $this->addError($model, $attribute, $this->tooMany, ['limit' => $this->maxFiles]);
         }
-        if ($this->minFiles && $this->minFiles > $filesCount) {
+        if ($this->minFiles > 0 && $this->minFiles > $filesCount) {
             $this->addError($model, $attribute, $this->tooFew, ['limit' => $this->minFiles]);
         }
 

--- a/tests/data/validators/models/FakedValidationTypedModel.php
+++ b/tests/data/validators/models/FakedValidationTypedModel.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace data\validators\models;
+
+use yii\base\Model;
+
+class FakedValidationTypedModel extends Model
+{
+    public ?UploadedFile $single = null;
+
+    public array $multiple = [];
+}

--- a/tests/data/validators/models/FakedValidationTypedModel.php
+++ b/tests/data/validators/models/FakedValidationTypedModel.php
@@ -5,9 +5,10 @@
  * @license https://www.yiiframework.com/license/
  */
 
-namespace data\validators\models;
+namespace yiiunit\data\validators\models;
 
 use yii\base\Model;
+use yii\web\UploadedFile;
 
 class FakedValidationTypedModel extends Model
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️ see below
| Fixed issues  | #19855 

Validator does not modify the attribute anymore - it was filtering out non-uploaded-files values from the array so far, but only for the array typed attributes with maxFiles != 1 or minFiles > 1.
Setting max files != 1 and sending empty array does not ends in error.