### PR TITLE
Fix restored vulnerability after #20232

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,8 +4,7 @@ Yii Framework 2 Change Log
 2.0.52 under development
 ------------------------
 
-- no changes in this release.
-
+- Bug #20232: Fix regression introduced in `GHSA-cjcc-p67m-7qxm` while attaching behavior defined by `__class` array key (erickskrauch)
 
 2.0.51 July 18, 2024
 --------------------

--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -190,7 +190,9 @@ class Component extends BaseObject
             $name = trim(substr($name, 3));
             if ($value instanceof Behavior) {
                 $this->attachBehavior($name, $value);
-            } elseif ((isset($value['class']) && is_subclass_of($value['class'], Behavior::class)) || (isset($value['__class']) && is_subclass_of($value['__class'], Behavior::class))) {
+            } elseif (isset($value['__class']) && is_subclass_of($value['__class'], Behavior::class)) {
+                $this->attachBehavior($name, Yii::createObject($value));
+            } elseif (!isset($value['__class']) && isset($value['class']) && is_subclass_of($value['class'], Behavior::class)) {
                 $this->attachBehavior($name, Yii::createObject($value));
             } elseif (is_string($value) && is_subclass_of($value, Behavior::class, true)) {
                 $this->attachBehavior($name, Yii::createObject($value));

--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -190,7 +190,7 @@ class Component extends BaseObject
             $name = trim(substr($name, 3));
             if ($value instanceof Behavior) {
                 $this->attachBehavior($name, $value);
-            } elseif (isset($value['class']) && is_subclass_of($value['class'], Behavior::class, true)) {
+            } elseif ((isset($value['class']) && is_subclass_of($value['class'], Behavior::class)) || (isset($value['__class']) && is_subclass_of($value['__class'], Behavior::class))) {
                 $this->attachBehavior($name, Yii::createObject($value));
             } elseif (is_string($value) && is_subclass_of($value, Behavior::class, true)) {
                 $this->attachBehavior($name, Yii::createObject($value));

--- a/tests/framework/base/ComponentTest.php
+++ b/tests/framework/base/ComponentTest.php
@@ -341,6 +341,9 @@ class ComponentTest extends TestCase
         $this->assertTrue($component->hasProperty('p'));
         $component->test();
         $this->assertTrue($component->behaviorCalled);
+
+        $component->{'as c'} = ['__class' => NewBehavior::class];
+        $this->assertNotNull($component->getBehavior('c'));
     }
 
     public function testAttachBehaviors()

--- a/tests/framework/base/ComponentTest.php
+++ b/tests/framework/base/ComponentTest.php
@@ -10,6 +10,8 @@ namespace yiiunit\framework\base;
 use yii\base\Behavior;
 use yii\base\Component;
 use yii\base\Event;
+use yii\base\InvalidConfigException;
+use yii\base\UnknownMethodException;
 use yiiunit\TestCase;
 
 function globalEventHandler($event)
@@ -331,19 +333,39 @@ class ComponentTest extends TestCase
 
         $this->assertSame($behavior, $component->detachBehavior('a'));
         $this->assertFalse($component->hasProperty('p'));
-        $this->expectException('yii\base\UnknownMethodException');
-        $component->test();
+        try {
+            $component->test();
+            $this->fail('Expected exception ' . UnknownMethodException::class . " wasn't thrown");
+        } catch (UnknownMethodException $e) {
+            // Expected
+        }
 
-        $p = 'as b';
         $component = new NewComponent();
-        $component->$p = ['class' => 'NewBehavior'];
-        $this->assertSame($behavior, $component->getBehavior('a'));
+        $component->{'as b'} = ['class' => NewBehavior::class];
+        $this->assertInstanceOf(NewBehavior::class, $component->getBehavior('b'));
         $this->assertTrue($component->hasProperty('p'));
         $component->test();
         $this->assertTrue($component->behaviorCalled);
 
         $component->{'as c'} = ['__class' => NewBehavior::class];
         $this->assertNotNull($component->getBehavior('c'));
+
+        $component->{'as d'} = [
+            '__class' => NewBehavior2::class,
+            'class' => NewBehavior::class,
+        ];
+        $this->assertInstanceOf(NewBehavior2::class, $component->getBehavior('d'));
+
+        // CVE-2024-4990
+        try {
+            $component->{'as e'} = [
+                '__class' => 'NotExistsBehavior',
+                'class' => NewBehavior::class,
+            ];
+            $this->fail('Expected exception ' . InvalidConfigException::class . " wasn't thrown");
+        } catch (InvalidConfigException $e) {
+            $this->assertSame('Class is not of type yii\base\Behavior or its subclasses', $e->getMessage());
+        }
     }
 
     public function testAttachBehaviors()
@@ -544,6 +566,10 @@ class NewBehavior extends Behavior
 
         return 2;
     }
+}
+
+class NewBehavior2 extends Behavior
+{
 }
 
 class NewComponent2 extends Component


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | See https://github.com/yiisoft/yii2/pull/20232#issuecomment-2252459709

I have also fixed the test for `Component` because after [this execution point](https://github.com/yiisoft/yii2/blob/34d2396920a34534fb19cc342b5f4fe863c6e3ac/tests/framework/base/ComponentTest.php#L334-L335) the test wasn't performed further.