### PR TITLE
Fix #20292: Fix `\yii\web\Session` should not set cookie params, when useCookie is false

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.52 under development
 ------------------------
 
+- Bug #20292: Fix `\yii\web\Session` should not set cookie params, when useCookie is false (cebe)
 - Bug #20232: Fix regression introduced in `GHSA-cjcc-p67m-7qxm` while attaching behavior defined by `__class` array key (erickskrauch)
 - Bug #20231: Fix regression introduced in #20167 in `yii\validators\FileValidator` (bizley)
 - Enh #20247: Support for variadic console controller action methods (brandonkelly)

--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -145,7 +145,9 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
 
         $this->registerSessionHandler();
 
-        $this->setCookieParamsInternal();
+        if ($this->getUseCookies() !== false) {
+            $this->setCookieParamsInternal();
+        }
 
         YII_DEBUG ? session_start() : @session_start();
 


### PR DESCRIPTION
Fix #20292: yii\web\Session should not set cookie params, when useCookies is false

Upgrading from PHP 8.3.7 to 8.3.14 breaks yii\web\Session when used with useCookies = false.

Error: Session cookies cannot be used when session.use_cookies is disabled.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  |❌
| Breaks BC?    | ❌ (should not)
| Fixed issues  | #20292
