### PR TITLE
Strengthened EmailValidatorTest with RFC boundary condition tests and client-side validation coverage

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.55 under development
 ------------------------
 
+- Enh #20744: Strengthen `EmailValidatorTest` coverage (WarLikeLaux)
 - Bug #20705: Replace `$this` with `self` in generics in Psalm annotations (mspirkov)
 - Bug #20715: Adjust `JSON` helper error message assertions for `PHP 8.6` compatibility in `JsonTest` class (terabytesoftw)
 - Enh #20714: Allow overriding the `yii\grid\GridView`'s default `filterSelector`, allow using `Closure`s for `filterSelector` (chriscpty)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,7 +4,6 @@ Yii Framework 2 Change Log
 2.0.55 under development
 ------------------------
 
-- Enh #20744: Strengthen `EmailValidatorTest` coverage (WarLikeLaux)
 - Bug #20705: Replace `$this` with `self` in generics in Psalm annotations (mspirkov)
 - Bug #20715: Adjust `JSON` helper error message assertions for `PHP 8.6` compatibility in `JsonTest` class (terabytesoftw)
 - Enh #20714: Allow overriding the `yii\grid\GridView`'s default `filterSelector`, allow using `Closure`s for `filterSelector` (chriscpty)

--- a/tests/framework/validators/EmailValidatorTest.php
+++ b/tests/framework/validators/EmailValidatorTest.php
@@ -243,7 +243,6 @@ class EmailValidatorTest extends TestCase
         $local = str_repeat('a', 64);
         $domain = str_repeat('a', 63) . '.' . str_repeat('b', 63) . '.' . str_repeat('c', 58) . '.com';
         $email = $local . '@' . $domain;
-        $this->assertSame(255, strlen($email));
 
         $this->assertFalse($validator->validate($email));
     }

--- a/tests/framework/validators/EmailValidatorTest.php
+++ b/tests/framework/validators/EmailValidatorTest.php
@@ -232,7 +232,6 @@ class EmailValidatorTest extends TestCase
         $local = str_repeat('a', 64);
         $domain = str_repeat('a', 63) . '.' . str_repeat('b', 63) . '.' . str_repeat('c', 57) . '.com';
         $email = $local . '@' . $domain;
-        $this->assertSame(254, strlen($email));
 
         $this->assertTrue($validator->validate($email));
     }

--- a/tests/framework/validators/EmailValidatorTest.php
+++ b/tests/framework/validators/EmailValidatorTest.php
@@ -203,4 +203,131 @@ class EmailValidatorTest extends TestCase
         $val->enableIDN = true;
         $this->assertFalse($val->validate($value));
     }
