### PR TITLE
Fix deprecation of `ReflectionMethod::setAccessible()` in PHP `8.5`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Enh #20461: Add PHPStan/Psalm annotations for `yii\filters\auth\AuthInterface` (max-s-lab)
 - Bug #20459: Fix return type in `RequestParserInterface::parse` (max-s-lab)
 - Bug #20475: Fix `Formatter` class `asScientific()` method for PHP `8.5` `sprintf` precision change (`6` to `0`) (terabytesoftw)
+- Bug #20482: Fix deprecation of `ReflectionMethod::setAccessible()` in PHP `8.5` (terabytesoftw)
 
 2.0.53 June 27, 2025
 --------------------

--- a/framework/base/ErrorException.php
+++ b/framework/base/ErrorException.php
@@ -69,7 +69,8 @@ class ErrorException extends \ErrorException
             $ref = new \ReflectionProperty('Exception', 'trace');
 
             // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-            if (PHP_VERSION_ID < 80500) {
+            // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+            if (PHP_VERSION_ID < 80100) {
                 $ref->setAccessible(true);
             }
 

--- a/framework/base/ErrorException.php
+++ b/framework/base/ErrorException.php
@@ -67,7 +67,12 @@ class ErrorException extends \ErrorException
             }
 
             $ref = new \ReflectionProperty('Exception', 'trace');
-            $ref->setAccessible(true);
+
+            // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+            if (PHP_VERSION_ID < 80500) {
+                $ref->setAccessible(true);
+            }
+
             $ref->setValue($this, $trace);
         }
     }

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -224,7 +224,8 @@ abstract class ErrorHandler extends Component
             $ref = new \ReflectionProperty('\Exception', 'trace');
 
             // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-            if (PHP_VERSION_ID < 80500) {
+            // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+            if (PHP_VERSION_ID < 80100) {
                 $ref->setAccessible(true);
             }
 

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -222,7 +222,12 @@ abstract class ErrorHandler extends Component
         if (E_ERROR & $code) {
             $exception = new ErrorException($message, $code, $code, $file, $line);
             $ref = new \ReflectionProperty('\Exception', 'trace');
-            $ref->setAccessible(true);
+
+            // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+            if (PHP_VERSION_ID < 80500) {
+                $ref->setAccessible(true);
+            }
+
             $ref->setValue($exception, $backtrace);
             $this->_hhvmException = $exception;
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -205,7 +205,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $result = $method->invokeArgs($object, $args);
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if ($revoke && PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if ($revoke && PHP_VERSION_ID < 80100) {
             $method->setAccessible(false);
         }
 
@@ -237,7 +238,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $property->setValue($object, $value);
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if ($revoke && PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if ($revoke && PHP_VERSION_ID < 80100) {
             $property->setAccessible(false);
         }
     }
@@ -266,7 +268,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $result = $property->getValue($object);
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if ($revoke && PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if ($revoke && PHP_VERSION_ID < 80100) {
             $property->setAccessible(false);
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -197,7 +197,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $method = $reflection->getMethod($method);
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $method->setAccessible(true);
         }
 
@@ -228,7 +229,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $property = $class->getProperty($propertyName);
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $property->setAccessible(true);
         }
 
@@ -256,7 +258,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $property = $class->getProperty($propertyName);
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $property->setAccessible(true);
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -195,9 +195,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     {
         $reflection = new \ReflectionObject($object);
         $method = $reflection->getMethod($method);
-        $method->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $method->setAccessible(true);
+        }
+
         $result = $method->invokeArgs($object, $args);
-        if ($revoke) {
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if ($revoke && PHP_VERSION_ID < 80500) {
             $method->setAccessible(false);
         }
 
@@ -219,9 +226,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             $class = $class->getParentClass();
         }
         $property = $class->getProperty($propertyName);
-        $property->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $property->setAccessible(true);
+        }
+
         $property->setValue($object, $value);
-        if ($revoke) {
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if ($revoke && PHP_VERSION_ID < 80500) {
             $property->setAccessible(false);
         }
     }
@@ -240,9 +254,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             $class = $class->getParentClass();
         }
         $property = $class->getProperty($propertyName);
