### PR TITLE
Fix `PHPdoc`, add `PHPStan/Psalm` annotations for `authMethods` property in `CompositeAuth` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -17,6 +17,7 @@ Yii Framework 2 Change Log
 - Enh #20480: Add PHPStan/Psalm annotations for `ServiceLocator::get` (max-s-lab)
 - Bug #20447: Fix behavior for `yii\web\Controller::bindActionParams` around `mixed` type (chriscpty)
 - Bug #20492: Fix deprecation of `finfo_close()` in PHP `8.5` by conditionally closing the resource (terabytesoftw)
+- Bug #20494: Fix `PHPdoc`, add `PHPStan/Psalm` annotations for `authMethods` property in `CompositeAuth` class (terabytesoftw)
 
 2.0.53 June 27, 2025
 --------------------

--- a/framework/filters/auth/CompositeAuth.php
+++ b/framework/filters/auth/CompositeAuth.php
@@ -41,12 +41,15 @@ use yii\base\InvalidConfigException;
 class CompositeAuth extends AuthMethod
 {
     /**
-     * @var list<(class-string<AuthInterface>|array{class: class-string<AuthInterface>})> the supported authentication methods. This property should take a list of supported
+     * @var array the supported authentication methods. This property should take a list of supported
      * authentication methods, each represented by an authentication class or configuration.
      *
      * If this property is empty, no authentication will be performed.
      *
      * Note that an auth method class must implement the [[\yii\filters\auth\AuthInterface]] interface.
+     *
+     * @phpstan-var list<(class-string<AuthInterface>|array{class: class-string<AuthInterface>})>
+     * @psalm-var list<(class-string<AuthInterface>|array{class: class-string<AuthInterface>})>
      */
     public $authMethods = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
