### PR TITLE
Fix PHP `8.5` `null` array offset deprecation warnings in `yiiunit\framework\rbac\ManagerTestCase` class.

### DIFF
--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -190,8 +190,6 @@ abstract class ManagerTestCase extends TestCase
                 'updatePost' => false,
                 'updateAnyPost' => true,
                 'blablabla' => false,
-                // using null as an array offset is deprecated in PHP 8.5
-                PHP_VERSION_ID >= 80500 ? '' : null => false,
             ],
             'guest' => [
                 // all actions denied for guest (user not exists)
@@ -201,10 +199,13 @@ abstract class ManagerTestCase extends TestCase
                 'deletePost' => false,
                 'updateAnyPost' => false,
                 'blablabla' => false,
-                // using null as an array offset is deprecated in PHP 8.5
-                PHP_VERSION_ID >= 80500 ? '' : null => false,
             ],
         ];
+
+        // using null as an array offset is deprecated in PHP 8.5
+        $invalidKey = PHP_VERSION_ID >= 80500 ? '' : null;
+        $testSuites['admin C'][$invalidKey] = false;
+        $testSuites['guest'][$invalidKey] = false;
 
         $params = ['authorID' => 'author B'];
 

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -190,7 +190,8 @@ abstract class ManagerTestCase extends TestCase
                 'updatePost' => false,
                 'updateAnyPost' => true,
                 'blablabla' => false,
-                null => false,
+                // using null as an array offset is deprecated in PHP 8.5
+                PHP_VERSION_ID >= 80500 ? '' : null => false,
             ],
             'guest' => [
                 // all actions denied for guest (user not exists)
@@ -200,7 +201,8 @@ abstract class ManagerTestCase extends TestCase
                 'deletePost' => false,
                 'updateAnyPost' => false,
                 'blablabla' => false,
-                null => false,
+                // using null as an array offset is deprecated in PHP 8.5
+                PHP_VERSION_ID >= 80500 ? '' : null => false,
             ],
         ];
 

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -202,7 +202,7 @@ abstract class ManagerTestCase extends TestCase
             ],
         ];
 
-        // using null as an array offset is deprecated in PHP 8.5
+        // using null as an array key is deprecated in PHP 8.5
         $invalidKey = PHP_VERSION_ID >= 80500 ? '' : null;
         $testSuites['admin C'][$invalidKey] = false;
         $testSuites['guest'][$invalidKey] = false;

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -206,7 +206,6 @@ abstract class ManagerTestCase extends TestCase
         $invalidKey = PHP_VERSION_ID >= 80500 ? '' : null;
         $testSuites['admin C'][$invalidKey] = false;
         $testSuites['guest'][$invalidKey] = false;
-
         $params = ['authorID' => 'author B'];
 
         foreach ($testSuites as $user => $tests) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
