### PR TITLE
Added PHPStan/Psalm annotations for AssetBundle, AssetManager and View

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,10 @@ Yii Framework 2 Change Log
 - Bug #8298: Loading fixtures does not update table sequence for Postgresql database (mtangoo)
 - Bug #20347: Fix compatibility with PHP 8.4: remove usage of `session.use_trans_sid` and `session.use_only_cookies` (tehmaestro)
 - Bug #20355: Fix SQL syntax for resetting sequence in `QueryBuilder` for `MSSQL` (terabytesoftw)
+- Enh #20354: Add PHPStan/Psalm annotations for `Container` and `Instance` (max-s-lab)
+- Enh #20361: Add PHPStan/Psalm annotations for `ActiveQuery` (max-s-lab)
+- Enh #20363: Add PHPStan/Psalm annotations for `ActiveRecord` and `ActiveQuery` (max-s-lab)
+- Enh #20372: Add PHPStan/Psalm annotations for `AssetBundle`, `AssetManager` and `View` (max-s-lab)
 
 
 2.0.52 February 13, 2025

--- a/framework/web/AssetBundle.php
+++ b/framework/web/AssetBundle.php
@@ -62,7 +62,7 @@ class AssetBundle extends BaseObject
      */
     public $baseUrl;
     /**
-     * @var array list of bundle class names that this bundle depends on.
+     * @var string[] list of bundle class names that this bundle depends on.
      *
      * For example:
      *
@@ -72,10 +72,13 @@ class AssetBundle extends BaseObject
      *    'yii\bootstrap\BootstrapAsset',
      * ];
      * ```
+     *
+     * @phpstan-var class-string[]
+     * @psalm-var class-string[]
      */
     public $depends = [];
     /**
-     * @var array list of JavaScript files that this bundle contains. Each JavaScript file can be
+     * @var mixed[] list of JavaScript files that this bundle contains. Each JavaScript file can be
      * specified in one of the following formats:
      *
      * - an absolute URL representing an external asset. For example,
@@ -92,25 +95,34 @@ class AssetBundle extends BaseObject
      */
     public $js = [];
     /**
-     * @var array list of CSS files that this bundle contains. Each CSS file can be specified
+     * @var mixed[] list of CSS files that this bundle contains. Each CSS file can be specified
      * in one of the three formats as explained in [[js]].
      *
      * Note that only a forward slash "/" should be used as directory separator.
      */
     public $css = [];
     /**
-     * @var array the options that will be passed to [[View::registerJsFile()]]
+     * @var mixed[] the options that will be passed to [[View::registerJsFile()]]
      * when registering the JS files in this bundle.
+     *
+     * @phpstan-var array<string, mixed>
+     * @psalm-var array<string, mixed>
      */
     public $jsOptions = [];
     /**
-     * @var array the options that will be passed to [[View::registerCssFile()]]
+     * @var mixed[] the options that will be passed to [[View::registerCssFile()]]
      * when registering the CSS files in this bundle.
+     *
+     * @phpstan-var array<string, mixed>
+     * @psalm-var array<string, mixed>
      */
     public $cssOptions = [];
     /**
-     * @var array the options to be passed to [[AssetManager::publish()]] when the asset bundle
+     * @var mixed[] the options to be passed to [[AssetManager::publish()]] when the asset bundle
      * is being published. This property is used only when [[sourcePath]] is set.
+     *
+     * @phpstan-var array<string, mixed>
+     * @psalm-var array<string, mixed>
      */
     public $publishOptions = [];
 

--- a/framework/web/AssetBundle.php
+++ b/framework/web/AssetBundle.php
@@ -102,8 +102,8 @@ class AssetBundle extends BaseObject
      *
      * Note that only a forward slash "/" should be used as directory separator.
      *
