### PR TITLE
Router not working in ServeCommand due to wrong param name

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.53 under development
 ------------------------
-
+- Bug #20387: Fixed the command generated to use router.php file in php buil-in server (eseperio)
 - Enh #20309: Add custom attributes support to style tags (nzwz)
 - Bug #20329: pgsql: Column Schema doesn't recognize PG type cast (arkhamvm)
 - Bug #8298: Loading fixtures does not update table sequence for Postgresql database (mtangoo)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.53 under development
 ------------------------
-- Bug #20387: Fixed the command generated to use router.php file in php buil-in server (eseperio)
+- Bug #20387: Fixed the command generated to use router.php file in php built-in server (eseperio)
 - Enh #20309: Add custom attributes support to style tags (nzwz)
 - Bug #20329: pgsql: Column Schema doesn't recognize PG type cast (arkhamvm)
 - Bug #8298: Loading fixtures does not update table sequence for Postgresql database (mtangoo)

--- a/framework/console/controllers/ServeController.php
+++ b/framework/console/controllers/ServeController.php
@@ -83,7 +83,7 @@ class ServeController extends Controller
         $command = '"' . PHP_BINARY . '"' . " -S {$address} -t \"{$documentRoot}\"";
 
         if ($this->router !== null && $router !== '') {
-            $command .= " -r \"{$router}\"";
+            $command .= " \"{$router}\"";
         }
 
         $this->runCommand($command);


### PR DESCRIPTION
Router file is passed to php as unnamed param. `php -S 0.0.0.0:8000 router.php`
 while `-r`  is used to run inline scripts in php. 
See https://www.php.net/manual/en/features.commandline.webserver.php

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
