### PR TITLE
Fix `PHP` `8.5` `null` array offset deprecation warnings.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -35,6 +35,7 @@ Yii Framework 2 Change Log
 - Bug #19655: Fix `LinkPager::getPageRange` when `maxButtons` is 2 (max-s-lab)
 - Enh #20539: Update minimum PHP version requirement from `7.3` to `7.4` (terabytesoftw)
 - Bug #20541: Remove deprecated caching components: `XCache` and `ZendDataCache`, and update related tests and documentation (terabytesoftw)
+- Bug #20548: Fix PHP `8.5` `null` array offset deprecation warnings (terabytesoftw)
 
 
 2.0.53 June 27, 2025

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -835,7 +835,8 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
             throw new StaleObjectException('The object being updated is outdated.');
         }
 
-        if (isset($values[$lock])) {
+        // using null as an array offset is deprecated in PHP `8.5`
+        if ($lock !== null && isset($values[$lock])) {
             $this->$lock = $values[$lock];
         }
 

--- a/framework/rbac/PhpManager.php
+++ b/framework/rbac/PhpManager.php
@@ -112,7 +112,12 @@ class PhpManager extends BaseManager
      */
     public function getAssignments($userId)
     {
-        return isset($this->assignments[$userId]) ? $this->assignments[$userId] : [];
+        // using null as an array offset is deprecated in PHP `8.5`
+        if ($userId !== null && isset($this->assignments[$userId])) {
+            return $this->assignments[$userId];
+        }
+
+        return [];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