+
+    /**
+     * RFC 5321 section 4.5.3.1.1: local part must be max 64 octets.
+     */
+    public function testLocalPartExactly64Characters(): void
+    {
+        $validator = new EmailValidator();
+        $local = str_repeat('a', 64);
+
+        $this->assertTrue($validator->validate($local . '@example.com'));
+    }
+
+    public function testLocalPartExceeds64Characters(): void
+    {
+        $validator = new EmailValidator();
+        $local = str_repeat('a', 65);
+
+        $this->assertFalse($validator->validate($local . '@example.com'));
+    }
+
+    /**
+     * RFC 2821: total address length must be max 254 characters.
+     */
+    public function testTotalLengthExactly254Characters(): void
+    {
+        $validator = new EmailValidator();
+        $local = str_repeat('a', 64);
+        $domain = str_repeat('a', 63) . '.' . str_repeat('b', 63) . '.' . str_repeat('c', 57) . '.com';
+        $email = $local . '@' . $domain;
+        $this->assertSame(254, strlen($email));
+
+        $this->assertTrue($validator->validate($email));
+    }
+
+    public function testTotalLengthExceeds254Characters(): void
+    {
+        $validator = new EmailValidator();
+        $local = str_repeat('a', 64);
+        $domain = str_repeat('a', 63) . '.' . str_repeat('b', 63) . '.' . str_repeat('c', 58) . '.com';
+        $email = $local . '@' . $domain;
+        $this->assertSame(255, strlen($email));
+
+        $this->assertFalse($validator->validate($email));
+    }
+
+    public function testCaseInsensitiveValidation(): void
+    {
+        $validator = new EmailValidator();
+
+        $this->assertTrue($validator->validate('USER@EXAMPLE.COM'));
+        $this->assertTrue($validator->validate('User@Example.Com'));
+    }
+
+    public function testDefaultMessageIsSet(): void
+    {
+        $this->mockApplication();
+        $validator = new EmailValidator();
+
+        $this->assertNotNull($validator->message);
+    }
+
+    public function testClientValidateAttribute(): void
+    {
+        $this->mockApplication();
+        $validator = new EmailValidator();
+        $model = new FakedValidationModel();
+        $model->attr_email = 'test@example.com';
+        $view = new \yii\web\View(['assetBundles' => ['yii\validators\ValidationAsset' => true]]);
+
+        $result = $validator->clientValidateAttribute($model, 'attr_email', $view);
+
+        $this->assertStringContainsString('yii.validation.email', $result);
+    }
+
+    public function testClientValidateAttributeWithIdn(): void
+    {
+        if (!function_exists('idn_to_ascii')) {
+            $this->markTestSkipped('Intl extension required');
+            return;
+        }
+
+        $this->mockApplication();
+        $validator = new EmailValidator();
+        $validator->enableIDN = true;
+        $model = new FakedValidationModel();
+        $model->attr_email = 'test@example.com';
+        $view = new \yii\web\View(['assetBundles' => [
+            'yii\validators\ValidationAsset' => true,
+            'yii\validators\PunycodeAsset' => true,
+        ]]);
+
+        $result = $validator->clientValidateAttribute($model, 'attr_email', $view);
+
+        $this->assertStringContainsString('yii.validation.email', $result);
+    }
+
+    public function testGetClientOptions(): void
+    {
+        $this->mockApplication();
+        $validator = new EmailValidator();
+        $model = new FakedValidationModel();
+        $model->attr_email = 'test@example.com';
+
+        $options = $validator->getClientOptions($model, 'attr_email');
+
+        $this->assertArrayHasKey('pattern', $options);
+        $this->assertArrayHasKey('fullPattern', $options);
+        $this->assertArrayHasKey('allowName', $options);
+        $this->assertArrayHasKey('message', $options);
+        $this->assertArrayHasKey('enableIDN', $options);
+        $this->assertFalse($options['allowName']);
+        $this->assertFalse($options['enableIDN']);
+        $this->assertArrayHasKey('skipOnEmpty', $options);
+    }
+
+    public function testGetClientOptionsWithoutSkipOnEmpty(): void
+    {
+        $this->mockApplication();
+        $validator = new EmailValidator();
+        $validator->skipOnEmpty = false;
+        $model = new FakedValidationModel();
+        $model->attr_email = 'test@example.com';
+
+        $options = $validator->getClientOptions($model, 'attr_email');
+
+        $this->assertArrayNotHasKey('skipOnEmpty', $options);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |

## What does this PR do?

Added 10 new tests to `EmailValidatorTest` to cover RFC boundary conditions and client-side validation methods that had 0% coverage before.

### New tests

- Local part exactly 64 characters (valid per RFC 5321 section 4.5.3.1.1)
- Local part 65 characters (rejected)
- Total address length exactly 254 characters (valid per RFC 2821)
- Total address length 255 characters (rejected)
- Case-insensitive validation
- Default message initialization
- `clientValidateAttribute()` output
- `clientValidateAttribute()` with IDN enabled
- `getClientOptions()` structure and types
- `getClientOptions()` without `skipOnEmpty`

### Before

```
$ vendor/bin/phpunit tests/framework/validators/EmailValidatorTest.php
OK (38 tests, 103 assertions)

$ vendor/bin/phpunit tests/framework/validators/EmailValidatorTest.php --coverage-text --coverage-filter framework/validators/EmailValidator.php
yii\validators\EmailValidator
  Methods:  37.50% ( 3/ 8)   Lines:  61.82% ( 34/ 55)
```

### After

```
$ vendor/bin/phpunit tests/framework/validators/EmailValidatorTest.php
OK (48 tests, 123 assertions)

$ vendor/bin/phpunit tests/framework/validators/EmailValidatorTest.php --coverage-text --coverage-filter framework/validators/EmailValidator.php
yii\validators\EmailValidator
  Methods:  62.50% ( 5/ 8)   Lines:  92.73% ( 51/ 55)
```

### Uncovered lines (4)

- L82: `throw InvalidConfigException` when `enableIDN=true` but intl extension is not installed. Cannot trigger in test environment where intl is present.
- L150-151: `catch ErrorException` in `dns_get_record`. Requires real DNS failure.
- L161: Dead code branch for `PHP_VERSION_ID < 50600`. Yii2 requires PHP >= 7.4.

### Mutation testing

```
$ infection --filter="EmailValidator" --only-covering-test-cases --test-framework-options="--group=validators --exclude-group=db"

100 mutations generated:
      68 mutants were killed
      32 covered mutants were not detected

Mutation Code Coverage: 100%
Covered Code MSI: 68%
```

Undetected mutants are equivalent: DNS network calls, dead code for PHP < 5.6, visibility changes, regex anchor equivalences.