### PR TITLE
Typed property must not be accessed before initialization

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #8298: Loading fixtures does not update table sequence for Postgresql database (mtangoo)
 - Bug #20347: Fix compatibility with PHP 8.4: remove usage of `session.use_trans_sid` and `session.use_only_cookies` (tehmaestro)
 - Bug #20355: Fix SQL syntax for resetting sequence in `QueryBuilder` for `MSSQL` (terabytesoftw)
+- Bug #20371: Fix "Typed property must not be accessed before initialization" when calling `toArray()` on a model with typed properties without default value
 
 
 2.0.52 February 13, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,7 +9,7 @@ Yii Framework 2 Change Log
 - Bug #8298: Loading fixtures does not update table sequence for Postgresql database (mtangoo)
 - Bug #20347: Fix compatibility with PHP 8.4: remove usage of `session.use_trans_sid` and `session.use_only_cookies` (tehmaestro)
 - Bug #20355: Fix SQL syntax for resetting sequence in `QueryBuilder` for `MSSQL` (terabytesoftw)
-- Bug #20371: Fix "Typed property must not be accessed before initialization" when calling `toArray()` on a model with typed properties without default value
+- Bug #20371: Fix "Typed property must not be accessed before initialization" when calling `toArray()` on a model with typed properties without default value (uaoleg)
 
 
 2.0.52 February 13, 2025

--- a/framework/base/ArrayableTrait.php
+++ b/framework/base/ArrayableTrait.php
@@ -123,7 +123,7 @@ trait ArrayableTrait
     {
         $data = [];
         foreach ($this->resolveFields($fields, $expand) as $field => $definition) {
-            $attribute = is_string($definition) ? $this->$definition : $definition($this, $field);
+            $attribute = is_string($definition) ? ($this->$definition ?? null) : $definition($this, $field);
 
             if ($recursive) {
                 $nestedFields = $this->extractFieldsFor($fields, $field);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

toArray() fails when model contains a typed property without value
