### PR TITLE
Fix `@var` annotation for `StringValidator::$length`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -43,6 +43,7 @@ Yii Framework 2 Change Log
 - Enh #19526: Add the `convertIniSizeToBytes` method to `BaseStringHelper` (max-s-lab)
 - Bug #20570: Fix `@var` annotation for `UrlManager::$cache` (max-s-lab)
 - Bug #20571: Fix `@var` annotation for `yii\web\Response::$stream` (max-s-lab)
+- Bug #20576: Fix `@var` annotation for `StringValidator::$length` (max-s-lab)
 
 
 2.0.53 June 27, 2025

--- a/framework/validators/StringValidator.php
+++ b/framework/validators/StringValidator.php
@@ -21,7 +21,7 @@ use yii\helpers\Json;
 class StringValidator extends Validator
 {
     /**
-     * @var int|array specifies the length limit of the value to be validated.
+     * @var int|array|null specifies the length limit of the value to be validated.
      * This can be specified in one of the following forms:
      *
      * - an integer: the exact length that the value should be of;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="870" height="149" alt="image" src="https://github.com/user-attachments/assets/3bc75e75-2cb8-4171-b83f-5a3b4aa9d328" />
