### PR TITLE
Fix PHP 8.4 deprecations for setting session settings

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Enh #20309: Add custom attributes support to style tags (nzwz)
 - Bug #20329: pgsql: Column Schema doesn't recognize PG type cast (arkhamvm)
 - Bug #8298: Loading fixtures does not update table sequence for Postgresql database (mtangoo)
+- Bug #20347: Fix compatibility with PHP 8.4: remove usage of `session.use_trans_sid` and `session.use_only_cookies` (tehmaestro)
 
 
 2.0.52 February 13, 2025

--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -260,7 +260,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
             $request = Yii::$app->getRequest();
             if (!empty($_COOKIE[$name]) && ini_get('session.use_cookies')) {
                 $this->_hasSessionId = true;
-            } elseif (!ini_get('session.use_only_cookies') && ini_get('session.use_trans_sid')) {
+            } elseif (PHP_VERSION_ID < 80400 && !ini_get('session.use_only_cookies') && ini_get('session.use_trans_sid')) {
                 $this->_hasSessionId = $request->get($name) != '';
             } else {
                 $this->_hasSessionId = false;
@@ -439,7 +439,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
     {
         if (ini_get('session.use_cookies') === '0') {
             return false;
-        } elseif (ini_get('session.use_only_cookies') === '1') {
+        } elseif (PHP_VERSION_ID >= 80400 || ini_get('session.use_only_cookies') === '1') {
             return true;
         }
 
@@ -462,13 +462,19 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         $this->freeze();
         if ($value === false) {
             ini_set('session.use_cookies', '0');
-            ini_set('session.use_only_cookies', '0');
+            if (PHP_VERSION_ID < 80400) {
+                ini_set('session.use_only_cookies', '0');
+            }
         } elseif ($value === true) {
             ini_set('session.use_cookies', '1');
-            ini_set('session.use_only_cookies', '1');
+            if (PHP_VERSION_ID < 80400) {
+                ini_set('session.use_only_cookies', '1');
+            }
         } else {
             ini_set('session.use_cookies', '1');
-            ini_set('session.use_only_cookies', '0');
+            if (PHP_VERSION_ID < 80400) {
+                ini_set('session.use_only_cookies', '0');
+            }
         }
         $this->unfreeze();
     }
@@ -503,7 +509,10 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      */
     public function getUseTransparentSessionID()
     {
-        return ini_get('session.use_trans_sid') == 1;
+        if (PHP_VERSION_ID < 80400) {
+            return ini_get('session.use_trans_sid') == 1;
+        }
+        return false;
     }
 
     /**
@@ -512,7 +521,9 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
     public function setUseTransparentSessionID($value)
     {
         $this->freeze();
-        ini_set('session.use_trans_sid', $value ? '1' : '0');
+        if (PHP_VERSION_ID < 80400) {
+            ini_set('session.use_trans_sid', $value ? '1' : '0');
+        }
         $this->unfreeze();
     }
 

--- a/tests/framework/web/session/SessionTest.php
+++ b/tests/framework/web/session/SessionTest.php
@@ -47,8 +47,13 @@ class SessionTest extends TestCase
         $oldUseTransparentSession = $session->getUseTransparentSessionID();
         $session->setUseTransparentSessionID(true);
         $newUseTransparentSession = $session->getUseTransparentSessionID();
-        $this->assertNotEquals($oldUseTransparentSession, $newUseTransparentSession);
-        $this->assertTrue($newUseTransparentSession);
+        if (PHP_VERSION_ID < 80400) {
+            $this->assertNotEquals($oldUseTransparentSession, $newUseTransparentSession);
+            $this->assertTrue($newUseTransparentSession);
+        } else {
+            $this->assertEquals($oldUseTransparentSession, $newUseTransparentSession);
+            $this->assertFalse($newUseTransparentSession);
+        }
         //without this line phpunit will complain about risky tests due to unclosed buffer
         $session->setUseTransparentSessionID(false);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️ ??
| Fixed issues  | #20347 

So I assumed that starting with PHP 8.4 we have:
`session.use_only_cookies` set to true
`session.use_trans_id` set to false

This is going to be the default starting with PHP 9 and it seems the settings will be completely removed, that's why I also added conditional reading of these settings starting with PHP 8.4 . Not sure if this should be considered a breaking change for PHP 8.4
