### PR TITLE
Remove `PHP_VERSION_ID` and `PHP_MAJOR_VERSION` checks from console `Controller` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Bug #20408: Remove unsed code in `Model` in `formName()` method to enforce explicit definition for anonymous models (terabytesoftw)
 - Bug #20421: Remove `PHP_VERSION_ID` check in `pbkdf2` method for `hash_pbkdf2` function (terabytesoftw)
 - Bug #20422: Remove `PHP_VERSION_ID` checks from `AttributeTypecastBehavior` and its tests for enum typecasting (terabytesoftw)
+- Bug #20427: Remove `PHP_VERSION_ID` and `PHP_MAJOR_VERSION` checks from console `Controller` class (terabytesoftw)
 
 2.0.53 under development
 ------------------------

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -214,11 +214,7 @@ class Controller extends \yii\base\Controller
                         unset($params[$jKey]);
                     }
                 } else {
-                    if (PHP_VERSION_ID >= 80000) {
-                        $isArray = ($type = $param->getType()) instanceof \ReflectionNamedType && $type->getName() === 'array';
-                    } else {
-                        $isArray = $param->isArray();
-                    }
+                    $isArray = ($type = $param->getType()) instanceof \ReflectionNamedType && $type->getName() === 'array';
                     if ($isArray) {
                         $params[$key] = $params[$key] === '' ? [] : preg_split('/\s*,\s*/', $params[$key]);
                     }
@@ -226,8 +222,7 @@ class Controller extends \yii\base\Controller
                     unset($params[$key]);
                 }
             } elseif (
-                PHP_VERSION_ID >= 70100
-                && ($type = $param->getType()) !== null
+                ($type = $param->getType()) !== null
                 && $type instanceof \ReflectionNamedType
                 && !$type->isBuiltin()
             ) {
@@ -583,17 +578,13 @@ class Controller extends \yii\base\Controller
         foreach ($method->getParameters() as $i => $parameter) {
             $type = null;
             $comment = '';
-            if (PHP_MAJOR_VERSION > 5 && $parameter->hasType()) {
+            if ($parameter->hasType()) {
                 $reflectionType = $parameter->getType();
-                if (PHP_VERSION_ID >= 70100) {
-                    $types = method_exists($reflectionType, 'getTypes') ? $reflectionType->getTypes() : [$reflectionType];
-                    foreach ($types as $key => $reflectionType) {
-                        $types[$key] = $reflectionType->getName();
-                    }
-                    $type = implode('|', $types);
-                } else {
-                    $type = (string) $reflectionType;
+                $types = method_exists($reflectionType, 'getTypes') ? $reflectionType->getTypes() : [$reflectionType];
+                foreach ($types as $key => $reflectionType) {
+                    $types[$key] = $reflectionType->getName();
                 }
+                $type = implode('|', $types);
             }
             // find PhpDoc tag by property name or position
             $key = isset($phpDocParams[$parameter->name]) ? $parameter->name : (isset($phpDocParams[$i]) ? $i : null);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
