### PR TITLE
Fix `@return` annotation for `ConditionInterface::fromArrayDefinition()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -49,6 +49,7 @@ Yii Framework 2 Change Log
 - Bug #20583: Fix return value in `Request::getServerPort` (mspirkov)
 - Bug #20587: Fix `@var` annotation for `yii\rbac\Item::$ruleName` (mspirkov)
 - Bug #20589: Fix `@var` annotations for `yii\rbac\DbManager` properties (mspirkov)
+- Bug #20599: Fix `@return` annotation for `ConditionInterface::fromArrayDefinition()` (mspirkov)
 
 
 2.0.53 June 27, 2025

--- a/framework/db/conditions/ConditionInterface.php
+++ b/framework/db/conditions/ConditionInterface.php
@@ -26,7 +26,7 @@ interface ConditionInterface extends ExpressionInterface
      * @param string $operator operator in uppercase.
      * @param array $operands array of corresponding operands
      *
-     * @return $this
+     * @return static
      * @throws InvalidParamException if input parameters are not suitable for this condition
      */
     public static function fromArrayDefinition($operator, $operands);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="1485" height="347" alt="image" src="https://github.com/user-attachments/assets/4594bd79-ae47-4398-a1cc-788b06a61b7c" />
<img width="1373" height="1182" alt="image" src="https://github.com/user-attachments/assets/e1fea0a5-9acd-43fb-aff6-207a0b508c10" />
