### PR TITLE
Fix #20273: Remove unnecessary `paragonie/random_compat` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,8 +78,7 @@
         "bower-asset/jquery": "3.7.*@stable | 3.6.*@stable | 3.5.*@stable | 3.4.*@stable | 3.3.*@stable | 3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
         "bower-asset/inputmask": "^5.0.8 ",
         "bower-asset/punycode": "^2.2",
-        "bower-asset/yii2-pjax": "~2.0.1",
-        "paragonie/random_compat": ">=1"
+        "bower-asset/yii2-pjax": "~2.0.1"
     },
     "require-dev": {
         "cebe/indent": "~1.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67d678d7fc90991fe6c1967c41f6264d",
+    "content-hash": "3faf6ba20beedc1db7758907d00f6681",
     "packages": [
         {
             "name": "bower-asset/inputmask",
@@ -205,56 +205,6 @@
                 "source": "https://github.com/ezyang/htmlpurifier/tree/v4.17.0"
             },
             "time": "2023-11-17T15:01:25+00:00"
-        },
-        {
-            "name": "paragonie/random_compat",
-            "version": "v9.99.100",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
-                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">= 7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*|5.*",
-                "vimeo/psalm": "^1"
-            },
-            "suggest": {
-                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com"
-                }
-            ],
-            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-            "keywords": [
-                "csprng",
-                "polyfill",
-                "pseudorandom",
-                "random"
-            ],
-            "support": {
-                "email": "info@paragonie.com",
-                "issues": "https://github.com/paragonie/random_compat/issues",
-                "source": "https://github.com/paragonie/random_compat"
-            },
-            "time": "2020-10-15T08:29:30+00:00"
         },
         {
             "name": "yiisoft/yii2-composer",

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Enh #20248: Add support for attaching behaviors in configurations with Closure (timkelty)
 - Enh #20267: Fixed called class check in `Widget::end()` when widget configured using callable (rob006, jrajamaki)
 - Enh #20268: Minor optimisation in `\yii\helpers\BaseArrayHelper::map` (chriscpty)
+- Enh #20273: Remove unnecessary `paragonie/random_compat` dependency (timwolla)
 
 2.0.51 July 18, 2024
 --------------------

--- a/framework/composer.json
+++ b/framework/composer.json
@@ -73,8 +73,7 @@
         "bower-asset/jquery": "3.7.*@stable | 3.6.*@stable | 3.5.*@stable | 3.4.*@stable | 3.3.*@stable | 3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
         "bower-asset/inputmask": "^5.0.8 ",
         "bower-asset/punycode": "^2.2",
-        "bower-asset/yii2-pjax": "~2.0.1",
-        "paragonie/random_compat": ">=1"
+        "bower-asset/yii2-pjax": "~2.0.1"
     },
     "autoload": {
         "psr-4": {"yii\\": ""}


### PR DESCRIPTION
Given that Yii itself requires PHP 7.3 since 2.0.50, this dependency does nothing, as PHP 7.0+ guarantees the existence of the CSPRNG.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | n/a
