### PR TITLE
Add PHP `8.0` to `ci-mariadb.yml` workflow matrix.

### DIFF
--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
         mariadb:
           - mariadb:latest
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
