### PR TITLE
Remove used code `E_STRICT` handling in `ErrorException` class and update tests to reflect changes.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Chg #19902: Remove support for CUBRID (mtangoo)
 - Chg #19891: Remove XCache and ZendDataCache support (mtangoo)
 - Enh #20368: Refactor asset management: Migrate from `Bower` to `NPM` for package dependencies and update related documentation (terabytesoftw)
+- Bug #20242: Remove used code `E_STRICT` handling in `ErrorException` class and update tests to reflect changes (terabytesoftw)
 
 
 2.0.53 under development

--- a/framework/base/ErrorException.php
+++ b/framework/base/ErrorException.php
@@ -130,7 +130,7 @@ class ErrorException extends \ErrorException
             E_USER_WARNING => 'PHP User Warning',
             E_WARNING => 'PHP Warning',
             self::E_HHVM_FATAL_ERROR => 'HHVM Fatal Error',
-        ] + (PHP_VERSION_ID < 80400 ? [E_STRICT => 'PHP Strict Warning'] : []);
+        ];
 
         return $names[$this->getCode()] ?? 'Error';
     }

--- a/tests/framework/base/ErrorExceptionTest.php
+++ b/tests/framework/base/ErrorExceptionTest.php
@@ -41,13 +41,4 @@ class ErrorExceptionTest extends TestCase
             $this->assertEquals(__FUNCTION__, $e->getTrace()[0]['function']);
         }
     }
-
-    public function testStrictError()
-    {
-        if (!defined('E_STRICT')) {
-            $this->markTestSkipped('E_STRICT has been removed.');
-        }
-        $e = new ErrorException('', @E_STRICT);
-        $this->assertEquals(PHP_VERSION_ID < 80400 ? 'PHP Strict Warning' : 'Error', $e->getName());
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
