### PR TITLE
Sanitize `null` bytes before `quoteValue()` on PHP 8.5+ in SQLite.

### DIFF
--- a/.github/workflows/ci-sqlite.yml
+++ b/.github/workflows/ci-sqlite.yml
@@ -39,25 +39,27 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PHP_EXTENSIONS: curl, intl, pdo, pdo_sqlite
+  PHP_INI_VALUES: apc.enabled=1,apc.shm_size=32M,apc.enable_cli=1, date.timezone='UTC'
+  PHPUNIT_GROUP: sqlite
+  XDEBUG_MODE: coverage
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }}-sqlite
 
     env:
-      COVERAGE_DRIVER: ${{ matrix.php == 7.4 && 'xdebug' || 'none' }}
-      PHP_EXTENSIONS: curl, intl, pdo, pdo_sqlite
-      PHP_INI_VALUES: apc.enabled=1,apc.shm_size=32M,apc.enable_cli=1, date.timezone='UTC'
-      PHPUNIT_GROUP: sqlite
-      XDEBUG_MODE: coverage
+      COVERAGE_DRIVER: xdebug
 
     runs-on: ubuntu-latest
 
     strategy:
         fail-fast: false
         matrix:
-            php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
+            php: [7.4, 8.5]
 
-    steps:
+    steps: &sqlite-steps
       - name: Monitor action permissions.
         if: runner.os != 'Windows'
         uses: GitHubSecurityLab/actions-permissions/monitor@v1
@@ -79,3 +81,18 @@ jobs:
           coverage-driver: ${{ env.COVERAGE_DRIVER }}
           coverage-token: ${{ secrets.CODECOV_TOKEN }}
           group: ${{ env.PHPUNIT_GROUP }}
+
+  tests-dev:
+    name: PHP ${{ matrix.php }}-sqlite
+
+    env:
+      COVERAGE_DRIVER: none
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
+
+    steps: *sqlite-steps

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -81,6 +81,7 @@ Yii Framework 2 Change Log
 - Bug #20665: Fix PHP `8.5` `null` array offset deprecation warnings in `yii\build\controllers\ReleaseController` class (terabytesoftw)
 - Bug #20658: Add missing generics in `yii\console`, `yii\captcha`, `yii\caching` and `yii\behaviors` namespaces (mspirkov)
 - Bug #20666: Add missing generics in `yii\base`, `yii\console`, `yii\filters` and `yii\web` namespaces (mspirkov)
+- Bug #20673: Sanitize `null` bytes before `quoteValue()` on PHP 8.5+ in SQLite (terabytesoftw)
 
 
 2.0.53 June 27, 2025

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -491,4 +491,22 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
     {
         return strncmp($identifier, 'sqlite_', 7) === 0;
     }
+
+    /**
+     * @inheritdoc
+     *
+     * Since PHP 8.5, `PDO::quote()` throws a ValueError when the string contains null bytes ("\0").
+     *
+     * This method sanitizes such bytes before calling the parent implementation to avoid exceptions while maintaining
+     * backward compatibility.
+     */
+    public function quoteValue($value)
+    {
+        if (PHP_VERSION_ID >= 80500 && is_string($value) && strpos($value, "\0") !== false) {
+            // Sanitize null bytes to prevent PDO ValueError on PHP 8.5+
+            $value = str_replace("\0", '', $value);
+        }
+
+        return parent::quoteValue($value);
+    }
 }

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -499,6 +499,8 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      *
      * This method sanitizes such bytes before calling the parent implementation to avoid exceptions while maintaining
      * backward compatibility.
+     *
+     * @link https://github.com/php/php-src/commit/0a10f6db26875e0f1d0f867307cee591d29a43c7
      */
     public function quoteValue($value)
     {

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -504,7 +504,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     public function quoteValue($value)
     {
-        if (PHP_VERSION_ID >= 80500 && is_string($value) && strpos($value, "\0") !== false) {
+        if (PHP_VERSION_ID >= 80500 && is_string($value) && str_contains($value, "\0")) {
             // Sanitize null bytes to prevent PDO ValueError on PHP 8.5+
             $value = str_replace("\0", '', $value);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
