### PR TITLE
refactor: replace `::className()` with `::class` for PHP 8.0 compatibility

### DIFF
--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -116,8 +116,8 @@ class Controller extends Component implements ViewContextInterface
     public function init()
     {
         parent::init();
-        $this->request = Instance::ensure($this->request, Request::className());
-        $this->response = Instance::ensure($this->response, Response::className());
+        $this->request = Instance::ensure($this->request, Request::class);
+        $this->response = Instance::ensure($this->response, Response::class);
     }
 
     /**

--- a/framework/behaviors/SluggableBehavior.php
+++ b/framework/behaviors/SluggableBehavior.php
@@ -245,7 +245,7 @@ class SluggableBehavior extends AttributeBehavior
         /** @var UniqueValidator $validator */
         $validator = Yii::createObject(array_merge(
             [
-                'class' => UniqueValidator::className(),
+                'class' => UniqueValidator::class,
             ],
             $this->uniqueValidator
         ));

--- a/framework/caching/DbCache.php
+++ b/framework/caching/DbCache.php
@@ -95,7 +95,7 @@ class DbCache extends Cache
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
     }
 
     /**

--- a/framework/caching/DbDependency.php
+++ b/framework/caching/DbDependency.php
@@ -49,7 +49,7 @@ class DbDependency extends Dependency
     protected function generateDependencyData($cache)
     {
         /** @var Connection $db */
-        $db = Instance::ensure($this->db, Connection::className());
+        $db = Instance::ensure($this->db, Connection::class);
         if ($this->sql === null) {
             throw new InvalidConfigException('DbDependency::sql must be set.');
         }

--- a/framework/captcha/Captcha.php
+++ b/framework/captcha/Captcha.php
@@ -49,7 +49,7 @@ use yii\widgets\InputWidget;
  * method, for example like this:
  *
  * ```
- * <?= $form->field($model, 'captcha')->widget(\yii\captcha\Captcha::classname(), [
+ * <?= $form->field($model, 'captcha')->widget(\yii\captcha\Captcha::class, [
  *     // configure additional widget properties here
  * ]) ?>
  * ```

--- a/framework/console/controllers/CacheController.php
+++ b/framework/console/controllers/CacheController.php
@@ -306,6 +306,6 @@ class CacheController extends Controller
      */
     private function canBeFlushed($className)
     {
-        return !is_a($className, ApcCache::className(), true) || PHP_SAPI !== 'cli';
+        return !is_a($className, ApcCache::class, true) || PHP_SAPI !== 'cli';
     }
 }

--- a/framework/console/controllers/FixtureController.php
+++ b/framework/console/controllers/FixtureController.php
@@ -263,7 +263,7 @@ class FixtureController extends Controller
         $fixtureClassNames = [];
 
         foreach ($fixtures as $fixture) {
-            $fixtureClassNames[] = $fixture::className();
+            $fixtureClassNames[] = $fixture::class;
         }
 
         $this->outputList($fixtureClassNames);

