### PR TITLE
Remove `PHP_VERSION_ID` checks from web `Controller` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -19,6 +19,7 @@ Yii Framework 2 Change Log
 - Chg #20448: Remove `PHP_VERSION_ID` checks from di `Container` class (terabytesoftw)
 - Chg #20450: Remove `PHP_VERSION_ID` checks from validators `EmailValidator` class (terabytesoftw)
 - Chg #20449: Remove `PHP_VERSION_ID` checks from helpers `BaseJson` class (terabytesoftw)
+- Chg #20452: Remove `PHP_VERSION_ID` checks from web `Controller` class (terabytesoftw)
 
 2.0.54 under development
 ------------------------

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -160,8 +160,7 @@ class Controller extends \yii\base\Controller
                 $args[] = $actionParams[$name] = $params[$name];
                 unset($params[$name]);
             } elseif (
-                PHP_VERSION_ID >= 70100
-                && ($type = $param->getType()) !== null
+                ($type = $param->getType()) !== null
                 && $type instanceof \ReflectionNamedType
                 && !$type->isBuiltin()
             ) {
@@ -214,12 +213,11 @@ class Controller extends \yii\base\Controller
         }
 
         if (
-            PHP_VERSION_ID >= 70000
-            && method_exists($type, 'isBuiltin')
+            method_exists($type, 'isBuiltin')
             && $type->isBuiltin()
             && ($param !== null || !$type->allowsNull())
         ) {
-            $typeName = PHP_VERSION_ID >= 70100 ? $type->getName() : (string)$type;
+            $typeName = $type->getName();
             if ($param === '' && $type->allowsNull()) {
                 if ($typeName !== 'string') { // for old string behavior compatibility
                     return [null, true];
@@ -256,7 +254,7 @@ class Controller extends \yii\base\Controller
                 ) {
                     continue;
                 }
-                $typeName = PHP_VERSION_ID >= 70100 ? $partialType->getName() : (string)$partialType;
+                $typeName = $partialType->getName();
                 if ($typeName === 'string') {
                     return ['', true];
                 }
@@ -277,7 +275,7 @@ class Controller extends \yii\base\Controller
                 continue;
             }
             $foundBuiltinType = true;
-            $typeName = PHP_VERSION_ID >= 70100 ? $partialType->getName() : (string)$partialType;
+            $typeName = $partialType->getName();
             $canBeArray |= $typeName === 'array';
             $canBeString |= $typeName === 'string';
             if (is_array($param)) {

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -160,7 +160,7 @@ class Controller extends \yii\base\Controller
                 $args[] = $actionParams[$name] = $params[$name];
                 unset($params[$name]);
             } elseif (
-                $type = $param->getType() !== null
+                ($type = $param->getType()) !== null
                 && $type instanceof \ReflectionNamedType
                 && !$type->isBuiltin()
             ) {

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -160,7 +160,7 @@ class Controller extends \yii\base\Controller
                 $args[] = $actionParams[$name] = $params[$name];
                 unset($params[$name]);
             } elseif (
-                ($type = $param->getType()) !== null
+                $type = $param->getType() !== null
                 && $type instanceof \ReflectionNamedType
                 && !$type->isBuiltin()
             ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
