### PR TITLE
Fix SQLite `CommandTest` skipped tests and minor fixes.

### DIFF
--- a/tests/framework/db/CommandTest.php
+++ b/tests/framework/db/CommandTest.php
@@ -1323,7 +1323,7 @@ SQL;
 
         $db->createCommand()->addUnique($name, $tableName, $columns)->execute();
 
-        $this->assertEquals((array) $columns, $schema->getTableUniques($tableName, true)[0]->columnNames);
+        $this->assertSame((array) $columns, $schema->getTableUniques($tableName, true)[0]->columnNames);
 
         $db->createCommand()->dropUnique($name, $tableName)->execute();
 

--- a/tests/framework/db/sqlite/CommandTest.php
+++ b/tests/framework/db/sqlite/CommandTest.php
@@ -8,6 +8,8 @@
 
 namespace yiiunit\framework\db\sqlite;
 
+use yii\base\InvalidArgumentException;
+use yii\base\NotSupportedException;
 use yii\db\sqlite\Schema;
 
 /**
@@ -42,67 +44,133 @@ class CommandTest extends \yiiunit\framework\db\CommandTest
         parent::testUpsert($firstData, $secondData);
     }
 
-    public function testAddDropPrimaryKey(): void
+    /**
+     * @dataProvider addPrimaryKeyProvider
+     *
+     * @param string $name
+     * @param string $tableName
+     * @param array|string $pk
+     *
+     * @phpstan-param list<string> $pk
+     */
+    public function testAddDropPrimaryKey(string $name, string $tableName, $pk): void
     {
-        $this->markTestSkipped('SQLite does not support adding/dropping primary keys.');
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessageMatches(
+            '/^.*::(addPrimaryKey|dropPrimaryKey) is not supported by SQLite\.$/',
+        );
+
+        parent::testAddDropPrimaryKey($name, $tableName, $pk);
     }
 
-    public function testAddDropForeignKey(): void
+    /**
+     * @dataProvider addForeignKeyProvider
+     *
+     * @param string $name
+     * @param string $tableName
+     * @param array|string $fkColumns
+     * @param array|string $refColumns
+     *
+     * @phpstan-param list<string> $fkColumns
+     * @phpstan-param list<string> $refColumns
+     */
+    public function testAddDropForeignKey(string $name, string $tableName, $fkColumns, $refColumns): void
     {
-        $this->markTestSkipped('SQLite does not support adding/dropping foreign keys.');
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessageMatches(
+            '/^.*::(addForeignKey|dropForeignKey) is not supported by SQLite\.$/',
+        );
+
+        parent::testAddDropForeignKey($name, $tableName, $fkColumns, $refColumns);
     }
 
