### PR TITLE
Add `@template` annotation for `yii\rest\OptionsAction`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -32,7 +32,7 @@ Yii Framework 2 Change Log
 - Bug #20515: Fix `@param` annotations in `BetweenColumnsCondition`, `InCondition` and `LikeCondition` (mspirkov)
 - Bug #20516: Fix `@template` annotations in `ActiveRecord` (mspirkov)
 - Bug #19506: Fix `@property` annotations in `yii\console\widgets\Table`, `yii\di\Container` and `yii\web\Session` (mspirkov)
-- Enh #20525, #20529, #20628: Add `@template` annotations for all actions (mspirkov)
+- Enh #20525, #20529, #20629: Add `@template` annotations for all actions (mspirkov)
 - Bug #20524: Fix PHPStan/Psalm annotations in `Yii::createObject` (mspirkov)
 - Bug #20530: Fix notice "Object of class DateTimeImmutable could not be converted to int" in `CookieCollection::has` (mspirkov)
 - Bug #20532: Add missing `return` statements in `CacheController::actionFlushSchema`, `FixtureController::actionUnload`, `HelpController::actionIndex` and `ServeController::actionIndex` (mspirkov)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -32,7 +32,7 @@ Yii Framework 2 Change Log
 - Bug #20515: Fix `@param` annotations in `BetweenColumnsCondition`, `InCondition` and `LikeCondition` (mspirkov)
 - Bug #20516: Fix `@template` annotations in `ActiveRecord` (mspirkov)
 - Bug #19506: Fix `@property` annotations in `yii\console\widgets\Table`, `yii\di\Container` and `yii\web\Session` (mspirkov)
-- Enh #20525: Add `@template` annotations for all actions (mspirkov)
+- Enh #20525, #20529, #20628: Add `@template` annotations for all actions (mspirkov)
 - Bug #20524: Fix PHPStan/Psalm annotations in `Yii::createObject` (mspirkov)
 - Bug #20530: Fix notice "Object of class DateTimeImmutable could not be converted to int" in `CookieCollection::has` (mspirkov)
 - Bug #20532: Add missing `return` statements in `CacheController::actionFlushSchema`, `FixtureController::actionUnload`, `HelpController::actionIndex` and `ServeController::actionIndex` (mspirkov)

--- a/framework/rest/OptionsAction.php
+++ b/framework/rest/OptionsAction.php
@@ -7,6 +7,7 @@
 
 namespace yii\rest;
 
+use yii\base\Action as BaseAction;
 use Yii;
 
 /**
@@ -16,8 +17,11 @@ use Yii;
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
+ *
+ * @template T of Controller
+ * @extends BaseAction<T>
  */
-class OptionsAction extends \yii\base\Action
+class OptionsAction extends BaseAction
 {
     /**
      * @var array the HTTP verbs that are supported by the collection URL


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

Missed this class here https://github.com/yiisoft/yii2/pull/20525