### PR TITLE
Fix #20322: Correct escaping of hex ranges in Html::escapeJsRegularEx…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Enh #20309: Add custom attributes support to style tags (nzwz)
-- Bug #20322: Correct escaping of hex ranges in Html::escapeJsRegularExpression
+- Bug #20322: Correct escaping of hex ranges in Html::escapeJsRegularExpression (kowap)
 
 
 2.0.52 February 13, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Enh #20309: Add custom attributes support to style tags (nzwz)
+- Bug #20322: Correct escaping of hex ranges in Html::escapeJsRegularExpression
 
 
 2.0.52 February 13, 2025

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2392,7 +2392,7 @@ class BaseHtml
      */
     public static function escapeJsRegularExpression($regexp)
     {
-        $pattern = preg_replace('/\\\\x\{?([0-9a-fA-F]+)\}?/', '\u$1', $regexp);
+        $pattern = preg_replace('/\\\\x([0-9a-fA-F]{2})/', '\\x{$1}', $regexp);
         $deliminator = substr($pattern, 0, 1);
         $pos = strrpos($pattern, $deliminator, 1);
         $flag = substr($pattern, $pos + 1);

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -38,6 +38,15 @@ class HtmlTest extends TestCase
         ]);
     }
 
+    public function testEscapeJsRegularExpressionHexRange()
+    {
+        $original = '/^[\x00-\xFF]{8,72}$/';
+        $expected = '/^[\x{00}-\x{FF}]{8,72}$/';
+        $escaped = Html::escapeJsRegularExpression($original);
+
+        $this->assertSame($expected, $escaped, "Hex range \x00-\xFF should be correctly converted.");
+    }
+
     public function testEncode()
     {
         $this->assertEquals('a&lt;&gt;&amp;&quot;&#039;�', Html::encode("a<>&\"'\x80"));

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -38,6 +38,9 @@ class HtmlTest extends TestCase
         ]);
     }
 
+    /**
+     * @covers \yii\helpers\Html::escapeJsRegularExpression
+     */
     public function testEscapeJsRegularExpressionHexRange()
     {
         $testCases = [

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -40,11 +40,22 @@ class HtmlTest extends TestCase
 
     public function testEscapeJsRegularExpressionHexRange()
     {
-        $original = '/^[\x00-\xFF]{8,72}$/';
-        $expected = '/^[\x{00}-\x{FF}]{8,72}$/';
-        $escaped = Html::escapeJsRegularExpression($original);
+        $testCases = [
+            '/^[\x00-\xFF]{8,72}$/',
+            '/^[\xA1-\xFE]{2}$/',
+            '/^\xFF\x00$/',
+        ];
 
-        $this->assertSame($expected, $escaped, "Hex range \x00-\xFF should be correctly converted.");
+        $expectedResults = [
+            '/^[\x{00}-\x{FF}]{8,72}$/',
+            '/^[\x{A1}-\x{FE}]{2}$/',
+            '/^\x{FF}\x{00}$/',
+        ];
+
+        foreach ($testCases as $index => $original) {
+            $escaped = Html::escapeJsRegularExpression($original);
+            $this->assertSame($expectedResults[$index], $escaped, "Test case #$index failed.");
+        }
     }
 
     public function testEncode()


### PR DESCRIPTION
Fixes #20322

This PR corrects the escaping of hex ranges (\x00-\xFF) in Html::escapeJsRegularExpression, ensuring compatibility with JavaScript regular expressions.