### PR TITLE
add csp nonce attribute to style tags (#20309)

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.53 under development
 ------------------------
 
-- no changes in this release.
+- Enh #20309 Add custom attributes support to style tags.
 
 
 2.0.52 February 13, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.53 under development
 ------------------------
 
-- Enh #20309 Add custom attributes support to style tags (nzwz)
+- Enh #20309: Add custom attributes support to style tags (nzwz)
 
 
 2.0.52 February 13, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.53 under development
 ------------------------
 
-- Enh #20309 Add custom attributes support to style tags.
+- Enh #20309 Add custom attributes support to style tags (nzwz)
 
 
 2.0.52 February 13, 2025

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -205,6 +205,11 @@ class BaseHtml
      */
     public static function style($content, $options = [])
     {
+        $view = Yii::$app->getView();
+        if ($view instanceof \yii\web\View && !empty($view->styleOptions)) {
+            $options = array_merge($view->styleOptions, $options);
+        }
+
         return static::tag('style', $content, $options);
     }
 

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -120,6 +120,13 @@ class View extends \yii\base\View
      * @see registerCssFile()
      */
     public $cssFiles = [];
+
+    /**
+     * @since 2.0.52
+     * @var array the style tag options.
+     */
+    public $styleOptions = [];
+
     /**
      * @var array the registered JS code blocks
      * @see registerJs()

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -122,7 +122,7 @@ class View extends \yii\base\View
     public $cssFiles = [];
 
     /**
-     * @since 2.0.52
+     * @since 2.0.53
      * @var array the style tag options.
      */
     public $styleOptions = [];

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -83,6 +83,21 @@ class HtmlTest extends TestCase
         $this->assertEquals("<style type=\"text/less\">{$content}</style>", Html::style($content, ['type' => 'text/less']));
     }
 
+    public function testStyleCustomAttribute()
+    {
+        $nonce = Yii::$app->security->generateRandomString();
+        $this->mockApplication([
+            'components' => [
+                'view' => [
+                    'class' => 'yii\web\View',
+                    'styleOptions' => ['nonce' => $nonce],
+                ],
+            ],
+        ]);
+        $content = 'a <>';
+        $this->assertEquals("<style nonce=\"{$nonce}\">{$content}</style>", Html::style($content));
+    }
+
     public function testScript()
     {
         $content = 'a <>';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |  #20309 
What attribute should be added to the style tag?

Only the nonce
Nonce use-case is easy to find in the API docs
Less flexible

