### PR TITLE
Fix #20232: Fix regression introduced in `GHSA-cjcc-p67m-7qxm` while attaching behavior defined by `__class` array key

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,8 +4,7 @@ Yii Framework 2 Change Log
 2.0.52 under development
 ------------------------
 
-- no changes in this release.
-
+- Bug #20232: Fix regression introduced in `GHSA-cjcc-p67m-7qxm` while attaching behavior defined by `__class` array key (erickskrauch)
 
 2.0.51 July 18, 2024
 --------------------

--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -190,7 +190,7 @@ class Component extends BaseObject
             $name = trim(substr($name, 3));
             if ($value instanceof Behavior) {
                 $this->attachBehavior($name, $value);
-            } elseif (isset($value['class']) && is_subclass_of($value['class'], Behavior::class, true)) {
+            } elseif ((isset($value['class']) && is_subclass_of($value['class'], Behavior::class)) || (isset($value['__class']) && is_subclass_of($value['__class'], Behavior::class))) {
                 $this->attachBehavior($name, Yii::createObject($value));
             } elseif (is_string($value) && is_subclass_of($value, Behavior::class, true)) {
                 $this->attachBehavior($name, Yii::createObject($value));

--- a/tests/framework/base/ComponentTest.php
+++ b/tests/framework/base/ComponentTest.php
@@ -341,6 +341,9 @@ class ComponentTest extends TestCase
         $this->assertTrue($component->hasProperty('p'));
         $component->test();
         $this->assertTrue($component->behaviorCalled);
+
+        $component->{'as c'} = ['__class' => NewBehavior::class];
+        $this->assertNotNull($component->getBehavior('c'));
     }
 
     public function testAttachBehaviors()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Just spotted this problem after upgrading to the latest version to fix CVE.

Context: configuration via `Yii2::createObject()` allows creating an object via `__class` definition. But after the changes in the https://github.com/yiisoft/yii2/commit/628d406bfafb80fc32147837888c0057d89a021e, this option was forgotten. This PR restores forgotten behavior.