### PR TITLE
Fix `checkbox`/`radio` label rendering when `enclosedByLabel` is `false` and raise code coverage `100%` in `ActiveField::class`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -28,6 +28,7 @@ Yii Framework 2 Change Log
 - Bug #20518: `PHP` 8.4 fixes for implicit nullability deprecation (terabytesoftw)
 - Enh #20537: Enhance `label()` method in `ActiveField` with `tag` option and fix `labelOptions` for `checkbox`/`radio` (terabytesoftw)
 - Bug #20547: `PHP` 8.4 fixes for implicit nullability deprecation (terabytesoftw)
+- Bug #20573: Fix `checkbox`/`radio` label rendering when `enclosedByLabel` is `false` and raise code coverage `100%` in `ActiveField::class` (terabytesoftw)
 
 2.0.54 under development
 ------------------------

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -583,7 +583,7 @@ class ActiveField extends Component
         $this->adjustLabelFor($options);
 
         if ($enclosedByLabel) {
-            $this->template = str_replace("{label}\n", '', $this->template);
+            $this->parts['{label}'] = '';
         } else {
             $options = $this->generateLabel($options);
         }
@@ -638,7 +638,7 @@ class ActiveField extends Component
         $this->adjustLabelFor($options);
 
         if ($enclosedByLabel) {
-            $this->template = str_replace("{label}\n", '', $this->template);
+            $this->parts['{label}'] = '';
         } else {
             $options = $this->generateLabel($options);
         }
@@ -1003,7 +1003,7 @@ class ActiveField extends Component
     {
         if (isset($options['label'])) {
             if ($options['label'] === false) {
-                $this->template = str_replace("{label}\n", '', $this->template);
+                $this->parts['{label}'] = '';
             } elseif (($this->parts['{label}'] ?? '') === '') {
                 $tag = false;
 

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -170,13 +170,7 @@ class ActiveField extends Component
      */
     public function __toString()
     {
-        // __toString cannot throw exception
-        // use trigger_error to bypass this limitation
-        try {
-            return $this->render();
-        } catch (\Throwable $e) {
-            throw $e;
-        }
+        return $this->render();
     }
 
     /**
@@ -588,9 +582,11 @@ class ActiveField extends Component
         $this->addAriaAttributes($options);
         $this->adjustLabelFor($options);
 
-        $this->parts['{label}'] = '';
-
-        $options = $enclosedByLabel ? $options : $this->generateLabel($options);
+        if ($enclosedByLabel) {
+            $this->template = str_replace("{label}\n", '', $this->template);
+        } else {
+            $options = $this->generateLabel($options);
+        }
 
         $this->parts['{input}'] = Html::activeRadio($this->model, $this->attribute, $options);
 
@@ -641,9 +637,11 @@ class ActiveField extends Component
         $this->addAriaAttributes($options);
         $this->adjustLabelFor($options);
 
-        $this->parts['{label}'] = '';
-
-        $options = $enclosedByLabel ? $options : $this->generateLabel($options);
+        if ($enclosedByLabel) {
+            $this->template = str_replace("{label}\n", '', $this->template);
+        } else {
+            $options = $this->generateLabel($options);
+        }
 
         $this->parts['{input}'] = Html::activeCheckbox($this->model, $this->attribute, $options);
 
@@ -1003,27 +1001,31 @@ class ActiveField extends Component
      */
     protected function generateLabel(array $options): array
     {
-        if (isset($options['label']) && $options['label'] !== false && $this->parts['{label}'] === '') {
-            $tag = false;
+        if (isset($options['label'])) {
+            if ($options['label'] === false) {
+                $this->template = str_replace("{label}\n", '', $this->template);
+            } elseif (($this->parts['{label}'] ?? '') === '') {
+                $tag = false;
 
-            if (!empty($options['labelOptions'])) {
-                $tag = $options['labelOptions']['tag'] ?? 'label';
+                if (!empty($options['labelOptions'])) {
+                    $tag = $options['labelOptions']['tag'] ?? 'label';
 
-                unset($options['labelOptions']['tag']);
+                    unset($options['labelOptions']['tag']);
 
-                $this->labelOptions = array_merge($this->labelOptions, $options['labelOptions']);
-            }
+                    $this->labelOptions = array_merge($this->labelOptions, $options['labelOptions']);
+                }
 
-            if ($tag === false) {
-                $this->parts['{label}'] = $options['label'];
-            } elseif ($tag === 'label') {
-                $this->parts['{label}'] = Html::activeLabel(
-                    $this->model,
-                    $this->attribute,
-                    array_merge(['label' => $options['label']], $this->labelOptions),
-                );
-            } else {
-                $this->parts['{label}'] = Html::tag($tag, $options['label'], $this->labelOptions);
+                if ($tag === false) {
+                    $this->parts['{label}'] = $options['label'];
+                } elseif ($tag === 'label') {
+                    $this->parts['{label}'] = Html::activeLabel(
+                        $this->model,
+                        $this->attribute,
+                        array_merge(['label' => $options['label']], $this->labelOptions),
+                    );
+                } else {
+                    $this->parts['{label}'] = Html::tag($tag, $options['label'], $this->labelOptions);
+                }
             }
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -263,4 +263,12 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             Yii::$app->db->password = $database['password'] ?? null;
         }
     }
+
+    /**
+     * Normalizes HTML string by removing redundant blank lines.
+     */
+    protected function normalizeHTML(string $html): string
+    {
+        return preg_replace('/^\h*\n/m', '', trim($html));
+    }
 }

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -100,7 +100,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <div class="custom-container">
             <div class="form-group field-activefieldtestmodel-attributename">
             <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
-            <input type="text" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]">
+            <input type="text" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[{$this->attributeName}]">
             <div class="hint-block">Hint for attributeName attribute</div>
             <div class="help-block"></div>
             </div>

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -1986,10 +1986,6 @@ class ActiveFieldTest extends \yiiunit\TestCase
             $this->normalizeHTML($view->render('@yiiunit/data/views/layout.php', ['content' => $expectedForm])),
             'Failed asserting that the generated form matches the expected view.',
         );
-        $this->assertFalse(
-            $form->getClientOptions()['updateAriaInvalid'] ?? null,
-            "'getClientOptions()' method should return correct options array.",
-        );
     }
 
     public function testGetClientOptionsWithCustomErrorSelector(): void

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -43,6 +43,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         // dirty way to have Request object not throwing exception when running testHomeLinkNull()
         $_SERVER['SCRIPT_FILENAME'] = 'index.php';
         $_SERVER['SCRIPT_NAME'] = 'index.php';
@@ -53,6 +54,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
         Yii::setAlias('@testWebRoot', '@yiiunit/data/web');
 
         $this->helperModel = new ActiveFieldTestModel(['attributeName']);
+
         ob_start();
         $this->helperForm = ActiveForm::begin(['action' => '/something', 'enableClientScript' => false]);
         ActiveForm::end();
@@ -60,7 +62,9 @@ class ActiveFieldTest extends \yiiunit\TestCase
 
         $this->activeField = new ActiveFieldExtend(true);
         $this->activeField->form = $this->helperForm;
+
         $this->activeField->form->setView($this->getView());
+
         $this->activeField->model = $this->helperModel;
         $this->activeField->attribute = $this->attributeName;
     }
