### PR TITLE
Remove deprecated method `convertExceptionToError()` in `ErrorHandler` class and clean tests.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Bug #20421: Remove `PHP_VERSION_ID` check in `pbkdf2` method for `hash_pbkdf2` function (terabytesoftw)
 - Bug #20422: Remove `PHP_VERSION_ID` checks from `AttributeTypecastBehavior` and its tests for enum typecasting (terabytesoftw)
 - Bug #20427: Remove `PHP_VERSION_ID` and `PHP_MAJOR_VERSION` checks from console `Controller` class (terabytesoftw)
+- Bug #20446: Remove deprecated method `convertExceptionToError()` in `ErrorHandler` class and clean tests (terabytesoftw)
 
 2.0.53 under development
 2.0.54 under development

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,7 +13,7 @@ Yii Framework 2 Change Log
 - Bug #20421: Remove `PHP_VERSION_ID` check in `pbkdf2` method for `hash_pbkdf2` function (terabytesoftw)
 - Bug #20422: Remove `PHP_VERSION_ID` checks from `AttributeTypecastBehavior` and its tests for enum typecasting (terabytesoftw)
 - Bug #20427: Remove `PHP_VERSION_ID` and `PHP_MAJOR_VERSION` checks from console `Controller` class (terabytesoftw)
