### PR TITLE
Add `PHPStan`/`Psalm` annotation for `controller` property in `Action` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -26,6 +26,7 @@ Yii Framework 2 Change Log
 - Enh #20413: Add PHPStan/Psalm annotations for `Action`, `ActionEvent`, `Application`, `DynamicModel` and `InlineAction` (max-s-lab)
 - Enh #20416: Add `PHPStan`/`PSalm` annotation for `owner` property in `Behavior` class (terabytesoftw)
 - Bug #20423: `strcmp()` Passing `null` to parameter `2` ($string2) of type string is deprecated (terabytesoftw)
+- Enh #20426: Add `PHPStan`/`Psalm` annotation for `controller` property in `Action` class (terabytesoftw)
 
 
 2.0.52 February 13, 2025

--- a/framework/base/Action.php
+++ b/framework/base/Action.php
@@ -30,7 +30,10 @@ use Yii;
  *
  * For more details and usage information on Action, see the [guide article on actions](guide:structure-controllers).
  *
+ * @template T of Controller
  * @property-read string $uniqueId The unique ID of this action among the whole application.
+ * @phpstan-property T $controller
+ * @psalm-property T $controller
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -43,6 +46,9 @@ class Action extends Component
     public $id;
     /**
      * @var Controller|\yii\web\Controller|\yii\console\Controller the controller that owns this action
+     *
+     * @phpstan-var T
+     * @psalm-var T
      */
     public $controller;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

```php
use yii\web\Controller;

/**
 * @template T of Controller
 * @extends Action<T>
 */
final class LoginAction extends Action
{
    public function run(): Response
    {
        $this->controller->goHome();
    }
}
```
