### PR TITLE
Add unit tests for REST classes

### DIFF
--- a/tests/framework/rest/ActionTest.php
+++ b/tests/framework/rest/ActionTest.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\rest;
+
+use Yii;
+use yii\base\InvalidConfigException;
+use yii\db\ActiveRecord;
+use yii\rest\Action;
+use yiiunit\framework\filters\stubs\UserIdentity;
+use yiiunit\framework\rest\stubs\RestController;
+use yiiunit\framework\rest\stubs\RestModule;
+use yiiunit\TestCase;
+
+/**
+ * @group rest
+ */
+class ActionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockWebApplication([
+            'components' => [
+                'db' => [
+                    'class' => '\yii\db\Connection',
+                    'dsn' => 'sqlite::memory:',
+                ],
+                'user' => [
+                    'identityClass' => UserIdentity::class,
+                ],
+            ],
+        ]);
+        Yii::$app->getDb()->createCommand()->createTable(ActionTestModel::tableName(), [
+            'id' => 'pk',
+            'name' => 'string',
+        ])->execute();
+    }
+
+    public function testInitWithoutModelClassThrowsException(): void
+    {
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => ActionTestModel::class,
+        ]);
+
+        $this->expectException(InvalidConfigException::class);
+        new Action('test', $controller);
+    }
+
+    public function testFindModelWithSinglePrimaryKey(): void
+    {
+        $model = new ActionTestModel();
+        $model->name = 'find-test';
+        $model->save(false);
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => ActionTestModel::class,
+        ]);
+
+        $action = new Action('test', $controller, [
+            'modelClass' => ActionTestModel::class,
+        ]);
+
+        $found = $action->findModel($model->id);
+
+        $this->assertSame($model->id, $found->id);
+        $this->assertSame('find-test', $found->name);
+    }
+
+    public function testFindModelNotFoundThrowsException(): void
+    {
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => ActionTestModel::class,
+        ]);
+
+        $action = new Action('test', $controller, [
+            'modelClass' => ActionTestModel::class,
+        ]);
+
+        $this->expectException('yii\web\NotFoundHttpException');
+        $action->findModel(999);
+    }
+
+    public function testFindModelWithCustomCallable(): void
+    {
+        $model = new ActionTestModel();
+        $model->name = 'custom-callable';
+        $model->save(false);
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => ActionTestModel::class,
+        ]);
+
+        $calledWithAction = null;
+        $action = new Action('test', $controller, [
+            'modelClass' => ActionTestModel::class,
+            'findModel' => function ($id, $actionInstance) use (&$calledWithAction) {
+                $calledWithAction = $actionInstance;
+                return ActionTestModel::findOne($id);
+            },
+        ]);
+
+        $found = $action->findModel($model->id);
+
+        $this->assertSame('custom-callable', $found->name);
+        $this->assertInstanceOf(Action::class, $calledWithAction);
+    }
+
+    public function testFindModelWithCompositePrimaryKey(): void
+    {
+        Yii::$app->getDb()->createCommand()->createTable(ActionTestCompositeModel::tableName(), [
+            'key1' => 'integer',
+            'key2' => 'integer',
+            'name' => 'string',
+            'PRIMARY KEY (key1, key2)',
+        ])->execute();
+        Yii::$app->getDb()->createCommand()->insert(ActionTestCompositeModel::tableName(), [
+            'key1' => 1,
+            'key2' => 2,
+            'name' => 'composite',
+        ])->execute();
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => ActionTestCompositeModel::class,
+        ]);
+
+        $action = new Action('test', $controller, [
+            'modelClass' => ActionTestCompositeModel::class,
+        ]);
+
+        $found = $action->findModel('1,2');
+
+        $this->assertSame('composite', $found->name);
+    }
+
+    public function testFindModelWithCompositePrimaryKeyMismatchThrowsException(): void
+    {
+        Yii::$app->getDb()->createCommand()->createTable(ActionTestCompositeModel::tableName(), [
+            'key1' => 'integer',
+            'key2' => 'integer',
+            'name' => 'string',
+            'PRIMARY KEY (key1, key2)',
+        ])->execute();
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => ActionTestCompositeModel::class,
+        ]);
+
+        $action = new Action('test', $controller, [
+            'modelClass' => ActionTestCompositeModel::class,
+        ]);
+
+        $this->expectException('yii\web\NotFoundHttpException');
+        $action->findModel('1,2,3');
+    }
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class ActionTestModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_action';
+    }
+}
+
+/**
+ * @property int $key1
+ * @property int $key2
+ * @property string $name
+ */
+class ActionTestCompositeModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_action_composite';
+    }
+
+    public static function primaryKey()
+    {
+        return ['key1', 'key2'];
+    }
+}

