### PR TITLE
Replace deprecated PHPUnit mock builder `setMethods()` usage with `createPartialMock()`, `onlyMethods()` and `addMethods()` methods.

### DIFF
--- a/tests/framework/BaseYiiTest.php
+++ b/tests/framework/BaseYiiTest.php
@@ -168,9 +168,8 @@ class BaseYiiTest extends TestCase
      */
     public function testLog(): void
     {
-        $logger = $this->getMockBuilder('yii\\log\\Logger')
-            ->setMethods(['log'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['log']);
+
         BaseYii::setLogger($logger);
 
         $logger->expects($this->exactly(6))

--- a/tests/framework/behaviors/CacheableWidgetBehaviorTest.php
+++ b/tests/framework/behaviors/CacheableWidgetBehaviorTest.php
@@ -119,13 +119,11 @@ class CacheableWidgetBehaviorTest extends TestCase
      */
     private function getWidgetMock($widgetClass)
     {
-        $widgetMock = $this->getMockBuilder($widgetClass)
-            ->setMethods(['run'])
+        return $this->getMockBuilder($widgetClass)
+            ->onlyMethods(['run'])
             ->enableOriginalConstructor()
             ->enableProxyingToOriginalMethods()
             ->getMock();
-
-        return $widgetMock;
     }
 }
 

--- a/tests/framework/console/controllers/AssetControllerTest.php
+++ b/tests/framework/console/controllers/AssetControllerTest.php
@@ -10,6 +10,7 @@ namespace yiiunit\framework\console\controllers;
 
 use Exception;
 use Yii;
+use yii\base\Module;
 use yii\console\controllers\AssetController;
 use yii\helpers\ArrayHelper;
 use yii\helpers\FileHelper;
@@ -74,10 +75,11 @@ class AssetControllerTest extends TestCase
      */
     protected function createAssetController()
     {
-        $module = $this->getMockBuilder('yii\\base\\Module')
-            ->setMethods(['fake'])
+        $module = $this->getMockBuilder(Module::class)
+            ->addMethods(['fake'])
             ->setConstructorArgs(['console'])
             ->getMock();
+
         $assetController = new AssetControllerMock('asset', $module);
         $assetController->interactive = false;
         $assetController->jsCompressor = 'cp {from} {to}';

--- a/tests/framework/console/controllers/BaseMessageControllerTest.php
+++ b/tests/framework/console/controllers/BaseMessageControllerTest.php
@@ -9,6 +9,7 @@
 namespace yiiunit\framework\console\controllers;
 
 use Yii;
+use yii\base\Module;
 use yii\console\controllers\MessageController;
 use yii\helpers\FileHelper;
 use yii\helpers\VarDumper;
@@ -62,10 +63,11 @@ abstract class BaseMessageControllerTest extends TestCase
      */
     protected function createMessageController()
     {
-        $module = $this->getMockBuilder('yii\\base\\Module')
-            ->setMethods(['fake'])
+        $module = $this->getMockBuilder(Module::class)
+            ->addMethods(['fake'])
             ->setConstructorArgs(['console'])
             ->getMock();
+
         $messageController = new MessageControllerMock('message', $module);
         $messageController->interactive = false;
 

--- a/tests/framework/console/controllers/HelpControllerTest.php
+++ b/tests/framework/console/controllers/HelpControllerTest.php
@@ -8,6 +8,7 @@
 
 namespace yiiunit\framework\console\controllers;
 
+use yii\base\Module;
 use yii\console\controllers\HelpController;
 use yii\helpers\Console;
 use yiiunit\TestCase;
@@ -33,10 +34,11 @@ class HelpControllerTest extends TestCase
      */
     protected function createController()
     {
-        $module = $this->getMockBuilder('yii\\base\\Module')
-            ->setMethods(['fake'])
+        $module = $this->getMockBuilder(Module::class)
+            ->addMethods(['fake'])
             ->setConstructorArgs(['console'])
             ->getMock();
+
         return new BufferedHelpController('help', $module);
     }
 

--- a/tests/framework/console/controllers/MigrateControllerTestTrait.php
+++ b/tests/framework/console/controllers/MigrateControllerTestTrait.php
@@ -9,6 +9,7 @@
 namespace yiiunit\framework\console\controllers;
 
 use Yii;
+use yii\base\Module;
 use yii\console\controllers\BaseMigrateController;
 use yii\console\ExitCode;
 use yii\helpers\FileHelper;
@@ -78,14 +79,16 @@ trait MigrateControllerTestTrait
      */
     protected function createMigrateController(array $config = [])
     {
-        $module = $this->getMockBuilder('yii\\base\\Module')
-            ->setMethods(['fake'])
+        $module = $this->getMockBuilder(Module::class)
+            ->addMethods(['fake'])
             ->setConstructorArgs(['console'])
             ->getMock();
+
         $class = $this->migrateControllerClass;
         $migrateController = new $class('migrate', $module);
         $migrateController->interactive = false;
         $migrateController->migrationPath = $this->migrationPath;
+
         return Yii::configure($migrateController, $config);
     }
 

--- a/tests/framework/console/controllers/ServeControllerTest.php
+++ b/tests/framework/console/controllers/ServeControllerTest.php
@@ -32,7 +32,7 @@ class ServeControllerTest extends TestCase
         /** @var ServeController $serveController */
         $serveController = $this->getMockBuilder(ServeControllerMocK::class)
             ->setConstructorArgs(['serve', Yii::$app])
-            ->setMethods(['isAddressTaken', 'runCommand'])
+            ->onlyMethods(['isAddressTaken', 'runCommand'])
             ->getMock();
 
         $serveController->expects($this->once())->method('isAddressTaken')->willReturn(true);
@@ -57,7 +57,7 @@ class ServeControllerTest extends TestCase
         /** @var ServeController $serveController */
         $serveController = $this->getMockBuilder(ServeControllerMock::class)
             ->setConstructorArgs(['serve', Yii::$app])
-            ->setMethods(['runCommand'])
+            ->onlyMethods(['runCommand'])
             ->getMock();
 
         $serveController->docroot = $docroot;
@@ -83,7 +83,7 @@ class ServeControllerTest extends TestCase
         /** @var ServeController $serveController */
         $serveController = $this->getMockBuilder(ServeControllerMock::class)
             ->setConstructorArgs(['serve', Yii::$app])
-            ->setMethods(['runCommand'])
+            ->onlyMethods(['runCommand'])
             ->getMock();
 
         $serveController->docroot = $docroot;
@@ -107,7 +107,7 @@ class ServeControllerTest extends TestCase
         /** @var ServeController $serveController */
         $serveController = $this->getMockBuilder(ServeControllerMock::class)
             ->setConstructorArgs(['serve', Yii::$app])
-            ->setMethods(['runCommand'])
+            ->onlyMethods(['runCommand'])
             ->getMock();
 
         $serveController->docroot = $docroot;
@@ -133,7 +133,7 @@ class ServeControllerTest extends TestCase
         /** @var ServeController $serveController */
         $serveController = $this->getMockBuilder(ServeControllerMock::class)
             ->setConstructorArgs(['serve', Yii::$app])
-            ->setMethods(['runCommand'])
+            ->onlyMethods(['runCommand'])
             ->getMock();
 
         $serveController->docroot = $docroot;

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -43,9 +43,7 @@ class AccessRuleTest extends TestCase
     protected function mockRequest($method = 'GET')
     {
         /** @var Request $request */
-        $request = $this->getMockBuilder('\yii\web\Request')
-            ->setMethods(['getMethod'])
-            ->getMock();
+        $request = $this->createPartialMock(Request::class, ['getMethod']);
         $request->method('getMethod')->willReturn($method);
 
         return $request;

--- a/tests/framework/filters/AjaxFilterTest.php
+++ b/tests/framework/filters/AjaxFilterTest.php
@@ -27,9 +27,7 @@ class AjaxFilterTest extends TestCase
     protected function mockRequest($isAjax)
     {
         /** @var Request $request */
-        $request = $this->getMockBuilder('\yii\web\Request')
-            ->setMethods(['getIsAjax'])
-            ->getMock();
+        $request = $this->createPartialMock(Request::class, ['getIsAjax']);
         $request->method('getIsAjax')->willReturn($isAjax);
 
         return $request;

--- a/tests/framework/filters/auth/AuthMethodTest.php
+++ b/tests/framework/filters/auth/AuthMethodTest.php
@@ -39,10 +39,9 @@ class AuthMethodTest extends TestCase
      */
     protected function createFilter($authenticateCallback)
     {
-        $filter = $this->getMockBuilder(AuthMethod::class)
-            ->setMethods(['authenticate'])
-            ->getMock();
+        $filter = $this->createPartialMock(AuthMethod::class, ['authenticate']);
         $filter->method('authenticate')->willReturnCallback($authenticateCallback);
+
 
         return $filter;
     }

--- a/tests/framework/log/DispatcherTest.php
+++ b/tests/framework/log/DispatcherTest.php
@@ -159,7 +159,6 @@ namespace yiiunit\framework\log {
             $target->expects($this->never())->method($this->anything());
 
             $target->enabled = false;
-            $target->enabled = false;
 
             $dispatcher = new Dispatcher(['targets' => ['fakeTarget' => $target]]);
             $dispatcher->dispatch('messages', true);

--- a/tests/framework/log/DispatcherTest.php
+++ b/tests/framework/log/DispatcherTest.php
@@ -23,6 +23,7 @@ namespace yiiunit\framework\log {
     use yii\base\UserException;
     use yii\log\Dispatcher;
     use yii\log\Logger;
+    use yii\log\Target;
     use yiiunit\TestCase;
 
     /**
@@ -154,11 +155,10 @@ namespace yiiunit\framework\log {
          */
         public function testDispatchWithDisabledTarget(): void
         {
-            $target = $this->getMockBuilder('yii\\log\\Target')
-                ->setMethods(['collect'])
-                ->getMockForAbstractClass();
-
+            $target = $this->createPartialMock(Target::class, ['collect', 'export']);
             $target->expects($this->never())->method($this->anything());
+
+            $target->enabled = false;
             $target->enabled = false;
 
             $dispatcher = new Dispatcher(['targets' => ['fakeTarget' => $target]]);
@@ -170,10 +170,7 @@ namespace yiiunit\framework\log {
          */
         public function testDispatchWithSuccessTargetCollect(): void
         {
-            $target = $this->getMockBuilder('yii\\log\\Target')
-                ->setMethods(['collect'])
-                ->getMockForAbstractClass();
-
+            $target = $this->createPartialMock(Target::class, ['collect', 'export']);
             $target->expects($this->once())
                 ->method('collect')
                 ->with(
@@ -191,13 +188,8 @@ namespace yiiunit\framework\log {
         public function testDispatchWithFakeTarget2ThrowExceptionWhenCollect(): void
         {
             static::$microtimeIsMocked = true;
-            $target1 = $this->getMockBuilder('yii\\log\\Target')
-                ->setMethods(['collect'])
-                ->getMockForAbstractClass();
-
-            $target2 = $this->getMockBuilder('yii\\log\\Target')
-                ->setMethods(['collect'])
-                ->getMockForAbstractClass();
+            $target1 = $this->createPartialMock(Target::class, ['collect', 'export']);
+            $target2 = $this->createPartialMock(Target::class, ['collect', 'export']);
 
             $target1->expects($this->exactly(2))
                 ->method('collect')

--- a/tests/framework/log/EmailTargetTest.php
+++ b/tests/framework/log/EmailTargetTest.php
@@ -159,7 +159,7 @@ class EmailTargetTest extends TestCase
         $this->mailer->expects($this->once())->method('compose')->willReturn($message);
 
         /** @var EmailTarget $mailTarget */
-        $mailTarget = $this->getMockBuilder('yii\\log\\EmailTarget')
+        $mailTarget = $this->getMockBuilder(EmailTarget::class)
             ->onlyMethods(['formatMessage'])
             ->setConstructorArgs([
                 [

--- a/tests/framework/log/EmailTargetTest.php
+++ b/tests/framework/log/EmailTargetTest.php
@@ -10,6 +10,8 @@ namespace yiiunit\framework\log;
 
 use yii\base\InvalidConfigException;
 use yii\log\EmailTarget;
+use yii\mail\BaseMailer;
+use yii\mail\BaseMessage;
 use yiiunit\TestCase;
 
 /**
@@ -29,9 +31,7 @@ class EmailTargetTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->mailer = $this->getMockBuilder('yii\\mail\\BaseMailer')
-            ->setMethods(['compose'])
-            ->getMockForAbstractClass();
+        $this->mailer = $this->createPartialMock(BaseMailer::class, ['compose', 'sendMessage']);
     }
 
     /**
@@ -65,8 +65,8 @@ class EmailTargetTest extends TestCase
         $messages = [$message1, $message2];
         $textBody = wordwrap(implode("\n", [$message1[0], $message2[0]]), 70);
 
-        $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
-            ->setMethods(['setTextBody', 'send', 'setSubject'])
+        $message = $this->getMockBuilder(BaseMessage::class)
+            ->onlyMethods(['setTextBody', 'send', 'setSubject'])
             ->getMockForAbstractClass();
         $message->method('send')->willReturn(true);
 
@@ -76,8 +76,9 @@ class EmailTargetTest extends TestCase
         $message->expects($this->once())->method('send')->with($this->equalTo($this->mailer));
         $message->expects($this->once())->method('setSubject')->with($this->equalTo('Hello world'));
 
-        $mailTarget = $this->getMockBuilder('yii\\log\\EmailTarget')
-            ->setMethods(['formatMessage'])
+        /** @var EmailTarget $mailTarget */
+        $mailTarget = $this->getMockBuilder(EmailTarget::class)
+            ->onlyMethods(['formatMessage'])
             ->setConstructorArgs([
                 [
                     'mailer' => $this->mailer,
@@ -110,8 +111,8 @@ class EmailTargetTest extends TestCase
         $messages = [$message1, $message2];
         $textBody = wordwrap(implode("\n", [$message1[0], $message2[0]]), 70);
 
-        $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
-            ->setMethods(['setTextBody', 'send', 'setSubject'])
+        $message = $this->getMockBuilder(BaseMessage::class)
+            ->onlyMethods(['setTextBody', 'send', 'setSubject'])
             ->getMockForAbstractClass();
         $message->method('send')->willReturn(true);
 
@@ -121,8 +122,9 @@ class EmailTargetTest extends TestCase
         $message->expects($this->once())->method('send')->with($this->equalTo($this->mailer));
         $message->expects($this->once())->method('setSubject')->with($this->equalTo('Application Log'));
 
-        $mailTarget = $this->getMockBuilder('yii\\log\\EmailTarget')
-            ->setMethods(['formatMessage'])
+        /** @var EmailTarget $mailTarget */
+        $mailTarget = $this->getMockBuilder(EmailTarget::class)
+            ->onlyMethods(['formatMessage'])
             ->setConstructorArgs([
                 [
                     'mailer' => $this->mailer,
@@ -150,13 +152,15 @@ class EmailTargetTest extends TestCase
      */
     public function testExportWithSendFailure(): void
     {
-        $message = $this->getMockBuilder('yii\\mail\\BaseMessage')
-            ->setMethods(['send'])
+        $message = $this->getMockBuilder(BaseMessage::class)
+            ->onlyMethods(['send'])
             ->getMockForAbstractClass();
         $message->method('send')->willReturn(false);
         $this->mailer->expects($this->once())->method('compose')->willReturn($message);
+
+        /** @var EmailTarget $mailTarget */
         $mailTarget = $this->getMockBuilder('yii\\log\\EmailTarget')
-            ->setMethods(['formatMessage'])
+            ->onlyMethods(['formatMessage'])
             ->setConstructorArgs([
                 [
                     'mailer' => $this->mailer,
@@ -166,6 +170,7 @@ class EmailTargetTest extends TestCase
                 ],
             ])
             ->getMock();
+
         $this->expectException('yii\log\LogRuntimeException');
         $mailTarget->export();
     }

--- a/tests/framework/log/LoggerTest.php
+++ b/tests/framework/log/LoggerTest.php
@@ -30,9 +30,7 @@ class LoggerTest extends TestCase
     protected function setUp(): void
     {
         $this->logger = new Logger();
-        $this->dispatcher = $this->getMockBuilder('yii\log\Dispatcher')
-            ->setMethods(['dispatch'])
-            ->getMock();
+        $this->dispatcher = $this->createPartialMock(Dispatcher::class, ['dispatch']);
     }
 
     /**
@@ -72,7 +70,7 @@ class LoggerTest extends TestCase
         $this->assertEquals('application', $this->logger->messages[0][2]);
         $this->assertEquals([
             'file' => __FILE__,
-            'line' => 68,
+            'line' => 66,
             'function' => 'log',
             'class' => get_class($this->logger),
             'type' => '->',
@@ -87,10 +85,10 @@ class LoggerTest extends TestCase
     public function testLogWithFlush(): void
     {
         /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $logger */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['flush'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['flush']);
+
         $logger->flushInterval = 1;
+
         $logger->expects($this->exactly(1))->method('flush');
         $logger->log('test1', Logger::LEVEL_INFO);
     }
@@ -151,13 +149,12 @@ class LoggerTest extends TestCase
         ];
 
         /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $logger */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['getProfiling'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['getProfiling']);
         $logger->method('getProfiling')->willReturn($timings);
         $logger->expects($this->once())
             ->method('getProfiling')
             ->with($this->equalTo(['yii\db\Command::query', 'yii\db\Command::execute']));
+
         $this->assertEquals([3, 50], $logger->getDbProfiling());
     }
 
@@ -348,12 +345,12 @@ class LoggerTest extends TestCase
     {
         $messages = ['anyData'];
         $returnValue = 'return value';
+
         /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $logger */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
+
         $logger->method('calculateTimings')->willReturn($returnValue);
         $logger->expects($this->once())->method('calculateTimings')->with($messages);
         $this->assertEquals($returnValue, $logger->getProfiling());
@@ -376,11 +373,10 @@ class LoggerTest extends TestCase
             ],
         ];
         /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $logger */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
+
         $logger->method('calculateTimings')->willReturn($returnValue);
         $logger->expects($this->once())->method('calculateTimings')->with($messages);
         $this->assertEquals([], $logger->getProfiling(['not-matched-category']));
@@ -416,11 +412,10 @@ class LoggerTest extends TestCase
          * Matched by category name
          */
         /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $logger */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
+
         $logger->method('calculateTimings')->willReturn($returnValue);
         $logger->expects($this->once())->method('calculateTimings')->with($messages);
         $this->assertEquals([$matchedByCategoryName], $logger->getProfiling(['category']));
@@ -429,11 +424,10 @@ class LoggerTest extends TestCase
          * Matched by prefix
          */
         /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $logger */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
+
         $logger->method('calculateTimings')->willReturn($returnValue);
         $logger->expects($this->once())->method('calculateTimings')->with($messages);
         $this->assertEquals([$matchedByCategoryName, $secondCategory], $logger->getProfiling(['category*']));
@@ -478,11 +472,10 @@ class LoggerTest extends TestCase
          * Exclude by category name
          */
         /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $logger */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
+
         $logger->method('calculateTimings')->willReturn($returnValue);
         $logger->expects($this->once())->method('calculateTimings')->with($messages);
         $this->assertEquals([$fistCategory, $secondCategory], $logger->getProfiling(['cat*'], ['category3']));
@@ -491,11 +484,10 @@ class LoggerTest extends TestCase
          * Exclude by category prefix
          */
         /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $logger */
-        $logger = $this->getMockBuilder('yii\log\Logger')
-            ->setMethods(['calculateTimings'])
-            ->getMock();
+        $logger = $this->createPartialMock(Logger::class, ['calculateTimings']);
 
         $logger->messages = $messages;
+
         $logger->method('calculateTimings')->willReturn($returnValue);
         $logger->expects($this->once())->method('calculateTimings')->with($messages);
         $this->assertEquals([$fistCategory], $logger->getProfiling(['cat*'], ['category*']));

--- a/tests/framework/log/SyslogTargetTest.php
+++ b/tests/framework/log/SyslogTargetTest.php
@@ -27,6 +27,7 @@ namespace yiiunit\framework\log {
     use PHPUnit_Framework_MockObject_MockObject;
     use yii\helpers\VarDumper;
     use yii\log\Logger;
+    use yii\log\SyslogTarget;
     use yiiunit\TestCase;
 
     /**
@@ -53,9 +54,7 @@ namespace yiiunit\framework\log {
          */
         protected function setUp(): void
         {
-            $this->syslogTarget = $this->getMockBuilder('yii\\log\\SyslogTarget')
-                ->setMethods(['getMessagePrefix'])
-                ->getMock();
+            $this->syslogTarget = $this->createPartialMock('yii\\log\\SyslogTarget', ['getMessagePrefix']);
         }
 
         /**
@@ -75,8 +74,11 @@ namespace yiiunit\framework\log {
                 ['profile begin message', Logger::LEVEL_PROFILE_BEGIN],
                 ['profile end message', Logger::LEVEL_PROFILE_END],
             ];
-            $syslogTarget = $this->getMockBuilder('yii\\log\\SyslogTarget')
-                ->setMethods(['openlog', 'syslog', 'formatMessage', 'closelog'])
+
+            /** @var SyslogTarget $syslogTarget */
+            $syslogTarget = $this->getMockBuilder(SyslogTarget::class)
+                ->addMethods(['openlog', 'syslog', 'closelog'])
+                ->onlyMethods(['formatMessage'])
                 ->getMock();
 
             $syslogTarget->identity = $identity;
@@ -151,9 +153,12 @@ namespace yiiunit\framework\log {
          */
         public function testFailedExport(): void
         {
-            $syslogTarget = $this->getMockBuilder('yii\\log\\SyslogTarget')
-                ->setMethods(['openlog', 'syslog', 'formatMessage', 'closelog'])
+            /** @var SyslogTarget $syslogTarget */
+            $syslogTarget = $this->getMockBuilder(SyslogTarget::class)
+                ->addMethods(['openlog', 'syslog', 'closelog'])
+                ->onlyMethods(['formatMessage'])
                 ->getMock();
+
             $syslogTarget->method('syslog')->willReturn(false);
 
             $syslogTarget->identity = 'identity string';

--- a/tests/framework/log/TargetTest.php
+++ b/tests/framework/log/TargetTest.php
@@ -245,9 +245,7 @@ class TargetTest extends TestCase
 
     public function testBreakProfilingWithFlushWithProfilingDisabled(): void
     {
-        $dispatcher = $this->getMockBuilder('yii\log\Dispatcher')
-            ->setMethods(['dispatch'])
-            ->getMock();
+        $dispatcher = $this->createPartialMock('yii\log\Dispatcher', ['dispatch']);
         $dispatcher->expects($this->once())->method('dispatch')->with($this->callback(function ($messages) {
             return count($messages) === 2
                 && $messages[0][0] === 'token.a'
@@ -267,9 +265,7 @@ class TargetTest extends TestCase
 
     public function testNotBreakProfilingWithFlushWithProfilingEnabled(): void
     {
-        $dispatcher = $this->getMockBuilder('yii\log\Dispatcher')
-            ->setMethods(['dispatch'])
-            ->getMock();
+        $dispatcher = $this->createPartialMock('yii\log\Dispatcher', ['dispatch']);
         $dispatcher->expects($this->exactly(2))->method('dispatch')->withConsecutive(
             [
                 $this->callback(function ($messages) {
@@ -302,9 +298,7 @@ class TargetTest extends TestCase
 
     public function testFlushingWithProfilingEnabledAndOverflow(): void
     {
-        $dispatcher = $this->getMockBuilder('yii\log\Dispatcher')
-            ->setMethods(['dispatch'])
-            ->getMock();
+        $dispatcher = $this->createPartialMock('yii\log\Dispatcher', ['dispatch']);
         $dispatcher->expects($this->exactly(3))->method('dispatch')->withConsecutive(
             [
                 $this->callback(function ($messages) {

--- a/tests/framework/mail/BaseMailerTest.php
+++ b/tests/framework/mail/BaseMailerTest.php
@@ -301,11 +301,18 @@ TEXT
     {
         $message = new Message();
 
-        $mailerMock = $this->getMockBuilder('yiiunit\framework\mail\Mailer')
-            ->setMethods(['beforeSend', 'afterSend'])
-            ->getMock();
+        /** @var Mailer $mailerMock */
+        $mailerMock = $this->createPartialMock(
+            Mailer::class,
+            [
+                'afterSend',
+                'beforeSend',
+            ],
+        );
+
         $mailerMock->expects($this->once())->method('beforeSend')->with($message)->will($this->returnValue(true));
         $mailerMock->expects($this->once())->method('afterSend')->with($message, true);
+
         $mailerMock->send($message);
     }
 }

--- a/tests/framework/web/UrlManagerParseUrlTest.php
+++ b/tests/framework/web/UrlManagerParseUrlTest.php
@@ -417,9 +417,13 @@ class UrlManagerParseUrlTest extends TestCase
 
     public function testRulesCacheIsUsed(): void
     {
-        $arrayCache = $this->getMockBuilder('yii\caching\ArrayCache')
-            ->setMethods(['get', 'set'])
-            ->getMock();
+        $arrayCache = $this->createPartialMock(
+            ArrayCache::class,
+            [
+                'get',
+                'set',
+            ],
+        );
 
         $manager = $this->getUrlManager([
             'rules' => ['post/<id:\d+>' => 'post/view'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
