### PR TITLE
Fix `@return` annotations for `yii\i18n\GettextMoFile` methods

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -56,6 +56,7 @@ Yii Framework 2 Change Log
 - Bug #20595: Fix `@return` annotation for `BaseHtml::getAttributeValue()` (mspirkov)
 - Bug #20604: Fix `@var` annotation for `yii\db\Command::$pdoStatement` (mspirkov)
 - Bug #20600: Fix `@var` annotation for `yii\test\FileFixtureTrait::$dataFile` (mspirkov)
+- Bug #20611: Fix `@return` annotations for `yii\i18n\GettextMoFile` methods (mspirkov)
 
 
 2.0.53 June 27, 2025

--- a/framework/i18n/GettextMoFile.php
+++ b/framework/i18n/GettextMoFile.php
@@ -201,7 +201,7 @@ class GettextMoFile extends GettextFile
      * Reads one or several bytes.
      * @param resource $fileHandle to read from
      * @param int $byteCount to be read
-     * @return string bytes
+     * @return string|null bytes
      */
     protected function readBytes($fileHandle, $byteCount = 1)
     {
@@ -251,7 +251,7 @@ class GettextMoFile extends GettextFile
      * @param resource $fileHandle file handle
      * @param int $length of the string
      * @param int|null $offset of the string in the file. If null, it reads from the current position.
-     * @return string the result
+     * @return string|null the result
      */
     protected function readString($fileHandle, $length, $offset = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="825" height="128" alt="image" src="https://github.com/user-attachments/assets/be4d8f09-3592-48d0-9e86-ba8e9fb79e77" />
