### PR TITLE
Fix `@return` annotation for `BaseHtml::getAttributeValue()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -49,6 +49,7 @@ Yii Framework 2 Change Log
 - Bug #20583: Fix return value in `Request::getServerPort` (mspirkov)
 - Bug #20587: Fix `@var` annotation for `yii\rbac\Item::$ruleName` (mspirkov)
 - Bug #20589: Fix `@var` annotations for `yii\rbac\DbManager` properties (mspirkov)
+- Bug #20595: Fix `@return` annotation for `BaseHtml::getAttributeValue()` (mspirkov)
 
 
 2.0.53 June 27, 2025

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2284,7 +2284,7 @@ class BaseHtml
      *
      * @param Model $model the model object
      * @param string $attribute the attribute name or expression
-     * @return string|array the corresponding attribute value
+     * @return string|array|null the corresponding attribute value
      * @throws InvalidArgumentException if the attribute name contains non-word characters.
      */
     public static function getAttributeValue($model, $attribute)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="961" height="142" alt="image" src="https://github.com/user-attachments/assets/ad7f22c0-a20c-4136-93a6-cfd7ab0f2b7c" />
