### PR TITLE
Fix #20247: Support for variadic console controller action methods

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Change Log
 
 - Bug #20232: Fix regression introduced in `GHSA-cjcc-p67m-7qxm` while attaching behavior defined by `__class` array key (erickskrauch)
 - Bug #20231: Fix regression introduced in #20167 in `yii\validators\FileValidator` (bizley)
+- Enh #20247: Support for variadic console controller action methods (brandonkelly)
 
 2.0.51 July 18, 2024
 --------------------

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -198,6 +198,7 @@ class Controller extends \yii\base\Controller
             $method = new \ReflectionMethod($action, 'run');
         }
 
+        $paramKeys = array_keys($params);
         $args = [];
         $missing = [];
         $actionParams = [];
@@ -212,16 +213,27 @@ class Controller extends \yii\base\Controller
             }
 
             if ($key !== null) {
-                if (PHP_VERSION_ID >= 80000) {
-                    $isArray = ($type = $param->getType()) instanceof \ReflectionNamedType && $type->getName() === 'array';
+                if ($param->isVariadic()) {
+                    for ($j = array_search($key, $paramKeys); $j < count($paramKeys); $j++) {
+                        $jKey = $paramKeys[$j];
+                        if ($j !== $key && !is_int($j)) {
+                            break;
+                        }
+                        $args[] = $actionParams[$key][] = $params[$jKey];
+                        unset($params[$jKey]);
+                    }
                 } else {
-                    $isArray = $param->isArray();
+                    if (PHP_VERSION_ID >= 80000) {
+                        $isArray = ($type = $param->getType()) instanceof \ReflectionNamedType && $type->getName() === 'array';
+                    } else {
+                        $isArray = $param->isArray();
+                    }
+                    if ($isArray) {
+                        $params[$key] = $params[$key] === '' ? [] : preg_split('/\s*,\s*/', $params[$key]);
+                    }
+                    $args[] = $actionParams[$key] = $params[$key];
+                    unset($params[$key]);
                 }
-                if ($isArray) {
-                    $params[$key] = $params[$key] === '' ? [] : preg_split('/\s*,\s*/', $params[$key]);
-                }
-                $args[] = $actionParams[$key] = $params[$key];
-                unset($params[$key]);
             } elseif (
                 PHP_VERSION_ID >= 70100
                 && ($type = $param->getType()) !== null

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -216,7 +216,7 @@ class Controller extends \yii\base\Controller
                 if ($param->isVariadic()) {
                     for ($j = array_search($key, $paramKeys); $j < count($paramKeys); $j++) {
                         $jKey = $paramKeys[$j];
-                        if ($j !== $key && !is_int($j)) {
+                        if ($jKey !== $key && !is_int($jKey)) {
                             break;
                         }
                         $args[] = $actionParams[$key][] = $params[$jKey];

--- a/tests/framework/console/ControllerTest.php
+++ b/tests/framework/console/ControllerTest.php
@@ -91,6 +91,12 @@ class ControllerTest extends TestCase
         $this->assertEquals('from params', $fromParam);
         $this->assertEquals('notdefault', $other);
 
+        $params = ['a', 'b', 'c1', 'c2', 'c3'];
+        [$a, $b, $c] = $controller->run('variadic', $params);
+        $this->assertEquals('a', $a);
+        $this->assertEquals('b', $b);
+        $this->assertEquals(['c1', 'c2', 'c3'], $c);
+
         $params = ['avaliable'];
         $message = Yii::t('yii', 'Missing required arguments: {params}', ['params' => implode(', ', ['missing'])]);
         $this->expectException('yii\console\Exception');

--- a/tests/framework/console/FakeController.php
+++ b/tests/framework/console/FakeController.php
@@ -104,4 +104,9 @@ class FakeController extends Controller
         $response->exitStatus = (int) $status;
         return $response;
     }
+
+    public function actionVariadic($foo, $bar, ...$baz)
+    {
+        return [$foo, $bar, $baz];
+    }
 }


### PR DESCRIPTION
Adds support for [variadic](https://www.php.net/manual/en/functions.arguments.php#functions.variable-arg-list) console controller action methods.

```php
public function actionMerge(string ...$names)
{
    // ...
}
```

```sh
php yii foo/bar/merge name1 name2 name3
```

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
