### PR TITLE
Adjust `JSON` helper error message assertions for `PHP 8.6` compatibility in `JsonTest` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #20705: Replace `$this` with `self` in generics in Psalm annotations (mspirkov)
+- Bug #20715: Adjust `JSON` helper error message assertions for `PHP 8.6` compatibility in `JsonTest` class (terabytesoftw)
 
 
 2.0.54 January 09, 2026

--- a/tests/framework/helpers/JsonTest.php
+++ b/tests/framework/helpers/JsonTest.php
@@ -232,9 +232,15 @@ PHP
             Json::decode($json);
         } catch (InvalidArgumentException $e) {
             if (PHP_VERSION_ID >= 80600) {
-                $this->assertStringContainsString(Json::$jsonErrorMessages['JSON_ERROR_SYNTAX'], $e->getMessage());
+                $this->assertStringContainsString(
+                    Json::$jsonErrorMessages['JSON_ERROR_SYNTAX'],
+                    $e->getMessage(),
+                );
             } else {
-                $this->assertSame(Json::$jsonErrorMessages['JSON_ERROR_SYNTAX'], $e->getMessage());
+                $this->assertSame(
+                    Json::$jsonErrorMessages['JSON_ERROR_SYNTAX'],
+                    $e->getMessage(),
+                );
             }
         }
 
@@ -245,12 +251,16 @@ PHP
             Json::encode($data);
             fclose($fp);
         } catch (InvalidArgumentException $e) {
-            if (PHP_VERSION_ID >= 50500) {
-                $this->assertSame(Json::$jsonErrorMessages['JSON_ERROR_UNSUPPORTED_TYPE'], $e->getMessage());
-            } elseif (PHP_VERSION_ID >= 80600) {
-                $this->assertStringContainsString(Json::$jsonErrorMessages['JSON_ERROR_SYNTAX'], $e->getMessage());
+            if (PHP_VERSION_ID >= 80600) {
+                $this->assertStringContainsString(
+                    Json::$jsonErrorMessages['JSON_ERROR_UNSUPPORTED_TYPE'],
+                    $e->getMessage(),
+                );
             } else {
-                $this->assertSame(Json::$jsonErrorMessages['JSON_ERROR_SYNTAX'], $e->getMessage());
+                $this->assertSame(
+                    Json::$jsonErrorMessages['JSON_ERROR_UNSUPPORTED_TYPE'],
+                    $e->getMessage(),
+                );
             }
         }
     }

--- a/tests/framework/helpers/JsonTest.php
+++ b/tests/framework/helpers/JsonTest.php
@@ -231,7 +231,11 @@ PHP
             $json = "{'a': '1'}";
             Json::decode($json);
         } catch (InvalidArgumentException $e) {
-            $this->assertSame(Json::$jsonErrorMessages['JSON_ERROR_SYNTAX'], $e->getMessage());
+            if (PHP_VERSION_ID >= 80600) {
+                $this->assertStringContainsString(Json::$jsonErrorMessages['JSON_ERROR_SYNTAX'], $e->getMessage());
+            } else {
+                $this->assertSame(Json::$jsonErrorMessages['JSON_ERROR_SYNTAX'], $e->getMessage());
+            }
         }
 
         // unsupported type since PHP 5.5
@@ -243,6 +247,8 @@ PHP
         } catch (InvalidArgumentException $e) {
             if (PHP_VERSION_ID >= 50500) {
                 $this->assertSame(Json::$jsonErrorMessages['JSON_ERROR_UNSUPPORTED_TYPE'], $e->getMessage());
+            } elseif (PHP_VERSION_ID >= 80600) {
+                $this->assertStringContainsString(Json::$jsonErrorMessages['JSON_ERROR_SYNTAX'], $e->getMessage());
             } else {
                 $this->assertSame(Json::$jsonErrorMessages['JSON_ERROR_SYNTAX'], $e->getMessage());
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
