### PR TITLE
Remove `PHP_VERSION_ID` checks from web `Response` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -22,6 +22,7 @@ Yii Framework 2 Change Log
 - Chg #20452: Remove `PHP_VERSION_ID` checks from web `Controller` class (terabytesoftw)
 - Chg #20451: Remove `PHP_VERSION_ID` checks from validators `UrlValidator` class (terabytesoftw)
 - Chg #20455: Remove `PHP_VERSION_ID` checks from web `Request` class (terabytesoftw)
+- Chg #20464: Remove `PHP_VERSION_ID` checks from web `Response` class (terabytesoftw)
 
 2.0.54 under development
 ------------------------

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -413,24 +413,14 @@ class Response extends \yii\base\Response
             if ($expire != 1 && isset($validationKey)) {
                 $value = Yii::$app->getSecurity()->hashData(serialize([$cookie->name, $value]), $validationKey);
             }
-            if (PHP_VERSION_ID >= 70300) {
-                setcookie($cookie->name, $value, [
-                    'expires' => $expire,
-                    'path' => $cookie->path,
-                    'domain' => $cookie->domain,
-                    'secure' => $cookie->secure,
-                    'httpOnly' => $cookie->httpOnly,
-                    'sameSite' => !empty($cookie->sameSite) ? $cookie->sameSite : null,
-                ]);
-            } else {
-                // Work around for setting sameSite cookie prior PHP 7.3
-                // https://stackoverflow.com/questions/39750906/php-setcookie-samesite-strict/46971326#46971326
-                $cookiePath = $cookie->path;
-                if (!is_null($cookie->sameSite)) {
-                    $cookiePath .= '; samesite=' . $cookie->sameSite;
-                }
-                setcookie($cookie->name, $value, $expire, $cookiePath, $cookie->domain, $cookie->secure, $cookie->httpOnly);
-            }
+            setcookie($cookie->name, $value, [
+                'expires' => $expire,
+                'path' => $cookie->path,
+                'domain' => $cookie->domain,
+                'secure' => $cookie->secure,
+                'httpOnly' => $cookie->httpOnly,
+                'sameSite' => !empty($cookie->sameSite) ? $cookie->sameSite : null,
+            ]);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
