### PR TITLE
Pass `$model` and `$attribute` in Compare Validator's compareValue property closure

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -73,6 +73,7 @@ Yii Framework 2 Change Log
 - Bug #20639: Add missing generics in `yii\web` namespace (mspirkov)
 - Bug #20645: Add missing generics in `yii\helpers` and `yii\test` namespaces. Fix PHPDoc annotations in `ArrayAccessTrait` (mspirkov)
 - Bug #20640: Fix `@param` annotation for `$block` in `yii\console\Markdown::renderParagraph()` (mspirkov)
+- Enh #20642: Pass `$model` and `$attribute` in Compare Validator's compareValue property closure (samuelrajan747)
 
 
 2.0.53 June 27, 2025

--- a/framework/validators/CompareValidator.php
+++ b/framework/validators/CompareValidator.php
@@ -57,8 +57,17 @@ class CompareValidator extends Validator
      */
     public $compareAttribute;
     /**
-     * @var mixed the constant value to be compared with. When both this property
-     * and [[compareAttribute]] are set, this property takes precedence.
+     * @var mixed the constant value to be compared with  or an anonymous function
+     * that returns the constant value. When both this property and
+     * [[compareAttribute]] are set, this property takes precedence.
+     * The signature of the anonymous function should be as follows,
+     *
+     * ```
+     * function($model, $attribute) {
+     *     // compute value to compare with
+     *     return $value;
+     * }
+     * ```
      * @see compareAttribute
      */
     public $compareValue;
@@ -144,7 +153,7 @@ class CompareValidator extends Validator
         }
         if ($this->compareValue !== null) {
             if ($this->compareValue instanceof \Closure) {
-                $this->compareValue = call_user_func($this->compareValue);
+                $this->compareValue = call_user_func($this->compareValue, $model, $attribute);
             }
             $compareLabel = $compareValue = $compareValueOrAttribute = $this->compareValue;
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #20642

Pass $model and $attribute in Compare Validator's compareValue property closure
Closes #20642.

