### PR TITLE
Refactor InitDbFixture to skip checkIntegrity for Oracle DB.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -39,6 +39,7 @@ Yii Framework 2 Change Log
 - Enh #20134: Raise minimum `PHP` version to `7.3` (@terabytesoftw)
 - Enh #20171: Support JSON columns for MariaDB 10.4 or higher (@terabytesoftw)
 - New #20137: Added `yii\caching\CallbackDependency` to allow using a callback to determine if a cache dependency is still valid (laxity7)
+- Bug #16116: Codeception: oci does not support enabling/disabling integrity check. (@terabytesoftw)
 
 
 2.0.49.2 October 12, 2023

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -39,7 +39,7 @@ Yii Framework 2 Change Log
 - Enh #20134: Raise minimum `PHP` version to `7.3` (@terabytesoftw)
 - Enh #20171: Support JSON columns for MariaDB 10.4 or higher (@terabytesoftw)
 - New #20137: Added `yii\caching\CallbackDependency` to allow using a callback to determine if a cache dependency is still valid (laxity7)
-- Bug #16116: Codeception: oci does not support enabling/disabling integrity check. (@terabytesoftw)
+- Bug #16116: Codeception: oci does not support enabling/disabling integrity check (@terabytesoftw)
 
 
 2.0.49.2 October 12, 2023

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.51 under development
 ------------------------
 
-- no changes in this release.
+- Bug #16116: Codeception: oci does not support enabling/disabling integrity check (@terabytesoftw)
 
 
 2.0.50 May 30, 2024
@@ -39,7 +39,6 @@ Yii Framework 2 Change Log
 - Enh #20134: Raise minimum `PHP` version to `7.3` (@terabytesoftw)
 - Enh #20171: Support JSON columns for MariaDB 10.4 or higher (@terabytesoftw)
 - New #20137: Added `yii\caching\CallbackDependency` to allow using a callback to determine if a cache dependency is still valid (laxity7)
-- Bug #16116: Codeception: oci does not support enabling/disabling integrity check (@terabytesoftw)
 
 
 2.0.49.2 October 12, 2023

--- a/framework/test/InitDbFixture.php
+++ b/framework/test/InitDbFixture.php
@@ -96,10 +96,12 @@ class InitDbFixture extends DbFixture
             return;
         }
 
+        if ($this->db->getDriverName() === 'oci') {
+            return;
+        }
+
         foreach ($this->schemas as $schema) {
-            if ($this->db->getDriverName() !== 'oci') {
-                $this->db->createCommand()->checkIntegrity($check, $schema)->execute();
-            }
+            $this->db->createCommand()->checkIntegrity($check, $schema)->execute();
         }
     }
 }

--- a/framework/test/InitDbFixture.php
+++ b/framework/test/InitDbFixture.php
@@ -95,8 +95,11 @@ class InitDbFixture extends DbFixture
         if (!$this->db instanceof \yii\db\Connection) {
             return;
         }
+
         foreach ($this->schemas as $schema) {
-            $this->db->createCommand()->checkIntegrity($check, $schema)->execute();
+            if ($this->db->getDriverName() !== 'oci') {
+                $this->db->createCommand()->checkIntegrity($check, $schema)->execute();
+            }
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/yii2/issues/16116
