### PR TITLE
Fix `@return` annotation for `yii\db\Query::prepare()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -61,6 +61,7 @@ Yii Framework 2 Change Log
 - Bug #20608: Fix `@return` annotations for `yii\rest\Serializer` methods (mspirkov)
 - Bug #20610: Fix `@var` annotation for `ActiveQueryTrait::$with` (mspirkov)
 - Bug #20611: Fix `@return` annotations for `yii\i18n\GettextMoFile` methods (mspirkov)
+- Bug #20619: Fix `@return` annotation for `yii\db\Query::prepare()` (mspirkov)
 
 
 2.0.53 June 27, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -40,7 +40,7 @@ Yii Framework 2 Change Log
 - Enh #20539: Update minimum PHP version requirement from `7.3` to `7.4` (terabytesoftw)
 - Bug #20541: Remove deprecated caching components: `XCache` and `ZendDataCache`, and update related tests and documentation (terabytesoftw)
 - Bug #20548: Fix PHP `8.5` `null` array offset deprecation warnings (terabytesoftw)
-- Enh #19526: Add the `convertIniSizeToBytes` method to `BaseStringHelper` (mspirkov)
+- New #19526: Add the `convertIniSizeToBytes` method to `BaseStringHelper` (mspirkov)
 - Bug #20570: Fix `@var` annotation for `UrlManager::$cache` (mspirkov)
 - Bug #20571: Fix `@var` annotation for `yii\web\Response::$stream` (mspirkov)
 - Bug #20569: Fix `@param` annotation for `$default` in `HeaderCollection::get` (mspirkov)

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -167,7 +167,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
      * This method is called by [[QueryBuilder]] when it starts to build SQL from a query object.
      * You may override this method to do some final preparation work when converting a query into a SQL statement.
      * @param QueryBuilder $builder
-     * @return $this a prepared query instance which will be used by [[QueryBuilder]] to build the SQL
+     * @return self a prepared query instance which will be used by [[QueryBuilder]] to build the SQL
      */
     public function prepare($builder)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="1330" height="228" alt="image" src="https://github.com/user-attachments/assets/da0b99ef-ddcb-4af3-848a-a60683dea817" />