-    public function testAddDropUnique(): void
+    /**
+     * @dataProvider addUniqueProvider
+     *
+     * @param string $name
+     * @param string $tableName
+     * @param array|string $columns
+     *
+     * @phpstan-param list<string> $columns
+     */
+    public function testAddDropUnique(string $name, string $tableName, $columns): void
     {
-        $this->markTestSkipped('SQLite does not support adding/dropping unique constraints.');
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessageMatches(
+            '/^.*::(addUnique|dropUnique) is not supported by SQLite\.$/',
+        );
+
+        parent::testAddDropUnique($name, $tableName, $columns);
     }
 
     public function testAddDropCheck(): void
     {
-        $this->markTestSkipped('SQLite does not support adding/dropping check constraints.');
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessageMatches(
+            '/^.*::(addCheck|dropCheck) is not supported by SQLite\.$/',
+        );
+
+        parent::testAddDropCheck();
     }
 
     public function testMultiStatementSupport(): void
     {
         $db = $this->getConnection(false);
-        $sql = <<<'SQL'
-DROP TABLE IF EXISTS {{T_multistatement}};
-CREATE TABLE {{T_multistatement}} (
-    [[intcol]] INTEGER,
-    [[textcol]] TEXT
-);
-INSERT INTO {{T_multistatement}} VALUES(41, :val1);
-INSERT INTO {{T_multistatement}} VALUES(42, :val2);
-SQL;
-        $db->createCommand($sql, [
-            'val1' => 'foo',
-            'val2' => 'bar',
-        ])->execute();
-        $this->assertSame([
+
+        $sql = <<<SQL
+        DROP TABLE IF EXISTS {{T_multistatement}};
+        CREATE TABLE {{T_multistatement}} (
+            [[intcol]] INTEGER,
+            [[textcol]] TEXT
+        );
+        INSERT INTO {{T_multistatement}} VALUES(41, :val1);
+        INSERT INTO {{T_multistatement}} VALUES(42, :val2);
+        SQL;
+
+        $db->createCommand(
+            $sql,
             [
-                'intcol' => '41',
-                'textcol' => 'foo',
+                'val1' => 'foo',
+                'val2' => 'bar',
             ],
+        )->execute();
+
+        $this->assertSame(
             [
-                'intcol' => '42',
-                'textcol' => 'bar',
+                [
+                    'intcol' => '41',
+                    'textcol' => 'foo',
+                ],
+                [
+                    'intcol' => '42',
+                    'textcol' => 'bar',
+                ],
             ],
-        ], $db->createCommand('SELECT * FROM {{T_multistatement}}')->queryAll());
-        $sql = <<<'SQL'
-UPDATE {{T_multistatement}} SET [[intcol]] = :newInt WHERE [[textcol]] = :val1;
-DELETE FROM {{T_multistatement}} WHERE [[textcol]] = :val2;
-SELECT * FROM {{T_multistatement}}
-SQL;
-        $this->assertSame([
+            $db->createCommand('SELECT * FROM {{T_multistatement}}')->queryAll(),
+        );
+
+        $sql = <<<SQL
+        UPDATE {{T_multistatement}} SET [[intcol]] = :newInt WHERE [[textcol]] = :val1;
+        DELETE FROM {{T_multistatement}} WHERE [[textcol]] = :val2;
+        SELECT * FROM {{T_multistatement}}
+        SQL;
+
+        $this->assertSame(
             [
-                'intcol' => '410',
-                'textcol' => 'foo',
+                [
+                    'intcol' => '410',
+                    'textcol' => 'foo',
+                ],
             ],
-        ], $db->createCommand($sql, [
-            'newInt' => 410,
-            'val1' => 'foo',
-            'val2' => 'bar',
-        ])->queryAll());
+            $db->createCommand(
+                $sql,
+                [
+                    'newInt' => 410,
+                    'val1' => 'foo',
+                    'val2' => 'bar',
+                ],
+            )->queryAll(),
+        );
     }
 
     public static function batchInsertSqlProvider(): array
@@ -153,19 +221,65 @@ SQL;
 
     public function testResetSequenceExceptionTableNoExist(): void
     {
-        $this->expectException('yii\base\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Table not found: no_exist_table');
 
-        $db = $this->getConnection();
+        $db = $this->getConnection(false);
         $db->createCommand()->resetSequence('no_exist_table', 5)->execute();
     }
 
     public function testResetSequenceExceptionSquenceNoExist(): void
     {
-        $this->expectException('yii\base\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("There is not sequence associated with table 'type'.");
 
-        $db = $this->getConnection();
+        $db = $this->getConnection(false);
         $db->createCommand()->resetSequence('type', 5)->execute();
+    }
+
+    public function testAlterTable(): void
+    {
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessage(
+            'yii\db\sqlite\QueryBuilder::alterColumn is not supported by SQLite.',
+        );
+
+        $db = $this->getConnection(false);
+        $db->createCommand()->alterColumn('table1', 'column1', 'INTEGER')->execute();
+    }
+
+    public function testAddDropDefaultValue(): void
+    {
+        $db = $this->getConnection(false);
+
+        try {
+            $db->createCommand()->addDefaultValue(
+                'test_def_constraint',
+                'test_def',
+                'int1',
+                41,
+            )->execute();
+
+            $this->fail("Expected 'NotSupportedException' for 'addDefaultValue' not thrown.");
+        } catch (NotSupportedException $e) {
+            $this->assertStringContainsString(
+                'yii\db\sqlite\QueryBuilder::addDefaultValue is not supported by SQLite.',
+                $e->getMessage(),
+            );
+        }
+
+        try {
+            $db->createCommand()->dropDefaultValue(
+                'test_def_constraint',
+                'test_def',
+            )->execute();
+
+            $this->fail("Expected 'NotSupportedException' for 'dropDefaultValue' not thrown.");
+        } catch (NotSupportedException $e) {
+            $this->assertStringContainsString(
+                'yii\db\sqlite\QueryBuilder::dropDefaultValue is not supported by SQLite.',
+                $e->getMessage(),
+            );
+        }
     }
 }

--- a/tests/framework/db/sqlite/CommandTest.php
+++ b/tests/framework/db/sqlite/CommandTest.php
@@ -228,7 +228,7 @@ class CommandTest extends \yiiunit\framework\db\CommandTest
         $db->createCommand()->resetSequence('no_exist_table', 5)->execute();
     }
 
