### PR TITLE
Replace `$this` with `static` and `covariant static` in generics

### DIFF
--- a/docs/internals-ru/git-workflow.md
+++ b/docs/internals-ru/git-workflow.md
@@ -91,8 +91,8 @@ git remote add upstream https://github.com/yiisoft/yii2.git
 
 ```php
 /**
- * @return Action<$this>|null
- * @phpstan-return Action<$this>|null
+ * @return Action<covariant static>|null
+ * @phpstan-return Action<covariant static>|null
  * @psalm-return Action<self>|null
  */
 public function createAction($id)

--- a/docs/internals/git-workflow.md
+++ b/docs/internals/git-workflow.md
@@ -91,8 +91,8 @@ An example of what it should look like:
 
 ```php
 /**
- * @return Action<$this>|null
- * @phpstan-return Action<$this>|null
+ * @return Action<covariant static>|null
+ * @phpstan-return Action<covariant static>|null
  * @psalm-return Action<self>|null
  */
 public function createAction($id)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 Change Log
 - Enh #20718: When set_time_limit() is not available, throw a warning only for big files (@marc-farre)
 - Enh #20729: Add default types in `@template` annotations (mspirkov)
 - Enh #20730: Make the configuration type for `Application` wider (mspirkov)
+- Bug #20733: Replace `$this` with `static` and `covariant static` in generics in PHPStan and PHPDoc annotations (mspirkov)
 
 
 2.0.54 January 09, 2026

--- a/framework/base/Component.php
+++ b/framework/base/Component.php
@@ -94,12 +94,12 @@ use yii\helpers\StringHelper;
  *
  * For more details and usage information on Component, see the [guide article on components](guide:concept-components).
  *
- * @property-read Behavior<$this>[] $behaviors List of behaviors attached to this component.
+ * @property-read Behavior<static>[] $behaviors List of behaviors attached to this component.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  *
- * @phpstan-property-read Behavior<$this>[] $behaviors
+ * @phpstan-property-read Behavior<static>[] $behaviors
  * @psalm-property-read Behavior<self>[] $behaviors
  */
 class Component extends BaseObject
@@ -114,7 +114,7 @@ class Component extends BaseObject
      */
     private $_eventWildcards = [];
     /**
-     * @var Behavior<$this>[]|null the attached behaviors (behavior name => behavior). This is `null` when not initialized.
+     * @var Behavior<static>[]|null the attached behaviors (behavior name => behavior). This is `null` when not initialized.
      */
     private $_behaviors;
 
@@ -661,9 +661,9 @@ class Component extends BaseObject
     /**
      * Returns the named behavior object.
      * @param string $name the behavior name
-     * @return Behavior<$this>|null the behavior object, or null if the behavior does not exist
+     * @return Behavior<static>|null the behavior object, or null if the behavior does not exist
      *
-     * @phpstan-return Behavior<$this>|null
+     * @phpstan-return Behavior<static>|null
      * @psalm-return Behavior<self>|null
      */
     public function getBehavior($name)
@@ -674,9 +674,9 @@ class Component extends BaseObject
 
     /**
      * Returns all behaviors attached to this component.
-     * @return Behavior<$this>[] list of behaviors attached to this component
+     * @return Behavior<static>[] list of behaviors attached to this component
      *
-     * @phpstan-return Behavior<$this>[]
+     * @phpstan-return Behavior<static>[]
      * @psalm-return Behavior<self>[]
      */
     public function getBehaviors()
@@ -691,19 +691,19 @@ class Component extends BaseObject
      * configuration. After that, the behavior object will be attached to
      * this component by calling the [[Behavior::attach()]] method.
      * @param string $name the name of the behavior.
-     * @param string|array|Behavior<$this> $behavior the behavior configuration. This can be one of the following:
+     * @param string|array|Behavior<static> $behavior the behavior configuration. This can be one of the following:
      *
      *  - a [[Behavior]] object
      *  - a string specifying the behavior class
      *  - an object configuration array that will be passed to [[Yii::createObject()]] to create the behavior object.
      *
