### PR TITLE
Fix `@var` annotation for `UrlManager::$cache`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -39,6 +39,7 @@ Yii Framework 2 Change Log
 - Bug #20541: Remove deprecated caching components: `XCache` and `ZendDataCache`, and update related tests and documentation (terabytesoftw)
 - Bug #20548: Fix PHP `8.5` `null` array offset deprecation warnings (terabytesoftw)
 - Enh #19526: Add the `convertIniSizeToBytes` method to `BaseStringHelper` (max-s-lab)
+- Bug #20570: Fix `@var` annotation for `UrlManager::$cache` (max-s-lab)
 
 
 2.0.53 June 27, 2025

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -119,7 +119,7 @@ class UrlManager extends Component
      */
     public $routeParam = 'r';
     /**
-     * @var CacheInterface|array|string|bool the cache object or the application component ID of the cache object.
+     * @var CacheInterface|array|string|bool|null the cache object or the application component ID of the cache object.
      * This can also be an array that is used to create a [[CacheInterface]] instance in case you do not want to use
      * an application component.
      * Compiled URL rules will be cached through this cache object, if it is available.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="1099" height="153" alt="image" src="https://github.com/user-attachments/assets/bdf1bfe2-c96b-4826-93b0-1abd6133dc5e" />

https://github.com/yiisoft/yii2/blob/a4bacdd913ed042141717b00d5399c1e540361ba/framework/web/UrlManager.php#L129
