### PR TITLE
 Fix SQL syntax for resetting sequence in `QueryBuilder` for `MSSQL`.

### DIFF
--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -34,11 +34,6 @@ jobs:
             mssql-tool: /opt/mssql-tools18/bin/sqlcmd -C
 
         include:
-          - php: 7.4
-            mssql:
-              version: server:2017-latest
-              mssql-tool: /opt/mssql-tools/bin/sqlcmd
-              os: ubuntu-22.04
           - php: 8.0
             mssql:
               version: server:2019-latest

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Bug #20329: pgsql: Column Schema doesn't recognize PG type cast (arkhamvm)
 - Bug #8298: Loading fixtures does not update table sequence for Postgresql database (mtangoo)
 - Bug #20347: Fix compatibility with PHP 8.4: remove usage of `session.use_trans_sid` and `session.use_only_cookies` (tehmaestro)
+- Bug #20355: Fix SQL syntax for resetting sequence in `QueryBuilder` for `MSSQL` (terabytesoftw)
 
 
 2.0.52 February 13, 2025

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -247,9 +247,11 @@ class QueryBuilder extends \yii\db\QueryBuilder
         $table = $this->db->getTableSchema($tableName);
         if ($table !== null && $table->sequenceName !== null) {
             $tableName = $this->db->quoteTableName($tableName);
+
             if ($value === null) {
                 $key = $this->db->quoteColumnName(reset($table->primaryKey));
-                $value = "(SELECT COALESCE(MAX({$key}),0) FROM {$tableName})+1";
+                $sql = "SELECT COALESCE(MAX({$key}), 0) + 1 FROM {$tableName}";
+                $value = $this->db->createCommand($sql)->queryScalar();
             } else {
                 $value = (int) $value;
             }

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -364,7 +364,7 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
     {
         $qb = $this->getQueryBuilder();
 
-        $expected = "DBCC CHECKIDENT ('[item]', RESEED, (SELECT COALESCE(MAX([id]),0) FROM [item])+1)";
+        $expected = "DBCC CHECKIDENT ('[item]', RESEED, 6)";
         $sql = $qb->resetSequence('item');
         $this->assertEquals($expected, $sql);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
