### PR TITLE
Fix `@var` annotation for `yii\web\Response::$acceptMimeType`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -61,6 +61,7 @@ Yii Framework 2 Change Log
 - Bug #20608: Fix `@return` annotations for `yii\rest\Serializer` methods (mspirkov)
 - Bug #20610: Fix `@var` annotation for `ActiveQueryTrait::$with` (mspirkov)
 - Bug #20611: Fix `@return` annotations for `yii\i18n\GettextMoFile` methods (mspirkov)
+- Bug #20618: Fix `@var` annotation for `yii\web\Response::$acceptMimeType` (mspirkov)
 
 
 2.0.53 June 27, 2025

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -103,7 +103,7 @@ class Response extends \yii\base\Response
      */
     public $format = self::FORMAT_HTML;
     /**
-     * @var string the MIME type (e.g. `application/json`) from the request ACCEPT header chosen for this response.
+     * @var string|null the MIME type (e.g. `application/json`) from the request ACCEPT header chosen for this response.
      * This property is mainly set by [[\yii\filters\ContentNegotiator]].
      */
     public $acceptMimeType;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="785" height="140" alt="image" src="https://github.com/user-attachments/assets/0c96d0aa-73bc-4b7b-bf65-a96acac498e8" />
