### PR TITLE
Fix PHP `8.5` `null` array offset deprecation warnings in `yii\build\controllers\ReleaseController` class.

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
 
     steps:
       - name: Monitor action permissions.

--- a/build/controllers/ReleaseController.php
+++ b/build/controllers/ReleaseController.php
@@ -888,7 +888,10 @@ class ReleaseController extends Controller
             // add continued lines to the last item to keep them together
             if (!empty(${$state}) && trim($line) !== '' && strncmp($line, '- ', 2) !== 0) {
                 end(${$state});
-                ${$state}[key(${$state})] .= "\n" . $line;
+
+                if (($k = key(${$state})) !== null) {
+                    ${$state}[$k] .= "\n" . $line;
+                }
             } else {
                 ${$state}[] = $line;
             }

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -77,7 +77,8 @@ Yii Framework 2 Change Log
 - Enh #20650: Add PHPStan/Psalm annotations for `yii\di\Container` (mspirkov)
 - Bug #20654: Add missing generics in `yii\db` namespace. Fix PHPDoc annotations in `yii\db\ArrayExpression` (mspirkov)
 - Bug #20651: Add missing generics in `yii\filters` namespace (mspirkov)
-- Bug #20659: Fix `PHP` `8.5` `null` array offset deprecation warnings in `MariaDB` driver (terabytesoftw)
+- Bug #20659: Fix PHP `8.5` `null` array offset deprecation warnings in `MariaDB` driver (terabytesoftw)
+- Bug #20665: Fix PHP `8.5` `null` array offset deprecation warnings in `yii\build\controllers\ReleaseController` class.
 
 
 2.0.53 June 27, 2025
@@ -181,7 +182,7 @@ Yii Framework 2 Change Log
 - Enh #20042: Add empty array check to `ActiveQueryTrait::findWith()` (renkas)
 - Enh #20087: Add custom attributes to script tags (skepticspriggan)
 - Enh #20121: Added `yiisoft/yii2-coding-standards` to composer `require-dev` and lint code to comply with PSR12 (razvanphp)
-- Enh #20134: Raise minimum `PHP` version to `7.3` (@terabytesoftw)
+- Enh #20134: Raise minimum PHP version to `7.3` (@terabytesoftw)
 - Enh #20171: Support JSON columns for MariaDB 10.4 or higher (@terabytesoftw)
 - New #20137: Added `yii\caching\CallbackDependency` to allow using a callback to determine if a cache dependency is still valid (laxity7)
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -80,7 +80,6 @@ Yii Framework 2 Change Log
 - Bug #20659: Fix PHP `8.5` `null` array offset deprecation warnings in `MariaDB` driver (terabytesoftw)
 - Bug #20665: Fix PHP `8.5` `null` array offset deprecation warnings in `yii\build\controllers\ReleaseController` class (terabytesoftw)
 - Bug #20658: Add missing generics in `yii\console`, `yii\captcha`, `yii\caching` and `yii\behaviors` namespaces (mspirkov)
-- Bug #20659: Fix `PHP` `8.5` `null` array offset deprecation warnings in `MariaDB` driver (terabytesoftw)
 
 
 2.0.53 June 27, 2025

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -78,7 +78,7 @@ Yii Framework 2 Change Log
 - Bug #20654: Add missing generics in `yii\db` namespace. Fix PHPDoc annotations in `yii\db\ArrayExpression` (mspirkov)
 - Bug #20651: Add missing generics in `yii\filters` namespace (mspirkov)
 - Bug #20659: Fix PHP `8.5` `null` array offset deprecation warnings in `MariaDB` driver (terabytesoftw)
-- Bug #20665: Fix PHP `8.5` `null` array offset deprecation warnings in `yii\build\controllers\ReleaseController` class.
+- Bug #20665: Fix PHP `8.5` `null` array offset deprecation warnings in `yii\build\controllers\ReleaseController` class (terabytesoftw)
 
 
 2.0.53 June 27, 2025

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -424,8 +424,3 @@ parameters:
 			message: "#^Property yii\\\\console\\\\Application\\:\\:\\$controller \\(yii\\\\console\\\\Controller\\|yii\\\\web\\\\Controller\\) does not accept yii\\\\base\\\\Controller\\.$#"
 			count: 1
 			path: framework/base/Module.php
-
-		-
-			message: "#^Offset null does not exist on array\\{\\}\\.$#"
-			count: 1
-			path: build/controllers/ReleaseController.php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