-     * @phpstan-var mixed[]
-     * @psalm-var mixed[]
+     * @phpstan-var (string|array<int|string, mixed>)[]
+     * @psalm-var (string|array<int|string, mixed>)[]
      */
     public $js = [];
     /**
@@ -112,8 +112,8 @@ class AssetBundle extends BaseObject
      *
      * Note that only a forward slash "/" should be used as directory separator.
      *
-     * @phpstan-var mixed[]
-     * @psalm-var mixed[]
+     * @phpstan-var (string|array<int|string, mixed>)[]
+     * @psalm-var (string|array<int|string, mixed>)[]
      */
     public $css = [];
     /**

--- a/framework/web/AssetBundle.php
+++ b/framework/web/AssetBundle.php
@@ -26,6 +26,15 @@ use yii\helpers\Url;
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
+ *
+ * @phpstan-import-type RegisterJsFileOptions from View
+ * @psalm-import-type RegisterJsFileOptions from View
+ *
+ * @phpstan-import-type RegisterCssFileOptions from View
+ * @psalm-import-type RegisterCssFileOptions from View
+ *
+ * @phpstan-import-type PublishOptions from AssetManager
+ * @psalm-import-type PublishOptions from AssetManager
  */
 class AssetBundle extends BaseObject
 {
@@ -62,7 +71,7 @@ class AssetBundle extends BaseObject
      */
     public $baseUrl;
     /**
-     * @var string[] list of bundle class names that this bundle depends on.
+     * @var array list of bundle class names that this bundle depends on.
      *
      * For example:
      *
@@ -78,7 +87,7 @@ class AssetBundle extends BaseObject
      */
     public $depends = [];
     /**
-     * @var mixed[] list of JavaScript files that this bundle contains. Each JavaScript file can be
+     * @var array list of JavaScript files that this bundle contains. Each JavaScript file can be
      * specified in one of the following formats:
      *
      * - an absolute URL representing an external asset. For example,
@@ -92,37 +101,43 @@ class AssetBundle extends BaseObject
      *   This functionality is available since version 2.0.7.
      *
      * Note that only a forward slash "/" should be used as directory separator.
+     *
+     * @phpstan-var mixed[]
+     * @psalm-var mixed[]
      */
     public $js = [];
     /**
-     * @var mixed[] list of CSS files that this bundle contains. Each CSS file can be specified
+     * @var array list of CSS files that this bundle contains. Each CSS file can be specified
      * in one of the three formats as explained in [[js]].
      *
      * Note that only a forward slash "/" should be used as directory separator.
+     *
+     * @phpstan-var mixed[]
+     * @psalm-var mixed[]
      */
     public $css = [];
     /**
-     * @var mixed[] the options that will be passed to [[View::registerJsFile()]]
+     * @var array the options that will be passed to [[View::registerJsFile()]]
      * when registering the JS files in this bundle.
      *
-     * @phpstan-var array<string, mixed>
-     * @psalm-var array<string, mixed>
+     * @phpstan-var RegisterJsFileOptions
+     * @psalm-var RegisterJsFileOptions
      */
     public $jsOptions = [];
     /**
-     * @var mixed[] the options that will be passed to [[View::registerCssFile()]]
+     * @var array the options that will be passed to [[View::registerCssFile()]]
      * when registering the CSS files in this bundle.
      *
-     * @phpstan-var array<string, mixed>
-     * @psalm-var array<string, mixed>
+     * @phpstan-var RegisterCssFileOptions
+     * @psalm-var RegisterCssFileOptions
      */
     public $cssOptions = [];
     /**
-     * @var mixed[] the options to be passed to [[AssetManager::publish()]] when the asset bundle
+     * @var array the options to be passed to [[AssetManager::publish()]] when the asset bundle
      * is being published. This property is used only when [[sourcePath]] is set.
      *
-     * @phpstan-var array<string, mixed>
-     * @psalm-var array<string, mixed>
+     * @phpstan-var PublishOptions
+     * @psalm-var PublishOptions
      */
     public $publishOptions = [];
 

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -38,6 +38,24 @@ use yii\helpers\Url;
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
+ *
+ * @phpstan-type PublishOptions array{
+ *     only?: string[],
+ *     except?: string[],
+ *     caseSensitive?: bool,
+ *     beforeCopy?: bool,
+ *     afterCopy?: bool,
+ *     forceCopy?: bool,
+ * }
+ *
+ * @psalm-type PublishOptions = array{
+ *     only?: string[],
+ *     except?: string[],
+ *     caseSensitive?: bool,
+ *     beforeCopy?: bool,
+ *     afterCopy?: bool,
+ *     forceCopy?: bool,
+ * }
  */
 class AssetManager extends Component
 {
@@ -463,6 +481,9 @@ class AssetManager extends Component
      * @return array the path (directory or file path) and the URL that the asset is published as.
      * @throws InvalidArgumentException if the asset to be published does not exist.
      * @throws InvalidConfigException if the target directory [[basePath]] is not writeable.
+     *
+     * @phpstan-param PublishOptions $options
+     * @psalm-param PublishOptions $options
      */
     public function publish($path, $options = [])
     {

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -43,8 +43,8 @@ use yii\helpers\Url;
  *     only?: string[],
  *     except?: string[],
  *     caseSensitive?: bool,
- *     beforeCopy?: bool,
- *     afterCopy?: bool,
+ *     beforeCopy?: callable,
+ *     afterCopy?: callable,
  *     forceCopy?: bool,
  * }
  *
@@ -52,8 +52,8 @@ use yii\helpers\Url;
  *     only?: string[],
  *     except?: string[],
  *     caseSensitive?: bool,
- *     beforeCopy?: bool,
- *     afterCopy?: bool,
+ *     beforeCopy?: callable,
+ *     afterCopy?: callable,
  *     forceCopy?: bool,
  * }
  */

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -41,6 +41,28 @@ use yii\helpers\Url;
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
+ *
+ * @phpstan-type RegisterJsFileOptions array{
+ *     depends?: class-string[],
+ *     position?: int,
+ *     appendTimestamp?: boolean
+ * }
+ *
+ * @psalm-type RegisterJsFileOptions = array{
+ *     depends?: class-string[],
+ *     position?: int,
+ *     appendTimestamp?: boolean
+ * }
+ *
+ * @phpstan-type RegisterCssFileOptions array{
+ *     depends?: class-string[],
+ *     appendTimestamp?: boolean
+ * }
+ *
+ * @psalm-type RegisterCssFileOptions = array{
+ *     depends?: class-string[],
+ *     appendTimestamp?: boolean
+ * }
  */
 class View extends \yii\base\View
 {
@@ -445,6 +467,9 @@ class View extends \yii\base\View
      * $url as the key. If two CSS files are registered with the same key, the latter
      * will overwrite the former.
      * @throws InvalidConfigException
+     *
+     * @phpstan-param RegisterCssFileOptions $options
+     * @psalm-param RegisterCssFileOptions $options
      */
     public function registerCssFile($url, $options = [], $key = null)
     {
@@ -569,6 +594,9 @@ class View extends \yii\base\View
      * will overwrite the former. Note that position option takes precedence, thus files registered with the same key,
      * but different position option will not override each other.
      * @throws InvalidConfigException
+     *
+     * @phpstan-type RegisterJsFileOptions $options
+     * @psalm-type RegisterJsFileOptions $options
      */
     public function registerJsFile($url, $options = [], $key = null)
     {

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -595,8 +595,8 @@ class View extends \yii\base\View
      * but different position option will not override each other.
      * @throws InvalidConfigException
      *
-     * @phpstan-type RegisterJsFileOptions $options
-     * @psalm-type RegisterJsFileOptions $options
+     * @phpstan-param RegisterJsFileOptions $options
+     * @psalm-param RegisterJsFileOptions $options
      */
     public function registerJsFile($url, $options = [], $key = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

I use PHPStan with level 6. Therefore, in each `Asset` I have to write annotations for properties every time. When I don't write them, I get these errors.

![image](https://github.com/user-attachments/assets/a373f8cc-170e-49ca-86af-6d4385ce3793)

It would be great if the types were described more precisely in the `AssetBundle`.

