### PR TITLE
Changing key type in PHPStan/Psalm annotations for `Controller::actions`

### DIFF
--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -131,8 +131,8 @@ class Controller extends Component implements ViewContextInterface
      * using the configuration provided here.
      * @return array
      *
-     * @phpstan-return array<string, class-string|array{class: class-string, ...}>
-     * @psalm-return array<string, class-string|array{class: class-string, ...}>
+     * @phpstan-return array<array-key, class-string|array{class: class-string, ...}>
+     * @psalm-return array<array-key, class-string|array{class: class-string, ...}>
      */
     public function actions()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

This has already been discussed [here](https://github.com/yiisoft/yii2/pull/20414#discussion_r2145927737). I've been looking into this a bit and found some information.

PHPStan Issues:
1. https://github.com/phpstan/phpstan/issues/11720
2. https://github.com/phpstan/phpstan/issues/13095

PHP documentation: https://www.php.net/manual/en/language.types.array.php#language.types.array.syntax

It turned out that PHP itself makes integer keys from string keys. 
Therefore, I suggest replacing `string` with `array-key` so that users don't have to redefine the type every time.