-     * @return Behavior<$this> the behavior object
+     * @return Behavior<static> the behavior object
      * @see detachBehavior()
      *
-     * @phpstan-param string|array|Behavior<$this> $behavior
+     * @phpstan-param string|array|Behavior<static> $behavior
      * @psalm-param string|array|Behavior<self> $behavior
      *
-     * @phpstan-return Behavior<$this>
+     * @phpstan-return Behavior<static>
      * @psalm-return Behavior<self>
      */
     public function attachBehavior($name, $behavior)
@@ -731,9 +731,9 @@ class Component extends BaseObject
      * Detaches a behavior from the component.
      * The behavior's [[Behavior::detach()]] method will be invoked.
      * @param string $name the behavior's name.
-     * @return Behavior<$this>|null the detached behavior. Null if the behavior does not exist.
+     * @return Behavior<static>|null the detached behavior. Null if the behavior does not exist.
      *
-     * @phpstan-return Behavior<$this>|null
+     * @phpstan-return Behavior<static>|null
      * @psalm-return Behavior<self>|null
      */
     public function detachBehavior($name)
@@ -778,8 +778,8 @@ class Component extends BaseObject
      * @param string|int $name the name of the behavior. If this is an integer, it means the behavior
      * is an anonymous one. Otherwise, the behavior is a named one and any existing behavior with the same name
      * will be detached first.
-     * @param string|array|Behavior<$this> $behavior the behavior to be attached
-     * @return Behavior<$this> the attached behavior.
+     * @param string|array|Behavior<static> $behavior the behavior to be attached
+     * @return Behavior<static> the attached behavior.
      */
     private function attachBehaviorInternal($name, $behavior)
     {

--- a/framework/base/Controller.php
+++ b/framework/base/Controller.php
@@ -60,10 +60,10 @@ class Controller extends Component implements ViewContextInterface
      */
     public $layout;
     /**
-     * @var Action<$this>|null the action that is currently being executed. This property will be set
+     * @var Action<covariant static>|null the action that is currently being executed. This property will be set
      * by [[run()]] when it is called by [[Application]] to run an action.
      *
-     * @phpstan-var Action<$this>|null
+     * @phpstan-var Action<covariant static>|null
      * @psalm-var Action<self>|null
      */
     public $action;
@@ -223,11 +223,11 @@ class Controller extends Component implements ViewContextInterface
     /**
      * Binds the parameters to the action.
      * This method is invoked by [[Action]] when it begins to run with the given parameters.
-     * @param Action<$this> $action the action to be bound with parameters.
+     * @param Action<static> $action the action to be bound with parameters.
      * @param array<array-key, mixed> $params the parameters to be bound to the action.
      * @return mixed[] the valid parameters that the action can run with.
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function bindActionParams($action, $params)
@@ -243,9 +243,9 @@ class Controller extends Component implements ViewContextInterface
      * where `xyz` is the action ID. If found, an [[InlineAction]] representing that
      * method will be created and returned.
      * @param string $id the action ID.
-     * @return Action<$this>|null the newly created action instance. Null if the ID doesn't resolve into any action.
+     * @return Action<covariant static>|null the newly created action instance. Null if the ID doesn't resolve into any action.
      *
-     * @phpstan-return Action<$this>|null
+     * @phpstan-return Action<covariant static>|null
      * @psalm-return Action<self>|null
      */
     public function createAction($id)
@@ -299,10 +299,10 @@ class Controller extends Component implements ViewContextInterface
      * }
      * ```
      *
-     * @param Action<$this> $action the action to be executed.
+     * @param Action<static> $action the action to be executed.
      * @return bool whether the action should continue to run.
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function beforeAction($action)
@@ -329,11 +329,11 @@ class Controller extends Component implements ViewContextInterface
      * }
      * ```
      *
-     * @param Action<$this> $action the action just executed.
+     * @param Action<static> $action the action just executed.
      * @param mixed $result the action return result.
      * @return mixed the processed action result.
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function afterAction($action, $result)

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -575,11 +575,11 @@ class Module extends ServiceLocator
      * part of the route which will be treated as the action ID. Otherwise, `false` will be returned.
      *
      * @param string $route the route consisting of module, controller and action IDs.
