### PR TITLE
Fix @var tags syntax in `base`, `behaviors` and `caching` folders

### DIFF
--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -187,7 +187,7 @@ class Controller extends Component implements ViewContextInterface
 
             // call afterAction on modules
             foreach ($modules as $module) {
-                /* @var $module Module */
+                /** @var Module $module */
                 $result = $module->afterAction($action, $result);
             }
         }

--- a/framework/base/DynamicModel.php
+++ b/framework/base/DynamicModel.php
@@ -217,7 +217,7 @@ class DynamicModel extends Model
      */
     public static function validateData(array $data, $rules = [])
     {
-        /* @var $model DynamicModel */
+        /** @var self $model */
         $model = new static($data);
         if (!empty($rules)) {
             $validators = $model->getValidators();

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -932,7 +932,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
     public static function loadMultiple($models, $data, $formName = null)
     {
         if ($formName === null) {
-            /* @var $first Model|false */
+            /** @var self|false $first */
             $first = reset($models);
             if ($first === false) {
                 return false;
@@ -942,7 +942,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
 
         $success = false;
         foreach ($models as $i => $model) {
-            /* @var $model Model */
+            /** @var self $model */
             if ($formName == '') {
                 if (!empty($data[$i]) && $model->load($data[$i], '')) {
                     $success = true;
@@ -969,7 +969,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
     public static function validateMultiple($models, $attributeNames = null)
     {
         $valid = true;
-        /* @var $model Model */
+        /** @var self $model */
         foreach ($models as $model) {
             $valid = $model->validate($attributeNames) && $valid;
         }

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -444,7 +444,7 @@ class Module extends ServiceLocator
                 return $this->_modules[$id];
             } elseif ($load) {
                 Yii::debug("Loading module: $id", __METHOD__);
-                /* @var $module Module */
+                /** @var self $module */
                 $module = Yii::createObject($this->_modules[$id], [$id, $this]);
                 $module::setInstance($module);
                 return $this->_modules[$id] = $module;
@@ -548,7 +548,7 @@ class Module extends ServiceLocator
     {
         $parts = $this->createController($route);
         if (is_array($parts)) {
-            /* @var $controller Controller */
+            /** @var Controller $controller */
             list($controller, $actionID) = $parts;
             $oldController = Yii::$app->controller;
             Yii::$app->controller = $controller;

--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -251,7 +251,7 @@ class View extends Component implements DynamicContentAwareInterface
                 if (is_array($this->renderers[$ext]) || is_string($this->renderers[$ext])) {
                     $this->renderers[$ext] = Yii::createObject($this->renderers[$ext]);
                 }
-                /* @var $renderer ViewRenderer */
+                /** @var ViewRenderer $renderer */
                 $renderer = $this->renderers[$ext];
                 $output = $renderer->render($this, $viewFile, $params);
             } else {
@@ -550,7 +550,7 @@ class View extends Component implements DynamicContentAwareInterface
     {
         $properties['id'] = $id;
         $properties['view'] = $this;
-        /* @var $cache FragmentCache */
+        /** @var FragmentCache $cache */
         $cache = FragmentCache::begin($properties);
         if ($cache->getCachedContent() !== false) {
             $this->endCache();

--- a/framework/base/Widget.php
+++ b/framework/base/Widget.php
@@ -90,7 +90,7 @@ class Widget extends Component implements ViewContextInterface
     public static function begin($config = [])
     {
         $config['class'] = get_called_class();
-        /* @var $widget Widget */
+        /** @var self $widget */
         $widget = Yii::createObject($config);
         self::$stack[] = $widget;
         self::$_resolvedClasses[get_called_class()] = get_class($widget);
@@ -113,7 +113,7 @@ class Widget extends Component implements ViewContextInterface
             $calledClass = self::$_resolvedClasses[get_called_class()] ?? get_called_class();
 
             if (get_class($widget) === $calledClass) {
-                /* @var $widget Widget */
+                /** @var self $widget */
                 if ($widget->beforeRun()) {
                     $result = $widget->run();
                     $result = $widget->afterRun($result);
@@ -141,8 +141,8 @@ class Widget extends Component implements ViewContextInterface
         ob_start();
         ob_implicit_flush(false);
         try {
-            /* @var $widget Widget */
             $config['class'] = get_called_class();
+            /** @var self $widget */
             $widget = Yii::createObject($config);
             $out = '';
             if ($widget->beforeRun()) {

--- a/framework/behaviors/OptimisticLockBehavior.php
+++ b/framework/behaviors/OptimisticLockBehavior.php
@@ -118,7 +118,7 @@ class OptimisticLockBehavior extends AttributeBehavior
             return $this->_lockAttribute;
         }
 
-        /* @var $owner BaseActiveRecord */
+        /** @var BaseActiveRecord $owner */
         $owner = $this->owner;
         $lock = $owner->optimisticLock();
         if ($lock === null || $owner->hasAttribute($lock) === false) {
@@ -159,7 +159,7 @@ class OptimisticLockBehavior extends AttributeBehavior
      */
     public function upgrade()
     {
-        /* @var $owner BaseActiveRecord */
+        /** @var BaseActiveRecord $owner */
         $owner = $this->owner;
         if ($owner->getIsNewRecord()) {
             throw new InvalidCallException('Upgrading the model version is not possible on a new record.');

--- a/framework/behaviors/SluggableBehavior.php
+++ b/framework/behaviors/SluggableBehavior.php
@@ -239,8 +239,7 @@ class SluggableBehavior extends AttributeBehavior
      */
     protected function validateSlug($slug)
     {
-        /* @var $validator UniqueValidator */
-        /* @var $model BaseActiveRecord */
+        /** @var UniqueValidator $validator */
         $validator = Yii::createObject(array_merge(
             [
                 'class' => UniqueValidator::className(),
@@ -248,6 +247,7 @@ class SluggableBehavior extends AttributeBehavior
             $this->uniqueValidator
         ));
 
+        /** @var BaseActiveRecord $model */
         $model = clone $this->owner;
         $model->clearErrors();
         $model->{$this->slugAttribute} = $slug;

--- a/framework/behaviors/TimestampBehavior.php
+++ b/framework/behaviors/TimestampBehavior.php
@@ -131,7 +131,7 @@ class TimestampBehavior extends AttributeBehavior
      */
     public function touch($attribute)
     {
-        /* @var $owner BaseActiveRecord */
+        /** @var BaseActiveRecord $owner */
         $owner = $this->owner;
         if ($owner->getIsNewRecord()) {
             throw new InvalidCallException('Updating the timestamp is not possible on a new record.');

--- a/framework/caching/DbDependency.php
+++ b/framework/caching/DbDependency.php
@@ -49,7 +49,7 @@ class DbDependency extends Dependency
      */
     protected function generateDependencyData($cache)
     {
-        /* @var $db Connection */
+        /** @var Connection $db */
         $db = Instance::ensure($this->db, Connection::className());
         if ($this->sql === null) {
             throw new InvalidConfigException('DbDependency::sql must be set.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

I see that incorrect syntax is used in many places. The correct syntax will allow the IDE to correctly identify the types. It should also help PHPStan/Psalm.

https://docs.phpdoc.org/guide/references/phpdoc/tags/var.html

I would like to fix this with a few pull requests, if no one is against it.