### PR TITLE
Fix `@var` annotation in `ActiveRecordTestTrait`

### DIFF
--- a/tests/framework/ar/ActiveRecordTestTrait.php
+++ b/tests/framework/ar/ActiveRecordTestTrait.php
@@ -1297,7 +1297,7 @@ trait ActiveRecordTestTrait
         /** @var ActiveRecordInterface $orderClass */
         $orderClass = $this->getOrderClass();
 
-        /* @var Order $order */
+        /** @var Order $order */
         $order = $orderClass::findOne(2);
 
         $expensiveItems = $order->expensiveItemsUsingViaWithCallable;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

The IDE treats this as a comment rather than a PHPDoc block. 

#### Before changes

<img width="705" height="192" alt="image" src="https://github.com/user-attachments/assets/f81956d8-cfc1-420b-b9d4-624d17f2555c" />

#### After changes

<img width="692" height="148" alt="image" src="https://github.com/user-attachments/assets/3c800c3f-9186-4c47-b447-bcac9230eb84" />

