### PR TITLE
Enh #20718: When set_time_limit() is not available, throw a warning o…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,7 +7,7 @@ Yii Framework 2 Change Log
 - Bug #20705: Replace `$this` with `self` in generics in Psalm annotations (mspirkov)
 - Bug #20715: Adjust `JSON` helper error message assertions for `PHP 8.6` compatibility in `JsonTest` class (terabytesoftw)
 - Enh #20717: Use PHPStan/Psalm types in PHPDoc annotations (mspirkov)
-- Enh #20718: When set_time_limit() is not available, throw a warning only for big files
+- Enh #20718: When set_time_limit() is not available, throw a warning only for big files (@marc-farre)
 
 
 2.0.54 January 09, 2026

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Change Log
 - Bug #20705: Replace `$this` with `self` in generics in Psalm annotations (mspirkov)
 - Bug #20715: Adjust `JSON` helper error message assertions for `PHP 8.6` compatibility in `JsonTest` class (terabytesoftw)
 - Enh #20717: Use PHPStan/Psalm types in PHPDoc annotations (mspirkov)
+- Enh #20718: When set_time_limit() is not available, throw a warning only for big files
 
 
 2.0.54 January 09, 2026

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -445,9 +445,7 @@ class Response extends \yii\base\Response
         }
 
         // Try to reset time limit for big files
-        if (!function_exists('set_time_limit') || !@set_time_limit(0)) {
-            Yii::warning('set_time_limit() is not available', __METHOD__);
-        }
+        $warnIfBigFile = !function_exists('set_time_limit') || !@set_time_limit(0);
 
         if (is_callable($this->stream)) {
             $data = call_user_func($this->stream);
@@ -460,6 +458,7 @@ class Response extends \yii\base\Response
 
         $chunkSize = 8 * 1024 * 1024; // 8MB per chunk
 
+        $firstIteration = true;
         if (is_array($this->stream)) {
             list($handle, $begin, $end) = $this->stream;
 
@@ -469,6 +468,10 @@ class Response extends \yii\base\Response
             }
 
             while (!feof($handle) && ($pos = ftell($handle)) <= $end) {
+                if (!$firstIteration && $warnIfBigFile) {
+                    Yii::warning('set_time_limit() is not available', __METHOD__);
+                }
+                $firstIteration = false;
                 if ($pos + $chunkSize > $end) {
                     $chunkSize = $end - $pos + 1;
                 }
@@ -478,6 +481,10 @@ class Response extends \yii\base\Response
             fclose($handle);
         } else {
             while (!feof($this->stream)) {
+                if (!$firstIteration && $warnIfBigFile) {
+                    Yii::warning('set_time_limit() is not available', __METHOD__);
+                }
+                $firstIteration = false;
                 echo fread($this->stream, $chunkSize);
                 flush();
             }

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -445,7 +445,7 @@ class Response extends \yii\base\Response
         }
 
         // Try to reset time limit for big files
-        $warnIfBigFile = !function_exists('set_time_limit') || !@set_time_limit(0);
+        $setTimeLimitFailed = !function_exists('set_time_limit') || !@set_time_limit(0);
 
         if (is_callable($this->stream)) {
             $data = call_user_func($this->stream);
@@ -458,7 +458,7 @@ class Response extends \yii\base\Response
 
         $chunkSize = 8 * 1024 * 1024; // 8MB per chunk
 
-        $firstIteration = true;
+        $iterationCount = 0;
         if (is_array($this->stream)) {
             list($handle, $begin, $end) = $this->stream;
 
@@ -468,10 +468,10 @@ class Response extends \yii\base\Response
             }
 
             while (!feof($handle) && ($pos = ftell($handle)) <= $end) {
-                if (!$firstIteration && $warnIfBigFile) {
+                $iterationCount++;
+                if ($setTimeLimitFailed && $iterationCount === 2) {
                     Yii::warning('set_time_limit() is not available', __METHOD__);
                 }
-                $firstIteration = false;
                 if ($pos + $chunkSize > $end) {
                     $chunkSize = $end - $pos + 1;
                 }
@@ -481,10 +481,10 @@ class Response extends \yii\base\Response
             fclose($handle);
         } else {
             while (!feof($this->stream)) {
-                if (!$firstIteration && $warnIfBigFile) {
+                $iterationCount++;
+                if ($setTimeLimitFailed && $iterationCount === 2) {
                     Yii::warning('set_time_limit() is not available', __METHOD__);
                 }
-                $firstIteration = false;
                 echo fread($this->stream, $chunkSize);
                 flush();
             }


### PR DESCRIPTION
…nly for big files

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20718
