### PR TITLE
fix regression in ArrayHelper::map

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Enh #20309: Add custom attributes support to style tags (nzwz)
+- Bug #20327: Fix regression in `\yii\helpers\BaseArrayHelper::map` (chriscpty)
 
 
 2.0.52 February 13, 2025

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -595,9 +595,6 @@ class BaseArrayHelper
      */
     public static function map($array, $from, $to, $group = null)
     {
-        if (is_string($from) && is_string($to) && $group === null && strpos($from, '.') === false && strpos($to, '.') === false) {
-            return array_column($array, $to, $from);
-        }
         $result = [];
         foreach ($array as $element) {
             $key = static::getValue($element, $from);

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -785,6 +785,12 @@ class ArrayHelperTest extends TestCase
             '33' => '44',
             '55' => '66'
         ], $result);
+
+        $array = [new MagicClass()];
+
+        $result = ArrayHelper::map($array, 'magic', 'moreMagic');
+
+        $this->assertEquals([42 => 'ta-da'], $result);
     }
 
     public function testKeyExists()
@@ -1862,5 +1868,27 @@ class MagicModel extends Model
     public function getMoreMagic()
     {
         return 'ta-da';
+    }
+}
+
+class MagicClass
+{
+    public function __get($name) {
+        if ($name === 'magic') {
+            return 42;
+        }
+        if ($name === 'moreMagic') {
+            return 'ta-da';
+        }
+        return $this->$name;
+    }
+
+    public function __set($name, $value) {
+        $this->$name = $value;
+    }
+
+    public function __isset($name)
+    {
+        return isset($this->$name);
     }
 }


### PR DESCRIPTION
fix regression in ArrayHelper::map when trying to use magic methods

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20327 

Also added a test to check for this regression in the future.