-    public function testResetSequenceExceptionSquenceNoExist(): void
+    public function testResetSequenceExceptionSequenceNoExist(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("There is not sequence associated with table 'type'.");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

Before:
```shell
There were 13 skipped tests:

1) yiiunit\framework\db\sqlite\CommandTest::testAddDropPrimaryKey
SQLite does not support adding/dropping primary keys.

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/CommandTest.php:47
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

2) yiiunit\framework\db\sqlite\CommandTest::testAddDropForeignKey
SQLite does not support adding/dropping foreign keys.

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/CommandTest.php:52
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

3) yiiunit\framework\db\sqlite\CommandTest::testAddDropUnique
SQLite does not support adding/dropping unique constraints.

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/CommandTest.php:57
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

4) yiiunit\framework\db\sqlite\CommandTest::testAddDropCheck
SQLite does not support adding/dropping check constraints.

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/CommandTest.php:62
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

5) yiiunit\framework\db\sqlite\CommandTest::testAlterTable
Sqlite does not support alterTable

/home/runner/work/yii2/yii2/tests/framework/db/CommandTest.php:745
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

6) yiiunit\framework\db\sqlite\CommandTest::testAddDropDefaultValue
sqlite does not support adding/dropping default value constraints.

/home/runner/work/yii2/yii2/tests/framework/db/CommandTest.php:1248
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

7) yiiunit\framework\db\sqlite\ConnectionTest::testExceptionContainsRawQuery
This test does not work on sqlite because preparing the failing query fails

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/ConnectionTest.php:224
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

8) yiiunit\framework\db\sqlite\QueryBuilderTest::testCommentColumn
Comments are not supported in SQLite

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/QueryBuilderTest.php:118
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

9) yiiunit\framework\db\sqlite\QueryBuilderTest::testCommentTable
Comments are not supported in SQLite

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/QueryBuilderTest.php:123
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

10) yiiunit\framework\db\sqlite\QueryBuilderTest::testBatchInsertOnOlderVersions
This test is only relevant for SQLite < 3.7.11

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/QueryBuilderTest.php:137
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

11) yiiunit\framework\db\sqlite\QueryTest::testCountHavingWithoutGroupBy
sqlite does not support having without group by.

/home/runner/work/yii2/yii2/tests/framework/db/QueryTest.php:511
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

12) yiiunit\framework\db\sqlite\SchemaTest::testGetSchemaNames
Schemas are not supported in SQLite.

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/SchemaTest.php:25
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

13) yiiunit\framework\log\SqliteTargetTest::testTransactionRollBack
It is not possible to test logging during transaction when the DB is in memory

/home/runner/work/yii2/yii2/tests/framework/log/SqliteTargetTest.php:23
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

OK, but incomplete, skipped, or risky tests!
Tests: 719, Assertions: 3114, Skipped: 13.
```

After:
```shell
There were 7 skipped tests:

1) yiiunit\framework\db\sqlite\ConnectionTest::testExceptionContainsRawQuery
This test does not work on sqlite because preparing the failing query fails

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/ConnectionTest.php:224
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

2) yiiunit\framework\db\sqlite\QueryBuilderTest::testCommentColumn
Comments are not supported in SQLite

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/QueryBuilderTest.php:118
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

3) yiiunit\framework\db\sqlite\QueryBuilderTest::testCommentTable
Comments are not supported in SQLite

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/QueryBuilderTest.php:123
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

4) yiiunit\framework\db\sqlite\QueryBuilderTest::testBatchInsertOnOlderVersions
This test is only relevant for SQLite < 3.7.11

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/QueryBuilderTest.php:137
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

5) yiiunit\framework\db\sqlite\QueryTest::testCountHavingWithoutGroupBy
sqlite does not support having without group by.

/home/runner/work/yii2/yii2/tests/framework/db/QueryTest.php:511
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

6) yiiunit\framework\db\sqlite\SchemaTest::testGetSchemaNames
Schemas are not supported in SQLite.

/home/runner/work/yii2/yii2/tests/framework/db/sqlite/SchemaTest.php:25
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

7) yiiunit\framework\log\SqliteTargetTest::testTransactionRollBack
It is not possible to test logging during transaction when the DB is in memory

/home/runner/work/yii2/yii2/tests/framework/log/SqliteTargetTest.php:23
/home/runner/work/yii2/yii2/vendor/bin/phpunit:122

OK, but incomplete, skipped, or risky tests!
Tests: 725, Assertions: 3148, Skipped: 7.
```