### PR TITLE
Remove unused imports

### DIFF
--- a/framework/caching/DbDependency.php
+++ b/framework/caching/DbDependency.php
@@ -7,7 +7,6 @@
 
 namespace yii\caching;
 
-use Yii;
 use yii\base\InvalidConfigException;
 use yii\db\Connection;
 use yii\di\Instance;

--- a/framework/captcha/Captcha.php
+++ b/framework/captcha/Captcha.php
@@ -7,7 +7,6 @@
 
 namespace yii\captcha;
 
-use Yii;
 use yii\base\InvalidConfigException;
 use yii\helpers\Html;
 use yii\helpers\Json;

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -8,7 +8,6 @@
 namespace yii\db\mysql;
 
 use yii\base\InvalidArgumentException;
-use yii\base\NotSupportedException;
 use yii\caching\CacheInterface;
 use yii\caching\DbCache;
 use yii\db\Exception;

--- a/framework/widgets/InputWidget.php
+++ b/framework/widgets/InputWidget.php
@@ -7,7 +7,6 @@
 
 namespace yii\widgets;
 
-use Yii;
 use yii\base\InvalidConfigException;
 use yii\base\Model;
 use yii\base\Widget;

--- a/framework/widgets/LinkPager.php
+++ b/framework/widgets/LinkPager.php
@@ -7,7 +7,6 @@
 
 namespace yii\widgets;
 
-use Yii;
 use yii\base\InvalidConfigException;
 use yii\base\Widget;
 use yii\data\Pagination;

--- a/framework/widgets/LinkSorter.php
+++ b/framework/widgets/LinkSorter.php
@@ -7,7 +7,6 @@
 
 namespace yii\widgets;
 
-use Yii;
 use yii\base\InvalidConfigException;
 use yii\base\Widget;
 use yii\data\Sort;

--- a/tests/framework/behaviors/BlameableBehaviorConsoleTest.php
+++ b/tests/framework/behaviors/BlameableBehaviorConsoleTest.php
@@ -8,10 +8,8 @@
 namespace yiiunit\framework\behaviors;
 
 use Yii;
-use yii\base\BaseObject;
 use yii\behaviors\BlameableBehavior;
 use yii\db\ActiveRecord;
-use yii\db\BaseActiveRecord;
 use yiiunit\TestCase;
 
 /**

--- a/tests/framework/behaviors/OptimisticLockBehaviorTest.php
+++ b/tests/framework/behaviors/OptimisticLockBehaviorTest.php
@@ -12,8 +12,6 @@ use yii\behaviors\OptimisticLockBehavior;
 use yii\web\Request;
 use yii\db\ActiveRecord;
 use yii\db\Connection;
-use yii\db\Expression;
-use yii\db\ExpressionInterface;
 use yiiunit\TestCase;
 
 /**

--- a/tests/framework/console/FakeHelpControllerWithoutOutput.php
+++ b/tests/framework/console/FakeHelpControllerWithoutOutput.php
@@ -8,7 +8,6 @@
 namespace yiiunit\framework\console;
 
 use yii\console\controllers\HelpController;
-use yii\helpers\Console;
 
 class FakeHelpControllerWithoutOutput extends HelpController
 {

--- a/tests/framework/db/ConnectionTest.php
+++ b/tests/framework/db/ConnectionTest.php
@@ -11,7 +11,6 @@ use Yii;
 use yii\base\InvalidConfigException;
 use yii\caching\ArrayCache;
 use yii\db\conditions\AndCondition;
-use yii\db\conditions\ExistsConditionBuilder;
 use yii\db\conditions\OrCondition;
 use yii\db\Connection;
 use yii\db\Transaction;

--- a/tests/framework/db/oci/ActiveRecordTest.php
+++ b/tests/framework/db/oci/ActiveRecordTest.php
@@ -8,9 +8,7 @@
 namespace yiiunit\framework\db\oci;
 
 use yii\db\ActiveQuery;
-use yii\db\Expression;
 use yiiunit\data\ar\BitValues;
-use yiiunit\data\ar\Customer;
 use yiiunit\data\ar\DefaultPk;
 use yiiunit\data\ar\DefaultMultiplePk;
 use yiiunit\data\ar\Order;

--- a/tests/framework/db/oci/UniqueValidatorTest.php
+++ b/tests/framework/db/oci/UniqueValidatorTest.php
@@ -9,7 +9,6 @@ namespace yiiunit\framework\db\oci;
 
 use yii\validators\UniqueValidator;
 use yiiunit\data\validators\models\ValidatorTestMainModel;
-use yiiunit\data\validators\models\ValidatorTestRefModel;
 
 /**
  * @group db

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -7,7 +7,6 @@
 
 namespace yiiunit\framework\db\pgsql;
 
-use yii\db\conditions\ExistsConditionBuilder;
 use yii\db\Expression;
 use yiiunit\data\ar\ActiveRecord;
 use yiiunit\data\ar\EnumTypeInCustomSchema;

--- a/tests/framework/helpers/FileHelperTest.php
+++ b/tests/framework/helpers/FileHelperTest.php
@@ -6,7 +6,6 @@
  */
 
 use yii\helpers\FileHelper;
-use yii\helpers\VarDumper;
 use yiiunit\TestCase;
 
 /**

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -7,7 +7,6 @@
 
 namespace yiiunit\framework\rbac;
 
-use yii\base\InvalidParamException;
 use yii\rbac\BaseManager;
 use yii\rbac\Item;
 use yii\rbac\Permission;

--- a/tests/framework/web/UploadedFileTest.php
+++ b/tests/framework/web/UploadedFileTest.php
@@ -7,9 +7,7 @@
 
 namespace yiiunit\framework\web;
 
-use Yii;
 use yii\web\UploadedFile;
-use yiiunit\framework\web\mocks\UploadedFileMock;
 use yiiunit\framework\web\stubs\ModelStub;
 use yiiunit\framework\web\stubs\VendorImage;
 use yiiunit\TestCase;

--- a/tests/framework/widgets/BreadcrumbsTest.php
+++ b/tests/framework/widgets/BreadcrumbsTest.php
@@ -7,7 +7,6 @@
 
 namespace yiiunit\framework\widgets;
 
-use Yii;
 use yii\widgets\Breadcrumbs;
 
 /**

--- a/tests/framework/widgets/MenuTest.php
+++ b/tests/framework/widgets/MenuTest.php
@@ -7,7 +7,6 @@
 
 namespace yiiunit\framework\widgets;
 
-use Yii;
 use yii\widgets\Menu;
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

I ran `php-cs-fixer` with the `no_unused_imports` rule on the `build`, `framework`, and `tests` folders