### PR TITLE
Update default `additional-args` for PHPUnit to include JUnit logging for codecov tests in `build.yml` workflow.

### DIFF
--- a/.github/actions/phpunit/action.yml
+++ b/.github/actions/phpunit/action.yml
@@ -5,7 +5,7 @@ description: Run PHPUnit tests with coverage and configurable options.
 inputs:
   additional-args:
     description: Additional PHPUnit arguments.
-    default: "--verbose"
+    default: "--log-junit junit.xml --verbose"
     required: false
     type: string
   configuration:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