--- a/tests/framework/rest/ActiveControllerTest.php
+++ b/tests/framework/rest/ActiveControllerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\rest;
+
+use yii\base\InvalidConfigException;
+use yii\base\Model;
+use yii\db\ActiveRecord;
+use yii\rest\ActiveController;
+use yiiunit\framework\rest\stubs\RestModule;
+use yiiunit\TestCase;
+
+/**
+ * @group rest
+ */
+class ActiveControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockWebApplication();
+    }
+
+    public function testInitWithoutModelClassThrowsException(): void
+    {
+        $this->expectException(InvalidConfigException::class);
+        new ActiveControllerTestController('test', new RestModule('rest'));
+    }
+
+    /**
+     * @dataProvider actionsDataProvider
+     */
+    public function testActionsReturnDefaultConfig(
+        string $actionId,
+        string $expectedClass,
+        bool $hasModelClass,
+        bool $hasCheckAccess,
+        ?string $expectedScenario
+    ): void {
+        $controller = $this->createController();
+        $actions = $controller->actions();
+
+        $this->assertCount(6, $actions);
+        $this->assertArrayHasKey($actionId, $actions);
+        $this->assertSame($expectedClass, $actions[$actionId]['class']);
+
+        if ($hasModelClass) {
+            $this->assertSame(ActiveControllerModel::class, $actions[$actionId]['modelClass']);
+        } else {
+            $this->assertArrayNotHasKey('modelClass', $actions[$actionId]);
+        }
+
+        if ($hasCheckAccess) {
+            $this->assertSame([$controller, 'checkAccess'], $actions[$actionId]['checkAccess']);
+        } else {
+            $this->assertArrayNotHasKey('checkAccess', $actions[$actionId]);
+        }
+
+        if ($expectedScenario !== null) {
+            $this->assertSame($expectedScenario, $actions[$actionId]['scenario']);
+        } else {
+            $this->assertArrayNotHasKey('scenario', $actions[$actionId]);
+        }
+    }
+
+    /**
+     * @dataProvider verbsDataProvider
+     */
+    public function testVerbsReturnsExpectedMethods(string $actionId, array $expectedVerbs): void
+    {
+        $controller = $this->createController();
+
+        $verbs = new \ReflectionMethod($controller, 'verbs');
+        $verbs->setAccessible(true);
+        $result = $verbs->invoke($controller);
+
+        $this->assertSame($expectedVerbs, $result[$actionId]);
+    }
+
+    public function testCheckAccessDoesNotThrow(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $controller = $this->createController();
+        $controller->checkAccess('view');
+        $controller->checkAccess('update', null, ['id' => 1]);
+    }
+
+    public function testCustomScenarios(): void
+    {
+        $controller = new ActiveControllerTestController('test', new RestModule('rest'), [
+            'modelClass' => ActiveControllerModel::class,
+            'createScenario' => 'custom-create',
+            'updateScenario' => 'custom-update',
+        ]);
+
+        $actions = $controller->actions();
+
+        $this->assertSame('custom-create', $actions['create']['scenario']);
+        $this->assertSame('custom-update', $actions['update']['scenario']);
+    }
+
+    private function createController(): ActiveControllerTestController
+    {
+        return new ActiveControllerTestController('test', new RestModule('rest'), [
+            'modelClass' => ActiveControllerModel::class,
+        ]);
+    }
+
+    public static function actionsDataProvider(): array
+    {
+        return [
+            'index' => ['index', 'yii\rest\IndexAction', true, true, null],
+            'view' => ['view', 'yii\rest\ViewAction', true, true, null],
+            'create' => ['create', 'yii\rest\CreateAction', true, true, Model::SCENARIO_DEFAULT],
+            'update' => ['update', 'yii\rest\UpdateAction', true, true, Model::SCENARIO_DEFAULT],
+            'delete' => ['delete', 'yii\rest\DeleteAction', true, true, null],
+            'options' => ['options', 'yii\rest\OptionsAction', false, false, null],
+        ];
+    }
+
+    public static function verbsDataProvider(): array
+    {
+        return [
+            'index' => ['index', ['GET', 'HEAD']],
+            'view' => ['view', ['GET', 'HEAD']],
+            'create' => ['create', ['POST']],
+            'update' => ['update', ['PUT', 'PATCH']],
+            'delete' => ['delete', ['DELETE']],
+        ];
+    }
+}
+
+class ActiveControllerTestController extends ActiveController
+{
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class ActiveControllerModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'active_controller_model';
+    }
+}

--- a/tests/framework/rest/ControllerTest.php
+++ b/tests/framework/rest/ControllerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\rest;
+
+use yii\base\InlineAction;
+use yii\filters\auth\CompositeAuth;
+use yii\filters\ContentNegotiator;
+use yii\filters\RateLimiter;
+use yii\filters\VerbFilter;
+use yii\rest\Controller;
+use yii\web\Response;
+use yiiunit\framework\rest\stubs\RestModule;
+use yiiunit\TestCase;
+
+/**
+ * @group rest
+ */
+class ControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockWebApplication();
+    }
+
+    public function testVerbsReturnsEmptyArray(): void
+    {
+        $controller = $this->createController();
+        $this->assertSame([], $controller->getVerbs());
+    }
+
+    public function testBehaviorsReturnExpectedConfig(): void
+    {
+        $controller = $this->createController();
+
+        $behaviors = $controller->behaviors();
+
+        $this->assertSame(ContentNegotiator::className(), $behaviors['contentNegotiator']['class']);
+        $this->assertSame(
+            [
+                'application/json' => Response::FORMAT_JSON,
+                'application/xml' => Response::FORMAT_XML,
+            ],
+            $behaviors['contentNegotiator']['formats']
+        );
+        $this->assertSame(VerbFilter::className(), $behaviors['verbFilter']['class']);
+        $this->assertSame([], $behaviors['verbFilter']['actions']);
+        $this->assertSame(CompositeAuth::className(), $behaviors['authenticator']['class']);
+        $this->assertSame(RateLimiter::className(), $behaviors['rateLimiter']['class']);
+    }
+
+    public function testSerializeDataUsesConfiguredSerializer(): void
+    {
+        $controller = new RestBaseController('test', new RestModule('rest'), [
+            'serializer' => ControllerSerializerStub::class,
+        ]);
+
+        $this->assertSame(
+            ['serialized' => ['name' => 'test']],
+            $controller->getSerializedData(['name' => 'test'])
+        );
+    }
+
+    public function testAfterActionSerializesResult(): void
+    {
+        $controller = new RestBaseController('test', new RestModule('rest'), [
+            'serializer' => ControllerSerializerStub::class,
+        ]);
+
+        $action = new InlineAction('verbs', $controller, 'getVerbs');
+
+        $this->assertSame(
+            ['serialized' => ['id' => 1]],
+            $controller->afterAction($action, ['id' => 1])
+        );
+    }
+
+    private function createController(): RestBaseController
+    {
+        return new RestBaseController('test', new RestModule('rest'));
+    }
+}
+
+class RestBaseController extends Controller
+{
+    public function getVerbs(): array
+    {
+        return $this->verbs();
+    }
+
+    public function getSerializedData(array $data): array
+    {
+        return $this->serializeData($data);
+    }
+}
+
+class ControllerSerializerStub
+{
+    public function serialize($data): array
+    {
+        return ['serialized' => $data];
+    }
+}

