### PR TITLE
Fix enum test. Value used in assertion did not match the actual enum name

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -22,6 +22,7 @@ Yii Framework 2 Change Log
 - Bug #20140: Fix compatibility with PHP 8.4: calling `session_set_save_handler()` (Izumi-kun)
 - New #20185: Add `BackedEnum` support to `AttributeTypecastBehavior` (briedis)
 - Bug #17365: Fix "Trying to access array offset on null" warning (xcopy)
+- Bug #20296: Fix broken enum test (briedis)
 
 2.0.51 July 18, 2024
 --------------------

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -1539,7 +1539,7 @@ SQL;
 		    $command = $db->createCommand();
 
 		    $command->setSql('SELECT :p1')->bindValues([':p1' => enums\Status::Active]);
-		    $this->assertSame('ACTIVE', $command->params[':p1']);
+		    $this->assertSame('Active', $command->params[':p1']);
 
 		    $command->setSql('SELECT :p1')->bindValues([':p1' => enums\StatusTypeString::Active]);
 		    $this->assertSame('active', $command->params[':p1']);


### PR DESCRIPTION
Fixes broken test (forgot to update the assertion)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | [Issue mentioned in a comment](https://github.com/yiisoft/yii2/pull/20185#pullrequestreview-2491013188)
