### PR TITLE
Use `::class` instead of `::className()` in tests.

### DIFF
--- a/tests/data/ar/Alpha.php
+++ b/tests/data/ar/Alpha.php
@@ -20,6 +20,6 @@ class Alpha extends ActiveRecord
 
     public function getBetas()
     {
-        return $this->hasMany(Beta::className(), ['alpha_string_identifier' => 'string_identifier']);
+        return $this->hasMany(Beta::class, ['alpha_string_identifier' => 'string_identifier']);
     }
 }

--- a/tests/data/ar/Animal.php
+++ b/tests/data/ar/Animal.php
@@ -29,7 +29,7 @@ class Animal extends ActiveRecord
     public function init(): void
     {
         parent::init();
-        $this->type = \get_called_class();
+        $this->type = static::class;
     }
 
     public function getDoes()

--- a/tests/data/ar/Beta.php
+++ b/tests/data/ar/Beta.php
@@ -21,6 +21,6 @@ class Beta extends ActiveRecord
 
     public function getAlpha()
     {
-        return $this->hasOne(Alpha::className(), ['string_identifier' => 'alpha_string_identifier']);
+        return $this->hasOne(Alpha::class, ['string_identifier' => 'alpha_string_identifier']);
     }
 }

--- a/tests/data/ar/Category.php
+++ b/tests/data/ar/Category.php
@@ -22,22 +22,22 @@ class Category extends ActiveRecord
 
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['category_id' => 'id']);
+        return $this->hasMany(Item::class, ['category_id' => 'id']);
     }
 
     public function getLimitedItems()
     {
-        return $this->hasMany(Item::className(), ['category_id' => 'id'])
+        return $this->hasMany(Item::class, ['category_id' => 'id'])
             ->onCondition(['item.id' => [1, 2, 3]]);
     }
 
     public function getOrderItems()
     {
-        return $this->hasMany(OrderItem::className(), ['item_id' => 'id'])->via('items');
+        return $this->hasMany(OrderItem::class, ['item_id' => 'id'])->via('items');
     }
 
     public function getOrders()
     {
-        return $this->hasMany(Order::className(), ['id' => 'order_id'])->via('orderItems');
+        return $this->hasMany(Order::class, ['id' => 'order_id'])->via('orderItems');
     }
 }

--- a/tests/data/ar/Customer.php
+++ b/tests/data/ar/Customer.php
@@ -113,6 +113,6 @@ class Customer extends ActiveRecord
      */
     public static function find()
     {
-        return new CustomerQuery(\get_called_class());
+        return new CustomerQuery(static::class);
     }
 }

--- a/tests/data/ar/CustomerWithAlias.php
+++ b/tests/data/ar/CustomerWithAlias.php
@@ -33,7 +33,7 @@ class CustomerWithAlias extends ActiveRecord
      */
     public static function find()
     {
-        $activeQuery = new CustomerQuery(get_called_class());
+        $activeQuery = new CustomerQuery(static::class);
         $activeQuery->alias('csr');
         return $activeQuery;
     }

--- a/tests/data/ar/Department.php
+++ b/tests/data/ar/Department.php
@@ -39,7 +39,7 @@ class Department extends ActiveRecord
     public function getEmployees()
     {
         return $this
-            ->hasMany(Employee::className(), [
+            ->hasMany(Employee::class, [
                 'department_id' => 'id',
             ])
             ->inverseOf('department')

--- a/tests/data/ar/Dossier.php
+++ b/tests/data/ar/Dossier.php
@@ -41,7 +41,7 @@ class Dossier extends ActiveRecord
     public function getEmployee()
     {
         return $this
-            ->hasOne(Employee::className(), [
+            ->hasOne(Employee::class, [
                 'department_id' => 'department_id',
                 'id' => 'employee_id',
             ])

--- a/tests/data/ar/Employee.php
+++ b/tests/data/ar/Employee.php
@@ -55,7 +55,7 @@ class Employee extends ActiveRecord
     public function getDepartment()
     {
         return $this
-            ->hasOne(Department::className(), [
+            ->hasOne(Department::class, [
                 'id' => 'department_id',
             ])
             ->inverseOf('employees')
@@ -70,7 +70,7 @@ class Employee extends ActiveRecord
     public function getDossier()
     {
         return $this
-            ->hasOne(Dossier::className(), [
+            ->hasOne(Dossier::class, [
                 'department_id' => 'department_id',
                 'employee_id' => 'id',
             ])

--- a/tests/data/ar/Item.php
+++ b/tests/data/ar/Item.php
@@ -23,6 +23,6 @@ class Item extends ActiveRecord
 
     public function getCategory()
     {
-        return $this->hasOne(Category::className(), ['id' => 'category_id']);
+        return $this->hasOne(Category::class, ['id' => 'category_id']);
     }
 }

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -34,40 +34,40 @@ class Order extends ActiveRecord
 
     public function getCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id']);
+        return $this->hasOne(Customer::class, ['id' => 'customer_id']);
     }
 
     public function getCustomerJoinedWithProfile()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id'])
+        return $this->hasOne(Customer::class, ['id' => 'customer_id'])
             ->joinWith('profile');
     }
 
     public function getCustomerJoinedWithProfileIndexOrdered()
     {
-        return $this->hasMany(Customer::className(), ['id' => 'customer_id'])
+        return $this->hasMany(Customer::class, ['id' => 'customer_id'])
             ->joinWith('profile')->orderBy(['profile.description' => SORT_ASC])->indexBy('name');
     }
 
     public function getCustomer2()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'customer_id'])->inverseOf('orders2');
+        return $this->hasOne(Customer::class, ['id' => 'customer_id'])->inverseOf('orders2');
     }
 
     public function getOrderItems()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id']);
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id']);
     }
 
     public function getOrderItems2()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id'])
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id'])
             ->indexBy('item_id');
     }
 
     public function getOrderItems3()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id'])
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id'])
             ->indexBy(function ($row) {
                 return $row['order_id'] . '_' . $row['item_id'];
             });
@@ -75,12 +75,12 @@ class Order extends ActiveRecord
 
     public function getOrderItemsWithNullFK()
     {
-        return $this->hasMany(OrderItemWithNullFK::className(), ['order_id' => 'id']);
+        return $this->hasMany(OrderItemWithNullFK::class, ['order_id' => 'id']);
     }
 
     public function getItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems', function ($q) {
                 // additional query configuration
             })->orderBy('item.id');
@@ -88,7 +88,7 @@ class Order extends ActiveRecord
 
     public function getExpensiveItemsUsingViaWithCallable()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems', function (ActiveQuery $q) {
                 $q->where(['>=', 'subtotal', 10]);
             });
@@ -96,7 +96,7 @@ class Order extends ActiveRecord
 
     public function getCheapItemsUsingViaWithCallable()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems', function (ActiveQuery $q) {
                 $q->where(['<', 'subtotal', 10]);
             });
@@ -104,19 +104,19 @@ class Order extends ActiveRecord
 
     public function getItemsIndexed()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems')->indexBy('id');
     }
 
     public function getItemsWithNullFK()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->viaTable('order_item_with_null_fk', ['order_id' => 'id']);
     }
 
     public function getItemsInOrder1()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems', function ($q) {
                 $q->orderBy(['subtotal' => SORT_ASC]);
             })->orderBy('name');
@@ -124,7 +124,7 @@ class Order extends ActiveRecord
 
     public function getItemsInOrder2()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems', function ($q) {
                 $q->orderBy(['subtotal' => SORT_DESC]);
             })->orderBy('name');
@@ -132,70 +132,70 @@ class Order extends ActiveRecord
 
     public function getBooks()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItems')
             ->where(['category_id' => 1]);
     }
 
     public function getBooksWithNullFK()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->via('orderItemsWithNullFK')
             ->where(['category_id' => 1]);
     }
 
     public function getBooksViaTable()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->viaTable('order_item', ['order_id' => 'id'])
             ->where(['category_id' => 1]);
     }
 
     public function getBooksWithNullFKViaTable()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->viaTable('order_item_with_null_fk', ['order_id' => 'id'])
             ->where(['category_id' => 1]);
     }
 
     public function getBooks2()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->onCondition(['category_id' => 1])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
     public function getBooksExplicit()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->onCondition(['category_id' => 1])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
     public function getBooksExplicitA()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('bo')
+        return $this->hasMany(Item::class, ['id' => 'item_id'])->alias('bo')
             ->onCondition(['bo.category_id' => 1])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
     public function getBookItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('books')
+        return $this->hasMany(Item::class, ['id' => 'item_id'])->alias('books')
             ->onCondition(['books.category_id' => 1])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
     public function getMovieItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])->alias('movies')
+        return $this->hasMany(Item::class, ['id' => 'item_id'])->alias('movies')
             ->onCondition(['movies.category_id' => 2])
             ->viaTable('order_item', ['order_id' => 'id']);
     }
 
     public function getLimitedItems()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])
+        return $this->hasMany(Item::class, ['id' => 'item_id'])
             ->onCondition(['item.id' => [3, 5]])
             ->via('orderItems');
     }
@@ -228,21 +228,21 @@ class Order extends ActiveRecord
 
     public function getQuantityOrderItems()
     {
-        return $this->hasMany(OrderItem::className(), ['order_id' => 'id', 'quantity' => 'id']);
+        return $this->hasMany(OrderItem::class, ['order_id' => 'id', 'quantity' => 'id']);
     }
 
     public function getOrderItemsFor8()
     {
-        return $this->hasMany(OrderItemWithNullFK::className(), ['order_id' => 'id'])->andOnCondition(['subtotal' => 8.0]);
+        return $this->hasMany(OrderItemWithNullFK::class, ['order_id' => 'id'])->andOnCondition(['subtotal' => 8.0]);
     }
 
     public function getItemsFor8()
     {
-        return $this->hasMany(Item::className(), ['id' => 'item_id'])->via('orderItemsFor8');
+        return $this->hasMany(Item::class, ['id' => 'item_id'])->via('orderItemsFor8');
     }
 
     public function getVirtualCustomer()
     {
-        return $this->hasOne(Customer::className(), ['id' => 'virtualCustomerId']);
+        return $this->hasOne(Customer::class, ['id' => 'virtualCustomerId']);
     }
 }

