### PR TITLE
Remove `PHP_VERSION_ID` checks from validators `UrlValidator` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -19,6 +19,7 @@ Yii Framework 2 Change Log
 - Chg #20448: Remove `PHP_VERSION_ID` checks from di `Container` class (terabytesoftw)
 - Chg #20450: Remove `PHP_VERSION_ID` checks from validators `EmailValidator` class (terabytesoftw)
 - Chg #20449: Remove `PHP_VERSION_ID` checks from helpers `BaseJson` class (terabytesoftw)
+- Chg #20451: Remove `PHP_VERSION_ID` checks from validators `UrlValidator` class (terabytesoftw)
 
 2.0.54 under development
 ------------------------

--- a/framework/validators/UrlValidator.php
+++ b/framework/validators/UrlValidator.php
@@ -110,11 +110,6 @@ class UrlValidator extends Validator
 
     private function idnToAscii($idn)
     {
-        if (PHP_VERSION_ID < 50600) {
-            // TODO: drop old PHP versions support
-            return idn_to_ascii($idn);
-        }
-
         return idn_to_ascii($idn, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
