### PR TITLE
Fix #20268: Minor optimisation in `\yii\helpers\BaseArrayHelper::map`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 Change Log
 - Bug #20256: Add support for dropping views in MSSQL server when running migrate/fresh (ambrozt)
 - Enh #20248: Add support for attaching behaviors in configurations with Closure (timkelty)
 - Enh #20268: Minor optimisation in `\yii\helpers\BaseArrayHelper::map` (chriscpty)
+- Enh #20268: Add `\yii\helpers\BaseStringHelper::contains()` as a polyfill for `str_contains` (chriscpty)
 
 2.0.51 July 18, 2024
 --------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Enh #20247: Support for variadic console controller action methods (brandonkelly)
 - Bug #20256: Add support for dropping views in MSSQL server when running migrate/fresh (ambrozt)
 - Enh #20248: Add support for attaching behaviors in configurations with Closure (timkelty)
+- Enh #20268: Minor optimisation in `\yii\helpers\BaseArrayHelper::map` (chriscpty)
 
 2.0.51 July 18, 2024
 --------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,7 +10,6 @@ Yii Framework 2 Change Log
 - Bug #20256: Add support for dropping views in MSSQL server when running migrate/fresh (ambrozt)
 - Enh #20248: Add support for attaching behaviors in configurations with Closure (timkelty)
 - Enh #20268: Minor optimisation in `\yii\helpers\BaseArrayHelper::map` (chriscpty)
