### PR TITLE
Enhance `PHPStan` and `Psalm` annotations for generic owner property in `Behavior` class.

### DIFF
--- a/framework/base/Behavior.php
+++ b/framework/base/Behavior.php
@@ -19,6 +19,11 @@ namespace yii\base;
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
+ *
+ * @template T of Component
+ *
+ * @phpstan-property T|null $owner
+ * @psalm-property T|null $owner
  */
 class Behavior extends BaseObject
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

```php
<?php
/**
 * @extends Behavior<ActiveRecord>
 */
class TimestampBehavior extends Behavior
{
    public function touch()
    {
        if ($this->owner !== null) {
            $this->owner->updated_at = time();
        }
    }
}
```
