### PR TITLE
Allow CompositeAuth auth methods to use their own user if defined

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -26,6 +26,7 @@ Yii Framework 2 Change Log
 - Bug #20296: Fix broken enum test (briedis)
 - Bug #20300: Clear stat cache in `FileCache::setValue()` (rob006)
 - Enh #20306: Add new `yii\helpers\ArrayHelper::flatten()` method (xcopy)
+- Bug #20308: Allow CompositeAuth auth methods to use their own user if defined (mtangoo)
 
 2.0.51 July 18, 2024
 --------------------

--- a/framework/filters/auth/CompositeAuth.php
+++ b/framework/filters/auth/CompositeAuth.php
@@ -88,7 +88,7 @@ class CompositeAuth extends AuthMethod
 
             $authUser = $auth->user;
             if ($authUser != null && !$authUser instanceof \yii\web\User) {
-                throw new InvalidConfigException(get_class($authUser) . ' must implement of a type yii\web\User');
+                throw new InvalidConfigException(get_class($authUser) . ' must implement yii\web\User');
             } elseif ($authUser != null) {
                 $user = $authUser;
             }

--- a/framework/filters/auth/CompositeAuth.php
+++ b/framework/filters/auth/CompositeAuth.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -83,6 +84,13 @@ class CompositeAuth extends AuthMethod
                 )
             ) {
                 continue;
+            }
+
+            $authUser = $auth->user;
+            if ($authUser != null && !$authUser instanceof \yii\web\User) {
+                throw new InvalidConfigException(get_class($authUser) . ' must implement of a type yii\web\User');
+            } elseif ($authUser != null) {
+                $user = $authUser;
             }
 
             $identity = $auth->authenticate($user, $request, $response);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  |  ❌
| Breaks BC?    |  ❌
| Fixed issues  |  #20238
