### PR TITLE
Support `JSON` columns for MariaDB 10.4 or higher.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -29,6 +29,7 @@ Yii Framework 2 Change Log
 - Bug #20141: Update `ezyang/htmlpurifier` dependency to version `4.17` (@terabytesoftw)
 - Bug #19817: Add MySQL Query `addCheck()` and `dropCheck()` (@bobonov)
 - Bug #20165: Adjust pretty name of closures for PHP 8.4 compatibility (@staabm)
+- Enh: #20171: Support JSON columns for MariaDB 10.4 or higher (@terabytesoftw)
 
 2.0.49.2 October 12, 2023
 -------------------------

--- a/framework/db/mysql/JsonExpressionBuilder.php
+++ b/framework/db/mysql/JsonExpressionBuilder.php
@@ -44,6 +44,6 @@ class JsonExpressionBuilder implements ExpressionBuilderInterface
         $placeholder = static::PARAM_PREFIX . count($params);
         $params[$placeholder] = Json::encode($value);
 
-        return "CAST($placeholder AS JSON)";
+        return $placeholder;
     }
 }

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -267,35 +267,35 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
             // json conditions
             [
                 ['=', 'jsoncol', new JsonExpression(['lang' => 'uk', 'country' => 'UA'])],
-                '[[jsoncol]] = CAST(:qp0 AS JSON)', [':qp0' => '{"lang":"uk","country":"UA"}'],
+                '[[jsoncol]] = :qp0', [':qp0' => '{"lang":"uk","country":"UA"}'],
             ],
             [
                 ['=', 'jsoncol', new JsonExpression([false])],
-                '[[jsoncol]] = CAST(:qp0 AS JSON)', [':qp0' => '[false]']
+                '[[jsoncol]] = :qp0', [':qp0' => '[false]']
             ],
             'object with type. Type is ignored for MySQL' => [
                 ['=', 'prices', new JsonExpression(['seeds' => 15, 'apples' => 25], 'jsonb')],
-                '[[prices]] = CAST(:qp0 AS JSON)', [':qp0' => '{"seeds":15,"apples":25}'],
+                '[[prices]] = :qp0', [':qp0' => '{"seeds":15,"apples":25}'],
             ],
             'nested json' => [
                 ['=', 'data', new JsonExpression(['user' => ['login' => 'silverfire', 'password' => 'c4ny0ur34d17?'], 'props' => ['mood' => 'good']])],
-                '[[data]] = CAST(:qp0 AS JSON)', [':qp0' => '{"user":{"login":"silverfire","password":"c4ny0ur34d17?"},"props":{"mood":"good"}}']
+                '[[data]] = :qp0', [':qp0' => '{"user":{"login":"silverfire","password":"c4ny0ur34d17?"},"props":{"mood":"good"}}']
             ],
             'null value' => [
                 ['=', 'jsoncol', new JsonExpression(null)],
-                '[[jsoncol]] = CAST(:qp0 AS JSON)', [':qp0' => 'null']
+                '[[jsoncol]] = :qp0', [':qp0' => 'null']
             ],
             'null as array value' => [
                 ['=', 'jsoncol', new JsonExpression([null])],
-                '[[jsoncol]] = CAST(:qp0 AS JSON)', [':qp0' => '[null]']
+                '[[jsoncol]] = :qp0', [':qp0' => '[null]']
             ],
             'null as object value' => [
                 ['=', 'jsoncol', new JsonExpression(['nil' => null])],
-                '[[jsoncol]] = CAST(:qp0 AS JSON)', [':qp0' => '{"nil":null}']
+                '[[jsoncol]] = :qp0', [':qp0' => '{"nil":null}']
             ],
             'with object as value' => [
                 ['=', 'jsoncol', new JsonExpression(new DynamicModel(['a' => 1, 'b' => 2]))],
-                '[[jsoncol]] = CAST(:qp0 AS JSON)', [':qp0' => '{"a":1,"b":2}']
+                '[[jsoncol]] = :qp0', [':qp0' => '{"a":1,"b":2}']
             ],
             'query' => [
                 ['=', 'jsoncol', new JsonExpression((new Query())->select('params')->from('user')->where(['id' => 1]))],
@@ -307,7 +307,7 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
             ],
             'nested and combined json expression' => [
                 ['=', 'jsoncol', new JsonExpression(new JsonExpression(['a' => 1, 'b' => 2, 'd' => new JsonExpression(['e' => 3])]))],
-                "[[jsoncol]] = CAST(:qp0 AS JSON)", [':qp0' => '{"a":1,"b":2,"d":{"e":3}}']
+                "[[jsoncol]] = :qp0", [':qp0' => '{"a":1,"b":2,"d":{"e":3}}']
             ],
             'search by property in JSON column (issue #15838)' => [
                 ['=', new Expression("(jsoncol->>'$.someKey')"), '42'],
@@ -328,7 +328,7 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
             [
                 'id' => 1,
             ],
-            $this->replaceQuotes('UPDATE [[profile]] SET [[description]]=CAST(:qp0 AS JSON) WHERE [[id]]=:qp1'),
+            $this->replaceQuotes('UPDATE [[profile]] SET [[description]]=:qp0 WHERE [[id]]=:qp1'),
             [
                 ':qp0' => '{"abc":"def","0":123,"1":null}',
                 ':qp1' => 1,

--- a/tests/framework/db/mysql/type/JsonTest.php
+++ b/tests/framework/db/mysql/type/JsonTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mysql\type;
+
+use yii\db\JsonExpression;
+use yii\db\mysql\Schema;
+use yiiunit\framework\db\DatabaseTestCase;
+
+/**
+ * @group db
+ * @group mysql
+ */
+class JsonTest extends DatabaseTestCase
+{
+    protected $driverName = 'mysql';
+
+    public function testCreateTable(): void
+    {
+        $db = $this->getConnection();
+
+        if ($db->getSchema()->getTableSchema('json') !== null) {
+            $db->createCommand()->dropTable('json')->execute();
+        }
+
+        $command = $db->createCommand();
+        $command->createTable('json', ['id' => Schema::TYPE_PK, 'data' => Schema::TYPE_JSON])->execute();
+
+        $this->assertTrue($db->getTableSchema('json') !== null);
+        $this->assertSame('data', $db->getTableSchema('json')->getColumn('data')->name);
+        $this->assertSame('json', $db->getTableSchema('json')->getColumn('data')->type);
+    }
+
+    public function testInsertAndSelect(): void
+    {
+        $db = $this->getConnection(true);
+        $version = $db->getServerVersion();
+
+        $command = $db->createCommand();
+        $command->insert('storage', ['data' => ['a' => 1, 'b' => 2]])->execute();
+
+        if (\stripos($version, 'MariaDb') === false) {
+            $rowExpected = '{"a": 1, "b": 2}';
+        } else {
+            $rowExpected = '{"a":1,"b":2}';
+        }
+
+        $this->assertSame(
+            $rowExpected,
+            $command->setSql(
+                <<<SQL
+                SELECT `data` FROM `storage`
+                SQL,
+            )->queryScalar(),
+        );
+    }
+
+    public function testInsertJsonExpressionAndSelect(): void
+    {
+        $db = $this->getConnection(true);
+        $version = $db->getServerVersion();
+
+        $command = $db->createCommand();
+        $command->insert('storage', ['data' => new JsonExpression(['a' => 1, 'b' => 2])])->execute();
+
+        if (\stripos($version, 'MariaDb') === false) {
+            $rowExpected = '{"a": 1, "b": 2}';
+        } else {
+            $rowExpected = '{"a":1,"b":2}';
+        }
+
+        $this->assertSame(
+            $rowExpected,
+            $command->setSql(
+                <<<SQL
+                SELECT `data` FROM `storage`
+                SQL,
+            )->queryScalar(),
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/yii2/issues/20168
