### PR TITLE
Remove `PHP_VERSION_ID` checks from helpers `BaseJson` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -17,6 +17,7 @@ Yii Framework 2 Change Log
 - Chg #20445: Remove `PHP_VERSION_ID` checks from db `Connection` class (terabytesoftw)
 - Chg #20446: Remove deprecated method `convertExceptionToError()` in `ErrorHandler` class and clean tests (terabytesoftw)
 - Chg #20448: Remove `PHP_VERSION_ID` checks from di `Container` class (terabytesoftw)
+- Chg #20449: Remove `PHP_VERSION_ID` checks from helpers `BaseJson` class (terabytesoftw)
 
 2.0.54 under development
 ------------------------

--- a/framework/helpers/BaseJson.php
+++ b/framework/helpers/BaseJson.php
@@ -143,17 +143,7 @@ class BaseJson
             return;
         }
 
-        if (PHP_VERSION_ID >= 50500) {
-            throw new InvalidArgumentException(json_last_error_msg(), $lastError);
-        }
-
-        foreach (static::$jsonErrorMessages as $const => $message) {
-            if (defined($const) && constant($const) === $lastError) {
-                throw new InvalidArgumentException($message, $lastError);
-            }
-        }
-
-        throw new InvalidArgumentException('Unknown JSON encoding/decoding error.');
+        throw new InvalidArgumentException(json_last_error_msg(), $lastError);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
