### PR TITLE
Check file existence before filemtime

### DIFF
--- a/framework/caching/FileCache.php
+++ b/framework/caching/FileCache.php
@@ -97,7 +97,7 @@ class FileCache extends Cache
     {
         $cacheFile = $this->getCacheFile($this->buildKey($key));
 
-        return @filemtime($cacheFile) > time();
+        return file_exists($cacheFile) && @filemtime($cacheFile) > time();
     }
 
     /**
@@ -110,7 +110,7 @@ class FileCache extends Cache
     {
         $cacheFile = $this->getCacheFile($key);
 
-        if (@filemtime($cacheFile) > time()) {
+        if (file_exists($cacheFile) && @filemtime($cacheFile) > time()) {
             $fp = @fopen($cacheFile, 'r');
             if ($fp !== false) {
                 @flock($fp, LOCK_SH);


### PR DESCRIPTION
Calling filemtime with a nonexistent file will cause a warning, even with the `@` error suppression. This avoids the warning by checking file existence before the modification time

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

Note, this shows up for me when using https://pestphp.com because any test that emits a warning is marked as `!` instead of `✓`. So for something like https://craftcms.com, which uses the `->exists` during bootstrapping you end up with every test marked with `!`.

----

Before:

```
$./vendor/bin/pest tests/ActingAsTest.php -vvv --display-warnings

   WARN  Tests\ActingAsTest
  ! it logs in users by factory → filemtime(): stat failed for /Users/markhuot/Sites/craft-pest-core/storage/runtime/cache/8e/CraftCMS8e0694a5966c89b99615fb42a4a74296.bin 0.28s
  ✓ it logs in users by email address                                                                 0.01s
  ✓ it logs in user objects                                                                           0.01s
  ! it logs in admins via shorthand → filemtime(): stat failed for /Users/markhuot/Sites/craft-pest-core/storage/runtime/cache/ba/CraftCMSbasePath.bin 0.21s
  ✓ it throws on missing users
  ✓ it should not be logged in on subsequent tests
  ! it acts as a user on get requests → filemtime(): stat failed for /Users/markhuot/Sites/craft-pest-core/storage/runtime/cache/62/CraftCMS62f10a620b432ee970868362b84379c4.bin 0.02s
  ! it creates admin users → filemtime(): stat failed for /Users/markhuot/Sites/craft-pest-core/storage/runtime/cache/62/CraftCMS62f10a620b432ee970868362b84379c4.bin 0.03s
  ! it resets globals during twig parsing → filemtime(): stat failed for /Users/markhuot/Sites/craft-pest-core/storage/runtime/cache/90/CraftCMS90d3d81bc326013c006a844c726840fb.bin 0.02s
```

After:

```
$./vendor/bin/pest tests/ActingAsTest.php -vvv --display-warnings

   PASS  Tests\ActingAsTest
  ✓ it logs in users by factory                                                                       0.24s
  ✓ it logs in users by email address                                                                 0.02s
  ✓ it logs in user objects                                                                           0.01s
  ✓ it logs in admins via shorthand                                                                   0.24s
  ✓ it throws on missing users                                                                        0.01s
  ✓ it should not be logged in on subsequent tests
  ✓ it acts as a user on get requests                                                                 0.02s
  ✓ it creates admin users                                                                            0.02s
  ✓ it resets globals during twig parsing                                                             0.02s

  Tests:    9 passed (10 assertions)
  Duration: 0.70s
```