### PR TITLE
Support BackedEnum attribute typecast behaviour.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -19,6 +19,7 @@ Yii Framework 2 Change Log
 - Enh #20279: Add to the `\yii\web\Request` `csrfHeader` property to configure a custom  HTTP header for CSRF validation (olegbaturin)
 - Enh #20279: Add to the `\yii\web\Request` `csrfTokenSafeMethods` property to configure a custom safe HTTP methods list (olegbaturin)
 - Bug #20140: Fix compatibility with PHP 8.4: calling `session_set_save_handler()` (Izumi-kun)
+- New #20185: Add `BackedEnum` support to `AttributeTypecastBehavior` (briedis)
 
 2.0.51 July 18, 2024
 --------------------

--- a/framework/behaviors/AttributeTypecastBehavior.php
+++ b/framework/behaviors/AttributeTypecastBehavior.php
@@ -267,9 +267,16 @@ class AttributeTypecastBehavior extends Behavior
                         return StringHelper::floatToString($value);
                     }
                     return (string) $value;
-                default:
-                    throw new InvalidArgumentException("Unsupported type '{$type}'");
             }
+
+            if (PHP_VERSION_ID >= 80100 && is_subclass_of($type, \BackedEnum::class)) {
+                if ($value instanceof $type) {
+                    return $value;
+                }
+                return $type::from($value);
+            }
+
+            throw new InvalidArgumentException("Unsupported type '{$type}'");
         }
 
         return call_user_func($type, $value);

--- a/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
@@ -91,11 +91,11 @@ class AttributeTypecastBehaviorTest extends TestCase
 
         $model = new ActiveRecordAttributeTypecastWithEnum();
 
-        $model->status = StatusTypeString::ACTIVE;
+        $model->status = StatusTypeString::Active;
 
         $model->getAttributeTypecastBehavior()->typecastAttributes();
 