-     * @return array{Controller<$this>, string}|false If the controller is created successfully, it will be returned together
+     * @return array{Controller<static>, string}|false If the controller is created successfully, it will be returned together
      * with the requested action ID. Otherwise `false` will be returned.
      * @throws InvalidConfigException if the controller class and its file do not match.
      *
-     * @phpstan-return array{Controller<$this>, string}|false
+     * @phpstan-return array{Controller<static>, string}|false
      * @psalm-return array{Controller<self>, string}|false
      */
     public function createController($route)
@@ -634,11 +634,11 @@ class Module extends ServiceLocator
      * Note that this method does not check [[modules]] or [[controllerMap]].
      *
      * @param string $id the controller ID.
-     * @return Controller<$this>|null the newly created controller instance, or `null` if the controller ID is invalid.
+     * @return Controller<static>|null the newly created controller instance, or `null` if the controller ID is invalid.
      * @throws InvalidConfigException if the controller class and its file name do not match.
      * This exception is only thrown when in debug mode.
      *
-     * @phpstan-return Controller<$this>|null
+     * @phpstan-return Controller<static>|null
      * @psalm-return Controller<self>|null
      */
     public function createControllerByID($id)
@@ -717,10 +717,10 @@ class Module extends ServiceLocator
      * }
      * ```
      *
-     * @param Action<Controller<$this>> $action the action to be executed.
+     * @param Action<Controller<static>> $action the action to be executed.
      * @return bool whether the action should continue to be executed.
      *
-     * @phpstan-param Action<Controller<$this>> $action
+     * @phpstan-param Action<Controller<static>> $action
      * @psalm-param Action<Controller<self>> $action
      */
     public function beforeAction($action)
@@ -747,11 +747,11 @@ class Module extends ServiceLocator
      * }
      * ```
      *
-     * @param Action<Controller<$this>> $action the action just executed.
+     * @param Action<Controller<static>> $action the action just executed.
      * @param mixed $result the action return result.
      * @return mixed the processed action result.
      *
-     * @phpstan-param Action<Controller<$this>> $action
+     * @phpstan-param Action<Controller<static>> $action
      * @psalm-param Action<Controller<self>> $action
      */
     public function afterAction($action, $result)

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -192,12 +192,12 @@ class Controller extends BaseController
      * This method is invoked by [[Action]] when it begins to run with the given parameters.
      * This method will first bind the parameters with the [[options()|options]]
      * available to the action. It then validates the given arguments.
-     * @param Action<$this> $action the action to be bound with parameters
+     * @param Action<static> $action the action to be bound with parameters
      * @param array<array-key, mixed> $params the parameters to be bound to the action
      * @return mixed[] the valid parameters that the action can run with.
      * @throws Exception if there are unknown options or missing arguments
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function bindActionParams($action, $params)
@@ -542,10 +542,10 @@ class Controller extends BaseController
 
     /**
      * Returns a one-line short summary describing the specified action.
-     * @param Action<$this> $action action to get summary for
+     * @param Action<static> $action action to get summary for
      * @return string a one-line short summary describing the specified action.
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function getActionHelpSummary($action)
@@ -559,10 +559,10 @@ class Controller extends BaseController
 
     /**
      * Returns the detailed help information for the specified action.
-     * @param Action<$this> $action action to get help for
+     * @param Action<static> $action action to get help for
      * @return string the detailed help information for the specified action.
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function getActionHelp($action)
@@ -584,10 +584,10 @@ class Controller extends BaseController
      * The default implementation will return the help information extracted from the Reflection or
      * DocBlock of the parameters corresponding to the action method.
      *
-     * @param Action<$this> $action the action instance
+     * @param Action<static> $action the action instance
      * @return array the help information of the action arguments
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function getActionArgsHelp($action)
@@ -660,10 +660,10 @@ class Controller extends BaseController
      * The default implementation will return the help information extracted from the doc-comment of
      * the properties corresponding to the action options.
      *
-     * @param Action<$this> $action
+     * @param Action<static> $action
      * @return array the help information of the action options
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function getActionOptionsHelp($action)
@@ -718,10 +718,10 @@ class Controller extends BaseController
     private $_reflections = [];
 
     /**
-     * @param Action<$this> $action
+     * @param Action<static> $action
      * @return \ReflectionFunctionAbstract
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     protected function getActionMethodReflection($action)
@@ -767,10 +767,10 @@ class Controller extends BaseController
     /**
      * Returns the first line of docblock.
      *
-     * @param \ReflectionClass<$this>|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
+     * @param \ReflectionClass<static>|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
      * @return string
      *
-     * @phpstan-param \ReflectionClass<$this>|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
+     * @phpstan-param \ReflectionClass<static>|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
      * @psalm-param \ReflectionClass<self>|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
      */
     protected function parseDocCommentSummary($reflection)
