### PR TITLE
Fix `Schema` class to handle `null` bytes in `PDO::quote()` for PHP `8.5` compatibility.

### DIFF
--- a/.github/workflows/ci-sqlite.yml
+++ b/.github/workflows/ci-sqlite.yml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       COVERAGE: ${{ matrix.php == '7.4' && '--coverage-clover=coverage.xml  --colors=always' || '--colors=always' }}
+      DEFAULT_COMPOSER_FLAGS: "--prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi"
       EXTENSIONS: pdo, pdo_sqlite, sqlite3, ${{ matrix.php == '8.0' && 'xdebug-3.3.2' || 'xdebug' }}
       XDEBUG_MODE: coverage
 
@@ -22,7 +23,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
+            php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
 
     steps:
       - name: Checkout.
@@ -41,7 +42,7 @@ jobs:
         run: composer self-update
 
       - name: Install dependencies with composer.
-        run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
+        run: composer update $DEFAULT_COMPOSER_FLAGS ${{ matrix.php == 8.5 && '--ignore-platform-reqs' || '' }}
 
       - name: Run SQLite tests with PHPUnit.
         run: vendor/bin/phpunit --group sqlite ${{ env.COVERAGE }}

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Enh #20461: Add PHPStan/Psalm annotations for `yii\filters\auth\AuthInterface` (max-s-lab)
 - Bug #20459: Fix return type in `RequestParserInterface::parse` (max-s-lab)
 - Bug #20475: Fix `Formatter` class `asScientific()` method for PHP `8.5` `sprintf` precision change (`6` to `0`) (terabytesoftw)
+- Bug #20478: Fix `Schema` class to handle `null` bytes in `PDO::quote()` for PHP `8.5` compatibility (terabytesoftw)
 
 2.0.53 June 27, 2025
 --------------------

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -458,7 +458,7 @@ abstract class Schema extends BaseObject
             return $str;
         }
 
-        // PHP 8.5, PDO::quote() throws if the string contains a null byte (\0).
+        // PHP 8.5, PDO::quote() throws if the string contains a `null` byte (`\0`).
         // @link https://github.com/php/php-src/commit/0a10f6db26875e0f1d0f867307cee591d29a43c7
         if (
             mb_stripos((string)$this->db->dsn, 'odbc:') === false &&

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -458,7 +458,13 @@ abstract class Schema extends BaseObject
             return $str;
         }
 
-        if (mb_stripos((string)$this->db->dsn, 'odbc:') === false && ($value = $this->db->getSlavePdo(true)->quote($str)) !== false) {
+        // PHP 8.5, PDO::quote() throws if the string contains a null byte (\0).
+        // @link https://github.com/php/php-src/commit/0a10f6db26875e0f1d0f867307cee591d29a43c7
+        if (
+            mb_stripos((string)$this->db->dsn, 'odbc:') === false &&
+            strpos($str, "\0") === false &&
+            ($value = $this->db->getSlavePdo(true)->quote($str)) !== false
+        ) {
             return $value;
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -195,9 +195,14 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     {
         $reflection = new \ReflectionObject($object);
         $method = $reflection->getMethod($method);
-        $method->setAccessible(true);
+
+        if (PHP_VERSION_ID < 80500) {
+            $method->setAccessible(true);
+        }
+
         $result = $method->invokeArgs($object, $args);
-        if ($revoke) {
+
+        if ($revoke && PHP_VERSION_ID < 80500) {
             $method->setAccessible(false);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
