### PR TITLE
Fix `ActiveField::generateLabel()` to strip `label`/`for` attributes for custom tags and preserve prior label in `radio()`/`checkbox()`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -35,6 +35,7 @@ Yii Framework 2 Change Log
 - Chg #15058: Remove remaining HHVM support from core error handling, tests, and the English installation guide (terabytesoftw)
 - Chg: Remove PHP < `8.3` version guards and dead fallbacks across framework and tests (terabytesoftw)
 - Chg #20808: Rename `ApcCache` to `ApcuCache` and remove legacy APC extension support (terabytesoftw)
+- Bug: Fix `ActiveField::generateLabel()` to strip `label`/`for` attributes for custom tags and preserve prior label in `radio()`/`checkbox()` (terabytesoftw)
 
 
 2.0.55 under development

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -12,18 +12,6 @@ For the historical `2.0.x` upgrade notes see [`UPGRADE.md`](UPGRADE.md).
 * Raised minimum supported PHP version to `8.3`.
 * All methods that were previously deprecated have been removed. If your application still uses any deprecated methods,
   you must update your code before upgrading.
-* `yii\widgets\ActiveField::label()` method now supports a `tag` option to control the wrapper element. This provides
-  flexibility for custom label rendering while maintaining full backward compatibility:
-
-  - `tag => 'label'` default generates standard `<label>` element with `for` attribute.
-  - `tag => false`  renders label content without any wrapper tag.
-  - `tag => 'span'/'div'/etc` uses specified HTML element as wrapper.
-
-  Example usage:
-
-  ```php
-  $field->label('My Label', ['tag' => 'span', 'class' => 'custom-label']);
-  ```
 * jQuery is now optional in the framework. A new `useJquery` property has been added to `yii\console\Application` and
   `yii\web\Application` to control whether jQuery-based client scripts are used. The default values differ by
   application type: `yii\web\Application::$useJquery` defaults to `true`, maintaining full backward compatibility for
@@ -128,6 +116,45 @@ For the historical `2.0.x` upgrade notes see [`UPGRADE.md`](UPGRADE.md).
 * Note: Setting `useJquery` to `false` only prevents the framework from registering jQuery-based scripts. 
   It does not remove jQuery from your application if you've included it manually or through other extensions. 
   You are responsible for ensuring your application works correctly without jQuery when this option is disabled.
+
+### ActiveField label, radio, and checkbox enhancements
+
+`yii\widgets\ActiveField::label()` now supports a `tag` option in `$options` to control the wrapper element:
+
+- `tag => 'label'` (default) generates a standard `<label>` element with `for` attribute.
+- `tag => false` renders label content without any wrapping tag.
+- `tag => 'span'`/`'div'`/etc. uses the specified HTML element as wrapper.
+
+Example usage:
+
+```php
+$field->label('My Label', ['tag' => 'span', 'class' => 'custom-label']);
+```
+
+Additionally, `radio()` and `checkbox()` now support a `tag` sub-option inside `labelOptions` when
+`enclosedByLabel` is `false`. This provides flexible label rendering for radio buttons and checkboxes:
+
+```php
+// Render radio label as a <span> instead of <label>
+$field->radio(
+    [
+        'label' => 'Option A',
+        'labelOptions' => ['tag' => 'span', 'class' => 'custom-label'],
+    ],
+    false,
+);
+
+// Render checkbox label without any wrapping tag
+$field->checkbox(
+    [
+        'label' => '<strong>Accept Terms</strong>',
+        'labelOptions' => ['tag' => false],
+    ],
+    false,
+);
+```
+
+These changes are fully backward compatible. Existing code continues to work without modification.
 
 ### ApcCache renamed to ApcuCache
 

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -576,11 +576,11 @@ class ActiveField extends Component
         $this->addAriaAttributes($options);
         $this->adjustLabelFor($options);
 
-        $this->parts['{label}'] ??= '';
-
         if (!$enclosedByLabel) {
             $options = $this->generateLabel($options);
         }
+
+        $this->parts['{label}'] ??= '';
 
         $this->parts['{input}'] = Html::activeRadio($this->model, $this->attribute, $options);
 
@@ -623,11 +623,11 @@ class ActiveField extends Component
         $this->addAriaAttributes($options);
         $this->adjustLabelFor($options);
 
-        $this->parts['{label}'] ??= '';
-
         if (!$enclosedByLabel) {
             $options = $this->generateLabel($options);
         }
+
+        $this->parts['{label}'] ??= '';
 
         $this->parts['{input}'] = Html::activeCheckbox($this->model, $this->attribute, $options);
 
