### PR TITLE
Fix `@var` annotations for `yii\db\Command` properties

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -53,6 +53,7 @@ Yii Framework 2 Change Log
 - Enh #20591: Add PHPStan/Psalm annotations for `yii\rbac\BaseManager::getItems()` (mspirkov)
 - Bug #20594: Fix `@return` annotation for `Instance::get()` (mspirkov)
 - Bug #20595: Fix `@return` annotation for `BaseHtml::getAttributeValue()` (mspirkov)
+- Bug #20604: Fix `@var` annotation for `yii\db\Command::$pdoStatement` (mspirkov)
 
 
 2.0.53 June 27, 2025

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -61,7 +61,7 @@ class Command extends Component
      */
     public $db;
     /**
-     * @var \PDOStatement the PDOStatement object that this command is associated with
+     * @var \PDOStatement|null the PDOStatement object that this command is associated with
      */
     public $pdoStatement;
     /**
@@ -95,11 +95,11 @@ class Command extends Component
     protected $pendingParams = [];
 
     /**
-     * @var string the SQL statement that this command represents
+     * @var string|null the SQL statement that this command represents
      */
     private $_sql;
     /**
-     * @var string name of the table, which schema, should be refreshed after command execution.
+     * @var string|null name of the table, which schema, should be refreshed after command execution.
      */
     private $_refreshTableName;
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="803" height="217" alt="image" src="https://github.com/user-attachments/assets/6fda7f17-cab8-4e32-a37f-7f1827dd0145" />
