### PR TITLE
Fix `@var` annotations for `yii\web\CompositeUrlRule::$rules` and `yii\web\GroupUrlRule::$rules`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -65,6 +65,7 @@ Yii Framework 2 Change Log
 - Bug #20619: Fix `@return` annotation for `yii\db\Query::prepare()` (mspirkov)
 - Bug #20618: Fix `@var` annotation for `yii\web\Response::$acceptMimeType` (mspirkov)
 - Bug #20617: Fix `@return` annotation for `DataColumn::getDataCellValue()` (mspirkov)
+- Bug #20630: Fix `@var` annotations for `yii\web\CompositeUrlRule::$rules` and `yii\web\GroupUrlRule::$rules` (mspirkov)
 
 
 2.0.53 June 27, 2025

--- a/framework/web/CompositeUrlRule.php
+++ b/framework/web/CompositeUrlRule.php
@@ -22,7 +22,7 @@ use yii\base\BaseObject;
 abstract class CompositeUrlRule extends BaseObject implements UrlRuleInterface
 {
     /**
-     * @var UrlRuleInterface[] the URL rules contained in this composite rule.
+     * @var UrlRuleInterface[]|UrlRuleInterface[][]|array[]|string[] the URL rules contained in this composite rule.
      * This property is set in [[init()]] by the return value of [[createRules()]].
      */
     protected $rules = [];

--- a/framework/web/GroupUrlRule.php
+++ b/framework/web/GroupUrlRule.php
@@ -48,7 +48,7 @@ use yii\base\InvalidConfigException;
 class GroupUrlRule extends CompositeUrlRule
 {
     /**
-     * @var array the rules contained within this composite rule. Please refer to [[UrlManager::rules]]
+     * @var UrlRuleInterface[]|array[]|string[] the rules contained within this composite rule. Please refer to [[UrlManager::rules]]
      * for the format of this property.
      * @see prefix
      * @see routePrefix


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="1440" height="211" alt="image" src="https://github.com/user-attachments/assets/c64dd0bd-7e68-4ea3-9031-98d8d9539181" />

<img width="1051" height="154" alt="image" src="https://github.com/user-attachments/assets/b744c212-2894-4afa-bcc0-112be72d661a" />
