### PR TITLE
Update PHPStan/Psalm annotations for `ArrayHelper::merge`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -26,6 +26,7 @@ Yii Framework 2 Change Log
 - Enh #20413: Add PHPStan/Psalm annotations for `Action`, `ActionEvent`, `Application`, `DynamicModel` and `InlineAction` (max-s-lab)
 - Enh #20416: Add `PHPStan`/`PSalm` annotation for `owner` property in `Behavior` class (terabytesoftw)
 - Bug #20423: `strcmp()` Passing `null` to parameter `2` ($string2) of type string is deprecated (terabytesoftw)
+- Enh #20430: Update PHPStan/Psalm annotations for `ArrayHelper::merge` to handle array-key (samuelrajan747)
 
 
 2.0.52 February 13, 2025

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -117,16 +117,20 @@ class BaseArrayHelper
      * @param array $b array to be merged from. You can specify additional
      * arrays via third argument, fourth argument etc.
      * @return array the merged array (the original arrays are not changed.)
-     * @phpstan-template TItemA
-     * @phpstan-template TItemB
-     * @psalm-template TItemA
-     * @psalm-template TItemB
-     * @phpstan-param array<TItemA> $a
-     * @phpstan-param array<array<TItemB>> ...$b
-     * @psalm-param array<TItemA> $a
-     * @psalm-param array<array<TItemB>> ...$b
-     * @phpstan-return array<TItemA|TItemB>
-     * @psalm-return array<TItemA|TItemB>
+     * @phpstan-template TKeyA
+     * @phpstan-template TValueA
+     * @phpstan-template TKeyB
+     * @phpstan-template TValueB
+     * @psalm-template TKeyA
+     * @psalm-template TValueA
+     * @psalm-template TKeyB
+     * @psalm-template TValueB
+     * @phpstan-param array<TKeyA, TValueA> $a
+     * @phpstan-param array<array<TKeyB, TValueB>> ...$b
+     * @psalm-param array<TKeyA, TValueA> $a
+     * @psalm-param array<array<TKeyB, TValueB>> ...$b
+     * @phpstan-return array<TKeyA|TKeyB, TValueA|TValueB>
+     * @psalm-return array<TKeyA|TKeyB, TValueA|TValueB>
      */
     public static function merge($a, ...$b)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |

I missed the type of the array-key earlier.