--- a/tests/framework/rest/CreateActionTest.php
+++ b/tests/framework/rest/CreateActionTest.php
@@ -1,0 +1,255 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\rest;
+
+use Yii;
+use yii\db\ActiveRecord;
+use yii\helpers\Url;
+use yii\rest\CreateAction;
+use yiiunit\framework\filters\stubs\UserIdentity;
+use yiiunit\framework\rest\stubs\RestController;
+use yiiunit\framework\rest\stubs\RestModule;
+use yiiunit\TestCase;
+
+/**
+ * @group rest
+ */
+class CreateActionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockWebApplication([
+            'components' => [
+                'db' => [
+                    'class' => '\yii\db\Connection',
+                    'dsn' => 'sqlite::memory:',
+                ],
+                'user' => [
+                    'identityClass' => UserIdentity::class,
+                ],
+            ],
+        ]);
+        Yii::$app->getDb()->createCommand()->createTable(CreateActionModel::tableName(), [
+            'id' => 'pk',
+            'name' => 'string',
+        ])->execute();
+    }
+
+    public function testSuccessfulCreate(): void
+    {
+        Yii::$app->getRequest()->setBodyParams(['name' => 'test-item']);
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => CreateActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new CreateAction('create', $controller, [
+            'modelClass' => CreateActionModel::class,
+        ]);
+
+        $model = $action->run();
+
+        $this->assertInstanceOf(CreateActionModel::class, $model);
+        $this->assertSame('test-item', $model->name);
+        $this->assertFalse($model->isNewRecord);
+        $this->assertSame(201, Yii::$app->getResponse()->getStatusCode());
+        $this->assertSame('test-item', CreateActionModel::findOne($model->id)->name);
+        $this->assertSame(
+            Url::toRoute(['view', 'id' => $model->id], true),
+            Yii::$app->getResponse()->getHeaders()->get('Location')
+        );
+    }
+
+    public function testCreateWithValidationErrors(): void
+    {
+        Yii::$app->getRequest()->setBodyParams([]);
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => CreateActionValidatingModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new CreateAction('create', $controller, [
+            'modelClass' => CreateActionValidatingModel::class,
+        ]);
+
+        $model = $action->run();
+
+        $this->assertTrue($model->hasErrors());
+        $this->assertTrue($model->isNewRecord);
+    }
+
+    public function testCreateWithCustomScenario(): void
+    {
+        Yii::$app->getRequest()->setBodyParams(['name' => 'scenario-test']);
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => CreateActionScenarioModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new CreateAction('create', $controller, [
+            'modelClass' => CreateActionScenarioModel::class,
+            'scenario' => 'custom',
+        ]);
+
+        $model = $action->run();
+
+        $this->assertFalse($model->isNewRecord);
+        $this->assertSame('custom', $model->scenario);
+    }
+
+    public function testCheckAccessIsCalled(): void
+    {
+        Yii::$app->getRequest()->setBodyParams(['name' => 'access-test']);
+
+        $accessChecked = false;
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => CreateActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new CreateAction('create', $controller, [
+            'modelClass' => CreateActionModel::class,
+            'checkAccess' => function ($actionId) use (&$accessChecked) {
+                $accessChecked = true;
+                $this->assertSame('create', $actionId);
+            },
+        ]);
+
+        $action->run();
+
+        $this->assertTrue($accessChecked);
+    }
+
+    public function testCustomViewAction(): void
+    {
+        Yii::$app->getRequest()->setBodyParams(['name' => 'view-action-test']);
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => CreateActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new CreateAction('create', $controller, [
+            'modelClass' => CreateActionModel::class,
+            'viewAction' => 'detail',
+        ]);
+
+        $action->run();
+
+        $location = Yii::$app->getResponse()->getHeaders()->get('Location');
+        $this->assertSame(
+            Url::toRoute(['detail', 'id' => 1], true),
+            $location
+        );
+    }
+
+    public function testSaveFailureWithoutErrorsThrowsException(): void
+    {
+        Yii::$app->getRequest()->setBodyParams(['name' => 'fail-test']);
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => CreateActionFailingModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new CreateAction('create', $controller, [
+            'modelClass' => CreateActionFailingModel::class,
+        ]);
+
+        $this->expectException('yii\web\ServerErrorHttpException');
+        $action->run();
+    }
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class CreateActionModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_create_action';
+    }
+
+    public function rules()
+    {
+        return [
+            ['name', 'safe'],
+        ];
+    }
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class CreateActionValidatingModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_create_action';
+    }
+
+    public function rules()
+    {
+        return [
+            ['name', 'required'],
+        ];
+    }
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class CreateActionScenarioModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_create_action';
+    }
+
+    public function rules()
+    {
+        return [
+            ['name', 'safe', 'on' => 'custom'],
+        ];
+    }
+
+    public function scenarios()
+    {
+        return array_merge(parent::scenarios(), [
+            'custom' => ['name'],
+        ]);
+    }
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class CreateActionFailingModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_create_action';
+    }
+
+    public function save($runValidation = true, $attributeNames = null)
+    {
+        return false;
+    }
+}