--- a/tests/data/ar/OrderItem.php
+++ b/tests/data/ar/OrderItem.php
@@ -30,7 +30,7 @@ class OrderItem extends ActiveRecord
     {
         return [
             'typecast' => [
-                'class' => AttributeTypecastBehavior::className(),
+                'class' => AttributeTypecastBehavior::class,
                 'attributeTypes' => [
                     'order_id' => AttributeTypecastBehavior::TYPE_STRING,
                 ],
@@ -44,23 +44,23 @@ class OrderItem extends ActiveRecord
 
     public function getOrder()
     {
-        return $this->hasOne(Order::className(), ['id' => 'order_id']);
+        return $this->hasOne(Order::class, ['id' => 'order_id']);
     }
 
     public function getItem()
     {
-        return $this->hasOne(Item::className(), ['id' => 'item_id']);
+        return $this->hasOne(Item::class, ['id' => 'item_id']);
     }
 
     // relations used by ::testFindCompositeWithJoin()
     public function getOrderItemCompositeWithJoin()
     {
-        return $this->hasOne(self::className(), ['item_id' => 'item_id', 'order_id' => 'order_id'])
+        return $this->hasOne(self::class, ['item_id' => 'item_id', 'order_id' => 'order_id'])
             ->joinWith('item');
     }
     public function getOrderItemCompositeNoJoin()
     {
-        return $this->hasOne(self::className(), ['item_id' => 'item_id', 'order_id' => 'order_id']);
+        return $this->hasOne(self::class, ['item_id' => 'item_id', 'order_id' => 'order_id']);
     }
 
     public function getCustom()

--- a/tests/data/validators/models/ValidatorTestMainModel.php
+++ b/tests/data/validators/models/ValidatorTestMainModel.php
@@ -20,6 +20,6 @@ class ValidatorTestMainModel extends ActiveRecord
 
     public function getReferences()
     {
-        return $this->hasMany(ValidatorTestRefModel::className(), ['ref' => 'id']);
+        return $this->hasMany(ValidatorTestRefModel::class, ['ref' => 'id']);
     }
 }

--- a/tests/data/validators/models/ValidatorTestRefModel.php
+++ b/tests/data/validators/models/ValidatorTestRefModel.php
@@ -26,6 +26,6 @@ class ValidatorTestRefModel extends ActiveRecord
 
     public function getMain()
     {
-        return $this->hasOne(ValidatorTestMainModel::className(), ['id' => 'ref']);
+        return $this->hasOne(ValidatorTestMainModel::class, ['id' => 'ref']);
     }
 }

--- a/tests/data/views/widgets/ListView/item.php
+++ b/tests/data/views/widgets/ListView/item.php
@@ -12,4 +12,4 @@ use yii\widgets\ListView;
  * @var int $index
  * @var ListView $widget
  */
-echo "Item #{$index}: {$model['login']} - Widget: " . $widget->className();
+echo "Item #{$index}: {$model['login']} - Widget: " . get_class($widget);

--- a/tests/framework/ar/ActiveRecordTestTrait.php
+++ b/tests/framework/ar/ActiveRecordTestTrait.php
@@ -1118,7 +1118,7 @@ trait ActiveRecordTestTrait
         /** @var TestCase|ActiveRecordTestTrait $this */
 
         $afterFindCalls = [];
-        Event::on(BaseActiveRecord::className(), BaseActiveRecord::EVENT_AFTER_FIND, function ($event) use (&$afterFindCalls) {
+        Event::on(BaseActiveRecord::class, BaseActiveRecord::EVENT_AFTER_FIND, function ($event) use (&$afterFindCalls) {
             /** @var BaseActiveRecord $ar */
             $ar = $event->sender;
             $afterFindCalls[] = [\get_class($ar), $ar->getIsNewRecord(), $ar->getPrimaryKey(), $ar->isRelationPopulated('orders')];
@@ -1163,7 +1163,7 @@ trait ActiveRecordTestTrait
         ], $afterFindCalls);
         $afterFindCalls = [];
 
-        Event::off(BaseActiveRecord::className(), BaseActiveRecord::EVENT_AFTER_FIND);
+        Event::off(BaseActiveRecord::class, BaseActiveRecord::EVENT_AFTER_FIND);
     }
 
     public function testAfterRefresh(): void
@@ -1173,7 +1173,7 @@ trait ActiveRecordTestTrait
         /** @var TestCase|ActiveRecordTestTrait $this */
 
         $afterRefreshCalls = [];
-        Event::on(BaseActiveRecord::className(), BaseActiveRecord::EVENT_AFTER_REFRESH, function ($event) use (&$afterRefreshCalls) {
+        Event::on(BaseActiveRecord::class, BaseActiveRecord::EVENT_AFTER_REFRESH, function ($event) use (&$afterRefreshCalls) {
             /** @var BaseActiveRecord $ar */
             $ar = $event->sender;
             $afterRefreshCalls[] = [\get_class($ar), $ar->getIsNewRecord(), $ar->getPrimaryKey(), $ar->isRelationPopulated('orders')];
@@ -1184,7 +1184,7 @@ trait ActiveRecordTestTrait
         $customer->refresh();
         $this->assertEquals([[$customerClass, false, 1, false]], $afterRefreshCalls);
         $afterRefreshCalls = [];
-        Event::off(BaseActiveRecord::className(), BaseActiveRecord::EVENT_AFTER_REFRESH);
+        Event::off(BaseActiveRecord::class, BaseActiveRecord::EVENT_AFTER_REFRESH);
     }
 
     public function testFindEmptyInCondition(): void

--- a/tests/framework/base/BaseObjectTest.php
+++ b/tests/framework/base/BaseObjectTest.php
@@ -138,7 +138,7 @@ class BaseObjectTest extends TestCase
 
     public function testObjectProperty(): void
     {
-        $this->assertInstanceOf(NewObject::className(), $this->object->object);
+        $this->assertInstanceOf(NewObject::class, $this->object->object);
         $this->assertEquals('object text', $this->object->object->text);
         $this->object->object->text = 'new text';
         $this->assertEquals('new text', $this->object->object->text);

--- a/tests/framework/behaviors/AttributeBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeBehaviorTest.php
@@ -137,7 +137,7 @@ class ActiveRecordWithAttributeBehavior extends ActiveRecord
     {
         return [
             'attribute' => [
-                'class' => AttributeBehavior::className(),
+                'class' => AttributeBehavior::class,
                 'attributes' => [
                     self::EVENT_BEFORE_VALIDATE => 'alias',
                 ],

--- a/tests/framework/behaviors/BlameableBehaviorConsoleTest.php
+++ b/tests/framework/behaviors/BlameableBehaviorConsoleTest.php
@@ -60,7 +60,7 @@ class BlameableBehaviorConsoleTest extends TestCase
     {
         $model = new ActiveRecordBlameableConsole([
             'as blameable' => [
-                'class' => BlameableBehavior::className(),
+                'class' => BlameableBehavior::class,
                 'defaultValue' => 2
             ],
         ]);
@@ -89,7 +89,7 @@ class ActiveRecordBlameableConsoleWithDefaultValueClosure extends ActiveRecordBl
     {
         return [
             'blameable' => [
-                'class' => BlameableBehavior::className(),
+                'class' => BlameableBehavior::class,
                 'defaultValue' => function () {
                     return 10 + 1;
                 }
@@ -113,7 +113,7 @@ class ActiveRecordBlameableConsole extends ActiveRecord
     {
         return [
             'blameable' => [
-                'class' => BlameableBehavior::className(),
+                'class' => BlameableBehavior::class,
             ],
         ];
     }

--- a/tests/framework/behaviors/BlameableBehaviorTest.php
+++ b/tests/framework/behaviors/BlameableBehaviorTest.php
@@ -101,7 +101,7 @@ class BlameableBehaviorTest extends TestCase
 
         $this->getUser()->login(20);
         $model = ActiveRecordBlameable::findOne(['name' => __METHOD__]);
-        $model->name = __CLASS__;
+        $model->name = self::class;
         $model->save();
 
         $this->assertEquals(10, $model->created_by);

--- a/tests/framework/behaviors/SluggableBehaviorTest.php
+++ b/tests/framework/behaviors/SluggableBehaviorTest.php
@@ -248,7 +248,7 @@ class ActiveRecordSluggable extends ActiveRecord
     {
         return [
             'sluggable' => [
-                'class' => SluggableBehavior::className(),
+                'class' => SluggableBehavior::class,
                 'attribute' => 'name',
             ],
         ];
@@ -269,7 +269,7 @@ class ActiveRecordSluggable extends ActiveRecord
 
     public function getRelated()
     {
-        return $this->hasOne(ActiveRecordRelated::className(), ['id' => 'belongs_to_id']);
+        return $this->hasOne(ActiveRecordRelated::class, ['id' => 'belongs_to_id']);
     }
 }
 
@@ -287,7 +287,7 @@ class ActiveRecordSluggableUnique extends ActiveRecordSluggable
     {
         return [
             'sluggable' => [
-                'class' => SluggableBehavior::className(),
+                'class' => SluggableBehavior::class,
                 'attribute' => 'name',
                 'ensureUnique' => true,
             ],
@@ -301,7 +301,7 @@ class SkipOnEmptySluggableActiveRecord extends ActiveRecordSluggable
     {
         return [
             'sluggable' => [
-                'class' => SluggableBehavior::className(),
+                'class' => SluggableBehavior::class,
                 'attribute' => 'name',
                 'slugAttribute' => 'slug',
                 'ensureUnique' => true,

--- a/tests/framework/behaviors/TimestampBehaviorTest.php
+++ b/tests/framework/behaviors/TimestampBehaviorTest.php
@@ -77,7 +77,7 @@ class TimestampBehaviorTest extends TestCase
         $currentTime = time();
 
         ActiveRecordTimestamp::$behaviors = [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
         ];
         $model = new ActiveRecordTimestamp();
         $model->save(false);
@@ -94,7 +94,7 @@ class TimestampBehaviorTest extends TestCase
         $currentTime = time();
 
         ActiveRecordTimestamp::$behaviors = [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
         ];
         $model = new ActiveRecordTimestamp();
         $model->save(false);
@@ -115,7 +115,7 @@ class TimestampBehaviorTest extends TestCase
     public function testUpdateCleanRecord(): void
     {
         ActiveRecordTimestamp::$behaviors = [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
         ];
         $model = new ActiveRecordTimestamp();
         $model->save(false);
@@ -156,7 +156,7 @@ class TimestampBehaviorTest extends TestCase
         ActiveRecordTimestamp::$tableName = 'test_auto_timestamp_string';
         ActiveRecordTimestamp::$behaviors = [
             'timestamp' => [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'value' => $expression,
             ],
         ];
@@ -184,7 +184,7 @@ class TimestampBehaviorTest extends TestCase
         ActiveRecordTimestamp::$tableName = 'test_auto_timestamp_string';
         ActiveRecordTimestamp::$behaviors = [
             'timestamp' => [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'value' => new Expression("strftime('%Y')"),
             ],
         ];
@@ -197,7 +197,7 @@ class TimestampBehaviorTest extends TestCase
         $model->updated_at = $enforcedTime;
         $model->save(false);
         $this->assertEquals($enforcedTime, $model->created_at, 'Create time has been set on update!');
-        $this->assertInstanceOf(Expression::className(), $model->updated_at);
+        $this->assertInstanceOf(Expression::class, $model->updated_at);
         $model->refresh();
         $this->assertEquals($enforcedTime, $model->created_at, 'Create time has been set on update!');
         $this->assertEquals(date('Y'), $model->updated_at);
@@ -207,7 +207,7 @@ class TimestampBehaviorTest extends TestCase
     {
         ActiveRecordTimestamp::$behaviors = [
             'timestamp' => [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'value' => new Expression("strftime('%Y')"),
             ],
         ];
@@ -222,7 +222,7 @@ class TimestampBehaviorTest extends TestCase
     {
         ActiveRecordTimestamp::$behaviors = [
             'timestamp' => [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'value' => new Expression("strftime('%Y')"),
             ],
         ];

--- a/tests/framework/caching/DependencyTest.php
+++ b/tests/framework/caching/DependencyTest.php
@@ -35,7 +35,7 @@ class DependencyTest extends TestCase
 
     public function testGenerateReusableHash(): void
     {
-        $dependency = $this->getMockForAbstractClass(Dependency::className());
+        $dependency = $this->getMockForAbstractClass(Dependency::class);
         $dependency->data = 'dummy';
 
         $result = $this->invokeMethod($dependency, 'generateReusableHash');
@@ -45,8 +45,8 @@ class DependencyTest extends TestCase
 
     public function testIsChanged(): void
     {
-        $dependency = $this->getMockForAbstractClass(Dependency::className());
-        $cache = $this->getMockForAbstractClass(Cache::className());
+        $dependency = $this->getMockForAbstractClass(Dependency::class);
+        $cache = $this->getMockForAbstractClass(Cache::class);
 
         $result = $dependency->isChanged($cache);
         $this->assertFalse($result);

--- a/tests/framework/console/ControllerTest.php
+++ b/tests/framework/console/ControllerTest.php
@@ -133,7 +133,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        Yii::$container->set(DummyService::className(), function () {
+        Yii::$container->set(DummyService::class, function () {
             throw new RuntimeException('uh oh');
         });
 
@@ -153,7 +153,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        Yii::$container->clear(DummyService::className());
+        Yii::$container->clear(DummyService::class);
         $this->expectException(get_class(new Exception()));
         $this->expectExceptionMessage('Could not load required service: dummyService');
         $this->controller->bindActionParams($injectionAction, $params);
@@ -170,13 +170,13 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        Yii::$container->set(DummyService::className(), DummyService::className());
+        Yii::$container->set(DummyService::class, DummyService::class);
         $args = $this->controller->bindActionParams($injectionAction, $params);
         $this->assertEquals($params['before'], $args[0]);
         $this->assertEquals(Yii::$app->request, $args[1]);
         $this->assertEquals('Component: yii\console\Request $request', Yii::$app->requestedParams['request']);
         $this->assertEquals($params['between'], $args[2]);
-        $this->assertInstanceOf(DummyService::className(), $args[3]);
+        $this->assertInstanceOf(DummyService::class, $args[3]);
         $this->assertEquals('Container DI: yiiunit\framework\console\stubs\DummyService $dummyService', Yii::$app->requestedParams['dummyService']);
         $this->assertNull($args[4]);
         $this->assertEquals('Unavailable service: post', Yii::$app->requestedParams['post']);
@@ -190,7 +190,7 @@ class ControllerTest extends TestCase
             'basePath' => __DIR__,
         ]));
         $module->set('yii\data\DataProviderInterface', [
-            'class' => ArrayDataProvider::className(),
+            'class' => ArrayDataProvider::class,
         ]);
         // Use the PHP71 controller for this test
         $this->controller = new FakePhp71Controller('fake', $module);
@@ -198,7 +198,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionModuleServiceInjection');
         $args = $this->controller->bindActionParams($injectionAction, []);
-        $this->assertInstanceOf(ArrayDataProvider::className(), $args[0]);
+        $this->assertInstanceOf(ArrayDataProvider::class, $args[0]);
         $this->assertEquals('Module yii\base\Module DI: yii\data\DataProviderInterface $dataProvider', Yii::$app->requestedParams['dataProvider']);
     }
 

--- a/tests/framework/console/controllers/DbMessageControllerTest.php
+++ b/tests/framework/console/controllers/DbMessageControllerTest.php
@@ -42,7 +42,7 @@ class DbMessageControllerTest extends BaseMessageControllerTest
                 'id' => 'Migrator',
                 'basePath' => '@yiiunit',
                 'controllerMap' => [
-                    'migrate' => EchoMigrateController::className(),
+                    'migrate' => EchoMigrateController::class,
                 ],
                 'components' => [
                     'db' => static::getConnection(),

--- a/tests/framework/console/controllers/FixtureControllerTest.php
+++ b/tests/framework/console/controllers/FixtureControllerTest.php
@@ -236,7 +236,7 @@ class FixtureControllerTest extends DatabaseTestCase
 
         $lastFixture = end(FixtureStorage::$activeFixtureSequence);
 
-        $this->assertEquals(DependentActiveFixture::className(), $lastFixture);
+        $this->assertEquals(DependentActiveFixture::class, $lastFixture);
     }
 }
 

--- a/tests/framework/console/controllers/MigrateControllerTest.php
+++ b/tests/framework/console/controllers/MigrateControllerTest.php
@@ -30,8 +30,8 @@ class MigrateControllerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->migrateControllerClass = EchoMigrateController::className();
-        $this->migrationBaseClass = Migration::className();
+        $this->migrateControllerClass = EchoMigrateController::class;
+        $this->migrationBaseClass = Migration::class;
 
         $this->mockApplication([
             'components' => [

--- a/tests/framework/console/controllers/ServeControllerTest.php
+++ b/tests/framework/console/controllers/ServeControllerTest.php
@@ -30,7 +30,7 @@ class ServeControllerTest extends TestCase
         $docroot = __DIR__ . '/stub';
 
         /** @var ServeController $serveController */
-        $serveController = $this->getMockBuilder(ServeControllerMocK::className())
+        $serveController = $this->getMockBuilder(ServeControllerMocK::class)
             ->setConstructorArgs(['serve', Yii::$app])
             ->setMethods(['isAddressTaken', 'runCommand'])
             ->getMock();
@@ -55,7 +55,7 @@ class ServeControllerTest extends TestCase
         $docroot = __DIR__ . '/stub';
 
         /** @var ServeController $serveController */
-        $serveController = $this->getMockBuilder(ServeControllerMock::className())
+        $serveController = $this->getMockBuilder(ServeControllerMock::class)
             ->setConstructorArgs(['serve', Yii::$app])
             ->setMethods(['runCommand'])
             ->getMock();
@@ -81,7 +81,7 @@ class ServeControllerTest extends TestCase
         $docroot = '/not/exist/path';
 
         /** @var ServeController $serveController */
-        $serveController = $this->getMockBuilder(ServeControllerMock::className())
+        $serveController = $this->getMockBuilder(ServeControllerMock::class)
             ->setConstructorArgs(['serve', Yii::$app])
             ->setMethods(['runCommand'])
             ->getMock();
@@ -105,7 +105,7 @@ class ServeControllerTest extends TestCase
         $router = '/not/exist/path';
 
         /** @var ServeController $serveController */
-        $serveController = $this->getMockBuilder(ServeControllerMock::className())
+        $serveController = $this->getMockBuilder(ServeControllerMock::class)
             ->setConstructorArgs(['serve', Yii::$app])
             ->setMethods(['runCommand'])
             ->getMock();
@@ -131,7 +131,7 @@ class ServeControllerTest extends TestCase
         $router = __DIR__ . '/stub/index.php';
 
         /** @var ServeController $serveController */
-        $serveController = $this->getMockBuilder(ServeControllerMock::className())
+        $serveController = $this->getMockBuilder(ServeControllerMock::class)
             ->setConstructorArgs(['serve', Yii::$app])
             ->setMethods(['runCommand'])
             ->getMock();

--- a/tests/framework/data/ActiveDataProviderTest.php
+++ b/tests/framework/data/ActiveDataProviderTest.php
@@ -40,9 +40,9 @@ abstract class ActiveDataProviderTest extends DatabaseTestCase
         ]);
         $orders = $provider->getModels();
         $this->assertCount(3, $orders);
-        $this->assertInstanceOf(Order::className(), $orders[0]);
-        $this->assertInstanceOf(Order::className(), $orders[1]);
-        $this->assertInstanceOf(Order::className(), $orders[2]);
+        $this->assertInstanceOf(Order::class, $orders[0]);
+        $this->assertInstanceOf(Order::class, $orders[1]);
+        $this->assertInstanceOf(Order::class, $orders[2]);
         $this->assertEquals([1, 2, 3], $provider->getKeys());
 
         $provider = new ActiveDataProvider([
@@ -64,8 +64,8 @@ abstract class ActiveDataProviderTest extends DatabaseTestCase
         ]);
         $orders = $provider->getModels();
         $this->assertCount(2, $orders);
-        $this->assertInstanceOf(Order::className(), $orders[0]);
-        $this->assertInstanceOf(Order::className(), $orders[1]);
+        $this->assertInstanceOf(Order::class, $orders[0]);
+        $this->assertInstanceOf(Order::class, $orders[1]);
         $this->assertEquals([2, 3], $provider->getKeys());
 
         $provider = new ActiveDataProvider([
@@ -87,9 +87,9 @@ abstract class ActiveDataProviderTest extends DatabaseTestCase
         ]);
         $items = $provider->getModels();
         $this->assertCount(3, $items);
-        $this->assertInstanceOf(Item::className(), $items[0]);
-        $this->assertInstanceOf(item::className(), $items[1]);
-        $this->assertInstanceOf(Item::className(), $items[2]);
+        $this->assertInstanceOf(Item::class, $items[0]);
+        $this->assertInstanceOf(item::class, $items[1]);
+        $this->assertInstanceOf(Item::class, $items[2]);
         $this->assertEquals([3, 4, 5], $provider->getKeys());
 
         $provider = new ActiveDataProvider([
@@ -111,8 +111,8 @@ abstract class ActiveDataProviderTest extends DatabaseTestCase
         ]);
         $items = $provider->getModels();
         $this->assertCount(2, $items);
-        $this->assertInstanceOf(Item::className(), $items[0]);
-        $this->assertInstanceOf(Item::className(), $items[1]);
+        $this->assertInstanceOf(Item::class, $items[0]);
+        $this->assertInstanceOf(Item::class, $items[1]);
 
         $provider = new ActiveDataProvider([
             'query' => $order->getBooks(),

--- a/tests/framework/data/BaseDataProviderTest.php
+++ b/tests/framework/data/BaseDataProviderTest.php
@@ -19,7 +19,7 @@ class BaseDataProviderTest extends TestCase
 {
     public function testGenerateId(): void
     {
-        $rc = new ReflectionClass(BaseDataProvider::className());
+        $rc = new ReflectionClass(BaseDataProvider::class);
         $rp = $rc->getProperty('counter');
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible

--- a/tests/framework/data/DataFilterTest.php
+++ b/tests/framework/data/DataFilterTest.php
@@ -36,12 +36,12 @@ class DataFilterTest extends TestCase
         $builder->setSearchModel($model);
         $this->assertSame($model, $builder->getSearchModel());
 
-        $builder->setSearchModel(Singer::className());
+        $builder->setSearchModel(Singer::class);
         $model = $builder->getSearchModel();
         $this->assertTrue($model instanceof Singer);
 
         $builder->setSearchModel([
-            'class' => Singer::className(),
+            'class' => Singer::class,
             'scenario' => 'search',
         ]);
         $model = $builder->getSearchModel();

--- a/tests/framework/db/ActiveQueryModelConnectionTest.php
+++ b/tests/framework/db/ActiveQueryModelConnectionTest.php
@@ -46,7 +46,7 @@ class ActiveQueryModelConnectionTest extends TestCase
         $this->globalConnection->expects($this->never())->method('getQueryBuilder');
         $this->prepareConnectionMock($this->modelConnection);
 
-        $query = new ActiveQuery(ActiveRecord::className());
+        $query = new ActiveQuery(ActiveRecord::class);
         $query->one();
     }
 
@@ -55,7 +55,7 @@ class ActiveQueryModelConnectionTest extends TestCase
         $this->modelConnection->expects($this->never())->method('getQueryBuilder');
         $this->prepareConnectionMock($this->globalConnection);
 
-        $query = new ActiveQuery(DefaultActiveRecord::className());
+        $query = new ActiveQuery(DefaultActiveRecord::class);
         $query->one();
     }
 
@@ -64,7 +64,7 @@ class ActiveQueryModelConnectionTest extends TestCase
         $this->globalConnection->expects($this->never())->method('getQueryBuilder');
         $this->prepareConnectionMock($this->modelConnection);
 
-        $query = new ActiveQuery(ActiveRecord::className());
+        $query = new ActiveQuery(ActiveRecord::class);
         $query->all();
     }
 
@@ -73,7 +73,7 @@ class ActiveQueryModelConnectionTest extends TestCase
         $this->modelConnection->expects($this->never())->method('getQueryBuilder');
         $this->prepareConnectionMock($this->globalConnection);
 
-        $query = new ActiveQuery(DefaultActiveRecord::className());
+        $query = new ActiveQuery(DefaultActiveRecord::class);
         $query->all();
     }
 }

--- a/tests/framework/db/ActiveQueryTest.php
+++ b/tests/framework/db/ActiveQueryTest.php
@@ -37,8 +37,8 @@ abstract class ActiveQueryTest extends DatabaseTestCase
             'on' => ['a' => 'b'],
             'joinWith' => ['dummy relation'],
         ];
-        $query = new ActiveQuery(Customer::className(), $config);
-        $this->assertEquals($query->modelClass, Customer::className());
+        $query = new ActiveQuery(Customer::class, $config);
+        $this->assertEquals($query->modelClass, Customer::class);
         $this->assertEquals($query->on, $config['on']);
         $this->assertEquals($query->joinWith, $config['joinWith']);
     }
@@ -49,10 +49,10 @@ abstract class ActiveQueryTest extends DatabaseTestCase
         $callback = function (Event $event) use ($where) {
             $event->sender->where = $where;
         };
-        Event::on(ActiveQuery::className(), ActiveQuery::EVENT_INIT, $callback);
-        $result = new ActiveQuery(Customer::className());
+        Event::on(ActiveQuery::class, ActiveQuery::EVENT_INIT, $callback);
+        $result = new ActiveQuery(Customer::class);
         $this->assertEquals($where, $result->where);
-        Event::off(ActiveQuery::className(), ActiveQuery::EVENT_INIT, $callback);
+        Event::off(ActiveQuery::class, ActiveQuery::EVENT_INIT, $callback);
     }
 
     /**
@@ -60,7 +60,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testPrepare(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $builder = new QueryBuilder(new Connection());
         $result = $query->prepare($builder);
         $this->assertInstanceOf('yii\db\Query', $result);
@@ -68,7 +68,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testPopulate_EmptyRows(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $rows = [];
         $result = $query->populate([]);
         $this->assertEquals($rows, $result);
@@ -79,7 +79,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testPopulate_FilledRows(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $rows = $query->all();
         $result = $query->populate($rows);
         $this->assertEquals($rows, $result);
@@ -90,7 +90,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testOne(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $query->one();
         $this->assertInstanceOf('yiiunit\data\ar\Customer', $result);
     }
@@ -100,7 +100,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testCreateCommand(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $query->createCommand();
         $this->assertInstanceOf('yii\db\Command', $result);
     }
@@ -110,7 +110,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testQueryScalar(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $this->invokeMethod($query, 'queryScalar', ['name', null]);
         $this->assertEquals('user1', $result);
     }
@@ -120,7 +120,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testJoinWith(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $query->joinWith('profile');
         $this->assertEquals([
             [['profile'], true, 'LEFT JOIN'],
@@ -132,7 +132,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testInnerJoinWith(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $query->innerJoinWith('profile');
         $this->assertEquals([
             [['profile'], true, 'INNER JOIN'],
@@ -141,7 +141,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testBuildJoinWithRemoveDuplicateJoinByTableName(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $query->innerJoinWith('orders')
             ->joinWith('orders.orderItems');
         $this->invokeMethod($query, 'buildJoinWith');
@@ -164,7 +164,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testGetQueryTableName_from_not_set(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $this->invokeMethod($query, 'getTableNameAndAlias');
         $this->assertEquals(['customer', 'customer'], $result);
     }
@@ -172,14 +172,14 @@ abstract class ActiveQueryTest extends DatabaseTestCase
     public function testGetQueryTableName_from_set(): void
     {
         $options = ['from' => ['alias' => 'customer']];
-        $query = new ActiveQuery(Customer::className(), $options);
+        $query = new ActiveQuery(Customer::class, $options);
         $result = $this->invokeMethod($query, 'getTableNameAndAlias');
         $this->assertEquals(['customer', 'alias'], $result);
     }
 
     public function testOnCondition(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $on = ['active' => true];
         $params = ['a' => 'b'];
         $result = $query->onCondition($on, $params);
@@ -189,7 +189,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testAndOnCondition_on_not_set(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $on = ['active' => true];
         $params = ['a' => 'b'];
         $result = $query->andOnCondition($on, $params);
@@ -200,7 +200,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
     public function testAndOnCondition_on_set(): void
     {
         $onOld = ['active' => true];
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $query->on = $onOld;
 
         $on = ['active' => true];
@@ -212,7 +212,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testOrOnCondition_on_not_set(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $on = ['active' => true];
         $params = ['a' => 'b'];
         $result = $query->orOnCondition($on, $params);
@@ -223,7 +223,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
     public function testOrOnCondition_on_set(): void
     {
         $onOld = ['active' => true];
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $query->on = $onOld;
 
         $on = ['active' => true];
@@ -238,15 +238,15 @@ abstract class ActiveQueryTest extends DatabaseTestCase
      */
     public function testViaTable(): void
     {
-        $query = new ActiveQuery(Customer::className(), ['primaryModel' => new Order()]);
-        $result = $query->viaTable(Profile::className(), ['id' => 'item_id']);
+        $query = new ActiveQuery(Customer::class, ['primaryModel' => new Order()]);
+        $result = $query->viaTable(Profile::class, ['id' => 'item_id']);
         $this->assertInstanceOf('yii\db\ActiveQuery', $result);
         $this->assertInstanceOf('yii\db\ActiveQuery', $result->via);
     }
 
     public function testAlias_not_set(): void
     {
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $result = $query->alias('alias');
         $this->assertInstanceOf('yii\db\ActiveQuery', $result);
         $this->assertEquals(['alias' => 'customer'], $result->from);
@@ -255,7 +255,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
     public function testAlias_yet_set(): void
     {
         $aliasOld = ['old'];
-        $query = new ActiveQuery(Customer::className());
+        $query = new ActiveQuery(Customer::class);
         $query->from = $aliasOld;
         $result = $query->alias('alias');
         $this->assertInstanceOf('yii\db\ActiveQuery', $result);
@@ -269,7 +269,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testGetTableNames_notFilledFrom(): void
     {
-        $query = new ActiveQuery(Profile::className());
+        $query = new ActiveQuery(Profile::class);
 
         $tables = $query->getTablesUsedInFrom();
 
@@ -280,7 +280,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
 
     public function testGetTableNames_wontFillFrom(): void
     {
-        $query = new ActiveQuery(Profile::className());
+        $query = new ActiveQuery(Profile::class);
         $this->assertEquals($query->from, null);
         $query->getTablesUsedInFrom();
         $this->assertEquals($query->from, null);
@@ -301,8 +301,8 @@ abstract class ActiveQueryTest extends DatabaseTestCase
         $this->assertNotNull($category);
         $orders = $category->orders;
         $this->assertEquals(2, count($orders));
-        $this->assertInstanceOf(Order::className(), $orders[0]);
-        $this->assertInstanceOf(Order::className(), $orders[1]);
+        $this->assertInstanceOf(Order::class, $orders[0]);
+        $this->assertInstanceOf(Order::class, $orders[1]);
         $ids = [$orders[0]->id, $orders[1]->id];
         sort($ids);
         $this->assertEquals([1, 3], $ids);
@@ -311,7 +311,7 @@ abstract class ActiveQueryTest extends DatabaseTestCase
         $this->assertNotNull($category);
         $orders = $category->orders;
         $this->assertEquals(1, count($orders));
-        $this->assertInstanceOf(Order::className(), $orders[0]);
+        $this->assertInstanceOf(Order::class, $orders[0]);
         $this->assertEquals(2, $orders[0]->id);
     }
 }

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -60,7 +60,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
      */
     public function getCustomerClass()
     {
-        return Customer::className();
+        return Customer::class;
     }
 
     /**
@@ -68,7 +68,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
      */
     public function getItemClass()
     {
-        return Item::className();
+        return Item::class;
     }
 
     /**
@@ -76,7 +76,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
      */
     public function getOrderClass()
     {
-        return Order::className();
+        return Order::class;
     }
 
     /**
@@ -84,7 +84,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
      */
     public function getOrderItemClass()
     {
-        return OrderItem::className();
+        return OrderItem::class;
     }
 
     /**
@@ -92,7 +92,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
      */
     public function getCategoryClass()
     {
-        return Category::className();
+        return Category::class;
     }
 
     /**
@@ -100,7 +100,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
      */
     public function getOrderWithNullFKClass()
     {
-        return OrderWithNullFK::className();
+        return OrderWithNullFK::class;
     }
 
     /**
@@ -108,7 +108,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
      */
     public function getOrderItemWithNullFKmClass()
     {
-        return OrderItemWithNullFK::className();
+        return OrderItemWithNullFK::class;
     }
 
     public function testCustomColumns(): void
@@ -163,7 +163,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
     {
         // find one
         $customer = Customer::findBySql('SELECT * FROM {{customer}} ORDER BY [[id]] DESC')->one();
-        $this->assertInstanceOf(Customer::className(), $customer);
+        $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals('user3', $customer->name);
 
         // find all
@@ -172,7 +172,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
 
         // find with parameter binding
         $customer = Customer::findBySql('SELECT * FROM {{customer}} WHERE [[id]]=:id', [':id' => 2])->one();
-        $this->assertInstanceOf(Customer::className(), $customer);
+        $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals('user2', $customer->name);
     }
 
@@ -249,8 +249,8 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $items = $customer->orderItems;
 
         $this->assertCount(2, $items);
-        $this->assertInstanceOf(Item::className(), $items[0]);
-        $this->assertInstanceOf(Item::className(), $items[1]);
+        $this->assertInstanceOf(Item::class, $items[0]);
+        $this->assertInstanceOf(Item::class, $items[1]);
         $this->assertEquals(1, $items[0]->id);
         $this->assertEquals(2, $items[1]->id);
     }
@@ -268,8 +268,8 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertNotNull($category);
         $orders = $category->orders;
         $this->assertCount(2, $orders);
-        $this->assertInstanceOf(Order::className(), $orders[0]);
-        $this->assertInstanceOf(Order::className(), $orders[1]);
+        $this->assertInstanceOf(Order::class, $orders[0]);
+        $this->assertInstanceOf(Order::class, $orders[1]);
         $ids = [$orders[0]->id, $orders[1]->id];
         sort($ids);
         $this->assertEquals([1, 3], $ids);
@@ -278,7 +278,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertNotNull($category);
         $orders = $category->orders;
         $this->assertCount(1, $orders);
-        $this->assertInstanceOf(Order::className(), $orders[0]);
+        $this->assertInstanceOf(Order::class, $orders[0]);
         $this->assertEquals(2, $orders[0]->id);
     }
 
@@ -759,7 +759,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals(2, $customers[1]->id);
         $this->assertTrue($customers[0]->isRelationPopulated('profile'));
         $this->assertTrue($customers[1]->isRelationPopulated('profile'));
-        $this->assertInstanceOf(Profile::className(), $customers[0]->profile);
+        $this->assertInstanceOf(Profile::class, $customers[0]->profile);
         $this->assertNull($customers[1]->profile);
 
         // hasMany
@@ -1458,7 +1458,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
     {
         // https://github.com/yiisoft/yii2/issues/4938
         $category = Category::findOne(2);
-        $this->assertInstanceOf(Category::className(), $category);
+        $this->assertInstanceOf(Category::class, $category);
         $this->assertEquals(3, $category->getItems()->count());
         $this->assertEquals(1, $category->getLimitedItems()->count());
         $this->assertEquals(1, $category->getLimitedItems()->distinct(true)->count());
@@ -1496,10 +1496,10 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         (new Cat())->save(false);
         (new Dog())->save(false);
 
-        $animal = Animal::find()->where(['type' => Dog::className()])->one();
+        $animal = Animal::find()->where(['type' => Dog::class])->one();
         $this->assertEquals('bark', $animal->getDoes());
 
-        $animal = Animal::find()->where(['type' => Cat::className()])->one();
+        $animal = Animal::find()->where(['type' => Cat::class])->one();
         $this->assertEquals('meow', $animal->getDoes());
     }
 
@@ -1579,7 +1579,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
             ->orderBy('status')
             ->all();
         $this->assertCount(2, $aggregation);
-        $this->assertContainsOnlyInstancesOf(Customer::className(), $aggregation);
+        $this->assertContainsOnlyInstancesOf(Customer::class, $aggregation);
         foreach ($aggregation as $item) {
             if ($item->status == 1) {
                 $this->assertEquals(183, $item->sumTotal);
@@ -1620,7 +1620,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
             ->orderBy('[[order_id]]')
             ->all();
         $this->assertCount(3, $aggregation);
-        $this->assertContainsOnlyInstancesOf(OrderItem::className(), $aggregation);
+        $this->assertContainsOnlyInstancesOf(OrderItem::class, $aggregation);
         foreach ($aggregation as $item) {
             if ($item->order_id == 1) {
                 $this->assertEquals(70, $item->subtotal);
@@ -1890,7 +1890,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
     public function testFilterTableNamesFromAliases($fromParams, $expectedAliases): void
     {
         $query = Customer::find()->from($fromParams);
-        $aliases = $this->invokeMethod(Yii::createObject(Customer::className()), 'filterValidAliases', [$query]);
+        $aliases = $this->invokeMethod(Yii::createObject(Customer::class), 'filterValidAliases', [$query]);
 
         $this->assertEquals($expectedAliases, $aliases);
     }
@@ -1910,19 +1910,19 @@ abstract class ActiveRecordTest extends DatabaseTestCase
     public function legalValuesForFindByCondition()
     {
         return [
-            [Customer::className(), ['id' => 1]],
-            [Customer::className(), ['customer.id' => 1]],
-            [Customer::className(), ['[[id]]' => 1]],
-            [Customer::className(), ['{{customer}}.[[id]]' => 1]],
-            [Customer::className(), ['{{%customer}}.[[id]]' => 1]],
+            [Customer::class, ['id' => 1]],
+            [Customer::class, ['customer.id' => 1]],
+            [Customer::class, ['[[id]]' => 1]],
+            [Customer::class, ['{{customer}}.[[id]]' => 1]],
+            [Customer::class, ['{{%customer}}.[[id]]' => 1]],
 
-            [CustomerWithAlias::className(), ['id' => 1]],
-            [CustomerWithAlias::className(), ['customer.id' => 1]],
-            [CustomerWithAlias::className(), ['[[id]]' => 1]],
-            [CustomerWithAlias::className(), ['{{customer}}.[[id]]' => 1]],
-            [CustomerWithAlias::className(), ['{{%customer}}.[[id]]' => 1]],
-            [CustomerWithAlias::className(), ['csr.id' => 1]],
-            [CustomerWithAlias::className(), ['{{csr}}.[[id]]' => 1]],
+            [CustomerWithAlias::class, ['id' => 1]],
+            [CustomerWithAlias::class, ['customer.id' => 1]],
+            [CustomerWithAlias::class, ['[[id]]' => 1]],
+            [CustomerWithAlias::class, ['{{customer}}.[[id]]' => 1]],
+            [CustomerWithAlias::class, ['{{%customer}}.[[id]]' => 1]],
+            [CustomerWithAlias::class, ['csr.id' => 1]],
+            [CustomerWithAlias::class, ['{{csr}}.[[id]]' => 1]],
         ];
     }
 
@@ -1941,29 +1941,29 @@ abstract class ActiveRecordTest extends DatabaseTestCase
     public function illegalValuesForFindByCondition()
     {
         return [
-            [Customer::className(), [['`id`=`id` and 1' => 1]]],
-            [Customer::className(), [[
+            [Customer::class, [['`id`=`id` and 1' => 1]]],
+            [Customer::class, [[
                 'legal' => 1,
                 '`id`=`id` and 1' => 1,
             ]]],
-            [Customer::className(), [[
+            [Customer::class, [[
                 'nested_illegal' => [
                     'false or 1=' => 1
                 ]
             ]]],
-            [Customer::className(), [['true--' => 1]]],
+            [Customer::class, [['true--' => 1]]],
 
-            [CustomerWithAlias::className(), [['`csr`.`id`=`csr`.`id` and 1' => 1]]],
-            [CustomerWithAlias::className(), [[
+            [CustomerWithAlias::class, [['`csr`.`id`=`csr`.`id` and 1' => 1]]],
+            [CustomerWithAlias::class, [[
                 'legal' => 1,
                 '`csr`.`id`=`csr`.`id` and 1' => 1,
             ]]],
-            [CustomerWithAlias::className(), [[
+            [CustomerWithAlias::class, [[
                 'nested_illegal' => [
                     'false or 1=' => 1
                 ]
             ]]],
-            [CustomerWithAlias::className(), [['true--' => 1]]],
+            [CustomerWithAlias::class, [['true--' => 1]]],
         ];
     }
 
@@ -2026,26 +2026,26 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals(1, $order->id);
 
         $this->assertNotNull($order->customer);
-        $this->assertInstanceOf(CustomerWithConstructor::className(), $order->customer);
+        $this->assertInstanceOf(CustomerWithConstructor::class, $order->customer);
         $this->assertEquals(1, $order->customer->id);
 
         $this->assertNotNull($order->customer->profile);
-        $this->assertInstanceOf(ProfileWithConstructor::className(), $order->customer->profile);
+        $this->assertInstanceOf(ProfileWithConstructor::class, $order->customer->profile);
         $this->assertEquals(1, $order->customer->profile->id);
 
         $this->assertNotNull($order->customerJoinedWithProfile);
         $customerWithProfile = $order->customerJoinedWithProfile;
-        $this->assertInstanceOf(CustomerWithConstructor::className(), $customerWithProfile);
+        $this->assertInstanceOf(CustomerWithConstructor::class, $customerWithProfile);
         $this->assertEquals(1, $customerWithProfile->id);
 
         $this->assertNotNull($customerProfile = $customerWithProfile->profile);
-        $this->assertInstanceOf(ProfileWithConstructor::className(), $customerProfile);
+        $this->assertInstanceOf(ProfileWithConstructor::class, $customerProfile);
         $this->assertEquals(1, $customerProfile->id);
 
         $this->assertCount(2, $order->orderItems);
 
         $item = $order->orderItems[0];
-        $this->assertInstanceOf(OrderItemWithConstructor::className(), $item);
+        $this->assertInstanceOf(OrderItemWithConstructor::class, $item);
 
         $this->assertEquals(1, $item->item_id);
 
@@ -2061,7 +2061,7 @@ abstract class ActiveRecordTest extends DatabaseTestCase
     public function testCustomARRelation(): void
     {
         $orderItem = OrderItem::findOne(1);
-        $this->assertInstanceOf(Order::className(), $orderItem->custom);
+        $this->assertInstanceOf(Order::class, $orderItem->custom);
     }
 
     public function testRefresh_querySetAlias_findRecord(): void
@@ -2277,7 +2277,7 @@ class LabelTestModel1 extends \yii\db\ActiveRecord
 
     public function getModel2()
     {
-        return $this->hasOne(LabelTestModel2::className(), []);
+        return $this->hasOne(LabelTestModel2::class, []);
     }
 }
 
@@ -2290,7 +2290,7 @@ class LabelTestModel2 extends \yii\db\ActiveRecord
 
     public function getModel3()
     {
-        return $this->hasOne(LabelTestModel3::className(), []);
+        return $this->hasOne(LabelTestModel3::class, []);
     }
 
     public function attributeLabels()

--- a/tests/framework/db/BatchQueryResultTest.php
+++ b/tests/framework/db/BatchQueryResultTest.php
@@ -29,7 +29,7 @@ abstract class BatchQueryResultTest extends DatabaseTestCase
         $query = new Query();
         $query->from('customer')->orderBy('id');
         $result = $query->batch(2, $db);
-        $this->assertInstanceOf(BatchQueryResult::className(), $result);
+        $this->assertInstanceOf(BatchQueryResult::class, $result);
         $this->assertEquals(2, $result->batchSize);
         $this->assertSame($result->query, $query);
 

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -99,7 +99,7 @@ abstract class CommandTest extends DatabaseTestCase
         // query
         $sql = 'SELECT * FROM {{customer}}';
         $reader = $db->createCommand($sql)->query();
-        $this->assertInstanceOf(DataReader::className(), $reader);
+        $this->assertInstanceOf(DataReader::class, $reader);
 
         // queryAll
         $rows = $db->createCommand('SELECT * FROM {{customer}}')->queryAll();

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -211,7 +211,7 @@ abstract class SchemaTest extends DatabaseTestCase
         $schema->db->tablePrefix = $tablePrefix;
         $schema->db->schemaCache = new ArrayCache();
         $noCacheTable = $schema->getTableSchema($tableName, true);
-        $this->assertInstanceOf(TableSchema::className(), $noCacheTable);
+        $this->assertInstanceOf(TableSchema::class, $noCacheTable);
 
         // Compare
         $schema->db->tablePrefix = $testTablePrefix;
@@ -221,14 +221,14 @@ abstract class SchemaTest extends DatabaseTestCase
         $schema->db->tablePrefix = $tablePrefix;
         $schema->refreshTableSchema($tableName);
         $refreshedTable = $schema->getTableSchema($tableName, false);
-        $this->assertInstanceOf(TableSchema::className(), $refreshedTable);
+        $this->assertInstanceOf(TableSchema::class, $refreshedTable);
         $this->assertNotSame($noCacheTable, $refreshedTable);
 
         // Compare
         $schema->db->tablePrefix = $testTablePrefix;
         $schema->refreshTableSchema($testTablePrefix);
         $testRefreshedTable = $schema->getTableSchema($testTableName, false);
-        $this->assertInstanceOf(TableSchema::className(), $testRefreshedTable);
+        $this->assertInstanceOf(TableSchema::class, $testRefreshedTable);
         $this->assertEquals($refreshedTable, $testRefreshedTable);
         $this->assertNotSame($testNoCacheTable, $testRefreshedTable);
     }
@@ -884,7 +884,7 @@ abstract class SchemaTest extends DatabaseTestCase
 
     protected function normalizeConstraintPair(Constraint $expectedConstraint, Constraint $actualConstraint)
     {
-        if ($expectedConstraint::className() !== $actualConstraint::className()) {
+        if (get_class($expectedConstraint) !== get_class($actualConstraint)) {
             return;
         }
 

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -42,7 +42,7 @@ SQL;
 
         $dt = $schema->columns['dt'];
 
-        $this->assertInstanceOf(Expression::className(), $dt->defaultValue);
+        $this->assertInstanceOf(Expression::class, $dt->defaultValue);
         $this->assertEquals('CURRENT_TIMESTAMP', (string)$dt->defaultValue);
     }
 
@@ -63,11 +63,11 @@ SQL;
         $schema = $this->getConnection()->getTableSchema('current_timestamp_test');
 
         $dt = $schema->columns['dt'];
-        $this->assertInstanceOf(Expression::className(), $dt->defaultValue);
+        $this->assertInstanceOf(Expression::class, $dt->defaultValue);
         $this->assertEquals('CURRENT_TIMESTAMP(2)', (string)$dt->defaultValue);
 
         $ts = $schema->columns['ts'];
-        $this->assertInstanceOf(Expression::className(), $ts->defaultValue);
+        $this->assertInstanceOf(Expression::class, $ts->defaultValue);
         $this->assertEquals('CURRENT_TIMESTAMP(3)', (string)$ts->defaultValue);
     }
 
@@ -225,8 +225,8 @@ SQL;
             'comment' => '',
         ]]);
 
-        $this->assertInstanceOf(ColumnSchema::className(), $column);
-        $this->assertInstanceOf(Expression::className(), $column->defaultValue);
+        $this->assertInstanceOf(ColumnSchema::class, $column);
+        $this->assertInstanceOf(Expression::class, $column->defaultValue);
         $this->assertEquals('CURRENT_TIMESTAMP', $column->defaultValue);
     }
 
@@ -251,7 +251,7 @@ SQL;
             'comment' => '',
         ]]);
 
-        $this->assertInstanceOf(ColumnSchema::className(), $column);
+        $this->assertInstanceOf(ColumnSchema::class, $column);
         $this->assertEquals(null, $column->defaultValue);
     }
 

--- a/tests/framework/db/pgsql/ActiveRecordTest.php
+++ b/tests/framework/db/pgsql/ActiveRecordTest.php
@@ -330,7 +330,7 @@ class UserAR extends ActiveRecord
     public function behaviors()
     {
         return [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
         ];
     }
 }

--- a/tests/framework/db/pgsql/ExistValidatorTest.php
+++ b/tests/framework/db/pgsql/ExistValidatorTest.php
@@ -31,7 +31,7 @@ class ExistValidatorTest extends \yiiunit\framework\validators\ExistValidatorTes
         $this->assertFalse($model->hasErrors());
 
         // Different target table
-        $validator = new ExistValidator(['targetClass' => ValidatorTestMainModel::className(), 'targetAttribute' => 'id']);
+        $validator = new ExistValidator(['targetClass' => ValidatorTestMainModel::class, 'targetAttribute' => 'id']);
         $model = ValidatorTestRefModel::findOne(['id' => 1]);
         $validator->validateAttribute($model, 'ref');
         $this->assertFalse($model->hasErrors());

--- a/tests/framework/db/sqlite/ConnectionTest.php
+++ b/tests/framework/db/sqlite/ConnectionTest.php
@@ -61,7 +61,7 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
 
             $db = $this->prepareMasterSlave($masterCount, $slaveCount);
 
-            $this->assertInstanceOf(Connection::className(), $db->getSlave());
+            $this->assertInstanceOf(Connection::class, $db->getSlave());
             $this->assertTrue($db->getSlave()->isActive);
             $this->assertFalse($db->isActive);
 
@@ -73,7 +73,7 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
             $db->createCommand("UPDATE profile SET description='test' WHERE id=1")->execute();
             $this->assertTrue($db->isActive);
             if ($masterCount > 0) {
-                $this->assertInstanceOf(Connection::className(), $db->getMaster());
+                $this->assertInstanceOf(Connection::class, $db->getMaster());
                 $this->assertTrue($db->getMaster()->isActive);
             } else {
                 $this->assertNull($db->getMaster());
@@ -89,7 +89,7 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
             $this->assertFalse($db->isActive);
 
             $customer = Customer::findOne(1);
-            $this->assertInstanceOf(Customer::className(), $customer);
+            $this->assertInstanceOf(Customer::class, $customer);
             $this->assertEquals('user1', $customer->name);
             $this->assertFalse($db->isActive);
 
@@ -97,7 +97,7 @@ class ConnectionTest extends \yiiunit\framework\db\ConnectionTest
             $customer->save();
             $this->assertTrue($db->isActive);
             $customer = Customer::findOne(1);
-            $this->assertInstanceOf(Customer::className(), $customer);
+            $this->assertInstanceOf(Customer::class, $customer);
             $this->assertEquals('user1', $customer->name);
             $result = $db->useMaster(function () {
                 return Customer::findOne(1)->name;

--- a/tests/framework/di/ContainerTest.php
+++ b/tests/framework/di/ContainerTest.php
@@ -56,9 +56,9 @@ class ContainerTest extends TestCase
     {
         $namespace = __NAMESPACE__ . '\stubs';
         $QuxInterface = "$namespace\\QuxInterface";
-        $Foo = Foo::className();
-        $Bar = Bar::className();
-        $Qux = Qux::className();
+        $Foo = Foo::class;
+        $Bar = Bar::class;
+        $Qux = Qux::class;
 
         // automatic wiring
         $container = new Container();
@@ -97,7 +97,7 @@ class ContainerTest extends TestCase
         $container = new Container();
         $container->set($QuxInterface, $Qux);
         $container->set('foo', function (Container $c, $params, $config) {
-            return $c->get(Foo::className());
+            return $c->get(Foo::class);
         });
         $foo = $container->get('foo');
         $this->assertInstanceOf($Foo, $foo);
@@ -115,8 +115,8 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf($Qux, $foo->bar->qux);
 
         // predefined property parameters
-        $fooSetter = FooProperty::className();
-        $barSetter = BarSetter::className();
+        $fooSetter = FooProperty::class;
+        $barSetter = BarSetter::class;
 
         $container = new Container();
         $container->set('foo', ['class' => $fooSetter, 'bar' => Instance::of('bar')]);
@@ -268,8 +268,8 @@ class ContainerTest extends TestCase
     {
         $container = new Container();
         $container->setDefinitions([
-            'model.order' => Order::className(),
-            Cat::className() => Type::className(),
+            'model.order' => Order::class,
+            Cat::class => Type::class,
             'test\TraversableInterface' => [
                 ['class' => 'yiiunit\data\base\TraversableObject'],
                 [['item1', 'item2']],
@@ -282,8 +282,8 @@ class ContainerTest extends TestCase
         ]);
         $container->setDefinitions([]);
 
-        $this->assertInstanceOf(Order::className(), $container->get('model.order'));
-        $this->assertInstanceOf(Type::className(), $container->get(Cat::className()));
+        $this->assertInstanceOf(Order::class, $container->get('model.order'));
+        $this->assertInstanceOf(Type::class, $container->get(Cat::class));
 
         $traversable = $container->get('test\TraversableInterface');
         $this->assertInstanceOf('yiiunit\data\base\TraversableObject', $traversable);
@@ -303,11 +303,11 @@ class ContainerTest extends TestCase
     {
         $container = new Container();
         $container->setDefinitions([
-            'qux' => [QuxFactory::className(), 'create'],
+            'qux' => [QuxFactory::class, 'create'],
         ]);
 
         $qux = $container->get('qux');
-        $this->assertInstanceOf(Qux::className(), $qux);
+        $this->assertInstanceOf(Qux::class, $qux);
         $this->assertSame(42, $qux->a);
     }
 
@@ -319,7 +319,7 @@ class ContainerTest extends TestCase
         ]);
 
         $qux = $container->get('qux');
-        $this->assertInstanceOf(Qux::className(), $qux);
+        $this->assertInstanceOf(Qux::class, $qux);
         $this->assertSame(42, $qux->a);
     }
 
@@ -332,13 +332,13 @@ class ContainerTest extends TestCase
                 '__construct()' => [['item1', 'item2']],
             ],
             'qux' => [
-                '__class' => Qux::className(),
+                '__class' => Qux::class,
                 'a' => 42,
             ],
         ]);
 
         $qux = $container->get('qux');
-        $this->assertInstanceOf(Qux::className(), $qux);
+        $this->assertInstanceOf(Qux::class, $qux);
         $this->assertSame(42, $qux->a);
 
         $traversable = $container->get('test\TraversableInterface');
@@ -351,20 +351,20 @@ class ContainerTest extends TestCase
         $container = new Container();
         $container->setDefinitions([
             'qux' => [
-                'class' => Qux::className(),
+                'class' => Qux::class,
                 'a' => 42,
             ],
             'bar' => [
-                '__class' => Bar::className(),
+                '__class' => Bar::class,
                 '__construct()' => [
                     Instance::of('qux')
                 ],
             ],
         ]);
         $bar = $container->get('bar');
-        $this->assertInstanceOf(Bar::className(), $bar);
+        $this->assertInstanceOf(Bar::class, $bar);
         $qux = $bar->qux;
-        $this->assertInstanceOf(Qux::className(), $qux);
+        $this->assertInstanceOf(Qux::class, $qux);
         $this->assertSame(42, $qux->a);
     }
 
@@ -375,15 +375,15 @@ class ContainerTest extends TestCase
         $container->resolveArrays = true;
         $container->setSingletons([
             $quxInterface => [
-                'class' => Qux::className(),
+                'class' => Qux::class,
                 'a' => 42,
             ],
             'qux' => Instance::of($quxInterface),
             'bar' => [
-                'class' => Bar::className(),
+                'class' => Bar::class,
             ],
             'corge' => [
-                '__class' => Corge::className(),
+                '__class' => Corge::class,
                 '__construct()' => [
                     [
                         'qux' => Instance::of('qux'),
@@ -394,15 +394,15 @@ class ContainerTest extends TestCase
             ],
         ]);
         $corge = $container->get('corge');
-        $this->assertInstanceOf(Corge::className(), $corge);
+        $this->assertInstanceOf(Corge::class, $corge);
         $qux = $corge->map['qux'];
-        $this->assertInstanceOf(Qux::className(), $qux);
+        $this->assertInstanceOf(Qux::class, $qux);
         $this->assertSame(42, $qux->a);
         $bar = $corge->map['bar'];
-        $this->assertInstanceOf(Bar::className(), $bar);
+        $this->assertInstanceOf(Bar::class, $bar);
         $this->assertSame($qux, $bar->qux);
         $q33 = $corge->map['q33'];
-        $this->assertInstanceOf(Qux::className(), $q33);
+        $this->assertInstanceOf(Qux::class, $q33);
         $this->assertSame(33, $q33->a);
     }
 
@@ -410,12 +410,12 @@ class ContainerTest extends TestCase
     {
         $container = new Container();
         $container->setSingletons([
-            'one' => Qux::className(),
+            'one' => Qux::class,
             'two' => Instance::of('one'),
         ]);
         $one = $container->get(Instance::of('one'));
         $two = $container->get(Instance::of('two'));
-        $this->assertInstanceOf(Qux::className(), $one);
+        $this->assertInstanceOf(Qux::class, $one);
         $this->assertSame($one, $two);
         $this->assertSame($one, $container->get('one'));
         $this->assertSame($one, $container->get('two'));
@@ -425,10 +425,10 @@ class ContainerTest extends TestCase
     {
         $container = new Container();
 
-        $one = $container->get(Qux::className());
-        $two = $container->get(Qux::className());
-        $this->assertInstanceOf(Qux::className(), $one);
-        $this->assertInstanceOf(Qux::className(), $two);
+        $one = $container->get(Qux::class);
+        $two = $container->get(Qux::class);
+        $this->assertInstanceOf(Qux::class, $one);
+        $this->assertInstanceOf(Qux::class, $two);
         $this->assertSame(1, $one->a);
         $this->assertSame(1, $two->a);
         $this->assertNotSame($one, $two);
@@ -438,14 +438,14 @@ class ContainerTest extends TestCase
     {
         $container = new Container();
         $container->setSingletons([
-            'qux' => Qux::className(),
-            Qux::className() => [
+            'qux' => Qux::class,
+            Qux::class => [
                 'a' => 42,
             ],
         ]);
 
         $qux = $container->get('qux');
-        $this->assertInstanceOf(Qux::className(), $qux);
+        $this->assertInstanceOf(Qux::class, $qux);
         $this->assertSame(42, $qux->a);
     }
 
@@ -461,7 +461,7 @@ class ContainerTest extends TestCase
     {
         $container = new Container();
         $container->setSingletons([
-            'model.order' => Order::className(),
+            'model.order' => Order::class,
             'test\TraversableInterface' => [
                 ['class' => 'yiiunit\data\base\TraversableObject'],
                 [['item1', 'item2']],
@@ -515,7 +515,7 @@ class ContainerTest extends TestCase
     {
         $definitions = [
             'test' => [
-                'class' => Corge::className(),
+                'class' => Corge::class,
                 '__construct()' => [
                     [Instance::of('setLater')],
                 ],
@@ -523,7 +523,7 @@ class ContainerTest extends TestCase
         ];
 
         $application = Yii::createObject([
-            '__class' => Application::className(),
+            '__class' => Application::class,
             'basePath' => __DIR__,
             'id' => 'test',
             'components' => [
@@ -547,22 +547,22 @@ class ContainerTest extends TestCase
      */
     public function testNulledConstructorParameters(): void
     {
-        $alpha = (new Container())->get(Alpha::className());
-        $this->assertInstanceOf(Beta::className(), $alpha->beta);
+        $alpha = (new Container())->get(Alpha::class);
+        $this->assertInstanceOf(Beta::class, $alpha->beta);
         $this->assertNull($alpha->omega);
 
         $QuxInterface = __NAMESPACE__ . '\stubs\QuxInterface';
         $container = new Container();
-        $container->set($QuxInterface, Qux::className());
-        $alpha = $container->get(Alpha::className());
-        $this->assertInstanceOf(Beta::className(), $alpha->beta);
+        $container->set($QuxInterface, Qux::class);
+        $alpha = $container->get(Alpha::class);
+        $this->assertInstanceOf(Beta::class, $alpha->beta);
         $this->assertInstanceOf($QuxInterface, $alpha->omega);
         $this->assertNull($alpha->unknown);
         $this->assertNull($alpha->color);
 
         $container = new Container();
         $container->set(__NAMESPACE__ . '\stubs\AbstractColor', __NAMESPACE__ . '\stubs\Color');
-        $alpha = $container->get(Alpha::className());
+        $alpha = $container->get(Alpha::class);
         $this->assertInstanceOf(__NAMESPACE__ . '\stubs\Color', $alpha->color);
     }
 
@@ -571,7 +571,7 @@ class ContainerTest extends TestCase
      */
     public function testNamedConstructorParameters(): void
     {
-        $test = (new Container())->get(Car::className(), [
+        $test = (new Container())->get(Car::class, [
             'name' => 'Hello',
             'color' => 'red',
         ]);
@@ -586,7 +586,7 @@ class ContainerTest extends TestCase
     {
         $this->expectException('yii\base\InvalidConfigException');
         $this->expectExceptionMessage('Dependencies indexed by name and by position in the same array are not allowed.');
-        (new Container())->get(Car::className(), [
+        (new Container())->get(Car::class, [
             'color' => 'red',
             'Hello',
         ]);
@@ -595,8 +595,8 @@ class ContainerTest extends TestCase
     public function dataNotInstantiableException()
     {
         return [
-            [Bar::className()],
-            [Kappa::className()],
+            [Bar::class],
+            [Kappa::class],
         ];
     }
 
@@ -615,9 +615,9 @@ class ContainerTest extends TestCase
 
     public function testNullTypeConstructorParameters(): void
     {
-        $zeta = (new Container())->get(Zeta::className());
-        $this->assertInstanceOf(Beta::className(), $zeta->beta);
-        $this->assertInstanceOf(Beta::className(), $zeta->betaNull);
+        $zeta = (new Container())->get(Zeta::class);
+        $this->assertInstanceOf(Beta::class, $zeta->beta);
+        $this->assertInstanceOf(Beta::class, $zeta->betaNull);
         $this->assertNull($zeta->color);
         $this->assertNull($zeta->colorNull);
         $this->assertNull($zeta->qux);
@@ -633,8 +633,8 @@ class ContainerTest extends TestCase
             return;
         }
 
-        $unionType = (new Container())->get(UnionTypeNull::className());
-        $this->assertInstanceOf(UnionTypeNull::className(), $unionType);
+        $unionType = (new Container())->get(UnionTypeNull::class);
+        $this->assertInstanceOf(UnionTypeNull::class, $unionType);
     }
 
     public function testUnionTypeWithoutNullConstructorParameters(): void
@@ -644,20 +644,20 @@ class ContainerTest extends TestCase
             return;
         }
 
-        $unionType = (new Container())->get(UnionTypeNotNull::className(), ['value' => 'a']);
-        $this->assertInstanceOf(UnionTypeNotNull::className(), $unionType);
+        $unionType = (new Container())->get(UnionTypeNotNull::class, ['value' => 'a']);
+        $this->assertInstanceOf(UnionTypeNotNull::class, $unionType);
 
-        $unionType = (new Container())->get(UnionTypeNotNull::className(), ['value' => 1]);
-        $this->assertInstanceOf(UnionTypeNotNull::className(), $unionType);
+        $unionType = (new Container())->get(UnionTypeNotNull::class, ['value' => 1]);
+        $this->assertInstanceOf(UnionTypeNotNull::class, $unionType);
 
-        $unionType = (new Container())->get(UnionTypeNotNull::className(), ['value' => 2.3]);
-        $this->assertInstanceOf(UnionTypeNotNull::className(), $unionType);
+        $unionType = (new Container())->get(UnionTypeNotNull::class, ['value' => 2.3]);
+        $this->assertInstanceOf(UnionTypeNotNull::class, $unionType);
 
-        $unionType = (new Container())->get(UnionTypeNotNull::className(), ['value' => true]);
-        $this->assertInstanceOf(UnionTypeNotNull::className(), $unionType);
+        $unionType = (new Container())->get(UnionTypeNotNull::class, ['value' => true]);
+        $this->assertInstanceOf(UnionTypeNotNull::class, $unionType);
 
         $this->expectException('TypeError');
-        (new Container())->get(UnionTypeNotNull::className());
+        (new Container())->get(UnionTypeNotNull::class);
     }
 
     public function testUnionTypeWithClassConstructorParameters(): void
@@ -667,12 +667,12 @@ class ContainerTest extends TestCase
             return;
         }
 
-        $unionType = (new Container())->get(UnionTypeWithClass::className(), ['value' => new Beta()]);
-        $this->assertInstanceOf(UnionTypeWithClass::className(), $unionType);
-        $this->assertInstanceOf(Beta::className(), $unionType->value);
+        $unionType = (new Container())->get(UnionTypeWithClass::class, ['value' => new Beta()]);
+        $this->assertInstanceOf(UnionTypeWithClass::class, $unionType);
+        $this->assertInstanceOf(Beta::class, $unionType->value);
 
         $this->expectException('TypeError');
-        (new Container())->get(UnionTypeNotNull::className());
+        (new Container())->get(UnionTypeNotNull::class);
     }
 
     public function testResolveCallableDependenciesUnionTypes(): void
@@ -684,27 +684,27 @@ class ContainerTest extends TestCase
 
         $this->mockApplication([
             'components' => [
-                Beta::className(),
+                Beta::class,
             ],
         ]);
 
         Yii::$container->set('yiiunit\framework\di\stubs\QuxInterface', [
-            'class' => Qux::className(),
+            'class' => Qux::class,
         ]);
 
         $className = 'yiiunit\framework\di\stubs\StaticMethodsWithUnionTypes';
 
         $params = Yii::$container->resolveCallableDependencies([$className, 'withBetaUnion']);
-        $this->assertInstanceOf(Beta::classname(), $params[0]);
+        $this->assertInstanceOf(Beta::class, $params[0]);
 
         $params = Yii::$container->resolveCallableDependencies([$className, 'withBetaUnionInverse']);
-        $this->assertInstanceOf(Beta::classname(), $params[0]);
+        $this->assertInstanceOf(Beta::class, $params[0]);
 
         $params = Yii::$container->resolveCallableDependencies([$className, 'withBetaAndQuxUnion']);
-        $this->assertInstanceOf(Beta::classname(), $params[0]);
+        $this->assertInstanceOf(Beta::class, $params[0]);
 
         $params = Yii::$container->resolveCallableDependencies([$className, 'withQuxAndBetaUnion']);
-        $this->assertInstanceOf(Qux::classname(), $params[0]);
+        $this->assertInstanceOf(Qux::class, $params[0]);
     }
 
     public function testResolveCallableDependenciesIntersectionTypes(): void
@@ -715,15 +715,15 @@ class ContainerTest extends TestCase
         }
 
         Yii::$container->set('yiiunit\framework\di\stubs\QuxInterface', [
-            'class' => Qux::className(),
+            'class' => Qux::class,
         ]);
 
         $className = 'yiiunit\framework\di\stubs\StaticMethodsWithIntersectionTypes';
 
         $params = Yii::$container->resolveCallableDependencies([$className, 'withQuxInterfaceAndQuxAnotherIntersection']);
-        $this->assertInstanceOf(Qux::classname(), $params[0]);
+        $this->assertInstanceOf(Qux::class, $params[0]);
 
         $params = Yii::$container->resolveCallableDependencies([$className, 'withQuxAnotherAndQuxInterfaceIntersection']);
-        $this->assertInstanceOf(QuxAnother::classname(), $params[0]);
+        $this->assertInstanceOf(QuxAnother::class, $params[0]);
     }
 }

--- a/tests/framework/di/InstanceTest.php
+++ b/tests/framework/di/InstanceTest.php
@@ -31,12 +31,12 @@ class InstanceTest extends TestCase
     public function testOf(): void
     {
         $container = new Container();
-        $className = Component::className();
+        $className = Component::class;
         $instance = Instance::of($className);
 
         $this->assertInstanceOf('\\yii\\di\\Instance', $instance);
-        $this->assertInstanceOf(Component::className(), $instance->get($container));
-        $this->assertInstanceOf(Component::className(), Instance::ensure($instance, $className, $container));
+        $this->assertInstanceOf(Component::class, $instance->get($container));
+        $this->assertInstanceOf(Component::class, Instance::ensure($instance, $className, $container));
         $this->assertNotSame($instance->get($container), Instance::ensure($instance, $className, $container));
     }
 
@@ -48,8 +48,8 @@ class InstanceTest extends TestCase
             'dsn' => 'test',
         ]);
 
-        $this->assertInstanceOf(Connection::className(), Instance::ensure('db', 'yii\db\Connection', $container));
-        $this->assertInstanceOf(Connection::className(), Instance::ensure(new Connection(), 'yii\db\Connection', $container));
+        $this->assertInstanceOf(Connection::class, Instance::ensure('db', 'yii\db\Connection', $container));
+        $this->assertInstanceOf(Connection::class, Instance::ensure(new Connection(), 'yii\db\Connection', $container));
         $this->assertInstanceOf('\\yii\\db\\Connection', Instance::ensure(['class' => 'yii\db\Connection', 'dsn' => 'test'], 'yii\db\Connection', $container));
         $this->assertInstanceOf('\\yii\\db\\Connection', Instance::ensure(['__class' => 'yii\db\Connection', 'dsn' => 'test'], 'yii\db\Connection', $container));
     }
@@ -84,8 +84,8 @@ class InstanceTest extends TestCase
             'dsn' => 'test',
         ]);
 
-        $this->assertInstanceOf(Connection::className(), Instance::ensure('db', null, $container));
-        $this->assertInstanceOf(Connection::className(), Instance::ensure(new Connection(), null, $container));
+        $this->assertInstanceOf(Connection::class, Instance::ensure('db', null, $container));
+        $this->assertInstanceOf(Connection::class, Instance::ensure(new Connection(), null, $container));
         $this->assertInstanceOf('\\yii\\db\\Connection', Instance::ensure(['class' => 'yii\db\Connection', 'dsn' => 'test'], null, $container));
     }
 
@@ -96,10 +96,10 @@ class InstanceTest extends TestCase
             'dsn' => 'test',
         ]);
 
-        $this->assertInstanceOf(Connection::className(), Instance::ensure('db'));
-        $this->assertInstanceOf(Connection::className(), Instance::ensure(new Connection()));
-        $this->assertInstanceOf(Connection::className(), Instance::ensure(['class' => 'yii\db\Connection', 'dsn' => 'test']));
-        $this->assertInstanceOf(Connection::className(), Instance::ensure(['__class' => 'yii\db\Connection', 'dsn' => 'test']));
+        $this->assertInstanceOf(Connection::class, Instance::ensure('db'));
+        $this->assertInstanceOf(Connection::class, Instance::ensure(new Connection()));
+        $this->assertInstanceOf(Connection::class, Instance::ensure(['class' => 'yii\db\Connection', 'dsn' => 'test']));
+        $this->assertInstanceOf(Connection::class, Instance::ensure(['__class' => 'yii\db\Connection', 'dsn' => 'test']));
         Yii::$container = new Container();
     }
 
@@ -144,7 +144,7 @@ class InstanceTest extends TestCase
 
         $container = Instance::of('db');
 
-        $this->assertInstanceOf(Connection::className(), $container->get());
+        $this->assertInstanceOf(Connection::class, $container->get());
 
         $this->destroyApplication();
     }
@@ -197,7 +197,7 @@ class InstanceTest extends TestCase
         $this->expectException('yii\base\InvalidConfigException');
         $this->expectExceptionMessage('Invalid data type: yii\db\Connection. yii\base\Widget is expected.');
         Instance::ensure([
-            'class' => Connection::className(),
+            'class' => Connection::class,
         ], 'yii\base\Widget');
     }
 }

--- a/tests/framework/di/ServiceLocatorTest.php
+++ b/tests/framework/di/ServiceLocatorTest.php
@@ -41,7 +41,7 @@ class ServiceLocatorTest extends TestCase
     {
         // anonymous function
         $container = new ServiceLocator();
-        $className = TestClass::className();
+        $className = TestClass::class;
         $container->set($className, function () {
             return new TestClass([
                 'prop1' => 100,
@@ -55,7 +55,7 @@ class ServiceLocatorTest extends TestCase
 
         // static method
         $container = new ServiceLocator();
-        $className = TestClass::className();
+        $className = TestClass::class;
         $container->set($className, [__NAMESPACE__ . '\\Creator', 'create']);
         $object = $container->get($className);
         $this->assertInstanceOf($className, $object);
@@ -66,7 +66,7 @@ class ServiceLocatorTest extends TestCase
     public function testObject(): void
     {
         $object = new TestClass();
-        $className = TestClass::className();
+        $className = TestClass::class;
         $container = new ServiceLocator();
         $container->set($className, $object);
         $this->assertSame($container->get($className), $object);
@@ -77,23 +77,23 @@ class ServiceLocatorTest extends TestCase
         $config = [
             'components' => [
                 'test' => [
-                    'class' => TestClass::className(),
+                    'class' => TestClass::class,
                 ],
             ],
         ];
 
         // User Defined Config
-        $config['components']['test']['__class'] = TestSubclass::className();
+        $config['components']['test']['__class'] = TestSubclass::class;
 
         $app = new ServiceLocator($config);
-        $this->assertInstanceOf(TestSubclass::className(), $app->get('test'));
+        $this->assertInstanceOf(TestSubclass::class, $app->get('test'));
     }
 
     public function testShared(): void
     {
         // with configuration: shared
         $container = new ServiceLocator();
-        $className = TestClass::className();
+        $className = TestClass::class;
         $container->set($className, [
             'class' => $className,
             'prop1' => 10,

--- a/tests/framework/di/stubs/FooBaz.php
+++ b/tests/framework/di/stubs/FooBaz.php
@@ -22,7 +22,7 @@ class FooBaz extends BaseObject
     public function init(): void
     {
         // default config usually used by Yii
-        $dependentConfig = array_merge(['class' => FooDependent::className()], $this->fooDependent);
+        $dependentConfig = array_merge(['class' => FooDependent::class], $this->fooDependent);
         $this->fooDependent = Yii::createObject($dependentConfig);
     }
 }

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -58,7 +58,7 @@ class AccessRuleTest extends TestCase
     protected function mockUser($userid = null)
     {
         $user = new User([
-            'identityClass' => UserIdentity::className(),
+            'identityClass' => UserIdentity::class,
             'enableAutoLogin' => false,
         ]);
         if ($userid !== null) {
@@ -381,7 +381,7 @@ class AccessRuleTest extends TestCase
     {
         $action = $this->mockAction();
         $user = $this->getMockBuilder('\yii\web\User')->getMock();
-        $user->identityCLass = UserIdentity::className();
+        $user->identityCLass = UserIdentity::class;
 
         $rule = new AccessRule([
             'allow' => true,

--- a/tests/framework/filters/PageCacheTest.php
+++ b/tests/framework/filters/PageCacheTest.php
@@ -422,7 +422,7 @@ class PageCacheTest extends TestCase
                 'cache' => $cache = new ArrayCache(),
                 'view' => new View(),
                 'dependency' => [
-                    'class' => ExpressionDependency::className(),
+                    'class' => ExpressionDependency::class,
                     'expression' => 'Yii::$app->params[\'dependency\']',
                 ],
             ]);

--- a/tests/framework/filters/RateLimiterTest.php
+++ b/tests/framework/filters/RateLimiterTest.php
@@ -48,7 +48,7 @@ class RateLimiterTest extends TestCase
     {
         $rateLimiter = new RateLimiter();
 
-        $this->assertInstanceOf(Request::className(), $rateLimiter->request);
+        $this->assertInstanceOf(Request::class, $rateLimiter->request);
     }
 
     public function testInitFilledResponse(): void
@@ -62,7 +62,7 @@ class RateLimiterTest extends TestCase
     {
         $rateLimiter = new RateLimiter();
 
-        $this->assertInstanceOf(Response::className(), $rateLimiter->response);
+        $this->assertInstanceOf(Response::class, $rateLimiter->response);
     }
 
     public function testBeforeActionUserInstanceOfRateLimitInterface(): void
@@ -94,7 +94,7 @@ class RateLimiterTest extends TestCase
 
     public function testBeforeActionEmptyUser(): void
     {
-        $user = new User(['identityClass' => RateLimit::className()]);
+        $user = new User(['identityClass' => RateLimit::class]);
         Yii::$app->set('user', $user);
         $rateLimiter = new RateLimiter();
 
@@ -159,13 +159,13 @@ class RateLimiterTest extends TestCase
     {
         $rateLimiter = new RateLimiter();
         $rateLimiter->user = function ($action) {
-            return new User(['identityClass' => RateLimit::className()]);
+            return new User(['identityClass' => RateLimit::class]);
         };
         $rateLimiter->beforeAction('test');
 
         // testing the evaluation of user closure, which in this case returns not the expect object and therefore
         // the log message "does not implement RateLimitInterface" is expected.
-        $this->assertInstanceOf(User::className(), $rateLimiter->user);
+        $this->assertInstanceOf(User::class, $rateLimiter->user);
         $this->assertContains(
             'Rate limit skipped: "user" does not implement RateLimitInterface.',
             Yii::getLogger()->messages

--- a/tests/framework/filters/auth/AuthMethodTest.php
+++ b/tests/framework/filters/auth/AuthMethodTest.php
@@ -26,7 +26,7 @@ class AuthMethodTest extends TestCase
         $this->mockWebApplication([
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ]);
@@ -39,7 +39,7 @@ class AuthMethodTest extends TestCase
      */
     protected function createFilter($authenticateCallback)
     {
-        $filter = $this->getMockBuilder(AuthMethod::className())
+        $filter = $this->getMockBuilder(AuthMethod::class)
             ->setMethods(['authenticate'])
             ->getMock();
         $filter->method('authenticate')->willReturnCallback($authenticateCallback);
@@ -78,7 +78,7 @@ class AuthMethodTest extends TestCase
 
     public function testIsOptional(): void
     {
-        $reflection = new ReflectionClass(AuthMethod::className());
+        $reflection = new ReflectionClass(AuthMethod::class);
         $method = $reflection->getMethod('isOptional');
 
         // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible

--- a/tests/framework/filters/auth/AuthTest.php
+++ b/tests/framework/filters/auth/AuthTest.php
@@ -38,11 +38,11 @@ class AuthTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
             'controllerMap' => [
-                'test-auth' => TestAuthController::className(),
+                'test-auth' => TestAuthController::class,
             ],
         ];
 
@@ -108,7 +108,7 @@ class AuthTest extends TestCase
     public function testQueryParamAuth($token, $login): void
     {
         $_GET['access-token'] = $token;
-        $filter = ['class' => QueryParamAuth::className()];
+        $filter = ['class' => QueryParamAuth::class];
         $this->ensureFilterApplies($token, $login, $filter);
     }
 
@@ -120,7 +120,7 @@ class AuthTest extends TestCase
     public function testHttpHeaderAuth($token, $login): void
     {
         Yii::$app->request->headers->set('X-Api-Key', $token);
-        $filter = ['class' => HttpHeaderAuth::className()];
+        $filter = ['class' => HttpHeaderAuth::class];
         $this->ensureFilterApplies($token, $login, $filter);
     }
 
@@ -132,7 +132,7 @@ class AuthTest extends TestCase
     public function testHttpBearerAuth($token, $login): void
     {
         Yii::$app->request->headers->set('Authorization', "Bearer $token");
-        $filter = ['class' => HttpBearerAuth::className()];
+        $filter = ['class' => HttpBearerAuth::class];
         $this->ensureFilterApplies($token, $login, $filter);
     }
 
@@ -203,7 +203,7 @@ class AuthTest extends TestCase
     public function testHeaders(): void
     {
         Yii::$app->request->headers->set('Authorization', 'Bearer wrong_token');
-        $filter = ['class' => HttpBearerAuth::className()];
+        $filter = ['class' => HttpBearerAuth::class];
         $controller = Yii::$app->createController('test-auth')[0];
         $controller->authenticatorConfig = ArrayHelper::merge($filter, ['only' => ['filtered']]);
         try {

--- a/tests/framework/filters/auth/BasicAuthTest.php
+++ b/tests/framework/filters/auth/BasicAuthTest.php
@@ -32,7 +32,7 @@ class BasicAuthTest extends AuthTest
 
         $_SERVER['PHP_AUTH_USER'] = $token;
         $_SERVER['PHP_AUTH_PW'] = 'whatever, we are testers';
-        $filter = ['class' => HttpBasicAuth::className()];
+        $filter = ['class' => HttpBasicAuth::class];
         $this->ensureFilterApplies($token, $login, $filter);
         $_SERVER = $original;
     }
@@ -47,7 +47,7 @@ class BasicAuthTest extends AuthTest
         $original = $_SERVER;
 
         $_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode($token . ':' . 'mypw');
-        $filter = ['class' => HttpBasicAuth::className()];
+        $filter = ['class' => HttpBasicAuth::class];
         $this->ensureFilterApplies($token, $login, $filter);
         $_SERVER = $original;
     }
@@ -62,7 +62,7 @@ class BasicAuthTest extends AuthTest
         $original = $_SERVER;
 
         $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode($token . ':' . 'mypw');
-        $filter = ['class' => HttpBasicAuth::className()];
+        $filter = ['class' => HttpBasicAuth::class];
         $this->ensureFilterApplies($token, $login, $filter);
         $_SERVER = $original;
     }
@@ -77,7 +77,7 @@ class BasicAuthTest extends AuthTest
         $_SERVER['PHP_AUTH_USER'] = $login;
         $_SERVER['PHP_AUTH_PW'] = 'whatever, we are testers';
         $filter = [
-            'class' => HttpBasicAuth::className(),
+            'class' => HttpBasicAuth::class,
             'auth' => function ($username, $password) {
                 if (preg_match('/\d$/', (string)$username)) {
                     return UserIdentity::findIdentity($username);
@@ -110,7 +110,7 @@ class BasicAuthTest extends AuthTest
         $sessionId = $session->getId();
 
         $filter = [
-            'class' => HttpBasicAuth::className(),
+            'class' => HttpBasicAuth::class,
             'auth' => function ($username, $password) {
                 $this->fail('Authentication closure should not be called when user is already authenticated');
             },

--- a/tests/framework/filters/auth/CompositeAuthTest.php
+++ b/tests/framework/filters/auth/CompositeAuthTest.php
@@ -92,8 +92,8 @@ class TestController extends Controller
          */
         return [
             'authenticator' => [
-                'class' => CompositeAuth::className(),
-                'authMethods' => $this->authMethods ?: [TestAuth::className()],
+                'class' => CompositeAuth::class,
+                'authMethods' => $this->authMethods ?: [TestAuth::class],
                 'optional' => $this->optional
             ],
         ];
@@ -115,11 +115,11 @@ class CompositeAuthTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
             'controllerMap' => [
-                'test' => TestController::className(),
+                'test' => TestController::class,
             ],
         ];
 
@@ -184,8 +184,8 @@ class CompositeAuthTest extends TestCase
             //base usage
             [
                 [
-                    HttpBearerAuth::className(),
-                    TestAuth::className(),
+                    HttpBearerAuth::class,
+                    TestAuth::class,
                 ],
                 'b',
                 true
@@ -199,9 +199,9 @@ class CompositeAuthTest extends TestCase
             //only "a", run "b"
             [
                 [
-                    HttpBearerAuth::className(),
+                    HttpBearerAuth::class,
                     [
-                        'class' => TestAuth::className(),
+                        'class' => TestAuth::class,
                         'only' => ['a']
                     ],
                 ],
@@ -211,9 +211,9 @@ class CompositeAuthTest extends TestCase
             //only "a", run "a"
             [
                 [
-                    HttpBearerAuth::className(),
+                    HttpBearerAuth::class,
                     [
-                        'class' => TestAuth::className(),
+                        'class' => TestAuth::class,
                         'only' => ['a']
                     ],
                 ],
@@ -223,9 +223,9 @@ class CompositeAuthTest extends TestCase
             //except "b", run "a"
             [
                 [
-                    HttpBearerAuth::className(),
+                    HttpBearerAuth::class,
                     [
-                        'class' => TestAuth::className(),
+                        'class' => TestAuth::class,
                         'except' => ['b']
                     ],
                 ],
@@ -235,9 +235,9 @@ class CompositeAuthTest extends TestCase
             //except "b", run "b"
             [
                 [
-                    HttpBearerAuth::className(),
+                    HttpBearerAuth::class,
                     [
-                        'class' => TestAuth::className(),
+                        'class' => TestAuth::class,
                         'except' => ['b']
                     ],
                 ],

--- a/tests/framework/grid/DataColumnTest.php
+++ b/tests/framework/grid/DataColumnTest.php
@@ -36,7 +36,7 @@ class DataColumnTest extends TestCase
             'dataProvider' => new ArrayDataProvider([
                 'allModels' => [],
                 'totalCount' => 0,
-                'modelClass' => Order::className(),
+                'modelClass' => Order::class,
             ]),
             'columns' => ['customer_id', 'total'],
         ]);

--- a/tests/framework/grid/GridViewTest.php
+++ b/tests/framework/grid/GridViewTest.php
@@ -102,7 +102,7 @@ class GridViewTest extends TestCase
         $this->assertCount(count($row), $columns);
 
         foreach ($columns as $index => $column) {
-            $this->assertInstanceOf(DataColumn::className(), $column);
+            $this->assertInstanceOf(DataColumn::class, $column);
             $this->assertArrayHasKey($column->attribute, $row);
         }
 
@@ -123,7 +123,7 @@ class GridViewTest extends TestCase
         $this->assertCount(count($row) - 2, $columns);
 
         foreach ($columns as $index => $column) {
-            $this->assertInstanceOf(DataColumn::className(), $column);
+            $this->assertInstanceOf(DataColumn::class, $column);
             $this->assertArrayHasKey($column->attribute, $row);
             $this->assertNotEquals('relation', $column->attribute);
             $this->assertNotEquals('otherRelation', $column->attribute);
@@ -166,7 +166,7 @@ class GridViewTest extends TestCase
         $this->mockApplication([
             'components' => [
                 'db' => [
-                    'class' => Connection::className(),
+                    'class' => Connection::class,
                     'dsn' => 'sqlite::memory:',
                 ],
             ],

--- a/tests/framework/grid/RadiobuttonColumnTest.php
+++ b/tests/framework/grid/RadiobuttonColumnTest.php
@@ -95,7 +95,7 @@ class RadiobuttonColumnTest extends TestCase
             'options' => ['id' => 'radio-gridview'],
             'columns' => [
                 [
-                    'class' => RadioButtonColumn::className(),
+                    'class' => RadioButtonColumn::class,
                     'radioOptions' => function ($model) {
                         return [
                             'value' => $model['value'],

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -65,7 +65,7 @@ class ArrayHelperTest extends TestCase
             '_content' => 'test',
             'length' => 4,
         ], ArrayHelper::toArray($object, [
-            $object::className() => [
+            get_class($object) => [
                 'id', 'secret',
                 '_content' => 'content',
                 'length' => function ($post) {
@@ -94,13 +94,13 @@ class ArrayHelperTest extends TestCase
                 'id_plus_1' => 124,
             ],
         ], ArrayHelper::toArray($object, [
-            $object::className() => [
+            get_class($object) => [
                 'id', 'subObject',
                 'id_plus_1' => function ($post) {
                     return $post->id + 1;
                 },
             ],
-            $subObject::className() => [
+            get_class($subObject) => [
                 'id',
                 'id_plus_1' => function ($post) {
                     return $post->id + 1;
@@ -116,7 +116,7 @@ class ArrayHelperTest extends TestCase
                 'id_plus_1' => 124,
             ],
         ], ArrayHelper::toArray($object, [
-            $subObject::className() => [
+            get_class($subObject) => [
                 'id',
                 'id_plus_1' => function ($post) {
                     return $post->id + 1;

--- a/tests/framework/helpers/UrlTest.php
+++ b/tests/framework/helpers/UrlTest.php
@@ -42,7 +42,7 @@ class UrlTest extends TestCase
                     'hostInfo' => 'http://example.com/',
                 ],
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ], '\yii\web\Application');

--- a/tests/framework/i18n/DbMessageSourceTest.php
+++ b/tests/framework/i18n/DbMessageSourceTest.php
@@ -51,7 +51,7 @@ class DbMessageSourceTest extends I18NTest
 
     private function getMessageSourceClass()
     {
-        return DbMessageSource::className();
+        return DbMessageSource::class;
     }
 
     protected static function runConsoleAction($route, $params = [])
@@ -61,7 +61,7 @@ class DbMessageSourceTest extends I18NTest
                 'id' => 'Migrator',
                 'basePath' => '@yiiunit',
                 'controllerMap' => [
-                    'migrate' => EchoMigrateController::className(),
+                    'migrate' => EchoMigrateController::class,
                 ],
                 'components' => [
                     'db' => static::getConnection(),
@@ -153,14 +153,14 @@ class DbMessageSourceTest extends I18NTest
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
 
-        Event::on(DbMessageSource::className(), DbMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
+        Event::on(DbMessageSource::class, DbMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
         });
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
-        Event::off(DbMessageSource::className(), DbMessageSource::EVENT_MISSING_TRANSLATION);
+        Event::off(DbMessageSource::class, DbMessageSource::EVENT_MISSING_TRANSLATION);
 
-        Event::on(DbMessageSource::className(), DbMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
+        Event::on(DbMessageSource::class, DbMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
             if ($event->message == 'New missing translation message.') {
                 $event->translatedMessage = 'TRANSLATION MISSING HERE!';
             }
@@ -170,7 +170,7 @@ class DbMessageSourceTest extends I18NTest
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('TRANSLATION MISSING HERE!', $this->i18n->translate('test', 'New missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
-        Event::off(DbMessageSource::className(), DbMessageSource::EVENT_MISSING_TRANSLATION);
+        Event::off(DbMessageSource::class, DbMessageSource::EVENT_MISSING_TRANSLATION);
     }
 
     public function testIssue11429($sourceLanguage = null): void

--- a/tests/framework/i18n/I18NTest.php
+++ b/tests/framework/i18n/I18NTest.php
@@ -47,7 +47,7 @@ class I18NTest extends TestCase
 
     private function getMessageSourceClass()
     {
-        return PhpMessageSource::className();
+        return PhpMessageSource::class;
     }
 
     public function testTranslate(): void
@@ -210,14 +210,14 @@ class I18NTest extends TestCase
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
 
-        Event::on(PhpMessageSource::className(), PhpMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
+        Event::on(PhpMessageSource::class, PhpMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
         });
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
-        Event::off(PhpMessageSource::className(), PhpMessageSource::EVENT_MISSING_TRANSLATION);
+        Event::off(PhpMessageSource::class, PhpMessageSource::EVENT_MISSING_TRANSLATION);
 
-        Event::on(PhpMessageSource::className(), PhpMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
+        Event::on(PhpMessageSource::class, PhpMessageSource::EVENT_MISSING_TRANSLATION, function ($event) {
             if ($event->message == 'New missing translation message.') {
                 $event->translatedMessage = 'TRANSLATION MISSING HERE!';
             }
@@ -227,7 +227,7 @@ class I18NTest extends TestCase
         $this->assertEquals('Missing translation message.', $this->i18n->translate('test', 'Missing translation message.', [], 'de-DE'));
         $this->assertEquals('TRANSLATION MISSING HERE!', $this->i18n->translate('test', 'New missing translation message.', [], 'de-DE'));
         $this->assertEquals('Hallo Welt!', $this->i18n->translate('test', 'Hello world!', [], 'de-DE'));
-        Event::off(PhpMessageSource::className(), PhpMessageSource::EVENT_MISSING_TRANSLATION);
+        Event::off(PhpMessageSource::class, PhpMessageSource::EVENT_MISSING_TRANSLATION);
     }
 
     public function sourceLanguageDataProvider()

--- a/tests/framework/log/DbTargetTest.php
+++ b/tests/framework/log/DbTargetTest.php
@@ -43,7 +43,7 @@ abstract class DbTargetTest extends TestCase
                 'id' => 'Migrator',
                 'basePath' => '@yiiunit',
                 'controllerMap' => [
-                    'migrate' => EchoMigrateController::className(),
+                    'migrate' => EchoMigrateController::class,
                 ],
                 'components' => [
                     'db' => static::getConnection(),

--- a/tests/framework/mutex/FileMutexTest.php
+++ b/tests/framework/mutex/FileMutexTest.php
@@ -29,7 +29,7 @@ class FileMutexTest extends TestCase
     protected function createMutex()
     {
         return Yii::createObject([
-            'class' => FileMutex::className(),
+            'class' => FileMutex::class,
             'mutexPath' => '@yiiunit/runtime/mutex',
         ]);
     }

--- a/tests/framework/mutex/MysqlMutexTest.php
+++ b/tests/framework/mutex/MysqlMutexTest.php
@@ -35,7 +35,7 @@ class MysqlMutexTest extends DatabaseTestCase
     protected function createMutex($additionalParams = [])
     {
         return Yii::createObject(array_merge([
-            'class' => MysqlMutex::className(),
+            'class' => MysqlMutex::class,
             'db' => $this->getConnection(),
         ], $additionalParams));
     }
@@ -106,8 +106,8 @@ class MysqlMutexTest extends DatabaseTestCase
     public function testCreateMutex(): void
     {
         $mutex = $this->createMutex(['keyPrefix' => new Expression('1+1')]);
-        $this->assertInstanceOf(MysqlMutex::classname(), $mutex);
-        $this->assertInstanceOf(Expression::classname(), $mutex->keyPrefix);
+        $this->assertInstanceOf(MysqlMutex::class, $mutex);
+        $this->assertInstanceOf(Expression::class, $mutex->keyPrefix);
         $this->assertSame('1+1', $mutex->keyPrefix->expression);
     }
 }

--- a/tests/framework/mutex/PgsqlMutexTest.php
+++ b/tests/framework/mutex/PgsqlMutexTest.php
@@ -33,7 +33,7 @@ class PgsqlMutexTest extends DatabaseTestCase
     protected function createMutex()
     {
         return Yii::createObject([
-            'class' => PgsqlMutex::className(),
+            'class' => PgsqlMutex::class,
             'db' => $this->getConnection(),
         ]);
     }

--- a/tests/framework/mutex/RetryAcquireTraitTest.php
+++ b/tests/framework/mutex/RetryAcquireTraitTest.php
@@ -90,7 +90,7 @@ class RetryAcquireTraitTest extends TestCase
     {
         return Yii::createObject(
             [
-                'class' => DumbMutex::className(),
+                'class' => DumbMutex::class,
             ]
         );
     }

--- a/tests/framework/rbac/DbManagerTestCase.php
+++ b/tests/framework/rbac/DbManagerTestCase.php
@@ -62,7 +62,7 @@ abstract class DbManagerTestCase extends ManagerTestCase
                 'id' => 'Migrator',
                 'basePath' => '@yiiunit',
                 'controllerMap' => [
-                    'migrate' => EchoMigrateController::className(),
+                    'migrate' => EchoMigrateController::class,
                 ],
                 'components' => [
                     'db' => static::createConnection(),
@@ -206,7 +206,7 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
         if ($isValid) {
             $this->assertTrue(isset($permissions['createPost']));
-            $this->assertInstanceOf(Permission::className(), $permissions['createPost']);
+            $this->assertInstanceOf(Permission::class, $permissions['createPost']);
         } else {
             $this->assertEmpty($permissions);
         }
@@ -226,7 +226,7 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
         if ($isValid) {
             $this->assertTrue(isset($roles['Author']));
-            $this->assertInstanceOf(Role::className(), $roles['Author']);
+            $this->assertInstanceOf(Role::class, $roles['Author']);
         } else {
             $this->assertEmpty($roles);
         }
@@ -277,7 +277,7 @@ abstract class DbManagerTestCase extends ManagerTestCase
         $assignment = $this->auth->getAssignment('createPost', $searchUserId);
 
         if ($isValid) {
-            $this->assertInstanceOf(Assignment::className(), $assignment);
+            $this->assertInstanceOf(Assignment::class, $assignment);
             $this->assertEquals($userId, $assignment->userId);
         } else {
             $this->assertEmpty($assignment);
@@ -298,8 +298,8 @@ abstract class DbManagerTestCase extends ManagerTestCase
 
         if ($isValid) {
             $this->assertNotEmpty($assignments);
-            $this->assertInstanceOf(Assignment::className(), $assignments['createPost']);
-            $this->assertInstanceOf(Assignment::className(), $assignments['updatePost']);
+            $this->assertInstanceOf(Assignment::class, $assignments['createPost']);
+            $this->assertInstanceOf(Assignment::class, $assignments['updatePost']);
         } else {
             $this->assertEmpty($assignments);
         }

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -35,7 +35,7 @@ abstract class ManagerTestCase extends TestCase
     public function testCreateRole(): void
     {
         $role = $this->auth->createRole('admin');
-        $this->assertInstanceOf(Role::className(), $role);
+        $this->assertInstanceOf(Role::class, $role);
         $this->assertEquals(Item::TYPE_ROLE, $role->type);
         $this->assertEquals('admin', $role->name);
     }
@@ -43,7 +43,7 @@ abstract class ManagerTestCase extends TestCase
     public function testCreatePermission(): void
     {
         $permission = $this->auth->createPermission('edit post');
-        $this->assertInstanceOf(Permission::className(), $permission);
+        $this->assertInstanceOf(Permission::class, $permission);
         $this->assertEquals(Item::TYPE_PERMISSION, $permission->type);
         $this->assertEquals('edit post', $permission->name);
     }
@@ -278,7 +278,7 @@ abstract class ManagerTestCase extends TestCase
         $expectedPermissions = ['createPost', 'updatePost', 'readPost', 'updateAnyPost'];
         $this->assertEquals(count($expectedPermissions), count($permissions));
         foreach ($expectedPermissions as $permissionName) {
-            $this->assertInstanceOf(Permission::className(), $permissions[$permissionName]);
+            $this->assertInstanceOf(Permission::class, $permissions[$permissionName]);
         }
     }
 
@@ -289,7 +289,7 @@ abstract class ManagerTestCase extends TestCase
         $expectedPermissions = ['deletePost', 'createPost', 'updatePost', 'readPost'];
         $this->assertEquals(count($expectedPermissions), count($permissions));
         foreach ($expectedPermissions as $permissionName) {
-            $this->assertInstanceOf(Permission::className(), $permissions[$permissionName]);
+            $this->assertInstanceOf(Permission::class, $permissions[$permissionName]);
         }
     }
 
@@ -319,15 +319,15 @@ abstract class ManagerTestCase extends TestCase
         $this->auth->assign($reader, 123);
 
         $roles = $this->auth->getRolesByUser('reader A');
-        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertInstanceOf(Role::class, reset($roles));
         $this->assertEquals($roles['reader']->name, 'reader');
 
         $roles = $this->auth->getRolesByUser(0);
-        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertInstanceOf(Role::class, reset($roles));
         $this->assertEquals($roles['reader']->name, 'reader');
 
         $roles = $this->auth->getRolesByUser(123);
-        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertInstanceOf(Role::class, reset($roles));
         $this->assertEquals($roles['reader']->name, 'reader');
 
         $this->assertContains('myDefaultRole', array_keys($roles));
@@ -339,12 +339,12 @@ abstract class ManagerTestCase extends TestCase
 
         $roles = $this->auth->getChildRoles('withoutChildren');
         $this->assertCount(1, $roles);
-        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertInstanceOf(Role::class, reset($roles));
         $this->assertSame(reset($roles)->name, 'withoutChildren');
 
         $roles = $this->auth->getChildRoles('reader');
         $this->assertCount(1, $roles);
-        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertInstanceOf(Role::class, reset($roles));
         $this->assertSame(reset($roles)->name, 'reader');
 
         $roles = $this->auth->getChildRoles('author');
@@ -623,7 +623,7 @@ abstract class ManagerTestCase extends TestCase
 
         /** @var ActionRule $rule */
         $rule = $this->auth->getRule('action_rule');
-        $this->assertInstanceOf(ActionRule::className(), $rule);
+        $this->assertInstanceOf(ActionRule::class, $rule);
     }
 
     public function testDefaultRolesWithClosureReturningNonArrayValue(): void

--- a/tests/framework/rest/IndexActionTest.php
+++ b/tests/framework/rest/IndexActionTest.php
@@ -28,7 +28,7 @@ class IndexActionTest extends TestCase
                     'dsn' => 'sqlite::memory:',
                 ],
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ]);
@@ -46,11 +46,11 @@ class IndexActionTest extends TestCase
             'rest',
             new Module('rest'),
             [
-                'modelClass' => IndexActionModel::className(),
+                'modelClass' => IndexActionModel::class,
                 'actions' => [
                     'index' => [
-                        'class' => IndexAction::className(),
-                        'modelClass' => IndexActionModel::className(),
+                        'class' => IndexAction::class,
+                        'modelClass' => IndexActionModel::class,
                         'prepareSearchQuery' => function ($query, $requestParams) use (&$sql) {
                             $this->assertTrue($query instanceof Query);
                             $sql = $query->createCommand()->getRawSql();
@@ -93,11 +93,11 @@ class IndexActionTest extends TestCase
             'rest',
             new Module('rest'),
             [
-                'modelClass' => IndexActionModel::className(),
+                'modelClass' => IndexActionModel::class,
                 'actions' => [
                     'index' => [
-                        'class' => IndexAction::className(),
-                        'modelClass' => IndexActionModel::className(),
+                        'class' => IndexAction::class,
+                        'modelClass' => IndexActionModel::class,
                         'pagination' => $pagination,
                         'sort' => $sort,
                     ],

--- a/tests/framework/test/ActiveFixtureTest.php
+++ b/tests/framework/test/ActiveFixtureTest.php
@@ -43,7 +43,7 @@ class ActiveFixtureTest extends DatabaseTestCase
         $test->setUp();
         $fixture = $test->getFixture('customers');
 
-        $this->assertEquals(CustomerFixture::className(), get_class($fixture));
+        $this->assertEquals(CustomerFixture::class, get_class($fixture));
         $this->assertCount(2, $fixture);
         $this->assertEquals(1, $fixture['customer1']['id']);
         $this->assertEquals('customer1@example.com', $fixture['customer1']['email']);
@@ -62,7 +62,7 @@ class ActiveFixtureTest extends DatabaseTestCase
         $test->setUp();
         $fixture = $test->getFixture('customers');
 
-        $this->assertEquals(Customer::className(), get_class($fixture->getModel('customer1')));
+        $this->assertEquals(Customer::class, get_class($fixture->getModel('customer1')));
         $this->assertEquals(1, $fixture->getModel('customer1')->id);
         $this->assertEquals('customer1@example.com', $fixture->getModel('customer1')->email);
         $this->assertEquals(1, $fixture['customer1']['profile_id']);
@@ -220,7 +220,7 @@ class CustomerDbTestCase extends BaseDbTestCase
     public function fixtures()
     {
         return [
-            'customers' => CustomerFixture::className(),
+            'customers' => CustomerFixture::class,
         ];
     }
 }
@@ -230,7 +230,7 @@ class CustomDirectoryDbTestCase extends BaseDbTestCase
     public function fixtures()
     {
         return [
-            'customers' => CustomDirectoryFixture::className(),
+            'customers' => CustomDirectoryFixture::class,
         ];
     }
 }
@@ -241,7 +241,7 @@ class DataPathDbTestCase extends BaseDbTestCase
     {
         return [
             'customers' => [
-                'class' => CustomDirectoryFixture::className(),
+                'class' => CustomDirectoryFixture::class,
                 'dataFile' => '@app/framework/test/data/customer.php'
             ]
         ];
@@ -254,7 +254,7 @@ class TruncateTestCase extends BaseDbTestCase
     {
         return [
             'animals' => [
-                'class' => AnimalFixture::className(),
+                'class' => AnimalFixture::class,
             ]
         ];
     }

--- a/tests/framework/test/FixtureTest.php
+++ b/tests/framework/test/FixtureTest.php
@@ -116,50 +116,50 @@ class MyTestCase
                 return [];
             case 1:
                 return [
-                    'fixture1' => Fixture1::className(),
+                    'fixture1' => Fixture1::class,
                 ];
             case 2:
                 return [
-                    'fixture2' => Fixture2::className(),
+                    'fixture2' => Fixture2::class,
                 ];
             case 3:
                 return [
-                    'fixture3' => Fixture3::className(),
+                    'fixture3' => Fixture3::class,
                 ];
             case 4:
                 return [
-                    'fixture1' => Fixture1::className(),
-                    'fixture2' => Fixture2::className(),
+                    'fixture1' => Fixture1::class,
+                    'fixture2' => Fixture2::class,
                 ];
             case 5:
                 return [
-                    'fixture2' => Fixture2::className(),
-                    'fixture3' => Fixture3::className(),
+                    'fixture2' => Fixture2::class,
+                    'fixture3' => Fixture3::class,
                 ];
             case 6:
                 return [
-                    'fixture1' => Fixture1::className(),
-                    'fixture3' => Fixture3::className(),
+                    'fixture1' => Fixture1::class,
+                    'fixture3' => Fixture3::class,
                 ];
             case 7:
                 return [
-                    'fixture1' => Fixture1::className(),
-                    'fixture2' => Fixture2::className(),
-                    'fixture3' => Fixture3::className(),
+                    'fixture1' => Fixture1::class,
+                    'fixture2' => Fixture2::class,
+                    'fixture3' => Fixture3::class,
                 ];
             case 8:
                 return [
-                    'fixture4' => Fixture4::className(),
+                    'fixture4' => Fixture4::class,
                 ];
             case 9:
                 return [
-                    'fixture5' => Fixture5::className(),
-                    'fixture4' => Fixture4::className(),
+                    'fixture5' => Fixture5::class,
+                    'fixture4' => Fixture4::class,
                 ];
             case 10:
                 return [
-                    'fixture3a' => Fixture3::className(), // duplicate fixtures may occur two fixtures depend on the same fixture.
-                    'fixture3b' => Fixture3::className(),
+                    'fixture3a' => Fixture3::class, // duplicate fixtures may occur two fixtures depend on the same fixture.
+                    'fixture3b' => Fixture3::class,
                 ];
             default:
                 return [];

--- a/tests/framework/validators/ExistValidatorTest.php
+++ b/tests/framework/validators/ExistValidatorTest.php
@@ -41,7 +41,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
         }
         // combine to save the time creating a new db-fixture set (likely ~5 sec)
         try {
-            $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::className()]);
+            $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::class]);
             $val->validate('ref');
             $this->fail('Exception should have been thrown at this time');
         } catch (Exception $e) {
@@ -52,7 +52,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
 
     public function testValidateValue(): void
     {
-        $val = new ExistValidator(['targetClass' => ValidatorTestRefModel::className(), 'targetAttribute' => 'id']);
+        $val = new ExistValidator(['targetClass' => ValidatorTestRefModel::class, 'targetAttribute' => 'id']);
         $this->assertTrue($val->validate(2));
         $this->assertTrue($val->validate(5));
         $this->assertFalse($val->validate(99));
@@ -62,12 +62,12 @@ abstract class ExistValidatorTest extends DatabaseTestCase
     public function testValidateAttribute(): void
     {
         // existing value on different table
-        $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::className(), 'targetAttribute' => 'id']);
+        $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::class, 'targetAttribute' => 'id']);
         $m = ValidatorTestRefModel::findOne(['id' => 1]);
         $val->validateAttribute($m, 'ref');
         $this->assertFalse($m->hasErrors());
         // non-existing value on different table
-        $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::className(), 'targetAttribute' => 'id']);
+        $val = new ExistValidator(['targetClass' => ValidatorTestMainModel::class, 'targetAttribute' => 'id']);
         $m = ValidatorTestRefModel::findOne(['id' => 6]);
         $val->validateAttribute($m, 'ref');
         $this->assertTrue($m->hasErrors('ref'));
@@ -139,7 +139,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
     public function testValidateCompositeKeys(): void
     {
         $val = new ExistValidator([
-            'targetClass' => OrderItem::className(),
+            'targetClass' => OrderItem::class,
             'targetAttribute' => ['order_id', 'item_id'],
         ]);
         // validate old record
@@ -159,7 +159,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
         $this->assertTrue($m->hasErrors('order_id'));
 
         $val = new ExistValidator([
-            'targetClass' => OrderItem::className(),
+            'targetClass' => OrderItem::class,
             'targetAttribute' => ['id' => 'order_id'],
         ]);
         // validate old record
@@ -188,7 +188,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
         OrderItem::$tableName = '{{%order_item}}';
 
         $val = new ExistValidator([
-            'targetClass' => OrderItem::className(),
+            'targetClass' => OrderItem::class,
             'targetAttribute' => ['id' => 'order_id'],
         ]);
 
@@ -206,7 +206,7 @@ abstract class ExistValidatorTest extends DatabaseTestCase
     public function testExpresionInAttributeColumnName(): void
     {
         $val = new ExistValidator([
-            'targetClass' => OrderItem::className(),
+            'targetClass' => OrderItem::class,
             'targetAttribute' => ['id' => 'COALESCE([[order_id]], 0)'],
         ]);
 

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -129,7 +129,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
 
     public function testValidateAttributeOfNonARModel(): void
     {
-        $val = new UniqueValidator(['targetClass' => ValidatorTestRefModel::className(), 'targetAttribute' => 'ref']);
+        $val = new UniqueValidator(['targetClass' => ValidatorTestRefModel::class, 'targetAttribute' => 'ref']);
         $m = FakedValidationModel::createWithAttributes(['attr_1' => 5, 'attr_2' => 1313]);
         $val->validateAttribute($m, 'attr_1');
         $this->assertTrue($m->hasErrors('attr_1'));
@@ -139,7 +139,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
 
     public function testValidateNonDatabaseAttribute(): void
     {
-        $val = new UniqueValidator(['targetClass' => ValidatorTestRefModel::className(), 'targetAttribute' => 'ref']);
+        $val = new UniqueValidator(['targetClass' => ValidatorTestRefModel::class, 'targetAttribute' => 'ref']);
         /** @var ValidatorTestMainModel $m */
         $m = ValidatorTestMainModel::findOne(1);
         $val->validateAttribute($m, 'testMainVal');
@@ -161,7 +161,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
     public function testValidateCompositeKeys(): void
     {
         $val = new UniqueValidator([
-            'targetClass' => OrderItem::className(),
+            'targetClass' => OrderItem::class,
             'targetAttribute' => ['order_id', 'item_id'],
         ]);
         // validate old record
@@ -184,7 +184,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $this->assertFalse($m->hasErrors('order_id'));
 
         $val = new UniqueValidator([
-            'targetClass' => OrderItem::className(),
+            'targetClass' => OrderItem::class,
             'targetAttribute' => ['id' => 'order_id'],
         ]);
         // validate old record
@@ -216,7 +216,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
     {
         // Check whether "Description" and "name" aren't equal
         $val = new UniqueValidator([
-            'targetClass' => Customer::className(),
+            'targetClass' => Customer::class,
             'targetAttribute' => ['description' => 'name'],
         ]);
 
@@ -364,11 +364,11 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
 
     public function testGetTargetClassWithFilledTargetClassProperty(): void
     {
-        $validator = new UniqueValidator(['targetClass' => Profile::className()]);
+        $validator = new UniqueValidator(['targetClass' => Profile::class]);
         $model = new FakedValidationModel();
         $actualTargetClass = $this->invokeMethod($validator, 'getTargetClass', [$model]);
 
-        $this->assertEquals(Profile::className(), $actualTargetClass);
+        $this->assertEquals(Profile::class, $actualTargetClass);
     }
 
     public function testGetTargetClassWithNotFilledTargetClassProperty(): void
@@ -377,7 +377,7 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $model = new FakedValidationModel();
         $actualTargetClass = $this->invokeMethod($validator, 'getTargetClass', [$model]);
 
-        $this->assertEquals(FakedValidationModel::className(), $actualTargetClass);
+        $this->assertEquals(FakedValidationModel::class, $actualTargetClass);
     }
 
     public function testPrepareQuery(): void

--- a/tests/framework/validators/ValidatorTest.php
+++ b/tests/framework/validators/ValidatorTest.php
@@ -50,9 +50,9 @@ class ValidatorTest extends TestCase
         $model = FakedValidationModel::createWithAttributes(['attr_test1' => 'abc', 'attr_test2' => '2013']);
         /** @var NumberValidator $numberVal */
         $numberVal = TestValidator::createValidator('number', $model, ['attr_test1']);
-        $this->assertInstanceOf(NumberValidator::className(), $numberVal);
+        $this->assertInstanceOf(NumberValidator::class, $numberVal);
         $numberVal = TestValidator::createValidator('integer', $model, ['attr_test2']);
-        $this->assertInstanceOf(NumberValidator::className(), $numberVal);
+        $this->assertInstanceOf(NumberValidator::class, $numberVal);
         $this->assertTrue($numberVal->integerOnly);
         $val = TestValidator::createValidator(
             'boolean',
@@ -60,7 +60,7 @@ class ValidatorTest extends TestCase
             ['attr_test1', 'attr_test2'],
             ['on' => ['a', 'b']]
         );
-        $this->assertInstanceOf(BooleanValidator::className(), $val);
+        $this->assertInstanceOf(BooleanValidator::class, $val);
         $this->assertSame(['a', 'b'], $val->on);
         $this->assertSame(['attr_test1', 'attr_test2'], $val->attributes);
         $val = TestValidator::createValidator(
@@ -69,11 +69,11 @@ class ValidatorTest extends TestCase
             ['attr_test1', 'attr_test2'],
             ['on' => ['a', 'b'], 'except' => ['c', 'd', 'e']]
         );
-        $this->assertInstanceOf(BooleanValidator::className(), $val);
+        $this->assertInstanceOf(BooleanValidator::class, $val);
         $this->assertSame(['a', 'b'], $val->on);
         $this->assertSame(['c', 'd', 'e'], $val->except);
         $val = TestValidator::createValidator('inlineVal', $model, ['val_attr_a'], ['params' => ['foo' => 'bar']]);
-        $this->assertInstanceOf(InlineValidator::className(), $val);
+        $this->assertInstanceOf(InlineValidator::class, $val);
         $this->assertSame('inlineVal', $val->method[1]);
         $this->assertSame(['foo' => 'bar'], $val->params);
     }
@@ -87,7 +87,7 @@ class ValidatorTest extends TestCase
 
         $validator = TestValidator::createValidator('required', $model, ['firstAttribute']);
 
-        $this->assertInstanceOf(RequiredValidator::className(), $validator);
+        $this->assertInstanceOf(RequiredValidator::class, $validator);
     }
 
     public function testValidateAttributes(): void
@@ -196,7 +196,7 @@ class ValidatorTest extends TestCase
     public function testValidateValue(): void
     {
         $this->expectException('yii\base\NotSupportedException');
-        $this->expectExceptionMessage(TestValidator::className() . ' does not support validateValue().');
+        $this->expectExceptionMessage(TestValidator::class . ' does not support validateValue().');
         $val = new TestValidator();
         $val->validate('abc');
     }
@@ -215,7 +215,7 @@ class ValidatorTest extends TestCase
         $this->assertEquals('val_attr_a', $args[0]);
         $this->assertEquals('a', $args[3]);
         $this->assertEquals(['foo' => 'bar'], $args[1]);
-        $this->assertInstanceOf(InlineValidator::className(), $args[2]);
+        $this->assertInstanceOf(InlineValidator::class, $args[2]);
     }
 
     public function testClientValidateAttribute(): void
@@ -236,7 +236,7 @@ class ValidatorTest extends TestCase
         $this->assertCount(5, $args);
         $this->assertEquals('val_attr_a', $args[0]);
         $this->assertEquals(['foo' => 'bar'], $args[1]);
-        $this->assertInstanceOf(InlineValidator::className(), $args[2]);
+        $this->assertInstanceOf(InlineValidator::class, $args[2]);
     }
 
     public function testIsActive(): void
@@ -322,7 +322,7 @@ class ValidatorTest extends TestCase
     {
         $model = new DynamicModel();
         $model->defineAttribute(1);
-        $model->addRule([1], SafeValidator::className());
+        $model->addRule([1], SafeValidator::class);
 
         $this->assertNull($model->{1});
         $this->assertTrue($model->validate([1]));

--- a/tests/framework/web/AssetBundleTest.php
+++ b/tests/framework/web/AssetBundleTest.php
@@ -234,7 +234,7 @@ class AssetBundleTest extends TestCase
         TestSimpleAsset::register($view);
         $this->assertCount(1, $view->assetBundles);
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestSimpleAsset', $view->assetBundles);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestSimpleAsset']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestSimpleAsset']);
 
         $expected = <<<'EOF'
 123<script src="/js/jquery.js"></script>4
@@ -252,9 +252,9 @@ EOF;
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetBundle', $view->assetBundles);
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetLevel3', $view->assetBundles);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3']);
 
         $expected = <<<'EOF'
 1<link href="/files/cssFile.css" rel="stylesheet">23<script src="/js/jquery.js"></script>
@@ -300,9 +300,9 @@ EOF;
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestJqueryAsset', $view->assetBundles);
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestAssetLevel3', $view->assetBundles);
 
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestJqueryAsset']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestAssetLevel3']);
 
         $this->assertArrayHasKey('position', $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']->jsOptions);
         $this->assertEquals($pos, $view->assetBundles['yiiunit\\framework\\web\\TestAssetBundle']->jsOptions['position']);
@@ -388,7 +388,7 @@ EOF;
         TestSimpleAsset::register($view);
         $this->assertCount(1, $view->assetBundles);
         $this->assertArrayHasKey('yiiunit\\framework\\web\\TestSimpleAsset', $view->assetBundles);
-        $this->assertInstanceOf(AssetBundle::className(), $view->assetBundles['yiiunit\\framework\\web\\TestSimpleAsset']);
+        $this->assertInstanceOf(AssetBundle::class, $view->assetBundles['yiiunit\\framework\\web\\TestSimpleAsset']);
         // register TestJqueryAsset which also has the jquery.js
         TestJqueryAsset::register($view);
 

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -95,8 +95,8 @@ class ControllerTest extends TestCase
             'basePath' => __DIR__,
             'container' => [
                 'definitions' => [
-                    ModelBindingStub::className() => [
-                        ModelBindingStub::className(),
+                    ModelBindingStub::class => [
+                        ModelBindingStub::class,
                         'build',
                     ],
                 ],
@@ -109,7 +109,7 @@ class ControllerTest extends TestCase
                 ],
             ],
         ]));
-        Yii::$container->set(VendorImage::className(), VendorImage::className());
+        Yii::$container->set(VendorImage::class, VendorImage::class);
         $this->mockWebApplication(['controller' => $this->controller]);
         $injectionAction = new InlineAction('injection', $this->controller, 'actionModelBindingInjection');
         $this->expectException(get_class(new NotFoundHttpException('Not Found Item.')));
@@ -136,7 +136,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        Yii::$container->set(VendorImage::className(), function () {
+        Yii::$container->set(VendorImage::class, function () {
             throw new RuntimeException('uh oh');
         });
 
@@ -163,7 +163,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        Yii::$container->clear(VendorImage::className());
+        Yii::$container->clear(VendorImage::class);
         $this->expectException(get_class(new ServerErrorHttpException()));
         $this->expectExceptionMessage('Could not load required service: vendorImage');
         $this->controller->bindActionParams($injectionAction, $params);
@@ -186,13 +186,13 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
-        Yii::$container->set(VendorImage::className(), VendorImage::className());
+        Yii::$container->set(VendorImage::class, VendorImage::class);
         $args = $this->controller->bindActionParams($injectionAction, $params);
         $this->assertEquals($params['before'], $args[0]);
         $this->assertEquals(Yii::$app->request, $args[1]);
         $this->assertEquals('Component: yii\web\Request $request', Yii::$app->requestedParams['request']);
         $this->assertEquals($params['between'], $args[2]);
-        $this->assertInstanceOf(VendorImage::className(), $args[3]);
+        $this->assertInstanceOf(VendorImage::class, $args[3]);
         $this->assertEquals('Container DI: yiiunit\framework\web\stubs\VendorImage $vendorImage', Yii::$app->requestedParams['vendorImage']);
         $this->assertNull($args[4]);
         $this->assertEquals('Unavailable service: post', Yii::$app->requestedParams['post']);
@@ -213,7 +213,7 @@ class ControllerTest extends TestCase
             ],
         ]));
         $module->set('yii\data\DataProviderInterface', [
-            'class' => ArrayDataProvider::className(),
+            'class' => ArrayDataProvider::class,
         ]);
         // Use the PHP71 controller for this test
         $this->controller = new FakePhp71Controller('fake', $module);
@@ -221,7 +221,7 @@ class ControllerTest extends TestCase
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionModuleServiceInjection');
         $args = $this->controller->bindActionParams($injectionAction, []);
-        $this->assertInstanceOf(ArrayDataProvider::className(), $args[0]);
+        $this->assertInstanceOf(ArrayDataProvider::class, $args[0]);
         $this->assertEquals('Module yii\base\Module DI: yii\data\DataProviderInterface $dataProvider', Yii::$app->requestedParams['dataProvider']);
     }
 

--- a/tests/framework/web/ErrorHandlerTest.php
+++ b/tests/framework/web/ErrorHandlerTest.php
@@ -124,7 +124,7 @@ Exception: yii\web\NotFoundHttpException', $out);
         $handler->traceLine = '<a href="netbeans://open?file={file}&line={line}">{html}</a>';
         $file = BaseYii::getAlias('@yii/web/Application.php');
 
-        $out = $handler->renderCallStackItem($file, 63, Application::className(), null, null, null);
+        $out = $handler->renderCallStackItem($file, 63, Application::class, null, null, null);
 
         $this->assertStringContainsString('<a href="netbeans://open?file=' . $file . '&line=63">', $out);
     }

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -37,7 +37,7 @@ class ResponseTest extends TestCase
         $this->mockWebApplication([
             'components' => [
                 'request' => [
-                    'class' => TestRequestComponent::className(),
+                    'class' => TestRequestComponent::class,
                 ],
             ],
         ]);

--- a/tests/framework/web/UploadedFileTest.php
+++ b/tests/framework/web/UploadedFileTest.php
@@ -69,8 +69,8 @@ class UploadedFileTest extends TestCase
         $productImage = UploadedFile::getInstance(new ModelStub(), 'prod_image');
         $vendorImage = VendorImage::getInstance(new ModelStub(), 'vendor_image');
 
-        $this->assertInstanceOf(UploadedFile::className(), $productImage);
-        $this->assertInstanceOf(VendorImage::className(), $vendorImage);
+        $this->assertInstanceOf(UploadedFile::class, $productImage);
+        $this->assertInstanceOf(VendorImage::class, $vendorImage);
     }
 
     public function testGetInstances(): void
@@ -79,11 +79,11 @@ class UploadedFileTest extends TestCase
         $vendorImages = VendorImage::getInstances(new ModelStub(), 'vendor_images');
 
         foreach ($productImages as $productImage) {
-            $this->assertInstanceOf(UploadedFile::className(), $productImage);
+            $this->assertInstanceOf(UploadedFile::class, $productImage);
         }
 
         foreach ($vendorImages as $vendorImage) {
-            $this->assertInstanceOf(VendorImage::className(), $vendorImage);
+            $this->assertInstanceOf(VendorImage::class, $vendorImage);
         }
     }
 

--- a/tests/framework/web/UrlManagerCreateUrlTest.php
+++ b/tests/framework/web/UrlManagerCreateUrlTest.php
@@ -731,12 +731,12 @@ class UrlManagerCreateUrlTest extends TestCase
         /** @var CachedUrlRule[] $rules */
         $rules = [
             Yii::createObject([
-                'class' => CachedUrlRule::className(),
+                'class' => CachedUrlRule::class,
                 'route' => 'user/show',
                 'pattern' => 'user/<name:[\w-]+>',
             ]),
             Yii::createObject([
-                'class' => CachedUrlRule::className(),
+                'class' => CachedUrlRule::class,
                 'route' => '<controller>/<action>',
                 'pattern' => '<controller:\w+>/<action:\w+>',
             ]),
@@ -778,12 +778,12 @@ class UrlManagerCreateUrlTest extends TestCase
         /** @var CachedUrlRule[] $rules */
         $rules = [
             Yii::createObject([
-                'class' => CachedUrlRule::className(),
+                'class' => CachedUrlRule::class,
                 'route' => 'user/show',
                 'pattern' => 'user/<name:[\w-]+>',
             ]),
             Yii::createObject([
-                'class' => CachedUrlRule::className(),
+                'class' => CachedUrlRule::class,
                 'route' => '<controller>/<action>',
                 'pattern' => '<controller:\w+>/<action:\w+>',
             ]),
@@ -811,7 +811,7 @@ class UrlManagerCreateUrlTest extends TestCase
     {
         $this->mockWebApplication([
             'components' => [
-                'cache' => ArrayCache::className(),
+                'cache' => ArrayCache::class,
             ],
         ]);
         $urlManager = $this->getUrlManager([
@@ -824,7 +824,7 @@ class UrlManagerCreateUrlTest extends TestCase
         $cachedUrlManager = $this->getUrlManager([
             'cache' => 'cache',
             'ruleConfig' => [
-                'class' => CachedUrlRule::className(),
+                'class' => CachedUrlRule::class,
             ],
             'rules' => [
                 '/' => 'site/index',
@@ -832,15 +832,15 @@ class UrlManagerCreateUrlTest extends TestCase
         ]);
 
         $this->assertNotEquals($urlManager->rules, $cachedUrlManager->rules);
-        $this->assertInstanceOf(UrlRule::className(), $urlManager->rules[0]);
-        $this->assertInstanceOf(CachedUrlRule::className(), $cachedUrlManager->rules[0]);
+        $this->assertInstanceOf(UrlRule::class, $urlManager->rules[0]);
+        $this->assertInstanceOf(CachedUrlRule::class, $cachedUrlManager->rules[0]);
     }
 
     public function testNotEnsuringCacheForEmptyRuleset(): void
     {
         $this->mockWebApplication([
             'components' => [
-                'cache' => ArrayCache::className(),
+                'cache' => ArrayCache::class,
             ],
         ]);
         // no rules - don't ensure cache
@@ -854,6 +854,6 @@ class UrlManagerCreateUrlTest extends TestCase
             'cache' => 'cache',
             'rules' => ['/' => 'site/index'],
         ]);
-        $this->assertInstanceOf(ArrayCache::className(), $urlManager->cache);
+        $this->assertInstanceOf(ArrayCache::class, $urlManager->cache);
     }
 }

--- a/tests/framework/web/UrlManagerParseUrlTest.php
+++ b/tests/framework/web/UrlManagerParseUrlTest.php
@@ -341,7 +341,7 @@ class UrlManagerParseUrlTest extends TestCase
                     'baseUrl' => '/app',
                 ],
             ],
-        ], Application::className());
+        ], Application::class);
         $this->assertEquals('/app/post/123', $manager->createUrl(['post/delete', 'id' => 123]));
         $this->destroyApplication();
 

--- a/tests/framework/web/UrlRuleTest.php
+++ b/tests/framework/web/UrlRuleTest.php
@@ -72,7 +72,7 @@ class UrlRuleTest extends TestCase
     {
         $manager = new UrlManager([
             'cache' => null,
-            'normalizer' => UrlNormalizer::className(),
+            'normalizer' => UrlNormalizer::class,
         ]);
         $request = new Request(['hostInfo' => 'http://en.example.com']);
         $suites = $this->getTestsForParseRequest();
@@ -101,7 +101,7 @@ class UrlRuleTest extends TestCase
         $manager = new UrlManager([
             'cache' => null,
             'normalizer' => [
-                'class' => UrlNormalizer::className(),
+                'class' => UrlNormalizer::class,
                 'action' => UrlNormalizer::ACTION_REDIRECT_PERMANENT,
             ],
         ]);
@@ -130,7 +130,7 @@ class UrlRuleTest extends TestCase
         $manager = new UrlManager([
             'cache' => null,
             'normalizer' => [
-                'class' => UrlNormalizer::className(),
+                'class' => UrlNormalizer::class,
                 'action' => UrlNormalizer::ACTION_REDIRECT_TEMPORARY,
             ],
         ]);
@@ -159,7 +159,7 @@ class UrlRuleTest extends TestCase
         $manager = new UrlManager([
             'cache' => null,
             'normalizer' => [
-                'class' => UrlNormalizer::className(),
+                'class' => UrlNormalizer::class,
                 'action' => UrlNormalizer::ACTION_NOT_FOUND,
             ],
         ]);
@@ -187,7 +187,7 @@ class UrlRuleTest extends TestCase
         $manager = new UrlManager([
             'cache' => null,
             'normalizer' => [
-                'class' => UrlNormalizer::className(),
+                'class' => UrlNormalizer::class,
                 'action' => null,
             ],
         ]);
@@ -216,7 +216,7 @@ class UrlRuleTest extends TestCase
         $manager = new UrlManager([
             'cache' => null,
             'normalizer' => [
-                'class' => UrlNormalizer::className(),
+                'class' => UrlNormalizer::class,
                 'action' => $normalizerAction,
             ],
         ]);

--- a/tests/framework/web/UserTest.php
+++ b/tests/framework/web/UserTest.php
@@ -51,11 +51,11 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                     'authTimeout' => 10,
                 ],
                 'authManager' => [
-                    'class' => PhpManager::className(),
+                    'class' => PhpManager::class,
                     'itemFile' => '@runtime/user_test_rbac_items.php',
                     'assignmentFile' => '@runtime/user_test_rbac_assignments.php',
                     'ruleFile' => '@runtime/user_test_rbac_rules.php',
@@ -105,16 +105,16 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                     'authTimeout' => 10,
                     'enableAutoLogin' => true,
                     'autoRenewCookie' => false,
                 ],
                 'response' => [
-                    'class' => MockResponse::className(),
+                    'class' => MockResponse::class,
                 ],
                 'request' => [
-                    'class' => MockRequest::className(),
+                    'class' => MockRequest::class,
                 ],
             ],
         ];
@@ -157,14 +157,14 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                     'enableAutoLogin' => true,
                 ],
                 'response' => [
-                    'class' => MockResponse::className(),
+                    'class' => MockResponse::class,
                 ],
                 'request' => [
-                    'class' => MockRequest::className(),
+                    'class' => MockRequest::class,
                 ],
             ],
         ];
@@ -222,10 +222,10 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
                 'authManager' => [
-                    'class' => PhpManager::className(),
+                    'class' => PhpManager::class,
                     'itemFile' => '@runtime/user_test_rbac_items.php',
                     'assignmentFile' => '@runtime/user_test_rbac_assignments.php',
                     'ruleFile' => '@runtime/user_test_rbac_rules.php',
@@ -348,10 +348,10 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
                 'authManager' => [
-                    'class' => PhpManager::className(),
+                    'class' => PhpManager::class,
                     'itemFile' => '@runtime/user_test_rbac_items.php',
                     'assignmentFile' => '@runtime/user_test_rbac_assignments.php',
                     'ruleFile' => '@runtime/user_test_rbac_rules.php',
@@ -371,37 +371,37 @@ class UserTest extends TestCase
         $this->mockWebApplication([
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
-                    'accessChecker' => AccessChecker::className()
+                    'identityClass' => UserIdentity::class,
+                    'accessChecker' => AccessChecker::class
                 ]
             ],
         ]);
-        $this->assertInstanceOf(AccessChecker::className(), Yii::$app->user->accessChecker);
+        $this->assertInstanceOf(AccessChecker::class, Yii::$app->user->accessChecker);
 
         $this->mockWebApplication([
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                     'accessChecker' => [
-                        'class' => AccessChecker::className(),
+                        'class' => AccessChecker::class,
                     ],
                 ],
             ],
         ]);
-        $this->assertInstanceOf(AccessChecker::className(), Yii::$app->user->accessChecker);
+        $this->assertInstanceOf(AccessChecker::class, Yii::$app->user->accessChecker);
 
         $this->mockWebApplication([
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                     'accessChecker' => 'accessChecker',
                 ],
                 'accessChecker' => [
-                    'class' => AccessChecker::className(),
+                    'class' => AccessChecker::class,
                 ]
             ],
         ]);
-        $this->assertInstanceOf(AccessChecker::className(), Yii::$app->user->accessChecker);
+        $this->assertInstanceOf(AccessChecker::class, Yii::$app->user->accessChecker);
     }
 
     public function testGetIdentityException(): void
@@ -413,7 +413,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => ExceptionIdentity::className(),
+                    'identityClass' => ExceptionIdentity::class,
                 ],
                 'session' => $session,
             ],
@@ -438,10 +438,10 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
                 'authManager' => [
-                    'class' => PhpManager::className(),
+                    'class' => PhpManager::class,
                     'itemFile' => '@runtime/user_test_rbac_items.php',
                     'assignmentFile' => '@runtime/user_test_rbac_assignments.php',
                     'ruleFile' => '@runtime/user_test_rbac_rules.php',
@@ -461,7 +461,7 @@ class UserTest extends TestCase
         $this->assertFalse(Yii::$app->user->can('doSomething'));
 
         Yii::$app->user->setIdentity(UserIdentity::findIdentity('user1'));
-        $this->assertInstanceOf(UserIdentity::className(), Yii::$app->user->identity);
+        $this->assertInstanceOf(UserIdentity::class, Yii::$app->user->identity);
         $this->assertTrue(Yii::$app->user->can('doSomething'));
 
         Yii::$app->user->setIdentity(null);
@@ -477,7 +477,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ];
@@ -494,7 +494,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ];
@@ -513,7 +513,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ];
@@ -533,7 +533,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ];
@@ -553,7 +553,7 @@ class UserTest extends TestCase
         $appConfig = [
             'components' => [
                 'user' => [
-                    'identityClass' => UserIdentity::className(),
+                    'identityClass' => UserIdentity::class,
                 ],
             ],
         ];

--- a/tests/framework/web/ViewTest.php
+++ b/tests/framework/web/ViewTest.php
@@ -122,7 +122,7 @@ class ViewTest extends TestCase
                     'scriptUrl' => '/baseUrl/index.php',
                 ],
                 'cache' => [
-                    'class' => FileCache::className(),
+                    'class' => FileCache::class,
                 ],
             ],
         ]);

--- a/tests/framework/web/session/AbstractDbSessionTest.php
+++ b/tests/framework/web/session/AbstractDbSessionTest.php
@@ -58,13 +58,13 @@ abstract class AbstractDbSessionTest extends TestCase
             }
         }
         if (!isset($driverAvailable)) {
-            $this->markTestIncomplete(get_called_class() . ' requires ' . implode(' or ', $driverNames) . ' PDO driver! Configuration for connection required too.');
+            $this->markTestIncomplete(static::class . ' requires ' . implode(' or ', $driverNames) . ' PDO driver! Configuration for connection required too.');
             return [];
         }
         $config = $databases[$driverAvailable];
 
         $result = [
-            'class' => Connection::className(),
+            'class' => Connection::class,
             'dsn' => $config['dsn'],
         ];
 
@@ -276,11 +276,11 @@ abstract class AbstractDbSessionTest extends TestCase
 
     public function testInitUseStrictMode(): void
     {
-        $this->initStrictModeTest(DbSession::className());
+        $this->initStrictModeTest(DbSession::class);
     }
 
     public function testUseStrictMode(): void
     {
-        $this->useStrictModeTest(DbSession::className());
+        $this->useStrictModeTest(DbSession::class);
     }
 }

--- a/tests/framework/web/session/CacheSessionTest.php
+++ b/tests/framework/web/session/CacheSessionTest.php
@@ -58,11 +58,11 @@ class CacheSessionTest extends TestCase
 
     public function testInitUseStrictMode(): void
     {
-        $this->initStrictModeTest(CacheSession::className());
+        $this->initStrictModeTest(CacheSession::class);
     }
 
     public function testUseStrictMode(): void
     {
-        $this->useStrictModeTest(CacheSession::className());
+        $this->useStrictModeTest(CacheSession::class);
     }
 }

--- a/tests/framework/web/session/SessionTest.php
+++ b/tests/framework/web/session/SessionTest.php
@@ -101,7 +101,7 @@ class SessionTest extends TestCase
 
     public function testInitUseStrictMode(): void
     {
-        $this->initStrictModeTest(Session::className());
+        $this->initStrictModeTest(Session::class);
     }
 
     public function testUseStrictMode(): void
@@ -116,6 +116,6 @@ class SessionTest extends TestCase
             }
         }
 
-        $this->useStrictModeTest(Session::className());
+        $this->useStrictModeTest(Session::class);
     }
 }

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -603,8 +603,8 @@ EOD;
 
     public function testWidget(): void
     {
-        $this->activeField->widget(TestInputWidget::className());
-        $this->assertEquals('Render: ' . TestInputWidget::className(), $this->activeField->parts['{input}']);
+        $this->activeField->widget(TestInputWidget::class);
+        $this->assertEquals('Render: ' . TestInputWidget::class, $this->activeField->parts['{input}']);
         $widget = TestInputWidget::$lastInstance;
 
         $this->assertSame($this->activeField->model, $widget->model);
@@ -612,7 +612,7 @@ EOD;
         $this->assertSame($this->activeField->form->view, $widget->view);
         $this->assertSame($this->activeField, $widget->field);
 
-        $this->activeField->widget(TestInputWidget::className(), ['options' => ['id' => 'test-id']]);
+        $this->activeField->widget(TestInputWidget::class, ['options' => ['id' => 'test-id']]);
         $this->assertEquals('test-id', $this->activeField->labelOptions['for']);
     }
 
@@ -621,7 +621,7 @@ EOD;
         $this->activeField->form->validationStateOn = ActiveForm::VALIDATION_STATE_ON_INPUT;
         $this->activeField->model->addError('attributeName', 'error');
 
-        $this->activeField->widget(TestInputWidget::className());
+        $this->activeField->widget(TestInputWidget::class);
         $widget = TestInputWidget::$lastInstance;
         $expectedOptions = [
             'class' => 'form-control has-error',
@@ -631,7 +631,7 @@ EOD;
         $this->assertEquals($expectedOptions, $widget->options);
 
         $this->activeField->inputOptions = [];
-        $this->activeField->widget(TestInputWidget::className());
+        $this->activeField->widget(TestInputWidget::class);
         $widget = TestInputWidget::$lastInstance;
         $expectedOptions = [
             'class' => 'has-error',
@@ -675,14 +675,14 @@ HTML;
 
     public function testInputOptionsTransferToWidget(): void
     {
-        $widget = $this->activeField->widget(TestMaskedInput::className(), [
+        $widget = $this->activeField->widget(TestMaskedInput::class, [
             'mask' => '999-999-9999',
             'options' => ['placeholder' => 'pholder_direct'],
         ]);
         $this->assertStringContainsString('placeholder="pholder_direct"', (string) $widget);
 
         // use regex clientOptions instead mask
-        $widget = $this->activeField->widget(TestMaskedInput::className(), [
+        $widget = $this->activeField->widget(TestMaskedInput::class, [
             'options' => ['placeholder' => 'pholder_direct'],
             'clientOptions' => ['regex' => '^.*$'],
         ]);
@@ -690,14 +690,14 @@ HTML;
 
         // transfer options from ActiveField to widget
         $this->activeField->inputOptions = ['placeholder' => 'pholder_input'];
-        $widget = $this->activeField->widget(TestMaskedInput::className(), [
+        $widget = $this->activeField->widget(TestMaskedInput::class, [
             'mask' => '999-999-9999',
         ]);
         $this->assertStringContainsString('placeholder="pholder_input"', (string) $widget);
 
         // set both AF and widget options (second one takes precedence)
         $this->activeField->inputOptions = ['placeholder' => 'pholder_both_input'];
-        $widget = $this->activeField->widget(TestMaskedInput::className(), [
+        $widget = $this->activeField->widget(TestMaskedInput::class, [
             'mask' => '999-999-9999',
             'options' => ['placeholder' => 'pholder_both_direct']
         ]);

--- a/tests/framework/widgets/ActiveFormTest.php
+++ b/tests/framework/widgets/ActiveFormTest.php
@@ -128,7 +128,7 @@ HTML,
         $model = new DynamicModel(['name']);
         $model->addRule(['name'], 'required');
 
-        $view = $this->getMockBuilder(View::className())->getMock();
+        $view = $this->getMockBuilder(View::class)->getMock();
         $view->method('registerJs')->with($this->matches("jQuery('#w0').yiiActiveForm([], {\"validateOnSubmit\":false});"));
         $view->method('registerAssetBundle')->willReturn(true);
 

--- a/tests/framework/widgets/FragmentCacheTest.php
+++ b/tests/framework/widgets/FragmentCacheTest.php
@@ -24,7 +24,7 @@ class FragmentCacheTest extends TestCase
         parent::setUp();
         $this->mockWebApplication();
         Yii::$app->set('cache', [
-            'class' => ArrayCache::className(),
+            'class' => ArrayCache::class,
         ]);
     }
 

--- a/tests/framework/widgets/ListViewTest.php
+++ b/tests/framework/widgets/ListViewTest.php
@@ -142,7 +142,7 @@ HTML,
             ],
             [
                 function ($model, $key, $index, $widget) {
-                    return "Item #{$index}: {$model['login']} - Widget: " . $widget->className();
+                    return "Item #{$index}: {$model['login']} - Widget: " . get_class($widget);
                 },
                 '<div id="w0" class="list-view"><div class="summary">Showing <b>1-3</b> of <b>3</b> items.</div>
 <div data-key="0">Item #0: silverfire - Widget: yii\widgets\ListView</div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
