### PR TITLE
Add `@property` annotations for `yii\console\Controller`

### DIFF
--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -10,7 +10,7 @@ namespace yii\build\controllers;
 use Yii;
 use yii\base\Model;
 use yii\base\Module;
-use yii\console\Controller;
+use yii\console\Controller as ConsoleController;
 use yii\db\QueryBuilder;
 use yii\helpers\Console;
 use yii\helpers\FileHelper;
@@ -27,7 +27,7 @@ use yii\web\Request as WebRequest;
  * @author Alexander Makarov <sam@rmcreative.ru>
  * @since 2.0
  */
-class PhpDocController extends Controller
+class PhpDocController extends ConsoleController
 {
     /**
      * Manually added PHPDoc properties that do not need to be removed or changed.
@@ -39,6 +39,10 @@ class PhpDocController extends Controller
             'request',
             'response',
             'view',
+        ],
+        ConsoleController::class => [
+            'request',
+            'response',
         ],
         Model::class => [
             'errors',

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -24,6 +24,8 @@ Yii Framework 2 Change Log
 - Bug #20485: Fix error `Cannot unset string offsets` in `yii\di\Instance:ensure(['__class' => ...], 'some\class\name')` (max-s-lab)
 - Enh #20505: `ArrayDataProvider` key handling with flexible path support (fetus-hina)
 - Bug #20508: Fix PHPDoc, add PHPStan/Psalm annotations for `yii\web\CookieCollection::getIterator`. Add missing `@property` annotation in `yii\base\Model` (max-s-lab)
+- Enh #20514: Add `@property` annotations for `yii\console\Controller` (max-s-lab)
+
 
 2.0.53 June 27, 2025
 --------------------

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -28,6 +28,8 @@ use yii\helpers\Inflector;
  * where `<route>` is a route to a controller action and the params will be populated as properties of a command.
  * See [[options()]] for details.
  *
+ * @property Request $request The request object.
+ * @property Response $response The response object.
  * @property-read string $help The help information for this controller.
  * @property-read string $helpSummary The one-line short summary describing this controller.
  * @property-read array $passedOptionValues The properties corresponding to the passed options.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

In `yii\web\Controller`, more specific types are specified for `$request` and `$response`. I think it would be great to do this here as well.

https://github.com/yiisoft/yii2/blob/aa04f38581fd8fbc727e6379a83ed608478adc66/framework/web/Controller.php#L21-L22