### PR TITLE
Fix PHPDoc annotations generation

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -23,6 +23,7 @@ Yii Framework 2 Change Log
 - Bug #20494: Fix `PHPdoc`, add `PHPStan/Psalm` annotations for `authMethods` property in `CompositeAuth` class (terabytesoftw)
 - Bug #20485: Fix error `Cannot unset string offsets` in `yii\di\Instance:ensure(['__class' => ...], 'some\class\name')` (max-s-lab)
 - Enh #20505: `ArrayDataProvider` key handling with flexible path support (fetus-hina)
+- Bug #20508: Fix PHPDoc, add PHPStan/Psalm annotations for `yii\web\CookieCollection::getIterator`. Add missing `@property` annotation in `yii\base\Model` (max-s-lab)
 
 2.0.53 June 27, 2025
 --------------------

--- a/framework/base/Action.php
+++ b/framework/base/Action.php
@@ -30,13 +30,15 @@ use Yii;
  *
  * For more details and usage information on Action, see the [guide article on actions](guide:structure-controllers).
  *
- * @template T of Controller
  * @property-read string $uniqueId The unique ID of this action among the whole application.
- * @phpstan-property T $controller
- * @psalm-property T $controller
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
+ *
+ * @template T of Controller
+ *
+ * @phpstan-property T $controller
+ * @psalm-property T $controller
  */
 class Action extends Component
 {

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -43,9 +43,10 @@ use yii\validators\Validator;
  * @property-read array $errors Errors for all attributes or the specified attribute. Empty array is returned
  * if no error. See [[getErrors()]] for detailed description. Note that when returning errors for all attributes,
  * the result is a two-dimensional array, like the following: ```php [ 'username' => [ 'Username is required.',
- * 'Username must contain only word characters.', ], 'email' => [ 'Email address is invalid.', ] ] ``` .
+ * 'Username must contain only word characters.', ], 'email' => [ 'Email address is invalid.', ] ] ```.
  * @property-read array $firstErrors The first errors. The array keys are the attribute names, and the array
  * values are the corresponding error messages. An empty array will be returned if there is no error.
+ * @property-read ArrayIterator $iterator An iterator for traversing the items in the list.
  * @property string $scenario The scenario that this model is in. Defaults to [[SCENARIO_DEFAULT]].
  * @property-read ArrayObject|\yii\validators\Validator[] $validators All the validators declared in the
  * model.

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -532,7 +532,7 @@ class Controller extends \yii\base\Controller
      *
      * You may override this method to return customized help.
      * The default implementation returns help information retrieved from the PHPDoc comment.
-     * @return string the help information for this controller
+     * @return string the help information for this controller.
      */
     public function getHelp()
     {

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -520,7 +520,7 @@ class Controller extends \yii\base\Controller
      * You may override this method to return customized summary.
      * The default implementation returns first line from the PHPDoc comment.
      *
-     * @return string the one-line short summary describing this controller
+     * @return string the one-line short summary describing this controller.
      */
     public function getHelpSummary()
     {

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -520,7 +520,7 @@ class Controller extends \yii\base\Controller
      * You may override this method to return customized summary.
      * The default implementation returns first line from the PHPDoc comment.
      *
-     * @return string
+     * @return string the one-line short summary describing this controller
      */
     public function getHelpSummary()
     {
@@ -532,7 +532,7 @@ class Controller extends \yii\base\Controller
      *
      * You may override this method to return customized help.
      * The default implementation returns help information retrieved from the PHPDoc comment.
-     * @return string
+     * @return string the help information for this controller
      */
     public function getHelp()
     {

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -23,7 +23,7 @@ use yii\helpers\StringHelper;
  * For more details and usage information on QueryBuilder, see the [guide article on query builders](guide:db-query-builder).
  *
  * @property-write string[] $conditionClasses Map of condition aliases to condition classes. For example:
- * ```php ['LIKE' => yii\db\condition\LikeCondition::class] ``` .
+ * ```php ['LIKE' => yii\db\condition\LikeCondition::class] ```.
  * @property-write string[] $expressionBuilders Array of builders that should be merged with the pre-defined
  * ones in [[expressionBuilders]] property.
  *

--- a/framework/web/CookieCollection.php
+++ b/framework/web/CookieCollection.php
@@ -52,7 +52,10 @@ class CookieCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      * Returns an iterator for traversing the cookies in the collection.
      * This method is required by the SPL interface [[\IteratorAggregate]].
      * It will be implicitly called when you use `foreach` to traverse the collection.
-     * @return ArrayIterator<string, Cookie> an iterator for traversing the cookies in the collection.
+     * @return ArrayIterator an iterator for traversing the cookies in the collection.
+     *
+     * @phpstan-return ArrayIterator<string, Cookie>
+     * @psalm-return ArrayIterator<string, Cookie>
      */
     #[\ReturnTypeWillChange]
     public function getIterator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

When I ran the script to generate PHPDoc annotations, I got the following result: https://github.com/max-s-lab/yii2/commit/91843743707ca3b3679d4b59046fd2c0d9b6eed4

