### PR TITLE
Add `PHPStan`/`Psalm` annotation for `owner` property in `Behavior` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -24,6 +24,7 @@ Yii Framework 2 Change Log
 - Enh #20395: Add PHPStan/Psalm annotations for `ActiveForm::validate` (samuelrajan747)
 - Enh #20397: Add PHPStan/Psalm annotations for `ArrayHelper::merge` (samuelrajan747)
 - Enh #20413: Add PHPStan/Psalm annotations for `Action`, `ActionEvent`, `Application`, `DynamicModel` and `InlineAction` (max-s-lab)
+- Enh #20416: Add `PHPStan`/`PSalm` annotation for `owner` property in `Behavior` class (terabytesoftw)
 
 
 2.0.52 February 13, 2025

--- a/framework/base/Behavior.php
+++ b/framework/base/Behavior.php
@@ -31,6 +31,7 @@ class Behavior extends BaseObject
      * @var Component|null the owner of this behavior
      *
      * @phpstan-var T|null
+     * @psalm-var T|null
      */
     public $owner;
 

--- a/framework/base/Behavior.php
+++ b/framework/base/Behavior.php
@@ -29,6 +29,8 @@ class Behavior extends BaseObject
 {
     /**
      * @var Component|null the owner of this behavior
+     *
+     * @phpstan-var T|null
      */
     public $owner;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

```php
/**
 * @template T of ActiveQuery
 *
 * @extends Behavior<T>
 */
class NestedSetsQueryBehavior extends Behavior
{
    /**
     * Gets the root nodes.
     *
     * @return ActiveQuery the owner
     */
    public function roots(): ActiveQuery
    {
        $model = new $this->owner->modelClass();

        $this->owner
            ->andWhere([$model->leftAttribute => 1])
            ->addOrderBy([$model::primaryKey()[0] => SORT_ASC]);

        return $this->owner;
    }
}
````