### PR TITLE
Handles situations with more complex ICU unit data structure

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,6 +3,7 @@ Yii Framework 2 Change Log
 
 2.0.60 under development
 ------------------------
+- Bug #20542: Fix `Formatter` working with more complex ICU unit data structure (OndrejVasicek)
 - Bug #20483: Fix `CompositeAuth` making bad assumptions on `AuthInterface` implementations (sammousa)
 - Bug #20432: Fix PHPStan/Psalm annotations for `ActiveQuery::asArray` (max-s-lab)
 - Bug #20437: Fix PHPStan/Psalm annotations for `BaseArrayHelper::merge` (max-s-lab)

--- a/framework/i18n/Formatter.php
+++ b/framework/i18n/Formatter.php
@@ -1679,7 +1679,7 @@ class Formatter extends Component
 
         $message = [];
         foreach ($unitBundle as $key => $value) {
-            if ($key === 'dnam') {
+            if ($key === 'dnam' || $key === 'case') {
                 continue;
             }
             $message[] = "$key{{$value}}";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

It turned out that the ICU unit data in version 7.1+ (at least this is what I found in PHP 8.2, where the ICU libraries are version 7.1) have a more complex structure for some locales (in my case cs_CZ).
Because of this, the current code attempts to traverse and use a structure that it’s not prepared to handle.

You can see an example here: https://intl.rmcreative.ru/
For English data: https://intl.rmcreative.ru/unit-data/en
Check the "mass - gram" branch. The structure is simple:
```
[
            'dnam' => 'grams'
            'one' => '{0} gram'
            'other' => '{0} grams'
            'per' => '{0} per gram'
 ]
```

But for cs_CZ: https://intl.rmcreative.ru/unit-data/cs_CZ The structure is significantly more complex:
```
[
            'case' => [
                'accusative' => [
                    'few' => '{0} gramy'
                    'many' => '{0} gramu'
                    'one' => '{0} gram'
                    'other' => '{0} gramů'
                ]
                'dative' => [
                    'few' => '{0} gramům'
                    'many' => '{0} gramu'
                    'one' => '{0} gramu'
                    'other' => '{0} gramům'
                ]
                'genitive' => [
                    'few' => '{0} gramů'
                    'many' => '{0} gramu'
                    'one' => '{0} gramu'
                    'other' => '{0} gramů'
                ]
                'instrumental' => [
                    'few' => '{0} gramy'
                    'many' => '{0} gramu'
                    'one' => '{0} gramem'
                    'other' => '{0} gramy'
                ]
                'locative' => [
                    'few' => '{0} gramech'
                    'many' => '{0} gramu'
                    'one' => '{0} gramu'
                    'other' => '{0} gramech'
                ]
            ]
            'dnam' => 'gramy'
            'few' => '{0} gramy'
            'gender' => 'inanimate'
            'many' => '{0} gramu'
            'one' => '{0} gram'
            'other' => '{0} gramů'
            'per' => '{0} na gram'
]
```

There is an additional nested array (case) that the current formatter cannot handle and therefore needs to skip.

My solution is not ideal — it’s a quick fix for my specific case. It’s not future-proof, and it may break again in the future just like the original code did.
And I haven’t even started exploring what surprises other languages might contain.