--- a/tests/framework/rest/DeleteActionTest.php
+++ b/tests/framework/rest/DeleteActionTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\rest;
+
+use Yii;
+use yii\db\ActiveRecord;
+use yii\rest\DeleteAction;
+use yiiunit\framework\filters\stubs\UserIdentity;
+use yiiunit\framework\rest\stubs\RestController;
+use yiiunit\framework\rest\stubs\RestModule;
+use yiiunit\TestCase;
+
+/**
+ * @group rest
+ */
+class DeleteActionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockWebApplication([
+            'components' => [
+                'db' => [
+                    'class' => '\yii\db\Connection',
+                    'dsn' => 'sqlite::memory:',
+                ],
+                'user' => [
+                    'identityClass' => UserIdentity::class,
+                ],
+            ],
+        ]);
+        Yii::$app->getDb()->createCommand()->createTable(DeleteActionModel::tableName(), [
+            'id' => 'pk',
+            'name' => 'string',
+        ])->execute();
+    }
+
+    private function createModel(string $name = 'to-delete'): DeleteActionModel
+    {
+        $model = new DeleteActionModel();
+        $model->name = $name;
+        $model->save(false);
+        return $model;
+    }
+
+    public function testSuccessfulDelete(): void
+    {
+        $model = $this->createModel();
+        $id = $model->id;
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => DeleteActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new DeleteAction('delete', $controller, [
+            'modelClass' => DeleteActionModel::class,
+        ]);
+
+        $action->run($id);
+
+        $this->assertSame(204, Yii::$app->getResponse()->getStatusCode());
+        $this->assertNull(DeleteActionModel::findOne($id));
+    }
+
+    public function testCheckAccessIsCalled(): void
+    {
+        $model = $this->createModel();
+
+        $accessChecked = false;
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => DeleteActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new DeleteAction('delete', $controller, [
+            'modelClass' => DeleteActionModel::class,
+            'checkAccess' => function ($actionId, $actionModel) use (&$accessChecked, $model) {
+                $accessChecked = true;
+                $this->assertSame('delete', $actionId);
+                $this->assertSame($model->id, $actionModel->id);
+            },
+        ]);
+
+        $action->run($model->id);
+
+        $this->assertTrue($accessChecked);
+    }
+
+    public function testDeleteNotFound(): void
+    {
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => DeleteActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new DeleteAction('delete', $controller, [
+            'modelClass' => DeleteActionModel::class,
+        ]);
+
+        $this->expectException('yii\web\NotFoundHttpException');
+        $action->run(999);
+    }
+
+    public function testDeleteFailureThrowsException(): void
+    {
+        Yii::$app->getDb()->createCommand()->createTable(DeleteActionFailingModel::tableName(), [
+            'id' => 'pk',
+            'name' => 'string',
+        ])->execute();
+        Yii::$app->getDb()->createCommand()->insert(DeleteActionFailingModel::tableName(), ['name' => 'no-delete'])->execute();
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => DeleteActionFailingModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new DeleteAction('delete', $controller, [
+            'modelClass' => DeleteActionFailingModel::class,
+        ]);
+
+        $this->expectException('yii\web\ServerErrorHttpException');
+        $action->run(1);
+    }
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class DeleteActionModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_delete_action';
+    }
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class DeleteActionFailingModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_delete_action_failing';
+    }
+
+    public function delete()
+    {
+        return false;
+    }
+}

--- a/tests/framework/rest/IndexActionTest.php
+++ b/tests/framework/rest/IndexActionTest.php
@@ -8,9 +8,10 @@ use yii\data\Pagination;
 use yii\data\Sort;
 use yii\db\ActiveRecord;
 use yii\db\Query;
-use yii\rest\ActiveController;
 use yii\rest\IndexAction;
 use yiiunit\framework\filters\stubs\UserIdentity;
