### PR TITLE
Fixes CodeSniffer errors

### DIFF
--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1783,7 +1783,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
     {
         if (is_array($newValue) && is_array($oldValue)) {
             // Only sort associative arrays
-            $sorter = function(&$array) {
+            $sorter = function (&$array) {
                 if (ArrayHelper::isAssociative($array)) {
                     ksort($array);
                 }

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -823,5 +823,4 @@ SQL;
     {
         return Yii::createObject(ColumnSchemaBuilder::className(), [$type, $length, $this->db]);
     }
-
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |

```
Run phpcs: framework/db/BaseActiveRecord.php#L1786
Expected 1 space after FUNCTION keyword; 0 found

Run phpcs: framework/db/mssql/Schema.php#L827
The closing brace for the class must go on the next line after the body
```
