### PR TITLE
Remove deprecated `Reflection::setAccessible` calls.

### DIFF
--- a/framework/base/ErrorException.php
+++ b/framework/base/ErrorException.php
@@ -68,12 +68,6 @@ class ErrorException extends \ErrorException
 
             $ref = new \ReflectionProperty('Exception', 'trace');
 
-            // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-            // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-            if (PHP_VERSION_ID < 80100) {
-                $ref->setAccessible(true);
-            }
-
             $ref->setValue($this, $trace);
         }
     }

--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -223,13 +223,8 @@ abstract class ErrorHandler extends Component
             $exception = new ErrorException($message, $code, $code, $file, $line);
             $ref = new \ReflectionProperty('\Exception', 'trace');
 
-            // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-            // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-            if (PHP_VERSION_ID < 80100) {
-                $ref->setAccessible(true);
-            }
-
             $ref->setValue($exception, $backtrace);
+
             $this->_hhvmException = $exception;
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -191,21 +191,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $reflection = new \ReflectionObject($object);
         $method = $reflection->getMethod($method);
 
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $method->setAccessible(true);
-        }
-
-        $result = $method->invokeArgs($object, $args);
-
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if ($revoke && PHP_VERSION_ID < 80100) {
-            $method->setAccessible(false);
-        }
-
-        return $result;
+        return $method->invokeArgs($object, $args);
     }
 
     /**
@@ -223,20 +209,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             $class = $class->getParentClass();
         }
         $property = $class->getProperty($propertyName);
-
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $property->setAccessible(true);
-        }
-
         $property->setValue($object, $value);
-
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if ($revoke && PHP_VERSION_ID < 80100) {
-            $property->setAccessible(false);
-        }
     }
 
     /**
@@ -254,21 +227,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         }
         $property = $class->getProperty($propertyName);
 
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $property->setAccessible(true);
-        }
-
-        $result = $property->getValue($object);
-
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if ($revoke && PHP_VERSION_ID < 80100) {
-            $property->setAccessible(false);
-        }
-
-        return $result;
+        return $property->getValue($object);
     }
 
 

--- a/tests/framework/base/ActionFilterTest.php
+++ b/tests/framework/base/ActionFilterTest.php
@@ -113,12 +113,6 @@ class ActionFilterTest extends TestCase
         $reflection = new \ReflectionClass($filter);
         $method = $reflection->getMethod('isActive');
 
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $method->setAccessible(true);
-        }
-
         $controller = new \yii\web\Controller('test', Yii::$app);
 
         // active by default
@@ -151,12 +145,6 @@ class ActionFilterTest extends TestCase
         $filter = new ActionFilter();
         $reflection = new \ReflectionClass($filter);
         $method = $reflection->getMethod('isActive');
-
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $method->setAccessible(true);
-        }
 
         $controller = new \yii\web\Controller('test', Yii::$app);
 

--- a/tests/framework/caching/FileCacheTest.php
+++ b/tests/framework/caching/FileCacheTest.php
@@ -71,12 +71,6 @@ class FileCacheTest extends CacheTestCase
 
         $refMethodGetCacheFile = $refClass->getMethod('getCacheFile');
 
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $refMethodGetCacheFile->setAccessible(true);
-        }
-
         $refMethodGet = $refClass->getMethod('get');
         $refMethodSet = $refClass->getMethod('set');
 
@@ -97,12 +91,6 @@ class FileCacheTest extends CacheTestCase
         $normalizeKey = $cache->buildKey(__FUNCTION__);
         $refClass = new \ReflectionClass($cache);
         $refMethodGetCacheFile = $refClass->getMethod('getCacheFile');
-
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $refMethodGetCacheFile->setAccessible(true);
-        }
 
         $cacheFile = $refMethodGetCacheFile->invoke($cache, $normalizeKey);
 

--- a/tests/framework/data/BaseDataProviderTest.php
+++ b/tests/framework/data/BaseDataProviderTest.php
@@ -20,12 +20,6 @@ class BaseDataProviderTest extends TestCase
         $rc = new \ReflectionClass(BaseDataProvider::class);
         $rp = $rc->getProperty('counter');
 
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $rp->setAccessible(true);
-        }
-
         $rp->setValue(new ConcreteDataProvider(), null);
 
         $this->assertNull((new ConcreteDataProvider())->id);

--- a/tests/framework/filters/HttpCacheTest.php
+++ b/tests/framework/filters/HttpCacheTest.php
@@ -52,12 +52,6 @@ class HttpCacheTest extends \yiiunit\TestCase
         $request = Yii::$app->getRequest();
         $method = new \ReflectionMethod($httpCache, 'validateCache');
 
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $method->setAccessible(true);
-        }
-
         $request->headers->remove('If-Modified-Since');
         $request->headers->remove('If-None-Match');
         $this->assertFalse($method->invoke($httpCache, null, null));

--- a/tests/framework/filters/auth/AuthMethodTest.php
+++ b/tests/framework/filters/auth/AuthMethodTest.php
@@ -73,12 +73,6 @@ class AuthMethodTest extends TestCase
         $reflection = new \ReflectionClass(AuthMethod::class);
         $method = $reflection->getMethod('isOptional');
 
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $method->setAccessible(true);
-        }
-
         $filter = $this->createFilter(fn() => new \stdClass());
 
         $filter->optional = ['some'];

--- a/tests/framework/filters/auth/AuthTest.php
+++ b/tests/framework/filters/auth/AuthTest.php
@@ -157,13 +157,7 @@ class AuthTest extends \yiiunit\TestCase
         $filter = new $authClass();
         $reflection = new \ReflectionClass($filter);
         $method = $reflection->getMethod('isActive');
-
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $method->setAccessible(true);
-        }
-
+        
         $controller = new \yii\web\Controller('test', Yii::$app);
 
         // active by default

--- a/tests/framework/widgets/BreadcrumbsTest.php
+++ b/tests/framework/widgets/BreadcrumbsTest.php
@@ -194,14 +194,6 @@ class BreadcrumbsTest extends \yiiunit\TestCase
      */
     protected function reflectMethod($class = '\yii\widgets\Breadcrumbs', $method = 'renderItem')
     {
-        $value = new \ReflectionMethod($class, $method);
-
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $value->setAccessible(true);
-        }
-
-        return $value;
+        return new \ReflectionMethod($class, $method);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
