### PR TITLE
Exclude commits with CS changes from Git Blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Reformat code to be PSR-2 compatible
+b5f8a4dc22d5f8188405a2099d85fc154226c9b2
+# Added php-cs-fixer coding standards validation to Travis CI
+ba0ab403b52124c941dbeb46fbd9efdc12252a5d

--- a/.gitattributes
+++ b/.gitattributes
@@ -22,15 +22,16 @@
 *.ttf  binary
 
 # Ignore some meta files when creating an archive of this repository
-# We do not ignore any content, because this repo represents the 
+# We do not ignore any content, because this repo represents the
 # `yiisoft/yii2-dev` package, which is expected to ship all tests and docs.
-/.appveyor.yml      export-ignore
-/.github            export-ignore
-/.editorconfig      export-ignore
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/.scrutinizer.yml   export-ignore
-/.travis.yml        export-ignore
+/.appveyor.yml              export-ignore
+/.github                    export-ignore
+/.editorconfig              export-ignore
+/.git-blame-ignore-revs     export-ignore
+/.gitattributes             export-ignore
+/.gitignore                 export-ignore
+/.scrutinizer.yml           export-ignore
+/.travis.yml                export-ignore
 
 # Avoid merge conflicts in CHANGELOG
 # https://about.gitlab.com/2015/02/10/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

Sometimes it's difficult to search for something using Git Blame because many lines were changed during a global code style change. I suggest excluding 2 commits that had massive code style changes to make Git Blame more informative.

#### Before

<img width="877" height="289" alt="image" src="https://github.com/user-attachments/assets/4c9ffc31-d1f1-48c9-b91f-71003794965f" />

<img width="1262" height="449" alt="image" src="https://github.com/user-attachments/assets/942c66c9-16de-4a9b-88e0-95766c2d1fa3" />

#### After

<img width="838" height="391" alt="image" src="https://github.com/user-attachments/assets/24a578b9-80c0-4f64-88cc-8d5cec0d0ac0" />

<img width="1276" height="345" alt="image" src="https://github.com/user-attachments/assets/d71c062c-7825-47c2-91af-10352b9a4fbe" />
