### PR TITLE
Fix `PHP` `8.5` `null` array offset deprecation warnings in `MariaDB` driver.

### DIFF
--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.4]
+        php: [7.4, 8.5]
         mariadb:
           - mariadb:10.4
           - mariadb:latest
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.5]
+        php: [8.1, 8.2, 8.3, 8.4]
         mariadb:
           - mariadb:latest
 

--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -39,28 +39,30 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PHP_EXTENSIONS: curl, intl, pdo, pdo_mysql
+  PHP_INI_VALUES: apc.enabled=1,apc.shm_size=32M,apc.enable_cli=1, date.timezone='UTC'
+  PHPUNIT_GROUP: mysql
+  XDEBUG_MODE: coverage
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }}-${{ matrix.mariadb }}
 
     env:
-      COVERAGE_DRIVER: ${{ matrix.php == 7.4 && 'xdebug' || 'none' }}
-      PHP_EXTENSIONS: curl, intl, pdo, pdo_mysql
-      PHP_INI_VALUES: apc.enabled=1,apc.shm_size=32M,apc.enable_cli=1, date.timezone='UTC'
-      PHPUNIT_GROUP: mysql
-      XDEBUG_MODE: coverage
+      COVERAGE_DRIVER: xdebug
 
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
+        php: [7.4, 8.4]
         mariadb:
           - mariadb:10.4
           - mariadb:latest
 
-    services:
+    services: &mariadb-service
       mysql:
         image: ${{ matrix.mariadb }}
         env:
@@ -76,7 +78,7 @@ jobs:
           --health-timeout=5s
           --mount type=tmpfs,destination=/var/lib/mysql
 
-    steps:
+    steps: &mariadb-steps
       - name: Monitor action permissions.
         if: runner.os != 'Windows'
         uses: GitHubSecurityLab/actions-permissions/monitor@v1
@@ -98,3 +100,22 @@ jobs:
           coverage-driver: ${{ env.COVERAGE_DRIVER }}
           coverage-token: ${{ secrets.CODECOV_TOKEN }}
           group: ${{ env.PHPUNIT_GROUP }}
+
+  tests-dev:
+    name: PHP ${{ matrix.php }}-${{ matrix.mariadb }}
+
+    env:
+      COVERAGE_DRIVER: none
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.1, 8.2, 8.3, 8.5]
+        mariadb:
+          - mariadb:latest
+
+    services: *mariadb-service
+
+    steps: *mariadb-steps

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -77,6 +77,7 @@ Yii Framework 2 Change Log
 - Enh #20650: Add PHPStan/Psalm annotations for `yii\di\Container` (mspirkov)
 - Bug #20654: Add missing generics in `yii\db` namespace. Fix PHPDoc annotations in `yii\db\ArrayExpression` (mspirkov)
 - Bug #20651: Add missing generics in `yii\filters` namespace (mspirkov)
+- Bug #20659: Fix `PHP` `8.5` `null` array offset deprecation warnings in `MariaDB` driver (terabytesoftw)
 
 
 2.0.53 June 27, 2025

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -512,6 +512,11 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function hasAttribute($name)
     {
+        // using null as an array offset is deprecated in PHP `8.5`
+        if ($name === null || $name === '') {
+            return false;
+        }
+
         return isset($this->_attributes[$name]) || in_array($name, $this->attributes(), true);
     }
 

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -512,7 +512,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
      */
     public function hasAttribute($name)
     {
-        // using null as an array offset is deprecated in PHP `8.5`
+        // using null as an array offset is deprecated in PHP 8.5
         if ($name === null || $name === '') {
             return false;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
