### PR TITLE
Fix \yii\filters\Cors::actions when attached to a module

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 Change Log
 - Bug #20211: Add acceptable parameters to `MaskedInput::init()` method (alxlnk)
 - Bug #20226: Revert all PR for "Data providers perform unnecessary COUNT queries that negatively affect performance" (@terabytesoftw)
 - Bug #20147: Fix error handler compatibility with PHP 8.3 (samdark)
+- Bug #20230: Fix getting ID in `\yii\filters\Cors::actions()` when attached to a module (timkelty)
 
 
 2.0.50 May 30, 2024

--- a/framework/filters/Cors.php
+++ b/framework/filters/Cors.php
@@ -123,8 +123,10 @@ class Cors extends ActionFilter
      */
     public function overrideDefaultSettings($action)
     {
-        if (isset($this->actions[$action->id])) {
-            $actionParams = $this->actions[$action->id];
+        $actionId = $this->getActionId($action);
+
+        if (isset($this->actions[$actionId])) {
+            $actionParams = $this->actions[$actionId];
             $actionParamsKeys = array_keys($actionParams);
             foreach ($this->cors as $headerField => $headerValue) {
                 if (in_array($headerField, $actionParamsKeys)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

When attached to a module (vs a controller), `\yii\filters\Cors::actions` should use the ID defined by `\yii\base\ActionFilter::getActionId`, so that the controller ID is included.

The `AuthMethod` already does this properly: https://github.com/yiisoft/yii2/blob/master/framework/filters/auth/AuthMethod.php#L106