### PR TITLE
Remove `PHP_VERSION_ID` checks from db `Connection` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,7 +13,7 @@ Yii Framework 2 Change Log
 - Bug #20421: Remove `PHP_VERSION_ID` check in `pbkdf2` method for `hash_pbkdf2` function (terabytesoftw)
 - Bug #20422: Remove `PHP_VERSION_ID` checks from `AttributeTypecastBehavior` and its tests for enum typecasting (terabytesoftw)
 - Bug #20427: Remove `PHP_VERSION_ID` and `PHP_MAJOR_VERSION` checks from console `Controller` class (terabytesoftw)
-- Bug #20445: Remove `PHP_VERSION_ID` checks from db `Connection` class (terabytesoftw)
+- Chg #20445: Remove `PHP_VERSION_ID` checks from db `Connection` class (terabytesoftw)
 
 2.0.53 under development
 2.0.54 under development

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Bug #20421: Remove `PHP_VERSION_ID` check in `pbkdf2` method for `hash_pbkdf2` function (terabytesoftw)
 - Bug #20422: Remove `PHP_VERSION_ID` checks from `AttributeTypecastBehavior` and its tests for enum typecasting (terabytesoftw)
 - Bug #20427: Remove `PHP_VERSION_ID` and `PHP_MAJOR_VERSION` checks from console `Controller` class (terabytesoftw)
+- Bug #20445: Remove `PHP_VERSION_ID` checks from db `Connection` class (terabytesoftw)
 
 2.0.53 under development
 2.0.54 under development

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -727,7 +727,7 @@ class Connection extends Component
             }
         }
 
-        if (PHP_VERSION_ID >= 80100 && $this->getDriverName() === 'sqlite') {
+        if ($this->getDriverName() === 'sqlite') {
             $this->pdo->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
