### PR TITLE
Added method "fallbackExceptionMessage" to customize fallback exception message

### DIFF
--- a/framework/base/ErrorHandler.php
+++ b/framework/base/ErrorHandler.php
@@ -188,13 +188,18 @@ abstract class ErrorHandler extends Component
             }
             $msg .= "\n\$_SERVER = " . VarDumper::export($_SERVER);
         } else {
-            echo 'An internal server error occurred.';
+            echo $this->fallbackExceptionMessage($exception);
         }
         error_log($msg);
         if (defined('HHVM_VERSION')) {
             flush();
         }
         exit(1);
+    }
+
+    protected function fallbackExceptionMessage($exception)
+    {
+        return 'An internal server error occurred.';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Added the ability to customize the critical error message for the `handleFallbackExceptionMessage` method.
  Previously, customizing this message required completely overriding the `handleFallbackExceptionMessage`
  method. This PR introduces the ability to customize the error text by overriding just one method:
  `fallbackExceptionMessage`