### PR TITLE
Make the configuration type for `Application` wider

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Enh #20714: Allow overriding the `yii\grid\GridView`'s default `filterSelector`, allow using `Closure`s for `filterSelector` (chriscpty)
 - Enh #20717: Use PHPStan/Psalm types in PHPDoc annotations (mspirkov)
 - Enh #20718: When set_time_limit() is not available, throw a warning only for big files (@marc-farre)
+- Enh #20730: Make the configuration type for `Application` wider (mspirkov)
 
 
 2.0.54 January 09, 2026

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -186,7 +186,7 @@ abstract class Application extends Module
 
     /**
      * Constructor.
-     * @param array<string, mixed> $config name-value pairs that will be used to initialize the object properties.
+     * @param mixed[] $config name-value pairs that will be used to initialize the object properties.
      * Note that the configuration must contain both [[id]] and [[basePath]].
      * @throws InvalidConfigException if either [[id]] or [[basePath]] configuration is missing.
      */

--- a/framework/base/Application.php
+++ b/framework/base/Application.php
@@ -186,7 +186,7 @@ abstract class Application extends Module
 
     /**
      * Constructor.
-     * @param mixed[] $config name-value pairs that will be used to initialize the object properties.
+     * @param array<array-key, mixed> $config name-value pairs that will be used to initialize the object properties.
      * Note that the configuration must contain both [[id]] and [[basePath]].
      * @throws InvalidConfigException if either [[id]] or [[basePath]] configuration is missing.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

Although the type reflects the reality, it makes development difficult. It was decided to use `array<array-key, mixed>` to avoid difficulties with static analysis.