### PR TITLE
`PHP` `8.4` fixes for implicit nullability deprecation.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -26,6 +26,7 @@ Yii Framework 2 Change Log
 - Chg #20464: Remove `PHP_VERSION_ID` checks from web `Response` class (terabytesoftw)
 - Enh #20511: Allow `jQuery` usage in `View` class while maintaining backward compatibility (terabytesoftw)
 - Bug #20518: `PHP` 8.4 fixes for implicit nullability deprecation (terabytesoftw)
+- Bug #20547: `PHP` 8.4 fixes for implicit nullability deprecation (terabytesoftw)
 
 2.0.54 under development
 ------------------------

--- a/tests/framework/behaviors/AttributesBehaviorTest.php
+++ b/tests/framework/behaviors/AttributesBehaviorTest.php
@@ -105,7 +105,7 @@ class AttributesBehaviorTest extends TestCase
         string $aliasExpected,
         bool $preserveNonEmptyValues,
         string $name,
-        string $alias = null
+        string|null $alias = null
     ): void {
         $model = new ActiveRecordWithAttributesBehavior();
         $model->attributesBehavior->preserveNonEmptyValues = $preserveNonEmptyValues;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