-- Enh #20268: Add `\yii\helpers\BaseStringHelper::contains()` as a polyfill for `str_contains` (chriscpty)
 
 2.0.51 July 18, 2024
 --------------------

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -595,7 +595,7 @@ class BaseArrayHelper
      */
     public static function map($array, $from, $to, $group = null)
     {
-        if (is_string($from) && is_string($to) && $group === null && !\yii\helpers\StringHelper::contains($from, '.') && !\yii\helpers\StringHelper::contains($to, '.')) {
+        if (is_string($from) && is_string($to) && $group === null && strpos($from, '.') === false && strpos($to, '.') === false) {
             return array_column($array, $to, $from);
         }
         $result = [];

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -595,6 +595,9 @@ class BaseArrayHelper
      */
     public static function map($array, $from, $to, $group = null)
     {
+        if (is_string($from) && is_string($to) && $group === null) {
+            return array_column($array, $to, $from);
+        }
         $result = [];
         foreach ($array as $element) {
             $key = static::getValue($element, $from);

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -595,7 +595,7 @@ class BaseArrayHelper
      */
     public static function map($array, $from, $to, $group = null)
     {
-        if (is_string($from) && is_string($to) && $group === null) {
+        if (is_string($from) && is_string($to) && $group === null && !\yii\helpers\StringHelper::contains($from, '.') && !\yii\helpers\StringHelper::contains($to, '.')) {
             return array_column($array, $to, $from);
         }
         $result = [];

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -227,30 +227,6 @@ class BaseStringHelper
     }
 
     /**
-     * @param string $string The input string.
-     * @param string $needle Part to search inside $string
-     * @param bool $caseSensitive Case sensitive search. Default is true. When case sensitive is enabled, `$with` must
-     * exactly match the starting of the string in order to get a true value.
-     * @return bool
-     */
-    public static function contains($string, $needle, $caseSensitive = true)
-    {
-        $string = (string)$string;
-        $needle = (string)$needle;
-
-        if ($caseSensitive) {
-            // can be replaced with just the str_contains call when minimum supported PHP version is raised to 8.0 or higher
-            if (function_exists('str_contains')) {
-                return str_contains($string, $needle);
-            }
-            $encoding = Yii::$app ? Yii::$app->charset : 'UTF-8';
-            return mb_strpos($string, $needle, 0, $encoding) !== false;
-        }
-        $encoding = Yii::$app ? Yii::$app->charset : 'UTF-8';
-        return mb_stripos($string, $needle, 0, $encoding) !== false;
-    }
-
-    /**
      * Check if given string starts with specified substring. Binary and multibyte safe.
      *
      * @param string $string Input string

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -227,6 +227,29 @@ class BaseStringHelper
     }
 
     /**
+     * @param string $string The input string.
+     * @param string $needle Part to search inside $string
+     * @param bool $caseSensitive Case sensitive search. Default is true. When case sensitive is enabled, `$with` must
+     * exactly match the starting of the string in order to get a true value.
+     * @return bool
+     */
+    public static function contains($string, $needle, $caseSensitive = true)
+    {
+        $string = (string)$string;
+        $needle = (string)$needle;
+
+        if ($caseSensitive) {
+            if (function_exists('str_contains')) {
+                return str_contains($string, $needle);
+            }
+            $encoding = Yii::$app ? Yii::$app->charset : 'UTF-8';
+            return mb_strpos($string, $needle, 0,  $encoding) !== false;
+        }
+        $encoding = Yii::$app ? Yii::$app->charset : 'UTF-8';
+        return mb_stripos($string, $needle, 0, $encoding) !== false;
+    }
+
+    /**
      * Check if given string starts with specified substring. Binary and multibyte safe.
      *
      * @param string $string Input string
@@ -313,9 +336,14 @@ class BaseStringHelper
         }
         if ($skipEmpty) {
             // Wrapped with array_values to make array keys sequential after empty values removing
-            $result = array_values(array_filter($result, function ($value) {
-                return $value !== '';
-            }));
+            $result = array_values(
+                array_filter(
+                    $result,
+                    function ($value) {
+                        return $value !== '';
+                    }
+                )
+            );
         }
 
         return $result;
@@ -343,7 +371,7 @@ class BaseStringHelper
      */
     public static function normalizeNumber($value)
     {
-        $value = (string) $value;
+        $value = (string)$value;
 
         $localeInfo = localeconv();
         $decimalSeparator = isset($localeInfo['decimal_point']) ? $localeInfo['decimal_point'] : null;
@@ -396,7 +424,7 @@ class BaseStringHelper
     {
         // . and , are the only decimal separators known in ICU data,
         // so its safe to call str_replace here
-        return str_replace(',', '.', (string) $number);
+        return str_replace(',', '.', (string)$number);
     }
 
     /**
@@ -422,14 +450,14 @@ class BaseStringHelper
 
         $replacements = [
             '\\\\\\\\' => '\\\\',
-            '\\\\\\*' => '[*]',
-            '\\\\\\?' => '[?]',
-            '\*' => '.*',
-            '\?' => '.',
-            '\[\!' => '[^',
-            '\[' => '[',
-            '\]' => ']',
-            '\-' => '-',
+            '\\\\\\*'  => '[*]',
+            '\\\\\\?'  => '[?]',
+            '\*'       => '.*',
+            '\?'       => '.',
+            '\[\!'     => '[^',
+            '\['       => '[',
+            '\]'       => ']',
+            '\-'       => '-',
         ];
 
         if (isset($options['escape']) && !$options['escape']) {
@@ -483,7 +511,7 @@ class BaseStringHelper
      */
     public static function mb_ucwords($string, $encoding = 'UTF-8')
     {
-        $string = (string) $string;
+        $string = (string)$string;
         if (empty($string)) {
             return $string;
         }

--- a/framework/helpers/BaseStringHelper.php
+++ b/framework/helpers/BaseStringHelper.php
@@ -239,11 +239,12 @@ class BaseStringHelper
         $needle = (string)$needle;
 
         if ($caseSensitive) {
+            // can be replaced with just the str_contains call when minimum supported PHP version is raised to 8.0 or higher
             if (function_exists('str_contains')) {
                 return str_contains($string, $needle);
             }
             $encoding = Yii::$app ? Yii::$app->charset : 'UTF-8';
-            return mb_strpos($string, $needle, 0,  $encoding) !== false;
+            return mb_strpos($string, $needle, 0, $encoding) !== false;
         }
         $encoding = Yii::$app ? Yii::$app->charset : 'UTF-8';
         return mb_stripos($string, $needle, 0, $encoding) !== false;

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -734,6 +734,44 @@ class ArrayHelperTest extends TestCase
                 '345' => 'ccc',
             ],
         ], $result);
+
+        $result = ArrayHelper::map($array,
+            static function (array $group) {
+                return $group['id'] . $group['name'];
+            },
+            static function (array $group) {
+                return $group['name'] . $group['class'];
+            }
+        );
+
+        $this->assertEquals([
+            '123aaa' => 'aaax',
+            '124bbb' => 'bbbx',
+            '345ccc' => 'cccy',
+        ], $result);
+
+        $result = ArrayHelper::map($array,
+            static function (array $group) {
+                return $group['id'] . $group['name'];
+            },
+            static function (array $group) {
+                return $group['name'] . $group['class'];
+            },
+            static function (array $group) {
+                return $group['class'] . '-' . $group['class'];
+            }
+        );
+
+        $this->assertEquals([
+            'x-x' => [
+                '123aaa' => 'aaax',
+                '124bbb' => 'bbbx',
+            ],
+            'y-y' => [
+                '345ccc' => 'cccy',
+            ],
+        ], $result);
+
     }
 
     public function testKeyExists()
@@ -759,7 +797,7 @@ class ArrayHelperTest extends TestCase
         if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
             $this->markTestSkipped('Using floats as array key is deprecated.');
         }
-        
+
         $array = [
             1 => 3,
             2.2 => 4, // Note: Floats are cast to ints, which means that the fractional part will be truncated.

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -772,6 +772,19 @@ class ArrayHelperTest extends TestCase
             ],
         ], $result);
 
