### PR TITLE
Exclude non-executable files from Codecov coverage reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "framework/classes.php"
+  - "framework/views/messageConfig.php"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Tests added?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |

## What does this PR do?

Adds `.codecov.yml` to exclude non-executable files from Codecov coverage reports.

### Excluded files

| File | Lines | Reason |
|---|---|---|
| `framework/classes.php` | 417 | Auto-generated classmap, no executable logic |
| `framework/views/messageConfig.php` | 58 | Static config array, no executable logic |

These 475 lines are counted as "uncovered" in Codecov but contain no testable code - just static `return [...]` arrays.

Changelog not required, because no source files changed.