+use yiiunit\framework\rest\stubs\RestController;
+use yiiunit\framework\rest\stubs\RestModule;
 use yiiunit\TestCase;
 
 /**
@@ -44,7 +45,7 @@ class IndexActionTest extends TestCase
         $sql = '';
         Yii::$app->controller = new RestController(
             'rest',
-            new Module('rest'),
+            new RestModule('rest'),
             [
                 'modelClass' => IndexActionModel::class,
                 'actions' => [
@@ -91,7 +92,7 @@ class IndexActionTest extends TestCase
 
         $controller = new RestController(
             'rest',
-            new Module('rest'),
+            new RestModule('rest'),
             [
                 'modelClass' => IndexActionModel::class,
                 'actions' => [
@@ -187,20 +188,6 @@ class IndexActionTest extends TestCase
             ]
         ];
     }
-}
-
-class RestController extends ActiveController
-{
-    public $actions = [];
-
-    public function actions()
-    {
-        return $this->actions;
-    }
-}
-
-class Module extends \yii\base\Module
-{
 }
 
 /**

--- a/tests/framework/rest/IndexActionTest.php
+++ b/tests/framework/rest/IndexActionTest.php
@@ -188,6 +188,126 @@ class IndexActionTest extends TestCase
             ]
         ];
     }
+
+    public function testRunCallsCheckAccess(): void
+    {
+        $accessChecked = false;
+        $controller = new RestController(
+            'rest',
+            new RestModule('rest'),
+            [
+                'modelClass' => IndexActionModel::class,
+                'actions' => [
+                    'index' => [
+                        'class' => IndexAction::class,
+                        'modelClass' => IndexActionModel::class,
+                        'checkAccess' => function ($actionId) use (&$accessChecked) {
+                            $accessChecked = true;
+                            $this->assertSame('index', $actionId);
+                        },
+                    ],
+                ],
+            ]
+        );
+        Yii::$app->controller = $controller;
+        $controller->run('index');
+
+        $this->assertTrue($accessChecked);
+    }
+
+    public function testPrepareDataProviderCallable(): void
+    {
+        $customCalled = false;
+        $controller = new RestController(
+            'rest',
+            new RestModule('rest'),
+            [
+                'modelClass' => IndexActionModel::class,
+                'actions' => [
+                    'index' => [
+                        'class' => IndexAction::class,
+                        'modelClass' => IndexActionModel::class,
+                        'prepareDataProvider' => function ($action, $filter) use (&$customCalled) {
+                            $customCalled = true;
+                            $this->assertNull($filter);
+                            return new \yii\data\ArrayDataProvider(['allModels' => []]);
+                        },
+                    ],
+                ],
+            ]
+        );
+        Yii::$app->controller = $controller;
+        $controller->run('index');
+
+        $this->assertTrue($customCalled);
+    }
+
+    public function testDataFilterIntegration(): void
+    {
+        Yii::$app->getRequest()->setQueryParams([
+            'filter' => ['name' => ['eq' => 'test']],
+        ]);
+
+        $controller = new RestController(
+            'rest',
+            new RestModule('rest'),
+            [
+                'modelClass' => IndexActionModel::class,
+                'actions' => [
+                    'index' => [
+                        'class' => IndexAction::class,
+                        'modelClass' => IndexActionModel::class,
+                        'dataFilter' => [
+                            'class' => 'yii\data\ActiveDataFilter',
+                            'searchModel' => function () {
+                                return (new \yii\base\DynamicModel(['name' => null]))
+                                    ->addRule('name', 'string');
+                            },
+                        ],
+                    ],
+                ],
+            ]
+        );
+        Yii::$app->controller = $controller;
+
+        $result = $controller->createAction('index')->runWithParams([]);
+
+        $this->assertInstanceOf(\yii\data\ActiveDataProvider::class, $result);
+    }
+
+    public function testDataFilterBuildFailureReturnsDataFilter(): void
+    {
+        Yii::$app->getRequest()->setQueryParams([
+            'filter' => ['invalid_field' => 'value'],
+        ]);
+
+        $controller = new RestController(
+            'rest',
+            new RestModule('rest'),
+            [
+                'modelClass' => IndexActionModel::class,
+                'actions' => [
+                    'index' => [
+                        'class' => IndexAction::class,
+                        'modelClass' => IndexActionModel::class,
+                        'dataFilter' => [
+                            'class' => 'yii\data\ActiveDataFilter',
+                            'searchModel' => function () {
+                                return (new \yii\base\DynamicModel(['name' => null]))
+                                    ->addRule('name', 'string');
+                            },
+                        ],
+                    ],
+                ],
+            ]
+        );
+        Yii::$app->controller = $controller;
+
+        $result = $controller->createAction('index')->runWithParams([]);
+
+        $this->assertInstanceOf(\yii\data\ActiveDataFilter::class, $result);
+        $this->assertTrue($result->hasErrors());
+    }
 }
 
 /**

--- a/tests/framework/rest/OptionsActionTest.php
+++ b/tests/framework/rest/OptionsActionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\rest;
+
+use Yii;
+use yii\rest\OptionsAction;
+use yiiunit\TestCase;
+
+/**
+ * @group rest
+ */
+class OptionsActionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockWebApplication();
+    }
+
+    public function testCollectionOptions(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+
+        $controller = new \yii\web\Controller('test', Yii::$app);
+        $action = new OptionsAction('options', $controller);
+
+        $action->run();
+
+        $headers = Yii::$app->getResponse()->getHeaders();
+        $this->assertSame('GET, POST, HEAD, OPTIONS', $headers->get('Allow'));
+        $this->assertSame('GET, POST, HEAD, OPTIONS', $headers->get('Access-Control-Allow-Methods'));
+    }
+
+    public function testResourceOptions(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+
+        $controller = new \yii\web\Controller('test', Yii::$app);
+        $action = new OptionsAction('options', $controller);
+
+        $action->run('123');
+
+        $headers = Yii::$app->getResponse()->getHeaders();
+        $this->assertSame('GET, PUT, PATCH, DELETE, HEAD, OPTIONS', $headers->get('Allow'));
+        $this->assertSame('GET, PUT, PATCH, DELETE, HEAD, OPTIONS', $headers->get('Access-Control-Allow-Methods'));
+    }
+
+    public function testCustomCollectionOptions(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+
+        $controller = new \yii\web\Controller('test', Yii::$app);
+        $action = new OptionsAction('options', $controller, [
+            'collectionOptions' => ['GET', 'OPTIONS'],
+        ]);
+
+        $action->run();
+
+        $headers = Yii::$app->getResponse()->getHeaders();
+        $this->assertSame('GET, OPTIONS', $headers->get('Allow'));
+    }
+
+    public function testCustomResourceOptions(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+
+        $controller = new \yii\web\Controller('test', Yii::$app);
+        $action = new OptionsAction('options', $controller, [
+            'resourceOptions' => ['GET', 'DELETE'],
+        ]);
+
+        $action->run('456');
+
+        $headers = Yii::$app->getResponse()->getHeaders();
+        $this->assertSame('GET, DELETE', $headers->get('Allow'));
+    }
+
+    public function testNonOptionsRequestReturns405(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $controller = new \yii\web\Controller('test', Yii::$app);
+        $action = new OptionsAction('options', $controller);
+
+        $action->run();
+
+        $this->assertSame(405, Yii::$app->getResponse()->getStatusCode());
+    }
+}

