### PR TITLE
Remove `PHP_VERSION_ID` checks from `AttributeTypecastBehavior` and its tests for enum typecasting.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Bug #20403: Remove unsed code in `ErrorHandler` class (terabytesoftw)
 - Bug #20408: Remove unsed code in `Model` in `formName()` method to enforce explicit definition for anonymous models (terabytesoftw)
 - Bug #20421: Remove `PHP_VERSION_ID` check in `pbkdf2` method for `hash_pbkdf2` function (terabytesoftw)
+- Bug #20422: Remove `PHP_VERSION_ID` checks from `AttributeTypecastBehavior` and its tests for enum typecasting (terabytesoftw)
 
 2.0.53 under development
 ------------------------

--- a/framework/behaviors/AttributeTypecastBehavior.php
+++ b/framework/behaviors/AttributeTypecastBehavior.php
@@ -269,7 +269,7 @@ class AttributeTypecastBehavior extends Behavior
                     return (string) $value;
             }
 
-            if (PHP_VERSION_ID >= 80100 && is_subclass_of($type, \BackedEnum::class)) {
+            if (is_subclass_of($type, \BackedEnum::class)) {
                 if ($value instanceof $type) {
                     return $value;
                 }

--- a/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
@@ -85,10 +85,6 @@ class AttributeTypecastBehaviorTest extends TestCase
 
     public function testTypecastEnum()
     {
-        if (PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Can not be tested on PHP < 8.1');
-        }
-
         $model = new ActiveRecordAttributeTypecastWithEnum();
 
         $model->status = StatusTypeString::Active;
@@ -103,10 +99,6 @@ class AttributeTypecastBehaviorTest extends TestCase
      */
     public function testTypecastEnumFromString()
     {
-        if (PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Can not be tested on PHP < 8.1');
-        }
-
         $model = new ActiveRecordAttributeTypecastWithEnum();
         $model->status = 'active'; // Same as StatusTypeString::ACTIVE->value;
 
@@ -120,10 +112,6 @@ class AttributeTypecastBehaviorTest extends TestCase
      */
     public function testTypecastEnumFailWithInvalidValue()
     {
-        if (PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Can not be tested on PHP < 8.1');
-        }
-
         $model = new ActiveRecordAttributeTypecastWithEnum();
         $model->status = 'invalid';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
