### PR TITLE
Fix `@return` annotations for `lastInsertId` methods in `yii\db\mssql` namespace

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -65,7 +65,7 @@ Yii Framework 2 Change Log
 - Bug #20619: Fix `@return` annotation for `yii\db\Query::prepare()` (mspirkov)
 - Bug #20618: Fix `@var` annotation for `yii\web\Response::$acceptMimeType` (mspirkov)
 - Bug #20617: Fix `@return` annotation for `DataColumn::getDataCellValue()` (mspirkov)
-- Bug #20621: Fix `@return` annotations for `lastInsertId` methods in `yii\db\mssql` namespace (mspirkov)
+- Bug #20628: Fix `@return` annotations for `lastInsertId` methods in `yii\db\mssql` namespace (mspirkov)
 
 
 2.0.53 June 27, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -65,6 +65,7 @@ Yii Framework 2 Change Log
 - Bug #20619: Fix `@return` annotation for `yii\db\Query::prepare()` (mspirkov)
 - Bug #20618: Fix `@var` annotation for `yii\web\Response::$acceptMimeType` (mspirkov)
 - Bug #20617: Fix `@return` annotation for `DataColumn::getDataCellValue()` (mspirkov)
+- Bug #20621: Fix `@return` annotations for `lastInsertId` methods in `yii\db\mssql` namespace (mspirkov)
 
 
 2.0.53 June 27, 2025

--- a/framework/db/mssql/DBLibPDO.php
+++ b/framework/db/mssql/DBLibPDO.php
@@ -19,7 +19,7 @@ class DBLibPDO extends \PDO
     /**
      * Returns value of the last inserted ID.
      * @param string|null $name the sequence name. Defaults to null.
-     * @return int last inserted ID value.
+     * @return string|false last inserted ID value.
      */
     #[\ReturnTypeWillChange]
     public function lastInsertId($name = null)

--- a/framework/db/mssql/PDO.php
+++ b/framework/db/mssql/PDO.php
@@ -19,7 +19,7 @@ class PDO extends \PDO
     /**
      * Returns value of the last inserted ID.
      * @param string|null $sequence the sequence name. Defaults to null.
-     * @return int last inserted ID value.
+     * @return string|false last inserted ID value.
      */
     #[\ReturnTypeWillChange]
     public function lastInsertId($sequence = null)

--- a/framework/db/mssql/SqlsrvPDO.php
+++ b/framework/db/mssql/SqlsrvPDO.php
@@ -24,7 +24,7 @@ class SqlsrvPDO extends \PDO
      * But when parameter is not specified it works as expected and returns actual
      * last inserted ID (like the other PDO drivers).
      * @param string|null $sequence the sequence name. Defaults to null.
-     * @return int last inserted ID value.
+     * @return string|false last inserted ID value.
      */
     #[\ReturnTypeWillChange]
     public function lastInsertId($sequence = null)

--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -1267,7 +1267,7 @@ SQL;
         $sql = 'INSERT INTO {{profile}}([[description]]) VALUES (\'non duplicate\')';
         $command = $db->createCommand($sql);
         $command->execute();
-        $this->assertEquals(3, $db->getSchema()->getLastInsertID());
+        $this->assertSame('3', $db->getSchema()->getLastInsertID());
     }
 
     public function testQueryCache(): void

--- a/tests/framework/db/oci/CommandTest.php
+++ b/tests/framework/db/oci/CommandTest.php
@@ -39,7 +39,7 @@ class CommandTest extends \yiiunit\framework\db\CommandTest
         $sql = 'INSERT INTO {{profile}}([[description]]) VALUES (\'non duplicate\')';
         $command = $db->createCommand($sql);
         $command->execute();
-        $this->assertEquals(3, $db->getSchema()->getLastInsertID('profile_SEQ'));
+        $this->assertSame('3', $db->getSchema()->getLastInsertID('profile_SEQ'));
     }
 
     public function batchInsertSqlProvider()

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -72,12 +72,12 @@ class CommandTest extends \yiiunit\framework\db\CommandTest
         $sql = 'INSERT INTO {{profile}}([[description]]) VALUES (\'non duplicate\')';
         $command = $db->createCommand($sql);
         $command->execute();
-        $this->assertEquals(3, $db->getSchema()->getLastInsertID('public.profile_id_seq'));
+        $this->assertSame('3', $db->getSchema()->getLastInsertID('public.profile_id_seq'));
 
         $sql = 'INSERT INTO {{schema1.profile}}([[description]]) VALUES (\'non duplicate\')';
         $command = $db->createCommand($sql);
         $command->execute();
-        $this->assertEquals(3, $db->getSchema()->getLastInsertID('schema1.profile_id_seq'));
+        $this->assertSame('3', $db->getSchema()->getLastInsertID('schema1.profile_id_seq'));
     }
 
     public function dataProviderGetRawSql()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