-- Bug #20446: Remove deprecated method `convertExceptionToError()` in `ErrorHandler` class and clean tests (terabytesoftw)
+- Chg #20446: Remove deprecated method `convertExceptionToError()` in `ErrorHandler` class and clean tests (terabytesoftw)
 
 2.0.53 under development
 2.0.54 under development

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -356,24 +356,6 @@ abstract class ErrorHandler extends Component
     }
 
     /**
-     * Converts an exception into a PHP error.
-     *
-     * This method can be used to convert exceptions inside of methods like `__toString()`
-     * to PHP errors because exceptions cannot be thrown inside of them.
-     * @param \Throwable $exception the exception to convert to a PHP error.
-     * @return never
-     *
-     * @deprecated since 2.0.53. Use conditional exception throwing in `__toString()` methods instead.
-     * For PHP < 7.4: use `trigger_error()` directly with `convertExceptionToString()` method.
-     * For PHP >= 7.4: throw the exception directly as `__toString()` supports exceptions.
-     * This method will be removed in 2.2.0.
-     */
-    public static function convertExceptionToError($exception)
-    {
-        trigger_error(static::convertExceptionToString($exception), E_USER_ERROR);
-    }
-
-    /**
      * Converts an exception into a simple string.
      * @param \Throwable $exception the exception being converted
      * @return string the string representation of the exception.

--- a/framework/mail/BaseMessage.php
+++ b/framework/mail/BaseMessage.php
@@ -60,12 +60,6 @@ abstract class BaseMessage extends BaseObject implements MessageInterface
         try {
             return $this->toString();
         } catch (\Throwable $e) {
-            if (PHP_VERSION_ID < 70400) {
-                trigger_error(ErrorHandler::convertExceptionToString($e), E_USER_ERROR);
-
-                return '';
-            }
-
             throw $e;
         }
     }

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -175,12 +175,6 @@ class ActiveField extends Component
         try {
             return $this->render();
         } catch (\Throwable $e) {
-            if (PHP_VERSION_ID < 70400) {
-                trigger_error(ErrorHandler::convertExceptionToString($e), E_USER_ERROR);
-
-                return '';
-            }
-
             throw $e;
         }
     }

--- a/tests/framework/caching/MemCachedTest.php
+++ b/tests/framework/caching/MemCachedTest.php
@@ -27,9 +27,8 @@ class MemCachedTest extends CacheTestCase
             $this->markTestSkipped('memcached not installed. Skipping.');
         }
 
-        if (
-            PHP_VERSION_ID >= 80100 && version_compare(phpversion('memcached'), '3.1.5', '<=')
-        ) {
+        if (version_compare(phpversion('memcached'), '3.1.5', '<='))
+        {
             $php_version = phpversion();
             $memcached_version = phpversion('memcached');
             $this->markTestSkipped("memcached version $memcached_version is not ready for PHP $php_version. Skipping.");

--- a/tests/framework/db/mysql/connection/DeadLockTest.php
+++ b/tests/framework/db/mysql/connection/DeadLockTest.php
@@ -263,11 +263,6 @@ class DeadLockTest extends \yiiunit\framework\db\mysql\ConnectionTest
      */
     private function setErrorHandler(): void
     {
-        if (PHP_VERSION_ID < 70000) {
-            set_error_handler(function ($errno, $errstr, $errfile, $errline): never {
-                throw new \ErrorException($errstr, $errno, $errno, $errfile, $errline);
-            });
-        }
     }
 
     /**

--- a/tests/framework/mail/BaseMessageTest.php
+++ b/tests/framework/mail/BaseMessageTest.php
@@ -63,50 +63,12 @@ class BaseMessageTest extends TestCase
 
     public function testExceptionToString()
     {
-        if (PHP_VERSION_ID < 70400) {
-            $this->markTestSkipped('This test is for PHP 7.4+ only');
-        }
-
         $message = new TestMessageWithException();
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Test exception in toString.');
 
         (string) $message;
-    }
-
-    public function testExceptionToStringLegacy()
-    {
-        if (PHP_VERSION_ID >= 70400) {
-            $this->markTestSkipped('This test is for PHP < 7.4 only');
-        }
-
-        $message = new TestMessageWithException();
-
-        $errorTriggered = false;
-        $errorMessage = '';
-
-        set_error_handler(
-            function ($severity, $message, $file, $line) use (&$errorTriggered, &$errorMessage) {
-                if ($severity === E_USER_ERROR) {
-                    $errorTriggered = true;
-                    $errorMessage = $message;
-
-                    return true;
-                }
-
-                return false;
-            },
-            E_USER_ERROR,
-        );
-
-        $result = (string) $message;
-
-        restore_error_handler();
-
-        $this->assertTrue($errorTriggered, 'E_USER_ERROR should have been triggered');
-        $this->assertStringContainsString('Test exception in toString.', $errorMessage);
-        $this->assertSame('', $result, 'Result should be an empty string');
     }
 }
 

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -336,10 +336,6 @@ class ControllerTest extends TestCase
 
     public function testUnionBindingActionParamsWithArray()
     {
-        if (PHP_VERSION_ID < 80000) {
-            $this->markTestSkipped('Can not be tested on PHP < 8.0');
-            return;
-        }
         // Use the PHP80 controller for this test
         $this->controller = new FakePhp80Controller('fake', new \yii\web\Application([
              'id' => 'app',

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -698,50 +698,12 @@ HTML;
 
     public function testExceptionToString()
     {
-        if (PHP_VERSION_ID < 70400) {
-            $this->markTestSkipped('This test is for PHP 7.4+ only');
-        }
-
         $field = new TestActiveFieldWithException();
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Test exception in toString.');
 
         (string) $field;
-    }
-
-    public function testExceptionToStringLegacy()
-    {
-        if (PHP_VERSION_ID >= 70400) {
-            $this->markTestSkipped('This test is for PHP < 7.4 only');
-        }
-
-        $field = new TestActiveFieldWithException();
-
-        $errorTriggered = false;
-        $errorMessage = '';
-
-        set_error_handler(
-            function ($severity, $message, $file, $line) use (&$errorTriggered, &$errorMessage) {
-                if ($severity === E_USER_ERROR) {
-                    $errorTriggered = true;
-                    $errorMessage = $message;
-
-                    return true;
-                }
-
-                return false;
-            },
-            E_USER_ERROR,
-        );
-
-        $result = (string) $field;
-
-        restore_error_handler();
-
-        $this->assertTrue($errorTriggered, 'E_USER_ERROR should have been triggered');
-        $this->assertStringContainsString('Test exception in toString.', $errorMessage);
-        $this->assertSame('', $result, 'Result should be an empty string');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
