### PR TITLE
Fix #20147: Fix error handler compatibility with PHP 8.3

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #20191: Fix `ActiveRecord::getDirtyAttributes()` for JSON columns with multi-dimensional array values (brandonkelly)
 - Bug #20211: Add acceptable parameters to `MaskedInput::init()` method (alxlnk)
 - Bug #20226: Revert all PR for "Data providers perform unnecessary COUNT queries that negatively affect performance" (@terabytesoftw)
+- Bug #20147: Fix error handler compatibility with PHP 8.3 (samdark)
 
 
 2.0.50 May 30, 2024

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -279,13 +279,13 @@ abstract class ErrorHandler extends Component
      */
     public function handleFatalError()
     {
-        unset($this->_memoryReserve);
+        $this->_memoryReserve = null;
 
-        if (isset($this->_workingDirectory)) {
+        if (!empty($this->_workingDirectory)) {
             // fix working directory for some Web servers e.g. Apache
             chdir($this->_workingDirectory);
             // flush memory
-            unset($this->_workingDirectory);
+            $this->_workingDirectory = null;
         }
 
         $error = error_get_last();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20147 
