### PR TITLE
Remove `PHP_VERSION_ID` check in `pbkdf2` method for `hash_pbkdf2` function.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 Change Log
 - Bug #20402: Remove unsed code `E_STRICT` handling in `ErrorException` class and update tests to reflect changes (terabytesoftw)
 - Bug #20403: Remove unsed code in `ErrorHandler` class (terabytesoftw)
 - Bug #20408: Remove unsed code in `Model` in `formName()` method to enforce explicit definition for anonymous models (terabytesoftw)
+- Bug #20421: Remove `PHP_VERSION_ID` check in `pbkdf2` method for `hash_pbkdf2` function (terabytesoftw)
 
 2.0.53 under development
 ------------------------

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -343,7 +343,7 @@ class Security extends Component
      */
     public function pbkdf2($algo, $password, $salt, $iterations, $length = 0)
     {
-        if (function_exists('hash_pbkdf2') && PHP_VERSION_ID >= 50500) {
+        if (function_exists('hash_pbkdf2')) {
             $outputKey = hash_pbkdf2($algo, $password, $salt, $iterations, $length, true);
             if ($outputKey === false) {
                 throw new InvalidArgumentException('Invalid parameters to hash_pbkdf2()');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
