### PR TITLE
Fix crash on PHP 8.3 when a file is missing

### DIFF
--- a/framework/caching/FileCache.php
+++ b/framework/caching/FileCache.php
@@ -97,7 +97,7 @@ class FileCache extends Cache
     {
         $cacheFile = $this->getCacheFile($this->buildKey($key));
 
-        set_error_handler(function($errno, $errstr) {
+        set_error_handler(function ($errno, $errstr) {
             return strpos($errstr, 'filemtime') !== false;
         }, E_WARNING);
 
@@ -117,7 +117,7 @@ class FileCache extends Cache
     {
         $cacheFile = $this->getCacheFile($key);
 
-        set_error_handler(function($errno, $errstr) {
+        set_error_handler(function ($errno, $errstr) {
             return strpos($errstr, 'filemtime') !== false;
         }, E_WARNING);
 

--- a/framework/caching/FileCache.php
+++ b/framework/caching/FileCache.php
@@ -110,7 +110,7 @@ class FileCache extends Cache
     {
         $cacheFile = $this->getCacheFile($key);
 
-        if (@filemtime($cacheFile) > time()) {
+        if (file_exists($cacheFile) && @filemtime($cacheFile) > time()) {
             $fp = @fopen($cacheFile, 'r');
             if ($fp !== false) {
                 @flock($fp, LOCK_SH);

--- a/framework/caching/FileCache.php
+++ b/framework/caching/FileCache.php
@@ -97,7 +97,14 @@ class FileCache extends Cache
     {
         $cacheFile = $this->getCacheFile($this->buildKey($key));
 
-        return @filemtime($cacheFile) > time();
+        set_error_handler(function($errno, $errstr) {
+            return strpos($errstr, 'filemtime') !== false;
+        }, E_WARNING);
+
+        $filemtime = filemtime($cacheFile);
+        restore_error_handler();
+
+        return $filemtime !== false && $filemtime > time();
     }
 
     /**
@@ -110,7 +117,14 @@ class FileCache extends Cache
     {
         $cacheFile = $this->getCacheFile($key);
 
-        if (file_exists($cacheFile) && @filemtime($cacheFile) > time()) {
+        set_error_handler(function($errno, $errstr) {
+            return strpos($errstr, 'filemtime') !== false;
+        }, E_WARNING);
+
+        $filemtime = filemtime($cacheFile);
+        restore_error_handler();
+
+        if ($filemtime !== false && $filemtime > time()) {
             $fp = @fopen($cacheFile, 'r');
             if ($fp !== false) {
                 @flock($fp, LOCK_SH);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

This fixes a problem I had after migrating Craft CMS (based on Yii2) to PHP 8.3