### PR TITLE
Remove unsed code in `Model` in `formName()` method to enforce explicit definition for anonymous models.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,7 +9,7 @@ Yii Framework 2 Change Log
 - Enh #20368: Refactor asset management: Migrate from `Bower` to `NPM` for package dependencies and update related documentation (terabytesoftw)
 - Bug #20402: Remove unsed code `E_STRICT` handling in `ErrorException` class and update tests to reflect changes (terabytesoftw)
 - Bug #20403: Remove unsed code in `ErrorHandler` class (terabytesoftw)
-
+- Bug #20408: Remove unsed code in `Model` in `formName()` method to enforce explicit definition for anonymous models (terabytesoftw)
 
 2.0.53 under development
 ------------------------

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -266,9 +266,11 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
     public function formName()
     {
         $reflector = new ReflectionClass($this);
-        if (PHP_VERSION_ID >= 70000 && $reflector->isAnonymous()) {
+
+        if ($reflector->isAnonymous()) {
             throw new InvalidConfigException('The "formName()" method should be explicitly defined for anonymous models');
         }
+
         return $reflector->getShortName();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
