### PR TITLE
Added Psalm/PHPStan annotations for ActiveQuery

### DIFF
--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -71,6 +71,10 @@ use yii\base\InvalidConfigException;
  * @since 2.0
  *
  * @template T of (ActiveRecord|array)
+ * @phpstan-method T|null one($db = null)
+ * @psalm-method T|null one($db = null)
+ * @phpstan-method T[] all($db = null)
+ * @psalm-method T[] all($db = null)
  */
 class ActiveQuery extends Query implements ActiveQueryInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

`ActiveRelationTrait` annotations do not allow PHPStan to correctly identify the type of data returned.

![image](https://github.com/user-attachments/assets/c10b3506-1f4d-40f4-89cd-69acbec3f5e8)

### Example

#### Before changes

![image](https://github.com/user-attachments/assets/136b78f7-4ec9-4cdb-a378-563cd0e5cfe3)

#### After changes

![image](https://github.com/user-attachments/assets/9d910a2a-428b-484c-a0f1-174bb8bdf870)

