### PR TITLE
Fix PHP 8.5 `imagedestroy` deprecation warning

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -84,6 +84,7 @@ Yii Framework 2 Change Log
 - Bug #20673: Sanitize `null` bytes before `quoteValue()` on PHP 8.5+ in SQLite (terabytesoftw)
 - Bug #20671: Fix PHPDoc annotations in `yii\base`, `yii\console`, `yii\web` and `yii\widgets` namespaces (mspirkov)
 - Bug #20675: Add generics for all controllers (mspirkov)
+- Bug #20689: Fix PHP `8.5` `imagedestroy` deprecation warning (ElisDN)
 
 
 2.0.53 June 27, 2025

--- a/framework/captcha/CaptchaAction.php
+++ b/framework/captcha/CaptchaAction.php
@@ -314,7 +314,11 @@ class CaptchaAction extends Action
 
         ob_start();
         imagepng($image);
-        imagedestroy($image);
+
+        // Function `imagedestroy` is deprecated since PHP `8.5`, as it has no effect since PHP `8.0`
+        if (PHP_VERSION_ID < 80000) {
+            imagedestroy($image);
+        }
 
         return ob_get_clean();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    |  ❌
| Fixed issues  | 