--- a/tests/framework/rest/SerializerTest.php
+++ b/tests/framework/rest/SerializerTest.php
@@ -478,6 +478,137 @@ class SerializerTest extends TestCase
             ],
         ], $serializer->serialize([$model1, $model2, 'testKey' => $model3]));
     }
+
+    public function testSerializeModelHeadRequest(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'HEAD';
+        $serializer = new Serializer();
+        $model = new TestModel();
+
+        $this->assertNull($serializer->serialize($model));
+
+        unset($_SERVER['REQUEST_METHOD']);
+    }
+
+    public function testSerializeDataProviderHeadRequest(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'HEAD';
+        $serializer = new Serializer();
+        $dataProvider = new ArrayDataProvider([
+            'allModels' => [
+                ['id' => 1, 'username' => 'Bob'],
+            ],
+            'pagination' => [
+                'route' => '/',
+            ],
+        ]);
+
+        $this->assertNull($serializer->serialize($dataProvider));
+
+        $headers = Yii::$app->response->getHeaders();
+        $this->assertSame(1, $headers->get('X-Pagination-Total-Count'));
+
+        unset($_SERVER['REQUEST_METHOD']);
+    }
+
+    public function testSerializeDataProviderWithCollectionEnvelope(): void
+    {
+        $serializer = new Serializer();
+        $serializer->collectionEnvelope = 'items';
+
+        $dataProvider = new ArrayDataProvider([
+            'allModels' => [
+                ['id' => 1, 'username' => 'Bob'],
+                ['id' => 2, 'username' => 'Tom'],
+            ],
+            'pagination' => [
+                'route' => '/',
+                'pageSize' => 10,
+            ],
+        ]);
+
+        $result = $serializer->serialize($dataProvider);
+
+        $this->assertSame([
+            ['id' => 1, 'username' => 'Bob'],
+            ['id' => 2, 'username' => 'Tom'],
+        ], $result['items']);
+        $this->assertArrayHasKey('_links', $result);
+        $this->assertArrayHasKey('_meta', $result);
+        $this->assertSame(2, $result['_meta']['totalCount']);
+        $this->assertSame(1, $result['_meta']['pageCount']);
+        $this->assertSame(1, $result['_meta']['currentPage']);
+        $this->assertSame(10, $result['_meta']['perPage']);
+    }
+
+    public function testSerializeDataProviderWithCollectionEnvelopeWithoutPagination(): void
+    {
+        $serializer = new Serializer();
+        $serializer->collectionEnvelope = 'items';
+
+        $dataProvider = new ArrayDataProvider([
+            'allModels' => [
+                ['id' => 1, 'username' => 'Bob'],
+            ],
+            'pagination' => false,
+        ]);
+
+        $result = $serializer->serialize($dataProvider);
+
+        $this->assertSame([
+            'items' => [
+                ['id' => 1, 'username' => 'Bob'],
+            ],
+        ], $result);
+    }
+
+    public function testAddPaginationHeaders(): void
+    {
+        $serializer = new Serializer();
+        $dataProvider = new ArrayDataProvider([
+            'allModels' => [
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+            ],
+            'pagination' => [
+                'route' => '/',
+                'pageSize' => 2,
+                'page' => 0,
+            ],
+        ]);
+
+        $serializer->serialize($dataProvider);
+
+        $headers = Yii::$app->response->getHeaders();
+        $this->assertSame(3, $headers->get('X-Pagination-Total-Count'));
+        $this->assertSame(2, $headers->get('X-Pagination-Page-Count'));
+        $this->assertSame(1, $headers->get('X-Pagination-Current-Page'));
+        $this->assertSame(2, $headers->get('X-Pagination-Per-Page'));
+        $this->assertStringContainsString('rel=self', $headers->get('Link'));
+    }
+
+    public function testSerializeNonObjectData(): void
+    {
+        $serializer = new Serializer();
+
+        $this->assertSame('plain string', $serializer->serialize('plain string'));
+        $this->assertSame(42, $serializer->serialize(42));
+        $this->assertNull($serializer->serialize(null));
+    }
+
+    public function testSerializeDataProviderWithArrayableModels(): void
+    {
+        $serializer = new Serializer();
+
+        $dataProvider = new ArrayDataProvider([
+            'allModels' => [new TestModel()],
+            'pagination' => false,
+        ]);
+
+        $result = $serializer->serialize($dataProvider);
+        $this->assertSame([['field1' => 'test', 'field2' => 2]], $result);
+    }
 }
 
 class TestModel extends Model

