### PR TITLE
Remove `PHP_VERSION_ID` checks from validators `EmailValidator` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -17,6 +17,7 @@ Yii Framework 2 Change Log
 - Chg #20445: Remove `PHP_VERSION_ID` checks from db `Connection` class (terabytesoftw)
 - Chg #20446: Remove deprecated method `convertExceptionToError()` in `ErrorHandler` class and clean tests (terabytesoftw)
 - Chg #20448: Remove `PHP_VERSION_ID` checks from di `Container` class (terabytesoftw)
+- Chg #20450: Remove `PHP_VERSION_ID` checks from validators `EmailValidator` class (terabytesoftw)
 
 2.0.54 under development
 ------------------------

--- a/framework/validators/EmailValidator.php
+++ b/framework/validators/EmailValidator.php
@@ -155,11 +155,6 @@ class EmailValidator extends Validator
 
     private function idnToAscii($idn)
     {
-        if (PHP_VERSION_ID < 50600) {
-            // TODO: drop old PHP versions support
-            return idn_to_ascii($idn);
-        }
-
         return idn_to_ascii($idn, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
