### PR TITLE
Added and fixed Psalm/PHPStan annotations for ActiveRecord and ActiveQuery

### DIFF
--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -75,8 +75,8 @@ use yii\base\InvalidConfigException;
  * @psalm-method T|null one($db = null)
  * @phpstan-method T[] all($db = null)
  * @psalm-method T[] all($db = null)
- * @phpstan-method self<array> asArray($value = true)
- * @psalm-method self<array> asArray($value = true)
+ * @phpstan-method ($value is true ? self<array> : self<T>) asArray($value = true)
+ * @psalm-method ($value is true ? self<array> : self<T>) asArray($value = true)
  */
 class ActiveQuery extends Query implements ActiveQueryInterface
 {

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -81,11 +81,11 @@ use yii\base\InvalidConfigException;
  * @phpstan-method ($value is true ? (T is array ? self<T> : self<array>) : self<T>) asArray($value = true)
  * @psalm-method ($value is true ? (T is array ? self<T> : self<array>) : self<T>) asArray($value = true)
  *
- * @phpstan-method BatchQueryResult<int,T[]> batch($batchSize = 100, $db = null)
- * @psalm-method BatchQueryResult<int,T[]> batch($batchSize = 100, $db = null)
+ * @phpstan-method BatchQueryResult<int, T[]> batch($batchSize = 100, $db = null)
+ * @psalm-method BatchQueryResult<int, T[]> batch($batchSize = 100, $db = null)
  *
- * @phpstan-method BatchQueryResult<int,T> each($batchSize = 100, $db = null)
- * @psalm-method BatchQueryResult<int,T> each($batchSize = 100, $db = null)
+ * @phpstan-method BatchQueryResult<int, T> each($batchSize = 100, $db = null)
+ * @psalm-method BatchQueryResult<int, T> each($batchSize = 100, $db = null)
  */
 class ActiveQuery extends Query implements ActiveQueryInterface
 {

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -75,6 +75,8 @@ use yii\base\InvalidConfigException;
  * @psalm-method T|null one($db = null)
  * @phpstan-method T[] all($db = null)
  * @psalm-method T[] all($db = null)
+ * @phpstan-method self<array> asArray($value = true)
+ * @psalm-method self<array> asArray($value = true)
  */
 class ActiveQuery extends Query implements ActiveQueryInterface
 {

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -80,6 +80,12 @@ use yii\base\InvalidConfigException;
  *
  * @phpstan-method ($value is true ? self<array> : self<T>) asArray($value = true)
  * @psalm-method ($value is true ? self<array> : self<T>) asArray($value = true)
+ *
+ * @phpstan-method BatchQueryResult<int,T[]> batch($batchSize = 100, $db = null)
+ * @psalm-method BatchQueryResult<int,T[]> batch($batchSize = 100, $db = null)
+ *
+ * @phpstan-method BatchQueryResult<int,T> each($batchSize = 100, $db = null)
+ * @psalm-method BatchQueryResult<int,T> each($batchSize = 100, $db = null)
  */
 class ActiveQuery extends Query implements ActiveQueryInterface
 {
@@ -323,32 +329,6 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         }
 
         return null;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return BatchQueryResult
-     * @psalm-return T[][]|BatchQueryResult
-     * @phpstan-return T[][]|BatchQueryResult
-     * @codeCoverageIgnore
-     */
-    public function batch($batchSize = 100, $db = null)
-    {
-        return parent::batch($batchSize, $db);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return BatchQueryResult
-     * @psalm-return T[]|BatchQueryResult
-     * @phpstan-return T[]|BatchQueryResult
-     * @codeCoverageIgnore
-     */
-    public function each($batchSize = 100, $db = null)
-    {
-        return parent::each($batchSize, $db);
     }
 
     /**

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -71,10 +71,13 @@ use yii\base\InvalidConfigException;
  * @since 2.0
  *
  * @template T of (ActiveRecord|array)
+ *
  * @phpstan-method T|null one($db = null)
  * @psalm-method T|null one($db = null)
+ *
  * @phpstan-method T[] all($db = null)
  * @psalm-method T[] all($db = null)
+ *
  * @phpstan-method ($value is true ? self<array> : self<T>) asArray($value = true)
  * @psalm-method ($value is true ? self<array> : self<T>) asArray($value = true)
  */

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -78,8 +78,8 @@ use yii\base\InvalidConfigException;
  * @phpstan-method T[] all($db = null)
  * @psalm-method T[] all($db = null)
  *
- * @phpstan-method ($value is true ? self<array> : self<T>) asArray($value = true)
- * @psalm-method ($value is true ? self<array> : self<T>) asArray($value = true)
+ * @phpstan-method ($value is true ? (T is array ? self<T> : self<array>) : self<T>) asArray($value = true)
+ * @psalm-method ($value is true ? (T is array ? self<T> : self<array>) : self<T>) asArray($value = true)
  *
  * @phpstan-method BatchQueryResult<int,T[]> batch($batchSize = 100, $db = null)
  * @psalm-method BatchQueryResult<int,T[]> batch($batchSize = 100, $db = null)

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -156,6 +156,9 @@ class ActiveRecord extends BaseActiveRecord
      * @param string $sql the SQL statement to be executed
      * @param array $params parameters to be bound to the SQL statement during execution.
      * @return ActiveQuery the newly created [[ActiveQuery]] instance
+     *
+     * @phpstan-return ActiveQuery<static>
+     * @psalm-return ActiveQuery<static>
      */
     public static function findBySql($sql, $params = [])
     {
@@ -408,6 +411,9 @@ class ActiveRecord extends BaseActiveRecord
     /**
      * {@inheritdoc}
      * @return ActiveQuery the newly created [[ActiveQuery]] instance.
+     *
+     * @phpstan-return ActiveQuery<static>
+     * @psalm-return ActiveQuery<static>
      */
     public static function find()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

### What's done:

1. Fixed the types of returned data for the methods: `each` and `batch`.
2. Fixed the type of data returned for the `asArray` method.
3. Annotations to `ActiveRecord`: `find` and `findBySql` methods have been added.

### Example

#### Code

```php
class Test extends ActiveRecord
{
    /**
     * @return self[]
     */
    public static function findAllTests(): array
    {
        return static::find()->all();
    }

    public static function findOneTest(): ?self
    {
        return static::find()->one();
    }

    public static function findOneBySql(): ?self
    {
        return static::findBySql('')->one();
    }

    /**
     * @return self[]
     */
    public static function findAllBySql(): array
    {
        return static::findBySql('')->all();
    }

    /**
     * @return array<string, mixed>[]
     */
    public static function findAllAsArray(): array
    {
        return static::find()->asArray()->all();
    }

    /**
     * @return array<string, mixed>|null
     */
    public static function findOneAsArray(): ?array
    {
        return static::find()->asArray()->one();
    }

    /**
     * @return self[]
     */
    public static function findAllAsArrayFalse(): array
    {
        return static::find()->asArray(false)->all();
    }

    public static function findOneAsArrayFalse(): ?self
    {
        return static::find()->asArray(false)->one();
    }

    /**
     * @return BatchQueryResult<int, self[]>
     */
    public static function findBatch(): BatchQueryResult
    {
        return static::find()->batch();
    }

    /**
     * @return BatchQueryResult<int, self>
     */
    public static function findEach(): BatchQueryResult
    {
        return static::find()->each();
    }

    /**
     * @return BatchQueryResult<int, array<string, mixed>[]>
     */
    public static function findBatchAsArray(): BatchQueryResult
    {
        return static::find()->asArray()->batch();
    }

    /**
     * @return BatchQueryResult<int, array<string, mixed>>
     */
    public static function findEachAsArray(): BatchQueryResult
    {
        return static::find()->asArray()->each();
    }
}
```

#### PHPStan output (before changes)

![image](https://github.com/user-attachments/assets/73a0a4b2-3400-4a01-822f-8d60b523376d)

#### PHPStan output (after changes)

![image](https://github.com/user-attachments/assets/d653cffd-7a80-4b4f-a096-ffc9af0baf38)
