### PR TITLE
Remove `PHP_VERSION_ID` checks from web `Request` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -21,6 +21,7 @@ Yii Framework 2 Change Log
 - Chg #20449: Remove `PHP_VERSION_ID` checks from helpers `BaseJson` class (terabytesoftw)
 - Chg #20452: Remove `PHP_VERSION_ID` checks from web `Controller` class (terabytesoftw)
 - Chg #20451: Remove `PHP_VERSION_ID` checks from validators `UrlValidator` class (terabytesoftw)
+- Chg #20455: Remove `PHP_VERSION_ID` checks from web `Request` class (terabytesoftw)
 
 2.0.54 under development
 ------------------------

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -1762,11 +1762,7 @@ class Request extends \yii\base\Request
                 if ($data === false) {
                     continue;
                 }
-                if (defined('PHP_VERSION_ID') && PHP_VERSION_ID >= 70000) {
-                    $data = @unserialize($data, ['allowed_classes' => false]);
-                } else {
-                    $data = @unserialize($data);
-                }
+                $data = @unserialize($data, ['allowed_classes' => false]);
                 if (is_array($data) && isset($data[0], $data[1]) && $data[0] === $name) {
                     $cookies[$name] = Yii::createObject([
                         'class' => 'yii\web\Cookie',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
