### PR TITLE
Fix return type in `RequestParserInterface::parse`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 Change Log
 - Enh #20433: Added PHPStan/Psalm annotations for some controllers methods: `beforeAction`, `afterAction` and `bindActionParams` (max-s-lab)
 - Enh #20442: Add PHPStan/Psalm annotations for `yii\base\Controller` methods: `runAction`, `run`, `render`, `renderPartial` and `renderFile` (max-s-lab)
 - Bug #20453: Fix PHPStan/Psalm types in `yii\web\View` (max-s-lab)
+- Bug #20459: Fix return type in `RequestParserInterface::parse` (max-s-lab)
 
 
 2.0.53 June 27, 2025

--- a/framework/web/RequestParserInterface.php
+++ b/framework/web/RequestParserInterface.php
@@ -19,7 +19,7 @@ interface RequestParserInterface
      * Parses a HTTP request body.
      * @param string $rawBody the raw HTTP request body.
      * @param string $contentType the content type specified for the request body.
-     * @return array parameters parsed from the request body
+     * @return array|object parameters parsed from the request body
      */
     public function parse($rawBody, $contentType);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20459
