### PR TITLE
Integrate PHPStan for static analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ phpunit.phar
 /node_modules
 .env
 package-lock.json
+
+# local phpstan config
+phpstan.neon

--- a/build/controllers/views/translation/report_html.php
+++ b/build/controllers/views/translation/report_html.php
@@ -2,6 +2,14 @@
 
 use yii\helpers\Html;
 
+/**
+ * @var \yii\web\View $this
+ * @var string $title
+ * @var string $sourcePath
+ * @var string $translationPath
+ * @var array $results
+ */
+
 ?><!doctype html>
 <html>
     <head>

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,8 @@
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "dms/phpunit-arraysubset-asserts": "^0.5",
         "phpunit/phpunit": "^9.6",
-        "yiisoft/yii2-coding-standards": "^3.0"
+        "yiisoft/yii2-coding-standards": "^3.0",
+        "phpstan/phpstan": "^2.1"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "dms/phpunit-arraysubset-asserts": "^0.5",
         "phpunit/phpunit": "^9.6",
         "yiisoft/yii2-coding-standards": "^3.0",
-        "phpstan/phpstan": "^2.1"
+        "phpstan/phpstan": "^1.12"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "670e71ac2220c5d1170a566e33baa013",
+    "content-hash": "3c79156a12fd45660fd7fe4831441b79",
     "packages": [
         {
             "name": "bower-asset/inputmask",
@@ -575,27 +575,25 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v4.19.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
-                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.4"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -603,7 +601,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.x-dev"
+                    "dev-master": "4.9-dev"
                 }
             },
             "autoload": {
@@ -627,9 +625,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2024-09-29T15:01:53+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -751,20 +749,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.22",
+            "version": "1.12.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4"
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/41600c8379eb5aee63e9413fe9e97273e25d57e4",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4|^8.0"
+                "php": "^7.2|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -805,7 +803,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-04T19:17:37+00:00"
+            "time": "2025-07-17T17:15:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3faf6ba20beedc1db7758907d00f6681",
+    "content-hash": "670e71ac2220c5d1170a566e33baa013",
     "packages": [
         {
             "name": "bower-asset/inputmask",
@@ -445,30 +445,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -495,7 +495,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -511,20 +511,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.0",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -563,7 +563,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -571,20 +571,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-12T14:39:25+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.1.0",
+            "version": "v5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
-                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
                 "shasum": ""
             },
             "require": {
@@ -603,7 +603,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -627,9 +627,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
             },
-            "time": "2024-07-01T20:03:41+00:00"
+            "time": "2025-08-13T20:13:15+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -750,36 +750,94 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "9.2.31",
+            "name": "phpstan/phpstan",
+            "version": "2.1.22",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-04T19:17:37+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -788,7 +846,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -817,7 +875,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -825,7 +883,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:37:42+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1070,45 +1128,45 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "version": "9.6.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "reference": "ea49afa29aeea25ea7bf9de9fdd7cab163cc0701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea49afa29aeea25ea7bf9de9fdd7cab163cc0701",
+                "reference": "ea49afa29aeea25ea7bf9de9fdd7cab163cc0701",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.9",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -1153,7 +1211,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.24"
             },
             "funding": [
                 {
@@ -1165,11 +1223,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
+            "time": "2025-08-10T08:32:42+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1340,16 +1406,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "4.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
                 "shasum": ""
             },
             "require": {
@@ -1402,15 +1468,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2025-08-10T06:51:50+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -1677,16 +1755,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
@@ -1729,15 +1807,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -1910,16 +2000,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
@@ -1961,15 +2051,27 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2364,6 +2466,6 @@
         "ext-ctype": "*",
         "lib-pcre": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,7 +14,7 @@ Yii Framework 2 Change Log
 - Bug #20459: Fix return type in `RequestParserInterface::parse` (max-s-lab)
 - Bug #20475: Fix `Formatter` class `asScientific()` method for PHP `8.5` `sprintf` precision change (`6` to `0`) (terabytesoftw)
 - Enh #20480: Add PHPStan/Psalm annotations for `ServiceLocator::get` (max-s-lab)
-- Bug #20485: Fix error `Cannot unset string offsets` in `\yii\di\Instance:ensure(['__class' => ...], 'class')` (max-s-lab)
+- Bug #20485: Fix error `Cannot unset string offsets` in `yii\di\Instance:ensure(['__class' => ...], 'some\class\name')` (max-s-lab)
 
 2.0.53 June 27, 2025
 --------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,7 +14,7 @@ Yii Framework 2 Change Log
 - Bug #20459: Fix return type in `RequestParserInterface::parse` (max-s-lab)
 - Bug #20475: Fix `Formatter` class `asScientific()` method for PHP `8.5` `sprintf` precision change (`6` to `0`) (terabytesoftw)
 - Enh #20480: Add PHPStan/Psalm annotations for `ServiceLocator::get` (max-s-lab)
-- Bug #20485: Fix error `Cannot unset string offsets` in `Instance::ensure` (max-s-lab)
+- Bug #20485: Fix error `Cannot unset string offsets` in `\yii\di\Instance:ensure(['__class' => ...], 'class')` (max-s-lab)
 
 2.0.53 June 27, 2025
 --------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Bug #20459: Fix return type in `RequestParserInterface::parse` (max-s-lab)
 - Bug #20475: Fix `Formatter` class `asScientific()` method for PHP `8.5` `sprintf` precision change (`6` to `0`) (terabytesoftw)
 - Enh #20480: Add PHPStan/Psalm annotations for `ServiceLocator::get` (max-s-lab)
+- Bug #20485: Fix error `Cannot unset string offsets` in `Instance::ensure` (max-s-lab)
 
 2.0.53 June 27, 2025
 --------------------

--- a/framework/caching/XCache.php
+++ b/framework/caching/XCache.php
@@ -101,9 +101,7 @@ class XCache extends Cache
     protected function flushValues()
     {
         for ($i = 0, $max = xcache_count(XC_TYPE_VAR); $i < $max; $i++) {
-            if (xcache_clear_cache(XC_TYPE_VAR, $i) === false) {
-                return false;
-            }
+            xcache_clear_cache(XC_TYPE_VAR, $i);
         }
 
         return true;

--- a/framework/console/controllers/HelpController.php
+++ b/framework/console/controllers/HelpController.php
@@ -432,9 +432,7 @@ class HelpController extends Controller
         ];
         ksort($options);
 
-        if (!empty($options)) {
-            $this->stdout(' [...options...]', Console::FG_RED);
-        }
+        $this->stdout(' [...options...]', Console::FG_RED);
         $this->stdout("\n\n");
 
         if (!empty($args)) {
@@ -449,21 +447,19 @@ class HelpController extends Controller
             }
         }
 
-        if (!empty($options)) {
-            $this->stdout("\nOPTIONS\n\n", Console::BOLD);
-            foreach ($options as $name => $option) {
-                $this->stdout($this->formatOptionHelp(
-                    $this->ansiFormat(
-                        '--' . $name . $this->formatOptionAliases($controller, $name),
-                        Console::FG_RED,
-                        empty($option['required']) ? Console::FG_RED : Console::BOLD
-                    ),
-                    !empty($option['required']),
-                    $option['type'],
-                    $option['default'],
-                    $option['comment']
-                ) . "\n\n");
-            }
+        $this->stdout("\nOPTIONS\n\n", Console::BOLD);
+        foreach ($options as $name => $option) {
+            $this->stdout($this->formatOptionHelp(
+                $this->ansiFormat(
+                    '--' . $name . $this->formatOptionAliases($controller, $name),
+                    Console::FG_RED,
+                    empty($option['required']) ? Console::FG_RED : Console::BOLD
+                ),
+                !empty($option['required']),
+                $option['type'],
+                $option['default'],
+                $option['comment']
+            ) . "\n\n");
         }
     }
 

--- a/framework/di/Instance.php
+++ b/framework/di/Instance.php
@@ -129,7 +129,7 @@ class Instance
             }
             if (isset($reference['__class'])) {
                 $class = $reference['__class'];
-                unset($reference['__class'], $type['class']);
+                unset($reference['__class']);
             } elseif (isset($reference['class'])) {
                 $class = $reference['class'];
                 unset($reference['class']);

--- a/framework/di/Instance.php
+++ b/framework/di/Instance.php
@@ -129,7 +129,7 @@ class Instance
             }
             if (isset($reference['__class'])) {
                 $class = $reference['__class'];
-                unset($reference['__class']);
+                unset($reference['__class'], $reference['class']);
             } elseif (isset($reference['class'])) {
                 $class = $reference['class'];
                 unset($reference['class']);

--- a/framework/views/_addColumns.php
+++ b/framework/views/_addColumns.php
@@ -1,3 +1,13 @@
+<?php
+
+/**
+ * @var \yii\web\View $this
+ * @var array $fields
+ * @var string $table
+ * @var array $foreignKeys
+ */
+
+?>
 <?php foreach ($fields as $field): ?>
         $this->addColumn('<?=
             $table

--- a/framework/views/_addForeignKeys.php
+++ b/framework/views/_addForeignKeys.php
@@ -1,3 +1,11 @@
+<?php
+
+/**
+ * @var array $foreignKeys
+ * @var string $table
+ */
+
+?>
 <?php foreach ($foreignKeys as $column => $fkData): ?>
 
         // creates index for column `<?= $column ?>`

--- a/framework/views/_createTable.php
+++ b/framework/views/_createTable.php
@@ -3,6 +3,7 @@
 /**
  * Creates a call for the method `yii\db\Migration::createTable()`.
  *
+ * @var \yii\web\View $this
  * @var string $table the name table
  * @var array $fields the fields
  * @var array $foreignKeys the foreign keys

--- a/framework/views/_dropColumns.php
+++ b/framework/views/_dropColumns.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * @var \yii\web\View $this
+ * @var string $table
+ * @var array $foreignKeys
+ * @var array $fields
+ */
+
 echo  $this->render('_dropForeignKeys', [
     'table' => $table,
     'foreignKeys' => $foreignKeys,

--- a/framework/views/_dropForeignKeys.php
+++ b/framework/views/_dropForeignKeys.php
@@ -1,3 +1,11 @@
+<?php
+
+/**
+ * @var array $foreignKeys
+ * @var string $table
+ */
+
+?>
 <?php foreach ($foreignKeys as $column => $fkData): ?>
         // drops foreign key for table `<?= $fkData['relatedTable'] ?>`
         $this->dropForeignKey(

--- a/framework/views/_dropTable.php
+++ b/framework/views/_dropTable.php
@@ -3,6 +3,7 @@
 /**
  * Creates a call for the method `yii\db\Migration::dropTable()`.
  *
+ * @var \yii\web\View $this
  * @var string $table the name table
  * @var array $foreignKeys the foreign keys
  */

--- a/framework/views/addColumnMigration.php
+++ b/framework/views/addColumnMigration.php
@@ -5,10 +5,12 @@
  *
  * The following variables are available in this view:
  *
+ * @var \yii\web\View $this
  * @var string $className the new migration class name without namespace
  * @var string $namespace the new migration class namespace
  * @var string $table the name table
  * @var array $fields the fields
+ * @var array $foreignKeys
  */
 
 echo "<?php\n";

--- a/framework/views/createTableMigration.php
+++ b/framework/views/createTableMigration.php
@@ -5,6 +5,7 @@
  *
  * The following variables are available in this view:
  *
+ * @var \yii\web\View $this
  * @var string $className the new migration class name without namespace
  * @var string $namespace the new migration class namespace
  * @var string $table the name table

--- a/framework/views/dropColumnMigration.php
+++ b/framework/views/dropColumnMigration.php
@@ -5,10 +5,12 @@
  *
  * The following variables are available in this view:
  *
+ * @var \yii\web\View $this
  * @var string $className the new migration class name without namespace
  * @var string $namespace the new migration class namespace
  * @var string $table the name table
  * @var array $fields the fields
+ * @var array $foreignKeys
  */
 
 echo "<?php\n";

--- a/framework/views/dropTableMigration.php
+++ b/framework/views/dropTableMigration.php
@@ -5,10 +5,12 @@
  *
  * The following variables are available in this view:
  *
+ * @var \yii\web\View $this
  * @var string $className the new migration class name without namespace
  * @var string $namespace the new migration class namespace
  * @var string $table the name table
  * @var array $fields the fields
+ * @var array $foreignKeys
  */
 
 echo "<?php\n";

--- a/framework/views/errorHandler/error.php
+++ b/framework/views/errorHandler/error.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * @var \yii\web\View $this
  * @var \Throwable $exception
  * @var \yii\web\ErrorHandler $handler
  */

--- a/framework/web/UploadedFile.php
+++ b/framework/web/UploadedFile.php
@@ -253,19 +253,17 @@ class UploadedFile extends BaseObject
     {
         if (self::$_files === null) {
             self::$_files = [];
-            if (isset($_FILES) && is_array($_FILES)) {
-                foreach ($_FILES as $key => $info) {
-                    self::loadFilesRecursive(
-                        $key,
-                        $info['name'],
-                        $info['tmp_name'],
-                        $info['type'],
-                        $info['size'],
-                        $info['error'],
-                        isset($info['full_path']) ? $info['full_path'] : [],
-                        isset($info['tmp_resource']) ? $info['tmp_resource'] : []
-                    );
-                }
+            foreach ($_FILES as $key => $info) {
+                self::loadFilesRecursive(
+                    $key,
+                    $info['name'],
+                    $info['tmp_name'],
+                    $info['type'],
+                    $info['size'],
+                    $info['error'],
+                    isset($info['full_path']) ? $info['full_path'] : [],
+                    isset($info['tmp_resource']) ? $info['tmp_resource'] : []
+                );
             }
         }
 

--- a/framework/web/UploadedFile.php
+++ b/framework/web/UploadedFile.php
@@ -253,17 +253,19 @@ class UploadedFile extends BaseObject
     {
         if (self::$_files === null) {
             self::$_files = [];
-            foreach ($_FILES as $key => $info) {
-                self::loadFilesRecursive(
-                    $key,
-                    $info['name'],
-                    $info['tmp_name'],
-                    $info['type'],
-                    $info['size'],
-                    $info['error'],
-                    isset($info['full_path']) ? $info['full_path'] : [],
-                    isset($info['tmp_resource']) ? $info['tmp_resource'] : []
-                );
+            if (is_array($_FILES)) {
+                foreach ($_FILES as $key => $info) {
+                    self::loadFilesRecursive(
+                        $key,
+                        $info['name'],
+                        $info['tmp_name'],
+                        $info['type'],
+                        $info['size'],
+                        $info['error'],
+                        isset($info['full_path']) ? $info['full_path'] : [],
+                        isset($info['tmp_resource']) ? $info['tmp_resource'] : []
+                    );
+                }
             }
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,41 @@
+parameters:
+    ignoreErrors:
+        - message: '#Variable \$error in isset\(\) always exists and is always null.#'
+          identifier: isset.variable
+          count: 1
+          path: framework/helpers/BaseConsole.php
+
+        - message: '#Variable \$rawValues in isset\(\) always exists and is not nullable.#'
+          identifier: isset.variable
+          count: 1
+          path: framework/db/conditions/InConditionBuilder.php
+
+        - message: '#Variable \$command might not be defined.#'
+          identifier: variable.undefined
+          count: 1
+          path: framework/db/Query.php
+
+        - message: '#Variable \$viaClass might not be defined.#'
+          identifier: variable.undefined
+          count: 5
+          path: framework/db/BaseActiveRecord.php
+
+        - message: '#Variable \$viaTable might not be defined.#'
+          identifier: variable.undefined
+          count: 5
+          path: framework/db/BaseActiveRecord.php
+
+        - message: '#^Method yii\\console\\controllers\\.*Controller::action.*\(\) should return int but return statement is missing.$#'
+          identifier: return.missing
+          count: 5
+          path: framework/console/controllers/*
+
+        - message: '#Method yii\\build\\controllers\\DevController::linkFrameworkAndExtensions\(\) should return int but return statement is missing.#'
+          identifier: return.missing
+          count: 1
+          path: build/controllers/DevController.php
+
+        - message: '#Result of function xcache_clear_cache \(void\) is used.#'
+          identifier: function.void
+          count: 1
+          path: framework/caching/XCache.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -34,8 +34,3 @@ parameters:
           identifier: return.missing
           count: 1
           path: build/controllers/DevController.php
-
-        - message: '#Result of function xcache_clear_cache \(void\) is used.#'
-          identifier: function.void
-          count: 1
-          path: framework/caching/XCache.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27,7 +27,7 @@ parameters:
 
         - message: '#^Method yii\\console\\controllers\\.*Controller::action.*\(\) should return int but return statement is missing.$#'
           identifier: return.missing
-          count: 5
+          count: 4
           path: framework/console/controllers/*
 
         - message: '#Method yii\\build\\controllers\\DevController::linkFrameworkAndExtensions\(\) should return int but return statement is missing.#'

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,24 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 1
+
+    excludePaths:
+        analyse:
+            - vendor
+        analyseAndScan:
+            - tests
+
+    bootstrapFiles:
+        - framework/BaseYii.php
+
+    dynamicConstantNames:
+        - YII_DEBUG
+        - YII_ENV
+        - YII_ENV_DEV
+        - YII_ENV_PROD
+        - YII_ENV_TEST
+
+    ignoreErrors:
+        - '#Unsafe usage of new static\(\).#'

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -4,11 +4,9 @@ includes:
 parameters:
     level: 1
 
-    excludePaths:
-        analyse:
-            - vendor
-        analyseAndScan:
-            - tests
+    paths:
+        - build
+        - framework
 
     bootstrapFiles:
         - framework/BaseYii.php

--- a/tests/framework/di/InstanceTest.php
+++ b/tests/framework/di/InstanceTest.php
@@ -50,6 +50,7 @@ class InstanceTest extends TestCase
         $this->assertInstanceOf(Connection::className(), Instance::ensure('db', 'yii\db\Connection', $container));
         $this->assertInstanceOf(Connection::className(), Instance::ensure(new Connection(), 'yii\db\Connection', $container));
         $this->assertInstanceOf('\\yii\\db\\Connection', Instance::ensure(['class' => 'yii\db\Connection', 'dsn' => 'test'], 'yii\db\Connection', $container));
+        $this->assertInstanceOf('\\yii\\db\\Connection', Instance::ensure(['__class' => 'yii\db\Connection', 'dsn' => 'test'], 'yii\db\Connection', $container));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19974

Recently, I've been adding PHPStan/Psalm annotations quite often, and I've encountered some issues:

1. It is very difficult to track down typos. Once I forgot to add one character and the annotations didn't work (https://github.com/yiisoft/yii2/commit/9fa5d4f46a5fff46bb33359472cc4e6ab1333c76)
2. Sometimes, due to carelessness, incorrect annotations are added. I usually manage to fix them before the release, but there is a risk of missing such issues (https://github.com/yiisoft/yii2/pull/20481/commits/bd6ddfdc0941a9b98737f82cdc1f56dc0dc312a4)

I would like to integrate PHPStan to catch such errors locally. It would be great if automatic checks were available in the future.
For now, PHPStan uses the first level of checks. I think it's worth increasing it gradually with separate PRs

#### Confirmation of the absence of errors

My config (phpstan.neon):

```neon
includes:
    - phpstan.dist.neon

parameters:
    ignoreErrors:
        - '#Class BackedEnum not found.#'
        - '#Class UnitEnum not found.#'
        - '#^Access to undefined constant PDO::.*.$#'
        - '#^Constant XC_.* not found.$#'
```

<img width="1103" height="163" alt="image" src="https://github.com/user-attachments/assets/8bf368fa-25f3-48fc-8243-d586d2d7c030" />
