### PR TITLE
Remove `PHP_VERSION_ID` checks from web `Session` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -22,6 +22,7 @@ Yii Framework 2 Change Log
 - Chg #20452: Remove `PHP_VERSION_ID` checks from web `Controller` class (terabytesoftw)
 - Chg #20451: Remove `PHP_VERSION_ID` checks from validators `UrlValidator` class (terabytesoftw)
 - Chg #20455: Remove `PHP_VERSION_ID` checks from web `Request` class (terabytesoftw)
+- Chg #20465: Remove `PHP_VERSION_ID` checks from web `Session` class (terabytesoftw)
 
 2.0.54 under development
 ------------------------

--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -417,14 +417,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
     {
         $data = $this->getCookieParams();
         if (isset($data['lifetime'], $data['path'], $data['domain'], $data['secure'], $data['httponly'])) {
-            if (PHP_VERSION_ID >= 70300) {
-                session_set_cookie_params($data);
-            } else {
-                if (!empty($data['samesite'])) {
-                    $data['path'] .= '; samesite=' . $data['samesite'];
-                }
-                session_set_cookie_params($data['lifetime'], $data['path'], $data['domain'], $data['secure'], $data['httponly']);
-            }
+            session_set_cookie_params($data);
         } else {
             throw new InvalidArgumentException('Please make sure cookieParams contains these elements: lifetime, path, domain, secure and httponly.');
         }
@@ -556,17 +549,9 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      */
     public function setUseStrictMode($value)
     {
-        if (PHP_VERSION_ID < 50502) {
-            if ($this->getUseCustomStorage() || !$value) {
-                self::$_useStrictModePolyfill = $value;
-            } else {
-                throw new InvalidConfigException('Enabling `useStrictMode` on PHP < 5.5.2 is only supported with custom storage classes.');
-            }
-        } else {
-            $this->freeze();
-            ini_set('session.use_strict_mode', $value ? '1' : '0');
-            $this->unfreeze();
-        }
+        $this->freeze();
+        ini_set('session.use_strict_mode', $value ? '1' : '0');
+        $this->unfreeze();
     }
 
     /**
@@ -576,10 +561,6 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      */
     public function getUseStrictMode()
     {
-        if (PHP_VERSION_ID < 50502) {
-            return self::$_useStrictModePolyfill;
-        }
-
         return (bool)ini_get('session.use_strict_mode');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
