### PR TITLE
feat: infer return type in CacheInterface::getOrSet

### DIFF
--- a/framework/caching/CacheInterface.php
+++ b/framework/caching/CacheInterface.php
@@ -188,6 +188,12 @@ interface CacheInterface extends \ArrayAccess
      * the corresponding value in the cache will be invalidated when it is fetched via [[get()]].
      * This parameter is ignored if [[serializer]] is `false`.
      * @return mixed result of $callable execution
+     *
+     * @template TResult of mixed
+     * @psalm-param callable():TResult|\Closure():TResult $callable
+     * @phpstan-param callable():TResult|\Closure():TResult $callable
+     * @psalm-return TResult
+     * @phpstan-return TResult
      */
     public function getOrSet($key, $callable, $duration = null, $dependency = null);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌


<img width="915" alt="image" src="https://github.com/user-attachments/assets/1ed82e3a-4ffd-417a-85ea-eb541d93e4b7" />

