### PR TITLE
Remove PHP < `8.3` version guards and dead fallbacks across framework and tests.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -33,6 +33,7 @@ Yii Framework 2 Change Log
 - Enh #20801: Update PHP `8.3` and PHPUnit `11.5` compatibility (terabytesoftw)
 - Chg #20804: Remove Yii runtime autoloader (`Yii::autoload()`, `Yii::$classMap`, `framework/classes.php`); rely on Composer autoload and fix related PSR-4 ambiguities in tests and legacy files (terabytesoftw)
 - Chg #15058: Remove remaining HHVM support from core error handling, tests, and the English installation guide (terabytesoftw)
+- Chg: Remove PHP < `8.3` version guards and dead fallbacks across framework and tests (terabytesoftw)
 
 2.0.54 under development
 ------------------------

--- a/framework/captcha/CaptchaAction.php
+++ b/framework/captcha/CaptchaAction.php
@@ -315,11 +315,6 @@ class CaptchaAction extends Action
         ob_start();
         imagepng($image);
 
-        // Function `imagedestroy` is deprecated since PHP `8.5`, as it has no effect since PHP `8.0`
-        if (PHP_VERSION_ID < 80000) {
-            imagedestroy($image);
-        }
-
         return ob_get_clean();
     }
 

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -378,12 +378,10 @@ class Command extends Component
                 $this->pendingParams[$name] = [$value->getValue(), $value->getType()];
                 $this->params[$name] = $value->getValue();
             } else {
-                if (version_compare(PHP_VERSION, '8.1.0') >= 0) {
-                    if ($value instanceof \BackedEnum) {
-                        $value = $value->value;
-                    } elseif ($value instanceof \UnitEnum) {
-                        $value = $value->name;
-                    }
+                if ($value instanceof \BackedEnum) {
+                    $value = $value->value;
+                } elseif ($value instanceof \UnitEnum) {
+                    $value = $value->name;
                 }
                 $type = $schema->getPdoType($value);
                 $this->pendingParams[$name] = [$value, $type];

--- a/framework/helpers/mimeTypes.php
+++ b/framework/helpers/mimeTypes.php
@@ -1018,9 +1018,4 @@ $mimeTypes = [
     'zmm' => 'application/vnd.handheld-entertainment+xml',
 ];
 
-# fix for bundled libmagic bug, see also https://github.com/yiisoft/yii2/issues/19925
-if ((PHP_VERSION_ID >= 80100 && PHP_VERSION_ID < 80122) || (PHP_VERSION_ID >= 80200 && PHP_VERSION_ID < 80209)) {
-    $mimeTypes = array_replace($mimeTypes, ['xz' => 'application/octet-stream']);
-}
-
 return $mimeTypes;

--- a/framework/requirements/YiiRequirementChecker.php
+++ b/framework/requirements/YiiRequirementChecker.php
@@ -46,8 +46,8 @@ if (version_compare(PHP_VERSION, '8.3', '<')) {
  * );
  * ```
  *
- * Note: this class definition does not match ordinary Yii style, because it should match PHP 4.3
- * and should not use features from newer PHP versions!
+ * Note: this class intentionally keeps a conservative standalone style
+ * for compatibility with requirement-check bootstrap environments.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0

--- a/framework/requirements/YiiRequirementChecker.php
+++ b/framework/requirements/YiiRequirementChecker.php
@@ -5,8 +5,8 @@
  * @license https://www.yiiframework.com/license/
  */
 
-if (version_compare(PHP_VERSION, '4.3', '<')) {
-    echo 'At least PHP 4.3 is required to run this script!';
+if (version_compare(PHP_VERSION, '8.3', '<')) {
+    echo 'At least PHP 8.3 is required to run this script!';
     exit(1);
 }
 

--- a/framework/requirements/requirements.php
+++ b/framework/requirements/requirements.php
@@ -13,9 +13,9 @@ return array(
     array(
         'name' => 'PHP version',
         'mandatory' => true,
-        'condition' => version_compare(PHP_VERSION, '7.3.0', '>='),
+        'condition' => version_compare(PHP_VERSION, '8.3.0', '>='),
         'by' => '<a href="https://www.yiiframework.com">Yii Framework</a>',
-        'memo' => 'PHP 7.3.0 or higher is required.',
+        'memo' => 'PHP 8.3.0 or higher is required.',
     ),
     array(
         'name' => 'Reflection extension',

--- a/framework/requirements/requirements.php
+++ b/framework/requirements/requirements.php
@@ -13,9 +13,9 @@ return array(
     array(
         'name' => 'PHP version',
         'mandatory' => true,
-        'condition' => version_compare(PHP_VERSION, '8.3.0', '>='),
+        'condition' => version_compare(PHP_VERSION, '8.3', '>='),
         'by' => '<a href="https://www.yiiframework.com">Yii Framework</a>',
-        'memo' => 'PHP 8.3.0 or higher is required.',
+        'memo' => 'PHP 8.3 or higher is required.',
     ),
     array(
         'name' => 'Reflection extension',

--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -392,13 +392,11 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
      * Sets the session cookie parameters.
      * The cookie parameters passed to this method will be merged with the result
      * of `session_get_cookie_params()`.
-     * @param array $value cookie parameters, valid keys include: `lifetime`, `path`, `domain`, `secure` and `httponly`.
-     * Starting with Yii 2.0.21 `sameSite` is also supported. It requires PHP version 7.3.0 or higher.
-     * For security, an exception will be thrown if `sameSite` is set while using an unsupported version of PHP.
-     * To use this feature across different PHP versions check the version first. E.g.
+     * @param array $value cookie parameters, valid keys include: `lifetime`, `path`, `domain`, `secure`, `httponly`
+     * and `sameSite`.
      * ```
      * [
-     *     'sameSite' => PHP_VERSION_ID >= 70300 ? yii\web\Cookie::SAME_SITE_LAX : null,
+     *     'sameSite' => yii\web\Cookie::SAME_SITE_LAX,
      * ]
      * ```
      * See https://owasp.org/www-community/SameSite for more information about `sameSite`.

--- a/tests/base/db/BaseCommand.php
+++ b/tests/base/db/BaseCommand.php
@@ -1675,20 +1675,16 @@ SQL;
 
     public function testBindValuesSupportsEnums(): void
     {
-        if (version_compare(PHP_VERSION, '8.1.0') >= 0) {
-            $db = $this->getConnection();
-            $command = $db->createCommand();
+        $db = $this->getConnection();
+        $command = $db->createCommand();
 
-            $command->setSql('SELECT :p1')->bindValues([':p1' => Status::Active]);
-            $this->assertSame('Active', $command->params[':p1']);
+        $command->setSql('SELECT :p1')->bindValues([':p1' => Status::Active]);
+        $this->assertSame('Active', $command->params[':p1']);
 
-            $command->setSql('SELECT :p1')->bindValues([':p1' => StatusTypeString::Active]);
-            $this->assertSame('active', $command->params[':p1']);
+        $command->setSql('SELECT :p1')->bindValues([':p1' => StatusTypeString::Active]);
+        $this->assertSame('active', $command->params[':p1']);
 
-            $command->setSql('SELECT :p1')->bindValues([':p1' => StatusTypeInt::Active]);
-            $this->assertSame(1, $command->params[':p1']);
-        } else {
-            $this->markTestSkipped('Enums are not supported in PHP < 8.1');
-        }
+        $command->setSql('SELECT :p1')->bindValues([':p1' => StatusTypeInt::Active]);
+        $this->assertSame(1, $command->params[':p1']);
     }
 }

--- a/tests/base/web/session/BaseDbSession.php
+++ b/tests/base/web/session/BaseDbSession.php
@@ -190,11 +190,6 @@ abstract class BaseDbSession extends TestCase
         $object->binary = base64_decode('5qS2UUcXWH7rjAmvhqGJTDNkYWFiOGMzNTFlMzNmMWIyMDhmOWIwYzAwYTVmOTFhM2E5MDg5YjViYzViN2RlOGZlNjllYWMxMDA0YmQxM2RQ3ZC0in5ahjNcehNB/oP/NtOWB0u3Skm67HWGwGt9MA==');
         $object->with_null_byte = 'hey!' . "\0" . 'y"ûƒ^äjw¾bðúl5êù-Ö=W¿Š±¬GP¥Œy÷&ø';
 
-        if (version_compare(PHP_VERSION, '5.5.0', '<')) {
-            unset($object->binary);
-            // Binary data can not be inserted on PHP <5.5
-        }
-
         return $object;
     }
 

--- a/tests/framework/db/mysql/ActiveRecordTest.php
+++ b/tests/framework/db/mysql/ActiveRecordTest.php
@@ -55,10 +55,6 @@ class ActiveRecordTest extends BaseActiveRecord
         if (version_compare($this->getConnection()->getSchema()->getServerVersion(), '5.7', '<')) {
             $this->markTestSkipped('JSON columns are not supported in MySQL < 5.7');
         }
-        if (version_compare(PHP_VERSION, '5.6', '<')) {
-            $this->markTestSkipped('JSON columns are not supported in PDO for PHP < 5.6');
-        }
-
         $data = [
             'obj' => ['a' => ['b' => ['c' => 2.7418]]],
             'array' => [1,2,null,3],

--- a/tests/framework/db/mysql/BaseActiveRecordTest.php
+++ b/tests/framework/db/mysql/BaseActiveRecordTest.php
@@ -23,10 +23,6 @@ class BaseActiveRecordTest extends BaseActiveRecordTemplate
         if (version_compare($this->getConnection()->getSchema()->getServerVersion(), '5.7', '<')) {
             $this->markTestSkipped('JSON columns are not supported in MySQL < 5.7');
         }
-        if (version_compare(PHP_VERSION, '5.6', '<')) {
-            $this->markTestSkipped('JSON columns are not supported in PDO for PHP < 5.6');
-        }
-
         $createdStorage = new Storage(['data' => $actual]);
 
         $createdStorage->save();

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -82,13 +82,11 @@ class QueryBuilderTest extends BaseQueryBuilder
          * Disabled due bug in MySQL extension
          * @link https://bugs.php.net/bug.php?id=70384
          */
-        if (version_compare(PHP_VERSION, '5.6', '>=')) {
-            $columns[] = [
-                Schema::TYPE_JSON,
-                $this->json(),
-                'json',
-            ];
-        }
+        $columns[] = [
+            Schema::TYPE_JSON,
+            $this->json(),
+            'json',
+        ];
 
         return array_merge(parent::columnTypes(), $this->columnTimeTypes(), $columns);
     }

--- a/tests/framework/filters/auth/AuthMethodTest.php
+++ b/tests/framework/filters/auth/AuthMethodTest.php
@@ -81,12 +81,6 @@ class AuthMethodTest extends TestCase
         $reflection = new ReflectionClass(AuthMethod::class);
         $method = $reflection->getMethod('isOptional');
 
-        // @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible
-        // @link https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
-        if (PHP_VERSION_ID < 80100) {
-            $method->setAccessible(true);
-        }
-
         $filter = $this->createFilter(function () {
             return new stdClass();
         });

--- a/tests/framework/helpers/ArrayHelperTest.php
+++ b/tests/framework/helpers/ArrayHelperTest.php
@@ -136,29 +136,6 @@ class ArrayHelperTest extends TestCase
         $this->assertEquals('defaultValue', $default);
     }
 
-    /**
-     * @return void
-     */
-    public function testRemoveWithFloat(): void
-    {
-        if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
-            $this->markTestSkipped('Using floats as array key is deprecated.');
-        }
-
-        $array = ['name' => 'b', 'age' => 3, 1.1 => null];
-
-        $name = ArrayHelper::remove($array, 'name');
-        $this->assertEquals($name, 'b');
-        $this->assertEquals($array, ['age' => 3, 1.1 => null]);
-
-        $floatVal = ArrayHelper::remove($array, 1.1);
-        $this->assertNull($floatVal);
-        $this->assertEquals($array, ['age' => 3]);
-
-        $default = ArrayHelper::remove($array, 'nonExisting', 'defaultValue');
-        $this->assertEquals('defaultValue', $default);
-    }
-
     public function testRemoveValueMultiple(): void
     {
         $array = [
@@ -527,26 +504,6 @@ class ArrayHelperTest extends TestCase
         $this->assertEquals([], ArrayHelper::merge([], [], []));
     }
 
-    /**
-     * @see https://github.com/yiisoft/yii2/pull/11549
-     */
-    public function testGetValueWithFloatKeys(): void
-    {
-        if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
-            $this->markTestSkipped('Using floats as array key is deprecated.');
-        }
-
-        $array = [];
-        $array[1.1] = 'some value';
-        $array[2.1] = null;
-
-        $result = ArrayHelper::getValue($array, 1.2);
-        $this->assertEquals('some value', $result);
-
-        $result = ArrayHelper::getValue($array, 2.2);
-        $this->assertNull($result);
-    }
-
     public function testIndex(): void
     {
         $array = [
@@ -792,27 +749,6 @@ class ArrayHelperTest extends TestCase
         $this->assertTrue(ArrayHelper::keyExists('b', $array, false));
         $this->assertTrue(ArrayHelper::keyExists('B', $array, false));
         $this->assertFalse(ArrayHelper::keyExists('c', $array, false));
-    }
-
-    public function testKeyExistsWithFloat(): void
-    {
-        if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
-            $this->markTestSkipped('Using floats as array key is deprecated.');
-        }
-
-        $array = [
-            1 => 3,
-            2.2 => 4, // Note: Floats are cast to ints, which means that the fractional part will be truncated.
-            3.3 => null,
-        ];
-
-        $this->assertTrue(ArrayHelper::keyExists(1, $array));
-        $this->assertTrue(ArrayHelper::keyExists(1.1, $array));
-        $this->assertTrue(ArrayHelper::keyExists(2, $array));
-        $this->assertTrue(ArrayHelper::keyExists('2', $array));
-        $this->assertTrue(ArrayHelper::keyExists(2.2, $array));
-        $this->assertTrue(ArrayHelper::keyExists(3, $array));
-        $this->assertTrue(ArrayHelper::keyExists(3.3, $array));
     }
 
     public function testKeyExistsArrayAccess(): void

--- a/tests/framework/i18n/FormatterDateTest.php
+++ b/tests/framework/i18n/FormatterDateTest.php
@@ -107,10 +107,8 @@ class FormatterDateTest extends TestCase
         $value->setTimestamp(1_451_606_400); // Fri, 01 Jan 2016 00:00:00 (UTC)
         $this->assertSame('۱۳۹۴', $this->formatter->asDate($value, 'php:Y'));
 
-        if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
-            $value = new DateTimeImmutable('2016-01-01 00:00:00', new DateTimeZone('UTC'));
-            $this->assertSame('۱۳۹۴', $this->formatter->asDate($value, 'php:Y'));
-        }
+        $value = new DateTimeImmutable('2016-01-01 00:00:00', new DateTimeZone('UTC'));
+        $this->assertSame('۱۳۹۴', $this->formatter->asDate($value, 'php:Y'));
 
         // Buddhist calendar
         $this->formatter->locale = 'fr_FR@calendar=buddhist';
@@ -124,10 +122,8 @@ class FormatterDateTest extends TestCase
         $value->setTimestamp(1_451_606_400); // Fri, 01 Jan 2016 00:00:00 (UTC)
         $this->assertSame('2559', $this->formatter->asDate($value, 'php:Y'));
 
-        if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
-            $value = new DateTimeImmutable('2016-01-01 00:00:00', new DateTimeZone('UTC'));
-            $this->assertSame('2559', $this->formatter->asDate($value, 'php:Y'));
-        }
+        $value = new DateTimeImmutable('2016-01-01 00:00:00', new DateTimeZone('UTC'));
+        $this->assertSame('2559', $this->formatter->asDate($value, 'php:Y'));
     }
 
     public function testIntlAsTime(): void
@@ -151,11 +147,9 @@ class FormatterDateTest extends TestCase
         $this->assertSameAnyWhitespace(date('g:i:s A', $value->getTimestamp()), $this->formatter->asTime($value));
         $this->assertSame(date('h:i:s A', $value->getTimestamp()), $this->formatter->asTime($value, 'php:h:i:s A'));
 
-        if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
-            $value = new DateTimeImmutable();
-            $this->assertSameAnyWhitespace(date('g:i:s A', $value->getTimestamp()), $this->formatter->asTime($value));
-            $this->assertSame(date('h:i:s A', $value->getTimestamp()), $this->formatter->asTime($value, 'php:h:i:s A'));
-        }
+        $value = new DateTimeImmutable();
+        $this->assertSameAnyWhitespace(date('g:i:s A', $value->getTimestamp()), $this->formatter->asTime($value));
+        $this->assertSame(date('h:i:s A', $value->getTimestamp()), $this->formatter->asTime($value, 'php:h:i:s A'));
 
         // empty input
         $this->assertSameAnyWhitespace('12:00:00 AM', $this->formatter->asTime(''));
@@ -611,10 +605,8 @@ class FormatterDateTest extends TestCase
             $result[] = [$tz[0], '2014-08-10T14:41:00+02:00',         '2014-01-01T13:41:00+01:00']; // ISO 8601
             $result[] = [$tz[0], new DateTime('2014-08-10 12:41:00', $utc), new DateTime('2014-01-01 12:41:00', $utc)];
             $result[] = [$tz[0], new DateTime('2014-08-10 14:41:00', $berlin), new DateTime('2014-01-01 13:41:00', $berlin)];
-            if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
-                $result[] = [$tz[0], new DateTimeImmutable('2014-08-10 12:41:00', $utc), new DateTimeImmutable('2014-01-01 12:41:00', $utc)];
-                $result[] = [$tz[0], new DateTimeImmutable('2014-08-10 14:41:00', $berlin), new DateTimeImmutable('2014-01-01 13:41:00', $berlin)];
-            }
+            $result[] = [$tz[0], new DateTimeImmutable('2014-08-10 12:41:00', $utc), new DateTimeImmutable('2014-01-01 12:41:00', $utc)];
+            $result[] = [$tz[0], new DateTimeImmutable('2014-08-10 14:41:00', $berlin), new DateTimeImmutable('2014-01-01 13:41:00', $berlin)];
         }
 
         return $result;

--- a/tests/framework/validators/FileValidatorTest.php
+++ b/tests/framework/validators/FileValidatorTest.php
@@ -573,13 +573,6 @@ class FileValidatorTest extends TestCase
             ['test.tar.xz', 'application/x-xz', 'tar.xz'],
         ]);
 
-        # fix for bundled libmagic bug, see also https://github.com/yiisoft/yii2/issues/19925
-        if ((PHP_VERSION_ID >= 80100 && PHP_VERSION_ID < 80122) || (PHP_VERSION_ID >= 80200 && PHP_VERSION_ID < 80209)) {
-            $v81_zx = ['test.tar.xz', 'application/octet-stream', 'tar.xz'];
-            array_pop($validMimeTypes);
-            $validMimeTypes[] = $v81_zx;
-        }
-
         return $validMimeTypes;
     }
 
@@ -699,10 +692,6 @@ class FileValidatorTest extends TestCase
 
     public function testValidateTypedAttributeNoErrors(): void
     {
-        if (version_compare(PHP_VERSION, '7.4', '<')) {
-            $this->markTestSkipped('Requires typed properties');
-        }
-
         $validator = new FileValidator(['minFiles' => 0, 'maxFiles' => 2]);
         $file = $this->createTestFiles(
             [
@@ -724,10 +713,6 @@ class FileValidatorTest extends TestCase
 
     public function testValidateTypedAttributeExactMinNoErrors(): void
     {
-        if (version_compare(PHP_VERSION, '7.4', '<')) {
-            $this->markTestSkipped('Requires typed properties');
-        }
-
         $validator = new FileValidator(['minFiles' => 1]);
         $file = $this->createTestFiles(
             [
@@ -749,10 +734,6 @@ class FileValidatorTest extends TestCase
 
     public function testValidateTypedAttributeExactMaxNoErrors(): void
     {
-        if (version_compare(PHP_VERSION, '7.4', '<')) {
-            $this->markTestSkipped('Requires typed properties');
-        }
-
         $validator = new FileValidator(['maxFiles' => 1]);
         $file = $this->createTestFiles(
             [
@@ -774,10 +755,6 @@ class FileValidatorTest extends TestCase
 
     public function testValidateTypedAttributeMinError(): void
     {
-        if (version_compare(PHP_VERSION, '7.4', '<')) {
-            $this->markTestSkipped('Requires typed properties');
-        }
-
         $validator = new FileValidator(['minFiles' => 2]);
         $file = $this->createTestFiles(
             [
@@ -799,10 +776,6 @@ class FileValidatorTest extends TestCase
 
     public function testValidateTypedAttributeMaxError(): void
     {
-        if (version_compare(PHP_VERSION, '7.4', '<')) {
-            $this->markTestSkipped('Requires typed properties');
-        }
-
         $validator = new FileValidator(['maxFiles' => 1]);
         $files = $this->createTestFiles(
             [

--- a/tests/framework/validators/providers/FileValidatorProvider.php
+++ b/tests/framework/validators/providers/FileValidatorProvider.php
@@ -152,19 +152,6 @@ final class FileValidatorProvider
                 ],
         ];
 
-        # fix for bundled libmagic bug, see also https://github.com/yiisoft/yii2/issues/19925
-        if (PHP_VERSION_ID < 80122 || (PHP_VERSION_ID >= 80200 && PHP_VERSION_ID < 80209)) {
-            $v81_zx = [
-                'test.tar.xz',
-                'application/octet-stream',
-                'tar.xz',
-            ];
-
-            array_pop($validMimeTypes);
-
-            $validMimeTypes[] = $v81_zx;
-        }
-
         return $validMimeTypes;
     }
 }

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -454,15 +454,13 @@ class ResponseTest extends TestCase
             ],
         ];
 
-        if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
-            $testCases = [...$testCases, 'expire-as-date_time' => [
-                ['expire' => new DateTime('@' . $expireInt)],
-                ['expires' => $expireString],
-            ], 'expire-as-date_time_immutable' => [
-                ['expire' => new DateTimeImmutable('@' . $expireInt)],
-                ['expires' => $expireString],
-            ]];
-        }
+        $testCases = [...$testCases, 'expire-as-date_time' => [
+            ['expire' => new DateTime('@' . $expireInt)],
+            ['expires' => $expireString],
+        ], 'expire-as-date_time_immutable' => [
+            ['expire' => new DateTimeImmutable('@' . $expireInt)],
+            ['expires' => $expireString],
+        ]];
 
         return $testCases;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
