### PR TITLE
Fix `QueryBuilder` to exclude `char` and `nchar` from dbType `MAX` condition; add test for strict mode with `char/nchar` columns.

### DIFF
--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -496,9 +496,11 @@ class QueryBuilder extends \yii\db\QueryBuilder
                 }
 
                 $dbType = $column->dbType;
-                if (in_array($dbType, ['char', 'varchar', 'nchar', 'nvarchar', 'binary', 'varbinary'])) {
+
+                if (in_array($dbType, ['varchar', 'nvarchar', 'binary', 'varbinary'])) {
                     $dbType .= '(MAX)';
                 }
+
                 if ($column->dbType === Schema::TYPE_TIMESTAMP) {
                     $dbType = $column->allowNull ? 'varbinary(8)' : 'binary(8)';
                 }

--- a/tests/framework/web/session/AbstractDbSessionTest.php
+++ b/tests/framework/web/session/AbstractDbSessionTest.php
@@ -9,7 +9,6 @@ namespace yiiunit\framework\web\session;
 
 use Yii;
 use yii\db\Connection;
-use yii\db\Exception;
 use yii\db\Migration;
 use yii\db\Query;
 use yii\web\DbSession;

--- a/tests/framework/web/session/AbstractDbSessionTest.php
+++ b/tests/framework/web/session/AbstractDbSessionTest.php
@@ -9,6 +9,7 @@ namespace yiiunit\framework\web\session;
 
 use Yii;
 use yii\db\Connection;
+use yii\db\Exception;
 use yii\db\Migration;
 use yii\db\Query;
 use yii\web\DbSession;
@@ -268,6 +269,19 @@ abstract class AbstractDbSessionTest extends TestCase
         Yii::$app->set('db', Yii::$app->sessionDb);
         Yii::$app->set('sessionDb', null);
         ini_set('session.gc_maxlifetime', $oldTimeout);
+    }
+
+    public function testStrictModeWithCharAndNcharColumns()
+    {
+        $session = new DbSession([
+            'useStrictMode' => true,
+        ]);
+
+        $this->expectNotToPerformAssertions();
+
+        $session->open();
+        $session->regenerateID(true);
+        $session->close();
     }
 
     public function testInitUseStrictMode()

--- a/tests/framework/web/session/AbstractDbSessionTest.php
+++ b/tests/framework/web/session/AbstractDbSessionTest.php
@@ -271,19 +271,6 @@ abstract class AbstractDbSessionTest extends TestCase
         ini_set('session.gc_maxlifetime', $oldTimeout);
     }
 
-    public function testStrictModeWithCharAndNcharColumns()
-    {
-        $session = new DbSession([
-            'useStrictMode' => true,
-        ]);
-
-        $this->expectNotToPerformAssertions();
-
-        $session->open();
-        $session->regenerateID(true);
-        $session->close();
-    }
-
     public function testInitUseStrictMode()
     {
         $this->initStrictModeTest(DbSession::className());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
