### PR TITLE
Fix deprecation of `finfo_close()` in PHP `8.5` by conditionally closing the resource.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20482: Fix deprecation of `ReflectionMethod::setAccessible()` in PHP `8.5` (terabytesoftw)
 - Enh #20480: Add PHPStan/Psalm annotations for `ServiceLocator::get` (max-s-lab)
 - Bug #20447: Fix behavior for `yii\web\Controller::bindActionParams` around `mixed` type (chriscpty)
+- Bug #20492: Fix deprecation of `finfo_close()` in PHP `8.5` by conditionally closing the resource (terabytesoftw)
 
 2.0.53 June 27, 2025
 --------------------

--- a/framework/helpers/BaseFileHelper.php
+++ b/framework/helpers/BaseFileHelper.php
@@ -171,7 +171,11 @@ class BaseFileHelper
 
         if ($info) {
             $result = finfo_file($info, $file);
-            finfo_close($info);
+            // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_finfo_close
+            // @link https://github.com/php/php-src/commit/ccb716dcadf60d989db48e4d2963e14d7dc63df3
+            if (PHP_VERSION_ID < 80500) {
+                finfo_close($info);
+            }
 
             if ($result !== false) {
                 return $result;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