@@ -77,6 +81,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -87,20 +92,23 @@ class ActiveFieldTest extends \yiiunit\TestCase
     {
         // field will be the html of the model's attribute wrapped with the return string below.
         $field = $this->attributeName;
-        $content = static fn (string $field): string => "<div class=\"custom-container\"> $field </div>";
+        $content = static fn (string $field): string => "<div class=\"custom-container\">\n$field\n</div>";
 
         $this->assertEqualsWithoutLE(
             <<<HTML
             <div class="form-group field-activefieldtestmodel-attributename">
-            <div class="custom-container"> <div class="form-group field-activefieldtestmodel-attributename">
+            <div class="custom-container">
+            <div class="form-group field-activefieldtestmodel-attributename">
             <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
-            <input type="text" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[{$this->attributeName}]">
+            <input type="text" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]">
             <div class="hint-block">Hint for attributeName attribute</div>
             <div class="help-block"></div>
-            </div> </div>
+            </div>
+            </div>
             </div>
             HTML,
             $this->activeField->render($content),
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -121,6 +129,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -133,6 +142,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <div class="form-group field-activefieldtestmodel-attributename has-error">
             HTML,
             $this->activeField->begin(),
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -145,6 +155,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <div class="form-group field-activefieldtestmodel-attributename required">
             HTML,
             $this->activeField->begin(),
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -158,55 +169,71 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <div class="form-group field-activefieldtestmodel-attributename required has-error">
             HTML,
             $this->activeField->begin(),
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testBegin(): void
     {
-        $expectedValue = '<article class="form-group field-activefieldtestmodel-attributename">';
         $this->activeField->options['tag'] = 'article';
-        $actualValue = $this->activeField->begin();
 
-        $this->assertSame($expectedValue, $actualValue);
+        $this->assertSame(
+            <<<HTML
+            <article class="form-group field-activefieldtestmodel-attributename">
+            HTML,
+            $this->activeField->begin(),
+            'Rendered HTML does not match expected output',
+        );
 
-        $expectedValue = '';
         $this->activeField->options['tag'] = null;
-        $actualValue = $this->activeField->begin();
 
-        $this->assertSame($expectedValue, $actualValue);
+        $this->assertEmpty(
+            $this->activeField->begin(),
+            "Failed asserting that 'begin()' does not render.",
+        );
 
-        $expectedValue = '';
         $this->activeField->options['tag'] = false;
-        $actualValue = $this->activeField->begin();
 
-        $this->assertSame($expectedValue, $actualValue);
+        $this->assertEmpty(
+            $this->activeField->begin(),
+            "Failed asserting that 'begin()' does not render.",
+        );
     }
 
     public function testEnd(): void
     {
-        $expectedValue = '</div>';
-        $actualValue = $this->activeField->end();
-
-        $this->assertSame($expectedValue, $actualValue);
+        $this->assertSame(
+            <<<HTML
+            </div>
+            HTML,
+            $this->activeField->end(),
+            'Rendered HTML does not match expected output',
+        );
 
         // other tag
-        $expectedValue = '</article>';
         $this->activeField->options['tag'] = 'article';
-        $actualValue = $this->activeField->end();
 
-        $this->assertSame($expectedValue, $actualValue);
+        $this->assertSame(
+            <<<HTML
+            </article>
+            HTML,
+            $this->activeField->end(),
+            'Rendered HTML does not match expected output',
+        );
 
-        $expectedValue = '';
         $this->activeField->options['tag'] = false;
-        $actualValue = $this->activeField->end();
 
-        $this->assertSame($expectedValue, $actualValue);
+        $this->assertEmpty(
+            $this->activeField->end(),
+            "Failed asserting that 'end()' does not render.",
+        );
 
-        $expectedValue = '';
         $this->activeField->options['tag'] = null;
-        $actualValue = $this->activeField->end();
 
-        $this->assertSame($expectedValue, $actualValue);
+        $this->assertEmpty(
+            $this->activeField->end(),
+            "Failed asserting that 'end()' does not render.",
+        );
     }
 
     public function testLabel(): void
@@ -218,7 +245,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -239,7 +266,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <label class="override-class" data-test="inherited-data" for="activefieldtestmodel-attributename">Test Label</label>
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -255,7 +282,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <label class="control-label" for="activefieldtestmodel-attributename">{$label}</label>
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
 
         $this->activeField->label(null, ['label' => $paramLabel]);
@@ -265,7 +292,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <label class="control-label" for="activefieldtestmodel-attributename">{$paramLabel}</label>
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
 
         $this->activeField->label();
@@ -275,7 +302,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -287,7 +314,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
 
         $this->assertEmpty(
             $this->activeField->parts['{label}'],
-            'Failed asserting that label does not render.',
+            "Failed asserting that 'label()' does not render.",
         );
     }
 
@@ -299,7 +326,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
 
         $this->assertEmpty(
             $this->activeField->parts['{label}'],
-            'Failed asserting that label does not render.',
+            "Failed asserting that 'label()' does not render.",
         );
     }
 
@@ -314,7 +341,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <label for="activefieldtestmodel-attributename">Override Label</label>
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -329,7 +356,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <label class="control-label" for="activefieldtestmodel-attributename">{$label}</label>
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -342,7 +369,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <label class="control-label" for="activefieldtestmodel-attributename"></label>
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -363,7 +390,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <h3 class="custom-class">{$label}</h3>
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
 
         $this->activeField->label(
@@ -380,7 +407,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <h3 class="custom-class">{$label}</h3>
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -401,7 +428,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             {$label}
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
 
         $this->activeField->label(
@@ -418,7 +445,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             {$label}
             HTML,
             $this->activeField->parts['{label}'],
-            'Failed asserting that label renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -431,13 +458,16 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
             HTML,
             $this->activeField->parts['{label}'],
+            'Rendered HTML does not match expected output',
        );
 
         // label = false
-        $expectedValue = '';
         $this->activeField->label(false);
 
-        $this->assertSame($expectedValue, $this->activeField->parts['{label}']);
+        $this->assertEmpty(
+            $this->activeField->parts['{label}'],
+            "Failed asserting that 'label()' does not render.",
+        );
 
         // $label = 'Label Name'
         $label = 'Label Name';
@@ -448,12 +478,14 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <label class="control-label" for="activefieldtestmodel-attributename">{$label}</label>
             HTML,
             $this->activeField->parts['{label}'],
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testTabularInputErrors(): void
     {
-        $this->activeField->attribute = '[0]'.$this->attributeName;
+        $this->activeField->attribute = "[0]$this->attributeName";
+
         $this->helperModel->addError($this->attributeName, 'Error Message');
 
         $this->assertEqualsWithoutLE(
@@ -461,29 +493,22 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <div class="form-group field-activefieldtestmodel-0-attributename has-error">
             HTML,
             $this->activeField->begin(),
+            'Rendered HTML does not match expected output',
         );
     }
 
-    public static function hintDataProvider(): array
-    {
-        return [
-            ['Hint Content', '<div class="hint-block">Hint Content</div>'],
-            [false, ''],
-            [null, '<div class="hint-block">Hint for attributeName attribute</div>'],
-        ];
-    }
-
     /**
-     * @dataProvider hintDataProvider
-     *
-     * @param mixed $hint The hint content.
-     * @param string $expectedHtml The expected HTML.
+     * @dataProvider \yiiunit\framework\widgets\providers\ActiveFieldProvider::hintDataProvider
      */
-    public function testHint(mixed $hint, string $expectedHtml): void
+    public function testHint(bool|string|null $hint, string $expectedHtml): void
     {
         $this->activeField->hint($hint);
 
-        $this->assertSame($expectedHtml, $this->activeField->parts['{hint}']);
+        $this->assertSame(
+            $expectedHtml,
+            $this->activeField->parts['{hint}'],
+            'Rendered HTML does not match expected output',
+        );
     }
 
     public function testInput(): void
@@ -495,6 +520,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <input type="password" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]">
             HTML,
             $this->activeField->parts['{input}'],