@@ -786,10 +786,10 @@ class Controller extends BaseController
     /**
      * Returns full description from the docblock.
      *
-     * @param \ReflectionClass<$this>|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
+     * @param \ReflectionClass<static>|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
      * @return string
      *
-     * @phpstan-param \ReflectionClass<$this>|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
+     * @phpstan-param \ReflectionClass<static>|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
      * @psalm-param \ReflectionClass<self>|\ReflectionProperty|\ReflectionFunctionAbstract $reflection
      */
     protected function parseDocCommentDetail($reflection)

--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -127,11 +127,11 @@ abstract class BaseMigrateController extends Controller
     /**
      * This method is invoked right before an action is to be executed (after all possible filters.)
      * It checks the existence of the [[migrationPath]].
-     * @param Action<$this> $action the action to be executed.
+     * @param Action<static> $action the action to be executed.
      * @throws InvalidConfigException if directory specified in migrationPath doesn't exist and action isn't "create".
      * @return bool whether the action should continue to be executed.
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function beforeAction($action)

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -179,10 +179,10 @@ class MigrateController extends BaseMigrateController
     /**
      * This method is invoked right before an action is to be executed (after all possible filters.)
      * It checks the existence of the [[migrationPath]].
-     * @param Action<$this> $action the action to be executed.
+     * @param Action<static> $action the action to be executed.
      * @return bool whether the action should continue to be executed.
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function beforeAction($action)

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -122,12 +122,12 @@ class Controller extends BaseController
      * This method will check the parameter names that the action requires and return
      * the provided parameters according to the requirement. If there is any missing parameter,
      * an exception will be thrown.
-     * @param Action<$this> $action the action to be bound with parameters
+     * @param Action<static> $action the action to be bound with parameters
      * @param array<array-key, mixed> $params the parameters to be bound to the action
      * @return mixed[] the valid parameters that the action can run with.
      * @throws BadRequestHttpException if there are missing or invalid parameters.
      *
-     * @phpstan-param Action<$this> $action
+     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function bindActionParams($action, $params)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -406,6 +406,6 @@ parameters:
 			path: framework/caching/Dependency.php
 
 		-
-			message: "#^Property yii\\\\console\\\\Application\\:\\:\\$controller \\(yii\\\\console\\\\Controller\\|yii\\\\web\\\\Controller\\|null\\) does not accept yii\\\\base\\\\Controller\\<\\$this\\(yii\\\\base\\\\Module\\)\\>\\.$#"
+			message: "#^Property yii\\\\console\\\\Application\\:\\:\\$controller \\(yii\\\\console\\\\Controller\\|yii\\\\web\\\\Controller\\|null\\) does not accept yii\\\\base\\\\Controller\\<static\\(yii\\\\base\\\\Module\\)\\>\\.$#"
 			count: 1
 			path: framework/base/Module.php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

Using `$this` as a generic causes problems, so it was decided to use `static`.
Example of a problem:

<img width="1460" height="1001" alt="image" src="https://github.com/user-attachments/assets/7bbc0f56-b311-4671-b8b3-9bd30257cb7d" />

