### PR TITLE
ActiveQuery::one() limiting database records #58

### DIFF
--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -280,6 +280,8 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      */
     public function one($db = null)
     {
+        $this->limit(1);
+
         if ($this->emulateExecution) {
             return false;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | [#58](https://github.com/yiisoft/active-record/issues/58)
