### PR TITLE
Refactor tests to use `willReturnCallback` with invocation matcher for `withConsecutive` deprecated method.

### DIFF
--- a/tests/framework/BaseYiiTest.php
+++ b/tests/framework/BaseYiiTest.php
@@ -172,27 +172,51 @@ class BaseYiiTest extends TestCase
 
         BaseYii::setLogger($logger);
 
-        $logger->expects($this->exactly(6))
+        /**
+         * @link https://github.com/sebastianbergmann/phpunit/issues/5063
+         */
+        $matcher = $this->exactly(6);
+        $logger
+            ->expects($matcher)
             ->method('log')
-            ->withConsecutive(
-                [$this->equalTo('info message'), $this->equalTo(Logger::LEVEL_INFO), $this->equalTo('info category')],
-                [
-                    $this->equalTo('warning message'),
-                    $this->equalTo(Logger::LEVEL_WARNING),
-                    $this->equalTo('warning category'),
-                ],
-                [$this->equalTo('trace message'), $this->equalTo(Logger::LEVEL_TRACE), $this->equalTo('trace category')],
-                [$this->equalTo('error message'), $this->equalTo(Logger::LEVEL_ERROR), $this->equalTo('error category')],
-                [
-                    $this->equalTo('beginProfile message'),
-                    $this->equalTo(Logger::LEVEL_PROFILE_BEGIN),
-                    $this->equalTo('beginProfile category'),
-                ],
-                [
-                    $this->equalTo('endProfile message'),
-                    $this->equalTo(Logger::LEVEL_PROFILE_END),
-                    $this->equalTo('endProfile category'),
-                ]
+            ->willReturnCallback(
+                function (...$parameters) use ($matcher): void {
+                    if ($matcher->getInvocationCount() === 1) {
+                        $this->assertEquals('info message', $parameters[0]);
+                        $this->assertEquals(Logger::LEVEL_INFO, $parameters[1]);
+                        $this->assertEquals('info category', $parameters[2]);
+                    }
+
+                    if ($matcher->getInvocationCount() === 2) {
+                        $this->assertEquals('warning message', $parameters[0]);
+                        $this->assertEquals(Logger::LEVEL_WARNING, $parameters[1]);
+                        $this->assertEquals('warning category', $parameters[2]);
+                    }
+
+                    if ($matcher->getInvocationCount() === 3) {
+                        $this->assertEquals('trace message', $parameters[0]);
+                        $this->assertEquals(Logger::LEVEL_TRACE, $parameters[1]);
+                        $this->assertEquals('trace category', $parameters[2]);
+                    }
+
+                    if ($matcher->getInvocationCount() === 4) {
+                        $this->assertEquals('error message', $parameters[0]);
+                        $this->assertEquals(Logger::LEVEL_ERROR, $parameters[1]);
+                        $this->assertEquals('error category', $parameters[2]);
+                    }
+
+                    if ($matcher->getInvocationCount() === 5) {
+                        $this->assertEquals('beginProfile message', $parameters[0]);
+                        $this->assertEquals(Logger::LEVEL_PROFILE_BEGIN, $parameters[1]);
+                        $this->assertEquals('beginProfile category', $parameters[2]);
+                    }
+
+                    if ($matcher->getInvocationCount() === 6) {
+                        $this->assertEquals('endProfile message', $parameters[0]);
+                        $this->assertEquals(Logger::LEVEL_PROFILE_END, $parameters[1]);
+                        $this->assertEquals('endProfile category', $parameters[2]);
+                    }
+                },
             );
 
         BaseYii::info('info message', 'info category');

--- a/tests/framework/log/DispatcherTest.php
+++ b/tests/framework/log/DispatcherTest.php
@@ -215,7 +215,7 @@ namespace yiiunit\framework\log {
                                     !str_starts_with(
                                         (string) $arg[0][0],
                                         'Unable to send log via ' .
-                                        $target1::class .
+                                        get_class($target1) .
                                         ': Exception (Exception) \'yii\base\UserException\' with message \'some error\''
                                     )
                                 ) {

--- a/tests/framework/log/DispatcherTest.php
+++ b/tests/framework/log/DispatcherTest.php
@@ -202,7 +202,7 @@ namespace yiiunit\framework\log {
                     function (...$parameters) use ($matcher): void {
                         if ($matcher->getInvocationCount() === 1) {
                             $this->assertEquals('messages', $parameters[0]);
-                            $this->assertEquals(true, $parameters[1]);
+                            $this->assertTrue($parameters[1]);
                         }
 
                         if ($matcher->getInvocationCount() === 2) {
@@ -242,7 +242,7 @@ namespace yiiunit\framework\log {
                             };
 
                             $this->assertTrue($callback($parameters[0]));
-                            $this->assertSame(true, $parameters[1]);
+                            $this->assertTrue($parameters[1]);
                         }
                     },
                 );

--- a/tests/framework/log/DispatcherTest.php
+++ b/tests/framework/log/DispatcherTest.php
@@ -212,12 +212,12 @@ namespace yiiunit\framework\log {
                                 }
 
                                 if (
-                                    !str_starts_with(
+                                    strpos(
                                         (string) $arg[0][0],
                                         'Unable to send log via ' .
                                         get_class($target1) .
                                         ': Exception (Exception) \'yii\base\UserException\' with message \'some error\''
-                                    )
+                                    ) !== 0
                                 ) {
                                     return false;
                                 }

--- a/tests/framework/log/DispatcherTest.php
+++ b/tests/framework/log/DispatcherTest.php
@@ -187,43 +187,64 @@ namespace yiiunit\framework\log {
         public function testDispatchWithFakeTarget2ThrowExceptionWhenCollect(): void
         {
             static::$microtimeIsMocked = true;
+
             $target1 = $this->createPartialMock(Target::class, ['collect', 'export']);
             $target2 = $this->createPartialMock(Target::class, ['collect', 'export']);
 
-            $target1->expects($this->exactly(2))
+            /**
+             * @link https://github.com/sebastianbergmann/phpunit/issues/5063
+             */
+            $matcher = $this->exactly(2);
+            $target1
+                ->expects($matcher)
                 ->method('collect')
-                ->withConsecutive(
-                    [$this->equalTo('messages'), $this->equalTo(true)],
-                    [
-                        $this->callback(function ($arg) use ($target1) {
-                            if (!isset($arg[0][0], $arg[0][1], $arg[0][2], $arg[0][3])) {
-                                return false;
-                            }
+                ->willReturnCallback(
+                    function (...$parameters) use ($matcher): void {
+                        if ($matcher->getInvocationCount() === 1) {
+                            $this->assertEquals('messages', $parameters[0]);
+                            $this->assertEquals(true, $parameters[1]);
+                        }
 
-                            if (strpos($arg[0][0], 'Unable to send log via ' . get_class($target1) . ': Exception (Exception) \'yii\base\UserException\' with message \'some error\'') !== 0) {
-                                return false;
-                            }
+                        if ($matcher->getInvocationCount() === 2) {
+                            $callback = function ($arg) use ($target1): bool {
+                                if (!isset($arg[0][0], $arg[0][1], $arg[0][2], $arg[0][3])) {
+                                    return false;
+                                }
 
-                            if ($arg[0][1] !== Logger::LEVEL_WARNING) {
-                                return false;
-                            }
+                                if (
+                                    !str_starts_with(
+                                        (string) $arg[0][0],
+                                        'Unable to send log via ' .
+                                        $target1::class .
+                                        ': Exception (Exception) \'yii\base\UserException\' with message \'some error\''
+                                    )
+                                ) {
+                                    return false;
+                                }
 
-                            if ($arg[0][2] !== 'yii\log\Dispatcher::dispatch') {
-                                return false;
-                            }
+                                if ($arg[0][1] !== Logger::LEVEL_WARNING) {
+                                    return false;
+                                }
 
-                            if ($arg[0][3] !== 'time data') {
-                                return false;
-                            }
+                                if ($arg[0][2] !== 'yii\log\Dispatcher::dispatch') {
+                                    return false;
+                                }
 
-                            if ($arg[0][4] !== []) {
-                                return false;
-                            }
+                                if ($arg[0][3] !== 'time data') {
+                                    return false;
+                                }
 
-                            return true;
-                        }),
-                        true,
-                    ]
+                                if ($arg[0][4] !== []) {
+                                    return false;
+                                }
+
+                                return true;
+                            };
+
+                            $this->assertTrue($callback($parameters[0]));
+                            $this->assertSame(true, $parameters[1]);
+                        }
+                    },
                 );
 
             $target2->expects($this->once())

--- a/tests/framework/log/SyslogTargetTest.php
+++ b/tests/framework/log/SyslogTargetTest.php
@@ -114,16 +114,50 @@ namespace yiiunit\framework\log {
                     [$messages[6], 'formatted message 7'],
                 ]);
 
-            $syslogTarget->expects($this->exactly(7))
+            /**
+             * @link https://github.com/sebastianbergmann/phpunit/issues/5063
+             */
+            $matcher = $this->exactly(7);
+            $syslogTarget
+                ->expects($matcher)
                 ->method('syslog')
-                ->withConsecutive(
-                    [$this->equalTo(LOG_INFO), $this->equalTo('formatted message 1')],
-                    [$this->equalTo(LOG_ERR), $this->equalTo('formatted message 2')],
-                    [$this->equalTo(LOG_WARNING), $this->equalTo('formatted message 3')],
-                    [$this->equalTo(LOG_DEBUG), $this->equalTo('formatted message 4')],
-                    [$this->equalTo(LOG_DEBUG), $this->equalTo('formatted message 5')],
-                    [$this->equalTo(LOG_DEBUG), $this->equalTo('formatted message 6')],
-                    [$this->equalTo(LOG_DEBUG), $this->equalTo('formatted message 7')]
+                ->willReturnCallback(
+                    function (...$parameters) use ($matcher): void {
+                        if ($matcher->getInvocationCount() === 1) {
+                            $this->assertEquals(LOG_INFO, $parameters[0]);
+                            $this->assertEquals('formatted message 1', $parameters[1]);
+                        }
+
+                        if ($matcher->getInvocationCount() === 2) {
+                            $this->assertEquals(LOG_ERR, $parameters[0]);
+                            $this->assertEquals('formatted message 2', $parameters[1]);
+                        }
+
+                        if ($matcher->getInvocationCount() === 3) {
+                            $this->assertEquals(LOG_WARNING, $parameters[0]);
+                            $this->assertEquals('formatted message 3', $parameters[1]);
+                        }
+
+                        if ($matcher->getInvocationCount() === 4) {
+                            $this->assertEquals(LOG_DEBUG, $parameters[0]);
+                            $this->assertEquals('formatted message 4', $parameters[1]);
+                        }
+
+                        if ($matcher->getInvocationCount() === 5) {
+                            $this->assertEquals(LOG_DEBUG, $parameters[0]);
+                            $this->assertEquals('formatted message 5', $parameters[1]);
+                        }
+
+                        if ($matcher->getInvocationCount() === 6) {
+                            $this->assertEquals(LOG_DEBUG, $parameters[0]);
+                            $this->assertEquals('formatted message 6', $parameters[1]);
+                        }
+
+                        if ($matcher->getInvocationCount() === 7) {
+                            $this->assertEquals(LOG_DEBUG, $parameters[0]);
+                            $this->assertEquals('formatted message 7', $parameters[1]);
+                        }
+                    }
                 );
 
             $syslogTarget->expects($this->once())->method('closelog');

--- a/tests/framework/log/TargetTest.php
+++ b/tests/framework/log/TargetTest.php
@@ -280,7 +280,7 @@ class TargetTest extends TestCase
                         $callback = fn($messages): bool => count($messages) === 1 && $messages[0][0] === 'info';
 
                         $this->assertTrue($callback($parameters[0]));
-                        $this->assertSame(false, $parameters[1]);
+                        $this->assertFalse($parameters[1]);
                     }
 
                     if ($matcher->getInvocationCount() === 2) {
@@ -291,7 +291,7 @@ class TargetTest extends TestCase
                             && $messages[1][1] == Logger::LEVEL_PROFILE_END;
 
                         $this->assertTrue($callback($parameters[0]));
-                        $this->assertSame(false, $parameters[1]);
+                        $this->assertFalse($parameters[1]);
                     }
                 },
             );
@@ -328,7 +328,7 @@ class TargetTest extends TestCase
                             && $messages[1][1] == Logger::LEVEL_PROFILE_BEGIN;
 
                         $this->assertTrue($callback($parameters[0]));
-                        $this->assertSame(false, $parameters[1]);
+                        $this->assertFalse($parameters[1]);
                     }
 
                     if ($matcher->getInvocationCount() === 2) {
@@ -336,7 +336,7 @@ class TargetTest extends TestCase
                             && $messages[0][0] === 'Number of dangling profiling block messages reached flushInterval value and therefore these were flushed. Please consider setting higher flushInterval value or making profiling blocks shorter.';
 
                         $this->assertTrue($callback($parameters[0]));
-                        $this->assertSame(false, $parameters[1]);
+                        $this->assertFalse($parameters[1]);
                     }
 
                     if ($matcher->getInvocationCount() === 3) {
@@ -347,7 +347,7 @@ class TargetTest extends TestCase
                             && $messages[1][1] == Logger::LEVEL_PROFILE_END;
 
                         $this->assertTrue($callback($parameters[0]));
-                        $this->assertSame(false, $parameters[1]);
+                        $this->assertFalse($parameters[1]);
                     }
                 },
             );

