### PR TITLE
Removed dead code for PHP < 5.6 in UrlValidator and EmailValidator

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.55 under development
 ------------------------
 
+- Enh #20743: Remove dead code for PHP < 5.6 in `UrlValidator` and `EmailValidator` (WarLikeLaux)
 - Bug #20705: Replace `$this` with `self` in generics in Psalm annotations (mspirkov)
 - Bug #20715: Adjust `JSON` helper error message assertions for `PHP 8.6` compatibility in `JsonTest` class (terabytesoftw)
 - Enh #20714: Allow overriding the `yii\grid\GridView`'s default `filterSelector`, allow using `Closure`s for `filterSelector` (chriscpty)

--- a/framework/validators/EmailValidator.php
+++ b/framework/validators/EmailValidator.php
@@ -156,11 +156,6 @@ class EmailValidator extends Validator
 
     private function idnToAscii($idn)
     {
-        if (PHP_VERSION_ID < 50600) {
-            // TODO: drop old PHP versions support
-            return idn_to_ascii($idn);
-        }
-
         return idn_to_ascii($idn, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
     }
 

--- a/framework/validators/UrlValidator.php
+++ b/framework/validators/UrlValidator.php
@@ -111,11 +111,6 @@ class UrlValidator extends Validator
 
     private function idnToAscii($idn)
     {
-        if (PHP_VERSION_ID < 50600) {
-            // TODO: drop old PHP versions support
-            return idn_to_ascii($idn);
-        }
-
         return idn_to_ascii($idn, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |

## What does this PR do?

Removes dead code branches in UrlValidator::idnToAscii() and EmailValidator::idnToAscii() that checked for PHP_VERSION_ID < 50600.

Since Yii2 requires PHP >= 7.4 (composer.json), this condition can never be true. The TODO comment in both files explicitly said "drop old PHP versions support".

Both methods now call idn_to_ascii() directly with IDNA_NONTRANSITIONAL_TO_ASCII and INTL_IDNA_VARIANT_UTS46 flags, which are available since PHP 5.4/5.6.

Existing UrlValidatorTest (7 tests) and EmailValidatorTest (38 tests) pass without changes.
