### PR TITLE
Fix #20329: pgsql: Column Schema doesn't recognize PG type cast

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Enh #20309: Add custom attributes support to style tags (nzwz)
+- Bug #20329: pgsql: Column Schema doesn't recognize PG type cast (arkhamvm)
 
 
 2.0.52 February 13, 2025

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -558,7 +558,7 @@ SQL;
                             ['NOW()', 'CURRENT_TIMESTAMP', 'CURRENT_DATE', 'CURRENT_TIME'],
                             true
                         ) ||
-                        preg_match("/TIMEZONE|NOW\(\)/i", $column->defaultValue)
+                        preg_match('/TIMEZONE|NOW\(\)/i', $column->defaultValue)
                     )
                 ) {
                     $column->defaultValue = new Expression($column->defaultValue);

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -558,7 +558,7 @@ SQL;
                             ['NOW()', 'CURRENT_TIMESTAMP', 'CURRENT_DATE', 'CURRENT_TIME'],
                             true
                         ) ||
-                        preg_match('/TIMEZONE|NOW\(\)/i', $column->defaultValue)
+                        str_contains($column->defaultValue, '(')
                     )
                 ) {
                     $column->defaultValue = new Expression($column->defaultValue);

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -552,10 +552,13 @@ SQL;
             } elseif ($column->defaultValue) {
                 if (
                     in_array($column->type, [self::TYPE_TIMESTAMP, self::TYPE_DATE, self::TYPE_TIME], true) &&
-                    in_array(
-                        strtoupper($column->defaultValue),
-                        ['NOW()', 'CURRENT_TIMESTAMP', 'CURRENT_DATE', 'CURRENT_TIME'],
-                        true
+                    (
+                        in_array(
+                            strtoupper($column->defaultValue),
+                            ['NOW()', 'CURRENT_TIMESTAMP', 'CURRENT_DATE', 'CURRENT_TIME'],
+                            true
+                        ) ||
+                        preg_match("/TIMEZONE|NOW\(\)/i", $column->defaultValue)
                     )
                 ) {
                     $column->defaultValue = new Expression($column->defaultValue);

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -558,7 +558,7 @@ SQL;
                             ['NOW()', 'CURRENT_TIMESTAMP', 'CURRENT_DATE', 'CURRENT_TIME'],
                             true
                         ) ||
-                        str_contains($column->defaultValue, '(')
+                        (false !== strpos($column->defaultValue, '('))
                     )
                 ) {
                     $column->defaultValue = new Expression($column->defaultValue);

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -341,6 +341,26 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         $this->assertNull($tableSchema->getColumn('timestamp')->defaultValue);
     }
 
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/20329
+     */
+    public function testTimestampUtcNowDefaultValue()
+    {
+        $db = $this->getConnection(false);
+        if ($db->schema->getTableSchema('test_timestamp_utc_now_default') !== null) {
+            $db->createCommand()->dropTable('test_timestamp_utc_now_default')->execute();
+        }
+
+        $db->createCommand()->createTable('test_timestamp_utc_now_default', [
+            'id' => 'pk',
+            'timestamp' => 'timestamp DEFAULT timezone(\'UTC\'::text, now()) NOT NULL',
+        ])->execute();
+
+        $db->schema->refreshTableSchema('test_timestamp_utc_now_default');
+        $tableSchema = $db->schema->getTableSchema('test_timestamp_utc_now_default');
+        $this->assertEquals('timezone(\'UTC\'::text, now())', $tableSchema->getColumn('timestamp')->defaultValue);
+    }
+    
     public function constraintsProvider()
     {
         $result = parent::constraintsProvider();

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -360,7 +360,47 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         $tableSchema = $db->schema->getTableSchema('test_timestamp_utc_now_default');
         $this->assertEquals('timezone(\'UTC\'::text, now())', $tableSchema->getColumn('timestamp')->defaultValue);
     }
-    
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/20329
+     */
+    public function testTimestampNowDefaultValue()
+    {
+        $db = $this->getConnection(false);
+        if ($db->schema->getTableSchema('test_timestamp_now_default') !== null) {
+            $db->createCommand()->dropTable('test_timestamp_now_default')->execute();
+        }
+
+        $db->createCommand()->createTable('test_timestamp_now_default', [
+            'id' => 'pk',
+            'timestamp' => 'timestamp DEFAULT now()',
+        ])->execute();
+
+        $db->schema->refreshTableSchema('test_timestamp_now_default');
+        $tableSchema = $db->schema->getTableSchema('test_timestamp_now_default');
+        $this->assertEquals('now()', $tableSchema->getColumn('timestamp')->defaultValue);
+    }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/20329
+     */
+    public function testTimestampUtcStringDefaultValue()
+    {
+        $db = $this->getConnection(false);
+        if ($db->schema->getTableSchema('test_timestamp_utc_string_default') !== null) {
+            $db->createCommand()->dropTable('test_timestamp_utc_string_default')->execute();
+        }
+
+        $db->createCommand()->createTable('test_timestamp_utc_string_default', [
+            'id' => 'pk',
+            'timestamp' => 'timestamp DEFAULT timezone(\'UTC\'::text, \'1970-01-01 00:00:00+00\'::timestamp with time zone) NOT NULL',
+        ])->execute();
+
+        $db->schema->refreshTableSchema('test_timestamp_utc_string_default');
+        $tableSchema = $db->schema->getTableSchema('test_timestamp_utc_string_default');
+        $this->assertEquals('timezone(\'UTC\'::text, \'1970-01-01 00:00:00+00\'::timestamp with time zone)', $tableSchema->getColumn('timestamp')->defaultValue);
+    }
+
     public function constraintsProvider()
     {
         $result = parent::constraintsProvider();

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -358,7 +358,7 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
 
         $db->schema->refreshTableSchema('test_timestamp_utc_now_default');
         $tableSchema = $db->schema->getTableSchema('test_timestamp_utc_now_default');
-        $this->assertEquals('timezone(\'UTC\'::text, now())', $tableSchema->getColumn('timestamp')->defaultValue);
+        $this->assertEquals(new Expression('timezone(\'UTC\'::text, now())'), $tableSchema->getColumn('timestamp')->defaultValue);
     }
 
     /**
@@ -378,7 +378,7 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
 
         $db->schema->refreshTableSchema('test_timestamp_now_default');
         $tableSchema = $db->schema->getTableSchema('test_timestamp_now_default');
-        $this->assertEquals('now()', $tableSchema->getColumn('timestamp')->defaultValue);
+        $this->assertEquals(new Expression('now()'), $tableSchema->getColumn('timestamp')->defaultValue);
     }
 
     /**
@@ -398,7 +398,7 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
 
         $db->schema->refreshTableSchema('test_timestamp_utc_string_default');
         $tableSchema = $db->schema->getTableSchema('test_timestamp_utc_string_default');
-        $this->assertEquals('timezone(\'UTC\'::text, \'1970-01-01 00:00:00+00\'::timestamp with time zone)', $tableSchema->getColumn('timestamp')->defaultValue);
+        $this->assertEquals(new Expression('timezone(\'UTC\'::text, \'1970-01-01 00:00:00+00\'::timestamp with time zone)'), $tableSchema->getColumn('timestamp')->defaultValue);
     }
 
     public function constraintsProvider()


### PR DESCRIPTION
Quick Fix for #20329

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

