### PR TITLE
(#8298) Restart sequence for Postgresql when loading fixtures

### DIFF
--- a/framework/test/ActiveFixture.php
+++ b/framework/test/ActiveFixture.php
@@ -130,7 +130,11 @@ class ActiveFixture extends BaseActiveFixture
         $table = $this->getTableSchema();
         $this->db->createCommand()->delete($table->fullName)->execute();
         if ($table->sequenceName !== null) {
-            $this->db->createCommand()->executeResetSequence($table->fullName, 1);
+            if ('pgsql' === $this->db->driverName) {
+                $this->db->createCommand("ALTER SEQUENCE {$table->sequenceName} RESTART;")->execute();
+            } else {
+                $this->db->createCommand()->executeResetSequence($table->fullName, 1);
+            }
         }
     }
 

--- a/tests/framework/test/data/customer_offset_sequence.php
+++ b/tests/framework/test/data/customer_offset_sequence.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+return [
+    'customer1' => [
+        'id' => 2,
+        'email' => 'customer1@example.com',
+        'name' => 'customer1',
+        'address' => 'address1',
+        'status' => 1,
+        'profile_id' => 1,
+    ],
+    'customer2' => [
+        'id' => 3,
+        'email' => 'customer2@example.com',
+        'name' => 'customer2',
+        'address' => 'address2',
+        'status' => 2,
+        'profile_id' => 2,
+    ],
+];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #8298

The solution in issue #17253 does notconsider the condition when the sequence does not start at 1.
For example, the sequence might look like this:

```sql
create sequence test_id_seq
    minvalue 3
    maxvalue 32767;
```

In order not to break potential BC, we make a fix only in `ActiveFixture` for the `pgsql` driver.
