### PR TITLE
Added PHPStan/Psalm annotations for some controllers methods

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.54 under development
 ------------------------
 
-- no changes in this release.
+- Enh #20433: Added PHPStan/Psalm annotations for `Controller::beforeAction` (max-s-lab)
 
 
 2.0.53 June 27, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.54 under development
 ------------------------
 
-- Enh #20433: Added PHPStan/Psalm annotations for some controllers methods (max-s-lab)
+- Enh #20433: Added PHPStan/Psalm annotations for some controllers methods: `beforeAction`, `afterAction` and `bindActionParams` (max-s-lab)
 
 
 2.0.53 June 27, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.54 under development
 ------------------------
 
-- Enh #20433: Added PHPStan/Psalm annotations for `Controller::beforeAction` (max-s-lab)
+- Enh #20433: Added PHPStan/Psalm annotations for some controller methods (max-s-lab)
 
 
 2.0.53 June 27, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Change Log
 2.0.54 under development
 ------------------------
 
-- Enh #20433: Added PHPStan/Psalm annotations for some controller methods (max-s-lab)
+- Enh #20433: Added PHPStan/Psalm annotations for some controllers methods (max-s-lab)
 
 
 2.0.53 June 27, 2025

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -327,6 +327,9 @@ class Controller extends Component implements ViewContextInterface
      * @param Action $action the action just executed.
      * @param mixed $result the action return result.
      * @return mixed the processed action result.
+     *
+     * @phpstan-param Action<static> $action
+     * @psalm-param Action<static> $action
      */
     public function afterAction($action, $result)
     {

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -230,6 +230,12 @@ class Controller extends Component implements ViewContextInterface
      *
      * @phpstan-param Action<static> $action
      * @psalm-param Action<static> $action
+     *
+     * @phpstan-param array<array-key, mixed> $params
+     * @psalm-param array<array-key, mixed> $params
+     *
+     * @phpstan-return mixed[]
+     * @psalm-return mixed[]
      */
     public function bindActionParams($action, $params)
     {

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -227,6 +227,9 @@ class Controller extends Component implements ViewContextInterface
      * @param Action $action the action to be bound with parameters.
      * @param array $params the parameters to be bound to the action.
      * @return array the valid parameters that the action can run with.
+     *
+     * @phpstan-param Action<static> $action
+     * @psalm-param Action<static> $action
      */
     public function bindActionParams($action, $params)
     {

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -296,6 +296,9 @@ class Controller extends Component implements ViewContextInterface
      *
      * @param Action $action the action to be executed.
      * @return bool whether the action should continue to run.
+     *
+     * @phpstan-param Action<static> $action
+     * @psalm-param Action<static> $action
      */
     public function beforeAction($action)
     {

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -193,8 +193,8 @@ class Controller extends \yii\base\Controller
      * @phpstan-param Action<static> $action
      * @psalm-param Action<static> $action
      *
-     * @phpstan-param array<array-key, string> $params
-     * @psalm-param array<array-key, string> $params
+     * @phpstan-param array<array-key, mixed> $params
+     * @psalm-param array<array-key, mixed> $params
      *
      * @phpstan-return mixed[]
      * @psalm-return mixed[]

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -192,6 +192,12 @@ class Controller extends \yii\base\Controller
      *
      * @phpstan-param Action<static> $action
      * @psalm-param Action<static> $action
+     *
+     * @phpstan-param array<array-key, string> $params
+     * @psalm-param array<array-key, string> $params
+     *
+     * @phpstan-return mixed[]
+     * @psalm-return mixed[]
      */
     public function bindActionParams($action, $params)
     {

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -189,6 +189,9 @@ class Controller extends \yii\base\Controller
      * @param array $params the parameters to be bound to the action
      * @return array the valid parameters that the action can run with.
      * @throws Exception if there are unknown options or missing arguments
+     *
+     * @phpstan-param Action<static> $action
+     * @psalm-param Action<static> $action
      */
     public function bindActionParams($action, $params)
     {

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -11,6 +11,7 @@ use Yii;
 use yii\base\Exception;
 use yii\base\InlineAction;
 use yii\helpers\Url;
+use yii\base\Action;
 
 /**
  * Controller is the base class of web controllers.
@@ -108,14 +109,17 @@ class Controller extends \yii\base\Controller
 
     /**
      * Binds the parameters to the action.
-     * This method is invoked by [[\yii\base\Action]] when it begins to run with the given parameters.
+     * This method is invoked by [[Action]] when it begins to run with the given parameters.
      * This method will check the parameter names that the action requires and return
      * the provided parameters according to the requirement. If there is any missing parameter,
      * an exception will be thrown.
-     * @param \yii\base\Action $action the action to be bound with parameters
+     * @param Action $action the action to be bound with parameters
      * @param array $params the parameters to be bound to the action
      * @return array the valid parameters that the action can run with.
      * @throws BadRequestHttpException if there are missing or invalid parameters.
+     *
+     * @phpstan-param Action<static> $action
+     * @psalm-param Action<static> $action
      */
     public function bindActionParams($action, $params)
     {

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -120,6 +120,12 @@ class Controller extends \yii\base\Controller
      *
      * @phpstan-param Action<static> $action
      * @psalm-param Action<static> $action
+     *
+     * @phpstan-param array<string, mixed> $params
+     * @psalm-param array<string, mixed> $params
+     *
+     * @phpstan-return mixed[]
+     * @psalm-return mixed[]
      */
     public function bindActionParams($action, $params)
     {

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -121,8 +121,8 @@ class Controller extends \yii\base\Controller
      * @phpstan-param Action<static> $action
      * @psalm-param Action<static> $action
      *
-     * @phpstan-param array<string, mixed> $params
-     * @psalm-param array<string, mixed> $params
+     * @phpstan-param array<array-key, mixed> $params
+     * @psalm-param array<array-key, mixed> $params
      *
      * @phpstan-return mixed[]
      * @psalm-return mixed[]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

In the current implementation, you need to define the type every time. My change will avoid this.

![image](https://github.com/user-attachments/assets/c283d635-adba-41c4-a70e-c39b7ea97257)
