### PR TITLE
Fix code examples in PHPDoc

### DIFF
--- a/docs/internals-ru/core-code-style.md
+++ b/docs/internals-ru/core-code-style.md
@@ -447,7 +447,7 @@ public function getEventHandlers($name)
  * Correct code example:
  * 
  * ```
- * $someClass->doMagic()
+ * $someClass->doMagic();
  * ```
  */
 public function doMagic()
@@ -458,7 +458,7 @@ public function doMagic()
  * Incorrect code example:
  * 
  * ```php
- * $someClass->doMagic()
+ * $someClass->doMagic();
  * ```
  */
 public function doMagic()

--- a/docs/internals-ru/core-code-style.md
+++ b/docs/internals-ru/core-code-style.md
@@ -447,7 +447,7 @@ public function getEventHandlers($name)
  * Correct code example:
  * 
  * ```
- * $someClass->doMagic();
+ * $object->doMagic();
  * ```
  */
 public function doMagic()
@@ -458,7 +458,7 @@ public function doMagic()
  * Incorrect code example:
  * 
  * ```php
- * $someClass->doMagic();
+ * $object->doMagic();
  * ```
  */
 public function doMagic()

--- a/docs/internals-ru/core-code-style.md
+++ b/docs/internals-ru/core-code-style.md
@@ -437,6 +437,35 @@ public function getEventHandlers($name)
 [Раздел руководства](guide:file-name.md#subsection)
 ```
 
+##### Примеры кода
+
+В примерах кода должен использоваться синтаксис Markdown, но не должен указываться язык.
+Указание языка в примерах кода может привести к нарушению их отображения в некоторых IDE. Пример:
+
+```php
+/**
+ * Correct code example:
+ * 
+ * ```
+ * $someClass->doMagic()
+ * ```
+ */
+public function doMagic()
+{
+}
+
+/**
+ * Incorrect code example:
+ * 
+ * ```php
+ * $someClass->doMagic()
+ * ```
+ */
+public function doMagic()
+{
+}
+```
+
 
 #### Комментарии
 

--- a/docs/internals/core-code-style.md
+++ b/docs/internals/core-code-style.md
@@ -478,7 +478,7 @@ Specifying a language in code examples may break their display in some IDEs. Her
  * Correct code example:
  * 
  * ```
- * $someClass->doMagic();
+ * $object->doMagic();
  * ```
  */
 function doMagic()
@@ -489,7 +489,7 @@ function doMagic()
  * Incorrect code example:
  * 
  * ```php
- * $someClass->doMagic();
+ * $object->doMagic();
  * ```
  */
 function doMagic()

--- a/docs/internals/core-code-style.md
+++ b/docs/internals/core-code-style.md
@@ -468,6 +468,35 @@ It is also possible to link to the Guide using the following syntax:
 [link to guide](guide:file-name.md#subsection)
 ```
 
+##### Code examples
+
+Code examples should use Markdown syntax, but they should not specify the language.
+Specifying a language in code examples may break their display in some IDEs. Here is an example:
+
+```php
+/**
+ * Correct code example:
+ * 
+ * ```
+ * $someClass->doMagic()
+ * ```
+ */
+function doMagic()
+{
+}
+
+/**
+ * Incorrect code example:
+ * 
+ * ```php
+ * $someClass->doMagic()
+ * ```
+ */
+function doMagic()
+{
+}
+```
+
 
 #### Comments
 

--- a/docs/internals/core-code-style.md
+++ b/docs/internals/core-code-style.md
@@ -478,7 +478,7 @@ Specifying a language in code examples may break their display in some IDEs. Her
  * Correct code example:
  * 
  * ```
- * $someClass->doMagic()
+ * $someClass->doMagic();
  * ```
  */
 function doMagic()
@@ -489,7 +489,7 @@ function doMagic()
  * Incorrect code example:
  * 
  * ```php
- * $someClass->doMagic()
+ * $someClass->doMagic();
  * ```
  */
 function doMagic()

--- a/framework/BaseYii.php
+++ b/framework/BaseYii.php
@@ -309,7 +309,7 @@ class BaseYii
      *
      * Below are some usage examples:
      *
-     * ```php
+     * ```
      * // create an object using a class name
      * $object = Yii::createObject('yii\db\Connection');
      *
@@ -474,7 +474,7 @@ class BaseYii
      * This has to be matched with a call to [[endProfile]] with the same category name.
      * The begin- and end- calls must also be properly nested. For example,
      *
-     * ```php
+     * ```
      * \Yii::beginProfile('block1');
      * // some code to be profiled
      *     \Yii::beginProfile('block2');
@@ -525,7 +525,7 @@ class BaseYii
      * You can add parameters to a translation message that will be substituted with the corresponding value after
      * translation. The format for this is to use curly brackets around the parameter name as you can see in the following example:
      *
-     * ```php
+     * ```
      * $username = 'Alexander';
      * echo \Yii::t('app', 'Hello, {username}!', ['username' => $username]);
      * ```

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -24,7 +24,7 @@ Yii Framework 2 Change Log
 - Bug #20485: Fix error `Cannot unset string offsets` in `yii\di\Instance:ensure(['__class' => ...], 'some\class\name')` (max-s-lab)
 - Enh #20505: `ArrayDataProvider` key handling with flexible path support (fetus-hina)
 - Bug #20508: Fix PHPDoc, add PHPStan/Psalm annotations for `yii\web\CookieCollection::getIterator`. Add missing `@property` annotation in `yii\base\Model` (max-s-lab)
-- Bug #20513: Fix PHP code examples in PHPDoc (max-s-lab)
+- Bug #20513: Fix code examples in PHPDoc (max-s-lab)
 
 
 2.0.53 June 27, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -24,6 +24,8 @@ Yii Framework 2 Change Log
 - Bug #20485: Fix error `Cannot unset string offsets` in `yii\di\Instance:ensure(['__class' => ...], 'some\class\name')` (max-s-lab)
 - Enh #20505: `ArrayDataProvider` key handling with flexible path support (fetus-hina)
 - Bug #20508: Fix PHPDoc, add PHPStan/Psalm annotations for `yii\web\CookieCollection::getIterator`. Add missing `@property` annotation in `yii\base\Model` (max-s-lab)
+- Bug #20513: Fix PHP code examples in PHPDoc (max-s-lab)
+
 
 2.0.53 June 27, 2025
 --------------------

--- a/framework/base/Action.php
+++ b/framework/base/Action.php
@@ -21,7 +21,7 @@ use Yii;
  * with user input values automatically according to their names.
  * For example, if the `run()` method is declared as follows:
  *
- * ```php
+ * ```
  * public function run($id, $type = 'book') { ... }
  * ```
  *

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -137,7 +137,7 @@ abstract class Application extends Module
      * @var array|null list of installed Yii extensions. Each array element represents a single extension
      * with the following structure:
      *
-     * ```php
+     * ```
      * [
      *     'name' => 'extension name',
      *     'version' => 'version number',

--- a/framework/base/Arrayable.php
+++ b/framework/base/Arrayable.php
@@ -33,7 +33,7 @@ interface Arrayable
      * the corresponding field definition which can be either an object property name or a PHP callable
      * returning the corresponding field value. The signature of the callable should be:
      *
-     * ```php
+     * ```
      * function ($model, $field) {
      *     // return field value
      * }
@@ -47,7 +47,7 @@ interface Arrayable
      * - `fullName`: the field name is `fullName`. Its value is obtained by concatenating `first_name`
      *   and `last_name`.
      *
-     * ```php
+     * ```
      * return [
      *     'email',
      *     'firstName' => 'first_name',

--- a/framework/base/ArrayableTrait.php
+++ b/framework/base/ArrayableTrait.php
@@ -34,7 +34,7 @@ trait ArrayableTrait
      * the corresponding field definition which can be either an object property name or a PHP callable
      * returning the corresponding field value. The signature of the callable should be:
      *
-     * ```php
+     * ```
      * function ($model, $field) {
      *     // return field value
      * }
@@ -48,7 +48,7 @@ trait ArrayableTrait
      * - `fullName`: the field name is `fullName`. Its value is obtained by concatenating `first_name`
      *   and `last_name`.
      *
-     * ```php
+     * ```
      * return [
      *     'email',
      *     'firstName' => 'first_name',

--- a/framework/base/BaseObject.php
+++ b/framework/base/BaseObject.php
@@ -15,7 +15,7 @@ use Yii;
  * A property is defined by a getter method (e.g. `getLabel`), and/or a setter method (e.g. `setLabel`). For example,
  * the following getter and setter methods define a property named `label`:
  *
- * ```php
+ * ```
  * private $_label;
  *
  * public function getLabel()
@@ -34,7 +34,7 @@ use Yii;
  * A property can be accessed like a member variable of an object. Reading or writing a property will cause the invocation
  * of the corresponding getter or setter method. For example,
  *
- * ```php
+ * ```
  * // equivalent to $label = $object->getLabel();
  * $label = $object->label;
  * // equivalent to $object->setLabel('abc');
@@ -60,7 +60,7 @@ use Yii;
  * In order to ensure the above life cycles, if a child class of BaseObject needs to override the constructor,
  * it should be done like the following:
  *
- * ```php
+ * ```
  * public function __construct($param1, $param2, ..., $config = [])
  * {
  *     ...

--- a/framework/base/Behavior.php
+++ b/framework/base/Behavior.php
@@ -60,7 +60,7 @@ class Behavior extends BaseObject
      *
      * The following is an example:
      *
-     * ```php
+     * ```
      * [
      *     Model::EVENT_BEFORE_VALIDATE => 'myBeforeValidate',
      *     Model::EVENT_AFTER_VALIDATE => 'myAfterValidate',

--- a/framework/base/BootstrapInterface.php
+++ b/framework/base/BootstrapInterface.php
@@ -17,7 +17,7 @@ namespace yii\base;
  * The first approach is mainly used by extensions and is managed by the Composer installation process.
  * You mainly need to list the bootstrapping class of your extension in the `composer.json` file like following,
  *
- * ```json
+ * ```
  * {
  *     // ...
  *     "extra": {

--- a/framework/base/BootstrapInterface.php
+++ b/framework/base/BootstrapInterface.php
@@ -31,7 +31,7 @@ namespace yii\base;
  * The second approach is used by application code which needs to register some code to be run during
  * the bootstrap process. This is done by configuring the [[Application::bootstrap]] property:
  *
- * ```php
+ * ```
  * return [
  *     // ...
  *     'bootstrap' => [

--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -28,7 +28,7 @@ use yii\helpers\StringHelper;
  *
  * To attach an event handler to an event, call [[on()]]:
  *
- * ```php
+ * ```
  * $post->on('update', function ($event) {
  *     // send email notification
  * });
@@ -44,7 +44,7 @@ use yii\helpers\StringHelper;
  *
  * The signature of an event handler should be like the following:
  *
- * ```php
+ * ```
  * function foo($event)
  * ```
  *
@@ -53,7 +53,7 @@ use yii\helpers\StringHelper;
  * You can also attach a handler to an event when configuring a component with a configuration array.
  * The syntax is like the following:
  *
- * ```php
+ * ```
  * [
  *     'on add' => function ($event) { ... }
  * ]
@@ -64,7 +64,7 @@ use yii\helpers\StringHelper;
  * Sometimes, you may want to associate extra data with an event handler when you attach it to an event
  * and then access it when the handler is invoked. You may do so by
  *
- * ```php
+ * ```
  * $post->on('update', function ($event) {
  *     // the data can be accessed via $event->data
  * }, $data);
@@ -80,7 +80,7 @@ use yii\helpers\StringHelper;
  * One can also attach a behavior to a component when configuring it with a configuration array. The syntax is like the
  * following:
  *
- * ```php
+ * ```
  * [
  *     'as tree' => [
  *         'class' => 'Tree',
@@ -446,7 +446,7 @@ class Component extends BaseObject
      * indexed by behavior names. A behavior configuration can be either a string specifying
      * the behavior class or an array of the following structure:
      *
-     * ```php
+     * ```
      * 'behaviorName' => [
      *     'class' => 'BehaviorClass',
      *     'property1' => 'value1',
@@ -515,7 +515,7 @@ class Component extends BaseObject
      *
      * Since 2.0.14 you can specify event name as a wildcard pattern:
      *
-     * ```php
+     * ```
      * $component->on('event.group.*', function ($event) {
      *     Yii::trace($event->name . ' is triggered.');
      * });

--- a/framework/base/Configurable.php
+++ b/framework/base/Configurable.php
@@ -14,7 +14,7 @@ namespace yii\base;
  * The interface does not declare any method. Classes implementing this interface must declare their constructors
  * like the following:
  *
- * ```php
+ * ```
  * public function __construct($param1, $param2, ..., $config = [])
  * ```
  *

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -116,7 +116,7 @@ class Controller extends Component implements ViewContextInterface
      * It should return an array, with array keys being action IDs, and array values the corresponding
      * action class names or action configuration arrays. For example,
      *
-     * ```php
+     * ```
      * return [
      *     'action1' => 'app\components\Action1',
      *     'action2' => [
@@ -293,7 +293,7 @@ class Controller extends Component implements ViewContextInterface
      *
      * If you override this method, your code should look like the following:
      *
-     * ```php
+     * ```
      * public function beforeAction($action)
      * {
      *     // your custom code here, if you want the code to run before action filters,
@@ -330,7 +330,7 @@ class Controller extends Component implements ViewContextInterface
      *
      * If you override this method, your code should look like the following:
      *
-     * ```php
+     * ```
      * public function afterAction($action, $result)
      * {
      *     $result = parent::afterAction($action, $result);

--- a/framework/base/DynamicModel.php
+++ b/framework/base/DynamicModel.php
@@ -16,7 +16,7 @@ use yii\validators\Validator;
  *
  * The typical usage of DynamicModel is as follows,
  *
- * ```php
+ * ```
  * public function actionSearch($name, $email)
  * {
  *     $model = DynamicModel::validateData(compact('name', 'email'), [
@@ -41,7 +41,7 @@ use yii\validators\Validator;
  *
  * Alternatively, you may use the following more "classic" syntax to perform ad-hoc data validation:
  *
- * ```php
+ * ```
  * $model = new DynamicModel(compact('name', 'email'));
  * $model->addRule(['name', 'email'], 'string', ['max' => 128])
  *     ->addRule('email', 'email')

--- a/framework/base/Event.php
+++ b/framework/base/Event.php
@@ -72,7 +72,7 @@ class Event extends BaseObject
      * For example, the following code attaches an event handler to `ActiveRecord`'s
      * `afterInsert` event:
      *
-     * ```php
+     * ```
      * Event::on(ActiveRecord::class, ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
      *     Yii::trace(get_class($event->sender) . ' is inserted.');
      * });
@@ -82,7 +82,7 @@ class Event extends BaseObject
      *
      * Since 2.0.14 you can specify either class name or event name as a wildcard pattern:
      *
-     * ```php
+     * ```
      * Event::on('app\models\db\*', '*Insert', function ($event) {
      *     Yii::trace(get_class($event->sender) . ' is inserted.');
      * });

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -40,7 +40,7 @@ use yii\validators\Validator;
  * @property-read array $errors Errors for all attributes. This is a two-dimensional
  * array of errors for all attributes, similar to the following:
  *
- * ```php
+ * ```
  * [
  *     'username' => [
  *         'Username is required.',
@@ -116,7 +116,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      *
      * Each rule is an array with the following structure:
      *
-     * ```php
+     * ```
      * [
      *     ['attribute1', 'attribute2'],
      *     'validator type',
@@ -138,7 +138,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      * A validator can be either an object of a class extending [[Validator]], or a model class method
      * (called *inline validator*) that has the following signature:
      *
-     * ```php
+     * ```
      * // $params refers to validation parameters given in the rule
      * function validatorName($attribute, $params)
      * ```
@@ -153,7 +153,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      *
      * Below are some examples:
      *
-     * ```php
+     * ```
      * [
      *     // built-in "required" validator
      *     [['username', 'password'], 'required'],
@@ -188,7 +188,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      * An active attribute is one that is subject to validation in the current scenario.
      * The returned array should be in the following format:
      *
-     * ```php
+     * ```
      * [
      *     'scenario1' => ['attribute11', 'attribute12', ...],
      *     'scenario2' => ['attribute21', 'attribute22', ...],
@@ -443,7 +443,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      * manipulate it by inserting or removing validators (useful in model behaviors).
      * For example,
      *
-     * ```php
+     * ```
      * $model->validators[] = $newValidator;
      * ```
      *
@@ -599,7 +599,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      * @return array errors for all attributes or the specified attribute. Empty array is returned if no error.
      * Note that when returning errors for all attributes, the result is a two-dimensional array, like the following:
      *
-     * ```php
+     * ```
      * [
      *     'username' => [
      *         'Username is required.',
@@ -882,7 +882,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      *
      * This method provides a convenient shortcut for:
      *
-     * ```php
+     * ```
      * if (isset($_POST['FormName'])) {
      *     $model->attributes = $_POST['FormName'];
      *     if ($model->save()) {
@@ -893,7 +893,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      *
      * which, with `load()` can be written as:
      *
-     * ```php
+     * ```
      * if ($model->load($_POST) && $model->save()) {
      *     // handle success
      * }
@@ -1000,7 +1000,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      * the corresponding field definition which can be either an object property name or a PHP callable
      * returning the corresponding field value. The signature of the callable should be:
      *
-     * ```php
+     * ```
      * function ($model, $field) {
      *     // return field value
      * }
@@ -1014,7 +1014,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
      * - `fullName`: the field name is `fullName`. Its value is obtained by concatenating `first_name`
      *   and `last_name`.
      *
-     * ```php
+     * ```
      * return [
      *     'email',
      *     'firstName' => 'first_name',

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -77,7 +77,7 @@ class Module extends ServiceLocator
      * the controller's fully qualified class name, and the rest of the name-value pairs
      * in the array are used to initialize the corresponding controller properties. For example,
      *
-     * ```php
+     * ```
      * [
      *   'account' => 'app\controllers\UserController',
      *   'article' => [
@@ -135,7 +135,7 @@ class Module extends ServiceLocator
      * Version can be specified as a PHP callback, which can accept module instance as an argument and should
      * return the actual version. For example:
      *
-     * ```php
+     * ```
      * function (Module $module) {
      *     //return string|int
      * }
@@ -349,7 +349,7 @@ class Module extends ServiceLocator
      * Version can be specified as a PHP callback, which can accept module instance as an argument and should
      * return the actual version. For example:
      *
-     * ```php
+     * ```
      * function (Module $module) {
      *     //return string
      * }
@@ -385,7 +385,7 @@ class Module extends ServiceLocator
      * (must start with `@`) and the array values are the corresponding paths or aliases.
      * For example,
      *
-     * ```php
+     * ```
      * [
      *     '@models' => '@app/models', // an existing alias
      *     '@backend' => __DIR__ . '/../backend',  // a directory
@@ -509,7 +509,7 @@ class Module extends ServiceLocator
      *
      * The following is an example for registering two sub-modules:
      *
-     * ```php
+     * ```
      * [
      *     'comment' => [
      *         'class' => 'app\modules\comment\CommentModule',
@@ -702,7 +702,7 @@ class Module extends ServiceLocator
      *
      * If you override this method, your code should look like the following:
      *
-     * ```php
+     * ```
      * public function beforeAction($action)
      * {
      *     if (!parent::beforeAction($action)) {
@@ -733,7 +733,7 @@ class Module extends ServiceLocator
      *
      * If you override this method, your code should look like the following:
      *
-     * ```php
+     * ```
      * public function afterAction($action, $result)
      * {
      *     $result = parent::afterAction($action, $result);

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -514,7 +514,7 @@ class Security extends Component
      * Later when a password needs to be validated, the hash can be fetched and passed
      * to [[validatePassword()]]. For example,
      *
-     * ```php
+     * ```
      * // generates the hash (usually done during user registration or when the password is changed)
      * $hash = Yii::$app->getSecurity()->generatePasswordHash($password);
      * // ...save $hash in database...

--- a/framework/base/Theme.php
+++ b/framework/base/Theme.php
@@ -33,7 +33,7 @@ use yii\helpers\FileHelper;
  *
  * It is possible to map a single path to multiple paths. For example,
  *
- * ```php
+ * ```
  * 'pathMap' => [
  *     '@app/views' => [
  *         '@app/themes/christmas',
@@ -48,7 +48,7 @@ use yii\helpers\FileHelper;
  * To use a theme, you should configure the [[View::theme|theme]] property of the "view" application
  * component like the following:
  *
- * ```php
+ * ```
  * 'view' => [
  *     'theme' => [
  *         'basePath' => '@app/themes/basic',

--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -59,7 +59,7 @@ class View extends Component implements DynamicContentAwareInterface
      * Each renderer may be a view renderer object or the configuration for creating the renderer object.
      * For example, the following configuration enables both Smarty and Twig view renderers:
      *
-     * ```php
+     * ```
      * [
      *     'tpl' => ['class' => 'yii\smarty\ViewRenderer'],
      *     'twig' => ['class' => 'yii\twig\ViewRenderer'],
@@ -497,7 +497,7 @@ class View extends Component implements DynamicContentAwareInterface
      * This method can be used to implement nested layout. For example, a layout can be embedded
      * in another layout file specified as '@app/views/layouts/base.php' like the following:
      *
-     * ```php
+     * ```
      * <?php $this->beginContent('@app/views/layouts/base.php'); ?>
      * //...layout content here...
      * <?php $this->endContent(); ?>
@@ -534,7 +534,7 @@ class View extends Component implements DynamicContentAwareInterface
      * call to end the cache and save the content into cache.
      * A typical usage of fragment caching is as follows,
      *
-     * ```php
+     * ```
      * if ($this->beginCache($id)) {
      *     // ...generate content here
      *     $this->endCache();

--- a/framework/base/Widget.php
+++ b/framework/base/Widget.php
@@ -284,7 +284,7 @@ class Widget extends Component implements ViewContextInterface
      *
      * When overriding this method, make sure you call the parent implementation like the following:
      *
-     * ```php
+     * ```
      * public function beforeRun()
      * {
      *     if (!parent::beforeRun()) {
@@ -315,7 +315,7 @@ class Widget extends Component implements ViewContextInterface
      *
      * If you override this method, your code should look like the following:
      *
-     * ```php
+     * ```
      * public function afterRun($result)
      * {
      *     $result = parent::afterRun($result);

--- a/framework/behaviors/AttributeBehavior.php
+++ b/framework/behaviors/AttributeBehavior.php
@@ -21,7 +21,7 @@ use yii\db\ActiveRecord;
  * [[value]] property with a PHP callable whose return value will be used to assign to the current attribute(s).
  * For example,
  *
- * ```php
+ * ```
  * use yii\behaviors\AttributeBehavior;
  *
  * public function behaviors()
@@ -56,7 +56,7 @@ class AttributeBehavior extends Behavior
      * and the array values are the corresponding attribute(s) to be updated. You can use a string to represent
      * a single attribute, or an array to represent a list of attributes. For example,
      *
-     * ```php
+     * ```
      * [
      *     ActiveRecord::EVENT_BEFORE_INSERT => ['attribute1', 'attribute2'],
      *     ActiveRecord::EVENT_BEFORE_UPDATE => 'attribute2',
@@ -71,7 +71,7 @@ class AttributeBehavior extends Behavior
      * function will be assigned to the attributes.
      * The signature of the function should be as follows,
      *
-     * ```php
+     * ```
      * function ($event)
      * {
      *     // return value will be assigned to the attribute

--- a/framework/behaviors/AttributeTypecastBehavior.php
+++ b/framework/behaviors/AttributeTypecastBehavior.php
@@ -28,7 +28,7 @@ use yii\validators\StringValidator;
  *
  * For example:
  *
- * ```php
+ * ```
  * use yii\behaviors\AttributeTypecastBehavior;
  *
  * class Item extends \yii\db\ActiveRecord
@@ -58,7 +58,7 @@ use yii\validators\StringValidator;
  * automatically based on owner validation rules.
  * Following example will automatically create same [[attributeTypes]] value as it was configured at the above one:
  *
- * ```php
+ * ```
  * use yii\behaviors\AttributeTypecastBehavior;
  *
  * class Item extends \yii\db\ActiveRecord
@@ -99,7 +99,7 @@ use yii\validators\StringValidator;
  *
  * Note: you can manually trigger attribute typecasting anytime invoking [[typecastAttributes()]] method:
  *
- * ```php
+ * ```
  * $model = new Item();
  * $model->price = '38.5';
  * $model->is_active = 1;
@@ -126,7 +126,7 @@ class AttributeTypecastBehavior extends Behavior
      * typecast result.
      * For example:
      *
-     * ```php
+     * ```
      * [
      *     'amount' => 'integer',
      *     'price' => 'float',

--- a/framework/behaviors/AttributesBehavior.php
+++ b/framework/behaviors/AttributesBehavior.php
@@ -21,7 +21,7 @@ use yii\db\ActiveRecord;
  * value of enclosed arrays with a PHP callable whose return value will be used to assign to the current attribute.
  * For example,
  *
- * ```php
+ * ```
  * use yii\behaviors\AttributesBehavior;
  *
  * public function behaviors()
@@ -73,7 +73,7 @@ class AttributesBehavior extends Behavior
      * (e.g. `new Expression('NOW()')`), scalar, string or an arbitrary value. If the former, the return value of the
      * function will be assigned to the attributes.
      *
-     * ```php
+     * ```
      * [
      *   'attribute1' => [
      *       ActiveRecord::EVENT_BEFORE_INSERT => new Expression('NOW()'),
@@ -103,7 +103,7 @@ class AttributesBehavior extends Behavior
      * The rest of the attributes are processed at the end.
      * If the [[attributes]] for this attribute do not specify this event, it is ignored
      *
-     * ```php
+     * ```
      * [
      *     ActiveRecord::EVENT_BEFORE_VALIDATE => ['attribute1', 'attribute2'],
      *     ActiveRecord::EVENT_AFTER_VALIDATE => ['attribute2', 'attribute1'],

--- a/framework/behaviors/BlameableBehavior.php
+++ b/framework/behaviors/BlameableBehavior.php
@@ -15,7 +15,7 @@ use yii\db\BaseActiveRecord;
  *
  * To use BlameableBehavior, insert the following code to your ActiveRecord class:
  *
- * ```php
+ * ```
  * use yii\behaviors\BlameableBehavior;
  *
  * public function behaviors()
@@ -36,7 +36,7 @@ use yii\db\BaseActiveRecord;
  * If your attribute names are different, you may configure the [[createdByAttribute]] and [[updatedByAttribute]]
  * properties like the following:
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [

--- a/framework/behaviors/CacheableWidgetBehavior.php
+++ b/framework/behaviors/CacheableWidgetBehavior.php
@@ -23,7 +23,7 @@ use yii\di\Instance;
  *
  * The following example will cache the posts widget for an indefinite duration until any post is modified.
  *
- * ```php
+ * ```
  * use yii\behaviors\CacheableWidgetBehavior;
  *
  * public function behaviors()
@@ -64,7 +64,7 @@ class CacheableWidgetBehavior extends Behavior
      *
      * For example,
      *
-     * ```php
+     * ```
      * [
      *     'class' => 'yii\caching\DbDependency',
      *     'sql' => 'SELECT MAX(updated_at) FROM posts',
@@ -82,7 +82,7 @@ class CacheableWidgetBehavior extends Behavior
      * The following variation setting will cause the content to be cached in different versions
      * according to the current application language:
      *
-     * ```php
+     * ```
      * [
      *     Yii::$app->language,
      * ]
@@ -94,7 +94,7 @@ class CacheableWidgetBehavior extends Behavior
      * on and off according to specific conditions.
      * The following configuration will disable caching when a special GET parameter is passed:
      *
-     * ```php
+     * ```
      * empty(Yii::$app->request->get('disable-caching'))
      * ```
      */

--- a/framework/behaviors/OptimisticLockBehavior.php
+++ b/framework/behaviors/OptimisticLockBehavior.php
@@ -27,7 +27,7 @@ use yii\helpers\ArrayHelper;
  * holding the lock version from the [[\yii\base\Model::rules()|rules()]] method of your
  * ActiveRecord class, then add the following code to it:
  *
- * ```php
+ * ```
  * use yii\behaviors\OptimisticLockBehavior;
  *
  * public function behaviors()
@@ -54,7 +54,7 @@ use yii\helpers\ArrayHelper;
  * version by one, that may be useful when you need to mark an entity as stale among connected clients
  * and avoid any change to it until they load it again:
  *
- * ```php
+ * ```
  * $model->upgrade();
  * ```
  *
@@ -151,7 +151,7 @@ class OptimisticLockBehavior extends AttributeBehavior
     /**
      * Upgrades the version value by one and stores it to database.
      *
-     * ```php
+     * ```
      * $model->upgrade();
      * ```
      * @throws InvalidCallException if owner is a new record.

--- a/framework/behaviors/SluggableBehavior.php
+++ b/framework/behaviors/SluggableBehavior.php
@@ -22,7 +22,7 @@ use yii\validators\UniqueValidator;
  *
  * To use SluggableBehavior, insert the following code to your ActiveRecord class:
  *
- * ```php
+ * ```
  * use yii\behaviors\SluggableBehavior;
  *
  * public function behaviors()
@@ -45,7 +45,7 @@ use yii\validators\UniqueValidator;
  *
  * If your attribute name is different, you may configure the [[slugAttribute]] property like the following:
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [
@@ -78,7 +78,7 @@ class SluggableBehavior extends AttributeBehavior
      * If `null` then the `$attribute` property will be used to generate a slug.
      * The signature of the function should be as follows,
      *
-     * ```php
+     * ```
      * function ($event)
      * {
      *     // return slug
@@ -114,7 +114,7 @@ class SluggableBehavior extends AttributeBehavior
      * @var callable|null slug unique value generator. It is used in case [[ensureUnique]] enabled and generated
      * slug is not unique. This should be a PHP callable with following signature:
      *
-     * ```php
+     * ```
      * function ($baseSlug, $iteration, $model)
      * {
      *     // return uniqueSlug

--- a/framework/behaviors/TimestampBehavior.php
+++ b/framework/behaviors/TimestampBehavior.php
@@ -15,7 +15,7 @@ use yii\db\BaseActiveRecord;
  *
  * To use TimestampBehavior, insert the following code to your ActiveRecord class:
  *
- * ```php
+ * ```
  * use yii\behaviors\TimestampBehavior;
  *
  * public function behaviors()
@@ -38,7 +38,7 @@ use yii\db\BaseActiveRecord;
  * If your attribute names are different or you want to use a different way of calculating the timestamp,
  * you may configure the [[createdAtAttribute]], [[updatedAtAttribute]] and [[value]] properties like the following:
  *
- * ```php
+ * ```
  * use yii\db\Expression;
  *
  * public function behaviors()
@@ -61,7 +61,7 @@ use yii\db\BaseActiveRecord;
  * TimestampBehavior also provides a method named [[touch()]] that allows you to assign the current
  * timestamp to the specified attribute(s) and save them to the database. For example,
  *
- * ```php
+ * ```
  * $model->touch('creation_time');
  * ```
  *
@@ -123,7 +123,7 @@ class TimestampBehavior extends AttributeBehavior
     /**
      * Updates a timestamp attribute to the current timestamp.
      *
-     * ```php
+     * ```
      * $model->touch('lastVisit');
      * ```
      * @param string $attribute the name of the attribute to update.

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -22,7 +22,7 @@ use yii\helpers\StringHelper;
  *
  * A typical usage pattern of cache is like the following:
  *
- * ```php
+ * ```
  * $key = 'demo';
  * $data = $cache->get($key);
  * if ($data === false) {
@@ -33,7 +33,7 @@ use yii\helpers\StringHelper;
  *
  * Because Cache implements the [[\ArrayAccess]] interface, it can be used like an array. For example,
  *
- * ```php
+ * ```
  * $cache['foo'] = 'some data';
  * echo $cache['foo'];
  * ```
@@ -576,7 +576,7 @@ abstract class Cache extends Component implements CacheInterface
      *
      * Usage example:
      *
-     * ```php
+     * ```
      * public function getTopProducts($count = 10) {
      *     $cache = $this->cache; // Could be Yii::$app->cache
      *     return $cache->getOrSet(['top-n-products', 'n' => $count], function () use ($count) {

--- a/framework/caching/CacheInterface.php
+++ b/framework/caching/CacheInterface.php
@@ -18,7 +18,7 @@ namespace yii\caching;
  *
  * A typical usage pattern of cache is like the following:
  *
- * ```php
+ * ```
  * $key = 'demo';
  * $data = $cache->get($key);
  * if ($data === false) {
@@ -29,7 +29,7 @@ namespace yii\caching;
  *
  * Because CacheInterface extends the [[\ArrayAccess]] interface, it can be used like an array. For example,
  *
- * ```php
+ * ```
  * $cache['foo'] = 'some data';
  * echo $cache['foo'];
  * ```
@@ -169,7 +169,7 @@ interface CacheInterface extends \ArrayAccess
      *
      * Usage example:
      *
-     * ```php
+     * ```
      * public function getTopProducts($count = 10) {
      *     $cache = $this->cache; // Could be Yii::$app->cache
      *     return $cache->getOrSet(['top-n-products', 'n' => $count], function ($cache) use ($count) {

--- a/framework/caching/DbCache.php
+++ b/framework/caching/DbCache.php
@@ -24,7 +24,7 @@ use yii\di\Instance;
  *
  * The following example shows how you can configure the application to use DbCache:
  *
- * ```php
+ * ```
  * 'cache' => [
  *     'class' => 'yii\caching\DbCache',
  *     // 'db' => 'mydb',
@@ -50,7 +50,7 @@ class DbCache extends Cache
      * @var string name of the DB table to store cache content.
      * The table should be pre-created as follows:
      *
-     * ```php
+     * ```
      * CREATE TABLE cache (
      *     id char(128) NOT NULL PRIMARY KEY,
      *     expire int(11),
@@ -59,7 +59,7 @@ class DbCache extends Cache
      * ```
      *
      * For MSSQL:
-     * ```php
+     * ```
      * CREATE TABLE cache (
      *     id VARCHAR(128) NOT NULL PRIMARY KEY,
      *     expire INT(11),

--- a/framework/caching/DbQueryDependency.php
+++ b/framework/caching/DbQueryDependency.php
@@ -48,7 +48,7 @@ class DbQueryDependency extends Dependency
      *
      * This field can be specified as a PHP callback of following signature:
      *
-     * ```php
+     * ```
      * function (QueryInterface $query, mixed $db) {
      *     //return mixed;
      * }

--- a/framework/caching/MemCache.php
+++ b/framework/caching/MemCache.php
@@ -28,7 +28,7 @@ use yii\base\InvalidConfigException;
  *
  * To use MemCache as the cache application component, configure the application as follows,
  *
- * ```php
+ * ```
  * [
  *     'components' => [
  *         'cache' => [

--- a/framework/caching/TagDependency.php
+++ b/framework/caching/TagDependency.php
@@ -12,7 +12,7 @@ namespace yii\caching;
  *
  * By calling [[invalidate()]], you can invalidate all cached data items that are associated with the specified tag name(s).
  *
- * ```php
+ * ```
  * // setting multiple cache keys to store data forever and tagging them with "user-123"
  * Yii::$app->cache->set('user_42_profile', '', 0, new TagDependency(['tags' => 'user-123']));
  * Yii::$app->cache->set('user_42_stats', '', 0, new TagDependency(['tags' => 'user-123']));

--- a/framework/captcha/Captcha.php
+++ b/framework/captcha/Captcha.php
@@ -31,7 +31,7 @@ use yii\widgets\InputWidget;
  *
  * The following example shows how to use this widget with a model attribute:
  *
- * ```php
+ * ```
  * echo Captcha::widget([
  *     'model' => $model,
  *     'attribute' => 'captcha',
@@ -40,7 +40,7 @@ use yii\widgets\InputWidget;
  *
  * The following example will use the name property instead:
  *
- * ```php
+ * ```
  * echo Captcha::widget([
  *     'name' => 'captcha',
  * ]);
@@ -49,7 +49,7 @@ use yii\widgets\InputWidget;
  * You can also use this widget in an [[\yii\widgets\ActiveForm|ActiveForm]] using the [[\yii\widgets\ActiveField::widget()|widget()]]
  * method, for example like this:
  *
- * ```php
+ * ```
  * <?= $form->field($model, 'captcha')->widget(\yii\captcha\Captcha::classname(), [
  *     // configure additional widget properties here
  * ]) ?>

--- a/framework/console/Application.php
+++ b/framework/console/Application.php
@@ -164,7 +164,7 @@ class Application extends \yii\base\Application
      * For example, to run `public function actionTest($a, $b)` assuming that the controller has options the following
      * code should be used:
      *
-     * ```php
+     * ```
      * \Yii::$app->runAction('controller/test', ['option' => 'value', $a, $b]);
      * ```
      *

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -367,7 +367,7 @@ class Controller extends \yii\base\Controller
      *
      * An example of how to use the prompt method with a validator function.
      *
-     * ```php
+     * ```
      * $code = $this->prompt('Enter 4-Chars-Pin', ['required' => true, 'validator' => function($input, &$error) {
      *     if (strlen($input) !== 4) {
      *         $error = 'The Pin must be exactly 4 chars!';
@@ -393,7 +393,7 @@ class Controller extends \yii\base\Controller
      *
      * A typical usage looks like the following:
      *
-     * ```php
+     * ```
      * if ($this->confirm("Are you sure?")) {
      *     echo "user typed yes\n";
      * } else {

--- a/framework/console/ExitCode.php
+++ b/framework/console/ExitCode.php
@@ -14,7 +14,7 @@ namespace yii\console;
  *
  * These constants can be used in console controllers for example like this:
  *
- * ```php
+ * ```
  * public function actionIndex()
  * {
  *     if (!$this->isAllowedToPerformAction()) {

--- a/framework/console/controllers/AssetController.php
+++ b/framework/console/controllers/AssetController.php
@@ -60,7 +60,7 @@ class AssetController extends Controller
      * You can specify the name of the output compressed file using 'css' and 'js' keys:
      * For example:
      *
-     * ```php
+     * ```
      * 'app\config\AllAsset' => [
      *     'js' => 'js/all-{hash}.js',
      *     'css' => 'css/all-{hash}.css',
@@ -76,7 +76,7 @@ class AssetController extends Controller
      * bundles in this case.
      * For example:
      *
-     * ```php
+     * ```
      * 'allShared' => [
      *     'js' => 'js/all-shared-{hash}.js',
      *     'css' => 'css/all-shared-{hash}.css',

--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -67,7 +67,7 @@ abstract class BaseMigrateController extends Controller
      *
      * For example:
      *
-     * ```php
+     * ```
      * [
      *     'app\migrations',
      *     'some\extension\migrations',

--- a/framework/console/controllers/FixtureController.php
+++ b/framework/console/controllers/FixtureController.php
@@ -493,7 +493,7 @@ class FixtureController extends Controller
      * If fixture is prefixed with "-", for example "-User", that means that fixture should not be loaded,
      * if it is not prefixed it is considered as one to be loaded. Returns array:
      *
-     * ```php
+     * ```
      * [
      *     'apply' => [
      *         'User',

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -54,7 +54,7 @@ use yii\helpers\Inflector;
  * Since 2.0.10 you can use namespaced migrations. In order to enable this feature you should configure [[migrationNamespaces]]
  * property for the controller at application configuration:
  *
- * ```php
+ * ```
  * return [
  *     'controllerMap' => [
  *         'migrate' => [

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -31,7 +31,7 @@ use yii\helpers\Inflector;
  * this command is executed, if it does not exist. You may also manually
  * create it as follows:
  *
- * ```sql
+ * ```
  * CREATE TABLE migration (
  *     version varchar(180) PRIMARY KEY,
  *     apply_time integer

--- a/framework/console/widgets/Table.php
+++ b/framework/console/widgets/Table.php
@@ -17,7 +17,7 @@ use yii\helpers\Console;
  *
  * For example,
  *
- * ```php
+ * ```
  * $table = new Table();
  *
  * echo $table
@@ -31,7 +31,7 @@ use yii\helpers\Console;
  *
  * or
  *
- * ```php
+ * ```
  * echo Table::widget([
  *     'headers' => ['test1', 'test2', 'test3'],
  *     'rows' => [

--- a/framework/data/ActiveDataFilter.php
+++ b/framework/data/ActiveDataFilter.php
@@ -22,7 +22,7 @@ class ActiveDataFilter extends DataFilter
      * These methods are used by [[buildCondition()]] to build the actual filtering conditions.
      * Particular condition builder can be specified using a PHP callback. For example:
      *
-     * ```php
+     * ```
      * [
      *     'XOR' => function (string $operator, mixed $condition) {
      *         //return array;
@@ -56,7 +56,7 @@ class ActiveDataFilter extends DataFilter
      * used in [[\yii\db\QueryInterface::where()]]. However, you may want to adjust it in some special cases.
      * For example, when using PostgreSQL you may want to setup the following map:
      *
-     * ```php
+     * ```
      * [
      *     'LIKE' => 'ILIKE'
      * ]

--- a/framework/data/ActiveDataProvider.php
+++ b/framework/data/ActiveDataProvider.php
@@ -21,7 +21,7 @@ use yii\di\Instance;
  *
  * The following is an example of using ActiveDataProvider to provide ActiveRecord instances:
  *
- * ```php
+ * ```
  * $provider = new ActiveDataProvider([
  *     'query' => Post::find(),
  *     'pagination' => [
@@ -35,7 +35,7 @@ use yii\di\Instance;
  *
  * And the following example shows how to use ActiveDataProvider without ActiveRecord:
  *
- * ```php
+ * ```
  * $query = new Query();
  * $provider = new ActiveDataProvider([
  *     'query' => $query->from('post'),

--- a/framework/data/ArrayDataProvider.php
+++ b/framework/data/ArrayDataProvider.php
@@ -27,7 +27,7 @@ use yii\helpers\ArrayHelper;
  *
  * ArrayDataProvider may be used in the following way:
  *
- * ```php
+ * ```
  * $query = new Query;
  * $provider = new ArrayDataProvider([
  *     'allModels' => $query->from('post')->all(),

--- a/framework/data/DataFilter.php
+++ b/framework/data/DataFilter.php
@@ -62,7 +62,7 @@ use yii\validators\Validator;
  * Raw filter value should be assigned to [[filter]] property of the model.
  * You may populate it from request data via [[load()]] method:
  *
- * ```php
+ * ```
  * use yii\data\DataFilter;
  *
  * $dataFilter = new DataFilter();
@@ -72,7 +72,7 @@ use yii\validators\Validator;
  * In order to function this class requires a search model specified via [[searchModel]]. This search model should declare
  * all available search attributes and their validation rules. For example:
  *
- * ```php
+ * ```
  * class SearchModel extends \yii\base\Model
  * {
  *     public $id;
@@ -92,7 +92,7 @@ use yii\validators\Validator;
  * In order to reduce amount of classes, you may use [[\yii\base\DynamicModel]] instance as a [[searchModel]].
  * In this case you should specify [[searchModel]] using a PHP callable:
  *
- * ```php
+ * ```
  * function () {
  *     return (new \yii\base\DynamicModel(['id' => null, 'name' => null]))
  *         ->addRule(['id', 'name'], 'trim')
@@ -156,7 +156,7 @@ class DataFilter extends Model
      *
      * You may specify several keywords for the same filter build key, creating multiple aliases. For example:
      *
-     * ```php
+     * ```
      * [
      *     'eq' => '=',
      *     '=' => '=',
@@ -230,7 +230,7 @@ class DataFilter extends Model
      * @var array actual attribute names to be used in searched condition, in format: [filterAttribute => actualAttribute].
      * For example, in case of using table joins in the search query, attribute map may look like the following:
      *
-     * ```php
+     * ```
      * [
      *     'authorName' => '{{author}}.[[name]]'
      * ]

--- a/framework/data/DataFilter.php
+++ b/framework/data/DataFilter.php
@@ -24,7 +24,7 @@ use yii\validators\Validator;
  *
  * Filter example:
  *
- * ```json
+ * ```
  * {
  *     "or": [
  *         {
@@ -51,7 +51,7 @@ use yii\validators\Validator;
  * In the request the filter should be specified using a key name equal to [[filterAttributeName]]. Thus actual HTTP request body
  * will look like following:
  *
- * ```json
+ * ```
  * {
  *     "filter": {"or": {...}},
  *     "page": 2,

--- a/framework/data/Pagination.php
+++ b/framework/data/Pagination.php
@@ -26,7 +26,7 @@ use yii\web\Request;
  *
  * Controller action:
  *
- * ```php
+ * ```
  * public function actionIndex()
  * {
  *     $query = Article::find()->where(['status' => 1]);
@@ -45,7 +45,7 @@ use yii\web\Request;
  *
  * View:
  *
- * ```php
+ * ```
  * foreach ($models as $model) {
  *     // display $model here
  * }

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -23,7 +23,7 @@ use yii\web\Request;
  *
  * A typical usage example is as follows,
  *
- * ```php
+ * ```
  * public function actionIndex()
  * {
  *     $sort = new Sort([
@@ -52,7 +52,7 @@ use yii\web\Request;
  *
  * View:
  *
- * ```php
+ * ```
  * // display links leading to sort actions
  * echo $sort->link('name') . ' | ' . $sort->link('age');
  *
@@ -88,7 +88,7 @@ class Sort extends BaseObject
      * @var array list of attributes that are allowed to be sorted. Its syntax can be
      * described using the following example:
      *
-     * ```php
+     * ```
      * [
      *     'age',
      *     'name' => [
@@ -103,7 +103,7 @@ class Sort extends BaseObject
      * In the above, two attributes are declared: `age` and `name`. The `age` attribute is
      * a simple attribute which is equivalent to the following:
      *
-     * ```php
+     * ```
      * 'age' => [
      *     'asc' => ['age' => SORT_ASC],
      *     'desc' => ['age' => SORT_DESC],
@@ -114,7 +114,7 @@ class Sort extends BaseObject
      *
      * Since 2.0.12 particular sort direction can be also specified as direct sort expression, like following:
      *
-     * ```php
+     * ```
      * 'name' => [
      *     'asc' => '[[last_name]] ASC NULLS FIRST', // PostgreSQL specific feature
      *     'desc' => '[[last_name]] DESC NULLS LAST',
@@ -148,7 +148,7 @@ class Sort extends BaseObject
      * @var array|null the order that should be used when the current request does not specify any order.
      * The array keys are attribute names and the array values are the corresponding sort directions. For example,
      *
-     * ```php
+     * ```
      * [
      *     'name' => SORT_ASC,
      *     'created_at' => SORT_DESC,
@@ -303,7 +303,7 @@ class Sort extends BaseObject
      * For example the following return value will result in ascending sort by
      * `category` and descending sort by `created_at`:
      *
-     * ```php
+     * ```
      * [
      *     'category',
      *     '-created_at'

--- a/framework/data/SqlDataProvider.php
+++ b/framework/data/SqlDataProvider.php
@@ -25,7 +25,7 @@ use yii\di\Instance;
  *
  * SqlDataProvider may be used in the following way:
  *
- * ```php
+ * ```
  * $count = Yii::$app->db->createCommand('
  *     SELECT COUNT(*) FROM user WHERE status=:status
  * ', [':status' => 1])->queryScalar();

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -45,7 +45,7 @@ use yii\base\InvalidConfigException;
  *
  * These options can be configured using methods of the same name. For example:
  *
- * ```php
+ * ```
  * $customers = Customer::find()->with('orders')->asArray()->all();
  * ```
  *
@@ -411,7 +411,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      *
      * In the following you find some examples:
      *
-     * ```php
+     * ```
      * // find all orders that contain books, and eager loading "books"
      * Order::find()->joinWith('books', true, 'INNER JOIN')->all();
      * // find all orders, eager loading "books", and sort the orders and books by the book names.
@@ -717,7 +717,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      *
      * Use this method to specify additional conditions when declaring a relation in the [[ActiveRecord]] class:
      *
-     * ```php
+     * ```
      * public function getActiveUsers()
      * {
      *     return $this->hasMany(User::class, ['id' => 'user_id'])
@@ -787,7 +787,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      *
      * Use this method to specify a junction table when declaring a relation in the [[ActiveRecord]] class:
      *
-     * ```php
+     * ```
      * public function getItems()
      * {
      *     return $this->hasMany(Item::class, ['id' => 'item_id'])

--- a/framework/db/ActiveQueryInterface.php
+++ b/framework/db/ActiveQueryInterface.php
@@ -45,7 +45,7 @@ interface ActiveQueryInterface extends QueryInterface
      * This can also be a callable (e.g. anonymous function) that returns the index value based on the given
      * row or model data. The signature of the callable should be:
      *
-     * ```php
+     * ```
      * // $model is an AR instance when `asArray` is false,
      * // or an array of column values when `asArray` is true.
      * function ($model)
@@ -71,7 +71,7 @@ interface ActiveQueryInterface extends QueryInterface
      *
      * The following are some usage examples:
      *
-     * ```php
+     * ```
      * // find customers together with their orders and country
      * Customer::find()->with('orders', 'country')->all();
      * // find customers together with their orders and the orders' shipping address

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -55,7 +55,7 @@ trait ActiveQueryTrait
      *
      * The following are some usage examples:
      *
-     * ```php
+     * ```
      * // find customers together with their orders and country
      * Customer::find()->with('orders', 'country')->all();
      * // find customers together with their orders and the orders' shipping address
@@ -72,7 +72,7 @@ trait ActiveQueryTrait
      * You can call `with()` multiple times. Each call will add relations to the existing ones.
      * For example, the following two statements are equivalent:
      *
-     * ```php
+     * ```
      * Customer::find()->with('orders', 'country')->all();
      * Customer::find()->with('orders')->with('country')->all();
      * ```

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -32,7 +32,7 @@ use yii\helpers\StringHelper;
  * To declare an ActiveRecord class you need to extend [[\yii\db\ActiveRecord]] and
  * implement the `tableName` method:
  *
- * ```php
+ * ```
  * <?php
  *
  * class Customer extends \yii\db\ActiveRecord
@@ -56,7 +56,7 @@ use yii\helpers\StringHelper;
  *
  * Below is an example showing some typical usage of ActiveRecord:
  *
- * ```php
+ * ```
  * $user = new User();
  * $user->name = 'Qiang';
  * $user->save();  // a new row is inserted into user table
@@ -100,7 +100,7 @@ class ActiveRecord extends BaseActiveRecord
      *
      * You may call this method to load default values after creating a new instance:
      *
-     * ```php
+     * ```
      * // class Customer extends \yii\db\ActiveRecord
      * $customer = new Customer();
      * $customer->loadDefaultValues();
@@ -146,7 +146,7 @@ class ActiveRecord extends BaseActiveRecord
      *
      * Below is an example:
      *
-     * ```php
+     * ```
      * $customers = Customer::findBySql('SELECT * FROM customer')->all();
      * ```
      *
@@ -302,7 +302,7 @@ class ActiveRecord extends BaseActiveRecord
      *
      * For example, to change the status to be 1 for all customers whose status is 2:
      *
-     * ```php
+     * ```
      * Customer::updateAll(['status' => 1], 'status = 2');
      * ```
      *
@@ -312,7 +312,7 @@ class ActiveRecord extends BaseActiveRecord
      * [[EVENT_AFTER_UPDATE]] to be triggered, you need to [[find()|find]] the models first and then
      * call [[update()]] on each of them. For example an equivalent of the example above would be:
      *
-     * ```php
+     * ```
      * $models = Customer::find()->where('status = 2')->all();
      * foreach ($models as $model) {
      *     $model->status = 1;
@@ -341,7 +341,7 @@ class ActiveRecord extends BaseActiveRecord
      *
      * For example, to increment all customers' age by 1,
      *
-     * ```php
+     * ```
      * Customer::updateAllCounters(['age' => 1]);
      * ```
      *
@@ -373,7 +373,7 @@ class ActiveRecord extends BaseActiveRecord
      *
      * For example, to delete all customers whose status is 3:
      *
-     * ```php
+     * ```
      * Customer::deleteAll('status = 3');
      * ```
      *
@@ -383,7 +383,7 @@ class ActiveRecord extends BaseActiveRecord
      * [[EVENT_AFTER_DELETE]] to be triggered, you need to [[find()|find]] the models first and then
      * call [[delete()]] on each of them. For example an equivalent of the example above would be:
      *
-     * ```php
+     * ```
      * $models = Customer::find()->where('status = 3')->all();
      * foreach ($models as $model) {
      *     $model->delete();
@@ -486,7 +486,7 @@ class ActiveRecord extends BaseActiveRecord
      * in transactions. You can do so by overriding this method and returning the operations
      * that need to be transactional. For example,
      *
-     * ```php
+     * ```
      * return [
      *     'admin' => self::OP_INSERT,
      *     'api' => self::OP_INSERT | self::OP_UPDATE | self::OP_DELETE,
@@ -547,7 +547,7 @@ class ActiveRecord extends BaseActiveRecord
      *
      * For example, to insert a customer record:
      *
-     * ```php
+     * ```
      * $customer = new Customer;
      * $customer->name = $name;
      * $customer->email = $email;
@@ -678,7 +678,7 @@ class ActiveRecord extends BaseActiveRecord
      *
      * For example, to update a customer record:
      *
-     * ```php
+     * ```
      * $customer = Customer::findOne($id);
      * $customer->name = $name;
      * $customer->email = $email;
@@ -689,7 +689,7 @@ class ActiveRecord extends BaseActiveRecord
      * In this case, this method will return 0. For this reason, you should use the following
      * code to check if update() is successful or not:
      *
-     * ```php
+     * ```
      * if ($customer->update() !== false) {
      *     // update successful
      * } else {

--- a/framework/db/ActiveRecordInterface.php
+++ b/framework/db/ActiveRecordInterface.php
@@ -99,7 +99,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      * methods defined in [[ActiveQueryInterface]] before `one()` or `all()` is called to return
      * populated ActiveRecord instances. For example,
      *
-     * ```php
+     * ```
      * // find the customer whose ID is 1
      * $customer = Customer::find()->where(['id' => 1])->one();
      *
@@ -115,7 +115,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      *
      * You may override this method to return a customized query. For example,
      *
-     * ```php
+     * ```
      * class Customer extends ActiveRecord
      * {
      *     public static function find()
@@ -128,7 +128,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      *
      * The following code shows how to apply a default condition for all queries:
      *
-     * ```php
+     * ```
      * class Customer extends ActiveRecord
      * {
      *     public static function find()
@@ -172,7 +172,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      *
      * See the following code for usage examples:
      *
-     * ```php
+     * ```
      * // find a single customer whose primary key value is 10
      * $customer = Customer::findOne(10);
      *
@@ -195,7 +195,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      * If you need to pass user input to this method, make sure the input value is scalar or in case of
      * array condition, make sure the array structure can not be changed from the outside:
      *
-     * ```php
+     * ```
      * // yii\web\Controller ensures that $id is scalar
      * public function actionView($id)
      * {
@@ -240,7 +240,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      *
      * See the following code for usage examples:
      *
-     * ```php
+     * ```
      * // find the customers whose primary key value is 10
      * $customers = Customer::findAll(10);
      *
@@ -263,7 +263,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      * If you need to pass user input to this method, make sure the input value is scalar or in case of
      * array condition, make sure the array structure can not be changed from the outside:
      *
-     * ```php
+     * ```
      * // yii\web\Controller ensures that $id is scalar
      * public function actionView($id)
      * {
@@ -288,7 +288,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      *
      * For example, to change the status to be 1 for all customers whose status is 2:
      *
-     * ```php
+     * ```
      * Customer::updateAll(['status' => 1], ['status' => '2']);
      * ```
      *
@@ -307,7 +307,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      *
      * For example, to delete all customers whose status is 3:
      *
-     * ```php
+     * ```
      * Customer::deleteAll([status = 3]);
      * ```
      *
@@ -326,7 +326,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      *
      * For example, to save a customer record:
      *
-     * ```php
+     * ```
      * $customer = new Customer; // or $customer = Customer::findOne($id);
      * $customer->name = $name;
      * $customer->email = $email;
@@ -347,7 +347,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      *
      * Usage example:
      *
-     * ```php
+     * ```
      * $customer = new Customer;
      * $customer->name = $name;
      * $customer->email = $email;
@@ -368,7 +368,7 @@ interface ActiveRecordInterface extends StaticInstanceInterface
      *
      * Usage example:
      *
-     * ```php
+     * ```
      * $customer = Customer::findOne($id);
      * $customer->name = $name;
      * $customer->email = $email;

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -84,7 +84,7 @@ trait ActiveRelationTrait
      *
      * Use this method to specify a pivot record/table when declaring a relation in the [[ActiveRecord]] class:
      *
-     * ```php
+     * ```
      * class Order extends ActiveRecord
      * {
      *    public function getOrderItems() {
@@ -124,7 +124,7 @@ trait ActiveRelationTrait
      *
      * Use this method when declaring a relation in the [[ActiveRecord]] class, e.g. in Customer model:
      *
-     * ```php
+     * ```
      * public function getOrders()
      * {
      *     return $this->hasMany(Order::class, ['customer_id' => 'id'])->inverseOf('customer');
@@ -133,7 +133,7 @@ trait ActiveRelationTrait
      *
      * This also may be used for Order model, but with caution:
      *
-     * ```php
+     * ```
      * public function getCustomer()
      * {
      *     return $this->hasOne(Customer::class, ['id' => 'customer_id'])->inverseOf('orders');
@@ -143,14 +143,14 @@ trait ActiveRelationTrait
      * in this case result will depend on how order(s) was loaded.
      * Let's suppose customer has several orders. If only one order was loaded:
      *
-     * ```php
+     * ```
      * $orders = Order::find()->where(['id' => 1])->all();
      * $customerOrders = $orders[0]->customer->orders;
      * ```
      *
      * variable `$customerOrders` will contain only one order. If orders was loaded like this:
      *
-     * ```php
+     * ```
      * $orders = Order::find()->with('customer')->where(['customer_id' => 1])->all();
      * $customerOrders = $orders[0]->customer->orders;
      * ```

--- a/framework/db/ArrayExpression.php
+++ b/framework/db/ArrayExpression.php
@@ -15,7 +15,7 @@ use yii\base\InvalidConfigException;
  *
  * Expressions of this type can be used in conditions as well:
  *
- * ```php
+ * ```
  * $query->andWhere(['@>', 'items', new ArrayExpression([1, 2, 3], 'integer')])
  * ```
  *

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -150,7 +150,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      *
      * For example, to change the status to be 1 for all customers whose status is 2:
      *
-     * ```php
+     * ```
      * Customer::updateAll(['status' => 1], 'status = 2');
      * ```
      *
@@ -170,7 +170,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      *
      * For example, to increment all customers' age by 1,
      *
-     * ```php
+     * ```
      * Customer::updateAllCounters(['age' => 1]);
      * ```
      *
@@ -192,7 +192,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      *
      * For example, to delete all customers whose status is 3:
      *
-     * ```php
+     * ```
      * Customer::deleteAll('status = 3');
      * ```
      *
@@ -371,7 +371,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * For example, to declare the `country` relation for `Customer` class, we can write
      * the following code in the `Customer` class:
      *
-     * ```php
+     * ```
      * public function getCountry()
      * {
      *     return $this->hasOne(Country::class, ['id' => 'country_id']);
@@ -412,7 +412,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * For example, to declare the `orders` relation for `Customer` class, we can write
      * the following code in the `Customer` class:
      *
-     * ```php
+     * ```
      * public function getOrders()
      * {
      *     return $this->hasMany(Order::class, ['customer_id' => 'id']);
@@ -679,7 +679,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      *
      * For example, to save a customer record:
      *
-     * ```php
+     * ```
      * $customer = new Customer; // or $customer = Customer::findOne($id);
      * $customer->name = $name;
      * $customer->email = $email;
@@ -725,7 +725,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      *
      * For example, to update a customer record:
      *
-     * ```php
+     * ```
      * $customer = Customer::findOne($id);
      * $customer->name = $name;
      * $customer->email = $email;
@@ -736,7 +736,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * In this case, this method will return 0. For this reason, you should use the following
      * code to check if update() is successful or not:
      *
-     * ```php
+     * ```
      * if ($customer->update() !== false) {
      *     // update successful
      * } else {
@@ -856,7 +856,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      *
      * An example usage is as follows:
      *
-     * ```php
+     * ```
      * $post = Post::findOne($id);
      * $post->updateCounters(['view_count' => 1]);
      * ```
@@ -973,7 +973,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * or an [[EVENT_BEFORE_UPDATE]] event if `$insert` is `false`.
      * When overriding this method, make sure you call the parent implementation like the following:
      *
-     * ```php
+     * ```
      * public function beforeSave($insert)
      * {
      *     if (!parent::beforeSave($insert)) {
@@ -1029,7 +1029,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * The default implementation raises the [[EVENT_BEFORE_DELETE]] event.
      * When overriding this method, make sure you call the parent implementation like the following:
      *
-     * ```php
+     * ```
      * public function beforeDelete()
      * {
      *     if (!parent::beforeDelete()) {
@@ -1813,7 +1813,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * Helps to reduce the number of queries performed against database if some related models are only used
      * when a specific condition is met. For example:
      *
-     * ```php
+     * ```
      * $customers = Customer::find()->where(['country_id' => 123])->all();
      * if (Yii:app()->getUser()->getIdentity()->canAccessOrders()) {
      *     Customer::loadRelationsFor($customers, 'orders.items');
@@ -1843,7 +1843,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      * Helps to reduce the number of queries performed against database if some related models are only used
      * when a specific condition is met. For example:
      *
-     * ```php
+     * ```
      * $customer = Customer::find()->where(['id' => 123])->one();
      * if (Yii:app()->getUser()->getIdentity()->canAccessOrders()) {
      *     $customer->loadRelations('orders.items');

--- a/framework/db/BatchQueryResult.php
+++ b/framework/db/BatchQueryResult.php
@@ -16,7 +16,7 @@ use yii\base\Component;
  * calling [[Query::batch()]] or [[Query::each()]]. Because BatchQueryResult implements the [[\Iterator]] interface,
  * you can iterate it to obtain a batch of data in each iteration. For example,
  *
- * ```php
+ * ```
  * $query = (new Query)->from('user');
  * foreach ($query->batch() as $i => $users) {
  *     // $users represents the rows in the $i-th batch

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -23,7 +23,7 @@ use yii\base\NotSupportedException;
  *
  * For example,
  *
- * ```php
+ * ```
  * $users = $connection->createCommand('SELECT * FROM user')->queryAll();
  * ```
  *
@@ -36,7 +36,7 @@ use yii\base\NotSupportedException;
  * Command also supports building SQL statements by providing methods such as [[insert()]],
  * [[update()]], etc. For example, the following code will create and execute an INSERT SQL statement:
  *
- * ```php
+ * ```
  * $connection->createCommand()->insert('user', [
  *     'name' => 'Sam',
  *     'age' => 30,
@@ -465,7 +465,7 @@ class Command extends Component
      *
      * For example,
      *
-     * ```php
+     * ```
      * $connection->createCommand()->insert('user', [
      *     'name' => 'Sam',
      *     'age' => 30,
@@ -495,7 +495,7 @@ class Command extends Component
      *
      * For example,
      *
-     * ```php
+     * ```
      * $connection->createCommand()->batchInsert('user', ['name', 'age'], [
      *     ['Tom', 30],
      *     ['Jane', 20],
@@ -537,7 +537,7 @@ class Command extends Component
      *
      * For example,
      *
-     * ```php
+     * ```
      * $sql = $queryBuilder->upsert('pages', [
      *     'name' => 'Front page',
      *     'url' => 'https://example.com/', // url is unique
@@ -571,13 +571,13 @@ class Command extends Component
      *
      * For example,
      *
-     * ```php
+     * ```
      * $connection->createCommand()->update('user', ['status' => 1], 'age > 30')->execute();
      * ```
      *
      * or with using parameter binding for the condition:
      *
-     * ```php
+     * ```
      * $minAge = 30;
      * $connection->createCommand()->update('user', ['status' => 1], 'age > :minAge', [':minAge' => $minAge])->execute();
      * ```
@@ -605,13 +605,13 @@ class Command extends Component
      *
      * For example,
      *
-     * ```php
+     * ```
      * $connection->createCommand()->delete('user', 'status = 0')->execute();
      * ```
      *
      * or with using parameter binding for the condition:
      *
-     * ```php
+     * ```
      * $status = 0;
      * $connection->createCommand()->delete('user', 'status = :status', [':status' => $status])->execute();
      * ```
@@ -648,7 +648,7 @@ class Command extends Component
      * inserted into the generated SQL.
      *
      * Example usage:
-     * ```php
+     * ```
      * Yii::$app->db->createCommand()->createTable('post', [
      *     'id' => 'pk',
      *     'title' => 'string',
@@ -1273,7 +1273,7 @@ class Command extends Component
      * Sets a callable (e.g. anonymous function) that is called when [[Exception]] is thrown
      * when executing the command. The signature of the callable should be:
      *
-     * ```php
+     * ```
      * function (\yii\db\Exception $e, $attempt)
      * {
      *     // return true or false (whether to retry the command or rethrow $e)

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -32,7 +32,7 @@ use yii\caching\CacheInterface;
  * The following example shows how to create a Connection instance and establish
  * the DB connection:
  *
- * ```php
+ * ```
  * $connection = new \yii\db\Connection([
  *     'dsn' => $dsn,
  *     'username' => $username,
@@ -43,7 +43,7 @@ use yii\caching\CacheInterface;
  *
  * After the DB connection is established, one can execute SQL statements like the following:
  *
- * ```php
+ * ```
  * $command = $connection->createCommand('SELECT * FROM post');
  * $posts = $command->queryAll();
  * $command = $connection->createCommand('UPDATE post SET status=1');
@@ -54,7 +54,7 @@ use yii\caching\CacheInterface;
  * When the parameters are coming from user input, you should use this approach
  * to prevent SQL injection attacks. The following is an example:
  *
- * ```php
+ * ```
  * $command = $connection->createCommand('SELECT * FROM post WHERE id=:id');
  * $command->bindValue(':id', $_GET['id']);
  * $post = $command->query();
@@ -65,7 +65,7 @@ use yii\caching\CacheInterface;
  * If the underlying DBMS supports transactions, you can perform transactional SQL queries
  * like the following:
  *
- * ```php
+ * ```
  * $transaction = $connection->beginTransaction();
  * try {
  *     $connection->createCommand($sql1)->execute();
@@ -79,7 +79,7 @@ use yii\caching\CacheInterface;
  *
  * You also can use shortcut for the above like the following:
  *
- * ```php
+ * ```
  * $connection->transaction(function () {
  *     $order = new Order($customer);
  *     $order->save();
@@ -89,7 +89,7 @@ use yii\caching\CacheInterface;
  *
  * If needed you can pass transaction isolation level as a second parameter:
  *
- * ```php
+ * ```
  * $connection->transaction(function (Connection $db) {
  *     //return $db->...
  * }, Transaction::READ_UNCOMMITTED);
@@ -98,7 +98,7 @@ use yii\caching\CacheInterface;
  * Connection is often used as an application component and configured in the application
  * configuration like the following:
  *
- * ```php
+ * ```
  * 'components' => [
  *     'db' => [
  *         'class' => '\yii\db\Connection',
@@ -357,7 +357,7 @@ class Connection extends Component
      * @var array the configuration that should be merged with every slave configuration listed in [[slaves]].
      * For example,
      *
-     * ```php
+     * ```
      * [
      *     'username' => 'slave',
      *     'password' => 'slave',
@@ -383,7 +383,7 @@ class Connection extends Component
      * @var array the configuration that should be merged with every master configuration listed in [[masters]].
      * For example,
      *
-     * ```php
+     * ```
      * [
      *     'username' => 'master',
      *     'password' => 'master',
@@ -480,7 +480,7 @@ class Connection extends Component
      * queries performed within the callable will be cached and their results will be fetched from cache if available.
      * For example,
      *
-     * ```php
+     * ```
      * // The customer will be fetched from cache if available.
      * // If not, the query will be made against DB and cached for use next time.
      * $customer = $db->cache(function (Connection $db) {
@@ -524,7 +524,7 @@ class Connection extends Component
      *
      * Queries performed within the callable will not use query cache at all. For example,
      *
-     * ```php
+     * ```
      * $db->cache(function (Connection $db) {
      *
      *     // ... queries that use query cache ...
@@ -1111,7 +1111,7 @@ class Connection extends Component
      * This method is provided so that you can temporarily force using the master connection to perform
      * DB operations even if they are read queries. For example,
      *
-     * ```php
+     * ```
      * $result = $db->useMaster(function ($db) {
      *     return $db->createCommand('SELECT * FROM user LIMIT 1')->queryOne();
      * });

--- a/framework/db/DataReader.php
+++ b/framework/db/DataReader.php
@@ -16,7 +16,7 @@ use yii\base\InvalidCallException;
  * returns all the rows in a single array. Rows of data can also be read by
  * iterating through the reader. For example,
  *
- * ```php
+ * ```
  * $command = $connection->createCommand('SELECT * FROM post');
  * $reader = $command->query();
  *

--- a/framework/db/Expression.php
+++ b/framework/db/Expression.php
@@ -14,7 +14,7 @@ namespace yii\db;
  * it will be replaced with the [[expression]] property value without any
  * DB escaping or quoting. For example,
  *
- * ```php
+ * ```
  * $expression = new Expression('NOW()');
  * $now = (new \yii\db\Query)->select($expression)->scalar();  // SELECT NOW();
  * echo $now; // prints the current date

--- a/framework/db/JsonExpression.php
+++ b/framework/db/JsonExpression.php
@@ -14,7 +14,7 @@ use yii\base\InvalidConfigException;
  *
  * For example:
  *
- * ```php
+ * ```
  * new JsonExpression(['a' => 1, 'b' => 2]); // will be encoded to '{"a": 1, "b": 2}'
  * ```
  *

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -56,7 +56,7 @@ class Migration extends Component implements MigrationInterface
      * by the command. If you do not want to use the DB connection provided by the command, you may override
      * the [[init()]] method like the following:
      *
-     * ```php
+     * ```
      * public function init()
      * {
      *     $this->db = 'db2';
@@ -313,7 +313,7 @@ class Migration extends Component implements MigrationInterface
      * put into the generated SQL.
      *
      * Example usage:
-     * ```php
+     * ```
      * class m200000_000000_create_table_fruits extends \yii\db\Migration
      * {
      *     public function safeUp()

--- a/framework/db/PdoValue.php
+++ b/framework/db/PdoValue.php
@@ -12,7 +12,7 @@ namespace yii\db;
  *
  * For example, it will be useful when you need to bind binary data to BLOB column in DBMS:
  *
- * ```php
+ * ```
  * [':name' => 'John', ':profile' => new PdoValue($profile, \PDO::PARAM_LOB)]`.
  * ```
  *

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -24,7 +24,7 @@ use yii\base\InvalidConfigException;
  *
  * For example,
  *
- * ```php
+ * ```
  * $query = new Query;
  * // compose the query
  * $query->select('id, name')
@@ -83,13 +83,13 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      * @var array|null how to join with other tables. Each array element represents the specification
      * of one join which has the following structure:
      *
-     * ```php
+     * ```
      * [$joinType, $tableName, $joinCondition]
      * ```
      *
      * For example,
      *
-     * ```php
+     * ```
      * [
      *     ['INNER JOIN', 'user', 'user.id = author_id'],
      *     ['LEFT JOIN', 'team', 'team.id = team_id'],
@@ -183,7 +183,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      *
      * For example,
      *
-     * ```php
+     * ```
      * $query = (new Query)->from('user');
      * foreach ($query->batch() as $rows) {
      *     // $rows is an array of 100 or fewer rows from user table
@@ -212,7 +212,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      * This method is similar to [[batch()]] except that in each iteration of the result,
      * only one row of data is returned. For example,
      *
-     * ```php
+     * ```
      * $query = (new Query)->from('user');
      * foreach ($query->each() as $row) {
      * }
@@ -650,7 +650,7 @@ PATTERN;
      * Note, that if [[select]] has not been specified before, you should include `*` explicitly
      * if you want to select all remaining columns too:
      *
-     * ```php
+     * ```
      * $query->addSelect(["*", "CONCAT(first_name, ' ', last_name) AS full_name"])->one();
      * ```
      *
@@ -797,7 +797,7 @@ PATTERN;
      *
      * Here are some examples:
      *
-     * ```php
+     * ```
      * // SELECT * FROM  `user` `u`, `profile`;
      * $query = (new \yii\db\Query)->from(['u' => 'user', 'profile']);
      *
@@ -956,7 +956,7 @@ PATTERN;
      * match the `post.author_id` column value against the string `'user.id'`.
      * It is recommended to use the string syntax here which is more suited for a join:
      *
-     * ```php
+     * ```
      * 'post.author_id = user.id'
      * ```
      *
@@ -1173,7 +1173,7 @@ PATTERN;
      *
      * The following code shows the difference between this method and [[having()]]:
      *
-     * ```php
+     * ```
      * // HAVING `age`=:age
      * $query->filterHaving(['name' => null, 'age' => 20]);
      * // HAVING `age`=:age

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -24,7 +24,7 @@ use yii\helpers\StringHelper;
  *
  * @property-write string[] $conditionClasses Map of condition aliases to condition classes. For example:
  *
- * ```php
+ * ```
  * ['LIKE' => yii\db\condition\LikeCondition::class]
  * ```
  * @property-write string[] $expressionBuilders Array of builders that should be merged with the pre-defined
@@ -65,7 +65,7 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * @var array map of condition aliases to condition classes. For example:
      *
-     * ```php
+     * ```
      * return [
      *     'LIKE' => yii\db\condition\LikeCondition::class,
      * ];
@@ -85,7 +85,7 @@ class QueryBuilder extends \yii\base\BaseObject
      * @var string[]|ExpressionBuilderInterface[] maps expression class to expression builder class.
      * For example:
      *
-     * ```php
+     * ```
      * [
      *    yii\db\Expression::class => yii\db\ExpressionBuilder::class
      * ]
@@ -203,7 +203,7 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * @param string[] $classes map of condition aliases to condition classes. For example:
      *
-     * ```php
+     * ```
      * ['LIKE' => yii\db\condition\LikeCondition::class]
      * ```
      *
@@ -332,7 +332,7 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * Creates an INSERT SQL statement.
      * For example,
-     * ```php
+     * ```
      * $sql = $queryBuilder->insert('user', [
      *     'name' => 'Sam',
      *     'age' => 30,
@@ -433,7 +433,7 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * For example,
      *
-     * ```php
+     * ```
      * $sql = $queryBuilder->batchInsert('user', ['name', 'age'], [
      *     ['Tom', 30],
      *     ['Jane', 20],
@@ -506,7 +506,7 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * For example,
      *
-     * ```php
+     * ```
      * $sql = $queryBuilder->upsert('pages', [
      *     'name' => 'Front page',
      *     'url' => 'https://example.com/', // url is unique
@@ -613,7 +613,7 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * For example,
      *
-     * ```php
+     * ```
      * $params = [];
      * $sql = $queryBuilder->update('user', ['status' => 1], 'age > 30', $params);
      * ```
@@ -668,7 +668,7 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * For example,
      *
-     * ```php
+     * ```
      * $sql = $queryBuilder->delete('user', 'status = 0');
      * ```
      *
@@ -702,7 +702,7 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * For example,
      *
-     * ```php
+     * ```
      * $sql = $queryBuilder->createTable('user', [
      *  'id' => 'pk',
      *  'name' => 'string',

--- a/framework/db/QueryInterface.php
+++ b/framework/db/QueryInterface.php
@@ -62,7 +62,7 @@ interface QueryInterface
      * This can also be a callable (e.g. anonymous function) that returns the index value based on the given
      * row data. The signature of the callable should be:
      *
-     * ```php
+     * ```
      * function ($row)
      * {
      *     // return the index value corresponding to $row

--- a/framework/db/QueryTrait.php
+++ b/framework/db/QueryTrait.php
@@ -65,7 +65,7 @@ trait QueryTrait
      * This can also be a callable (e.g. anonymous function) that returns the index value based on the given
      * row data. The signature of the callable should be:
      *
-     * ```php
+     * ```
      * function ($row)
      * {
      *     // return the index value corresponding to $row
@@ -145,7 +145,7 @@ trait QueryTrait
      *
      * The following code shows the difference between this method and [[where()]]:
      *
-     * ```php
+     * ```
      * // WHERE `age`=:age
      * $query->filterWhere(['name' => null, 'age' => 20]);
      * // WHERE `age`=:age

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -336,7 +336,7 @@ abstract class Schema extends BaseObject
      *
      * Each array element is of the following structure:
      *
-     * ```php
+     * ```
      * [
      *  'IndexName1' => ['col1' [, ...]],
      *  'IndexName2' => ['col2' [, ...]],

--- a/framework/db/SchemaBuilderTrait.php
+++ b/framework/db/SchemaBuilderTrait.php
@@ -16,7 +16,7 @@ namespace yii\db;
  *
  * For example you may use the following code inside your migration files:
  *
- * ```php
+ * ```
  * $this->createTable('example_table', [
  *   'id' => $this->primaryKey(),
  *   'name' => $this->string(64)->notNull(),

--- a/framework/db/SqlToken.php
+++ b/framework/db/SqlToken.php
@@ -202,7 +202,7 @@ class SqlToken extends BaseObject implements \ArrayAccess
      *
      * Usage Example:
      *
-     * ```php
+     * ```
      * $patternToken = (new \yii\db\sqlite\SqlTokenizer('SELECT any FROM any'))->tokenize();
      * if ($sqlToken->matches($patternToken, 0, $firstMatchIndex, $lastMatchIndex)) {
      *     // ...

--- a/framework/db/SqlTokenizer.php
+++ b/framework/db/SqlTokenizer.php
@@ -17,7 +17,7 @@ use yii\base\InvalidArgumentException;
  *
  * Usage example:
  *
- * ```php
+ * ```
  * $tokenizer = new SqlTokenizer("SELECT * FROM user WHERE id = 1");
  * $root = $tokeinzer->tokenize();
  * $sqlTokens = $root->getChildren();

--- a/framework/db/TableSchema.php
+++ b/framework/db/TableSchema.php
@@ -45,7 +45,7 @@ class TableSchema extends BaseObject
     /**
      * @var array foreign keys of this table. Each array element is of the following structure:
      *
-     * ```php
+     * ```
      * [
      *  'ForeignTableName',
      *  'fk1' => 'pk1',  // pk1 is in foreign table

--- a/framework/db/Transaction.php
+++ b/framework/db/Transaction.php
@@ -19,7 +19,7 @@ use yii\base\NotSupportedException;
  * The following code is a typical example of using transactions (note that some
  * DBMS may not support transactions):
  *
- * ```php
+ * ```
  * $transaction = $connection->beginTransaction();
  * try {
  *     $connection->createCommand($sql1)->execute();

--- a/framework/db/conditions/BetweenColumnsCondition.php
+++ b/framework/db/conditions/BetweenColumnsCondition.php
@@ -15,7 +15,7 @@ use yii\db\Query;
  * Class BetweenColumnCondition represents a `BETWEEN` condition where
  * values is between two columns. For example:
  *
- * ```php
+ * ```
  * new BetweenColumnsCondition(42, 'BETWEEN', 'min_value', 'max_value')
  * // Will be build to:
  * // 42 BETWEEN min_value AND max_value
@@ -23,7 +23,7 @@ use yii\db\Query;
  *
  * And a more complex example:
  *
- * ```php
+ * ```
  * new BetweenColumnsCondition(
  *    new Expression('NOW()'),
  *    'NOT BETWEEN',

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -634,7 +634,7 @@ SQL;
      *
      * Each array element is of the following structure:
      *
-     * ```php
+     * ```
      * [
      *     'IndexName1' => ['col1' [, ...]],
      *     'IndexName2' => ['col2' [, ...]],

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -487,7 +487,7 @@ SQL;
      *
      * Each array element is of the following structure:
      *
-     * ```php
+     * ```
      * [
      *     'IndexName1' => ['col1' [, ...]],
      *     'IndexName2' => ['col2' [, ...]],

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -280,7 +280,7 @@ EOD;
      *
      * For example,
      *
-     * ```php
+     * ```
      * $sql = $queryBuilder->batchInsert('user', ['name', 'age'], [
      *     ['Tom', 30],
      *     ['Jane', 20],

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -509,7 +509,7 @@ SQL;
      * Returns all unique indexes for the given table.
      * Each array element is of the following structure:.
      *
-     * ```php
+     * ```
      * [
      *     'IndexName1' => ['col1' [, ...]],
      *     'IndexName2' => ['col2' [, ...]],

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -425,7 +425,7 @@ SQL;
      *
      * Each array element is of the following structure:
      *
-     * ```php
+     * ```
      * [
      *     'IndexName1' => ['col1' [, ...]],
      *     'IndexName2' => ['col2' [, ...]],

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -116,7 +116,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      *
      * For example,
      *
-     * ```php
+     * ```
      * $connection->createCommand()->batchInsert('user', ['name', 'age'], [
      *     ['Tom', 30],
      *     ['Jane', 20],

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -271,7 +271,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      *
      * Each array element is of the following structure:
      *
-     * ```php
+     * ```
      * [
      *     'IndexName1' => ['col1' [, ...]],
      *     'IndexName2' => ['col2' [, ...]],

--- a/framework/di/Container.php
+++ b/framework/di/Container.php
@@ -36,7 +36,7 @@ use yii\helpers\ArrayHelper;
  *
  * Below is an example of using Container:
  *
- * ```php
+ * ```
  * namespace app\models;
  *
  * use yii\base\BaseObject;
@@ -212,7 +212,7 @@ class Container extends Component
      *
      * For example,
      *
-     * ```php
+     * ```
      * // register a class name as is. This can be skipped.
      * $container->set('yii\db\Connection');
      *
@@ -616,7 +616,7 @@ class Container extends Component
      *
      * For example, the following callback may be invoked using the Container to resolve the formatter dependency:
      *
-     * ```php
+     * ```
      * $formatString = function($string, \yii\i18n\Formatter $formatter) {
      *    // ...
      * }
@@ -746,7 +746,7 @@ class Container extends Component
      *    as the second argument `$definition`.
      *
      * Example:
-     * ```php
+     * ```
      * $container->setDefinitions([
      *     'yii\web\Request' => 'app\components\Request',
      *     'yii\web\Response' => [
@@ -768,7 +768,7 @@ class Container extends Component
      *    second argument `$definition`, the second one — as `$params`.
      *
      * Example:
-     * ```php
+     * ```
      * $container->setDefinitions([
      *     'foo\Bar' => [
      *          ['class' => 'app\Bar'],

--- a/framework/di/Instance.php
+++ b/framework/di/Instance.php
@@ -23,7 +23,7 @@ use yii\base\InvalidConfigException;
  *
  * The following example shows how to configure a DI container with Instance:
  *
- * ```php
+ * ```
  * $container = new \yii\di\Container;
  * $container->set('cache', [
  *     'class' => 'yii\caching\DbCache',
@@ -37,7 +37,7 @@ use yii\base\InvalidConfigException;
  *
  * And the following example shows how a class retrieves a component from a service locator:
  *
- * ```php
+ * ```
  * class DbCache extends Cache
  * {
  *     public $db = 'db';
@@ -97,7 +97,7 @@ class Instance
      *
      * For example,
      *
-     * ```php
+     * ```
      * use yii\db\Connection;
      *
      * // returns Yii::$app->db

--- a/framework/di/ServiceLocator.php
+++ b/framework/di/ServiceLocator.php
@@ -22,7 +22,7 @@ use yii\base\InvalidConfigException;
  *
  * For example,
  *
- * ```php
+ * ```
  * $locator = new \yii\di\ServiceLocator;
  * $locator->setComponents([
  *     'db' => [
@@ -150,7 +150,7 @@ class ServiceLocator extends Component
      *
      * For example,
      *
-     * ```php
+     * ```
      * // a class name
      * $locator->set('cache', 'yii\caching\FileCache');
      *
@@ -247,7 +247,7 @@ class ServiceLocator extends Component
      *
      * The following is an example for registering two component definitions:
      *
-     * ```php
+     * ```
      * [
      *     'db' => [
      *         'class' => 'yii\db\Connection',

--- a/framework/filters/AccessControl.php
+++ b/framework/filters/AccessControl.php
@@ -26,7 +26,7 @@ use yii\web\User;
  * For example, the following declarations will allow authenticated users to access the "create"
  * and "update" actions and deny all other users from accessing these two actions.
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [
@@ -70,7 +70,7 @@ class AccessControl extends ActionFilter
      *
      * The signature of the callback should be as follows:
      *
-     * ```php
+     * ```
      * function ($rule, $action)
      * ```
      *

--- a/framework/filters/AccessRule.php
+++ b/framework/filters/AccessRule.php
@@ -83,7 +83,7 @@ class AccessRule extends Component
      * If this is an array, it will be passed directly to [[User::can()]]. For example for passing an
      * ID from the current request, you may use the following:
      *
-     * ```php
+     * ```
      * ['postId' => Yii::$app->request->get('id')]
      * ```
      *
@@ -91,7 +91,7 @@ class AccessRule extends Component
      * evaluate the array values only if they are needed, for example when a model needs to be
      * loaded like in the following code:
      *
-     * ```php
+     * ```
      * 'rules' => [
      *     [
      *         'allow' => true,
@@ -131,7 +131,7 @@ class AccessRule extends Component
      * @var callable a callback that will be called to determine if the rule should be applied.
      * The signature of the callback should be as follows:
      *
-     * ```php
+     * ```
      * function ($rule, $action)
      * ```
      *
@@ -150,7 +150,7 @@ class AccessRule extends Component
      *
      * The signature of the callback should be as follows:
      *
-     * ```php
+     * ```
      * function ($rule, $action)
      * ```
      *

--- a/framework/filters/AjaxFilter.php
+++ b/framework/filters/AjaxFilter.php
@@ -15,7 +15,7 @@ use yii\web\Request;
 /**
  * AjaxFilter allow to limit access only for ajax requests.
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [

--- a/framework/filters/ContentNegotiator.php
+++ b/framework/filters/ContentNegotiator.php
@@ -32,7 +32,7 @@ use yii\web\Response;
  * The following code shows how you can use ContentNegotiator as a bootstrapping component. Note that in this case,
  * the content negotiation applies to the whole application.
  *
- * ```php
+ * ```
  * // in application configuration
  * use yii\web\Response;
  *
@@ -57,7 +57,7 @@ use yii\web\Response;
  * In this case, the content negotiation result only applies to the corresponding controller or module, or even
  * specific actions if you configure the `only` or `except` property of the filter.
  *
- * ```php
+ * ```
  * use yii\web\Response;
  *
  * public function behaviors()

--- a/framework/filters/Cors.php
+++ b/framework/filters/Cors.php
@@ -21,7 +21,7 @@ use yii\web\Response;
  *
  * You may use CORS filter by attaching it as a behavior to a controller or module, like the following,
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [
@@ -35,7 +35,7 @@ use yii\web\Response;
  * The CORS filter can be specialized to restrict parameters, like this,
  * [MDN CORS Information](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [

--- a/framework/filters/HostControl.php
+++ b/framework/filters/HostControl.php
@@ -20,7 +20,7 @@ use yii\web\NotFoundHttpException;
  *
  * Application configuration example:
  *
- * ```php
+ * ```
  * return [
  *     'as hostControl' => [
  *         'class' => 'yii\filters\HostControl',
@@ -35,7 +35,7 @@ use yii\web\NotFoundHttpException;
  *
  * Controller configuration example:
  *
- * ```php
+ * ```
  * use yii\web\Controller;
  * use yii\filters\HostControl;
  *
@@ -70,7 +70,7 @@ class HostControl extends ActionFilter
      * @var array|\Closure|null list of host names, which are allowed.
      * Each host can be specified as a wildcard pattern. For example:
      *
-     * ```php
+     * ```
      * [
      *     'example.com',
      *     '*.example.com',
@@ -79,7 +79,7 @@ class HostControl extends ActionFilter
      *
      * This field can be specified as a PHP callback of following signature:
      *
-     * ```php
+     * ```
      * function (\yii\base\Action $action) {
      *     //return array of strings
      * }
@@ -96,7 +96,7 @@ class HostControl extends ActionFilter
      *
      * The signature of the callback should be as follows:
      *
-     * ```php
+     * ```
      * function (\yii\base\Action $action)
      * ```
      *

--- a/framework/filters/HttpCache.php
+++ b/framework/filters/HttpCache.php
@@ -20,7 +20,7 @@ use yii\base\ActionFilter;
  * In the following example the filter will be applied to the `index` action and
  * the Last-Modified header will contain the date of the last update to the user table in the database.
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [
@@ -49,7 +49,7 @@ class HttpCache extends ActionFilter
      * @var callable a PHP callback that returns the UNIX timestamp of the last modification time.
      * The callback's signature should be:
      *
-     * ```php
+     * ```
      * function ($action, $params)
      * ```
      *
@@ -63,7 +63,7 @@ class HttpCache extends ActionFilter
      * @var callable a PHP callback that generates the ETag seed string.
      * The callback's signature should be:
      *
-     * ```php
+     * ```
      * function ($action, $params)
      * ```
      *

--- a/framework/filters/PageCache.php
+++ b/framework/filters/PageCache.php
@@ -28,7 +28,7 @@ use yii\web\Response;
  * cache the whole page for maximum 60 seconds or until the count of entries in the post table changes.
  * It also stores different versions of the page depending on the application language.
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [
@@ -84,7 +84,7 @@ class PageCache extends ActionFilter implements DynamicContentAwareInterface
      * This can be either a [[Dependency]] object or a configuration array for creating the dependency object.
      * For example,
      *
-     * ```php
+     * ```
      * [
      *     'class' => 'yii\caching\DbDependency',
      *     'sql' => 'SELECT MAX(updated_at) FROM post',
@@ -104,7 +104,7 @@ class PageCache extends ActionFilter implements DynamicContentAwareInterface
      * The following variation setting will cause the content to be cached in different versions
      * according to the current application language:
      *
-     * ```php
+     * ```
      * [
      *     Yii::$app->language,
      * ]
@@ -113,7 +113,7 @@ class PageCache extends ActionFilter implements DynamicContentAwareInterface
      * Since version 2.0.48 you can provide an anonymous function to generate variations. This is especially helpful
      * when you need to access the User component, which is resolved before the PageCache behavior:
      *
-     * ```php
+     * ```
      * 'variations' => function() {
      *     return [
      *         Yii::$app->language,

--- a/framework/filters/RateLimiter.php
+++ b/framework/filters/RateLimiter.php
@@ -19,7 +19,7 @@ use yii\web\TooManyRequestsHttpException;
  *
  * You may use RateLimiter by attaching it as a behavior to a controller or module, like the following,
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [
@@ -52,7 +52,7 @@ class RateLimiter extends ActionFilter
      * @var RateLimitInterface|Closure|null the user object that implements the RateLimitInterface. If not set, it will take the value of `Yii::$app->user->getIdentity(false)`.
      * {@since 2.0.38} It's possible to provide a closure function in order to assign the user identity on runtime. Using a closure to assign the user identity is recommend
      * when you are **not** using the standard `Yii::$app->user` component. See the example below:
-     * ```php
+     * ```
      * 'user' => function() {
      *     return Yii::$app->apiUser->identity;
      * }

--- a/framework/filters/VerbFilter.php
+++ b/framework/filters/VerbFilter.php
@@ -23,7 +23,7 @@ use yii\web\MethodNotAllowedHttpException;
  * For example, the following declarations will define a typical set of allowed
  * request methods for REST CRUD actions.
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [
@@ -61,7 +61,7 @@ class VerbFilter extends Behavior
      *
      * For example,
      *
-     * ```php
+     * ```
      * [
      *   'create' => ['GET', 'POST'],
      *   'update' => ['GET', 'PUT', 'POST'],

--- a/framework/filters/auth/CompositeAuth.php
+++ b/framework/filters/auth/CompositeAuth.php
@@ -20,7 +20,7 @@ use yii\base\InvalidConfigException;
  *
  * The following example shows how to support three authentication methods:
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [

--- a/framework/filters/auth/HttpBasicAuth.php
+++ b/framework/filters/auth/HttpBasicAuth.php
@@ -12,7 +12,7 @@ namespace yii\filters\auth;
  *
  * You may use HttpBasicAuth by attaching it as a behavior to a controller or module, like the following:
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [
@@ -29,7 +29,7 @@ namespace yii\filters\auth;
  *
  * If you want to authenticate users using username and password, you should provide the [[auth]] function for example like the following:
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [
@@ -71,7 +71,7 @@ class HttpBasicAuth extends AuthMethod
      *
      * The following code is a typical implementation of this callable:
      *
-     * ```php
+     * ```
      * function ($username, $password) {
      *     return \app\models\User::findOne([
      *         'username' => $username,

--- a/framework/filters/auth/HttpBearerAuth.php
+++ b/framework/filters/auth/HttpBearerAuth.php
@@ -12,7 +12,7 @@ namespace yii\filters\auth;
  *
  * You may use HttpBearerAuth by attaching it as a behavior to a controller or module, like the following:
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [

--- a/framework/filters/auth/HttpHeaderAuth.php
+++ b/framework/filters/auth/HttpHeaderAuth.php
@@ -12,7 +12,7 @@ namespace yii\filters\auth;
  *
  * You may use HttpHeaderAuth by attaching it as a behavior to a controller or module, like the following:
  *
- * ```php
+ * ```
  * public function behaviors()
  * {
  *     return [

--- a/framework/grid/ActionColumn.php
+++ b/framework/grid/ActionColumn.php
@@ -16,7 +16,7 @@ use yii\helpers\Url;
  *
  * To add an ActionColumn to the gridview, add it to the [[GridView::columns|columns]] configuration as follows:
  *
- * ```php
+ * ```
  * 'columns' => [
  *     // ...
  *     [
@@ -53,7 +53,7 @@ class ActionColumn extends Column
      *
      * As an example, to only have the view, and update button you can add the ActionColumn to your GridView columns as follows:
      *
-     * ```php
+     * ```
      * ['class' => 'yii\grid\ActionColumn', 'template' => '{view} {update}'],
      * ```
      *
@@ -65,7 +65,7 @@ class ActionColumn extends Column
      * and the values are the corresponding button rendering callbacks. The callbacks should use the following
      * signature:
      *
-     * ```php
+     * ```
      * function ($url, $model, $key) {
      *     // return the button HTML code
      * }
@@ -77,7 +77,7 @@ class ActionColumn extends Column
      * You can add further conditions to the button, for example only display it, when the model is
      * editable (here assuming you have a status field that indicates that):
      *
-     * ```php
+     * ```
      * [
      *     'update' => function ($url, $model, $key) {
      *         return $model->status === 'editable' ? Html::a('Update', $url) : '';
@@ -88,7 +88,7 @@ class ActionColumn extends Column
     public $buttons = [];
     /**
      * @var array button icons. The array keys are the icon names and the values the corresponding html:
-     * ```php
+     * ```
      * [
      *     'eye-open' => '<svg ...></svg>',
      *     'pencil' => Html::tag('span', '', ['class' => 'glyphicon glyphicon-pencil'])
@@ -108,7 +108,7 @@ class ActionColumn extends Column
      * this array it will be shown by default.
      * The callbacks must use the following signature:
      *
-     * ```php
+     * ```
      * function ($model, $key, $index) {
      *     return $model->status === 'editable';
      * }
@@ -116,7 +116,7 @@ class ActionColumn extends Column
      *
      * Or you can pass a boolean value:
      *
-     * ```php
+     * ```
      * [
      *     'update' => \Yii::$app->user->can('update'),
      * ],
@@ -129,7 +129,7 @@ class ActionColumn extends Column
      * The signature of the callback should be the same as that of [[createUrl()]]
      * Since 2.0.10 it can accept additional parameter, which refers to the column instance itself:
      *
-     * ```php
+     * ```
      * function (string $action, mixed $model, mixed $key, integer $index, ActionColumn $this) {
      *     //return string;
      * }

--- a/framework/grid/CheckboxColumn.php
+++ b/framework/grid/CheckboxColumn.php
@@ -30,7 +30,7 @@ use yii\helpers\Json;
  * Users may click on the checkboxes to select rows of the grid. The selected rows may be
  * obtained by calling the following JavaScript code:
  *
- * ```javascript
+ * ```
  * var keys = $('#grid').yiiGridView('getSelectedRows');
  * // keys is an array consisting of the keys associated with the selected rows
  * ```

--- a/framework/grid/CheckboxColumn.php
+++ b/framework/grid/CheckboxColumn.php
@@ -17,7 +17,7 @@ use yii\helpers\Json;
  *
  * To add a CheckboxColumn to the [[GridView]], add it to the [[GridView::columns|columns]] configuration as follows:
  *
- * ```php
+ * ```
  * 'columns' => [
  *     // ...
  *     [
@@ -56,7 +56,7 @@ class CheckboxColumn extends Column
      * Specifically if you want to set a different value for the checkbox
      * you can use this option in the following way (in this example using the `name` attribute of the model):
      *
-     * ```php
+     * ```
      * 'checkboxOptions' => function ($model, $key, $index, $column) {
      *     return ['value' => $model->name];
      * }

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -24,7 +24,7 @@ use yii\widgets\BaseListView;
  *
  * A basic usage looks like the following:
  *
- * ```php
+ * ```
  * <?= GridView::widget([
  *     'dataProvider' => $dataProvider,
  *     'columns' => [
@@ -95,7 +95,7 @@ class GridView extends BaseListView
      * returns an array of the HTML attributes. The anonymous function will be called once for every
      * data model returned by [[dataProvider]]. It should have the following signature:
      *
-     * ```php
+     * ```
      * function ($model, $key, $index, $grid)
      * ```
      *
@@ -146,7 +146,7 @@ class GridView extends BaseListView
      * @var array grid column configuration. Each array element represents the configuration
      * for one particular grid column. For example,
      *
-     * ```php
+     * ```
      * [
      *     ['class' => SerialColumn::class],
      *     [
@@ -169,7 +169,7 @@ class GridView extends BaseListView
      *
      * Using the shortcut format the configuration for columns in simple cases would look like this:
      *
-     * ```php
+     * ```
      * [
      *     'id',
      *     'amount:currency:Total Amount',
@@ -180,7 +180,7 @@ class GridView extends BaseListView
      * When using a [[dataProvider]] with active records, you can also display values from related records,
      * e.g. the `name` attribute of the `author` relation:
      *
-     * ```php
+     * ```
      * // shortcut syntax
      * 'author.name',
      * // full syntax

--- a/framework/grid/RadioButtonColumn.php
+++ b/framework/grid/RadioButtonColumn.php
@@ -16,7 +16,7 @@ use yii\helpers\Html;
  *
  * To add a RadioButtonColumn to the [[GridView]], add it to the [[GridView::columns|columns]] configuration as follows:
  *
- * ```php
+ * ```
  * 'columns' => [
  *     // ...
  *     [
@@ -52,7 +52,7 @@ class RadioButtonColumn extends Column
      * Specifically if you want to set a different value for the radio button you can use this option
      * in the following way (in this example using the `name` attribute of the model):
      *
-     * ```php
+     * ```
      * 'radioOptions' => function ($model, $key, $index, $column) {
      *     return ['value' => $model->attribute];
      * }

--- a/framework/grid/SerialColumn.php
+++ b/framework/grid/SerialColumn.php
@@ -12,7 +12,7 @@ namespace yii\grid;
  *
  * To add a SerialColumn to the [[GridView]], add it to the [[GridView::columns|columns]] configuration as follows:
  *
- * ```php
+ * ```
  * 'columns' => [
  *     // ...
  *     [

--- a/framework/helpers/BaseArrayHelper.php
+++ b/framework/helpers/BaseArrayHelper.php
@@ -29,7 +29,7 @@ class BaseArrayHelper
      * @param array $properties a mapping from object class names to the properties that need to put into the resulting arrays.
      * The properties specified for each class is an array of the following format:
      *
-     * ```php
+     * ```
      * [
      *     'app\models\Post' => [
      *         'id',
@@ -46,7 +46,7 @@ class BaseArrayHelper
      *
      * The result of `ArrayHelper::toArray($post, $properties)` could be like the following:
      *
-     * ```php
+     * ```
      * [
      *     'id' => 123,
      *     'title' => 'test',
@@ -169,7 +169,7 @@ class BaseArrayHelper
      *
      * Below are some usage examples,
      *
-     * ```php
+     * ```
      * // working with array
      * $username = \yii\helpers\ArrayHelper::getValue($_POST, 'username');
      * // working with object
@@ -244,7 +244,7 @@ class BaseArrayHelper
      * If there is no such key path yet, it will be created recursively.
      * If the key exists, it will be overwritten.
      *
-     * ```php
+     * ```
      *  $array = [
      *      'key' => [
      *          'in' => [
@@ -257,7 +257,7 @@ class BaseArrayHelper
      *
      * The result of `ArrayHelper::setValue($array, 'key.in.0', ['arr' => 'val']);` will be the following:
      *
-     * ```php
+     * ```
      *  [
      *      'key' => [
      *          'in' => [
@@ -274,7 +274,7 @@ class BaseArrayHelper
      * `ArrayHelper::setValue($array, ['key', 'in'], ['arr' => 'val']);`
      * will be the following:
      *
-     * ```php
+     * ```
      *  [
      *      'key' => [
      *          'in' => [
@@ -321,7 +321,7 @@ class BaseArrayHelper
      *
      * Usage examples,
      *
-     * ```php
+     * ```
      * // $array = ['type' => 'A', 'options' => [1, 2]];
      * // working with array
      * $type = \yii\helpers\ArrayHelper::remove($array, 'type');
@@ -356,7 +356,7 @@ class BaseArrayHelper
      *
      * Example,
      *
-     * ```php
+     * ```
      * $array = ['Bob' => 'Dylan', 'Michael' => 'Jackson', 'Mick' => 'Jagger', 'Janet' => 'Jackson'];
      * $removed = \yii\helpers\ArrayHelper::removeValue($array, 'Jackson');
      * // result:
@@ -399,7 +399,7 @@ class BaseArrayHelper
      *
      * For example:
      *
-     * ```php
+     * ```
      * $array = [
      *     ['id' => '123', 'data' => 'abc', 'device' => 'laptop'],
      *     ['id' => '345', 'data' => 'def', 'device' => 'tablet'],
@@ -410,7 +410,7 @@ class BaseArrayHelper
      *
      * The result will be an associative array, where the key is the value of `id` attribute
      *
-     * ```php
+     * ```
      * [
      *     '123' => ['id' => '123', 'data' => 'abc', 'device' => 'laptop'],
      *     '345' => ['id' => '345', 'data' => 'hgi', 'device' => 'smartphone']
@@ -420,7 +420,7 @@ class BaseArrayHelper
      *
      * An anonymous function can be used in the grouping array as well.
      *
-     * ```php
+     * ```
      * $result = ArrayHelper::index($array, function ($element) {
      *     return $element['id'];
      * });
@@ -428,13 +428,13 @@ class BaseArrayHelper
      *
      * Passing `id` as a third argument will group `$array` by `id`:
      *
-     * ```php
+     * ```
      * $result = ArrayHelper::index($array, null, 'id');
      * ```
      *
      * The result will be a multidimensional array grouped by `id`:
      *
-     * ```php
+     * ```
      * [
      *     '123' => [
      *         ['id' => '123', 'data' => 'abc', 'device' => 'laptop']
@@ -448,7 +448,7 @@ class BaseArrayHelper
      *
      * The anonymous function can be used in the array of grouping keys as well:
      *
-     * ```php
+     * ```
      * $result = ArrayHelper::index($array, 'data', [function ($element) {
      *     return $element['id'];
      * }, 'device']);
@@ -457,7 +457,7 @@ class BaseArrayHelper
      * The result will be a multidimensional array grouped by `id` on the first level, by the `device` on the second one
      * and indexed by the `data` on the third level:
      *
-     * ```php
+     * ```
      * [
      *     '123' => [
      *         'laptop' => [
@@ -524,7 +524,7 @@ class BaseArrayHelper
      *
      * For example,
      *
-     * ```php
+     * ```
      * $array = [
      *     ['id' => '123', 'data' => 'abc'],
      *     ['id' => '345', 'data' => 'def'],
@@ -567,7 +567,7 @@ class BaseArrayHelper
      *
      * For example,
      *
-     * ```php
+     * ```
      * $array = [
      *     ['id' => '123', 'name' => 'aaa', 'class' => 'x'],
      *     ['id' => '124', 'name' => 'bbb', 'class' => 'x'],
@@ -932,7 +932,7 @@ class BaseArrayHelper
      *
      * For example:
      *
-     * ```php
+     * ```
      * $array = [
      *     'A' => [1, 2],
      *     'B' => [
@@ -1060,7 +1060,7 @@ class BaseArrayHelper
      *
      * Example:
      *
-     * ```php
+     * ```
      * $array = [
      *      'A' => [1, 2],
      *      'B' => [

--- a/framework/helpers/BaseConsole.php
+++ b/framework/helpers/BaseConsole.php
@@ -268,7 +268,7 @@ class BaseConsole
      * Any output after this will have default text format.
      * This is equal to calling.
      *
-     * ```php
+     * ```
      * echo Console::ansiFormatCode([Console::RESET])
      * ```
      */
@@ -676,7 +676,7 @@ class BaseConsole
      *
      * Usage:
      *
-     * ```php
+     * ```
      * list($width, $height) = ConsoleHelper::getScreenSize();
      * ```
      *
@@ -907,7 +907,7 @@ class BaseConsole
      *
      * A typical usage looks like the following:
      *
-     * ```php
+     * ```
      * if (Console::confirm("Are you sure?")) {
      *     echo "user typed yes\n";
      * } else {
@@ -987,7 +987,7 @@ class BaseConsole
      *
      * The following example shows a simple usage of a progress bar:
      *
-     * ```php
+     * ```
      * Console::startProgress(0, 1000);
      * for ($n = 1; $n <= 1000; $n++) {
      *     usleep(1000);
@@ -998,7 +998,7 @@ class BaseConsole
      *
      * Git clone like progress (showing only status information):
      *
-     * ```php
+     * ```
      * Console::startProgress(0, 1000, 'Counting objects: ', false);
      * for ($n = 1; $n <= 1000; $n++) {
      *     usleep(1000);

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -412,7 +412,7 @@ class BaseHtml
      * If you want to use an absolute url you can call [[Url::to()]] yourself, before passing the URL to this method,
      * like this:
      *
-     * ```php
+     * ```
      * Html::a('link text', Url::to($url, true))
      * ```
      *
@@ -817,14 +817,14 @@ class BaseHtml
      * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use an array
      *   to override the value and to set other tag attributes:
      *
-     *   ```php
+     *   ```
      *   ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
      *   ```
      *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,
      *
-     *   ```php
+     *   ```
      *   [
      *       'value1' => ['disabled' => true],
      *       'value2' => ['label' => 'value 2'],
@@ -875,14 +875,14 @@ class BaseHtml
      * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use an array
      *   to override the value and to set other tag attributes:
      *
-     *   ```php
+     *   ```
      *   ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
      *   ```
      *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,
      *
-     *   ```php
+     *   ```
      *   [
      *       'value1' => ['disabled' => true],
      *       'value2' => ['label' => 'value 2'],
@@ -961,7 +961,7 @@ class BaseHtml
      * - item: callable, a callback that can be used to customize the generation of the HTML code
      *   corresponding to a single item in $items. The signature of this callback must be:
      *
-     *   ```php
+     *   ```
      *   function ($index, $label, $name, $checked, $value)
      *   ```
      *
@@ -1054,7 +1054,7 @@ class BaseHtml
      * - item: callable, a callback that can be used to customize the generation of the HTML code
      *   corresponding to a single item in $items. The signature of this callback must be:
      *
-     *   ```php
+     *   ```
      *   function ($index, $label, $name, $checked, $value)
      *   ```
      *
@@ -1130,7 +1130,7 @@ class BaseHtml
      * - item: callable, a callback that is used to generate each individual list item.
      *   The signature of this callback must be:
      *
-     *   ```php
+     *   ```
      *   function ($item, $index)
      *   ```
      *
@@ -1181,7 +1181,7 @@ class BaseHtml
      * - item: callable, a callback that is used to generate each individual list item.
      *   The signature of this callback must be:
      *
-     *   ```php
+     *   ```
      *   function ($item, $index)
      *   ```
      *
@@ -1670,14 +1670,14 @@ class BaseHtml
      * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use an array
      *   to override the value and to set other tag attributes:
      *
-     *   ```php
+     *   ```
      *   ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
      *   ```
      *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,
      *
-     *   ```php
+     *   ```
      *   [
      *       'value1' => ['disabled' => true],
      *       'value2' => ['label' => 'value 2'],
@@ -1725,14 +1725,14 @@ class BaseHtml
      * - prompt: string, a prompt text to be displayed as the first option. Since version 2.0.11 you can use an array
      *   to override the value and to set other tag attributes:
      *
-     *   ```php
+     *   ```
      *   ['text' => 'Please select', 'options' => ['value' => 'none', 'class' => 'prompt', 'label' => 'Select']],
      *   ```
      *
      * - options: array, the attributes for the select option tags. The array keys must be valid option values,
      *   and the array values are the extra attributes for the corresponding option tags. For example,
      *
-     *   ```php
+     *   ```
      *   [
      *       'value1' => ['disabled' => true],
      *       'value2' => ['label' => 'value 2'],
@@ -1785,7 +1785,7 @@ class BaseHtml
      * - item: callable, a callback that can be used to customize the generation of the HTML code
      *   corresponding to a single item in $items. The signature of this callback must be:
      *
-     *   ```php
+     *   ```
      *   function ($index, $label, $name, $checked, $value)
      *   ```
      *
@@ -1826,7 +1826,7 @@ class BaseHtml
      * - item: callable, a callback that can be used to customize the generation of the HTML code
      *   corresponding to a single item in $items. The signature of this callback must be:
      *
-     *   ```php
+     *   ```
      *   function ($index, $label, $name, $checked, $value)
      *   ```
      *
@@ -2057,7 +2057,7 @@ class BaseHtml
      * If class specification at given options is an array, and some class placed there with the named (string) key,
      * overriding of such key will have no effect. For example:
      *
-     * ```php
+     * ```
      * $options = ['class' => ['persistent' => 'initial']];
      * Html::addCssClass($options, ['persistent' => 'override']);
      * var_dump($options['class']); // outputs: array('persistent' => 'initial');
@@ -2139,7 +2139,7 @@ class BaseHtml
      *
      * For example,
      *
-     * ```php
+     * ```
      * Html::addCssStyle($options, 'width: 100px; height: 200px');
      * ```
      *
@@ -2174,7 +2174,7 @@ class BaseHtml
      *
      * For example,
      *
-     * ```php
+     * ```
      * Html::removeCssStyle($options, ['width', 'height']);
      * ```
      *
@@ -2199,7 +2199,7 @@ class BaseHtml
      *
      * For example,
      *
-     * ```php
+     * ```
      * print_r(Html::cssStyleFromArray(['width' => '100px', 'height' => '200px']));
      * // will display: 'width: 100px; height: 200px;'
      * ```
@@ -2226,7 +2226,7 @@ class BaseHtml
      *
      * For example,
      *
-     * ```php
+     * ```
      * print_r(Html::cssStyleToArray('width: 100px; height: 200px;'));
      * // will display: ['width' => '100px', 'height' => '200px']
      * ```

--- a/framework/helpers/BaseHtmlPurifier.php
+++ b/framework/helpers/BaseHtmlPurifier.php
@@ -32,7 +32,7 @@ class BaseHtmlPurifier
      *
      *   Here is a usage example of such a function:
      *
-     *   ```php
+     *   ```
      *   // Allow the HTML5 data attribute `data-type` on `img` elements.
      *   $content = HtmlPurifier::process($content, function ($config) {
      *     $config->getHTMLDefinition(true)

--- a/framework/helpers/BaseInflector.php
+++ b/framework/helpers/BaseInflector.php
@@ -613,7 +613,7 @@ class BaseInflector
      *
      * Special treatment is done for the last few words. For example,
      *
-     * ```php
+     * ```
      * $words = ['Spain', 'France'];
      * echo Inflector::sentence($words);
      * // output: Spain and France

--- a/framework/helpers/BaseIpHelper.php
+++ b/framework/helpers/BaseIpHelper.php
@@ -47,14 +47,14 @@ class BaseIpHelper
      *
      * For example, the following code checks whether subnet `192.168.1.0/24` is in subnet `192.168.0.0/22`:
      *
-     * ```php
+     * ```
      * IpHelper::inRange('192.168.1.0/24', '192.168.0.0/22'); // true
      * ```
      *
      * In case you need to check whether a single IP address `192.168.1.21` is in the subnet `192.168.1.0/24`,
      * you can use any of theses examples:
      *
-     * ```php
+     * ```
      * IpHelper::inRange('192.168.1.21', '192.168.1.0/24'); // true
      * IpHelper::inRange('192.168.1.21/32', '192.168.1.0/24'); // true
      * ```

--- a/framework/helpers/BaseUrl.php
+++ b/framework/helpers/BaseUrl.php
@@ -36,7 +36,7 @@ class BaseUrl
      * if you want to specify additional query parameters for the URL being created. The
      * array format must be:
      *
-     * ```php
+     * ```
      * // generates: /index.php?r=site/index&param1=value1&param2=value2
      * ['site/index', 'param1' => 'value1', 'param2' => 'value2']
      * ```
@@ -44,7 +44,7 @@ class BaseUrl
      * If you want to create a URL with an anchor, you can use the array format with a `#` parameter.
      * For example,
      *
-     * ```php
+     * ```
      * // generates: /index.php?r=site/index&param1=value1#name
      * ['site/index', 'param1' => 'value1', '#' => 'name']
      * ```
@@ -64,7 +64,7 @@ class BaseUrl
      *
      * Below are some examples of using this method:
      *
-     * ```php
+     * ```
      * // /index.php?r=site%2Findex
      * echo Url::toRoute('site/index');
      *
@@ -167,7 +167,7 @@ class BaseUrl
      *
      * Below are some examples of using this method:
      *
-     * ```php
+     * ```
      * // /index.php?r=site%2Findex
      * echo Url::to(['site/index']);
      *
@@ -332,7 +332,7 @@ class BaseUrl
      * [[\yii\web\Controller::actionParams]]. You may use the following code in the layout view to add a link tag
      * about canonical URL:
      *
-     * ```php
+     * ```
      * $this->registerLinkTag(['rel' => 'canonical', 'href' => Url::canonical()]);
      * ```
      *
@@ -389,7 +389,7 @@ class BaseUrl
      * will be removed from the existing GET parameters; all other parameters specified in `$params` will
      * be merged with the existing GET parameters. For example,
      *
-     * ```php
+     * ```
      * // assume $_GET = ['id' => 123, 'src' => 'google'], current route is "post/view"
      *
      * // /index.php?r=post%2Fview&id=123&src=google
@@ -406,7 +406,7 @@ class BaseUrl
      * For a `PostSearchForm` model where parameter names are `PostSearchForm[id]` and `PostSearchForm[src]` the syntax
      * would be the following:
      *
-     * ```php
+     * ```
      * // index.php?r=post%2Findex&PostSearchForm%5Bid%5D=100&PostSearchForm%5Bsrc%5D=google
      * echo Url::current([
      *     $postSearch->formName() => ['id' => 100, 'src' => 'google'],

--- a/framework/helpers/HtmlPurifier.php
+++ b/framework/helpers/HtmlPurifier.php
@@ -12,13 +12,13 @@ namespace yii\helpers;
  *
  * Basic usage is the following:
  *
- * ```php
+ * ```
  * echo HtmlPurifier::process($html);
  * ```
  *
  * If you want to configure it:
  *
- * ```php
+ * ```
  * echo HtmlPurifier::process($html, [
  *     'Attr.EnableID' => true,
  * ]);

--- a/framework/helpers/Markdown.php
+++ b/framework/helpers/Markdown.php
@@ -12,7 +12,7 @@ namespace yii\helpers;
  *
  * Basic usage is the following:
  *
- * ```php
+ * ```
  * $myHtml = Markdown::process($myText); // use original markdown flavor
  * $myHtml = Markdown::process($myText, 'gfm'); // use github flavored markdown
  * $myHtml = Markdown::process($myText, 'extra'); // use markdown extra

--- a/framework/helpers/ReplaceArrayValue.php
+++ b/framework/helpers/ReplaceArrayValue.php
@@ -14,7 +14,7 @@ use yii\base\InvalidConfigException;
  *
  * Usage example:
  *
- * ```php
+ * ```
  * $array1 = [
  *     'ids' => [
  *         1,
@@ -40,7 +40,7 @@ use yii\base\InvalidConfigException;
  *
  * The result will be
  *
- * ```php
+ * ```
  * [
  *     'ids' => [
  *         1,

--- a/framework/helpers/UnsetArrayValue.php
+++ b/framework/helpers/UnsetArrayValue.php
@@ -12,7 +12,7 @@ namespace yii\helpers;
  *
  * Usage example:
  *
- * ```php
+ * ```
  * $array1 = [
  *     'ids' => [
  *         1,
@@ -35,7 +35,7 @@ namespace yii\helpers;
  *
  * The result will be
  *
- * ```php
+ * ```
  * [
  *     'ids' => [
  *         1,

--- a/framework/helpers/VarDumper.php
+++ b/framework/helpers/VarDumper.php
@@ -15,7 +15,7 @@ namespace yii\helpers;
  *
  * VarDumper can be used as follows,
  *
- * ```php
+ * ```
  * VarDumper::dump($var);
  * ```
  *

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -141,7 +141,7 @@ class Formatter extends Component
      *
      * For example:
      *
-     * ```php
+     * ```
      * 'MM/dd/yyyy' // date in ICU format
      * 'php:m/d/Y' // the same date in PHP format
      * ```
@@ -157,7 +157,7 @@ class Formatter extends Component
      *
      * For example:
      *
-     * ```php
+     * ```
      * 'HH:mm:ss' // time in ICU format
      * 'php:H:i:s' // the same time in PHP format
      * ```
@@ -174,7 +174,7 @@ class Formatter extends Component
      *
      * For example:
      *
-     * ```php
+     * ```
      * 'MM/dd/yyyy HH:mm:ss' // date and time in ICU format
      * 'php:m/d/Y H:i:s' // the same date and time in PHP format
      * ```
@@ -191,7 +191,7 @@ class Formatter extends Component
      * set this property to `\IntlDateFormatter::TRADITIONAL`.
      * The calendar must then be specified in the [[locale]], for example for the persian calendar the configuration for the formatter would be:
      *
-     * ```php
+     * ```
      * 'formatter' => [
      *     'locale' => 'fa_IR@calendar=persian',
      *     'calendar' => \IntlDateFormatter::TRADITIONAL,
@@ -241,7 +241,7 @@ class Formatter extends Component
      *
      * For example to adjust the maximum and minimum value of fraction digits you can configure this property like the following:
      *
-     * ```php
+     * ```
      * [
      *     NumberFormatter::MIN_FRACTION_DIGITS => 0,
      *     NumberFormatter::MAX_FRACTION_DIGITS => 2,
@@ -260,7 +260,7 @@ class Formatter extends Component
      *
      * For example to change the minus sign for negative numbers you can configure this property like the following:
      *
-     * ```php
+     * ```
      * [
      *     NumberFormatter::NEGATIVE_PREFIX => 'MINUS',
      * ]
@@ -278,7 +278,7 @@ class Formatter extends Component
      *
      * For example to choose a custom currency symbol, e.g. [U+20BD](https://unicode-table.com/en/20BD/) instead of `руб.` for Russian Ruble:
      *
-     * ```php
+     * ```
      * [
      *     NumberFormatter::CURRENCY_SYMBOL => '₽',
      * ]
@@ -317,7 +317,7 @@ class Formatter extends Component
      *
      * For example, you can add smaller measure unit:
      *
-     * ```php
+     * ```
      * $this->measureUnits[self::UNIT_LENGTH][self::UNIT_SYSTEM_METRIC] = [
      *     'nanometer' => 0.000001
      * ]

--- a/framework/i18n/PhpMessageSource.php
+++ b/framework/i18n/PhpMessageSource.php
@@ -20,7 +20,7 @@ use yii\base\InvalidArgumentException;
  * - Each PHP script is saved as a file named as "[[basePath]]/LanguageID/CategoryName.php";
  * - Within each PHP script, the message translations are returned as an array like the following:
  *
- * ```php
+ * ```
  * return [
  *     'original message 1' => 'translated message 1',
  *     'original message 2' => 'translated message 2',
@@ -42,7 +42,7 @@ class PhpMessageSource extends MessageSource
      * @var array mapping between message categories and the corresponding message file paths.
      * The file paths are relative to [[basePath]]. For example,
      *
-     * ```php
+     * ```
      * [
      *     'core' => 'core.php',
      *     'ext' => 'extensions.php',

--- a/framework/log/Dispatcher.php
+++ b/framework/log/Dispatcher.php
@@ -21,7 +21,7 @@ use yii\base\ErrorHandler;
  *
  * You may configure the targets in application configuration, like the following:
  *
- * ```php
+ * ```
  * [
  *     'components' => [
  *         'log' => [
@@ -46,7 +46,7 @@ use yii\base\ErrorHandler;
  *
  * Each log target can have a name and can be referenced via the [[targets]] property as follows:
  *
- * ```php
+ * ```
  * Yii::$app->log->targets['file']->enabled = false;
  * ```
  *

--- a/framework/log/EmailTarget.php
+++ b/framework/log/EmailTarget.php
@@ -18,7 +18,7 @@ use yii\mail\MailerInterface;
  * You may configure the email to be sent by setting the [[message]] property, through which
  * you can set the target email addresses, subject, etc.:
  *
- * ```php
+ * ```
  * 'components' => [
  *     'log' => [
  *          'targets' => [

--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -211,7 +211,7 @@ abstract class Target extends Component
      *
      * For example,
      *
-     * ```php
+     * ```
      * ['error', 'warning']
      * // which is equivalent to:
      * Logger::LEVEL_ERROR | Logger::LEVEL_WARNING
@@ -368,7 +368,7 @@ abstract class Target extends Component
      * For example, to only enable a log if the current user is logged in you can configure the target
      * as follows:
      *
-     * ```php
+     * ```
      * 'enabled' => function() {
      *     return !Yii::$app->user->isGuest;
      * }

--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -63,7 +63,7 @@ abstract class BaseMailer extends Component implements MailerInterface, ViewCont
      *
      * For example:
      *
-     * ```php
+     * ```
      * [
      *     'charset' => 'UTF-8',
      *     'from' => 'noreply@mydomain.com',
@@ -93,7 +93,7 @@ abstract class BaseMailer extends Component implements MailerInterface, ViewCont
      *
      * The signature of the callback is:
      *
-     * ```php
+     * ```
      * function ($mailer, $message)
      * ```
      */

--- a/framework/mail/MailerInterface.php
+++ b/framework/mail/MailerInterface.php
@@ -13,7 +13,7 @@ namespace yii\mail;
  * A mailer should mainly support creating and sending [[MessageInterface|mail messages]]. It should
  * also support composition of the message body through the view rendering mechanism. For example,
  *
- * ```php
+ * ```
  * Yii::$app->mailer->compose('contact/html', ['contactForm' => $form])
  *     ->setFrom('from@domain.com')
  *     ->setTo($form->email)

--- a/framework/mail/MessageInterface.php
+++ b/framework/mail/MessageInterface.php
@@ -15,7 +15,7 @@ namespace yii\mail;
  *
  * Messages are sent by a [[\yii\mail\MailerInterface|mailer]], like the following,
  *
- * ```php
+ * ```
  * Yii::$app->mailer->compose()
  *     ->setFrom('from@domain.com')
  *     ->setTo($form->email)

--- a/framework/mutex/FileMutex.php
+++ b/framework/mutex/FileMutex.php
@@ -18,7 +18,7 @@ use yii\helpers\FileHelper;
  *
  * Application configuration example:
  *
- * ```php
+ * ```
  * [
  *     'components' => [
  *         'mutex' => [

--- a/framework/requirements/YiiRequirementChecker.php
+++ b/framework/requirements/YiiRequirementChecker.php
@@ -16,7 +16,7 @@ if (version_compare(PHP_VERSION, '4.3', '<')) {
  *
  * Example:
  *
- * ```php
+ * ```
  * require_once 'path/to/YiiRequirementChecker.php';
  * $requirementsChecker = new YiiRequirementChecker();
  * $requirements = array(
@@ -37,7 +37,7 @@ if (version_compare(PHP_VERSION, '4.3', '<')) {
  * In this case specified PHP expression will be evaluated in the context of this class instance.
  * For example:
  *
- * ```php
+ * ```
  * $requirements = array(
  *     array(
  *         'name' => 'Upload max file size',
@@ -124,7 +124,7 @@ class YiiRequirementChecker
      * Return the check results.
      * @return array|null check results in format:
      *
-     * ```php
+     * ```
      * array(
      *     'summary' => array(
      *         'total' => total number of checks,

--- a/framework/rest/Action.php
+++ b/framework/rest/Action.php
@@ -32,7 +32,7 @@ class Action extends \yii\base\Action
      * to the specified primary key value. If not set, [[findModel()]] will be used instead.
      * The signature of the callable should be:
      *
-     * ```php
+     * ```
      * function ($id, $action) {
      *     // $id is the primary key value. If composite primary key, the key values
      *     // will be separated by comma.
@@ -48,7 +48,7 @@ class Action extends \yii\base\Action
      * if the current user has the permission to execute the action. If not set, the access
      * check will not be performed. The signature of the callable should be as follows,
      *
-     * ```php
+     * ```
      * function ($action, $model = null) {
      *     // $model is the requested model instance.
      *     // If null, it means no specific model (e.g. IndexAction)

--- a/framework/rest/IndexAction.php
+++ b/framework/rest/IndexAction.php
@@ -29,7 +29,7 @@ class IndexAction extends Action
      * should return a collection of the models. If not set, [[prepareDataProvider()]] will be used instead.
      * The signature of the callable should be:
      *
-     * ```php
+     * ```
      * function (IndexAction $action) {
      *     // $action is the action object currently running
      * }
@@ -40,7 +40,7 @@ class IndexAction extends Action
      * If [[dataFilter]] is set the result of [[DataFilter::build()]] will be passed to the callable as a second parameter.
      * In this case the signature of the callable should be the following:
      *
-     * ```php
+     * ```
      * function (IndexAction $action, mixed $filter) {
      *     // $action is the action object currently running
      *     // $filter the built filter condition
@@ -53,7 +53,7 @@ class IndexAction extends Action
      * Should return $query.
      * For example:
      *
-     * ```php
+     * ```
      * function ($query, $requestParams) {
      *     $query->andFilterWhere(['id' => 1]);
      *     ...
@@ -69,7 +69,7 @@ class IndexAction extends Action
      * You must set up this field explicitly in order to enable filter processing.
      * For example:
      *
-     * ```php
+     * ```
      * [
      *     'class' => 'yii\data\ActiveDataFilter',
      *     'searchModel' => function () {

--- a/framework/rest/Serializer.php
+++ b/framework/rest/Serializer.php
@@ -68,7 +68,7 @@ class Serializer extends Component
      * This is used when serving a resource collection. When this is set and pagination is enabled, the serializer
      * will return a collection in the following format:
      *
-     * ```php
+     * ```
      * [
      *     'items' => [...],  // assuming collectionEnvelope is "items"
      *     '_links' => {  // pagination links as returned by Pagination::getLinks()

--- a/framework/rest/UrlRule.php
+++ b/framework/rest/UrlRule.php
@@ -19,7 +19,7 @@ use yii\web\UrlRuleInterface;
  *
  * The simplest usage of UrlRule is to declare a rule like the following in the application configuration,
  *
- * ```php
+ * ```
  * [
  *     'class' => 'yii\rest\UrlRule',
  *     'controller' => 'user',
@@ -41,7 +41,7 @@ use yii\web\UrlRuleInterface;
  * You may configure [[controller]] with multiple controller IDs to generate rules for all these controllers.
  * For example, the following code will disable the `delete` rule and generate rules for both `user` and `post` controllers:
  *
- * ```php
+ * ```
  * [
  *     'class' => 'yii\rest\UrlRule',
  *     'controller' => ['user', 'post'],

--- a/framework/test/FixtureTrait.php
+++ b/framework/test/FixtureTrait.php
@@ -40,7 +40,7 @@ trait FixtureTrait
      *
      * The return value of this method must be an array of fixture configurations. For example,
      *
-     * ```php
+     * ```
      * [
      *     // anonymous fixture
      *     PostFixture::class,

--- a/framework/validators/DateValidator.php
+++ b/framework/validators/DateValidator.php
@@ -88,7 +88,7 @@ class DateValidator extends Validator
      *
      * Here are some example values:
      *
-     * ```php
+     * ```
      * 'MM/dd/yyyy' // date in ICU format
      * 'php:m/d/Y' // the same date in PHP format
      * 'MM/dd/yyyy HH:mm' // not only dates but also times can be validated

--- a/framework/validators/DefaultValueValidator.php
+++ b/framework/validators/DefaultValueValidator.php
@@ -23,7 +23,7 @@ class DefaultValueValidator extends Validator
      * be assigned to the attributes being validated if they are empty. The signature of the anonymous function
      * should be as follows,
      *
-     * ```php
+     * ```
      * function($model, $attribute) {
      *     // compute value
      *     return $value;

--- a/framework/validators/EachValidator.php
+++ b/framework/validators/EachValidator.php
@@ -15,7 +15,7 @@ use yii\base\Model;
 /**
  * EachValidator validates an array by checking each of its elements against an embedded validation rule.
  *
- * ```php
+ * ```
  * class MyModel extends Model
  * {
  *     public $categoryIDs = [];
@@ -47,7 +47,7 @@ class EachValidator extends Validator
      * contain attribute list as the first element.
      * For example:
      *
-     * ```php
+     * ```
      * ['integer']
      * ['match', 'pattern' => '/[a-z]/is']
      * ```

--- a/framework/validators/ExistValidator.php
+++ b/framework/validators/ExistValidator.php
@@ -26,7 +26,7 @@ use yii\db\QueryInterface;
  *
  * The following are examples of validation rules using this validator:
  *
- * ```php
+ * ```
  * // a1 needs to exist
  * ['a1', 'exist']
  * // a1 needs to exist, but its value will use a2 to check for the existence

--- a/framework/validators/FilterValidator.php
+++ b/framework/validators/FilterValidator.php
@@ -18,7 +18,7 @@ use yii\helpers\Json;
  * and save the processed value back to the attribute. The filter must be
  * a valid PHP callback with the following signature:
  *
- * ```php
+ * ```
  * function foo($value) {
  *     // compute $newValue here
  *     return $newValue;
@@ -40,7 +40,7 @@ class FilterValidator extends Validator
      * @var callable the filter. This can be a global function name, anonymous function, etc.
      * The function signature must be as follows,
      *
-     * ```php
+     * ```
      * function foo($value) {
      *     // compute $newValue here
      *     return $newValue;

--- a/framework/validators/InlineValidator.php
+++ b/framework/validators/InlineValidator.php
@@ -19,7 +19,7 @@ class InlineValidator extends Validator
      * @var string|callable an anonymous function or the name of a model class method that will be
      * called to perform the actual validation. The signature of the method should be like the following:
      *
-     * ```php
+     * ```
      * function (string $attribute, mixed $params, InlineValidator $validator, mixed $current): bool {
      * }
      * ```
@@ -38,7 +38,7 @@ class InlineValidator extends Validator
      * @var string|\Closure an anonymous function or the name of a model class method that returns the client validation code.
      * The signature of the method should be like the following:
      *
-     * ```php
+     * ```
      * function (string $attribute, mixed $params, InlineValidator $validator, mixed $current, View $view): string
      * {
      *     // $view->registerJs('JS validation function');

--- a/framework/validators/IpValidator.php
+++ b/framework/validators/IpValidator.php
@@ -21,7 +21,7 @@ use yii\web\JsExpression;
  *
  * The following are examples of validation rules using this validator:
  *
- * ```php
+ * ```
  * ['ip_address', 'ip'], // IPv4 or IPv6 address
  * ['ip_address', 'ip', 'ipv6' => false], // IPv4 address (IPv6 is disabled)
  * ['ip_address', 'ip', 'subnet' => true], // requires a CIDR prefix (like 10.0.0.1/24) for the IP address
@@ -254,7 +254,7 @@ class IpValidator extends Validator
      *
      * Example:
      *
-     * ```php
+     * ```
      * [
      *      'ranges' => [
      *          '192.168.10.128'

--- a/framework/validators/RangeValidator.php
+++ b/framework/validators/RangeValidator.php
@@ -28,7 +28,7 @@ class RangeValidator extends Validator
      * @var array|\Traversable|\Closure a list of valid values that the attribute value should be among or an anonymous function that returns
      * such a list. The signature of the anonymous function should be as follows,
      *
-     * ```php
+     * ```
      * function($model, $attribute) {
      *     // compute range
      *     return $range;

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -23,7 +23,7 @@ use yii\helpers\Inflector;
  *
  * The following are examples of validation rules using this validator:
  *
- * ```php
+ * ```
  * // a1 needs to be unique
  * ['a1', 'unique']
  * // a1 needs to be unique, but column a2 will be used to check the uniqueness of the a1 value

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -160,7 +160,7 @@ class Validator extends Component
      *
      * The following example will enable the validator only when the country currently selected is USA:
      *
-     * ```php
+     * ```
      * function ($model) {
      *     return $model->country == Country::USA;
      * }
@@ -342,7 +342,7 @@ class Validator extends Component
      * A validator class can implement this method to support data validation out of the context of a data model.
      * @param mixed $value the data value to be validated.
      * @return array|null the error message and the array of parameters to be inserted into the error message.
-     * ```php
+     * ```
      * if (!$valid) {
      *     return [$this->message, [
      *         'param1' => $this->param1,

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -180,7 +180,7 @@ class Validator extends Component
      *
      * The following example will enable the validator only when the country currently selected is USA:
      *
-     * ```javascript
+     * ```
      * function (attribute, value) {
      *     return $('#country').val() === 'USA';
      * }

--- a/framework/web/Application.php
+++ b/framework/web/Application.php
@@ -40,7 +40,7 @@ class Application extends \yii\base\Application
      * The rest of the array elements (key-value pairs) specify the parameters to be bound
      * to the action. For example,
      *
-     * ```php
+     * ```
      * [
      *     'offline/notice',
      *     'param1' => 'value1',

--- a/framework/web/AssetBundle.php
+++ b/framework/web/AssetBundle.php
@@ -75,7 +75,7 @@ class AssetBundle extends BaseObject
      *
      * For example:
      *
-     * ```php
+     * ```
      * public $depends = [
      *    'yii\web\YiiAsset',
      *    'yii\bootstrap\BootstrapAsset',

--- a/framework/web/AssetConverter.php
+++ b/framework/web/AssetConverter.php
@@ -30,7 +30,7 @@ class AssetConverter extends Component implements AssetConverterInterface
      *
      * You may also use a [path alias](guide:concept-aliases) to specify the location of the command:
      *
-     * ```php
+     * ```
      * [
      *     'styl' => ['css', '@app/node_modules/bin/stylus < {from} > {to}'],
      * ]

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -23,7 +23,7 @@ use yii\helpers\Url;
  * You can modify its configuration by adding an array to your application config under `components`
  * as shown in the following example:
  *
- * ```php
+ * ```
  * 'assetManager' => [
  *     'bundles' => [
  *         // you can override AssetBundle configs here
@@ -74,7 +74,7 @@ class AssetManager extends Component
      * The following example shows how to disable the bootstrap css file used by Bootstrap widgets
      * (because you want to use your own styles):
      *
-     * ```php
+     * ```
      * [
      *     'yii\bootstrap\BootstrapAsset' => [
      *         'css' => [],
@@ -107,7 +107,7 @@ class AssetManager extends Component
      * In the following example, any assets ending with `jquery.min.js` will be replaced with `jquery/dist/jquery.js`
      * which is relative to [[baseUrl]] and [[basePath]].
      *
-     * ```php
+     * ```
      * [
      *     'jquery.min.js' => 'jquery/dist/jquery.js',
      * ]
@@ -115,7 +115,7 @@ class AssetManager extends Component
      *
      * You may also use aliases while specifying map value, for example:
      *
-     * ```php
+     * ```
      * [
      *     'jquery.min.js' => '@web/js/jquery/jquery.js',
      * ]
@@ -206,7 +206,7 @@ class AssetManager extends Component
      *
      * Example of an implementation using MD4 hash:
      *
-     * ```php
+     * ```
      * function ($path) {
      *     return hash('md4', $path);
      * }

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -135,7 +135,7 @@ class AssetManager extends Component
      * to Web users. For example, for Apache Web server, the following configuration directive should be added
      * for the Web folder:
      *
-     * ```apache
+     * ```
      * Options FollowSymLinks
      * ```
      */

--- a/framework/web/CacheSession.php
+++ b/framework/web/CacheSession.php
@@ -23,7 +23,7 @@ use yii\di\Instance;
  * The following example shows how you can configure the application to use CacheSession:
  * Add the following to your application config under `components`:
  *
- * ```php
+ * ```
  * 'session' => [
  *     'class' => 'yii\web\CacheSession',
  *     // 'cache' => 'mycache',

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -63,7 +63,7 @@ class Controller extends \yii\base\Controller
      * the [[Response::$format|format]] and setting the [[Response::$data|data]] that should
      * be formatted. A common usage will be:
      *
-     * ```php
+     * ```
      * return $this->asJson($data);
      * ```
      *
@@ -89,7 +89,7 @@ class Controller extends \yii\base\Controller
      * the [[Response::$format|format]] and setting the [[Response::$data|data]] that should
      * be formatted. A common usage will be:
      *
-     * ```php
+     * ```
      * return $this->asXml($data);
      * ```
      *
@@ -346,7 +346,7 @@ class Controller extends \yii\base\Controller
      *
      * You can use it in an action by returning the [[Response]] directly:
      *
-     * ```php
+     * ```
      * // stop executing this action and redirect to login page
      * return $this->redirect(['login']);
      * ```
@@ -377,7 +377,7 @@ class Controller extends \yii\base\Controller
      *
      * You can use this method in an action by returning the [[Response]] directly:
      *
-     * ```php
+     * ```
      * // stop executing this action and redirect to home page
      * return $this->goHome();
      * ```
@@ -394,7 +394,7 @@ class Controller extends \yii\base\Controller
      *
      * You can use this method in an action by returning the [[Response]] directly:
      *
-     * ```php
+     * ```
      * // stop executing this action and redirect to last visited page
      * return $this->goBack();
      * ```
@@ -418,7 +418,7 @@ class Controller extends \yii\base\Controller
      *
      * You can use it in an action by returning the [[Response]] directly:
      *
-     * ```php
+     * ```
      * // stop executing this action and refresh the current page
      * return $this->refresh();
      * ```

--- a/framework/web/Cookie.php
+++ b/framework/web/Cookie.php
@@ -88,7 +88,7 @@ class Cookie extends \yii\base\BaseObject
     /**
      * Magic method to turn a cookie object into a string without having to explicitly access [[value]].
      *
-     * ```php
+     * ```
      * if (isset($request->cookies['name'])) {
      *     $value = (string) $request->cookies['name'];
      * }

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -23,7 +23,7 @@ use yii\di\Instance;
  * The following example shows how you can configure the application to use DbSession:
  * Add the following to your application config under `components`:
  *
- * ```php
+ * ```
  * 'session' => [
  *     'class' => 'yii\web\DbSession',
  *     // 'db' => 'mydb',

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -50,7 +50,7 @@ class DbSession extends MultiFieldSession
      * @var string the name of the DB table that stores the session data.
      * The table should be pre-created as follows:
      *
-     * ```sql
+     * ```
      * CREATE TABLE session
      * (
      *     id CHAR(40) NOT NULL PRIMARY KEY,

--- a/framework/web/ErrorAction.php
+++ b/framework/web/ErrorAction.php
@@ -20,7 +20,7 @@ use yii\base\UserException;
  * First, declare an action of ErrorAction type in the `actions()` method of your `SiteController`
  * class (or whatever controller you prefer), like the following:
  *
- * ```php
+ * ```
  * public function actions()
  * {
  *     return [
@@ -38,7 +38,7 @@ use yii\base\UserException;
  *
  * Finally, configure the "errorHandler" application component as follows,
  *
- * ```php
+ * ```
  * 'errorHandler' => [
  *     'errorAction' => 'site/error',
  * ]

--- a/framework/web/GroupUrlRule.php
+++ b/framework/web/GroupUrlRule.php
@@ -16,7 +16,7 @@ use yii\base\InvalidConfigException;
  * GroupUrlRule is best used by a module which often uses module ID as the prefix for the URL rules.
  * For example, the following code creates a rule for the `admin` module:
  *
- * ```php
+ * ```
  * new GroupUrlRule([
  *     'prefix' => 'admin',
  *     'rules' => [

--- a/framework/web/HttpException.php
+++ b/framework/web/HttpException.php
@@ -18,7 +18,7 @@ use yii\base\UserException;
  *
  * Throwing an HttpException like in the following example will result in the 404 page to be displayed.
  *
- * ```php
+ * ```
  * if ($item === null) { // item does not exist
  *     throw new \yii\web\HttpException(404, 'The requested Item could not be found.');
  * }

--- a/framework/web/IdentityInterface.php
+++ b/framework/web/IdentityInterface.php
@@ -13,7 +13,7 @@ namespace yii\web;
  * This interface can typically be implemented by a user model class. For example, the following
  * code shows how to implement this interface by a User ActiveRecord class:
  *
- * ```php
+ * ```
  * class User extends ActiveRecord implements IdentityInterface
  * {
  *     public static function findIdentity($id)

--- a/framework/web/JsonParser.php
+++ b/framework/web/JsonParser.php
@@ -15,7 +15,7 @@ use yii\helpers\Json;
  *
  * To enable parsing for JSON requests you can configure [[Request::parsers]] using this class:
  *
- * ```php
+ * ```
  * 'request' => [
  *     'parsers' => [
  *         'application/json' => 'yii\web\JsonParser',

--- a/framework/web/JsonResponseFormatter.php
+++ b/framework/web/JsonResponseFormatter.php
@@ -19,7 +19,7 @@ use yii\helpers\Json;
  * To configure properties like [[encodeOptions]] or [[prettyPrint]], you can configure the `response`
  * application component like the following:
  *
- * ```php
+ * ```
  * 'response' => [
  *     // ...
  *     'formatters' => [

--- a/framework/web/Linkable.php
+++ b/framework/web/Linkable.php
@@ -25,7 +25,7 @@ interface Linkable
      *
      * For example,
      *
-     * ```php
+     * ```
      * [
      *     'self' => 'https://example.com/users/1',
      *     'friends' => [

--- a/framework/web/MultiFieldSession.php
+++ b/framework/web/MultiFieldSession.php
@@ -42,7 +42,7 @@ abstract class MultiFieldSession extends Session
      *
      * For example:
      *
-     * ```php
+     * ```
      * function ($fields) {
      *     return [
      *         'expireDate' => Yii::$app->formatter->asDate($fields['expire']),
@@ -64,7 +64,7 @@ abstract class MultiFieldSession extends Session
      *
      * For example:
      *
-     * ```php
+     * ```
      * function ($session) {
      *     return [
      *         'user_id' => Yii::$app->user->id,

--- a/framework/web/MultipartFormDataParser.php
+++ b/framework/web/MultipartFormDataParser.php
@@ -18,7 +18,7 @@ use yii\helpers\StringHelper;
  *
  * In order to enable this parser you should configure [[Request::parsers]] in the following way:
  *
- * ```php
+ * ```
  * return [
  *     'components' => [
  *         'request' => [
@@ -41,7 +41,7 @@ use yii\helpers\StringHelper;
  *
  * Usage example:
  *
- * ```php
+ * ```
  * use yii\web\UploadedFile;
  *
  * $restRequestData = Yii::$app->request->getBodyParams();

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -212,7 +212,7 @@ class Request extends \yii\base\Request
      * For example, to trust all headers listed in [[secureHeaders]] for IP addresses
      * in range `192.168.0.0-192.168.0.254` write the following:
      *
-     * ```php
+     * ```
      * [
      *     '192.168.0.0/24',
      * ]
@@ -1487,7 +1487,7 @@ class Request extends \yii\base\Request
      *
      * This is determined by the `Accept` HTTP header. For example,
      *
-     * ```php
+     * ```
      * $_SERVER['HTTP_ACCEPT'] = 'text/plain; q=0.5, application/json; version=1.0, application/xml; version=2.0;';
      * $types = $request->getAcceptableContentTypes();
      * print_r($types);
@@ -1587,7 +1587,7 @@ class Request extends \yii\base\Request
      * while the array values consisting of the corresponding quality scores and parameters. The acceptable
      * values with the highest quality scores will be returned first. For example,
      *
-     * ```php
+     * ```
      * $header = 'text/plain; q=0.5, application/json; version=1.0, application/xml; version=2.0;';
      * $accepts = $request->parseAcceptHeader($header);
      * print_r($accepts);
@@ -1721,7 +1721,7 @@ class Request extends \yii\base\Request
      *
      * Through the returned cookie collection, you may access a cookie using the following syntax:
      *
-     * ```php
+     * ```
      * $cookie = $request->cookies['name']
      * if ($cookie !== null) {
      *     $value = $cookie->value;

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -858,7 +858,7 @@ class Response extends \yii\base\Response
      * described above. Otherwise, you should write the following JavaScript code to
      * handle the redirection:
      *
-     * ```javascript
+     * ```
      * $document.ajaxComplete(function (event, xhr, settings) {
      *     var url = xhr && xhr.getResponseHeader('X-Redirect');
      *     if (url) {

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -28,7 +28,7 @@ use yii\helpers\Url;
  * You can modify its configuration by adding an array to your application config under `components`
  * as it is shown in the following example:
  *
- * ```php
+ * ```
  * 'response' => [
  *     'format' => yii\web\Response::FORMAT_JSON,
  *     'charset' => 'UTF-8',
@@ -495,7 +495,7 @@ class Response extends \yii\base\Response
      * The following is an example implementation of a controller action that allows requesting files from a directory
      * that is not accessible from web:
      *
-     * ```php
+     * ```
      * public function actionFile($filename)
      * {
      *     $storagePath = Yii::getAlias('@app/files');
@@ -748,7 +748,7 @@ class Response extends \yii\base\Response
      *
      * **Example**
      *
-     * ```php
+     * ```
      * Yii::$app->response->xSendFile('/home/user/Pictures/picture1.jpg');
      * ```
      *
@@ -838,14 +838,14 @@ class Response extends \yii\base\Response
      * This method adds a "Location" header to the current response. Note that it does not send out
      * the header until [[send()]] is called. In a controller action you may use this method as follows:
      *
-     * ```php
+     * ```
      * return Yii::$app->getResponse()->redirect($url);
      * ```
      *
      * In other places, if you want to send out the "Location" header immediately, you should use
      * the following code:
      *
-     * ```php
+     * ```
      * Yii::$app->getResponse()->redirect($url)->send();
      * return;
      * ```
@@ -933,7 +933,7 @@ class Response extends \yii\base\Response
      *
      * In a controller action you may use this method like this:
      *
-     * ```php
+     * ```
      * return Yii::$app->getResponse()->refresh();
      * ```
      *
@@ -953,7 +953,7 @@ class Response extends \yii\base\Response
      *
      * Through the returned cookie collection, you add or remove cookies as follows,
      *
-     * ```php
+     * ```
      * // add a cookie
      * $response->cookies->add(new Cookie([
      *     'name' => $name,

--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -22,7 +22,7 @@ use yii\base\InvalidConfigException;
  *
  * Session can be used like an array to set and get session data. For example,
  *
- * ```php
+ * ```
  * $session = new Session;
  * $session->open();
  * $value1 = $session['name1'];  // get session variable 'name1'
@@ -392,7 +392,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      * Starting with Yii 2.0.21 `sameSite` is also supported. It requires PHP version 7.3.0 or higher.
      * For security, an exception will be thrown if `sameSite` is set while using an unsupported version of PHP.
      * To use this feature across different PHP versions check the version first. E.g.
-     * ```php
+     * ```
      * [
      *     'sameSite' => PHP_VERSION_ID >= 70300 ? yii\web\Cookie::SAME_SITE_LAX : null,
      * ]
@@ -812,7 +812,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      *
      * You may use this method to display all the flash messages in a view file:
      *
-     * ```php
+     * ```
      * <?php
      * foreach (Yii::$app->session->getAllFlashes() as $key => $message) {
      *     echo '<div class="alert alert-' . $key . '">' . $message . '</div>';

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -23,7 +23,7 @@ use yii\helpers\Url;
  * You can modify its configuration by adding an array to your application config under `components`
  * as it is shown in the following example:
  *
- * ```php
+ * ```
  * 'urlManager' => [
  *     'enablePrettyUrl' => true,
  *     'rules' => [
@@ -86,7 +86,7 @@ class UrlManager extends Component
      *
      * Here is an example configuration for RESTful CRUD controller:
      *
-     * ```php
+     * ```
      * [
      *     'dashboard' => 'site/index',
      *
@@ -144,7 +144,7 @@ class UrlManager extends Component
      * If you wish to enable URL normalization, you should configure this property manually.
      * For example:
      *
-     * ```php
+     * ```
      * [
      *     'class' => 'yii\web\UrlNormalizer',
      *     'collapseSlashes' => true,
@@ -385,7 +385,7 @@ class UrlManager extends Component
      * if you want to specify additional query parameters for the URL being created. The
      * array format must be:
      *
-     * ```php
+     * ```
      * // generates: /index.php?r=site%2Findex&param1=value1&param2=value2
      * ['site/index', 'param1' => 'value1', 'param2' => 'value2']
      * ```
@@ -393,7 +393,7 @@ class UrlManager extends Component
      * If you want to create a URL with an anchor, you can use the array format with a `#` parameter.
      * For example,
      *
-     * ```php
+     * ```
      * // generates: /index.php?r=site%2Findex&param1=value1#name
      * ['site/index', 'param1' => 'value1', '#' => 'name']
      * ```

--- a/framework/web/UrlNormalizer.php
+++ b/framework/web/UrlNormalizer.php
@@ -57,7 +57,7 @@ class UrlNormalizer extends BaseObject
      * - `404` - [[NotFoundHttpException]] will be thrown
      * - `callable` - custom user callback, for example:
      *
-     *   ```php
+     *   ```
      *   function ($route, $normalizer) {
      *       // use custom action for redirections
      *       $route[1]['oldRoute'] = $route[0];

--- a/framework/web/UrlRule.php
+++ b/framework/web/UrlRule.php
@@ -17,7 +17,7 @@ use yii\base\InvalidConfigException;
  * To define your own URL parsing and creation logic you can extend from this class
  * and add it to [[UrlManager::rules]] like this:
  *
- * ```php
+ * ```
  * 'rules' => [
  *     ['class' => 'MyUrlRule', 'pattern' => '...', 'route' => 'site/index', ...],
  *     // ...

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -38,7 +38,7 @@ use yii\rbac\CheckAccessInterface;
  * You can modify its configuration by adding an array to your application config under `components`
  * as it is shown in the following example:
  *
- * ```php
+ * ```
  * 'user' => [
  *     'identityClass' => 'app\models\User', // User must implement the IdentityInterface
  *     'enableAutoLogin' => true,
@@ -92,7 +92,7 @@ class User extends Component
      * The first element of the array should be the route to the login action, and the rest of
      * the name-value pairs are GET parameters used to construct the login URL. For example,
      *
-     * ```php
+     * ```
      * ['site/login', 'ref' => 1]
      * ```
      *
@@ -430,7 +430,7 @@ class User extends Component
      * The first element of the array should be the route, and the rest of
      * the name-value pairs are GET parameters used to construct the URL. For example,
      *
-     * ```php
+     * ```
      * ['admin/index', 'ref' => 1]
      * ```
      */

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -24,7 +24,7 @@ use yii\helpers\Url;
  * You can modify its configuration by adding an array to your application config under `components`
  * as it is shown in the following example:
  *
- * ```php
+ * ```
  * 'view' => [
  *     'theme' => 'app\themes\MyTheme',
  *     'renderers' => [
@@ -364,7 +364,7 @@ class View extends \yii\base\View
      *
      * For example, a description meta tag can be added like the following:
      *
-     * ```php
+     * ```
      * $view->registerMetaTag([
      *     'name' => 'description',
      *     'content' => 'This website is about funny raccoons.'
@@ -391,7 +391,7 @@ class View extends \yii\base\View
      * Registers CSRF meta tags.
      * They are rendered dynamically to retrieve a new CSRF token for each request.
      *
-     * ```php
+     * ```
      * $view->registerCsrfMetaTags();
      * ```
      *
@@ -414,7 +414,7 @@ class View extends \yii\base\View
      * For example, a link tag for a custom [favicon](https://www.w3.org/2005/10/howto-favicon)
      * can be added like the following:
      *
-     * ```php
+     * ```
      * $view->registerLinkTag(['rel' => 'icon', 'type' => 'image/png', 'href' => '/myicon.png']);
      * ```
      *

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -194,7 +194,7 @@ class ActiveField extends Component
      * and use them as the content.
      * If a callable, it will be called to generate the content. The signature of the callable should be:
      *
-     * ```php
+     * ```
      * function ($field) {
      *     return $html;
      * }
@@ -757,7 +757,7 @@ class ActiveField extends Component
      * For example to use the [[MaskedInput]] widget to get some date input, you can use
      * the following code, assuming that `$form` is your [[ActiveForm]] instance:
      *
-     * ```php
+     * ```
      * $form->field($model, 'date')->widget(\yii\widgets\MaskedInput::class, [
      *     'mask' => '99/99/9999',
      * ]);

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -50,7 +50,7 @@ class ActiveForm extends Widget
      * will add new parameters instead of replacing existing ones.
      * You may set [[action]] explicitly to avoid this:
      *
-     * ```php
+     * ```
      * $form = ActiveForm::begin([
      *     'method' => 'get',
      *     'action' => ['controller/action'],
@@ -73,7 +73,7 @@ class ActiveForm extends Widget
      * This can be either a configuration array or an anonymous function returning a configuration array.
      * If the latter, the signature should be as follows:
      *
-     * ```php
+     * ```
      * function ($model, $attribute)
      * ```
      *
@@ -377,7 +377,7 @@ class ActiveForm extends Widget
      * For example, you may use the following code in a controller action to respond
      * to an AJAX validation request:
      *
-     * ```php
+     * ```
      * $model = new Post;
      * $model->load(Yii::$app->request->post());
      * if (Yii::$app->request->isAjax) {
@@ -390,7 +390,7 @@ class ActiveForm extends Widget
      * To validate multiple models, simply pass each model as a parameter to this method, like
      * the following:
      *
-     * ```php
+     * ```
      * ActiveForm::validate($model1, $model2, ...);
      * ```
      *
@@ -435,7 +435,7 @@ class ActiveForm extends Widget
      * For example, you may use the following code in a controller action to respond
      * to an AJAX validation request:
      *
-     * ```php
+     * ```
      * // ... load $models ...
      * if (Yii::$app->request->isAjax) {
      *     Yii::$app->response->format = Response::FORMAT_JSON;

--- a/framework/widgets/Block.php
+++ b/framework/widgets/Block.php
@@ -16,7 +16,7 @@ use yii\base\Widget;
  * [[\yii\base\View]] component contains two methods [[\yii\base\View::beginBlock()]] and [[\yii\base\View::endBlock()]].
  * The general idea is that you're defining block default in a view or layout:
  *
- * ```php
+ * ```
  * <?php $this->beginBlock('messages', true) ?>
  * Nothing.
  * <?php $this->endBlock() ?>
@@ -24,7 +24,7 @@ use yii\base\Widget;
  *
  * And then overriding default in sub-views:
  *
- * ```php
+ * ```
  * <?php $this->beginBlock('username') ?>
  * Umm... hello?
  * <?php $this->endBlock() ?>

--- a/framework/widgets/Breadcrumbs.php
+++ b/framework/widgets/Breadcrumbs.php
@@ -22,7 +22,7 @@ use yii\helpers\Html;
  *
  * To use Breadcrumbs, you need to configure its [[links]] property, which specifies the links to be displayed. For example,
  *
- * ```php
+ * ```
  * // $this is the view object currently being used
  * echo Breadcrumbs::widget([
  *     'itemTemplate' => "<li><i>{link}</i></li>\n", // template for all links
@@ -42,7 +42,7 @@ use yii\helpers\Html;
  * You can use a view parameter (e.g. `$this->params['breadcrumbs']`) to configure the links in different
  * views. In the layout view, you assign this view parameter to the [[links]] property like the following:
  *
- * ```php
+ * ```
  * // $this is the view object currently being used
  * echo Breadcrumbs::widget([
  *     'links' => isset($this->params['breadcrumbs']) ? $this->params['breadcrumbs'] : [],
@@ -79,7 +79,7 @@ class Breadcrumbs extends Widget
      * the widget will not render anything. Each array element represents a single link in the breadcrumbs
      * with the following structure:
      *
-     * ```php
+     * ```
      * [
      *     'label' => 'label of the link',  // required
      *     'url' => 'url of the link',      // optional, will be processed by Url::to()
@@ -94,7 +94,7 @@ class Breadcrumbs extends Widget
      * for the hyperlink tag. For example, the following link specification will generate a hyperlink
      * with CSS class `external`:
      *
-     * ```php
+     * ```
      * [
      *     'label' => 'demo',
      *     'url' => 'https://example.com',
@@ -104,7 +104,7 @@ class Breadcrumbs extends Widget
      *
      * Since version 2.0.3 each individual link can override global [[encodeLabels]] param like the following:
      *
-     * ```php
+     * ```
      * [
      *     'label' => '<strong>Hello!</strong>',
      *     'encode' => false,

--- a/framework/widgets/ContentDecorator.php
+++ b/framework/widgets/ContentDecorator.php
@@ -14,7 +14,7 @@ use yii\base\Widget;
  * ContentDecorator records all output between [[begin()]] and [[end()]] calls, passes it to the given view file
  * as `$content` and then echoes rendering result.
  *
- * ```php
+ * ```
  * <?php ContentDecorator::begin([
  *     'viewFile' => '@app/views/layouts/base.php',
  *     'params' => [],
@@ -29,7 +29,7 @@ use yii\base\Widget;
  * There are [[\yii\base\View::beginContent()]] and [[\yii\base\View::endContent()]] wrapper methods in the
  * [[\yii\base\View]] component to make syntax more friendly. In the view these could be used as follows:
  *
- * ```php
+ * ```
  * <?php $this->beginContent('@app/views/layouts/base.php') ?>
  *
  * some content here

--- a/framework/widgets/DetailView.php
+++ b/framework/widgets/DetailView.php
@@ -29,7 +29,7 @@ use yii\i18n\Formatter;
  *
  * A typical usage of DetailView is as follows:
  *
- * ```php
+ * ```
  * echo DetailView::widget([
  *     'model' => $model,
  *     'attributes' => [
@@ -76,7 +76,7 @@ class DetailView extends Widget
      *   according to the `format` option. Since version 2.0.11 it can be defined as closure with the following
      *   parameters:
      *
-     *   ```php
+     *   ```
      *   function ($model, $widget)
      *   ```
      *
@@ -96,7 +96,7 @@ class DetailView extends Widget
      * and `{value}` will be replaced with the label and the value of the corresponding attribute.
      * If a callback (e.g. an anonymous function), the signature must be as follows:
      *
-     * ```php
+     * ```
      * function ($attribute, $index, $widget)
      * ```
      *

--- a/framework/widgets/FragmentCache.php
+++ b/framework/widgets/FragmentCache.php
@@ -45,7 +45,7 @@ class FragmentCache extends Widget implements DynamicContentAwareInterface
      * This can be either a [[Dependency]] object or a configuration array for creating the dependency object.
      * For example,
      *
-     * ```php
+     * ```
      * [
      *     'class' => 'yii\caching\DbDependency',
      *     'sql' => 'SELECT MAX(updated_at) FROM post',
@@ -62,7 +62,7 @@ class FragmentCache extends Widget implements DynamicContentAwareInterface
      * The following variation setting will cause the content to be cached in different versions
      * according to the current application language:
      *
-     * ```php
+     * ```
      * [
      *     Yii::$app->language,
      * ]

--- a/framework/widgets/InputWidget.php
+++ b/framework/widgets/InputWidget.php
@@ -23,7 +23,7 @@ use yii\helpers\Html;
  * Classes extending from this widget can be used in an [[\yii\widgets\ActiveForm|ActiveForm]]
  * using the [[\yii\widgets\ActiveField::widget()|widget()]] method, for example like this:
  *
- * ```php
+ * ```
  * <?= $form->field($model, 'from_date')->widget('WidgetClassName', [
  *     // configure additional widget properties here
  * ]) ?>

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -84,7 +84,7 @@ class LinkPager extends Widget
      * @var array the options for the disabled tag to be generated inside the disabled list element.
      * In order to customize the html tag, please use the tag key.
      *
-     * ```php
+     * ```
      * $disabledListItemSubTagOptions = ['tag' => 'div', 'class' => 'disabled-div'];
      * ```
      * @since 2.0.11

--- a/framework/widgets/ListView.php
+++ b/framework/widgets/ListView.php
@@ -33,7 +33,7 @@ class ListView extends BaseListView
      *
      * If this property is specified as an anonymous function, it should have the following signature:
      *
-     * ```php
+     * ```
      * function ($model, $key, $index, $widget)
      * ```
      *
@@ -54,7 +54,7 @@ class ListView extends BaseListView
      *
      * If this property is specified as a callback, it should have the following signature:
      *
-     * ```php
+     * ```
      * function ($model, $key, $index, $widget)
      * ```
      */
@@ -78,7 +78,7 @@ class ListView extends BaseListView
      * @var Closure an anonymous function that is called once BEFORE rendering each data model.
      * It should have the following signature:
      *
-     * ```php
+     * ```
      * function ($model, $key, $index, $widget)
      * ```
      *

--- a/framework/widgets/MaskedInput.php
+++ b/framework/widgets/MaskedInput.php
@@ -21,7 +21,7 @@ use yii\web\View;
  * To use MaskedInput, you must set the [[mask]] property. The following example
  * shows how to use MaskedInput to collect phone numbers:
  *
- * ```php
+ * ```
  * echo MaskedInput::widget([
  *     'name' => 'phone',
  *     'mask' => '999-999-9999',
@@ -31,7 +31,7 @@ use yii\web\View;
  * You can also use this widget in an [[ActiveForm]] using the [[ActiveField::widget()|widget()]]
  * method, for example like this:
  *
- * ```php
+ * ```
  * <?= $form->field($model, 'from_date')->widget(\yii\widgets\MaskedInput::class, [
  *     'mask' => '999-999-9999',
  * ]) ?>

--- a/framework/widgets/Menu.php
+++ b/framework/widgets/Menu.php
@@ -28,7 +28,7 @@ use yii\helpers\Url;
  *
  * The following example shows how to use Menu:
  *
- * ```php
+ * ```
  * echo Menu::widget([
  *     'items' => [
  *         // Important: you need to specify url as 'controller/action',

--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -31,7 +31,7 @@ use yii\web\Response;
  * The following example shows how to use Pjax with the [[\yii\grid\GridView]] widget so that the grid pagination,
  * sorting and filtering can be done via pjax:
  *
- * ```php
+ * ```
  * use yii\widgets\Pjax;
  *
  * Pjax::begin();

--- a/framework/widgets/Spaceless.php
+++ b/framework/widgets/Spaceless.php
@@ -30,7 +30,7 @@ use yii\base\Widget;
  *
  * This example will generate the following HTML:
  *
- * ```html
+ * ```
  * <body>
  *     <div class="nav-bar"><!-- tags --></div><div class="content"><!-- tags --></div></body>
  * ```

--- a/framework/widgets/Spaceless.php
+++ b/framework/widgets/Spaceless.php
@@ -15,7 +15,7 @@ use yii\base\Widget;
  *
  * Usage example:
  *
- * ```php
+ * ```
  * <body>
  *     <?php Spaceless::begin(); ?>
  *         <div class="nav-bar">

--- a/tests/data/config-docker.php
+++ b/tests/data/config-docker.php
@@ -13,7 +13,7 @@
  * For example to change MySQL username and password your `config.local.php` should
  * contain the following:
  *
- * ```php
+ * ```
  * <?php
  * $config['databases']['mysql']['username'] = 'yiitest';
  * $config['databases']['mysql']['password'] = 'changeme';

--- a/tests/data/config.php
+++ b/tests/data/config.php
@@ -12,7 +12,7 @@
  * and manipulate the `$config` variable.
  * For example to change MySQL username and password your `config.local.php` should
  * contain the following:
- * ```php
+ * ```
  * <?php
  * $config['databases']['mysql']['username'] = 'yiitest';
  * $config['databases']['mysql']['password'] = 'changeme';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

Yesterday, @rob006 found out that PHPStorm's code examples don't always display correctly (https://github.com/yiisoft/yii2/pull/20510#discussion_r2321216298).
<img width="1075" height="754" alt="image" src="https://github.com/user-attachments/assets/5c75da16-d2cb-460a-b853-321135f51844" />

VS Code displays the code correctly in both cases.
<img width="1101" height="385" alt="image" src="https://github.com/user-attachments/assets/0a30c271-83f1-44f4-8416-7d9a2b12dda9" />
<img width="1037" height="372" alt="image" src="https://github.com/user-attachments/assets/c6bd12ed-b392-4c64-a4c3-7c431cd5acfb" />

This seems to be a PhpStorm issue, but I think it can be fixed here without breaking the code examples in other IDEs. I suggest removing the `php` in the code examples to fix this for PHPStorm. This shouldn't break the documentation, as it has automatic language detection.
https://github.com/yiisoft/yii2-apidoc/blob/5fede3df2de288ce7c0b035cb8fc48d2a6b73b1a/helpers/MarkdownHighlightTrait.php#L39
For example: https://github.com/yiisoft/yii2/pull/20510#discussion_r2321248723

