### PR TITLE
strcmp(): Passing `null` to parameter `2` ($string2) of type string is deprecated.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -25,6 +25,7 @@ Yii Framework 2 Change Log
 - Enh #20397: Add PHPStan/Psalm annotations for `ArrayHelper::merge` (samuelrajan747)
 - Enh #20413: Add PHPStan/Psalm annotations for `Action`, `ActionEvent`, `Application`, `DynamicModel` and `InlineAction` (max-s-lab)
 - Enh #20416: Add `PHPStan`/`PSalm` annotation for `owner` property in `Behavior` class (terabytesoftw)
+- Bug #20423: `strcmp()` Passing `null` to parameter `2` ($string2) of type string is deprecated (terabytesoftw)
 
 
 2.0.52 February 13, 2025

--- a/framework/web/UrlRule.php
+++ b/framework/web/UrlRule.php
@@ -97,6 +97,8 @@ class UrlRule extends BaseObject implements UrlRuleInterface
      * @var string|null the URL suffix used for this rule.
      * For example, ".html" can be used so that the URL looks like pointing to a static HTML page.
      * If not set, the value of [[UrlManager::suffix]] will be used.
+     * Default values should be strings. Non-string values will be automatically converted to
+     * strings for comparison with URL parameters.
      */
     public $suffix;
     /**
@@ -494,7 +496,7 @@ class UrlRule extends BaseObject implements UrlRuleInterface
                     return false;
                 }
             }
-            if (strcmp($params[$name], $value) === 0) { // strcmp will do string conversion automatically
+            if (strcmp($params[$name], (string) $value) === 0) {
                 unset($params[$name]);
                 if (isset($this->_paramRules[$name])) {
                     $tr["<$name>"] = '';

--- a/tests/framework/web/UrlRuleTest.php
+++ b/tests/framework/web/UrlRuleTest.php
@@ -1320,6 +1320,30 @@ class UrlRuleTest extends TestCase
         }
     }
 
+    public function testUrlRuleDefaultsWithNonStringValues()
+    {
+        $this->mockWebApplication();
+
+        $manager = new UrlManager(
+            [
+                'cache' => null,
+            ],
+        );
+
+        $rule = new UrlRule(
+            [
+                'pattern' => 'post/index',
+                'route' => 'post/index',
+                'defaults' => ['page' => 1],
+            ],
+        );
+
+        $this->assertSame(
+            'post/index',
+            $rule->createUrl($manager, 'post/index', ['page' => '1']),
+        );
+    }
+
     /**
      * Provides test cases for getCreateUrlStatus() method.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
