### PR TITLE
Fix PHPStan/Psalm annotations for `ActiveQuery::asArray`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.54 under development
 ------------------------
 
-- Enh #20432: Updated PHPStan/Psalm annotations for `ActiveQuery::asArray` (max-s-lab)
+- Bug #20432: Fix PHPStan/Psalm annotations for `ActiveQuery::asArray` (max-s-lab)
 - Bug #20437: Fix PHPStan/Psalm annotations for `BaseArrayHelper::merge` (max-s-lab)
 - Enh #20434: Added PHPStan/Psalm annotations for `hasMany` and `hasOne` methods (max-s-lab)
 - Enh #20433: Added PHPStan/Psalm annotations for some controllers methods: `beforeAction`, `afterAction` and `bindActionParams` (max-s-lab)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.54 under development
 ------------------------
 
-- no changes in this release.
+- Enh #20432: Updated PHPStan/Psalm annotations for `ActiveQuery::asArray` (max-s-lab)
 
 
 2.0.53 June 27, 2025

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -78,8 +78,8 @@ use yii\base\InvalidConfigException;
  * @phpstan-method T[] all($db = null)
  * @psalm-method T[] all($db = null)
  *
- * @phpstan-method ($value is true ? (T is array ? self<T> : self<array<string, mixed>>) : self<T>) asArray($value = true)
- * @psalm-method ($value is true ? (T is array ? self<T> : self<array<string, mixed>>) : self<T>) asArray($value = true)
+ * @phpstan-method ($value is true ? (T is array ? static<T> : static<array<string, mixed>>) : static<T>) asArray($value = true)
+ * @psalm-method ($value is true ? (T is array ? static<T> : static<array<string, mixed>>) : static<T>) asArray($value = true)
  *
  * @phpstan-method BatchQueryResult<int, T[]> batch($batchSize = 100, $db = null)
  * @psalm-method BatchQueryResult<int, T[]> batch($batchSize = 100, $db = null)

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -78,8 +78,8 @@ use yii\base\InvalidConfigException;
  * @phpstan-method T[] all($db = null)
  * @psalm-method T[] all($db = null)
  *
- * @phpstan-method ($value is true ? (T is array ? self<T> : self<array>) : self<T>) asArray($value = true)
- * @psalm-method ($value is true ? (T is array ? self<T> : self<array>) : self<T>) asArray($value = true)
+ * @phpstan-method ($value is true ? (T is array ? self<T> : self<array<string, mixed>>) : self<T>) asArray($value = true)
+ * @psalm-method ($value is true ? (T is array ? self<T> : self<array<string, mixed>>) : self<T>) asArray($value = true)
  *
  * @phpstan-method BatchQueryResult<int, T[]> batch($batchSize = 100, $db = null)
  * @psalm-method BatchQueryResult<int, T[]> batch($batchSize = 100, $db = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

The previous type was not detailed enough for PHPStan 6+