--- a/tests/framework/rest/UpdateActionTest.php
+++ b/tests/framework/rest/UpdateActionTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\rest;
+
+use Yii;
+use yii\db\ActiveRecord;
+use yii\rest\UpdateAction;
+use yiiunit\framework\filters\stubs\UserIdentity;
+use yiiunit\framework\rest\stubs\RestController;
+use yiiunit\framework\rest\stubs\RestModule;
+use yiiunit\TestCase;
+
+/**
+ * @group rest
+ */
+class UpdateActionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockWebApplication([
+            'components' => [
+                'db' => [
+                    'class' => '\yii\db\Connection',
+                    'dsn' => 'sqlite::memory:',
+                ],
+                'user' => [
+                    'identityClass' => UserIdentity::class,
+                ],
+            ],
+        ]);
+        Yii::$app->getDb()->createCommand()->createTable(UpdateActionModel::tableName(), [
+            'id' => 'pk',
+            'name' => 'string',
+        ])->execute();
+    }
+
+    private function createModel(string $name = 'original'): UpdateActionModel
+    {
+        $model = new UpdateActionModel();
+        $model->name = $name;
+        $model->save(false);
+        return $model;
+    }
+
+    public function testSuccessfulUpdate(): void
+    {
+        $model = $this->createModel();
+        Yii::$app->getRequest()->setBodyParams(['name' => 'updated']);
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => UpdateActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new UpdateAction('update', $controller, [
+            'modelClass' => UpdateActionModel::class,
+        ]);
+
+        $result = $action->run($model->id);
+
+        $this->assertSame('updated', $result->name);
+        $this->assertSame('updated', UpdateActionModel::findOne($model->id)->name);
+    }
+
+    public function testCheckAccessIsCalled(): void
+    {
+        $model = $this->createModel();
+        Yii::$app->getRequest()->setBodyParams(['name' => 'access-update']);
+
+        $accessChecked = false;
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => UpdateActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new UpdateAction('update', $controller, [
+            'modelClass' => UpdateActionModel::class,
+            'checkAccess' => function ($actionId, $actionModel) use (&$accessChecked, $model) {
+                $accessChecked = true;
+                $this->assertSame('update', $actionId);
+                $this->assertSame($model->id, $actionModel->id);
+            },
+        ]);
+
+        $action->run($model->id);
+
+        $this->assertTrue($accessChecked);
+    }
+
+    public function testUpdateWithCustomScenario(): void
+    {
+        Yii::$app->getDb()->createCommand()->createTable(UpdateActionScenarioModel::tableName(), [
+            'id' => 'pk',
+            'name' => 'string',
+        ])->execute();
+        Yii::$app->getDb()->createCommand()->insert(UpdateActionScenarioModel::tableName(), ['name' => 'original'])->execute();
+
+        Yii::$app->getRequest()->setBodyParams(['name' => 'scenario-update']);
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => UpdateActionScenarioModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new UpdateAction('update', $controller, [
+            'modelClass' => UpdateActionScenarioModel::class,
+            'scenario' => 'custom',
+        ]);
+
+        $result = $action->run(1);
+
+        $this->assertSame('scenario-update', $result->name);
+        $this->assertSame('custom', $result->scenario);
+        $this->assertSame('scenario-update', UpdateActionScenarioModel::findOne(1)->name);
+    }
+
+    public function testUpdateNotFound(): void
+    {
+        Yii::$app->getRequest()->setBodyParams(['name' => 'not-found']);
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => UpdateActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new UpdateAction('update', $controller, [
+            'modelClass' => UpdateActionModel::class,
+        ]);
+
+        $this->expectException('yii\web\NotFoundHttpException');
+        $action->run(999);
+    }
+
+    public function testSaveFailureWithoutErrorsThrowsException(): void
+    {
+        Yii::$app->getDb()->createCommand()->createTable(UpdateActionFailingModel::tableName(), [
+            'id' => 'pk',
+            'name' => 'string',
+        ])->execute();
+        Yii::$app->getDb()->createCommand()->insert(UpdateActionFailingModel::tableName(), ['name' => 'original'])->execute();
+
+        Yii::$app->getRequest()->setBodyParams(['name' => 'fail-update']);
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => UpdateActionFailingModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new UpdateAction('update', $controller, [
+            'modelClass' => UpdateActionFailingModel::class,
+        ]);
+
+        $this->expectException('yii\web\ServerErrorHttpException');
+        $action->run(1);
+    }
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class UpdateActionModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_update_action';
+    }
+
+    public function rules()
+    {
+        return [
+            ['name', 'safe'],
+        ];
+    }
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class UpdateActionScenarioModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_update_action_scenario';
+    }
+
+    public function rules()
+    {
+        return [
+            ['name', 'safe', 'on' => 'custom'],
+        ];
+    }
+
+    public function scenarios()
+    {
+        return array_merge(parent::scenarios(), [
+            'custom' => ['name'],
+        ]);
+    }
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class UpdateActionFailingModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_update_action_failing';
+    }
+
+    public function save($runValidation = true, $attributeNames = null)
+    {
+        return false;
+    }
+}

--- a/tests/framework/rest/UrlRuleTest.php
+++ b/tests/framework/rest/UrlRuleTest.php
@@ -475,4 +475,10 @@ class UrlRuleTest extends TestCase
             ],
         ];
     }
+
+    public function testInitWithEmptyControllerThrowsException(): void
+    {
+        $this->expectException('yii\base\InvalidConfigException');
+        new UrlRule(['controller' => '']);
+    }
 }