-        $property->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $property->setAccessible(true);
+        }
+
         $result = $property->getValue($object);
-        if ($revoke) {
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if ($revoke && PHP_VERSION_ID < 80500) {
             $property->setAccessible(false);
         }
 

--- a/tests/framework/base/ActionFilterTest.php
+++ b/tests/framework/base/ActionFilterTest.php
@@ -111,7 +111,11 @@ class ActionFilterTest extends TestCase
         $filter = Yii::createObject($filterClass);
         $reflection = new \ReflectionClass($filter);
         $method = $reflection->getMethod('isActive');
-        $method->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $method->setAccessible(true);
+        }
 
         $controller = new \yii\web\Controller('test', Yii::$app);
 
@@ -145,7 +149,11 @@ class ActionFilterTest extends TestCase
         $filter = new ActionFilter();
         $reflection = new \ReflectionClass($filter);
         $method = $reflection->getMethod('isActive');
-        $method->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $method->setAccessible(true);
+        }
 
         $controller = new \yii\web\Controller('test', Yii::$app);
 

--- a/tests/framework/base/ActionFilterTest.php
+++ b/tests/framework/base/ActionFilterTest.php
@@ -113,7 +113,8 @@ class ActionFilterTest extends TestCase
         $method = $reflection->getMethod('isActive');
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $method->setAccessible(true);
         }
 
@@ -151,7 +152,8 @@ class ActionFilterTest extends TestCase
         $method = $reflection->getMethod('isActive');
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $method->setAccessible(true);
         }
 

--- a/tests/framework/caching/FileCacheTest.php
+++ b/tests/framework/caching/FileCacheTest.php
@@ -70,7 +70,12 @@ class FileCacheTest extends CacheTestCase
         $refClass = new \ReflectionClass($cache);
 
         $refMethodGetCacheFile = $refClass->getMethod('getCacheFile');
-        $refMethodGetCacheFile->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $refMethodGetCacheFile->setAccessible(true);
+        }
+
         $refMethodGet = $refClass->getMethod('get');
         $refMethodSet = $refClass->getMethod('set');
 
@@ -91,7 +96,12 @@ class FileCacheTest extends CacheTestCase
         $normalizeKey = $cache->buildKey(__FUNCTION__);
         $refClass = new \ReflectionClass($cache);
         $refMethodGetCacheFile = $refClass->getMethod('getCacheFile');
-        $refMethodGetCacheFile->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $refMethodGetCacheFile->setAccessible(true);
+        }
+
         $cacheFile = $refMethodGetCacheFile->invoke($cache, $normalizeKey);
 
         // simulate cache expire 10 seconds ago

--- a/tests/framework/caching/FileCacheTest.php
+++ b/tests/framework/caching/FileCacheTest.php
@@ -72,7 +72,8 @@ class FileCacheTest extends CacheTestCase
         $refMethodGetCacheFile = $refClass->getMethod('getCacheFile');
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $refMethodGetCacheFile->setAccessible(true);
         }
 
@@ -98,7 +99,8 @@ class FileCacheTest extends CacheTestCase
         $refMethodGetCacheFile = $refClass->getMethod('getCacheFile');
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $refMethodGetCacheFile->setAccessible(true);
         }
 

