### PR TITLE
Fix notice "Object of class DateTimeImmutable could not be converted to int" in `CookieCollection::has`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -31,6 +31,7 @@ Yii Framework 2 Change Log
 - Bug #19506: Fix `@property` annotations in `yii\console\widgets\Table`, `yii\di\Container` and `yii\web\Session` (max-s-lab)
 - Enh #20525: Add `@template` annotations for all actions (max-s-lab)
 - Bug #20524: Fix PHPStan/Psalm annotations in `Yii::createObject` (max-s-lab)
+- Bug #20530: Fix notice "Object of class DateTimeImmutable could not be converted to int" in `CookieCollection::has` (max-s-lab)
 
 
 2.0.53 June 27, 2025

--- a/framework/web/CookieCollection.php
+++ b/framework/web/CookieCollection.php
@@ -132,7 +132,7 @@ class CookieCollection extends BaseObject implements \IteratorAggregate, \ArrayA
             return (int) $expire >= $currentTime;
         }
 
-        if (is_string($expire)){
+        if (is_string($expire)) {
             return strtotime($expire) >= $currentTime;
         }
 

--- a/framework/web/CookieCollection.php
+++ b/framework/web/CookieCollection.php
@@ -116,19 +116,27 @@ class CookieCollection extends BaseObject implements \IteratorAggregate, \ArrayA
      */
     public function has($name)
     {
-        return isset($this->_cookies[$name]) && $this->_cookies[$name]->value !== ''
-            && ($this->_cookies[$name]->expire === null
-                || $this->_cookies[$name]->expire === 0
-                || (
-                    (is_string($this->_cookies[$name]->expire) && strtotime($this->_cookies[$name]->expire) >= time())
-                    || (
-                        interface_exists('\\DateTimeInterface')
-                        && $this->_cookies[$name]->expire instanceof \DateTimeInterface
-                        && $this->_cookies[$name]->expire->getTimestamp() >= time()
-                    )
-                    || $this->_cookies[$name]->expire >= time()
-                )
-            );
+        if (!isset($this->_cookies[$name]) || $this->_cookies[$name]->value === '') {
+            return false;
+        }
+
+        $expire = $this->_cookies[$name]->expire;
+
+        if ($expire === null || $expire === 0) {
+            return true;
+        }
+
+        $currentTime = time();
+
+        if (is_numeric($expire)) {
+            return (int) $expire >= $currentTime;
+        }
+
+        if (is_string($expire)){
+            return strtotime($expire) >= $currentTime;
+        }
+
+        return $expire->getTimestamp() >= $currentTime;
     }
 
     /**

--- a/tests/framework/web/CookieCollectionTest.php
+++ b/tests/framework/web/CookieCollectionTest.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\web;
+
+use DateTime;
+use DateTimeImmutable;
+use yii\web\Cookie;
+use yii\web\CookieCollection;
+use yiiunit\TestCase;
+
+/**
+ * @group web
+ */
+class CookieCollectionTest extends TestCase
+{
+    /**
+     * @dataProvider provideHasData
+     */
+    public function testHas(string $name, array $cookies, bool $expectedResult): void
+    {
+        $cookieCollection = new CookieCollection($cookies);
+        $result = $cookieCollection->has($name);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public static function provideHasData(): array
+    {
+        $pastTime = time() - 100;
+        $futureTime = time() + 100;
+
+        return [
+            [
+                'test',
+                [],
+                false,
+            ],
+            [
+                'test',
+                [
+                    'abc' => new Cookie([
+                        'value' => 'abc',
+                    ]),
+                ],
+                false,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie(),
+                ],
+                false,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                        'expire' => null,
+                    ]),
+                ],
+                true,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                    ]),
+                ],
+                true,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                    ]),
+                ],
+                true,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                        'expire' => (string) $futureTime,
+                    ]),
+                ],
+                true,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                        'expire' => (string) $pastTime,
+                    ]),
+                ],
+                false,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                        'expire' => $futureTime,
+                    ]),
+                ],
+                true,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                        'expire' => $pastTime,
+                    ]),
+                ],
+                false,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                        'expire' => date('Y-m-d H:i:s', $futureTime),
+                    ]),
+                ],
+                true,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                        'expire' => date('Y-m-d', $pastTime),
+                    ]),
+                ],
+                false,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                        'expire' => (new DateTimeImmutable())->setTimestamp($futureTime),
+                    ]),
+                ],
+                true,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                        'expire' => (new DateTimeImmutable())->setTimestamp($pastTime),
+                    ]),
+                ],
+                false,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                        'expire' => (new DateTime())->setTimestamp($futureTime),
+                    ]),
+                ],
+                true,
+            ],
+            [
+                'test',
+                [
+                    'test' => new Cookie([
+                        'value' => 'test',
+                        'expire' => (new DateTime())->setTimestamp($pastTime),
+                    ]),
+                ],
+                false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

Found this bug using PHPStan.

<img width="1217" height="130" alt="image" src="https://github.com/user-attachments/assets/0cfcf070-bfee-47ee-ad13-a58dd0e16d56" />

Then I wrote tests, and they confirmed the error.

<img width="1168" height="246" alt="image" src="https://github.com/user-attachments/assets/a83c4734-f730-48d1-badd-b1f4f1c3f4bc" />