--- a/tests/framework/rest/ViewActionTest.php
+++ b/tests/framework/rest/ViewActionTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\rest;
+
+use Yii;
+use yii\db\ActiveRecord;
+use yii\rest\ViewAction;
+use yiiunit\framework\filters\stubs\UserIdentity;
+use yiiunit\framework\rest\stubs\RestController;
+use yiiunit\framework\rest\stubs\RestModule;
+use yiiunit\TestCase;
+
+/**
+ * @group rest
+ */
+class ViewActionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockWebApplication([
+            'components' => [
+                'db' => [
+                    'class' => '\yii\db\Connection',
+                    'dsn' => 'sqlite::memory:',
+                ],
+                'user' => [
+                    'identityClass' => UserIdentity::class,
+                ],
+            ],
+        ]);
+        Yii::$app->getDb()->createCommand()->createTable(ViewActionModel::tableName(), [
+            'id' => 'pk',
+            'name' => 'string',
+        ])->execute();
+    }
+
+    private function createModel(string $name = 'test-view'): ViewActionModel
+    {
+        $model = new ViewActionModel();
+        $model->name = $name;
+        $model->save(false);
+        return $model;
+    }
+
+    public function testSuccessfulView(): void
+    {
+        $model = $this->createModel();
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => ViewActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new ViewAction('view', $controller, [
+            'modelClass' => ViewActionModel::class,
+        ]);
+
+        $result = $action->run($model->id);
+
+        $this->assertInstanceOf(ViewActionModel::class, $result);
+        $this->assertSame($model->id, $result->id);
+        $this->assertSame('test-view', $result->name);
+    }
+
+    public function testCheckAccessIsCalled(): void
+    {
+        $model = $this->createModel();
+
+        $accessChecked = false;
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => ViewActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new ViewAction('view', $controller, [
+            'modelClass' => ViewActionModel::class,
+            'checkAccess' => function ($actionId, $actionModel) use (&$accessChecked, $model) {
+                $accessChecked = true;
+                $this->assertSame('view', $actionId);
+                $this->assertSame($model->id, $actionModel->id);
+            },
+        ]);
+
+        $action->run($model->id);
+
+        $this->assertTrue($accessChecked);
+    }
+
+    public function testViewNotFound(): void
+    {
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => ViewActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new ViewAction('view', $controller, [
+            'modelClass' => ViewActionModel::class,
+        ]);
+
+        $this->expectException('yii\web\NotFoundHttpException');
+        $action->run(999);
+    }
+
+    public function testViewWithCustomFindModel(): void
+    {
+        $model = $this->createModel('custom-find');
+        $findModelCalled = false;
+        $calledWithAction = null;
+
+        $controller = new RestController('rest', new RestModule('rest'), [
+            'modelClass' => ViewActionModel::class,
+        ]);
+        Yii::$app->controller = $controller;
+
+        $action = new ViewAction('view', $controller, [
+            'modelClass' => ViewActionModel::class,
+            'findModel' => function ($id, $actionInstance) use (&$findModelCalled, &$calledWithAction) {
+                $findModelCalled = true;
+                $calledWithAction = $actionInstance;
+                return ViewActionModel::findOne($id);
+            },
+        ]);
+
+        $result = $action->run($model->id);
+
+        $this->assertTrue($findModelCalled);
+        $this->assertSame($action, $calledWithAction);
+        $this->assertSame('custom-find', $result->name);
+    }
+}
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class ViewActionModel extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'test_view_action';
+    }
+}

--- a/tests/framework/rest/stubs/RestController.php
+++ b/tests/framework/rest/stubs/RestController.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\rest\stubs;
+
+use yii\rest\ActiveController;
+
+class RestController extends ActiveController
+{
+    public $actions = [];
+
+    public function actions()
+    {
+        return $this->actions;
+    }
+}

--- a/tests/framework/rest/stubs/RestModule.php
+++ b/tests/framework/rest/stubs/RestModule.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\rest\stubs;
+
+class RestModule extends \yii\base\Module
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |

## What does this PR do?

Add tests for all `yii\rest` classes - covers `Action`, `ActiveController`, `Controller`, `CreateAction`, `UpdateAction`, `DeleteAction`, `ViewAction`, `OptionsAction`, and fills gaps in `IndexAction`, `Serializer`, `UrlRule`. Extract shared stubs from `IndexActionTest` into `stubs/RestController` and `stubs/RestModule`.

### Coverage

| File | Tests | Lines | MSI |
|---|---|---|---|
| `Action.php` | 6 | 15/15 (100%) | 70% (12/17) |
| `ActiveController.php` | 14 | 43/43 (100%) | 77% (23/30) |
| `Controller.php` | 4 | 23/23 (100%) | 100% (13/13) |
| `CreateAction.php` | 6 | 14/14 (100%) | 93% (15/16) |
| `UpdateAction.php` | 5 | 8/8 (100%) | 100% (8/8) |
| `DeleteAction.php` | 4 | 6/6 (100%) | 100% (5/5) |
| `ViewAction.php` | 4 | 4/4 (100%) | 100% (4/4) |
| `OptionsAction.php` | 5 | 6/6 (100%) | 100% (6/6) |
| `IndexAction.php` | 6 → 10 | 39/47 (83%) → 47/47 (100%) | 77% (17/22) |
| `Serializer.php` | 15 → 22 | 57/76 (75%) → 76/76 (100%) | 83% (65/78) |
| `UrlRule.php` | 11 → 12 | 58/60 (97%) → 59/60 (98%) | 84% (69/82) |

`UrlRule` L271 is dead code: `CREATE_STATUS_PARSING_ONLY` branch is unreachable because `createRules()` doesn't create a key in `$this->rules` when all actions are filtered, but `createUrl()` accesses `$this->rules[$urlName]` without isset check - crashes before reaching L271.

Changelog not required, because no source files changed.