-        $this->assertSame(StatusTypeString::ACTIVE, $model->status);
+        $this->assertSame(StatusTypeString::Active, $model->status);
     }
 
     /**
@@ -112,7 +112,7 @@ class AttributeTypecastBehaviorTest extends TestCase
 
         $model->getAttributeTypecastBehavior()->typecastAttributes();
 
-        $this->assertSame(StatusTypeString::ACTIVE, $model->status);
+        $this->assertSame(StatusTypeString::Active, $model->status);
     }
 
     /**

--- a/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
@@ -7,11 +7,13 @@
 
 namespace yiiunit\framework\behaviors;
 
+use ValueError;
 use Yii;
 use yii\base\DynamicModel;
 use yii\base\Event;
 use yii\behaviors\AttributeTypecastBehavior;
 use yii\db\ActiveRecord;
+use yiiunit\framework\db\enums\StatusTypeString;
 use yiiunit\TestCase;
 
 /**
@@ -47,6 +49,7 @@ class AttributeTypecastBehaviorTest extends TestCase
             'price' => 'float',
             'isActive' => 'boolean',
             'callback' => 'string',
+            'status' => 'string',
         ];
         Yii::$app->getDb()->createCommand()->createTable('test_attribute_typecast', $columns)->execute();
     }
@@ -78,6 +81,55 @@ class AttributeTypecastBehaviorTest extends TestCase
         $this->assertSame(100.8, $model->price);
         $this->assertTrue($model->isActive);
         $this->assertSame('callback: foo', $model->callback);
+    }
+
+    public function testTypecastEnum()
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Can not be tested on PHP < 8.1');
+        }
+
+        $model = new ActiveRecordAttributeTypecastWithEnum();
+
+        $model->status = StatusTypeString::ACTIVE;
+
+        $model->getAttributeTypecastBehavior()->typecastAttributes();
+
+        $this->assertSame(StatusTypeString::ACTIVE, $model->status);
+    }
+
+    /**
+     * @depends testTypecastEnum
+     */
+    public function testTypecastEnumFromString()
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Can not be tested on PHP < 8.1');
+        }
+
+        $model = new ActiveRecordAttributeTypecastWithEnum();
+        $model->status = 'active'; // Same as StatusTypeString::ACTIVE->value;
+
+        $model->getAttributeTypecastBehavior()->typecastAttributes();
+
+        $this->assertSame(StatusTypeString::ACTIVE, $model->status);
+    }
+
+    /**
+     * @depends testTypecastEnum
+     */
+    public function testTypecastEnumFailWithInvalidValue()
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Can not be tested on PHP < 8.1');
+        }
+
+        $model = new ActiveRecordAttributeTypecastWithEnum();
+        $model->status = 'invalid';
+
+        self::expectException(ValueError::class);
+
+        $model->getAttributeTypecastBehavior()->typecastAttributes();
     }
 
     /**
@@ -329,6 +381,40 @@ class ActiveRecordAttributeTypecast extends ActiveRecord
             ['price', 'number'],
             ['isActive', 'boolean'],
         ];
+    }
+
+    /**
+     * @return AttributeTypecastBehavior
+     */
+    public function getAttributeTypecastBehavior()
+    {
+        return $this->getBehavior('attributeTypecast');
+    }
+}
+
+/**
+ * Test Active Record class with [[AttributeTypecastBehavior]] behavior attached with an enum field.
+ *
+ * @property StatusTypeString $status
+ */
+class ActiveRecordAttributeTypecastWithEnum extends ActiveRecord
+{
+    public function behaviors()
+    {
+        return [
+            'attributeTypecast' => [
+                'class' => AttributeTypecastBehavior::className(),
+                'attributeTypes' => [
+                    'status' => StatusTypeString::class,
+                ],
+                'typecastBeforeSave' => true,
+            ],
+        ];
+    }
+
+    public static function tableName()
+    {
+        return 'test_attribute_typecast';
     }
 
     /**

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -1538,13 +1538,13 @@ SQL;
 		    $db = $this->getConnection();
 		    $command = $db->createCommand();
 
-		    $command->setSql('SELECT :p1')->bindValues([':p1' => enums\Status::ACTIVE]);
+		    $command->setSql('SELECT :p1')->bindValues([':p1' => enums\Status::Active]);
 		    $this->assertSame('ACTIVE', $command->params[':p1']);
 
-		    $command->setSql('SELECT :p1')->bindValues([':p1' => enums\StatusTypeString::ACTIVE]);
+		    $command->setSql('SELECT :p1')->bindValues([':p1' => enums\StatusTypeString::Active]);
 		    $this->assertSame('active', $command->params[':p1']);
 
-		    $command->setSql('SELECT :p1')->bindValues([':p1' => enums\StatusTypeInt::ACTIVE]);
+		    $command->setSql('SELECT :p1')->bindValues([':p1' => enums\StatusTypeInt::Active]);
 		    $this->assertSame(1, $command->params[':p1']);
 		} else {
             $this->markTestSkipped('Enums are not supported in PHP < 8.1');

--- a/tests/framework/db/enums/Status.php
+++ b/tests/framework/db/enums/Status.php
@@ -4,6 +4,6 @@ namespace yiiunit\framework\db\enums;
 
 enum Status
 {
-    case ACTIVE;
-    case INACTIVE;
+    case Active;
+    case Inactive;
 }

--- a/tests/framework/db/enums/StatusTypeInt.php
+++ b/tests/framework/db/enums/StatusTypeInt.php
@@ -4,6 +4,6 @@ namespace yiiunit\framework\db\enums;
 
 enum StatusTypeInt: int
 {
-    case ACTIVE = 1;
-    case INACTIVE = 0;
+    case Active = 1;
+    case Inactive = 0;
 }

--- a/tests/framework/db/enums/StatusTypeString.php
+++ b/tests/framework/db/enums/StatusTypeString.php
@@ -4,6 +4,6 @@ namespace yiiunit\framework\db\enums;
 
 enum StatusTypeString: string
 {
-    case ACTIVE = 'active';
-    case INACTIVE = 'inactive';
+    case Active = 'active';
+    case Inactive = 'inactive';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Based on the casting approach that Laravel has implemented.
Not sure about validation, I think that should be implemented separately.