@@ -930,7 +930,7 @@ class ActiveField extends Component
      */
     protected function generateLabel(array $options): array
     {
-        if (isset($options['label']) && $options['label'] !== false && $this->parts['{label}'] === '') {
+        if (isset($options['label']) && $options['label'] !== false && !array_key_exists('{label}', $this->parts)) {
             $tag = false;
             $labelOptions = $this->labelOptions;
 
@@ -952,8 +952,8 @@ class ActiveField extends Component
                     $this->model,
                     $this->attribute,
                     [
-                        'label' => $options['label'],
                         ...$labelOptions,
+                        'label' => $options['label'],
                     ],
                 );
             } else {

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -261,15 +261,16 @@ class ActiveField extends Component
      * @param array|null $options the tag options in terms of name-value pairs. It will be merged with [[labelOptions]].
      * The options will be rendered as the attributes of the resulting tag. The values will be HTML-encoded using
      * [[Html::encode()]]. If a value is `null`, the corresponding attribute will not be rendered.
+     *
      * The following special options are recognized:
-     * - `label`: string|false|null, if specified in $options (or previously set in [[labelOptions]]), this value will
-     *   be used when the $label parameter is `null`. If set to `false`, the label will not be rendered (same behavior
-     *   as passing $label = `false`). The $label parameter always takes precedence over this option.
-     * - `tag`: string|false, specifies the tag name for the label element.
-     *   - If not specified, defaults to `'label'`.
-     *   - If set to `false`, the label content will be rendered as raw HTML without any wrapper tag.
-     *   - If set to `'label'`, uses [[Html::activeLabel()]] to generate a standard label element.
-     *   - If set to another tag name (for example, `'span'`, `'div'`), uses [[Html::tag()]] to generate that element.
+     *
+     * - `label`: `string|false|null`, the label text. Used as fallback when `$label` parameter is `null`.
+     *   If set to `false`, the label will not be rendered. The `$label` parameter always takes precedence over this
+     *   option.
+     * - `tag`: `string|false`, the tag name for the label element. Defaults to `'label'`.
+     *   If set to `false`, the label content is rendered without any wrapping tag.
+     *   If set to `'label'`, [[Html::activeLabel()]] is used (default behavior).
+     *   Any other string value (e.g. `'span'`, `'div'`, `'h3'`) will use [[Html::tag()]] with that element.
      *
      * @return $this the field object itself.
      */
@@ -548,21 +549,13 @@ class ActiveField extends Component
      *   it will take the default value `0`. This method will render a hidden input so that if the radio button
      *   is not checked and is submitted, the value of this attribute will still be submitted to the server
      *   via the hidden input. If you do not want any hidden input, you should explicitly set this option as `null`.
-     * - `label`: string|false|null, a label displayed next to the radio.
-     *   - If a string, it will NOT be HTML-encoded. Therefore you can pass in HTML code such as an image tag.
-     *   - If this is coming from end users, you should [[Html::encode()|encode]] it to prevent XSS attacks.
-     *   - If `false`, no label will be rendered.
-     *   - If `null`, no label will be rendered (same as `false`).
-     *   When this option is specified as a string and `enclosedByLabel` is `true`, the radio will be enclosed by a
-     *   label tag.
-     * - `labelOptions`: array, the HTML attributes for the label tag. This is only used when the `label` option is
-     *   specified and `enclosedByLabel` is `false`. The following special option is recognized:
-     *   - `tag`: string|false, specifies the tag name for the label element.
-     *     - If `labelOptions` is not provided, the label content will be rendered as raw HTML without any wrapper tag.
-     *     - If `labelOptions` is provided but `tag` is not specified, defaults to `'label'`.
-     *     - If set to `'label'`, uses [[Html::activeLabel()]] to generate a standard label element.
-     *     - If set to another tag name (for example, `'span'`, `'div'`), uses [[Html::tag()]] to generate that element.
-     *     - If set to `false`, the label content will be rendered as raw HTML without any wrapper tag.
+     * - `label`: `string|false|null`, a label displayed next to the radio button. It will NOT be HTML-encoded.
+     *   Therefore you can pass in HTML code such as an image tag. If this is coming from end users,
+     *   you should [[Html::encode()|encode]] it to prevent XSS attacks.
+     *   When this option is specified, the radio button will be enclosed by a label tag.
+     *   If you do not want any label, you should explicitly set this option as `null`.
+     * - `labelOptions`: array, the HTML attributes for the label tag. This is only used when the `label` option
+     *   is specified. Supports a `tag` sub-option (`'label'`/`false`/custom tag) for flexible label rendering.
      *
      * The rest of the options will be rendered as the attributes of the resulting tag. The values will
      * be HTML-encoded using [[Html::encode()]]. If a value is `null`, the corresponding attribute will not be rendered.
@@ -583,9 +576,9 @@ class ActiveField extends Component
         $this->addAriaAttributes($options);
         $this->adjustLabelFor($options);
 
-        if ($enclosedByLabel) {
-            $this->parts['{label}'] = '';
-        } else {
+        $this->parts['{label}'] ??= '';
+
+        if (!$enclosedByLabel) {
             $options = $this->generateLabel($options);
         }
 
@@ -603,21 +596,13 @@ class ActiveField extends Component
      *   it will take the default value `0`. This method will render a hidden input so that if the checkbox
      *   is not checked and is submitted, the value of this attribute will still be submitted to the server
      *   via the hidden input. If you do not want any hidden input, you should explicitly set this option as `null`.
-     * - `label`: string|false|null, a label displayed next to the checkbox.
-     *   - If a string, it will NOT be HTML-encoded. Therefore you can pass in HTML code such as an image tag.
-     *   - If this is coming from end users, you should [[Html::encode()|encode]] it to prevent XSS attacks.
-     *   - If `false`, no label will be rendered.
-     *   - If `null`, no label will be rendered (same as `false`).
-     *   When this option is specified as a string and `enclosedByLabel` is `true`, the checkbox will be enclosed by a
-     *   label tag.
+     * - `label`: `string|false|null`, a label displayed next to the checkbox. It will NOT be HTML-encoded.
+     *   Therefore you can pass in HTML code such as an image tag. If this is coming from end users, you should
+     *   [[Html::encode()|encode]] it to prevent XSS attacks.
+     *   When this option is specified, the checkbox will be enclosed by a label tag.
+     *   If you do not want any label, you should explicitly set this option as `null`.
      * - `labelOptions`: array, the HTML attributes for the label tag. This is only used when the `label` option is
-     *   specified and `enclosedByLabel` is `false`. The following special option is recognized:
-     *   - `tag`: string|false, specifies the tag name for the label element.
-     *     - If `labelOptions` is not provided, the label content will be rendered as raw HTML without any wrapper tag.
-     *     - If `labelOptions` is provided but `tag` is not specified, defaults to `'label'`.
-     *     - If set to `'label'`, uses [[Html::activeLabel()]] to generate a standard label element.
-     *     - If set to another tag name (for example, `'span'`, `'div'`), uses [[Html::tag()]] to generate that element.
-     *     - If set to `false`, the label content will be rendered as raw HTML without any wrapper tag.
+     *   specified. Supports a `tag` sub-option (`'label'`/`false`/custom tag) for flexible label rendering.
      *
      * The rest of the options will be rendered as the attributes of the resulting tag. The values will
      * be HTML-encoded using [[Html::encode()]]. If a value is `null`, the corresponding attribute will not be rendered.
@@ -638,9 +623,9 @@ class ActiveField extends Component
         $this->addAriaAttributes($options);
         $this->adjustLabelFor($options);
 
-        if ($enclosedByLabel) {
-            $this->parts['{label}'] = '';
-        } else {
+        $this->parts['{label}'] ??= '';
+
+        if (!$enclosedByLabel) {
             $options = $this->generateLabel($options);
         }
 
@@ -945,31 +930,37 @@ class ActiveField extends Component
      */
     protected function generateLabel(array $options): array
     {
-        if (isset($options['label'])) {
-            if ($options['label'] === false) {
-                $this->parts['{label}'] = '';
-            } elseif (($this->parts['{label}'] ?? '') === '') {
-                $tag = false;
+        if (isset($options['label']) && $options['label'] !== false && $this->parts['{label}'] === '') {
+            $tag = false;
 
-                if (!empty($options['labelOptions'])) {
-                    $tag = $options['labelOptions']['tag'] ?? 'label';
+            if (!empty($options['labelOptions'])) {
+                $tag = $options['labelOptions']['tag'] ?? 'label';
 
-                    unset($options['labelOptions']['tag']);
+                unset($options['labelOptions']['tag']);
 
-                    $this->labelOptions = array_merge($this->labelOptions, $options['labelOptions']);
-                }
+                $this->labelOptions = [
+                    ...$this->labelOptions,
+                    ...$options['labelOptions'],
+                ];
+            }
 
-                if ($tag === false) {
-                    $this->parts['{label}'] = $options['label'];
-                } elseif ($tag === 'label') {
-                    $this->parts['{label}'] = Html::activeLabel(
-                        $this->model,
-                        $this->attribute,
-                        array_merge(['label' => $options['label']], $this->labelOptions),
-                    );
-                } else {
-                    $this->parts['{label}'] = Html::tag($tag, $options['label'], $this->labelOptions);
-                }
+            if ($tag === false) {
+                $this->parts['{label}'] = $options['label'];
+            } elseif ($tag === 'label') {
+                $this->parts['{label}'] = Html::activeLabel(
+                    $this->model,
+                    $this->attribute,
+                    [
+                        'label' => $options['label'],
+                        ...$this->labelOptions,
+                    ],
+                );
+            } else {
+                $labelOpts = $this->labelOptions;
+
+                unset($labelOpts['label'], $labelOpts['for']);
+
+                $this->parts['{label}'] = Html::tag($tag, $options['label'], $labelOpts);
             }
         }
 

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -932,14 +932,15 @@ class ActiveField extends Component
     {
         if (isset($options['label']) && $options['label'] !== false && $this->parts['{label}'] === '') {
             $tag = false;
+            $labelOptions = $this->labelOptions;
 
-            if (!empty($options['labelOptions'])) {
+            if (array_key_exists('labelOptions', $options)) {
                 $tag = $options['labelOptions']['tag'] ?? 'label';
 
                 unset($options['labelOptions']['tag']);
 
-                $this->labelOptions = [
-                    ...$this->labelOptions,
+                $labelOptions = [
+                    ...$labelOptions,
                     ...$options['labelOptions'],
                 ];
             }
@@ -952,11 +953,11 @@ class ActiveField extends Component
                     $this->attribute,
                     [
                         'label' => $options['label'],
-                        ...$this->labelOptions,
+                        ...$labelOptions,
                     ],
                 );
             } else {
-                $labelOpts = $this->labelOptions;
+                $labelOpts = $labelOptions;
 
                 unset($labelOpts['label'], $labelOpts['for']);
 

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -13,6 +13,7 @@ namespace yiiunit\framework\widgets;
 use Exception;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\base\DynamicModel;
 use yii\validators\Validator;
@@ -30,12 +31,12 @@ use function array_map;
 use function sprintf;
 
 /**
- *  * Unit tests for {@see ActiveField} widget.
+ * Unit tests for {@see ActiveField} widget.
  *
  * @author Nelson J Morais <njmorais@gmail.com>
- *
- * @group widgets
  */
+#[Group('widgets')]
+#[Group('active-field')]
 class ActiveFieldTest extends TestCase
 {
     private \yiiunit\framework\widgets\ActiveFieldExtend $activeField;
@@ -1192,6 +1193,30 @@ class ActiveFieldTest extends TestCase
         );
     }
 
+    public function testRadioEnclosedByLabelFalsePreservesLabelFalse(): void
+    {
+        $this->activeField->label(false);
+        $this->activeField->radio(['label' => 'Radio Label'], false);
+
+        self::assertSame(
+            '',
+            $this->activeField->parts['{label}'],
+            "Should preserve label 'false' and not regenerate a label.",
+        );
+    }
+
+    public function testCheckboxEnclosedByLabelFalsePreservesLabelFalse(): void
+    {
+        $this->activeField->label(false);
+        $this->activeField->checkbox(['label' => 'Checkbox Label'], false);
+
+        self::assertSame(
+            '',
+            $this->activeField->parts['{label}'],
+            "Should preserve label 'false' and not regenerate a label.",
+        );
+    }
+
     public function testRadioEnclosedByLabelFalseWithEmptyLabelOptions(): void
     {
         $this->activeField->radio(
@@ -1249,6 +1274,27 @@ class ActiveFieldTest extends TestCase
             $originalLabelOptions,
             $this->activeField->labelOptions,
             "Should not mutate 'labelOptions' property when generating the label.",
+        );
+    }
+
+    public function testRadioExplicitLabelOverridesLabelOptionsLabel(): void
+    {
+        $this->activeField->labelOptions = ['label' => false];
+
+        $this->activeField->radio(
+            [
+                'label' => 'Explicit Radio Label',
+                'labelOptions' => ['class' => 'custom'],
+            ],
+            false,
+        );
+
+        self::assertSame(
+            <<<HTML
+            <label class="custom" for="activefieldtestmodel-attributename">Explicit Radio Label</label>
+            HTML,
+            $this->activeField->parts['{label}'],
+            "Explicit radio label should override 'labelOptions' when| label value is 'false'.",
         );
     }
 

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -323,7 +323,7 @@ class ActiveFieldTest extends TestCase
 
         $this->assertEmpty(
             $this->activeField->parts['{label}'],
-            "Failed asserting that 'label()' does not render.",
+            'Failed asserting that label does not render.',
         );
     }
 
@@ -335,7 +335,7 @@ class ActiveFieldTest extends TestCase
 
         $this->assertEmpty(
             $this->activeField->parts['{label}'],
-            "Failed asserting that 'label()' does not render.",
+            'Failed asserting that label does not render.',
         );
     }
 
@@ -475,7 +475,7 @@ class ActiveFieldTest extends TestCase
 
         $this->assertEmpty(
             $this->activeField->parts['{label}'],
-            "Failed asserting that 'label()' does not render.",
+            'Failed asserting that label does not render.',
         );
 
         // $label = 'Label Name'
@@ -1161,6 +1161,94 @@ class ActiveFieldTest extends TestCase
             $expectedLabel,
             $this->activeField->parts['{label}'],
             "Should render the expected label when 'enclosedByLabel' is 'false'.",
+        );
+    }
+
+    public function testRadioEnclosedByLabelFalsePreservesExistingLabel(): void
+    {
+        $this->activeField->label('Existing Label');
+        $this->activeField->radio(['label' => 'Radio Label'], false);
+
+        self::assertSame(
+            <<<HTML
+            <label class="control-label" for="activefieldtestmodel-attributename">Existing Label</label>
+            HTML,
+            $this->activeField->parts['{label}'],
+            'Should preserve the label set by a prior label call.',
+        );
+    }
+
+    public function testCheckboxEnclosedByLabelFalsePreservesExistingLabel(): void
+    {
+        $this->activeField->label('Existing Label');
+        $this->activeField->checkbox(['label' => 'Checkbox Label'], false);
+
+        self::assertSame(
+            <<<HTML
+            <label class="control-label" for="activefieldtestmodel-attributename">Existing Label</label>
+            HTML,
+            $this->activeField->parts['{label}'],
+            'Should preserve the label set by a prior label call.',
+        );
+    }
+
+    public function testRadioEnclosedByLabelFalseWithEmptyLabelOptions(): void
+    {
+        $this->activeField->radio(
+            [
+                'label' => 'Radio Label',
+                'labelOptions' => [],
+            ],
+            false,
+        );
+
+        self::assertSame(
+            <<<HTML
+            <label class="control-label" for="activefieldtestmodel-attributename">Radio Label</label>
+            HTML,
+            $this->activeField->parts['{label}'],
+            "Empty 'labelOptions' should default to a wrapped label tag.",
+        );
+    }
+
+    public function testCheckboxEnclosedByLabelFalseWithEmptyLabelOptions(): void
+    {
+        $this->activeField->checkbox(
+            [
+                'label' => 'Checkbox Label',
+                'labelOptions' => [],
+            ],
+            false,
+        );
+
+        self::assertSame(
+            <<<HTML
+            <label class="control-label" for="activefieldtestmodel-attributename">Checkbox Label</label>
+            HTML,
+            $this->activeField->parts['{label}'],
+            "Empty 'labelOptions' should default to a wrapped label tag.",
+        );
+    }
+
+    public function testGenerateLabelDoesNotMutateLabelOptions(): void
+    {
+        $originalLabelOptions = $this->activeField->labelOptions;
+
+        $this->activeField->radio(
+            [
+                'label' => 'Radio Label',
+                'labelOptions' => [
+                    'class' => 'temporary-class',
+                    'data-temp' => 'value',
+                ],
+            ],
+            false,
+        );
+
+        self::assertSame(
+            $originalLabelOptions,
+            $this->activeField->labelOptions,
+            "Should not mutate 'labelOptions' property when generating the label.",
         );
     }
 

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -1,28 +1,37 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\widgets;
 
-use yiiunit\TestCase;
 use Exception;
-use yii\validators\Validator;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Depends;
 use Yii;
 use yii\base\DynamicModel;
+use yii\validators\Validator;
 use yii\web\AssetManager;
 use yii\web\View;
 use yii\widgets\ActiveField;
 use yii\widgets\ActiveForm;
 use yii\widgets\InputWidget;
 use yii\widgets\MaskedInput;
+use yiiunit\framework\widgets\providers\ActiveFieldProvider;
+use yiiunit\TestCase;
+
+use function array_keys;
+use function array_map;
+use function sprintf;
 
 /**
+ *  * Unit tests for {@see ActiveField} widget.
+ *
  * @author Nelson J Morais <njmorais@gmail.com>
  *
  * @group widgets
@@ -497,9 +506,7 @@ class ActiveFieldTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider \yiiunit\framework\widgets\providers\ActiveFieldProvider::hintDataProvider
-     */
+    #[DataProviderExternal(ActiveFieldProvider::class, 'hint')]
     public function testHint(bool|string|null $hint, string $expectedHtml): void
     {
         $this->activeField->hint($hint);
@@ -1040,10 +1047,9 @@ class ActiveFieldTest extends TestCase
     }
 
     /**
-     * @depends testHiddenInput
-     *
      * @see https://github.com/yiisoft/yii2/issues/14773
      */
+    #[Depends('testHiddenInput')]
     public function testOptionsClass(): void
     {
         $this->activeField->options = ['class' => 'test-wrapper'];
@@ -1134,235 +1140,27 @@ class ActiveFieldTest extends TestCase
         );
     }
 
-    public function testRadioEnclosedByLabelFalseWithLabelOptions(): void
+    #[DataProviderExternal(ActiveFieldProvider::class, 'radioEnclosedByLabelFalse')]
+    public function testRadioEnclosedByLabelFalse(array $options, string $expectedLabel): void
     {
-        $this->activeField->radio(
-            [
-                'label' => 'Select Option A',
-                'labelOptions' => [
-                    'class' => 'custom-radio-label',
-                    'data-option' => 'option-a',
-                ],
-            ],
-            false,
-        );
+        $this->activeField->radio($options, false);
 
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <label class="custom-radio-label" data-option="option-a" for="activefieldtestmodel-attributename">Select Option A</label>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
+        self::assertSame(
+            $expectedLabel,
+            $this->activeField->parts['{label}'],
+            "Should render the expected label when 'enclosedByLabel' is 'false'.",
         );
     }
 
-    public function testRadioEnclosedByLabelFalseWithLabelOptionsAndLabelFalse(): void
+    #[DataProviderExternal(ActiveFieldProvider::class, 'checkboxEnclosedByLabelFalse')]
+    public function testCheckboxEnclosedByLabelFalse(array $options, string $expectedLabel): void
     {
-        $this->activeField->radio(['label' => false], false);
+        $this->activeField->checkbox($options, false);
 
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->normalizeHTML($this->activeField->render()),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testRadioEnclosedByLabelFalseWithLabelOptionsAndTagLabel(): void
-    {
-        $this->activeField->radio(
-            [
-                'label' => 'Choose This Option',
-                'labelOptions' => [
-                    'class' => 'radio-option-label',
-                    'data-value' => 'choice-1',
-                    'tag' => 'span',
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <span class="radio-option-label" data-value="choice-1">Choose This Option</span>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testRadioEnclosedByLabelFalseWithLabelOptionsAndTagLabelFalse(): void
-    {
-        $this->activeField->radio(
-            [
-                'label' => '<div class="custom-label-wrapper"><strong>Premium Option</strong> <em>(Recommended)</em></div>',
-                'labelOptions' => [
-                    'tag' => false,
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <div class="custom-label-wrapper"><strong>Premium Option</strong> <em>(Recommended)</em></div>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testRadioEnclosedByLabelFalseWithoutLabelOptions(): void
-    {
-        $this->activeField->radio(['label' => 'Select Option A'], false);
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            Select Option A
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testCheckboxEnclosedByLabelFalseWithLabelOptions(): void
-    {
-        $this->activeField->checkbox(
-            [
-                'label' => 'Custom Label',
-                'labelOptions' => [
-                    'class' => 'custom-label-class',
-                    'data-test' => 'custom-label-data',
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <label class="custom-label-class" data-test="custom-label-data" for="activefieldtestmodel-attributename">Custom Label</label>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testCheckboxEnclosedByLabelFalseWithLabelOptionsAndLabelFalse(): void
-    {
-        $this->activeField->checkbox(['label' => false], false);
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->normalizeHTML($this->activeField->render()),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testCheckboxEnclosedByLabelFalseWithLabelOptionsAndTagLabel(): void
-    {
-        $this->activeField->checkbox(
-            [
-                'label' => 'Custom Label',
-                'labelOptions' => [
-                    'class' => 'custom-label-class',
-                    'data-test' => 'custom-label-data',
-                    'tag' => 'span',
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <span class="custom-label-class" data-test="custom-label-data">Custom Label</span>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testCheckboxEnclosedByLabelFalseWithLabelOptionsAndTagLabelFalse(): void
-    {
-        $this->activeField->checkbox(
-            [
-                'label' => '<div class="custom-label-wrapper"><strong>Custom</strong> <em>Label</em></div>',
-                'labelOptions' => [
-                    'tag' => false,
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <div class="custom-label-wrapper"><strong>Custom</strong> <em>Label</em></div>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testCheckboxEnclosedByLabelFalseWithoutLabelOptions(): void
-    {
-        $this->activeField->checkbox(['label' => 'Custom Label'], false);
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            Custom Label
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
+        self::assertSame(
+            $expectedLabel,
+            $this->activeField->parts['{label}'],
+            "Should render the expected label when 'enclosedByLabel' is 'false'.",
         );
     }
 
@@ -1507,130 +1305,6 @@ class ActiveFieldTest extends TestCase
         );
     }
 
-    public function testRadioEnclosedByLabelFalse(): void
-    {
-        $this->activeField->radio([], false);
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testRadioEnclosedByLabelFalseWithCustomLabel(): void
-    {
-        $this->activeField->radio(
-            [
-                'label' => 'Select Option A',
-                'labelOptions' => [
-                    'class' => 'custom-radio-label',
-                    'data-option' => 'option-a',
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <label class="custom-radio-label" data-option="option-a" for="activefieldtestmodel-attributename">Select Option A</label>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testRadioEnclosedByLabelFalseWithCustomLabelFalse(): void
-    {
-        $this->activeField->radio(
-            [
-                'label' => false,
-                'labelOptions' => [
-                    'class' => 'custom-radio-label',
-                    'data-option' => 'option-a',
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->normalizeHTML($this->activeField->render()),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-
-    public function testRadioEnclosedByLabelFalseWithCustomLabelTag(): void
-    {
-        $this->activeField->radio(
-            [
-                'label' => 'Choose This Option',
-                'labelOptions' => [
-                    'class' => 'radio-option-label',
-                    'data-value' => 'choice-1',
-                    'tag' => 'span',
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <span class="radio-option-label" data-value="choice-1">Choose This Option</span>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testRadioEnclosedByLabelFalseWithCustomLabelTagFalse(): void
-    {
-        $this->activeField->radio(
-            [
-                'label' => '<div class="radio-custom-wrapper"><strong>Premium Option</strong> <em>(Recommended)</em></div>',
-                'labelOptions' => ['tag' => false],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <div class="radio-custom-wrapper"><strong>Premium Option</strong> <em>(Recommended)</em></div>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="radio" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
     public function testRadioEnclosedByLabelTrue(): void
     {
         $this->activeField->radio([], true);
@@ -1644,131 +1318,6 @@ class ActiveFieldTest extends TestCase
             </div>
             HTML,
             $this->normalizeHTML($this->activeField->render()),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testCheckboxEnclosedByLabelFalse(): void
-    {
-        $this->activeField->checkbox([], false);
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <label class="control-label" for="activefieldtestmodel-attributename">Attribute Name</label>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testCheckboxEnclosedByLabelFalseWithCustomLabel(): void
-    {
-        $this->activeField->checkbox(
-            [
-                'label' => 'Custom Label',
-                'labelOptions' => [
-                    'class' => 'custom-label-class',
-                    'data-test' => 'custom-label-data',
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <label class="custom-label-class" data-test="custom-label-data" for="activefieldtestmodel-attributename">Custom Label</label>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testCheckboxEnclosedByLabelFalseWithCustomLabelFalse(): void
-    {
-        $this->activeField->checkbox(
-            [
-                'label' => false,
-                'labelOptions' => [
-                    'class' => 'custom-label-class',
-                    'data-test' => 'custom-label-data',
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->normalizeHTML($this->activeField->render()),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testCheckboxEnclosedByLabelFalseWithCustomLabelTag(): void
-    {
-        $this->activeField->checkbox(
-            [
-                'label' => 'Custom Label',
-                'labelOptions' => [
-                    'class' => 'custom-label-class',
-                    'data-test' => 'custom-label-data',
-                    'tag' => 'span',
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            <span class="custom-label-class" data-test="custom-label-data">Custom Label</span>
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
-            'Rendered HTML does not match expected output',
-        );
-    }
-
-    public function testCheckboxEnclosedByLabelFalseWithCustomLabelTagFalse(): void
-    {
-        $this->activeField->checkbox(
-            [
-                'label' => 'Custom Label',
-                'labelOptions' => [
-                    'tag' => false,
-                ],
-            ],
-            false,
-        );
-
-        $this->assertEqualsWithoutLE(
-            <<<HTML
-            <div class="form-group field-activefieldtestmodel-attributename">
-            Custom Label
-            <input type="hidden" name="ActiveFieldTestModel[attributeName]" value="0"><input type="checkbox" id="activefieldtestmodel-attributename" name="ActiveFieldTestModel[attributeName]" value="1">
-            <div class="hint-block">Hint for attributeName attribute</div>
-            <div class="help-block"></div>
-            </div>
-            HTML,
-            $this->activeField->render(),
             'Rendered HTML does not match expected output',
         );
     }
@@ -2040,11 +1589,14 @@ class TestMaskedInput extends MaskedInput
 
     public function run()
     {
-        return 'Options: ' . implode(', ', array_map(
-            fn($v, $k) => sprintf('%s="%s"', $k, $v),
-            $this->options,
-            array_keys($this->options)
-        ));
+        return 'Options: ' . implode(
+            ', ',
+            array_map(
+                static fn ($v, $k): string => sprintf('%s="%s"', $k, $v),
+                $this->options,
+                array_keys($this->options),
+            ),
+        );
     }
 }
 

--- a/tests/framework/widgets/providers/ActiveFieldProvider.php
+++ b/tests/framework/widgets/providers/ActiveFieldProvider.php
@@ -1,46 +1,182 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
+/**
+ * Data provider for {@see \yiiunit\framework\widgets\ActiveFieldTest} test cases.
+ *
+ * Provides representative input/output pairs for label, hint, radio, and checkbox attributes.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 2.2
+ */
 
 namespace yiiunit\framework\widgets\providers;
 
-/**
- * @author Wilmer Arambula <terabytesoftw@gmail.com>
- *
- * @since 2.2.0
- */
 final class ActiveFieldProvider
 {
-    /**
-     * Provides test data for hint field rendering validation.
-     *
-     * This provider supplies test cases for validating hint content rendering in ActiveField widgets, including
-     * scenarios with false values, null values, and custom hint content.
-     *
-     * @return array test data with hint configurations and expected HTML output.
-     *
-     * @phpstan-return array<array{bool|string|null, string}>
-     */
-    public static function hintDataProvider(): array
+    public static function hint(): array
     {
         return [
-            [
+            'false' => [
                 false,
                 '',
             ],
-            [
+            'null' => [
                 null,
-                '<div class="hint-block">Hint for attributeName attribute</div>',
+                <<<HTML
+                <div class="hint-block">Hint for attributeName attribute</div>
+                HTML,
             ],
-            [
+            'string' => [
                 'Hint Content',
-                '<div class="hint-block">Hint Content</div>',
+                <<<HTML
+                <div class="hint-block">Hint Content</div>
+                HTML,
+            ],
+        ];
+    }
+
+    public static function labelWithTagCustom(): array
+    {
+        return [
+            'h3' => [
+                'h3',
+                'Custom Label',
+                <<<HTML
+                <h3 class="control-label">Custom Label</h3>
+                HTML,
+            ],
+            'span' => [
+                'span',
+                null,
+                <<<HTML
+                <span class="control-label">Attribute Name</span>
+                HTML,
+            ],
+        ];
+    }
+
+    public static function labelWithTagFalse(): array
+    {
+        return [
+            'null' => [
+                null,
+                'Attribute Name',
+            ],
+            'label' => [
+                'Custom Label',
+                'Custom Label',
+            ],
+        ];
+    }
+
+    public static function radioEnclosedByLabelFalse(): array
+    {
+        return [
+            'label with false' => [
+                [
+                    'label' => false,
+                    'labelOptions' => [
+                        'class' => 'custom-label',
+                    ],
+                ],
+                '',
+            ],
+            'labelOptions' => [
+                [
+                    'label' => 'Radio Label',
+                    'labelOptions' => [
+                        'class' => 'custom-label',
+                        'data-type' => 'radio',
+                    ],
+                ],
+                <<<HTML
+                <label class="custom-label" data-type="radio" for="activefieldtestmodel-attributename">Radio Label</label>
+                HTML,
+            ],
+            'labelOptions with custom tag' => [
+                [
+                    'label' => 'Radio Label',
+                    'labelOptions' => [
+                        'tag' => 'span',
+                        'class' => 'custom-label',
+                    ],
+                ],
+                <<<HTML
+                <span class="custom-label">Radio Label</span>
+                HTML,
+            ],
+            'labelOptions with tag false' => [
+                [
+                    'label' => 'Radio Label',
+                    'labelOptions' => [
+                        'tag' => false,
+                    ],
+                ],
+                'Radio Label',
+            ],
+            'without labelOptions' => [
+                [
+                    'label' => 'Radio Label',
+                ],
+                'Radio Label',
+            ],
+        ];
+    }
+
+    public static function checkboxEnclosedByLabelFalse(): array
+    {
+        return [
+            'label with false' => [
+                [
+                    'label' => false,
+                    'labelOptions' => ['class' => 'custom-label'],
+                ],
+                '',
+            ],
+            'labelOptions' => [
+                [
+                    'label' => 'Checkbox Label',
+                    'labelOptions' => [
+                        'class' => 'custom-label',
+                        'data-type' => 'checkbox',
+                    ],
+                ],
+                <<<HTML
+                <label class="custom-label" data-type="checkbox" for="activefieldtestmodel-attributename">Checkbox Label</label>
+                HTML,
+            ],
+            'labelOptions with custom tag' => [
+                [
+                    'label' => 'Checkbox Label',
+                    'labelOptions' => [
+                        'tag' => 'span',
+                        'class' => 'custom-label',
+                    ],
+                ],
+                <<<HTML
+                <span class="custom-label">Checkbox Label</span>
+                HTML,
+            ],
+            'labelOptions with tag false' => [
+                [
+                    'label' => 'Checkbox Label',
+                    'labelOptions' => ['tag' => false],
+                ],
+                'Checkbox Label',
+            ],
+            'without labelOptions' => [
+                [
+                    'label' => 'Checkbox Label',
+                ],
+                'Checkbox Label',
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

Related: #20537
