### PR TITLE
Fix `@return` annotations for `yii\rest\Serializer` methods

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -56,6 +56,7 @@ Yii Framework 2 Change Log
 - Bug #20595: Fix `@return` annotation for `BaseHtml::getAttributeValue()` (mspirkov)
 - Bug #20604: Fix `@var` annotation for `yii\db\Command::$pdoStatement` (mspirkov)
 - Bug #20600: Fix `@var` annotation for `yii\test\FileFixtureTrait::$dataFile` (mspirkov)
+- Bug #20608: Fix `@return` annotations for `yii\rest\Serializer` methods (mspirkov)
 
 
 2.0.53 June 27, 2025

--- a/framework/rest/Serializer.php
+++ b/framework/rest/Serializer.php
@@ -184,7 +184,7 @@ class Serializer extends Component
     /**
      * Serializes a data provider.
      * @param DataProviderInterface $dataProvider
-     * @return array the array representation of the data provider.
+     * @return array|null the array representation of the data provider.
      */
     protected function serializeDataProvider($dataProvider)
     {
@@ -256,7 +256,7 @@ class Serializer extends Component
     /**
      * Serializes a model object.
      * @param Arrayable $model
-     * @return array the array representation of the model
+     * @return array|null the array representation of the model
      */
     protected function serializeModel($model)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="925" height="178" alt="image" src="https://github.com/user-attachments/assets/384b54e1-c87e-4701-8444-45eb26d4da2c" />
