### PR TITLE
Fix #20191

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.51 under development
 ------------------------
 
-- no changes in this release.
+- Bug #20191: Fix `ActiveRecord::getDirtyAttributes()` for JSON columns with multi-dimensional array values (brandonkelly)
 
 
 2.0.50 May 30, 2024

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1781,9 +1781,15 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     private function isValueDifferent($newValue, $oldValue)
     {
-        if (is_array($newValue) && is_array($oldValue) && ArrayHelper::isAssociative($oldValue)) {
-            $newValue = ArrayHelper::recursiveSort($newValue);
-            $oldValue = ArrayHelper::recursiveSort($oldValue);
+        if (is_array($newValue) && is_array($oldValue)) {
+            // Only sort associative arrays
+            $sorter = function(&$array) {
+                if (ArrayHelper::isAssociative($array)) {
+                    ksort($array);
+                }
+            };
+            $newValue = ArrayHelper::recursiveSort($newValue, $sorter);
+            $oldValue = ArrayHelper::recursiveSort($oldValue, $sorter);
         }
 
         return $newValue !== $oldValue;

--- a/tests/framework/db/BaseActiveRecordTest.php
+++ b/tests/framework/db/BaseActiveRecordTest.php
@@ -28,6 +28,10 @@ abstract class BaseActiveRecordTest extends DatabaseTestCase
                 ['pineapple' => 2, 'apple' => 5, 'banana' => 1],
                 ['pineapple' => 2, 'apple' => 3, 'banana' => 1],
             ],
+            'multi-dimensional array' => [
+                ['foo' => ['c', 'b', 'a']],
+                ['foo' => ['b', 'c', 'a']],
+            ],
 
             'filling an empty array' => [
                 [],


### PR DESCRIPTION
Fixes #20191 by only sorting associative arrays when comparing old/new array column values, recursively.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20191 