--- a/framework/console/controllers/MessageController.php
+++ b/framework/console/controllers/MessageController.php
@@ -323,7 +323,7 @@ EOD;
             }
         } elseif ($this->config['format'] === 'db') {
             /** @var Connection $db */
-            $db = Instance::ensure($this->config['db'], Connection::className());
+            $db = Instance::ensure($this->config['db'], Connection::class);
             $sourceMessageTable = isset($this->config['sourceMessageTable']) ? $this->config['sourceMessageTable'] : '{{%source_message}}';
             $messageTable = isset($this->config['messageTable']) ? $this->config['messageTable'] : '{{%message}}';
             $this->saveMessagesToDb(

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -188,7 +188,7 @@ class MigrateController extends BaseMigrateController
     public function beforeAction($action)
     {
         if (parent::beforeAction($action)) {
-            $this->db = Instance::ensure($this->db, Connection::className());
+            $this->db = Instance::ensure($this->db, Connection::class);
             return true;
         }
 
@@ -476,7 +476,7 @@ class MigrateController extends BaseMigrateController
             if ($relatedColumn === null) {
                 $relatedColumn = 'id';
                 try {
-                    $this->db = Instance::ensure($this->db, Connection::className());
+                    $this->db = Instance::ensure($this->db, Connection::class);
                     $relatedTableSchema = $this->db->getTableSchema($relatedTable);
                     if ($relatedTableSchema !== null) {
                         $primaryKeyCount = count($relatedTableSchema->primaryKey);

--- a/framework/data/BaseDataProvider.php
+++ b/framework/data/BaseDataProvider.php
@@ -211,7 +211,7 @@ abstract class BaseDataProvider extends Component implements DataProviderInterfa
     public function setPagination($value)
     {
         if (is_array($value)) {
-            $config = ['class' => Pagination::className()];
+            $config = ['class' => Pagination::class];
             if ($this->id !== null) {
                 $config['pageParam'] = $this->id . '-page';
                 $config['pageSizeParam'] = $this->id . '-per-page';
@@ -252,7 +252,7 @@ abstract class BaseDataProvider extends Component implements DataProviderInterfa
     public function setSort($value)
     {
         if (is_array($value)) {
-            $config = ['class' => Sort::className()];
+            $config = ['class' => Sort::class];
             if ($this->id !== null) {
                 $config['sortParam'] = $this->id . '-sort';
             }

--- a/framework/data/DataFilter.php
+++ b/framework/data/DataFilter.php
@@ -288,7 +288,7 @@ class DataFilter extends Model
         if (!is_object($this->_searchModel) || $this->_searchModel instanceof \Closure) {
             $model = Yii::createObject($this->_searchModel);
             if (!$model instanceof Model) {
-                throw new InvalidConfigException('`' . get_class($this) . '::$searchModel` should be an instance of `' . Model::className() . '` or its DI compatible configuration.');
+                throw new InvalidConfigException('`' . get_class($this) . '::$searchModel` should be an instance of `' . Model::class . '` or its DI compatible configuration.');
             }
             $this->_searchModel = $model;
         }
@@ -302,7 +302,7 @@ class DataFilter extends Model
     public function setSearchModel($model)
     {
         if (is_object($model) && !$model instanceof Model && !$model instanceof \Closure) {
-            throw new InvalidConfigException('`' . get_class($this) . '::$searchModel` should be an instance of `' . Model::className() . '` or its DI compatible configuration.');
+            throw new InvalidConfigException('`' . get_class($this) . '::$searchModel` should be an instance of `' . Model::class . '` or its DI compatible configuration.');
         }
         $this->_searchModel = $model;
     }

--- a/framework/data/SqlDataProvider.php
+++ b/framework/data/SqlDataProvider.php
@@ -95,7 +95,7 @@ class SqlDataProvider extends BaseDataProvider
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
         if ($this->sql === null) {
             throw new InvalidConfigException('The "sql" property must be set.');
         }

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -414,7 +414,7 @@ class ActiveRecord extends BaseActiveRecord
      */
     public static function find()
     {
-        return Yii::createObject(ActiveQuery::className(), [get_called_class()]);
+        return Yii::createObject(ActiveQuery::class, [get_called_class()]);
     }
 
     /**

--- a/framework/db/Migration.php
+++ b/framework/db/Migration.php
@@ -87,7 +87,7 @@ class Migration extends Component implements MigrationInterface
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
         $this->db->getSchema()->refresh();
         $this->db->enableSlaves = false;
     }

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -198,7 +198,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
     public function batch($batchSize = 100, $db = null)
     {
         return Yii::createObject([
-            'class' => BatchQueryResult::className(),
+            'class' => BatchQueryResult::class,
             'query' => $this,
             'batchSize' => $batchSize,
             'db' => $db,
@@ -226,7 +226,7 @@ class Query extends Component implements QueryInterface, ExpressionInterface
     public function each($batchSize = 100, $db = null)
     {
         return Yii::createObject([
-            'class' => BatchQueryResult::className(),
+            'class' => BatchQueryResult::class,
             'query' => $this,
             'batchSize' => $batchSize,
             'db' => $db,

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -321,7 +321,7 @@ abstract class Schema extends BaseObject
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**
@@ -336,7 +336,7 @@ abstract class Schema extends BaseObject
      */
     public function createColumnSchemaBuilder($type, $length = null)
     {
-        return Yii::createObject(ColumnSchemaBuilder::className(), [$type, $length]);
+        return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length]);
     }
 
     /**

--- a/framework/db/cubrid/Schema.php
+++ b/framework/db/cubrid/Schema.php
@@ -254,7 +254,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -336,7 +336,7 @@ SQL;
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**
@@ -828,6 +828,6 @@ SQL;
      */
     public function createColumnSchemaBuilder($type, $length = null)
     {
-        return Yii::createObject(ColumnSchemaBuilder::className(), [$type, $length, $this->db]);
+        return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length, $this->db]);
     }
 }

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -262,7 +262,7 @@ SQL;
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**
@@ -526,7 +526,7 @@ SQL;
      */
     public function createColumnSchemaBuilder($type, $length = null)
     {
-        return Yii::createObject(ColumnSchemaBuilder::className(), [$type, $length, $this->db]);
+        return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length, $this->db]);
     }
 
     /**

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -266,7 +266,7 @@ SQL;
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**
@@ -274,7 +274,7 @@ SQL;
      */
     public function createColumnSchemaBuilder($type, $length = null)
     {
-        return Yii::createObject(ColumnSchemaBuilder::className(), [$type, $length]);
+        return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length]);
     }
 
     /**

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -293,7 +293,7 @@ SQL;
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -211,7 +211,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     public function createQueryBuilder()
     {
-        return Yii::createObject(QueryBuilder::className(), [$this->db]);
+        return Yii::createObject(QueryBuilder::class, [$this->db]);
     }
 
     /**
@@ -220,7 +220,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     public function createColumnSchemaBuilder($type, $length = null)
     {
-        return Yii::createObject(ColumnSchemaBuilder::className(), [$type, $length]);
+        return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length]);
     }
 
     /**

--- a/framework/filters/AccessControl.php
+++ b/framework/filters/AccessControl.php
@@ -106,7 +106,7 @@ class AccessControl extends ActionFilter
     {
         parent::init();
         if ($this->user !== false) {
-            $this->user = Instance::ensure($this->user, User::className());
+            $this->user = Instance::ensure($this->user, User::class);
         }
         foreach ($this->rules as $i => $rule) {
             if (is_array($rule)) {

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -547,7 +547,7 @@ class GridView extends BaseListView
                 $column = $this->createDataColumn($column);
             } else {
                 $column = Yii::createObject(array_merge([
-                    'class' => $this->dataColumnClass ?: DataColumn::className(),
+                    'class' => $this->dataColumnClass ?: DataColumn::class,
                     'grid' => $this,
                 ], $column));
             }
@@ -572,7 +572,7 @@ class GridView extends BaseListView
         }
 
         return Yii::createObject([
-            'class' => $this->dataColumnClass ?: DataColumn::className(),
+            'class' => $this->dataColumnClass ?: DataColumn::class,
             'grid' => $this,
             'attribute' => $matches[1],
             'format' => isset($matches[3]) ? $matches[3] : 'text',

--- a/framework/i18n/DbMessageSource.php
+++ b/framework/i18n/DbMessageSource.php
@@ -95,7 +95,7 @@ class DbMessageSource extends MessageSource
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
         if ($this->enableCaching) {
             $this->cache = Instance::ensure($this->cache, 'yii\caching\CacheInterface');
         }

--- a/framework/log/DbTarget.php
+++ b/framework/log/DbTarget.php
@@ -52,7 +52,7 @@ class DbTarget extends Target
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
     }
 
     /**

--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -142,7 +142,7 @@ abstract class BaseMailer extends Component implements MailerInterface, ViewCont
     protected function createView(array $config)
     {
         if (!array_key_exists('class', $config)) {
-            $config['class'] = View::className();
+            $config['class'] = View::class;
         }
 
         return Yii::createObject($config);

--- a/framework/mutex/DbMutex.php
+++ b/framework/mutex/DbMutex.php
@@ -37,6 +37,6 @@ abstract class DbMutex extends Mutex
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
     }
 }

--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -119,7 +119,7 @@ class DbManager extends BaseManager
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
         if ($this->cache !== null) {
             $this->cache = Instance::ensure($this->cache, 'yii\caching\CacheInterface');
         }
@@ -451,7 +451,7 @@ class DbManager extends BaseManager
      */
     protected function populateItem($row)
     {
-        $class = $row['type'] == Item::TYPE_PERMISSION ? Permission::className() : Role::className();
+        $class = $row['type'] == Item::TYPE_PERMISSION ? Permission::class : Role::class;
 
         if (!isset($row['data']) || ($data = @unserialize(is_resource($row['data']) ? stream_get_contents($row['data']) : $row['data'])) === false) {
             $data = null;

--- a/framework/rbac/PhpManager.php
+++ b/framework/rbac/PhpManager.php
@@ -731,7 +731,7 @@ class PhpManager extends BaseManager
         $rules = $this->loadFromFile($this->ruleFile);
 
         foreach ($items as $name => $item) {
-            $class = $item['type'] == Item::TYPE_PERMISSION ? Permission::className() : Role::className();
+            $class = $item['type'] == Item::TYPE_PERMISSION ? Permission::class : Role::class;
 
             $this->items[$name] = new $class([
                 'name' => $name,

--- a/framework/rest/Controller.php
+++ b/framework/rest/Controller.php
@@ -54,21 +54,21 @@ class Controller extends WebController
     {
         return [
             'contentNegotiator' => [
-                'class' => ContentNegotiator::className(),
+                'class' => ContentNegotiator::class,
                 'formats' => [
                     'application/json' => Response::FORMAT_JSON,
                     'application/xml' => Response::FORMAT_XML,
                 ],
             ],
             'verbFilter' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => $this->verbs(),
             ],
             'authenticator' => [
-                'class' => CompositeAuth::className(),
+                'class' => CompositeAuth::class,
             ],
             'rateLimiter' => [
-                'class' => RateLimiter::className(),
+                'class' => RateLimiter::class,
             ],
         ];
     }

--- a/framework/rest/IndexAction.php
+++ b/framework/rest/IndexAction.php
@@ -186,7 +186,7 @@ class IndexAction extends Action
         }
 
         return Yii::createObject([
-            'class' => ActiveDataProvider::className(),
+            'class' => ActiveDataProvider::class,
             'query' => $query,
             'pagination' => $pagination,
             'sort' => $sort,

--- a/framework/rest/UrlRule.php
+++ b/framework/rest/UrlRule.php
@@ -233,7 +233,7 @@ class UrlRule extends CompositeUrlRule
                         Yii::debug([
                             'rule' => method_exists($rule, '__toString') ? $rule->__toString() : get_class($rule),
                             'match' => $result !== false,
-                            'parent' => self::className(),
+                            'parent' => self::class,
                         ], __METHOD__);
                     }
                     if ($result !== false) {

--- a/framework/test/DbFixture.php
+++ b/framework/test/DbFixture.php
@@ -38,6 +38,6 @@ abstract class DbFixture extends Fixture
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, BaseObject::className());
+        $this->db = Instance::ensure($this->db, BaseObject::class);
     }
 }

--- a/framework/validators/UniqueValidator.php
+++ b/framework/validators/UniqueValidator.php
@@ -189,7 +189,7 @@ class UniqueValidator extends Validator
         /** @var ActiveRecordInterface|\yii\base\BaseObject $targetClass $query */
         $query = $this->prepareQuery($targetClass, $conditions);
 
-        if (!$model instanceof ActiveRecordInterface || $model->getIsNewRecord() || $model::className() !== $targetClass::className()) {
+        if (!$model instanceof ActiveRecordInterface || $model->getIsNewRecord() || $model::class !== $targetClass::class) {
             // if current $model isn't in the database yet, then it's OK just to call exists()
             // also there's no need to run check based on primary keys, when $targetClass is not the same as $model's class
             $exists = $query->exists();

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -412,10 +412,10 @@ class AssetManager extends Component
     public function getConverter()
     {
         if ($this->_converter === null) {
-            $this->_converter = Yii::createObject(AssetConverter::className());
+            $this->_converter = Yii::createObject(AssetConverter::class);
         } elseif (is_array($this->_converter) || is_string($this->_converter)) {
             if (is_array($this->_converter) && !isset($this->_converter['class'])) {
-                $this->_converter['class'] = AssetConverter::className();
+                $this->_converter['class'] = AssetConverter::class;
             }
             $this->_converter = Yii::createObject($this->_converter);
         }

--- a/framework/web/CompositeUrlRule.php
+++ b/framework/web/CompositeUrlRule.php
@@ -60,7 +60,7 @@ abstract class CompositeUrlRule extends BaseObject implements UrlRuleInterface
                 Yii::debug([
                     'rule' => method_exists($rule, '__toString') ? $rule->__toString() : get_class($rule),
                     'match' => $result !== false,
-                    'parent' => self::className(),
+                    'parent' => self::class,
                 ], __METHOD__);
             }
             if ($result !== false) {

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -90,7 +90,7 @@ class DbSession extends MultiFieldSession
     public function init()
     {
         parent::init();
-        $this->db = Instance::ensure($this->db, Connection::className());
+        $this->db = Instance::ensure($this->db, Connection::class);
     }
 
     /**

--- a/framework/web/UrlManager.php
+++ b/framework/web/UrlManager.php
@@ -178,7 +178,7 @@ class UrlManager extends Component
         if ($this->normalizer !== false) {
             $this->normalizer = Yii::createObject($this->normalizer);
             if (!$this->normalizer instanceof UrlNormalizer) {
-                throw new InvalidConfigException('`' . get_class($this) . '::normalizer` should be an instance of `' . UrlNormalizer::className() . '` or its DI compatible configuration.');
+                throw new InvalidConfigException('`' . get_class($this) . '::normalizer` should be an instance of `' . UrlNormalizer::class . '` or its DI compatible configuration.');
             }
         }
 

--- a/framework/web/UrlRule.php
+++ b/framework/web/UrlRule.php
@@ -197,7 +197,7 @@ class UrlRule extends BaseObject implements UrlRuleInterface
             throw new InvalidConfigException('UrlRule::route must be set.');
         }
         if (is_array($this->normalizer)) {
-            $normalizerConfig = array_merge(['class' => UrlNormalizer::className()], $this->normalizer);
+            $normalizerConfig = array_merge(['class' => UrlNormalizer::class], $this->normalizer);
             $this->normalizer = Yii::createObject($normalizerConfig);
         }
         if ($this->normalizer !== null && $this->normalizer !== false && !$this->normalizer instanceof UrlNormalizer) {

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -560,7 +560,7 @@ class View extends \yii\base\View
             }
         } else {
             $this->getAssetManager()->bundles[$key] = Yii::createObject([
-                'class' => AssetBundle::className(),
+                'class' => AssetBundle::class,
                 'baseUrl' => '',
                 'basePath' => '@webroot',
                 (string)$type => [ArrayHelper::merge([!Url::isRelative($url) ? $url : ltrim($url, '/')], $originalOptions)],

--- a/framework/widgets/BaseListView.php
+++ b/framework/widgets/BaseListView.php
@@ -253,7 +253,7 @@ abstract class BaseListView extends Widget
         }
         $pager = $this->pager;
         /** @var LinkPager $class */
-        $class = ArrayHelper::remove($pager, 'class', LinkPager::className());
+        $class = ArrayHelper::remove($pager, 'class', LinkPager::class);
         $pager['pagination'] = $pagination;
         $pager['view'] = $this->getView();
 
@@ -272,7 +272,7 @@ abstract class BaseListView extends Widget
         }
         $sorter = $this->sorter;
         /** @var LinkSorter $class */
-        $class = ArrayHelper::remove($sorter, 'class', LinkSorter::className());
+        $class = ArrayHelper::remove($sorter, 'class', LinkSorter::class);
         $sorter['sort'] = $sort;
         $sorter['view'] = $this->getView();
 

--- a/tests/framework/base/BaseObjectTest.php
+++ b/tests/framework/base/BaseObjectTest.php
@@ -153,7 +153,7 @@ class BaseObjectTest extends TestCase
     public function testGetClassName(): void
     {
         $object = $this->object;
-        $this->assertSame(get_class($object), $object::className());
+        $this->assertSame(get_class($object), $object::class);
     }
 
     public function testReadingWriteOnlyProperty(): void


### PR DESCRIPTION

Updated 43 files across the framework to use the modern `::class` constant instead of the deprecated `::className()` method. This change improves code consistency and ensures compatibility with current PHP standards while maintaining the same functionality.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
