### PR TITLE
Update PHPDoc for numeric type conversion and value conversion providers in `CompareValidatorProvider::class`.

### DIFF
--- a/tests/framework/validators/CompareValidatorTest.php
+++ b/tests/framework/validators/CompareValidatorTest.php
@@ -66,7 +66,10 @@ class CompareValidatorTest extends TestCase
         }
     }
 
-    protected function getOperationTestData($value)
+    /**
+     * @phpstan-return array<string, array<int, array{mixed, bool}>>
+     */
+    protected function getOperationTestData(int $value): array
     {
         return [
             '===' => [
@@ -202,7 +205,10 @@ class CompareValidatorTest extends TestCase
         }
     }
 
-    protected function getTestDataForMessages()
+    /**
+     * @phpstan-return array<array-key, array{string, string, int|string, string, string}>
+     */
+    protected function getTestDataForMessages(): array
     {
         return [
             ['attr1', '==', 2, 'attr1 must be equal to "2".', 'compareValue'],
@@ -259,6 +265,8 @@ class CompareValidatorTest extends TestCase
 
     /**
      * @dataProvider \yiiunit\framework\validators\providers\CompareValidatorProvider::numericTypeConversionProvider
+     *
+     * @phpstan-param array<string, mixed> $validatorConfig
      */
     public function testValidateAttributeWithNumericTypeConversion(
         array $validatorConfig,

--- a/tests/framework/validators/providers/CompareValidatorProvider.php
+++ b/tests/framework/validators/providers/CompareValidatorProvider.php
@@ -28,7 +28,7 @@ final class CompareValidatorProvider
      *
      * @return array test data for numeric type conversion and comparison.
      *
-     * @phpstan-return array<string, array{array<string, mixed>, int|string, bool, string}>
+     * @phpstan-return array<string, array{array<string, mixed>, int|string, string|null, bool, string}>
      */
     public static function numericTypeConversionProvider(): array
     {

--- a/tests/framework/validators/providers/CompareValidatorProvider.php
+++ b/tests/framework/validators/providers/CompareValidatorProvider.php
@@ -28,7 +28,7 @@ final class CompareValidatorProvider
      *
      * @return array test data for numeric type conversion and comparison.
      *
-     * @phpstan-return array<string, array{array<string, mixed>, mixed, mixed, bool, string}>
+     * @phpstan-return array<string, array{array<string, mixed>, int|string, bool, string}>
      */
     public static function numericTypeConversionProvider(): array
     {
@@ -167,7 +167,7 @@ final class CompareValidatorProvider
      *
      * @return array test data for numeric value conversion and comparison.
      *
-     * @phpstan-return array<string, array{array<string, mixed>, mixed, bool, string}>
+     * @phpstan-return array<string, array{array<string, mixed>, float|int|string, bool, string}>
      */
     public static function numericValueConversionProvider(): array
     {

--- a/tests/framework/validators/providers/CompareValidatorProvider.php
+++ b/tests/framework/validators/providers/CompareValidatorProvider.php
@@ -12,8 +12,24 @@ namespace yiiunit\framework\validators\providers;
 
 use yii\validators\CompareValidator;
 
+/**
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ *
+ * @since 2.2.0
+ */
 final class CompareValidatorProvider
 {
+    /**
+     * Provides test cases for numeric type conversion and comparison.
+     *
+     * This provider supplies scenarios for validating numeric comparisons, including type coercion between strings,
+     * integers, and floats, strict and loose operators, closure-based compare values, and edge cases such as zero and
+     * negative numbers. It ensures that CompareValidator correctly handles numeric type conversion and operator logic.
+     *
+     * @return array test data for numeric type conversion and comparison.
+     *
+     * @phpstan-return array<string, array{array<string, mixed>, mixed, mixed, bool, string}>
+     */
     public static function numericTypeConversionProvider(): array
     {
         return [
@@ -141,6 +157,18 @@ final class CompareValidatorProvider
         ];
     }
 
+    /**
+     * Provides test cases for numeric value conversion and comparison.
+     *
+     * This data provider covers scenarios involving numeric type coercion, strict and loose comparison operators,
+     * closure-based compare values, string-to-float conversion, negative numbers, zero, and edge cases for
+     * CompareValidator with TYPE_NUMBER. It ensures that numeric values are properly converted and compared according
+     * to the specified operator, including strict equality, inequality, and relational operators.
+     *
+     * @return array test data for numeric value conversion and comparison.
+     *
+     * @phpstan-return array<string, array{array<string, mixed>, mixed, bool, string}>
+     */
     public static function numericValueConversionProvider(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
