### PR TITLE
Replace `int|string` key types with `array-key` in PHPStan/Psalm annotations

### DIFF
--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -462,8 +462,8 @@ class Component extends BaseObject
      *
      * @return array the behavior configurations.
      *
-     * @phpstan-return array<int|string, class-string|array{class: class-string, ...}>
-     * @psalm-return array<int|string, class-string|array{class: class-string, ...}>
+     * @phpstan-return array<array-key, class-string|array{class: class-string, ...}>
+     * @psalm-return array<array-key, class-string|array{class: class-string, ...}>
      */
     public function behaviors()
     {

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -161,8 +161,8 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      * @return array validation rules
      * @see scenarios()
      *
-     * @phpstan-return array<int|string, mixed>[]
-     * @psalm-return array<int|string, mixed>[]
+     * @phpstan-return array<array-key, mixed>[]
+     * @psalm-return array<array-key, mixed>[]
      */
     public function rules()
     {

--- a/framework/web/AssetBundle.php
+++ b/framework/web/AssetBundle.php
@@ -102,8 +102,8 @@ class AssetBundle extends BaseObject
      *
      * Note that only a forward slash "/" should be used as directory separator.
      *
-     * @phpstan-var (string|array<int|string, mixed>)[]
-     * @psalm-var (string|array<int|string, mixed>)[]
+     * @phpstan-var (string|array<array-key, mixed>)[]
+     * @psalm-var (string|array<array-key, mixed>)[]
      */
     public $js = [];
     /**
@@ -112,8 +112,8 @@ class AssetBundle extends BaseObject
      *
      * Note that only a forward slash "/" should be used as directory separator.
      *
-     * @phpstan-var (string|array<int|string, mixed>)[]
-     * @psalm-var (string|array<int|string, mixed>)[]
+     * @phpstan-var (string|array<array-key, mixed>)[]
+     * @psalm-var (string|array<array-key, mixed>)[]
      */
     public $css = [];
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
