### PR TITLE
#20199 Reverted BaseUrl::isRelative() behaviour to previous 2.0.49 ve…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #20191: Fix `ActiveRecord::getDirtyAttributes()` for JSON columns with multi-dimensional array values (brandonkelly)
 - Bug #20175: Fix bad result for pagination when used with GridView (@lav45)
+- Bug #20199: Fix yii\web\UrlManager::createAbsoluteUrl() external absolute links creation (@edegaudenzi)
 
 
 2.0.50 May 30, 2024

--- a/framework/helpers/BaseUrl.php
+++ b/framework/helpers/BaseUrl.php
@@ -378,7 +378,7 @@ class BaseUrl
      */
     public static function isRelative($url)
     {
-        return preg_match('~^[[:alpha:]][[:alnum:]+-.]*://|^//~', $url) === 0;
+        return strncmp($url, '//', 2) && strpos($url, '://') === false;
     }
 
     /**

--- a/tests/framework/helpers/BaseUrlTest.php
+++ b/tests/framework/helpers/BaseUrlTest.php
@@ -37,9 +37,14 @@ class BaseUrlTest extends TestCase
                 'expected result' => 'acme.com?name=bugs.bunny',
             ],
             'relative url and another url as parameter will return input url' => [
-                'url' => 'acme.com/test?tnt-link=https://tnt.com/',
+                'url' => 'acme.com/test?tnt-link=https%3A%2F%2Ftnt.com%2F%3Fq%3Dvalue',
                 'scheme' => 'https',
-                'expected' => 'acme.com/test?tnt-link=https://tnt.com/',
+                'expected' => 'acme.com/test?tnt-link=https%3A%2F%2Ftnt.com%2F%3Fq%3Dvalue',
+            ],
+            'relative url and another url as parameter, using more relaxed rfc3986 3.4, will return input url' => [
+                'url' => 'acme.com/test?tnt-link=https%3A//tnt.com/?q%3Dvalue',
+                'scheme' => 'https',
+                'expected' => 'acme.com/test?tnt-link=https%3A//tnt.com/?q%3Dvalue',
             ],
             'url with scheme not a string will return input url' => [
                 'url' => 'acme.com?name=bugs.bunny',
@@ -76,7 +81,10 @@ class BaseUrlTest extends TestCase
                 'url' => 'acme.com/tnt-room=123',
             ],
             'url without protocol and another url in a parameter value' => [
-                'url' => 'acme.com?tnt-room-link=https://tnt.com',
+                'url' => 'acme.com?tnt-room-link=https%3A%2F%2Ftnt.com%2F%3Fq%3Dvalue',
+            ],
+            'url without protocol and another url in a parameter value, using more relaxed rfc3986 3.4' => [
+                'url' => 'acme.com?tnt-room-link=https%3A//tnt.com/?q%3Dvalue',
             ],
             'path only' => [
                 'url' => '/path',


### PR DESCRIPTION
…rsion due to yii\web\UrlManager::createAbsoluteUrl() malfunction depending on this.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20199
