### PR TITLE
Use 'files' input for codecov/codecov-action `v5` in PHPUnit `action.yml`.

### DIFF
--- a/.github/actions/phpunit/action.yml
+++ b/.github/actions/phpunit/action.yml
@@ -125,5 +125,5 @@ runs:
       if: ${{ !cancelled() && inputs.coverage-driver != 'none' }}
       uses: codecov/codecov-action@v5
       with:
+        files: ./${{ inputs.coverage-file }}
         token: ${{ inputs.coverage-token }}
-        file: ./${{ inputs.coverage-file }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

Before:
```shell
info - 2025-10-28 23:42:04,235 -- ci service found: github-actions
warning - 2025-10-28 23:42:04,244 -- No config file could be found. Ignoring config.
info - 2025-10-28 23:42:04,341 -- Found 2 test_results files to report
info - 2025-10-28 23:42:04,342 -- > /home/runner/work/yii2/yii2/tests/framework/validators/data/mimeType/test.xml
info - 2025-10-28 23:42:04,342 -- > /home/runner/work/yii2/yii2/junit.xml
info - 2025-10-28 23:42:04,992 -- Process Upload complete
Sentry is attempting to send 2 pending events
Waiting up to 2 seconds
Press Ctrl-C to quit
Warning: Unexpected input(s) 'file', valid inputs are ['base_sha', 'binary', 'codecov_yml_path', 'commit_parent', 'directory', 'disable_file_fixes', 'disable_search', 'disable_safe_directory', 'disable_telem', 'dry_run', 'env_vars', 'exclude', 'fail_ci_if_error', 'files', 'flags', 'force', 'git_service', 'gcov_args', 'gcov_executable', 'gcov_ignore', 'gcov_include', 'handle_no_reports_found', 'job_code', 'name', 'network_filter', 'network_prefix', 'os', 'override_branch', 'override_build', 'override_build_url', 'override_commit', 'override_pr', 'plugins', 'recurse_submodules', 'report_code', 'report_type', 'root_dir', 'run_command', 'skip_validation', 'slug', 'swift_project', 'token', 'url', 'use_legacy_upload_endpoint', 'use_oidc', 'use_pypi', 'verbose', 'version', 'working-directory']
```

After:
```shell
 -> Token length: 0
==> Running upload-coverage
      ./codecov  upload-coverage --git-service github --pr 20649 --sha 249e1cded2de30a01bf9ad6d5a3f3cff3256e8da --branch terabytesoftw:fix-ci-github-actions --file ./coverage.xml --gcov-executable gcov
info - 2025-10-28 23:48:58,171 -- ci service found: github-actions
warning - 2025-10-28 23:48:58,180 -- No config file could be found. Ignoring config.
warning - 2025-10-28 23:48:58,213 -- xcrun is not installed or can't be found.
warning - 2025-10-28 23:48:58,285 -- No gcov data found.
warning - 2025-10-28 23:48:58,285 -- coverage.py is not installed or can't be found.
info - 2025-10-28 23:48:58,415 -- Found 1 coverage files to report
info - 2025-10-28 23:48:58,415 -- > /home/runner/work/yii2/yii2/coverage.xml
info - 2025-10-28 23:48:59,152 -- Your upload is now processing. When finished, results will be available at: https://app.codecov.io/github/yiisoft/yii2/commit/249e1cded2de30a01bf9ad6d5a3f3cff3256e8da
info - 2025-10-28 23:48:59,444 -- Process Upload complete
```