### PR TITLE
Update  PHPDocs - ArrayHelper::merge()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -19,8 +19,8 @@ Yii Framework 2 Change Log
 - Bug #20373: Fixed the type of the first parameter `yii\base\Controller::bindInjectedParams()` (max-s-lab)
 - Enh #20374: Add PHPStan/Psalm annotations for `BaseYii`, `BaseObject`, `Component`, `Model`, `Module` and `yii\base\Controller` (max-s-lab)
 - Enh #20394: Add PHPStan/Psalm annotations for `Yii::getAlias` (max-s-lab)
-- Enh #20395: Add PHPStan/Psalm annotations for 'ActiveForm::validate' (samuelrajan747)
-- Enh #20397: Add PHPStan/Psalm annotations for 'ArrayHelper::merge' (samuelrajan747)
+- Enh #20395: Add PHPStan/Psalm annotations for `ActiveForm::validate` (samuelrajan747)
+- Enh #20397: Add PHPStan/Psalm annotations for `ArrayHelper::merge` (samuelrajan747)
 
 
 2.0.52 February 13, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -19,6 +19,8 @@ Yii Framework 2 Change Log
 - Bug #20373: Fixed the type of the first parameter `yii\base\Controller::bindInjectedParams()` (max-s-lab)
 - Enh #20374: Add PHPStan/Psalm annotations for `BaseYii`, `BaseObject`, `Component`, `Model`, `Module` and `yii\base\Controller` (max-s-lab)
 - Enh #20394: Add PHPStan/Psalm annotations for `Yii::getAlias` (max-s-lab)
+- Enh #20395: Update PHPDocs - ActiveForm::validate() (samuelrajan747)
+- Enh #20397: Update PHPDocs - ArrayHelper::merge() (samuelrajan747)
 
 
 2.0.52 February 13, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -19,8 +19,8 @@ Yii Framework 2 Change Log
 - Bug #20373: Fixed the type of the first parameter `yii\base\Controller::bindInjectedParams()` (max-s-lab)
 - Enh #20374: Add PHPStan/Psalm annotations for `BaseYii`, `BaseObject`, `Component`, `Model`, `Module` and `yii\base\Controller` (max-s-lab)
 - Enh #20394: Add PHPStan/Psalm annotations for `Yii::getAlias` (max-s-lab)
-- Enh #20395: Update PHPDocs - ActiveForm::validate() (samuelrajan747)
-- Enh #20397: Update PHPDocs - ArrayHelper::merge() (samuelrajan747)
+- Enh #20395: Add PHPStan/Psalm annotations for 'ActiveForm::validate' (samuelrajan747)
+- Enh #20397: Add PHPStan/Psalm annotations for 'ArrayHelper::merge' (samuelrajan747)
 
 
 2.0.52 February 13, 2025

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -104,8 +104,6 @@ class BaseArrayHelper
     }
 
     /**
-     * @template TItemA
-     * @template TItemB
      * Merges two or more arrays into one recursively.
      * If each array has an element with the same string key value, the latter
      * will overwrite the former (different from array_merge_recursive).
@@ -119,6 +117,10 @@ class BaseArrayHelper
      * @param array $b array to be merged from. You can specify additional
      * arrays via third argument, fourth argument etc.
      * @return array the merged array (the original arrays are not changed.)
+     * @phpstan-template TItemA
+     * @phpstan-template TItemB
+     * @psalm-template TItemA
+     * @psalm-template TItemB
      * @phpstan-param array<TItemA> $a
      * @phpstan-param array<array<TItemB>> ...$b
      * @psalm-param array<TItemA> $a

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -122,13 +122,13 @@ class BaseArrayHelper
      * arrays via third argument, fourth argument etc.
      * @return array the merged array (the original arrays are not changed.)
      * @phpstan-param array<TItemA> $a
-     * @phpstan-param array<TItemB> $b
+     * @phpstan-param array<array<TItemB>> ...$b
      * @psalm-param array<TItemA> $a
-     * @psalm-param array<TItemB> $b
+     * @psalm-param array<array<TItemB>> ...$b
      * @phpstan-return array<TItemA|TItemB>
      * @psalm-return array<TItemA|TItemB>
      */
-    public static function merge($a, $b)
+    public static function merge($a, ...$b)
     {
         $args = func_get_args();
         $res = array_shift($args);

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -104,10 +104,8 @@ class BaseArrayHelper
     }
 
     /**
-     * @phpstan-template TItemA
-     * @phpstan-template TItemB
-     * @psalm-template TItemA
-     * @psalm-template TItemB
+     * @template TItemA
+     * @template TItemB
      * Merges two or more arrays into one recursively.
      * If each array has an element with the same string key value, the latter
      * will overwrite the former (different from array_merge_recursive).

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -104,6 +104,10 @@ class BaseArrayHelper
     }
 
     /**
+     * @phpstan-template TItemA
+     * @phpstan-template TItemB
+     * @psalm-template TItemA
+     * @psalm-template TItemB
      * Merges two or more arrays into one recursively.
      * If each array has an element with the same string key value, the latter
      * will overwrite the former (different from array_merge_recursive).
@@ -117,6 +121,12 @@ class BaseArrayHelper
      * @param array $b array to be merged from. You can specify additional
      * arrays via third argument, fourth argument etc.
      * @return array the merged array (the original arrays are not changed.)
+     * @phpstan-param array<TItemA> $a
+     * @phpstan-param array<TItemB> $b
+     * @psalm-param array<TItemA> $a
+     * @psalm-param array<TItemB> $b
+     * @phpstan-return array<TItemA|TItemB>
+     * @psalm-return array<TItemA|TItemB>
      */
     public static function merge($a, $b)
     {


### PR DESCRIPTION
Updated PHPDocs for the merge function defined in
yii\helpers\BaseArrayHelper to return array whose items's type is union of input array's types.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |
