### PR TITLE
Fix docblock return type mismatch in DataReader::read() method

### DIFF
--- a/framework/db/DataReader.php
+++ b/framework/db/DataReader.php
@@ -105,7 +105,7 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
 
     /**
      * Advances the reader to the next row in a result set.
-     * @return array the current row, false if no more row available
+     * @return array|false the current row, false if no more row available
      */
     public function read()
     {


### PR DESCRIPTION
This pull request addresses a mismatch between the docblock return type and the actual behavior of the `DataReader::read()` method.

Previously, the docblock indicated that the method would return an `array`, even though `false` had already been noted in the method’s comment.

This change is trivial, but it helps static analysis tools correctly identify the method’s possible return values.


| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
