### PR TITLE
Fix tests `addCheck()`, `dropCheck()` MariaDB.

### DIFF
--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -205,8 +205,10 @@ SQL;
      */
     protected function loadTableChecks($tableName)
     {
+        $version = $this->db->getServerVersion();
+
         // check version MySQL >= 8.0.16
-        if (version_compare($this->db->getSlavePdo()->getAttribute(\PDO::ATTR_SERVER_VERSION), '8.0.16', '<')) {
+        if (\stripos($version, 'MariaDb') === false && \version_compare($version, '8.0.16', '<')) {
             throw new NotSupportedException('MySQL < 8.0.16 does not support check constraints.');
         }
 
@@ -230,17 +232,9 @@ SQL;
         $tableRows = $this->normalizePdoRowKeyCase($tableRows, true);
 
         foreach ($tableRows as $tableRow) {
-            $matches = [];
-            $columnName = null;
-
-            if (preg_match('/\(`?([a-zA-Z0-9_]+)`?\s*[><=]/', $tableRow['check_clause'], $matches)) {
-                $columnName = $matches[1];
-            }
-
             $check = new CheckConstraint(
                 [
                     'name' => $tableRow['constraint_name'],
-                    'columnNames' => [$columnName],
                     'expression' => $tableRow['check_clause'],
                 ]
             );

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -773,14 +773,6 @@ abstract class SchemaTest extends DatabaseTestCase
             $this->expectException('yii\base\NotSupportedException');
         }
 
-        if (
-            $this->driverName === 'mysql' &&
-            version_compare($this->getConnection(false)->getServerVersion(), '8.0.16', '<') &&
-            $type === 'checks'
-        ) {
-            $this->expectException('yii\base\NotSupportedException');
-        }
-
         $constraints = $this->getConnection(false)->getSchema()->{'getTable' . ucfirst($type)}($tableName);
         $this->assertMetadataEquals($expected, $constraints);
     }
@@ -794,14 +786,6 @@ abstract class SchemaTest extends DatabaseTestCase
     public function testTableSchemaConstraintsWithPdoUppercase($tableName, $type, $expected)
     {
         if ($expected === false) {
-            $this->expectException('yii\base\NotSupportedException');
-        }
-
-        if (
-            $this->driverName === 'mysql' &&
-            version_compare($this->getConnection(false)->getServerVersion(), '8.0.16', '<') &&
-            $type === 'checks'
-        ) {
             $this->expectException('yii\base\NotSupportedException');
         }
 
@@ -823,21 +807,13 @@ abstract class SchemaTest extends DatabaseTestCase
             $this->expectException('yii\base\NotSupportedException');
         }
 
-        if (
-            $this->driverName === 'mysql' &&
-            version_compare($this->getConnection(false)->getServerVersion(), '8.0.16', '<') &&
-            $type === 'checks'
-        ) {
-            $this->expectException('yii\base\NotSupportedException');
-        }
-
         $connection = $this->getConnection(false);
         $connection->getSlavePdo(true)->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
         $constraints = $connection->getSchema()->{'getTable' . ucfirst($type)}($tableName, true);
         $this->assertMetadataEquals($expected, $constraints);
     }
 
-    private function assertMetadataEquals($expected, $actual)
+    protected function assertMetadataEquals($expected, $actual)
     {
         switch (\strtolower(\gettype($expected))) {
             case 'object':
@@ -865,7 +841,7 @@ abstract class SchemaTest extends DatabaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    private function normalizeArrayKeys(array &$array, $caseSensitive)
+    protected function normalizeArrayKeys(array &$array, $caseSensitive)
     {
         $newArray = [];
         foreach ($array as $value) {
@@ -889,7 +865,7 @@ abstract class SchemaTest extends DatabaseTestCase
         $array = $newArray;
     }
 
-    private function normalizeConstraints(&$expected, &$actual)
+    protected function normalizeConstraints(&$expected, &$actual)
     {
         if (\is_array($expected)) {
             foreach ($expected as $key => $value) {
@@ -904,7 +880,7 @@ abstract class SchemaTest extends DatabaseTestCase
         }
     }
 
-    private function normalizeConstraintPair(Constraint $expectedConstraint, Constraint $actualConstraint)
+    protected function normalizeConstraintPair(Constraint $expectedConstraint, Constraint $actualConstraint)
     {
         if ($expectedConstraint::className() !== $actualConstraint::className()) {
             return;

--- a/tests/framework/db/mysql/CommandTest.php
+++ b/tests/framework/db/mysql/CommandTest.php
@@ -35,6 +35,7 @@ class CommandTest extends \yiiunit\framework\db\CommandTest
             'int1' => 'integer',
             'int2' => 'integer',
             'int3' => 'integer',
+            'int4' => 'integer',
         ])->execute();
 
         $this->assertEmpty($schema->getTableChecks($tableName, true));
@@ -43,14 +44,22 @@ class CommandTest extends \yiiunit\framework\db\CommandTest
             ['name' => 'check_int1_positive', 'expression' => '[[int1]] > 0', 'expected' => '(`int1` > 0)'],
             ['name' => 'check_int2_nonzero', 'expression' => '[[int2]] <> 0', 'expected' => '(`int2` <> 0)'],
             ['name' => 'check_int3_less_than_100', 'expression' => '[[int3]] < 100', 'expected' => '(`int3` < 100)'],
+            ['name' => 'check_int1_less_than_int2', 'expression' => '[[int1]] < [[int2]]', 'expected' => '(`int1` < `int2`)'],
         ];
+
+        if (\stripos($db->getServerVersion(), 'MariaDb') !== false) {
+            $constraints[0]['expected'] = '`int1` > 0';
+            $constraints[1]['expected'] = '`int2` <> 0';
+            $constraints[2]['expected'] = '`int3` < 100';
+            $constraints[3]['expected'] = '`int1` < `int2`';
+        }
 
         foreach ($constraints as $constraint) {
             $db->createCommand()->addCheck($constraint['name'], $tableName, $constraint['expression'])->execute();
         }
 
         $tableChecks = $schema->getTableChecks($tableName, true);
-        $this->assertCount(3, $tableChecks);
+        $this->assertCount(4, $tableChecks);
 
         foreach ($constraints as $index => $constraint) {
             $this->assertSame(

--- a/tests/framework/db/mysql/connection/DeadLockTest.php
+++ b/tests/framework/db/mysql/connection/DeadLockTest.php
@@ -31,6 +31,9 @@ class DeadLockTest extends \yiiunit\framework\db\mysql\ConnectionTest
      */
     public function testDeadlockException()
     {
+        if (\stripos($this->getConnection(false)->getServerVersion(), 'MariaDB') !== false) {
+            $this->markTestSkipped('MariaDB does not support this test');
+        }
         if (PHP_VERSION_ID >= 70400 && PHP_VERSION_ID < 70500) {
             $this->markTestSkipped('Stable failed in PHP 7.4');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/yii2/issues/20168

- Remove `columnNames` in `CheckConstraint::class`, `MySQL` and `MariaDB` not support.

Mysql 8.0.16: https://dev.mysql.com/blog-archive/mysql-8-0-16-introducing-check-constraint/
MariaDB 10.2.1: https://mariadb.com/kb/en/constraint/

