### PR TITLE
fix: allow controller action params with mixed type

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 Change Log
 - Bug #20459: Fix return type in `RequestParserInterface::parse` (max-s-lab)
 - Bug #20475: Fix `Formatter` class `asScientific()` method for PHP `8.5` `sprintf` precision change (`6` to `0`) (terabytesoftw)
 - Enh #20480: Add PHPStan/Psalm annotations for `ServiceLocator::get` (max-s-lab)
+- Bug #20447: Fix behavior for `yii\web\Controller::bindActionParams` around `mixed` type (chriscpty)
 
 2.0.53 June 27, 2025
 --------------------

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -208,6 +208,10 @@ class Controller extends \yii\base\Controller
         if ($isArray) {
             return [(array)$param, true];
         }
+        $isMixed = $type->getName() === 'mixed';
+        if ($isMixed) {
+            return [$param, true];
+        }
 
         if (is_array($param)) {
             return [$param, false];

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -254,6 +254,17 @@ class ControllerTest extends TestCase
         list($foo) = $this->controller->bindActionParams($stringy, ['foo' => '']);
         $this->assertSame('', $foo);
 
+        // make sure mixed type works
+        $params = ['foo' => 100];
+        $mixedParameter = new InlineAction('mixed-parameter', $this->controller, 'actionMixedParameter');
+        list($foo) = $this->controller->bindActionParams($mixedParameter, $params);
+        $this->assertSame(100, $foo);
+        $params = ['foo' => 'foobar'];
+        $mixedParameter = new InlineAction('mixed-parameter', $this->controller, 'actionMixedParameter');
+        list($foo) = $this->controller->bindActionParams($mixedParameter, $params);
+        $this->assertSame('foobar', $foo);
+
+
         $params = ['foo' => 'oops', 'bar' => null];
         $this->expectException('yii\web\BadRequestHttpException');
         $this->expectExceptionMessage('Invalid data received for parameter "foo".');

--- a/tests/framework/web/FakePhp7Controller.php
+++ b/tests/framework/web/FakePhp7Controller.php
@@ -24,4 +24,8 @@ class FakePhp7Controller extends Controller
     public function actionStringy(?string $foo = null)
     {
     }
+
+    public function actionMixedParameter(mixed $foo)
+    {
+    }
 }


### PR DESCRIPTION
Add missing logic to deserialize action parameters with type "mixed" and a related test.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20447
