### PR TITLE
Revert punycode to 1.4.x which supports pre ES6 format

### DIFF
--- a/framework/composer.json
+++ b/framework/composer.json
@@ -72,7 +72,7 @@
         "cebe/markdown": "~1.0.0 | ~1.1.0 | ~1.2.0",
         "bower-asset/jquery": "3.7.*@stable | 3.6.*@stable | 3.5.*@stable | 3.4.*@stable | 3.3.*@stable | 3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
         "bower-asset/inputmask": "^5.0.8 ",
-        "bower-asset/punycode": "^2.2",
+        "bower-asset/punycode": "^1.4",
         "bower-asset/yii2-pjax": "~2.0.1"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 20283
