### PR TITLE
Fix PHPDoc annotations in `yii\web\Response`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -39,6 +39,7 @@ Yii Framework 2 Change Log
 - Bug #20541: Remove deprecated caching components: `XCache` and `ZendDataCache`, and update related tests and documentation (terabytesoftw)
 - Bug #20548: Fix PHP `8.5` `null` array offset deprecation warnings (terabytesoftw)
 - Enh #19526: Add the `convertIniSizeToBytes` method to `BaseStringHelper` (max-s-lab)
+- Bug #20571: Fix `@var` annotation for `yii\web\Response::$stream` (max-s-lab)
 
 
 2.0.53 June 27, 2025

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -134,7 +134,7 @@ class Response extends \yii\base\Response
      */
     public $content;
     /**
-     * @var resource|array|callable the stream to be sent. This can be a stream handle or an array of stream handle,
+     * @var resource|array|callable|null the stream to be sent. This can be a stream handle or an array of stream handle,
      * the begin position and the end position. Alternatively it can be set to a callable, which returns
      * (or [yields](https://www.php.net/manual/en/language.generators.syntax.php)) an array of strings that should
      * be echoed and flushed out one by one.
@@ -239,7 +239,7 @@ class Response extends \yii\base\Response
      */
     private $_statusCode = 200;
     /**
-     * @var HeaderCollection
+     * @var HeaderCollection|null
      */
     private $_headers;
 
@@ -946,6 +946,9 @@ class Response extends \yii\base\Response
         return $this->redirect(Yii::$app->getRequest()->getUrl() . $anchor);
     }
 
+    /**
+     * @var CookieCollection|null
+     */
     private $_cookies;
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="978" height="209" alt="image" src="https://github.com/user-attachments/assets/f3101e6f-f362-40a8-b2ba-2a28cbffb84c" />