--- a/tests/framework/log/TargetTest.php
+++ b/tests/framework/log/TargetTest.php
@@ -323,9 +323,9 @@ class TargetTest extends TestCase
                     if ($matcher->getInvocationCount() === 1) {
                         $callback = fn($messages): bool => count($messages) === 2
                             && $messages[0][0] === 'token.a'
-                            && $messages[0][1] == Logger::LEVEL_PROFILE_BEGIN
+                            && $messages[0][1] === Logger::LEVEL_PROFILE_BEGIN
                             && $messages[1][0] === 'token.b'
-                            && $messages[1][1] == Logger::LEVEL_PROFILE_BEGIN;
+                            && $messages[1][1] === Logger::LEVEL_PROFILE_BEGIN;
 
                         $this->assertTrue($callback($parameters[0]));
                         $this->assertFalse($parameters[1]);

--- a/tests/framework/log/TargetTest.php
+++ b/tests/framework/log/TargetTest.php
@@ -342,9 +342,9 @@ class TargetTest extends TestCase
                     if ($matcher->getInvocationCount() === 3) {
                         $callback = fn($messages): bool => count($messages) === 2
                             && $messages[0][0] === 'token.b'
-                            && $messages[0][1] == Logger::LEVEL_PROFILE_END
+                            && $messages[0][1] === Logger::LEVEL_PROFILE_END
                             && $messages[1][0] === 'token.a'
-                            && $messages[1][1] == Logger::LEVEL_PROFILE_END;
+                            && $messages[1][1] === Logger::LEVEL_PROFILE_END;
 
                         $this->assertTrue($callback($parameters[0]));
                         $this->assertFalse($parameters[1]);

--- a/tests/framework/log/TargetTest.php
+++ b/tests/framework/log/TargetTest.php
@@ -286,9 +286,9 @@ class TargetTest extends TestCase
                     if ($matcher->getInvocationCount() === 2) {
                         $callback = fn($messages): bool => count($messages) === 2
                             && $messages[0][0] === 'token.a'
-                            && $messages[0][1] == Logger::LEVEL_PROFILE_BEGIN
+                            && $messages[0][1] === Logger::LEVEL_PROFILE_BEGIN
                             && $messages[1][0] === 'token.a'
-                            && $messages[1][1] == Logger::LEVEL_PROFILE_END;
+                            && $messages[1][1] === Logger::LEVEL_PROFILE_END;
 
                         $this->assertTrue($callback($parameters[0]));
                         $this->assertFalse($parameters[1]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

https://github.com/sebastianbergmann/phpunit/issues/5063