### PR TITLE
Prepare `MSSQL` workflow for `ubuntu-24.04` runner image

### DIFF
--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -16,7 +16,7 @@ jobs:
       EXTENSIONS: pdo, pdo_sqlsrv
       XDEBUG_MODE: coverage, develop
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.mssql.os || 'ubuntu-latest' }}
 
     strategy:
       fail-fast: false
@@ -38,6 +38,7 @@ jobs:
             mssql:
               version: server:2017-latest
               mssql-tool: /opt/mssql-tools/bin/sqlcmd
+              os: ubuntu-22.04
           - php: 8.0
             mssql:
               version: server:2019-latest

--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -55,6 +55,9 @@ jobs:
           options: --name=mssql --health-cmd="${{ matrix.mssql.mssql-tool }} -S localhost -U SA -P 'YourStrong!Passw0rd' -Q 'SELECT 1'" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
+      - name: Install ODBC driver
+        run: sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/tests/data/config.php
+++ b/tests/data/config.php
@@ -37,7 +37,7 @@ $config = [
             'fixture' => __DIR__ . '/sqlite.sql',
         ],
         'sqlsrv' => [
-            'dsn' => 'sqlsrv:Server=127.0.0.1,1433;Database=yiitest',
+            'dsn' => 'sqlsrv:Server=127.0.0.1,1433;Database=yiitest;Encrypt=no',
             'username' => 'SA',
             'password' => 'YourStrong!Passw0rd',
             'fixture' => __DIR__ . '/mssql.sql',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/actions/runner-images/issues/10636

The `ubuntu-24.04` runner image does not include the ODBC driver, so an additional step is required to install it.
ODBC Driver 18 introduces a breaking change: the default `Encrypt` setting is now set to `yes`. To address this, I added `Encrypt=no` to the connection settings.

Another way to fix the tests is to explicitly specify `runs-on: ubuntu-22.04`.
