### PR TITLE
Fix `@return` annotation for `DataColumn::getDataCellValue()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -61,6 +61,7 @@ Yii Framework 2 Change Log
 - Bug #20608: Fix `@return` annotations for `yii\rest\Serializer` methods (mspirkov)
 - Bug #20610: Fix `@var` annotation for `ActiveQueryTrait::$with` (mspirkov)
 - Bug #20611: Fix `@return` annotations for `yii\i18n\GettextMoFile` methods (mspirkov)
+- Bug #20617: Fix `@return` annotation for `DataColumn::getDataCellValue()` (mspirkov)
 
 
 2.0.53 June 27, 2025

--- a/framework/grid/DataColumn.php
+++ b/framework/grid/DataColumn.php
@@ -240,7 +240,7 @@ class DataColumn extends Column
      * @param mixed $model the data model
      * @param mixed $key the key associated with the data model
      * @param int $index the zero-based index of the data model among the models array returned by [[GridView::dataProvider]].
-     * @return string the data cell value
+     * @return string|null the data cell value
      */
     public function getDataCellValue($model, $key, $index)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="896" height="142" alt="image" src="https://github.com/user-attachments/assets/1f43b357-3de5-40a9-8454-9f6313fe6680" />