+            'Rendered HTML does not match expected output',
         );
 
         // with options
@@ -505,6 +531,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <input type="password" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]" weird="value">
             HTML,
             $this->activeField->parts['{input}'],
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -517,6 +544,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <input type="text" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]">
             HTML,
             $this->activeField->parts['{input}'],
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -529,12 +557,18 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <input type="hidden" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]">
             HTML,
             $this->activeField->parts['{input}'],
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testListBox(): void
     {
-        $this->activeField->listBox(['1' => 'Item One', '2' => 'Item 2']);
+        $this->activeField->listBox(
+            [
+                '1' => 'Item One',
+                '2' => 'Item 2',
+            ],
+        );
 
         $this->assertEqualsWithoutLE(
             <<<HTML
@@ -544,13 +578,22 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </select>
             HTML,
             $this->activeField->parts['{input}'],
+            'Rendered HTML does not match expected output',
         );
 
         // https://github.com/yiisoft/yii2/issues/8848
-        $this->activeField->listBox(['value1' => 'Item One', 'value2' => 'Item 2'], ['options' => [
-            'value1' => ['disabled' => true],
-            'value2' => ['label' => 'value 2'],
-        ]]);
+        $this->activeField->listBox(
+            [
+                'value1' => 'Item One',
+                'value2' => 'Item 2',
+            ],
+            [
+                'options' => [
+                    'value1' => ['disabled' => true],
+                    'value2' => ['label' => 'value 2'],
+                ],
+            ],
+        );
 
         $this->assertEqualsWithoutLE(
             <<<HTML
@@ -560,13 +603,23 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </select>
             HTML,
             $this->activeField->parts['{input}'],
+            'Rendered HTML does not match expected output',
         );
 
         $this->activeField->model->{$this->attributeName} = 'value2';
-        $this->activeField->listBox(['value1' => 'Item One', 'value2' => 'Item 2'], ['options' => [
-            'value1' => ['disabled' => true],
-            'value2' => ['label' => 'value 2'],
-        ]]);
+
+        $this->activeField->listBox(
+            [
+                'value1' => 'Item One',
+                'value2' => 'Item 2',
+            ],
+            [
+                'options' => [
+                    'value1' => ['disabled' => true],
+                    'value2' => ['label' => 'value 2'],
+                ],
+            ]
+        );
 
         $this->assertEqualsWithoutLE(
             <<<HTML
@@ -576,6 +629,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </select>
             HTML,
             $this->activeField->parts['{input}'],
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -593,6 +647,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -601,23 +656,23 @@ class ActiveFieldTest extends \yiiunit\TestCase
         // setup: we want the real deal here!
         $this->activeField->setClientOptionsEmpty(false);
 
-        // expected empty
-        $actualValue = $this->activeField->getClientOptions();
-
-        $this->assertEmpty($actualValue);
+        $this->assertEmpty(
+            $this->activeField->getClientOptions(),
+            "'getClientOptions()' method should return an empty array.",
+        );
     }
 
     public function testGetClientOptionsWithActiveAttributeInScenario(): void
     {
         $this->activeField->setClientOptionsEmpty(false);
-
         $this->activeField->model->addRule($this->attributeName, 'yiiunit\framework\widgets\TestValidator');
+
         $this->activeField->form->enableClientValidation = false;
 
-        // expected empty
-        $actualValue = $this->activeField->getClientOptions();
-
-        $this->assertEmpty($actualValue);
+        $this->assertEmpty(
+            $this->activeField->getClientOptions(),
+            "'getClientOptions()' method should return an empty array.",
+        );
     }
 
     public function testGetClientOptionsClientValidation(): void
@@ -625,16 +680,36 @@ class ActiveFieldTest extends \yiiunit\TestCase
         $this->activeField->setClientOptionsEmpty(false);
 
         $this->activeField->model->addRule($this->attributeName, 'yiiunit\framework\widgets\TestValidator');
-        $this->activeField->enableClientValidation = true;
-        $actualValue = $this->activeField->getClientOptions();
-        $expectedJsExpression = 'function (attribute, value, messages, deferred, $form) {return true;}';
-        $this->assertEquals($expectedJsExpression, $actualValue['validate']);
 
-        $this->assertNotTrue(isset($actualValue['validateOnChange']));
-        $this->assertNotTrue(isset($actualValue['validateOnBlur']));
-        $this->assertNotTrue(isset($actualValue['validateOnType']));
-        $this->assertNotTrue(isset($actualValue['validationDelay']));
-        $this->assertNotTrue(isset($actualValue['enableAjaxValidation']));
+        $this->activeField->enableClientValidation = true;
+
+        $actualValue = $this->activeField->getClientOptions();
+
+        $this->assertEquals(
+            'function (attribute, value, messages, deferred, $form) {return true;}',
+            $actualValue['validate'],
+            'Client validation function is not as expected.',
+        );
+        $this->assertNotTrue(
+            isset($actualValue['validateOnChange']),
+            "Should not be set by default",
+        );
+        $this->assertNotTrue(
+            isset($actualValue['validateOnBlur']),
+            "Should not be set by default",
+        );
+        $this->assertNotTrue(
+            isset($actualValue['validateOnType']),
+            "Should not be set by default",
+        );
+        $this->assertNotTrue(
+            isset($actualValue['validationDelay']),
+            "Should not be set by default",
+        );
+        $this->assertNotTrue(
+            isset($actualValue['enableAjaxValidation']),
+            "Should not be set by default",
+        );
 
         $this->activeField->validateOnChange = $expectedValidateOnChange = false;
         $this->activeField->validateOnBlur = $expectedValidateOnBlur = false;
@@ -644,17 +719,39 @@ class ActiveFieldTest extends \yiiunit\TestCase
 
         $actualValue = $this->activeField->getClientOptions();
 
-        $this->assertSame($expectedValidateOnChange, $actualValue['validateOnChange']);
-        $this->assertSame($expectedValidateOnBlur, $actualValue['validateOnBlur']);
-        $this->assertSame($expectedValidateOnType, $actualValue['validateOnType']);
-        $this->assertSame($expectedValidationDelay, $actualValue['validationDelay']);
-        $this->assertSame($expectedEnableAjaxValidation, $actualValue['enableAjaxValidation']);
+        $this->assertSame(
+            $expectedValidateOnChange,
+            $actualValue['validateOnChange'],
+            'Should be the same as the set value.',
+        );
+        $this->assertSame(
+            $expectedValidateOnBlur,
+            $actualValue['validateOnBlur'],
+            'Should be the same as the set value.',
+        );
+        $this->assertSame(
+            $expectedValidateOnType,
+            $actualValue['validateOnType'],
+            'Should be the same as the set value.',
+        );
+        $this->assertSame(
+            $expectedValidationDelay,
+            $actualValue['validationDelay'],
+            'Should be the same as the set value.',
+        );
+        $this->assertSame(
+            $expectedEnableAjaxValidation,
+            $actualValue['enableAjaxValidation'],
+            'Should be the same as the set value.',
+        );
     }
 
     public function testGetClientOptionsValidatorWhenClientSet(): void
     {
         $this->activeField->setClientOptionsEmpty(false);
+
         $this->activeField->enableAjaxValidation = true;
+
         $this->activeField->model->addRule($this->attributeName, 'yiiunit\framework\widgets\TestValidator');
 
         foreach ($this->activeField->model->validators as $validator) {
@@ -662,10 +759,15 @@ class ActiveFieldTest extends \yiiunit\TestCase
         }
 
         $actualValue = $this->activeField->getClientOptions();
+
         $expectedJsExpression = 'function (attribute, value, messages, deferred, $form) {if ((function (attribute, value) '
             . "{ return 'yii2' == 'yii2'; })(attribute, value)) { return true; }}";
 
-        $this->assertSame($expectedJsExpression, $actualValue['validate']->expression);
+        $this->assertSame(
+            $expectedJsExpression,
+            $actualValue['validate']->expression,
+            'Client validation function is not as expected.',
+        );
     }
 
     /**
@@ -675,7 +777,11 @@ class ActiveFieldTest extends \yiiunit\TestCase
     {
         $this->activeField->fileInput();
 
-        $this->assertSame('multipart/form-data', $this->activeField->form->options['enctype']);
+        $this->assertSame(
+            'multipart/form-data',
+            $this->activeField->form->options['enctype'],
+            'Should be the same as the set value.',
+        );
     }
 
     /**
@@ -684,28 +790,35 @@ class ActiveFieldTest extends \yiiunit\TestCase
     public function testGetClientOptionsWithCustomInputId(): void
     {
         $this->activeField->setClientOptionsEmpty(false);
-
         $this->activeField->model->addRule($this->attributeName, 'yiiunit\framework\widgets\TestValidator');
-        $this->activeField->inputOptions['id'] = 'custom-input-id';
-        $this->activeField->textInput();
-        $actualValue = $this->activeField->getClientOptions();
 
-        $this->assertArraySubset([
-            'id' => 'custom-input-id',
-            'name' => $this->attributeName,
-            'container' => '.field-custom-input-id',
-            'input' => '#custom-input-id',
-        ], $actualValue);
+        $this->activeField->inputOptions['id'] = 'custom-input-id';
+
+        $this->activeField->textInput();
+
+        $this->assertArraySubset(
+            [
+                'id' => 'custom-input-id',
+                'name' => $this->attributeName,
+                'container' => '.field-custom-input-id',
+                'input' => '#custom-input-id',
+            ],
+            $this->activeField->getClientOptions(),
+            message: "'getClientOptions()' method should return correct options array.",
+        );
 
         $this->activeField->textInput(['id' => 'custom-textinput-id']);
-        $actualValue = $this->activeField->getClientOptions();
 
-        $this->assertArraySubset([
-            'id' => 'custom-textinput-id',
-            'name' => $this->attributeName,
-            'container' => '.field-custom-textinput-id',
-            'input' => '#custom-textinput-id',
-        ], $actualValue);
+        $this->assertArraySubset(
+            [
+                'id' => 'custom-textinput-id',
+                'name' => $this->attributeName,
+                'container' => '.field-custom-textinput-id',
+                'input' => '#custom-textinput-id',
+            ],
+            $this->activeField->getClientOptions(),
+            message: "'getClientOptions()' method should return correct options array.",
+        );
     }
 
     public function testAriaAttributes(): void
@@ -722,12 +835,14 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testAriaRequiredAttribute(): void
     {
         $this->activeField->addAriaAttributes = true;
+
         $this->helperModel->addRule([$this->attributeName], 'required');
 
         $this->assertEqualsWithoutLE(
@@ -740,12 +855,14 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testAriaInvalidAttribute(): void
     {
         $this->activeField->addAriaAttributes = true;
+
         $this->helperModel->addError($this->attributeName, 'Some error');
 
         $this->assertEqualsWithoutLE(
@@ -758,12 +875,13 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testTabularAriaAttributes(): void
     {
-        $this->activeField->attribute = '[0]' . $this->attributeName;
+        $this->activeField->attribute = "[0]{$this->attributeName}";
         $this->activeField->addAriaAttributes = true;
 
         $this->assertEqualsWithoutLE(
@@ -776,13 +894,15 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testTabularAriaRequiredAttribute(): void
     {
-        $this->activeField->attribute = '[0]' . $this->attributeName;
+        $this->activeField->attribute = "[0]{$this->attributeName}";
         $this->activeField->addAriaAttributes = true;
+
         $this->helperModel->addRule([$this->attributeName], 'required');
 
         $this->assertEqualsWithoutLE(
@@ -795,13 +915,15 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testTabularAriaInvalidAttribute(): void
     {
-        $this->activeField->attribute = '[0]' . $this->attributeName;
+        $this->activeField->attribute = "[0]{$this->attributeName}";
         $this->activeField->addAriaAttributes = true;
+
         $this->helperModel->addError($this->attributeName, 'Some error');
 
         $this->assertEqualsWithoutLE(
@@ -814,6 +936,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -826,47 +949,91 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <input type="hidden" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]">
             HTML,
             trim($this->activeField->hiddenInput()->label(false)->error(false)->hint(false)->render()),
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testWidget(): void
     {
         $this->activeField->widget(TestInputWidget::class);
-        $this->assertSame('Render: ' . TestInputWidget::class, $this->activeField->parts['{input}']);
+
+        $this->assertSame(
+            'Render: ' . TestInputWidget::class,
+            $this->activeField->parts['{input}'],
+            'Rendered HTML does not match expected output',
+        );
+
         $widget = TestInputWidget::$lastInstance;
 
-        $this->assertSame($this->activeField->model, $widget->model);
-        $this->assertSame($this->activeField->attribute, $widget->attribute);
-        $this->assertSame($this->activeField->form->view, $widget->view);
-        $this->assertSame($this->activeField, $widget->field);
+        $this->assertSame(
+            $this->activeField->model,
+            $widget->model,
+            'Should be the same as the set value.',
+        );
+        $this->assertSame(
+            $this->activeField->attribute,
+            $widget->attribute,
+            'Should be the same as the set value.',
+        );
+        $this->assertSame(
+            $this->activeField->form->view,
+            $widget->view,
+            'Should be the same as the set value.',
+        );
+        $this->assertSame(
+            $this->activeField,
+            $widget->field,
+            'Should be the same as the set value.',
+        );
 
         $this->activeField->widget(TestInputWidget::class, ['options' => ['id' => 'test-id']]);
-        $this->assertSame('test-id', $this->activeField->labelOptions['for']);
+
+        $this->assertSame(
+            'test-id',
+            $this->activeField->labelOptions['for'],
+            'Should be the same as the set value.',
+        );
     }
 
     public function testWidgetOptions(): void
     {
         $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
+
         $this->activeField->model->addError('attributeName', 'error');
 
         $this->activeField->widget(TestInputWidget::class);
+
         $widget = TestInputWidget::$lastInstance;
+
         $expectedOptions = [
             'class' => 'form-control has-error',
             'aria-invalid' => 'true',
             'id' => 'activefieldtestmodel-attributename',
         ];
-        $this->assertSame($expectedOptions, $widget->options);
+
+        $this->assertSame(
+            $expectedOptions,
+            $widget->options,
+            'Should be the same as the set value.',
+        );
 
         $this->activeField->inputOptions = [];
+
         $this->activeField->widget(TestInputWidget::class);
+
         $widget = TestInputWidget::$lastInstance;
+
         $expectedOptions = [
             'class' => 'has-error',
             'aria-invalid' => 'true',
             'id' => 'activefieldtestmodel-attributename',
         ];
-        $this->assertSame($expectedOptions, $widget->options);
+
+        $this->assertSame(
+            $expectedOptions,
+            $widget->options,
+            'Should be the same as the set value.',
+        );
     }
 
     /**
@@ -881,13 +1048,11 @@ class ActiveFieldTest extends \yiiunit\TestCase
         $this->assertEqualsWithoutLE(
             <<<HTML
             <div class="test-wrapper field-activefieldtestmodel-attributename">
-
             <input type="hidden" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]">
-
-
             </div>
             HTML,
-            trim($this->activeField->hiddenInput()->label(false)->error(false)->hint(false)->render()),
+            $this->normalizeHTML($this->activeField->hiddenInput()->label(false)->error(false)->hint(false)->render()),
+            'Rendered HTML does not match expected output',
         );
 
         $this->activeField->options = ['class' => ['test-wrapper', 'test-add']];
@@ -895,45 +1060,75 @@ class ActiveFieldTest extends \yiiunit\TestCase
         $this->assertEqualsWithoutLE(
             <<<HTML
             <div class="test-wrapper test-add field-activefieldtestmodel-attributename">
-
             <input type="hidden" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]">
-
-
             </div>
             HTML,
-            trim($this->activeField->hiddenInput()->label(false)->error(false)->hint(false)->render()),
+            $this->normalizeHTML($this->activeField->hiddenInput()->label(false)->error(false)->hint(false)->render()),
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testInputOptionsTransferToWidget(): void
     {
-        $widget = $this->activeField->widget(TestMaskedInput::class, [
-            'mask' => '999-999-9999',
-            'options' => ['placeholder' => 'pholder_direct'],
-        ]);
-        $this->assertStringContainsString('placeholder="pholder_direct"', (string) $widget);
+        $widget = $this->activeField->widget(
+            TestMaskedInput::class,
+            [
+                'mask' => '999-999-9999',
+                'options' => ['placeholder' => 'pholder_direct'],
+            ],
+        );
+
+        $this->assertStringContainsString(
+            'placeholder="pholder_direct"',
+            (string) $widget,
+            'Should be the same as the set value.',
+        );
 
         // use regex clientOptions instead mask
-        $widget = $this->activeField->widget(TestMaskedInput::class, [
-            'options' => ['placeholder' => 'pholder_direct'],
-            'clientOptions' => ['regex' => '^.*$'],
-        ]);
-        $this->assertStringContainsString('placeholder="pholder_direct"', (string) $widget);
+        $widget = $this->activeField->widget(
+            TestMaskedInput::class,
+            [
+                'options' => ['placeholder' => 'pholder_direct'],
+                'clientOptions' => ['regex' => '^.*$'],
+            ],
+        );
+
+        $this->assertStringContainsString(
+            'placeholder="pholder_direct"',
+            (string) $widget,
+            'Should be the same as the set value.',
+        );
 
         // transfer options from ActiveField to widget
         $this->activeField->inputOptions = ['placeholder' => 'pholder_input'];
-        $widget = $this->activeField->widget(TestMaskedInput::class, [
-            'mask' => '999-999-9999',
-        ]);
-        $this->assertStringContainsString('placeholder="pholder_input"', (string) $widget);
+
+        $widget = $this->activeField->widget(
+            TestMaskedInput::class,
+            ['mask' => '999-999-9999'],
+        );
+
+        $this->assertStringContainsString(
+            'placeholder="pholder_input"',
+            (string) $widget,
+            'Should be the same as the set value.',
+        );
 
         // set both AF and widget options (second one takes precedence)
         $this->activeField->inputOptions = ['placeholder' => 'pholder_both_input'];
-        $widget = $this->activeField->widget(TestMaskedInput::class, [
-            'mask' => '999-999-9999',
-            'options' => ['placeholder' => 'pholder_both_direct']
-        ]);
-        $this->assertStringContainsString('placeholder="pholder_both_direct"', (string) $widget);
+
+        $widget = $this->activeField->widget(
+            TestMaskedInput::class,
+            [
+                'mask' => '999-999-9999',
+                'options' => ['placeholder' => 'pholder_both_direct']
+            ],
+        );
+
+        $this->assertStringContainsString(
+            'placeholder="pholder_both_direct"',
+            (string) $widget,
+            'Should be the same as the set value.',
+        );
     }
 
     public function testRadioEnclosedByLabelFalseWithLabelOptions(): void
@@ -959,30 +1154,24 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
-            'Failed asserting that radio renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testRadioEnclosedByLabelFalseWithLabelOptionsAndLabelFalse(): void
     {
-        $this->activeField->radio(
-            [
-                'label' => false,
-            ],
-            false,
-        );
+        $this->activeField->radio(['label' => false], false);
 
         $this->assertEqualsWithoutLE(
             <<<HTML
             <div class="form-group field-activefieldtestmodel-attributename">
-
             <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
             <div class="hint-block">Hint for attributeName attribute</div>
             <div class="help-block"></div>
             </div>
             HTML,
-            $this->activeField->render(),
-            'Failed asserting that radio renders correctly.',
+            $this->normalizeHTML($this->activeField->render()),
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -1010,7 +1199,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
-            'Failed asserting that radio renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -1036,18 +1225,13 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
-            'Failed asserting that radio renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testRadioEnclosedByLabelFalseWithoutLabelOptions(): void
     {
-        $this->activeField->radio(
-            [
-                'label' => 'Select Option A',
-            ],
-            false,
-        );
+        $this->activeField->radio(['label' => 'Select Option A'], false);
 
         $this->assertEqualsWithoutLE(
             <<<HTML
@@ -1059,7 +1243,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
-            'Failed asserting that radio renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -1086,30 +1270,24 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
-            'Failed asserting that checkbox renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testCheckboxEnclosedByLabelFalseWithLabelOptionsAndLabelFalse(): void
     {
-        $this->activeField->checkbox(
-            [
-                'label' => false,
-            ],
-            false,
-        );
+        $this->activeField->checkbox(['label' => false], false);
 
         $this->assertEqualsWithoutLE(
             <<<HTML
             <div class="form-group field-activefieldtestmodel-attributename">
-
             <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
             <div class="hint-block">Hint for attributeName attribute</div>
             <div class="help-block"></div>
             </div>
             HTML,
-            $this->activeField->render(),
-            'Failed asserting that checkbox renders correctly.',
+            $this->normalizeHTML($this->activeField->render()),
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -1137,7 +1315,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
-            'Failed asserting that checkbox renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
@@ -1163,15 +1341,417 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
-            'Failed asserting that checkbox renders correctly.',
+            'Rendered HTML does not match expected output',
         );
     }
 
     public function testCheckboxEnclosedByLabelFalseWithoutLabelOptions(): void
     {
+        $this->activeField->checkbox(['label' => 'Custom Label'], false);
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            Custom Label
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testInputWithValidationStateOnInput(): void
+    {
+        $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
+
+        $this->activeField->model->addError($this->attributeName, 'Input validation error');
+        $this->activeField->input('number');
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
+            <input type="number" id="activefieldtestmodel-attributename" class="form-control has-error" name="ActiveFieldTestModel[attributeName]" aria-invalid="true">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block">Input validation error</div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testPasswordInput(): void
+    {
+        $this->activeField->passwordInput();
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
+            <input type="password" id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testPasswordInputWithValidationStateOnInput(): void
+    {
+        $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
+        $this->activeField->model->addError($this->attributeName, 'Password error');
+
+        $this->activeField->passwordInput();
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
+            <input type="password" id="activefieldtestmodel-attributename" class="form-control has-error" name="ActiveFieldTestModel[attributeName]" aria-invalid="true">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block">Password error</div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testFileInputWithCustomInputOptions(): void
+    {
+        $this->activeField->inputOptions = ['class' => 'custom-file-input', 'data-test' => 'file-upload'];
+
+        $this->activeField->fileInput(['accept' => 'image/*', 'id' => 'custom-file-id']);
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-custom-file-id">
+            <label class="control-label" for="custom-file-id">Attribute Name</label>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value=""><input type="file" id="custom-file-id" class="custom-file-input" name="ActiveFieldTestModel[attributeName]" data-test="file-upload" accept="image/*">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testFileInputWithValidationStateOnInput(): void
+    {
+        $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
+
+        $this->activeField->model->addError($this->attributeName, 'File upload error');
+
+        $this->activeField->fileInput();
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value=""><input type="file" id="activefieldtestmodel-attributename" class="has-error" name="ActiveFieldTestModel[attributeName]" aria-invalid="true">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block">File upload error</div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testTextarea(): void
+    {
+        $this->activeField->textarea();
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
+            <textarea id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]"></textarea>
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testTextareaWithValidationStateOnInput(): void
+    {
+        $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
+        $this->activeField->model->addError($this->attributeName, 'Some error');
+
+        $this->activeField->textarea();
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
+            <textarea id="activefieldtestmodel-attributename" class="form-control has-error" name="ActiveFieldTestModel[attributeName]" aria-invalid="true"></textarea>
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block">Some error</div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testRadioEnclosedByLabelFalse(): void
+    {
+        $this->activeField->radio([], false);
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testRadioEnclosedByLabelFalseWithCustomLabel(): void
+    {
+        $this->activeField->radio(
+            [
+                'label' => 'Select Option A',
+                'labelOptions' => [
+                    'class' => 'custom-radio-label',
+                    'data-option' => 'option-a',
+                ],
+            ],
+            false,
+        );
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="custom-radio-label" data-option="option-a" for="activefieldtestmodel-attributename">Select Option A</label>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testRadioEnclosedByLabelFalseWithCustomLabelFalse(): void
+    {
+        $this->activeField->radio(
+            [
+                'label' => false,
+                'labelOptions' => [
+                    'class' => 'custom-radio-label',
+                    'data-option' => 'option-a',
+                ],
+            ],
+            false,
+        );
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+
+    public function testRadioEnclosedByLabelFalseWithCustomLabelTag(): void
+    {
+        $this->activeField->radio(
+            [
+                'label' => 'Choose This Option',
+                'labelOptions' => [
+                    'class' => 'radio-option-label',
+                    'data-value' => 'choice-1',
+                    'tag' => 'span',
+                ],
+            ],
+            false,
+        );
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <span class="radio-option-label" data-value="choice-1">Choose This Option</span>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testRadioEnclosedByLabelFalseWithCustomLabelTagFalse(): void
+    {
+        $this->activeField->radio(
+            [
+                'label' => '<div class="radio-custom-wrapper"><strong>Premium Option</strong> <em>(Recommended)</em></div>',
+                'labelOptions' => ['tag' => false],
+            ],
+            false,
+        );
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <div class="radio-custom-wrapper"><strong>Premium Option</strong> <em>(Recommended)</em></div>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testRadioEnclosedByLabelTrue(): void
+    {
+        $this->activeField->radio([], true);
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><label><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1"> Attribute Name</label>
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->normalizeHTML($this->activeField->render()),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testCheckboxEnclosedByLabelFalse(): void
+    {
+        $this->activeField->checkbox([], false);
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testCheckboxEnclosedByLabelFalseWithCustomLabel(): void
+    {
         $this->activeField->checkbox(
             [
                 'label' => 'Custom Label',
+                'labelOptions' => [
+                    'class' => 'custom-label-class',
+                    'data-test' => 'custom-label-data',
+                ],
+            ],
+            false,
+        );
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="custom-label-class" data-test="custom-label-data" for="activefieldtestmodel-attributename">Custom Label</label>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testCheckboxEnclosedByLabelFalseWithCustomLabelFalse(): void
+    {
+        $this->activeField->checkbox(
+            [
+                'label' => false,
+                'labelOptions' => [
+                    'class' => 'custom-label-class',
+                    'data-test' => 'custom-label-data',
+                ],
+            ],
+            false,
+        );
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testCheckboxEnclosedByLabelFalseWithCustomLabelTag(): void
+    {
+        $this->activeField->checkbox(
+            [
+                'label' => 'Custom Label',
+                'labelOptions' => [
+                    'class' => 'custom-label-class',
+                    'data-test' => 'custom-label-data',
+                    'tag' => 'span',
+                ],
+            ],
+            false,
+        );
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <span class="custom-label-class" data-test="custom-label-data">Custom Label</span>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testCheckboxEnclosedByLabelFalseWithCustomLabelTagFalse(): void
+    {
+        $this->activeField->checkbox(
+            [
+                'label' => 'Custom Label',
+                'labelOptions' => [
+                    'tag' => false,
+                ],
             ],
             false,
         );
@@ -1186,7 +1766,400 @@ class ActiveFieldTest extends \yiiunit\TestCase
             </div>
             HTML,
             $this->activeField->render(),
-            'Failed asserting that checkbox renders correctly.',
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testCheckboxEnclosedByLabelTrue(): void
+    {
+        $this->activeField->checkbox([], true);
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><label><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1"> Attribute Name</label>
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testDropDownList(): void
+    {
+        $this->activeField->dropDownList(
+            [
+                '1' => 'Item One',
+                '2' => 'Item Two',
+            ],
+        );
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
+            <select id="activefieldtestmodel-attributename" class="form-control" name="ActiveFieldTestModel[attributeName]">
+            <option value="1">Item One</option>
+            <option value="2">Item Two</option>
+            </select>
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testDropDownListWithValidationStateOnInput(): void
+    {
+        $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
+
+        $this->activeField->model->addError($this->attributeName, 'Some error');
+        $this->activeField->dropDownList(['1' => 'Item One']);
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
+            <select id="activefieldtestmodel-attributename" class="form-control has-error" name="ActiveFieldTestModel[attributeName]" aria-invalid="true">
+            <option value="1">Item One</option>
+            </select>
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block">Some error</div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testListboxWithValidationStateOnInput(): void
+    {
+        $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
+
+        $this->activeField->model->addError($this->attributeName, 'Some error');
+        $this->activeField->listBox(
+            [
+                '1' => 'Item One',
+                '2' => 'Item 2',
+            ],
+        );
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value=""><select id="activefieldtestmodel-attributename" class="form-control has-error" name="ActiveFieldTestModel[attributeName]" size="4" aria-invalid="true">
+            <option value="1">Item One</option>
+            <option value="2">Item 2</option>
+            </select>
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block">Some error</div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testCheckboxList(): void
+    {
+        $this->activeField->checkboxList(
+            [
+                '1' => 'Item One',
+                '2' => 'Item Two',
+            ],
+        );
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label">Attribute Name</label>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value=""><div id="activefieldtestmodel-attributename"><label><input type="checkbox" name="ActiveFieldTestModel[attributeName][]" value="1"> Item One</label>
+            <label><input type="checkbox" name="ActiveFieldTestModel[attributeName][]" value="2"> Item Two</label></div>
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block"></div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testCheckboxListWithValidationStateOnInput(): void
+    {
+        $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
+
+        $this->activeField->model->addError($this->attributeName, 'Some error');
+        $this->activeField->checkboxList(['1' => 'Item One']);
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label">Attribute Name</label>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value=""><div id="activefieldtestmodel-attributename" class="has-error" aria-invalid="true"><label><input type="checkbox" name="ActiveFieldTestModel[attributeName][]" value="1"> Item One</label></div>
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block">Some error</div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testRadioListWithValidationStateOnInput(): void
+    {
+        $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
+
+        $this->activeField->model->addError($this->attributeName, 'Some error');
+        $this->activeField->radioList(['1' => 'Item One']);
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <div class="form-group field-activefieldtestmodel-attributename">
+            <label class="control-label">Attribute Name</label>
+            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value=""><div id="activefieldtestmodel-attributename" class="has-error" role="radiogroup" aria-invalid="true"><label><input type="radio" name="ActiveFieldTestModel[attributeName]" value="1"> Item One</label></div>
+            <div class="hint-block">Hint for attributeName attribute</div>
+            <div class="help-block">Some error</div>
+            </div>
+            HTML,
+            $this->activeField->render(),
+            'Rendered HTML does not match expected output',
+        );
+    }
+
+    public function testGetClientOptionsWithAriaAttributesFalse(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.com/';
+
+        Yii::$app->assetManager->hashCallback = static fn ($path): string => '5a1b552';
+
+        $model = new DynamicModel(['name']);
+
+        $model->addRule(['name'], 'required');
+
+        $view = Yii::$app->getView();
+
+        ob_start();
+        ob_implicit_flush(false);
+        $form = ActiveForm::begin(
+            [
+                'id' => 'w0',
+                'view' => $view,
+            ],
+        );
+        $field = $form->field($model, 'name');
+        $field->addAriaAttributes = false;
+        echo $field;
+        $form::end();
+        $expectedForm = ob_get_clean();
+
+        $csrfToken = Yii::$app->request->csrfToken;
+        $validate = '"validate":function (attribute, value, messages, deferred, $form) {yii.validation.required(value, messages, {"message":"Name cannot be blank."}';
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <title>Test</title>
+                </head>
+            <body>
+            <form id="w0" action="/" method="post">
+            <input type="hidden" name="_csrf" value="$csrfToken"><div class="form-group field-dynamicmodel-name required">
+            <label class="control-label" for="dynamicmodel-name">Name</label>
+            <input type="text" id="dynamicmodel-name" class="form-control" name="DynamicModel[name]">
+            <div class="help-block"></div>
+            </div></form>
+            <script src="/assets/5a1b552/jquery.js"></script>
+            <script src="/assets/5a1b552/yii.js"></script>
+            <script src="/assets/5a1b552/yii.validation.js"></script>
+            <script src="/assets/5a1b552/yii.activeForm.js"></script>
+            <script>jQuery(function ($) {
+            jQuery('#w0').yiiActiveForm([{"id":"dynamicmodel-name","name":"name","container":".field-dynamicmodel-name","input":"#dynamicmodel-name",$validate);},"updateAriaInvalid":false}], []);
+            });</script></body>
+            </html>
+            HTML,
+            $this->normalizeHTML($view->render('@yiiunit/data/views/layout.php', ['content' => $expectedForm])),
+            'Failed asserting that the generated form matches the expected view.',
+        );
+        $this->assertFalse(
+            $form->getClientOptions()['updateAriaInvalid'] ?? null,
+            "'getClientOptions()' method should return correct options array.",
+        );
+    }
+
+    public function testGetClientOptionsWithCustomErrorSelector(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.com/';
+
+        Yii::$app->assetManager->hashCallback = static fn ($path): string => '5a1b552';
+
+        $model = new DynamicModel(['name']);
+
+        $model->addRule(['name'], 'required');
+
+        $view = Yii::$app->getView();
+
+        ob_start();
+        ob_implicit_flush(false);
+        $form = ActiveForm::begin(
+            [
+                'id' => 'w0',
+                'view' => $view,
+            ],
+        );
+        $field = $form->field($model, 'name');
+        $field->selectors = ['error' => '.custom-error-selector'];
+        echo $field;
+        $form::end();
+        $expectedForm = ob_get_clean();
+
+        $csrfToken = Yii::$app->request->csrfToken;
+        $validate = '"validate":function (attribute, value, messages, deferred, $form) {yii.validation.required(value, messages, {"message":"Name cannot be blank."});}';
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <title>Test</title>
+                </head>
+            <body>
+            <form id="w0" action="/" method="post">
+            <input type="hidden" name="_csrf" value="$csrfToken"><div class="form-group field-dynamicmodel-name required">
+            <label class="control-label" for="dynamicmodel-name">Name</label>
+            <input type="text" id="dynamicmodel-name" class="form-control" name="DynamicModel[name]" aria-required="true">
+            <div class="help-block"></div>
+            </div></form>
+            <script src="/assets/5a1b552/jquery.js"></script>
+            <script src="/assets/5a1b552/yii.js"></script>
+            <script src="/assets/5a1b552/yii.validation.js"></script>
+            <script src="/assets/5a1b552/yii.activeForm.js"></script>
+            <script>jQuery(function ($) {
+            jQuery('#w0').yiiActiveForm([{"id":"dynamicmodel-name","name":"name","container":".field-dynamicmodel-name","input":"#dynamicmodel-name","error":".custom-error-selector",$validate}], []);
+            });</script></body>
+            </html>
+            HTML,
+            $this->normalizeHTML($view->render('@yiiunit/data/views/layout.php', ['content' => $expectedForm])),
+            'Failed asserting that the generated form matches the expected view.',
+        );
+    }
+
+    public function testGetClientOptionsWithErrorDefaultTag(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.com/';
+
+        Yii::$app->assetManager->hashCallback = static fn ($path): string => '5a1b552';
+
+        $model = new DynamicModel(['name']);
+
+        $model->addRule(['name'], 'string');
+
+        $view = Yii::$app->getView();
+
+        ob_start();
+        ob_implicit_flush(false);
+        $form = ActiveForm::begin([
+            'id' => 'w0',
+            'view' => $view,
+        ]);
+        $field = $form->field($model, 'name');
+        unset($field->selectors['error']);
+        $field->errorOptions = [];
+        echo $field;
+        $form::end();
+        $expectedForm = ob_get_clean();
+
+        $csrfToken = Yii::$app->request->csrfToken;
+        $validate = '"validate":function (attribute, value, messages, deferred, $form) {yii.validation.string(value, messages, {"message":"Name must be a string.","skipOnEmpty":1';
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <title>Test</title>
+                </head>
+            <body>
+            <form id="w0" action="/" method="post">
+            <input type="hidden" name="_csrf" value="$csrfToken"><div class="form-group field-dynamicmodel-name">
+            <label class="control-label" for="dynamicmodel-name">Name</label>
+            <input type="text" id="dynamicmodel-name" class="form-control" name="DynamicModel[name]">
+            <div></div>
+            </div></form>
+            <script src="/assets/5a1b552/jquery.js"></script>
+            <script src="/assets/5a1b552/yii.js"></script>
+            <script src="/assets/5a1b552/yii.validation.js"></script>
+            <script src="/assets/5a1b552/yii.activeForm.js"></script>
+            <script>jQuery(function ($) {
+            jQuery('#w0').yiiActiveForm([{"id":"dynamicmodel-name","name":"name","container":".field-dynamicmodel-name","input":"#dynamicmodel-name","error":"span",$validate});}}], []);
+            });</script></body>
+            </html>
+            HTML,
+            $this->normalizeHTML($view->render('@yiiunit/data/views/layout.php', ['content' => $expectedForm])),
+            'Failed asserting that the generated form matches the expected view.',
+        );
+    }
+
+    public function testGetClientOptionsWithErrorOptionsClass(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.com/';
+
+        Yii::$app->assetManager->hashCallback = static fn ($path): string => '5a1b552';
+
+        $model = new DynamicModel(['name']);
+
+        $model->addRule(['name'], 'required');
+
+        $view = Yii::$app->getView();
+
+        ob_start();
+        ob_implicit_flush(false);
+        $form = ActiveForm::begin(
+            [
+                'id' => 'w0',
+                'view' => $view,
+            ],
+        );
+        $field = $form->field($model, 'name');
+        unset($field->selectors['error']);
+        $field->errorOptions = ['class' => 'error-class another-class'];
+        echo $field;
+        $form::end();
+        $expectedForm = ob_get_clean();
+
+        $csrfToken = Yii::$app->request->csrfToken;
+        $validate = '"validate":function (attribute, value, messages, deferred, $form) {yii.validation.required(value, messages, {"message":"Name cannot be blank."});}';
+
+        $this->assertEqualsWithoutLE(
+            <<<HTML
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <title>Test</title>
+                </head>
+            <body>
+            <form id="w0" action="/" method="post">
+            <input type="hidden" name="_csrf" value="$csrfToken"><div class="form-group field-dynamicmodel-name required">
+            <label class="control-label" for="dynamicmodel-name">Name</label>
+            <input type="text" id="dynamicmodel-name" class="form-control" name="DynamicModel[name]" aria-required="true">
+            <div class="error-class another-class"></div>
+            </div></form>
+            <script src="/assets/5a1b552/jquery.js"></script>
+            <script src="/assets/5a1b552/yii.js"></script>
+            <script src="/assets/5a1b552/yii.validation.js"></script>
+            <script src="/assets/5a1b552/yii.activeForm.js"></script>
+            <script>jQuery(function ($) {
+            jQuery('#w0').yiiActiveForm([{"id":"dynamicmodel-name","name":"name","container":".field-dynamicmodel-name","input":"#dynamicmodel-name","error":".error-class.another-class",$validate}], []);
+            });</script></body>
+            </html>
+            HTML,
+            $this->normalizeHTML($view->render('@yiiunit/data/views/layout.php', ['content' => $expectedForm])),
+            'Failed asserting that the generated form matches the expected view.',
         );
     }
 
@@ -1196,10 +2169,15 @@ class ActiveFieldTest extends \yiiunit\TestCase
     protected function getView()
     {
         $view = new View();
-        $view->setAssetManager(new AssetManager([
-            'basePath' => '@testWebRoot/assets',
-            'baseUrl' => '@testWeb/assets',
-        ]));
+
+        $view->setAssetManager(
+            new AssetManager(
+                [
+                    'basePath' => '@testWebRoot/assets',
+                    'baseUrl' => '@testWeb/assets',
+                ],
+            ),
+        );
 
         return $view;
     }

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -1570,7 +1570,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <div class="help-block"></div>
             </div>
             HTML,
-            $this->activeField->render(),
+            $this->normalizeHTML($this->activeField->render()),
             'Rendered HTML does not match expected output',
         );
     }
@@ -1711,7 +1711,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <div class="help-block"></div>
             </div>
             HTML,
-            $this->activeField->render(),
+            $this->normalizeHTML($this->activeField->render()),
             'Rendered HTML does not match expected output',
         );
     }
@@ -1782,7 +1782,7 @@ class ActiveFieldTest extends \yiiunit\TestCase
             <div class="help-block"></div>
             </div>
             HTML,
-            $this->activeField->render(),
+            $this->normalizeHTML($this->activeField->render()),
             'Rendered HTML does not match expected output',
         );
     }

--- a/tests/framework/widgets/ActiveFormTest.php
+++ b/tests/framework/widgets/ActiveFormTest.php
@@ -211,7 +211,6 @@ final class ActiveFormTest extends \yiiunit\TestCase
         $this->assertEqualsWithoutLE(
             <<<HTML
             <div class="form-group field-dynamicmodel-name">
-
             <input type="hidden" name="DynamicModel[name]" value="0"><label><input type="checkbox" id="dynamicmodel-name" class="has-error" name="DynamicModel[name]" value="1" aria-invalid="true"> Name</label>
 
             <div class="help-block">I have an error!</div>
@@ -222,7 +221,6 @@ final class ActiveFormTest extends \yiiunit\TestCase
         $this->assertEqualsWithoutLE(
             <<<HTML
             <div class="form-group field-dynamicmodel-name">
-
             <input type="hidden" name="DynamicModel[name]" value="0"><label><input type="radio" id="dynamicmodel-name" class="has-error" name="DynamicModel[name]" value="1" aria-invalid="true"> Name</label>
 
             <div class="help-block">I have an error!</div>

--- a/tests/framework/widgets/ActiveFormTest.php
+++ b/tests/framework/widgets/ActiveFormTest.php
@@ -202,31 +202,28 @@ final class ActiveFormTest extends \yiiunit\TestCase
             <div class="form-group field-dynamicmodel-name">
             <label class="control-label" for="dynamicmodel-name">Name</label>
             <input type="text" id="dynamicmodel-name" class="form-control has-error" name="DynamicModel[name]" aria-invalid="true">
-
             <div class="help-block">I have an error!</div>
             </div>
             HTML,
-            (string) $form->field($model, 'name'),
+            $this->normalizeHTML((string) $form->field($model, 'name')),
         );
         $this->assertEqualsWithoutLE(
             <<<HTML
             <div class="form-group field-dynamicmodel-name">
             <input type="hidden" name="DynamicModel[name]" value="0"><label><input type="checkbox" id="dynamicmodel-name" class="has-error" name="DynamicModel[name]" value="1" aria-invalid="true"> Name</label>
-
             <div class="help-block">I have an error!</div>
             </div>
             HTML,
-            (string) $form->field($model, 'name')->checkbox(),
+            $this->normalizeHTML((string) $form->field($model, 'name')->checkbox()),
         );
         $this->assertEqualsWithoutLE(
             <<<HTML
             <div class="form-group field-dynamicmodel-name">
             <input type="hidden" name="DynamicModel[name]" value="0"><label><input type="radio" id="dynamicmodel-name" class="has-error" name="DynamicModel[name]" value="1" aria-invalid="true"> Name</label>
-
             <div class="help-block">I have an error!</div>
             </div>
             HTML,
-            (string) $form->field($model, 'name')->radio(),
+            $this->normalizeHTML((string) $form->field($model, 'name')->radio()),
         );
     }
 

--- a/tests/framework/widgets/providers/ActiveFieldProvider.php
+++ b/tests/framework/widgets/providers/ActiveFieldProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\widgets\providers;
+
+/**
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ *
+ * @since 2.2.0
+ */
+final class ActiveFieldProvider
+{
+    /**
+     * Provides test data for hint field rendering validation.
+     *
+     * This provider supplies test cases for validating hint content rendering in ActiveField widgets, including
+     * scenarios with false values, null values, and custom hint content.
+     *
+     * @return array test data with hint configurations and expected HTML output.
+     *
+     * @phpstan-return array<array{bool|string|null, string}>
+     */
+    public static function hintDataProvider(): array
+    {
+        return [
+            [
+                false,
+                '',
+            ],
+            [
+                null,
+                '<div class="hint-block">Hint for attributeName attribute</div>',
+            ],
+            [
+                'Hint Content',
+                '<div class="hint-block">Hint Content</div>',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