--- a/tests/framework/console/controllers/AssetControllerTest.php
+++ b/tests/framework/console/controllers/AssetControllerTest.php
@@ -183,13 +183,8 @@ class AssetControllerTest extends TestCase
     protected function invokeAssetControllerMethod($methodName, array $args = [])
     {
         $controller = $this->createAssetController();
-        $controllerClassReflection = new \ReflectionClass(get_class($controller));
-        $methodReflection = $controllerClassReflection->getMethod($methodName);
-        $methodReflection->setAccessible(true);
-        $result = $methodReflection->invokeArgs($controller, $args);
-        $methodReflection->setAccessible(false);
 
-        return $result;
+        return $this->invokeMethod($controller, $methodName, $args);
     }
 
     /**

--- a/tests/framework/data/BaseDataProviderTest.php
+++ b/tests/framework/data/BaseDataProviderTest.php
@@ -19,7 +19,12 @@ class BaseDataProviderTest extends TestCase
     {
         $rc = new \ReflectionClass(BaseDataProvider::className());
         $rp = $rc->getProperty('counter');
-        $rp->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $rp->setAccessible(true);
+        }
+
         $rp->setValue(new ConcreteDataProvider(), null);
 
         $this->assertNull((new ConcreteDataProvider())->id);

--- a/tests/framework/data/BaseDataProviderTest.php
+++ b/tests/framework/data/BaseDataProviderTest.php
@@ -21,7 +21,8 @@ class BaseDataProviderTest extends TestCase
         $rp = $rc->getProperty('counter');
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $rp->setAccessible(true);
         }
 

--- a/tests/framework/filters/HttpCacheTest.php
+++ b/tests/framework/filters/HttpCacheTest.php
@@ -52,9 +52,12 @@ class HttpCacheTest extends \yiiunit\TestCase
     {
         $httpCache = new HttpCache();
         $request = Yii::$app->getRequest();
-
         $method = new \ReflectionMethod($httpCache, 'validateCache');
-        $method->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $method->setAccessible(true);
+        }
 
         $request->headers->remove('If-Modified-Since');
         $request->headers->remove('If-None-Match');

--- a/tests/framework/filters/HttpCacheTest.php
+++ b/tests/framework/filters/HttpCacheTest.php
@@ -55,7 +55,8 @@ class HttpCacheTest extends \yiiunit\TestCase
         $method = new \ReflectionMethod($httpCache, 'validateCache');
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $method->setAccessible(true);
         }
 

--- a/tests/framework/filters/auth/AuthMethodTest.php
+++ b/tests/framework/filters/auth/AuthMethodTest.php
@@ -73,7 +73,11 @@ class AuthMethodTest extends TestCase
     {
         $reflection = new \ReflectionClass(AuthMethod::className());
         $method = $reflection->getMethod('isOptional');
-        $method->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $method->setAccessible(true);
+        }
 
         $filter = $this->createFilter(function () {return new \stdClass();});
 

--- a/tests/framework/filters/auth/AuthMethodTest.php
+++ b/tests/framework/filters/auth/AuthMethodTest.php
@@ -75,7 +75,8 @@ class AuthMethodTest extends TestCase
         $method = $reflection->getMethod('isOptional');
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $method->setAccessible(true);
         }
 

--- a/tests/framework/filters/auth/AuthTest.php
+++ b/tests/framework/filters/auth/AuthTest.php
@@ -155,7 +155,8 @@ class AuthTest extends \yiiunit\TestCase
         $method = $reflection->getMethod('isActive');
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $method->setAccessible(true);
         }
 

--- a/tests/framework/filters/auth/AuthTest.php
+++ b/tests/framework/filters/auth/AuthTest.php
@@ -153,7 +153,11 @@ class AuthTest extends \yiiunit\TestCase
         $filter = new $authClass();
         $reflection = new \ReflectionClass($filter);
         $method = $reflection->getMethod('isActive');
-        $method->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $method->setAccessible(true);
+        }
 
         $controller = new \yii\web\Controller('test', Yii::$app);
 

--- a/tests/framework/grid/DataColumnTest.php
+++ b/tests/framework/grid/DataColumnTest.php
@@ -39,9 +39,7 @@ class DataColumnTest extends \yiiunit\TestCase
         ]);
         $labels = [];
         foreach ($grid->columns as $column) {
-            $method = new \ReflectionMethod($column, 'getHeaderCellLabel');
-            $method->setAccessible(true);
-            $labels[] = $method->invoke($column);
+            $labels[] = $this->invokeMethod($column, 'getHeaderCellLabel');
         }
         $this->assertEquals(['Customer', 'Invoice Total'], $labels);
     }
@@ -62,9 +60,7 @@ class DataColumnTest extends \yiiunit\TestCase
         ]);
         $labels = [];
         foreach ($grid->columns as $column) {
-            $method = new \ReflectionMethod($column, 'getHeaderCellLabel');
-            $method->setAccessible(true);
-            $labels[] = $method->invoke($column);
+            $labels[] = $this->invokeMethod($column, 'getHeaderCellLabel');
         }
         $this->assertEquals(['Customer', 'Invoice Total'], $labels);
     }
@@ -91,10 +87,8 @@ class DataColumnTest extends \yiiunit\TestCase
         ]);
         //print_r($grid->columns);exit();
         $dataColumn = $grid->columns[0];
-        $method = new \ReflectionMethod($dataColumn, 'renderFilterCellContent');
-        $method->setAccessible(true);
-        $result = $method->invoke($dataColumn);
-        $this->assertEquals($result, $filterInput);
+
+        $this->assertEquals($this->invokeMethod($dataColumn, 'renderFilterCellContent'), $filterInput);
     }
 
     /**
@@ -128,10 +122,8 @@ class DataColumnTest extends \yiiunit\TestCase
         ]);
 
         $dataColumn = $grid->columns[0];
-        $method = new \ReflectionMethod($dataColumn, 'renderFilterCellContent');
-        $method->setAccessible(true);
-        $result = $method->invoke($dataColumn);
-        $this->assertEquals($result, $filterInput);
+
+        $this->assertEquals($this->invokeMethod($dataColumn, 'renderFilterCellContent'), $filterInput);
     }
 
 
@@ -172,9 +164,6 @@ class DataColumnTest extends \yiiunit\TestCase
         ]);
 
         $dataColumn = $grid->columns[0];
-        $method = new \ReflectionMethod($dataColumn, 'renderFilterCellContent');
-        $method->setAccessible(true);
-        $result = $method->invoke($dataColumn);
 
         $this->assertEqualsWithoutLE(<<<'HTML'
 <select class="form-control" name="Order[customer_id]">
@@ -183,7 +172,8 @@ class DataColumnTest extends \yiiunit\TestCase
 <option value="1">2</option>
 </select>
 HTML
-            , $result);
+            , $this->invokeMethod($dataColumn, 'renderFilterCellContent'),
+        );
     }
 
     /**
@@ -222,9 +212,6 @@ HTML
         ]);
 
         $dataColumn = $grid->columns[0];
-        $method = new \ReflectionMethod($dataColumn, 'renderFilterCellContent');
-        $method->setAccessible(true);
-        $result = $method->invoke($dataColumn);
 
         $this->assertEqualsWithoutLE(<<<'HTML'
 <select class="form-control" name="Order[customer_id]">
@@ -233,7 +220,8 @@ HTML
 <option value="0">No</option>
 </select>
 HTML
-            , $result);
+            , $this->invokeMethod($dataColumn, 'renderFilterCellContent'),
+        );
     }
 
     /**
@@ -258,10 +246,10 @@ HTML
         ]);
 
         $dataColumn = $grid->columns[0];
-        $method = new \ReflectionMethod($dataColumn, 'renderFilterCellContent');
-        $method->setAccessible(true);
-        $result = $method->invoke($dataColumn);
 
-        $this->assertEquals('<input type="text" class="form-control" name="RulesModel[user_id]">', $result);
+        $this->assertEquals(
+            '<input type="text" class="form-control" name="RulesModel[user_id]">',
+            $this->invokeMethod($dataColumn, 'renderFilterCellContent'),
+        );
     }
 }

--- a/tests/framework/widgets/BreadcrumbsTest.php
+++ b/tests/framework/widgets/BreadcrumbsTest.php
@@ -197,7 +197,8 @@ class BreadcrumbsTest extends \yiiunit\TestCase
         $value = new \ReflectionMethod($class, $method);
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        if (PHP_VERSION_ID < 80500) {
+        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
+        if (PHP_VERSION_ID < 80100) {
             $value->setAccessible(true);
         }
 

--- a/tests/framework/widgets/BreadcrumbsTest.php
+++ b/tests/framework/widgets/BreadcrumbsTest.php
@@ -195,7 +195,11 @@ class BreadcrumbsTest extends \yiiunit\TestCase
     protected function reflectMethod($class = '\yii\widgets\Breadcrumbs', $method = 'renderItem')
     {
         $value = new \ReflectionMethod($class, $method);
-        $value->setAccessible(true);
+
+        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
+        if (PHP_VERSION_ID < 80500) {
+            $value->setAccessible(true);
+        }
 
         return $value;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