+        $array = [
+            ['id' => '123', 'name' => 'aaa', 'class' => 'x', 'map' => ['a' => '11', 'b' => '22']],
+            ['id' => '124', 'name' => 'bbb', 'class' => 'x', 'map' => ['a' => '33', 'b' => '44']],
+            ['id' => '345', 'name' => 'ccc', 'class' => 'y', 'map' => ['a' => '55', 'b' => '66']],
+        ];
+
+        $result = ArrayHelper::map($array, 'map.a', 'map.b');
+
+        $this->assertEquals([
+            '11' => '22',
+            '33' => '44',
+            '55' => '66'
+        ], $result);
     }
 
     public function testKeyExists()

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -150,6 +150,15 @@ class StringHelperTest extends TestCase
         $this->assertEquals('<span><img src="image.png" />This is a test</span><strong> for</strong>...', StringHelper::truncateWords('<span><img src="image.png" />This is a test</span><strong> for a sentance</strong>', 5, '...', true));
     }
 
+    public function testContains()
+    {
+        $this->assertEquals(true, StringHelper::contains('Test', 'st'));
+        $this->assertEquals(false, StringHelper::contains('Test', 'ts'));
+        $this->assertEquals(false, StringHelper::contains('Test', 'St'));
+        $this->assertEquals(true, StringHelper::contains('Test', 'St', false));
+        $this->assertEquals(false, StringHelper::contains('Test', 'Ste', false));
+    }
+
     /**
      * @dataProvider providerStartsWith
      * @param bool $result

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -150,15 +150,6 @@ class StringHelperTest extends TestCase
         $this->assertEquals('<span><img src="image.png" />This is a test</span><strong> for</strong>...', StringHelper::truncateWords('<span><img src="image.png" />This is a test</span><strong> for a sentance</strong>', 5, '...', true));
     }
 
-    public function testContains()
-    {
-        $this->assertEquals(true, StringHelper::contains('Test', 'st'));
-        $this->assertEquals(false, StringHelper::contains('Test', 'ts'));
-        $this->assertEquals(false, StringHelper::contains('Test', 'St'));
-        $this->assertEquals(true, StringHelper::contains('Test', 'St', false));
-        $this->assertEquals(false, StringHelper::contains('Test', 'Ste', false));
-    }
-
     /**
      * @dataProvider providerStartsWith
      * @param bool $result


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #20268 

Information re: what this does is in the issue.

In the process, I also improved the ArrayHelper::map() tests a bit to also test cases where callbacks are passed in for the three parameters.
