### PR TITLE
Fix `clientScript` not being instantiated in validators when a custom array config is set and `useJquery` is `false`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -36,6 +36,7 @@ Yii Framework 2 Change Log
 - Chg: Remove PHP < `8.3` version guards and dead fallbacks across framework and tests (terabytesoftw)
 - Chg #20808: Rename `ApcCache` to `ApcuCache` and remove legacy APC extension support (terabytesoftw)
 - Bug: Fix `ActiveField::generateLabel()` to strip `label`/`for` attributes for custom tags and preserve prior label in `radio()`/`checkbox()` (terabytesoftw)
+- Bug: Fix `clientScript` not being instantiated in validators when a custom array config is set and `useJquery` is `false` (terabytesoftw)
 
 
 2.0.55 under development

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -12,110 +12,6 @@ For the historical `2.0.x` upgrade notes see [`UPGRADE.md`](UPGRADE.md).
 * Raised minimum supported PHP version to `8.3`.
 * All methods that were previously deprecated have been removed. If your application still uses any deprecated methods,
   you must update your code before upgrading.
-* jQuery is now optional in the framework. A new `useJquery` property has been added to `yii\console\Application` and
-  `yii\web\Application` to control whether jQuery-based client scripts are used. The default values differ by
-  application type: `yii\web\Application::$useJquery` defaults to `true`, maintaining full backward compatibility for
-  web applications, while `yii\console\Application::$useJquery` defaults to `false` because console applications do not
-  register client-side scripts unless you explicitly enable them. Where client-side scripts apply, setting the property
-  to `false` disables jQuery-based scripts and framework uses plain JavaScript instead.
-  
-  To disable jQuery globally, configure your application:
-  
-  ```php
-  return [
-      'useJquery' => false,
-      // ... other config
-  ];
-  ```
-  
-  Or dynamically at runtime:
-  
-  ```php
-  Yii::$app->useJquery = false;
-  ```
-
-* Two new interfaces have been introduced to support alternative client-side script implementations:
-  
-  - `yii\web\client\ClientScriptInterface` - for widgets and components (ActiveForm, GridView, etc.)
-  - `yii\validators\client\ClientValidatorScriptInterface` - for validators
-  
-  These interfaces allow you to provide custom client-side validation and behavior without jQuery dependency.
-
-* Widgets and validators now support a `clientScript` configuration option to specify custom client script handlers:
-  
-  ```php
-  // Using default jQuery behavior (no changes needed)
-  $form = ActiveForm::begin([]);
-  
-  // Using custom client script implementation without jQuery
-  $form = ActiveForm::begin(['clientScript' => MyCustomClientScript::class]);
-  ```
-  
-  The following components support custom client scripts via the new interfaces:
-
-  - `yii\widgets\ActiveForm` and `yii\widgets\ActiveField`
-  - `yii\grid\GridView` and `yii\grid\CheckboxColumn`
-  - All built-in validators (RequiredValidator, EmailValidator, StringValidator, etc.)
-
-* If you are extending any of the following classes and overriding client-side script generation methods, you should 
-  review your code to ensure compatibility:
-  
-  - `yii\widgets\ActiveForm::getClientOptions()`
-  - `yii\widgets\ActiveField::getClientOptions()`
-  - `yii\validators\Validator::clientValidateAttribute()`
-  
-  The default implementations now delegate to the configured `clientScript` handler when jQuery is enabled.
-
-* Example of implementing a custom client script handler:
-  
-  ```php
-  use yii\base\BaseObject;
-  use yii\web\client\ClientScriptInterface;
-  use yii\web\View;
-  use yii\widgets\ActiveField;
-  use yii\widgets\ActiveForm;  
-  
-  /**
-   * @template T of ActiveForm|ActiveField
-   * @implements ClientScriptInterface<T>
-   */
-  class MyCustomClientScript implements ClientScriptInterface
-  {
-      public function getClientOptions(BaseObject $object, array $options = []): array
-      {
-          // Return client-side options for your custom implementation
-          return [
-              'myOption' => 'value',
-          ];
-      }
-      
-      public function register(BaseObject $object, View $view, array $options = []): void
-      {
-          // Register your custom JavaScript/CSS assets
-          MyCustomAsset::register($view);
-          
-          // Register initialization script
-          $view->registerJs("MyCustomLib.init('#" . $object->options['id'] . "');");
-      }
-  }
-  ```
-
-* If your application doesn't use jQuery and you want to completely remove the dependency, after setting `useJquery` to
-  `false`, you'll need to provide your own client script implementations for any widgets or validators that require 
-  client-side functionality. Alternatively, you can disable client-side validation entirely:
-  
-  ```php
-  $form = ActiveForm::begin(
-      [
-          'enableClientValidation' => false,
-          'enableAjaxValidation' => false,
-      ],
-  );
-  ```
-
-* Note: Setting `useJquery` to `false` only prevents the framework from registering jQuery-based scripts. 
-  It does not remove jQuery from your application if you've included it manually or through other extensions. 
-  You are responsible for ensuring your application works correctly without jQuery when this option is disabled.
 
 ### ActiveField label, radio, and checkbox enhancements
 
@@ -198,6 +94,91 @@ All HHVM-specific code has been removed from the framework. Yii `22.x` targets P
 If your application references `ErrorException::E_HHVM_FATAL_ERROR` or `ErrorHandler::handleHhvmError()`, remove those 
 references when upgrading.
 
+### jQuery is now optional (strategy pattern)
+
+jQuery is no longer hardcoded in validators and widgets. A new `useJquery` property controls whether jQuery-based client 
+scripts are registered. It defaults to `true` on `yii\web\Application` (full backward compatibility) and to `false` on 
+`yii\console\Application` (no client scripts in console context).
+
+**No action required** for existing web applications  the default behavior is fully backward compatible.
+
+#### New interfaces
+
+Two interfaces allow replacing the jQuery implementation with any alternative:
+
+- `yii\web\client\ClientScriptInterface` strategy for widgets and components (`ActiveForm`, `GridView`,
+  `CheckboxColumn`).
+- `yii\validators\client\ClientValidatorScriptInterface` strategy for validators.
+
+#### New `clientScript` property
+
+All 13 built-in validators that support client-side validation and the widgets listed below now expose a `clientScript`
+property that accepts an array config or an object implementing the matching interface:
+
+- `yii\widgets\ActiveForm` and `yii\widgets\ActiveField`
+- `yii\grid\GridView` and `yii\grid\CheckboxColumn`
+- `BooleanValidator`, `CompareValidator`, `EmailValidator`, `FileValidator`, `ImageValidator`, `IpValidator`,
+  `NumberValidator`, `RangeValidator`, `RegularExpressionValidator`, `RequiredValidator`, `StringValidator`,
+  `TrimValidator`, `UrlValidator`
+
+The custom strategy is **always instantiated** regardless of `useJquery`, enabling framework-agnostic client scripts.
+
+#### New method
+
+`Validator::getFormattedClientMessage(string $message, array $params): string` public wrapper around the protected
+`formatMessage()`, used by extracted jQuery client script classes when composing error messages.
+
+#### Opting out of jQuery
+
+```php
+// In application configuration
+return [
+    'useJquery' => false,
+    // ... other config
+];
+```
+
+When `useJquery` is `false` and no custom `clientScript` strategy is configured:
+
+- `clientValidateAttribute()` returns `null` on all built-in validators.
+- `getClientOptions()` returns `[]` on all built-in validators.
+- `ActiveForm`, `GridView`, and `CheckboxColumn` do not register their built-in jQuery plugins.
+- No built-in `JqueryAsset`, `ValidationAsset`, `ActiveFormAsset`, or `GridViewAsset` bundles are registered.
+
+#### Custom client script strategy
+
+```php
+// Custom validator client script works even when useJquery is false
+public function rules(): array
+{
+    return [
+        ['username', 'required', 'clientScript' => ['class' => MyRequiredClientScript::class]],
+    ];
+}
+
+// Custom form client script
+ActiveForm::begin(
+    [
+        'clientScript' => ['class' => MyFormClientScript::class],
+    ],
+);
+```
+
+#### BC impact on subclasses
+
+If you extend any of the following classes and override client-side script generation methods, review your code for
+compatibility:
+
+- `yii\widgets\ActiveForm::getClientOptions()`
+- `yii\widgets\ActiveField::getClientOptions()`
+- `yii\validators\Validator::clientValidateAttribute()`
+
+The default implementations now delegate to the configured `$clientScript` handler when jQuery is enabled. Subclasses
+that call `parent::clientValidateAttribute()` or `parent::getClientOptions()` are not affected.
+
+> **Note:** Setting `useJquery` to `false` only prevents the framework from registering jQuery-based scripts. It does
+> not remove jQuery from your application if you have included it manually or through other extensions.
+
 ### Yii runtime autoloader removed
 
 The framework no longer registers its own SPL autoloader. The following public API has been removed:
@@ -217,10 +198,10 @@ All framework classes are now loaded exclusively by Composer:
 1. Remove any code that writes to `Yii::$classMap` or calls `Yii::autoload()`. Both no longer exist and will produce a 
    fatal error.
 2. Make sure every class your application uses is reachable through Composer autoload. Declare it under one of:
-    - `autoload.psr-4` — namespace mapping (preferred for application code).
-    - `autoload.classmap` — explicit class-to-file mapping (use for non-PSR-4 files or vendor overrides).
-    - `autoload.exclude-from-classmap` — paired with `classmap` when overriding a vendor class.
-    - `autoload-dev` — development and test-only classes.
+    - `autoload.psr-4` namespace mapping (preferred for application code).
+    - `autoload.classmap` explicit class-to-file mapping (use for non-PSR-4 files or vendor overrides).
+    - `autoload.exclude-from-classmap` paired with `classmap` when overriding a vendor class.
+    - `autoload-dev` development and test-only classes.
 3. Regenerate the autoload files after editing `composer.json`:
 
    ```bash
@@ -303,7 +284,7 @@ authoritative classmaps because it is resolved at autoload-generation time, not 
 
 > Important: because the original `yii\web\Request` file is excluded from the classmap, the FQCN `yii\web\Request` is 
 > now defined exclusively by your override file. You **cannot** write `class Request extends \yii\web\Request` inside 
-> `namespace yii\web;` — that would be self-inheritance and PHP will reject it. You must reimplement the full public 
+> `namespace yii\web;` that would be self-inheritance and PHP will reject it. You must reimplement the full public 
 > surface of the original class.
 >
 > If you only need to *extend* the framework class, do **not** use `exclude-from-classmap`. Instead, declare a subclass 

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -100,7 +100,7 @@ jQuery is no longer hardcoded in validators and widgets. A new `useJquery` prope
 scripts are registered. It defaults to `true` on `yii\web\Application` (full backward compatibility) and to `false` on 
 `yii\console\Application` (no client scripts in console context).
 
-**No action required** for existing web applications  the default behavior is fully backward compatible.
+**No action required** for existing web applications; the default behavior is fully backward compatible.
 
 #### New interfaces
 

--- a/framework/grid/CheckboxColumn.php
+++ b/framework/grid/CheckboxColumn.php
@@ -97,8 +97,11 @@ class CheckboxColumn extends Column
             $this->name .= '[]';
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientScriptInterface) {
-            $this->clientScript ??= ['class' => CheckboxColumnJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => CheckboxColumnJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
 

--- a/framework/grid/GridView.php
+++ b/framework/grid/GridView.php
@@ -296,8 +296,11 @@ class GridView extends BaseListView
             $this->filterRowOptions['id'] = $this->options['id'] . '-filters';
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientScriptInterface) {
-            $this->clientScript ??= ['class' => GridViewJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => GridViewJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
 
@@ -334,12 +337,10 @@ class GridView extends BaseListView
      */
     public function renderSection($name)
     {
-        switch ($name) {
-            case '{errors}':
-                return $this->renderErrors();
-            default:
-                return parent::renderSection($name);
-        }
+        return match ($name) {
+            '{errors}' => $this->renderErrors(),
+            default => parent::renderSection($name),
+        };
     }
 
     /**
@@ -441,7 +442,7 @@ class GridView extends BaseListView
             $content .= $this->renderFilters();
         }
 
-        return "<thead>\n" . $content . "\n</thead>";
+        return "<thead>\n{$content}\n</thead>";
     }
 
     /**
@@ -460,7 +461,7 @@ class GridView extends BaseListView
             $content .= $this->renderFilters();
         }
 
-        return "<tfoot>\n" . $content . "\n</tfoot>";
+        return "<tfoot>\n{$content}\n</tfoot>";
     }
 
     /**
@@ -584,8 +585,8 @@ class GridView extends BaseListView
             'class' => $this->dataColumnClass ?: DataColumn::class,
             'grid' => $this,
             'attribute' => $matches[1],
-            'format' => isset($matches[3]) ? $matches[3] : 'text',
-            'label' => isset($matches[5]) ? $matches[5] : null,
+            'format' => $matches[3] ?? 'text',
+            'label' => $matches[5] ?? null,
         ]);
     }
 

--- a/framework/jquery/validators/RegularExpressionValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/RegularExpressionValidatorJqueryClientScript.php
@@ -21,8 +21,8 @@ use yii\web\JsExpression;
 use yii\web\View;
 
 /**
- * RegularValidatorJqueryClientScript provides client-side validation script generation for regular expression
- * attributes.
+ * RegularExpressionValidatorJqueryClientScript provides client-side validation script generation for regular
+ * expression attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for regular expression validation in Yii2 forms using jQuery.
@@ -33,7 +33,7 @@ use yii\web\View;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 2.2.0
  */
-class RegularValidatorJqueryClientScript implements ClientValidatorScriptInterface
+class RegularExpressionValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {
     public function getClientOptions(Validator $validator, Model $model, string $attribute): array
     {

--- a/framework/jquery/validators/RequiredValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/RequiredValidatorJqueryClientScript.php
@@ -19,7 +19,7 @@ use yii\validators\Validator;
 use yii\web\View;
 
 /**
- * RequireValidatorJqueryClientScript provides client-side validation script generation for required attributes.
+ * RequiredValidatorJqueryClientScript provides client-side validation script generation for required attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for required value validation in Yii2 forms using jQuery.
@@ -30,7 +30,7 @@ use yii\web\View;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 2.2.0
  */
-class RequireValidatorJqueryClientScript implements ClientValidatorScriptInterface
+class RequiredValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {
     public function getClientOptions(Validator $validator, Model $model, string $attribute): array
     {

--- a/framework/validators/BooleanValidator.php
+++ b/framework/validators/BooleanValidator.php
@@ -53,8 +53,11 @@ class BooleanValidator extends Validator
             $this->message = Yii::t('yii', '{attribute} must be either "{true}" or "{false}".');
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => BooleanValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => BooleanValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/CompareValidator.php
+++ b/framework/validators/CompareValidator.php
@@ -142,8 +142,11 @@ class CompareValidator extends Validator
             }
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => CompareValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => CompareValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/EmailValidator.php
+++ b/framework/validators/EmailValidator.php
@@ -88,8 +88,11 @@ class EmailValidator extends Validator
             $this->message = Yii::t('yii', '{attribute} is not a valid email address.');
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => EmailValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => EmailValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/FileValidator.php
+++ b/framework/validators/FileValidator.php
@@ -204,8 +204,11 @@ class FileValidator extends Validator
             $this->mimeTypes = array_map('strtolower', $this->mimeTypes);
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => FileValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => FileValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/ImageValidator.php
+++ b/framework/validators/ImageValidator.php
@@ -99,8 +99,8 @@ class ImageValidator extends FileValidator
      */
     public function init()
     {
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => ImageValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => ImageValidatorJqueryClientScript::class];
         }
 
         parent::init();

--- a/framework/validators/IpValidator.php
+++ b/framework/validators/IpValidator.php
@@ -238,8 +238,11 @@ class IpValidator extends Validator
             $this->notInRange = Yii::t('yii', '{attribute} is not in the allowed range.');
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => IpValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => IpValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/NumberValidator.php
+++ b/framework/validators/NumberValidator.php
@@ -83,8 +83,11 @@ class NumberValidator extends Validator
             $this->tooBig = Yii::t('yii', '{attribute} must be no greater than {max}.');
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => NumberValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => NumberValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/RangeValidator.php
+++ b/framework/validators/RangeValidator.php
@@ -73,8 +73,11 @@ class RangeValidator extends Validator
             $this->message = Yii::t('yii', '{attribute} is invalid.');
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => RangeValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => RangeValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/RegularExpressionValidator.php
+++ b/framework/validators/RegularExpressionValidator.php
@@ -10,7 +10,7 @@ namespace yii\validators;
 
 use Yii;
 use yii\base\InvalidConfigException;
-use yii\jquery\validators\RegularValidatorJqueryClientScript;
+use yii\jquery\validators\RegularExpressionValidatorJqueryClientScript;
 use yii\validators\client\ClientValidatorScriptInterface;
 
 /**
@@ -50,8 +50,11 @@ class RegularExpressionValidator extends Validator
             $this->message = Yii::t('yii', '{attribute} is invalid.');
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => RegularValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => RegularExpressionValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/RequiredValidator.php
+++ b/framework/validators/RequiredValidator.php
@@ -9,7 +9,7 @@
 namespace yii\validators;
 
 use Yii;
-use yii\jquery\validators\RequireValidatorJqueryClientScript;
+use yii\jquery\validators\RequiredValidatorJqueryClientScript;
 use yii\validators\client\ClientValidatorScriptInterface;
 
 /**
@@ -69,8 +69,11 @@ class RequiredValidator extends Validator
                 : Yii::t('yii', '{attribute} must be "{requiredValue}".');
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => RequireValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => RequiredValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/StringValidator.php
+++ b/framework/validators/StringValidator.php
@@ -109,8 +109,11 @@ class StringValidator extends Validator
             $this->notEqual = Yii::t('yii', '{attribute} should contain {length, number} {length, plural, one{character} other{characters}}.');
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => StringValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => StringValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/TrimValidator.php
+++ b/framework/validators/TrimValidator.php
@@ -45,8 +45,11 @@ class TrimValidator extends Validator
     {
         parent::init();
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => TrimValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => TrimValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/UrlValidator.php
+++ b/framework/validators/UrlValidator.php
@@ -66,8 +66,11 @@ class UrlValidator extends Validator
             $this->message = Yii::t('yii', '{attribute} is not a valid URL.');
         }
 
-        if (Yii::$app?->useJquery && !$this->clientScript instanceof ClientValidatorScriptInterface) {
-            $this->clientScript ??= ['class' => UrlValidatorJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false)) {
+            $this->clientScript = ['class' => UrlValidatorJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientValidatorScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
     }

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -8,9 +8,16 @@
 
 namespace yii\validators;
 
+use Closure;
 use Yii;
 use yii\base\Component;
 use yii\base\NotSupportedException;
+
+use function call_user_func;
+use function in_array;
+use function is_array;
+use function is_object;
+use function is_scalar;
 
 /**
  * Validator is the base class for all validators.
@@ -191,7 +198,6 @@ class Validator extends Component
      */
     public $whenClient;
 
-
     /**
      * Creates a validator object.
      * @param string|\Closure $type the validator type. This can be either:
@@ -209,7 +215,7 @@ class Validator extends Component
     {
         $params['attributes'] = $attributes;
 
-        if ($type instanceof \Closure) {
+        if ($type instanceof Closure) {
             $params['class'] = __NAMESPACE__ . '\InlineValidator';
             $params['method'] = $type;
         } elseif (!isset(static::$builtInValidators[$type]) && $model->hasMethod($type)) {
@@ -324,7 +330,7 @@ class Validator extends Component
             return true;
         }
 
-        list($message, $params) = $result;
+        [$message, $params] = $result;
         $params['attribute'] = Yii::t('yii', 'the input value');
         if (is_array($value)) {
             $params['value'] = 'array()';

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -210,12 +210,11 @@ class ActiveForm extends Widget
             $this->options['id'] = $this->getId();
         }
 
-        if (
-            Yii::$app?->useJquery &&
-            $this->enableClientScript &&
-            !$this->clientScript instanceof ActiveFormJqueryClientScript
-        ) {
-            $this->clientScript ??= ['class' => ActiveFormJqueryClientScript::class];
+        if ($this->clientScript === null && (Yii::$app->useJquery ?? false) && $this->enableClientScript) {
+            $this->clientScript = ['class' => ActiveFormJqueryClientScript::class];
+        }
+
+        if ($this->clientScript !== null && !$this->clientScript instanceof ClientScriptInterface) {
             $this->clientScript = Yii::createObject($this->clientScript);
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1402,7 +1402,7 @@ parameters:
 			message: '#^Access to an undefined property yiiunit\\data\\validators\\models\\FakedValidationModel\:\:\$attrA\.$#'
 			identifier: property.notFound
 			count: 4
-			path: tests/framework/jquery/validators/RequireValidatorJqueryClientScriptTest.php
+			path: tests/framework/jquery/validators/RequiredValidatorJqueryClientScriptTest.php
 
 		-
 			message: '#^Access to an undefined property yiiunit\\data\\validators\\models\\FakedValidationModel\:\:\$attrA\.$#'

--- a/tests/framework/jquery/validators/BooleanValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/BooleanValidatorJqueryClientScriptTest.php
@@ -1,25 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\BooleanValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see BooleanValidator} client validation script.
  */
-final class BooleanValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class BooleanValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,6 +40,9 @@ final class BooleanValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = true;
+
         $validator = new BooleanValidator(
             [
                 'trueValue' => true,
@@ -46,15 +51,14 @@ final class BooleanValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = true;
-
-        $this->assertSame(
-            'yii.validation.boolean(value, messages, {"trueValue":true,"falseValue":false,"message":"attrA ' .
-            'must be either \u0022true\u0022 or \u0022false\u0022.","skipOnEmpty":1,"strict":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.boolean(value, messages, {"trueValue":true,"falseValue":false,"message":"attrA must be either \u0022true\u0022 or \u0022false\u0022.","skipOnEmpty":1,"strict":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'trueValue' => true,
                 'falseValue' => false,
@@ -63,12 +67,12 @@ final class BooleanValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'strict' => 1,
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be either "true" or "false".',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -80,6 +84,9 @@ final class BooleanValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = true;
+
         $validator = new BooleanValidator(
             [
                 'trueValue' => true,
@@ -88,24 +95,22 @@ final class BooleanValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = true;
-
-        $this->assertNull(
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Sould return an empty array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be either "true" or "false".',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/jquery/validators/BooleanValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/BooleanValidatorJqueryClientScriptTest.php
@@ -105,7 +105,7 @@ final class BooleanValidatorJqueryClientScriptTest extends TestCase
         );
         self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            'Sould return an empty array.',
+            'Should return an empty array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);

--- a/tests/framework/jquery/validators/CompareValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/CompareValidatorJqueryClientScriptTest.php
@@ -1,25 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\CompareValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see CompareValidator} client validation script.
  */
-final class CompareValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class CompareValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,6 +40,9 @@ final class CompareValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'test_value';
+
         $validator = new CompareValidator(
             [
                 'compareValue' => 'test_value',
@@ -46,15 +51,14 @@ final class CompareValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'test_value';
-
-        $this->assertSame(
-            'yii.validation.compare(value, messages, {"operator":"==","type":"string","compareValue":' .
-            '"test_value","skipOnEmpty":1,"message":"attrA must be equal to \u0022test_value\u0022."}, $form);',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.compare(value, messages, {"operator":"==","type":"string","compareValue":"test_value","skipOnEmpty":1,"message":"attrA must be equal to \u0022test_value\u0022."}, \$form);
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'operator' => '==',
                 'type' => 'string',
@@ -63,12 +67,12 @@ final class CompareValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'message' => 'attrA must be equal to "test_value".',
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be equal to "test_value".',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -78,6 +82,7 @@ final class CompareValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithClosureCompareValue(): void
     {
         $modelValidator = new FakedValidationModel();
+
         $validator = new CompareValidator(
             [
                 'compareValue' => static fn(): string => 'closure_value',
@@ -86,13 +91,14 @@ final class CompareValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $this->assertSame(
-            'yii.validation.compare(value, messages, {"operator":"==","type":"string","compareValue":' .
-            '"closure_value","skipOnEmpty":1,"message":"attrA must be equal to \u0022closure_value\u0022."}, $form);',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.compare(value, messages, {"operator":"==","type":"string","compareValue":"closure_value","skipOnEmpty":1,"message":"attrA must be equal to \u0022closure_value\u0022."}, \$form);
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'operator' => '==',
                 'type' => 'string',
@@ -101,12 +107,12 @@ final class CompareValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'message' => 'attrA must be equal to "closure_value".',
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be equal to "closure_value".',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -116,6 +122,10 @@ final class CompareValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithNullCompareAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'test';
+        $modelValidator->attrA_repeat = 'test';
+
         $validator = new CompareValidator(
             [
                 'compareAttribute' => 'attrA_repeat',
@@ -124,17 +134,14 @@ final class CompareValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'test';
-        $modelValidator->attrA_repeat = 'test';
-
-        $this->assertSame(
-            'yii.validation.compare(value, messages, {"operator":"==","type":"string","compareAttribute":' .
-            '"fakedvalidationmodel-attra_repeat","compareAttributeName":"FakedValidationModel[attrA_repeat]",' .
-            '"skipOnEmpty":1,"message":"attrA must be equal to \u0022attrA_repeat\u0022."}, $form);',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.compare(value, messages, {"operator":"==","type":"string","compareAttribute":"fakedvalidationmodel-attra_repeat","compareAttributeName":"FakedValidationModel[attrA_repeat]","skipOnEmpty":1,"message":"attrA must be equal to \u0022attrA_repeat\u0022."}, \$form);
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'operator' => '==',
                 'type' => 'string',
@@ -144,13 +151,17 @@ final class CompareValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'message' => 'attrA must be equal to "attrA_repeat".',
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
     }
 
     public function testClientValidateAttributeWithUseJqueryFalse(): void
     {
         Yii::$app->useJquery = false;
+
+        $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'test_value';
 
         $validator = new CompareValidator(
             [
@@ -160,26 +171,22 @@ final class CompareValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator = new FakedValidationModel();
-
-        $modelValidator->attrA = 'test_value';
-
-        $this->assertNull(
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be equal to "test_value".',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/jquery/validators/EmailValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/EmailValidatorJqueryClientScriptTest.php
@@ -1,25 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\EmailValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see EmailValidator} client validation script.
  */
-final class EmailValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class EmailValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,16 +40,17 @@ final class EmailValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new EmailValidator();
 
         $modelValidator->attrA = 'test@example.com';
 
-        $this->assertSame(
-            'yii.validation.email(value, messages, {"pattern":' . $validator->pattern . ',"fullPattern":' .
-            $validator->fullPattern . ',"allowName":false,"message":"attrA is not a valid email address.",' .
-            '"enableIDN":false,"skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        $validator = new EmailValidator();
+
+        self::assertSame(
+            <<<JS
+            yii.validation.email(value, messages, {"pattern":{$validator->pattern},"fullPattern":{$validator->fullPattern},"allowName":false,"message":"attrA is not a valid email address.","enableIDN":false,"skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
@@ -55,7 +58,7 @@ final class EmailValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         $clientOptions['pattern'] = (string) ($clientOptions['pattern'] ?? '');
         $clientOptions['fullPattern'] = (string) ($clientOptions['fullPattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'pattern' => $validator->pattern,
                 'fullPattern' => $validator->fullPattern,
@@ -65,12 +68,12 @@ final class EmailValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('invalid-email', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is not a valid email address.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -80,14 +83,15 @@ final class EmailValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithEnableIDN(): void
     {
         $modelValidator = new FakedValidationModel();
+
         $validator = new EmailValidator(['enableIDN' => true]);
 
-        $this->assertSame(
-            'yii.validation.email(value, messages, {"pattern":' . $validator->pattern . ',"fullPattern":' .
-            $validator->fullPattern . ',"allowName":false,"message":"attrA is not a valid email address.",' .
-            '"enableIDN":true,"skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.email(value, messages, {"pattern":{$validator->pattern},"fullPattern":{$validator->fullPattern},"allowName":false,"message":"attrA is not a valid email address.","enableIDN":true,"skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
@@ -95,7 +99,7 @@ final class EmailValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         $clientOptions['pattern'] = (string) ($clientOptions['pattern'] ?? '');
         $clientOptions['fullPattern'] = (string) ($clientOptions['fullPattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'pattern' => $validator->pattern,
                 'fullPattern' => $validator->fullPattern,
@@ -105,12 +109,12 @@ final class EmailValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('invalid-email', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is not a valid email address.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -122,6 +126,9 @@ final class EmailValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'test@example.com';
+
         $validator = new EmailValidator(
             [
                 'allowName' => true,
@@ -129,24 +136,22 @@ final class EmailValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'test@example.com';
-
-        $this->assertNull(
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validate('invalid-email', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is not a valid email address.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/jquery/validators/FileValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/FileValidatorJqueryClientScriptTest.php
@@ -1,25 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\FileValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see FileValidator} client validation script.
  */
-final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class FileValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,6 +40,9 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'test-file.jpg';
+
         $validator = new FileValidator(
             [
                 'extensions' => [
@@ -49,19 +54,14 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'test-file.jpg';
-
-        $this->assertSame(
-            'yii.validation.file(attribute, messages, {"message":"File upload failed.","skipOnEmpty":true,' .
-            '"mimeTypes":[],"wrongMimeType":"Only files with these MIME types are allowed: .",' .
-            '"extensions":["jpg","png"],"wrongExtension":"Only files with these extensions are allowed: jpg, png.",' .
-            '"minSize":1024,"tooSmall":"The file \u0022{file}\u0022 is too small. Its size cannot be smaller than 1 KiB.",' .
-            '"maxSize":1048576,"tooBig":"The file \u0022{file}\u0022 is too big. Its size cannot exceed 1 MiB.",' .
-            '"maxFiles":1,"tooMany":"You can upload at most 1 file."});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.file(attribute, messages, {"message":"File upload failed.","skipOnEmpty":true,"mimeTypes":[],"wrongMimeType":"Only files with these MIME types are allowed: .","extensions":["jpg","png"],"wrongExtension":"Only files with these extensions are allowed: jpg, png.","minSize":1024,"tooSmall":"The file \u0022{file}\u0022 is too small. Its size cannot be smaller than 1 KiB.","maxSize":1048576,"tooBig":"The file \u0022{file}\u0022 is too big. Its size cannot exceed 1 MiB.","maxFiles":1,"tooMany":"You can upload at most 1 file."});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'message' => 'File upload failed.',
                 'skipOnEmpty' => true,
@@ -81,12 +81,12 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
 
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'Please upload a file.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -96,6 +96,7 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithMimeTypes(): void
     {
         $modelValidator = new FakedValidationModel();
+
         $validator = new FileValidator(
             [
                 'mimeTypes' => [
@@ -106,23 +107,22 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $this->assertSame(
-            'yii.validation.file(attribute, messages, {"message":"File upload failed.","skipOnEmpty":true,' .
-            '"mimeTypes":[/^image\/jpeg$/i,/^image\/png$/i],' .
-            '"wrongMimeType":"Only files with these MIME types are allowed: image\/jpeg, image\/png.",' .
-            '"extensions":[],"wrongExtension":"Only files with these extensions are allowed: .","maxFiles":3,' .
-            '"tooMany":"You can upload at most 3 files."});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.file(attribute, messages, {"message":"File upload failed.","skipOnEmpty":true,"mimeTypes":[/^image\/jpeg$/i,/^image\/png$/i],"wrongMimeType":"Only files with these MIME types are allowed: image\/jpeg, image\/png.","extensions":[],"wrongExtension":"Only files with these extensions are allowed: .","maxFiles":3,"tooMany":"You can upload at most 3 files."});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
+
         $clientOptions['mimeTypes'] = array_map(
             fn ($pattern) => (string) $pattern,
             $clientOptions['mimeTypes'] ?? [],
         );
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'message' => 'File upload failed.',
                 'skipOnEmpty' => true,
@@ -137,12 +137,12 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'tooMany' => 'You can upload at most 3 files.',
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'Please upload a file.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -152,18 +152,17 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithUploadRequired(): void
     {
         $modelValidator = new FakedValidationModel();
+
         $validator = new FileValidator(['skipOnEmpty' => false]);
 
-        $this->assertSame(
-            'yii.validation.file(attribute, messages, {"message":"File upload failed.","skipOnEmpty":false,' .
-            '"uploadRequired":"Please upload a file.","mimeTypes":[],' .
-            '"wrongMimeType":"Only files with these MIME types are allowed: .","extensions":[],' .
-            '"wrongExtension":"Only files with these extensions are allowed: .","maxFiles":1,' .
-            '"tooMany":"You can upload at most 1 file."});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.file(attribute, messages, {"message":"File upload failed.","skipOnEmpty":false,"uploadRequired":"Please upload a file.","mimeTypes":[],"wrongMimeType":"Only files with these MIME types are allowed: .","extensions":[],"wrongExtension":"Only files with these extensions are allowed: .","maxFiles":1,"tooMany":"You can upload at most 1 file."});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'message' => 'File upload failed.',
                 'skipOnEmpty' => false,
@@ -176,12 +175,12 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'tooMany' => 'You can upload at most 1 file.',
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'Please upload a file.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -191,6 +190,7 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithCustomMessages(): void
     {
         $modelValidator = new FakedValidationModel();
+
         $validator = new FileValidator(
             [
                 'extensions' => ['pdf'],
@@ -203,23 +203,22 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $this->assertSame(
-            'yii.validation.file(attribute, messages, {"message":"Custom file validation message.",' .
-            '"skipOnEmpty":true,"mimeTypes":[],"wrongMimeType":"Only files with these MIME types are allowed: .",' .
-            '"extensions":["pdf"],"wrongExtension":"Custom wrong extension message.","minSize":512,' .
-            '"tooSmall":"Custom too small message.","maxSize":2048,"tooBig":"Custom too big message.","maxFiles":1,' .
-            '"tooMany":"You can upload at most 1 file."});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.file(attribute, messages, {"message":"Custom file validation message.","skipOnEmpty":true,"mimeTypes":[],"wrongMimeType":"Only files with these MIME types are allowed: .","extensions":["pdf"],"wrongExtension":"Custom wrong extension message.","minSize":512,"tooSmall":"Custom too small message.","maxSize":2048,"tooBig":"Custom too big message.","maxFiles":1,"tooMany":"You can upload at most 1 file."});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
+
         $clientOptions['mimeTypes'] = array_map(
             fn ($pattern) => (string) $pattern,
             $clientOptions['mimeTypes'] ?? [],
         );
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'message' => 'Custom file validation message.',
                 'skipOnEmpty' => true,
@@ -235,12 +234,12 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'tooMany' => 'You can upload at most 1 file.',
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'Please upload a file.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -250,17 +249,17 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithMinimalOptions(): void
     {
         $modelValidator = new FakedValidationModel();
+
         $validator = new FileValidator();
 
-        $this->assertSame(
-            'yii.validation.file(attribute, messages, {"message":"File upload failed.","skipOnEmpty":true,' .
-            '"mimeTypes":[],"wrongMimeType":"Only files with these MIME types are allowed: .","extensions":[],' .
-            '"wrongExtension":"Only files with these extensions are allowed: .","maxFiles":1,' .
-            '"tooMany":"You can upload at most 1 file."});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.file(attribute, messages, {"message":"File upload failed.","skipOnEmpty":true,"mimeTypes":[],"wrongMimeType":"Only files with these MIME types are allowed: .","extensions":[],"wrongExtension":"Only files with these extensions are allowed: .","maxFiles":1,"tooMany":"You can upload at most 1 file."});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'message' => 'File upload failed.',
                 'skipOnEmpty' => true,
@@ -272,12 +271,12 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'tooMany' => 'You can upload at most 1 file.',
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'Please upload a file.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -289,6 +288,9 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'test-file.jpg';
+
         $validator = new FileValidator(
             [
                 'extensions' => [
@@ -300,24 +302,22 @@ final class FileValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'test-file.jpg';
-
-        $this->assertNull(
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'Please upload a file.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/jquery/validators/ImageValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/ImageValidatorJqueryClientScriptTest.php
@@ -1,25 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\ImageValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see ImageValidator} client validation script.
  */
-final class ImageValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class ImageValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,6 +40,9 @@ final class ImageValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'test-image.jpg';
+
         $validator = new ImageValidator(
             [
                 'maxHeight' => 600,
@@ -47,22 +52,14 @@ final class ImageValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'test-image.jpg';
-
-        $this->assertSame(
-            'yii.validation.image(attribute, messages, {"message":"File upload failed.","skipOnEmpty":true,' .
-            '"mimeTypes":[],"wrongMimeType":"Only files with these MIME types are allowed: .","extensions":[],' .
-            '"wrongExtension":"Only files with these extensions are allowed: .","maxFiles":1,' .
-            '"tooMany":"You can upload at most 1 file.","notImage":"The file \u0022{file}\u0022 is not an image.",' .
-            '"minWidth":100,"underWidth":"The image \u0022{file}\u0022 is too small. The width cannot be smaller than 100 pixels.",' .
-            '"maxWidth":800,"overWidth":"The image \u0022{file}\u0022 is too large. The width cannot be larger than 800 pixels.",' .
-            '"minHeight":50,"underHeight":"The image \u0022{file}\u0022 is too small. The height cannot be smaller than 50 pixels.",' .
-            '"maxHeight":600,"overHeight":"The image \u0022{file}\u0022 is too large. The height cannot be larger than 600 pixels."}, ' .
-            'deferred);',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.image(attribute, messages, {"message":"File upload failed.","skipOnEmpty":true,"mimeTypes":[],"wrongMimeType":"Only files with these MIME types are allowed: .","extensions":[],"wrongExtension":"Only files with these extensions are allowed: .","maxFiles":1,"tooMany":"You can upload at most 1 file.","notImage":"The file \u0022{file}\u0022 is not an image.","minWidth":100,"underWidth":"The image \u0022{file}\u0022 is too small. The width cannot be smaller than 100 pixels.","maxWidth":800,"overWidth":"The image \u0022{file}\u0022 is too large. The width cannot be larger than 800 pixels.","minHeight":50,"underHeight":"The image \u0022{file}\u0022 is too small. The height cannot be smaller than 50 pixels.","maxHeight":600,"overHeight":"The image \u0022{file}\u0022 is too large. The height cannot be larger than 600 pixels."}, deferred);
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'message' => 'File upload failed.',
                 'skipOnEmpty' => true,
@@ -83,12 +80,12 @@ final class ImageValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'overHeight' => 'The image "{file}" is too large. The height cannot be larger than 600 pixels.',
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'Please upload a file.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -100,6 +97,9 @@ final class ImageValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'test-image.jpg';
+
         $validator = new ImageValidator(
             [
                 'minWidth' => 100,
@@ -109,24 +109,22 @@ final class ImageValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'test-image.jpg';
-
-        $this->assertNull(
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'Please upload a file.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/jquery/validators/IpValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/IpValidatorJqueryClientScriptTest.php
@@ -1,25 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\IpValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see IpValidator} client validation script.
  */
-final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class IpValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,21 +40,19 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new IpValidator();
 
         $modelValidator->attrA = '192.168.1.1';
 
+        $validator = new IpValidator();
+
         $ipParsePattern = $this->invokeMethod($validator, 'getIpParsePattern');
 
-        $this->assertSame(
-            'yii.validation.ip(value, messages, {"ipv4Pattern":' . $validator->ipv4Pattern . ',"ipv6Pattern":' .
-            $validator->ipv6Pattern . ',"messages":{"ipv6NotAllowed":"attrA must not be an IPv6 address.",' .
-            '"ipv4NotAllowed":"attrA must not be an IPv4 address.","message":"attrA must be a valid IP address.",' .
-            '"noSubnet":"attrA must be an IP address with specified subnet.",' .
-            '"hasSubnet":"attrA must not be a subnet."},"ipv4":true,"ipv6":true,"ipParsePattern":' . $ipParsePattern .
-            ',"negation":false,"subnet":false,"skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.ip(value, messages, {"ipv4Pattern":{$validator->ipv4Pattern},"ipv6Pattern":{$validator->ipv6Pattern},"messages":{"ipv6NotAllowed":"attrA must not be an IPv6 address.","ipv4NotAllowed":"attrA must not be an IPv4 address.","message":"attrA must be a valid IP address.","noSubnet":"attrA must be an IP address with specified subnet.","hasSubnet":"attrA must not be a subnet."},"ipv4":true,"ipv6":true,"ipParsePattern":{$ipParsePattern},"negation":false,"subnet":false,"skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
@@ -61,7 +61,7 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         $clientOptions['ipv6Pattern'] = (string) ($clientOptions['ipv6Pattern'] ?? '');
         $clientOptions['ipParsePattern'] = (string) ($clientOptions['ipParsePattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'ipv4Pattern' => $validator->ipv4Pattern,
                 'ipv6Pattern' => $validator->ipv6Pattern,
@@ -80,12 +80,12 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('invalid-ip', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be a valid IP address.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -95,19 +95,17 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithIpv4Only(): void
     {
         $modelValidator = new FakedValidationModel();
+
         $validator = new IpValidator(['ipv6' => false]);
 
         $ipParsePattern = $this->invokeMethod($validator, 'getIpParsePattern');
 
-        $this->assertSame(
-            'yii.validation.ip(value, messages, {"ipv4Pattern":' . $validator->ipv4Pattern . ',"ipv6Pattern":' .
-            $validator->ipv6Pattern . ',"messages":{"ipv6NotAllowed":"attrA must not be an IPv6 address.",' .
-            '"ipv4NotAllowed":"attrA must not be an IPv4 address.","message":"attrA must be a valid IP address.",' .
-            '"noSubnet":"attrA must be an IP address with specified subnet.",' .
-            '"hasSubnet":"attrA must not be a subnet."},"ipv4":true,"ipv6":false,"ipParsePattern":' . $ipParsePattern .
-            ',"negation":false,"subnet":false,"skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.ip(value, messages, {"ipv4Pattern":{$validator->ipv4Pattern},"ipv6Pattern":{$validator->ipv6Pattern},"messages":{"ipv6NotAllowed":"attrA must not be an IPv6 address.","ipv4NotAllowed":"attrA must not be an IPv4 address.","message":"attrA must be a valid IP address.","noSubnet":"attrA must be an IP address with specified subnet.","hasSubnet":"attrA must not be a subnet."},"ipv4":true,"ipv6":false,"ipParsePattern":{$ipParsePattern},"negation":false,"subnet":false,"skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
@@ -116,7 +114,7 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         $clientOptions['ipv6Pattern'] = (string) ($clientOptions['ipv6Pattern'] ?? '');
         $clientOptions['ipParsePattern'] = (string) ($clientOptions['ipParsePattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'ipv4Pattern' => $validator->ipv4Pattern,
                 'ipv6Pattern' => $validator->ipv6Pattern,
@@ -135,12 +133,12 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('invalid-ip', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be a valid IP address.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -150,19 +148,17 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithIpv6Only(): void
     {
         $modelValidator = new FakedValidationModel();
+
         $validator = new IpValidator(['ipv4' => false]);
 
         $ipParsePattern = $this->invokeMethod($validator, 'getIpParsePattern');
 
-        $this->assertSame(
-            'yii.validation.ip(value, messages, {"ipv4Pattern":' . $validator->ipv4Pattern . ',"ipv6Pattern":' .
-            $validator->ipv6Pattern . ',"messages":{"ipv6NotAllowed":"attrA must not be an IPv6 address.",' .
-            '"ipv4NotAllowed":"attrA must not be an IPv4 address.","message":"attrA must be a valid IP address.",' .
-            '"noSubnet":"attrA must be an IP address with specified subnet.",' .
-            '"hasSubnet":"attrA must not be a subnet."},"ipv4":false,"ipv6":true,"ipParsePattern":' . $ipParsePattern .
-            ',"negation":false,"subnet":false,"skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.ip(value, messages, {"ipv4Pattern":{$validator->ipv4Pattern},"ipv6Pattern":{$validator->ipv6Pattern},"messages":{"ipv6NotAllowed":"attrA must not be an IPv6 address.","ipv4NotAllowed":"attrA must not be an IPv4 address.","message":"attrA must be a valid IP address.","noSubnet":"attrA must be an IP address with specified subnet.","hasSubnet":"attrA must not be a subnet."},"ipv4":false,"ipv6":true,"ipParsePattern":{$ipParsePattern},"negation":false,"subnet":false,"skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
@@ -171,7 +167,7 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         $clientOptions['ipv6Pattern'] = (string) ($clientOptions['ipv6Pattern'] ?? '');
         $clientOptions['ipParsePattern'] = (string) ($clientOptions['ipParsePattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'ipv4Pattern' => $validator->ipv4Pattern,
                 'ipv6Pattern' => $validator->ipv6Pattern,
@@ -190,12 +186,12 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('invalid-ip', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be a valid IP address.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -205,19 +201,17 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithSubnetRequired(): void
     {
         $modelValidator = new FakedValidationModel();
+
         $validator = new IpValidator(['subnet' => true]);
 
         $ipParsePattern = $this->invokeMethod($validator, 'getIpParsePattern');
 
-        $this->assertSame(
-            'yii.validation.ip(value, messages, {"ipv4Pattern":' . $validator->ipv4Pattern . ',"ipv6Pattern":' .
-            $validator->ipv6Pattern . ',"messages":{"ipv6NotAllowed":"attrA must not be an IPv6 address.",' .
-            '"ipv4NotAllowed":"attrA must not be an IPv4 address.","message":"attrA must be a valid IP address.",' .
-            '"noSubnet":"attrA must be an IP address with specified subnet.",' .
-            '"hasSubnet":"attrA must not be a subnet."},"ipv4":true,"ipv6":true,"ipParsePattern":' . $ipParsePattern .
-            ',"negation":false,"subnet":true,"skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.ip(value, messages, {"ipv4Pattern":{$validator->ipv4Pattern},"ipv6Pattern":{$validator->ipv6Pattern},"messages":{"ipv6NotAllowed":"attrA must not be an IPv6 address.","ipv4NotAllowed":"attrA must not be an IPv4 address.","message":"attrA must be a valid IP address.","noSubnet":"attrA must be an IP address with specified subnet.","hasSubnet":"attrA must not be a subnet."},"ipv4":true,"ipv6":true,"ipParsePattern":{$ipParsePattern},"negation":false,"subnet":true,"skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
@@ -226,7 +220,7 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         $clientOptions['ipv6Pattern'] = (string) ($clientOptions['ipv6Pattern'] ?? '');
         $clientOptions['ipParsePattern'] = (string) ($clientOptions['ipParsePattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'ipv4Pattern' => $validator->ipv4Pattern,
                 'ipv6Pattern' => $validator->ipv6Pattern,
@@ -245,12 +239,12 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('invalid-ip', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be an IP address with specified subnet.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -262,26 +256,27 @@ final class IpValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
-        $validator = new IpValidator();
 
         $modelValidator->attrA = '192.168.1.1';
 
-        $this->assertNull(
+        $validator = new IpValidator();
+
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validate('invalid-ip', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be a valid IP address.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/jquery/validators/NumberValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/NumberValidatorJqueryClientScriptTest.php
@@ -191,8 +191,6 @@ final class NumberValidatorJqueryClientScriptTest extends TestCase
     {
         Yii::$app->useJquery = false;
 
-        $modelValidator = new FakedValidationModel();
-
         $validator = new NumberValidator(
             [
                 'clientScript' => ['class' => NumberValidatorJqueryClientScript::class],

--- a/tests/framework/jquery/validators/NumberValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/NumberValidatorJqueryClientScriptTest.php
@@ -12,6 +12,8 @@ namespace yiiunit\framework\jquery\validators;
 
 use PHPUnit\Framework\Attributes\Group;
 use Yii;
+use yii\jquery\validators\NumberValidatorJqueryClientScript;
+use yii\validators\client\ClientValidatorScriptInterface;
 use yii\validators\NumberValidator;
 use yii\validators\ValidationAsset;
 use yii\web\View;
@@ -182,6 +184,30 @@ final class NumberValidatorJqueryClientScriptTest extends TestCase
             '"max":13.37',
             $js,
             "Failed asserting that the generated client validation script contains the expected 'max' value.",
+        );
+    }
+
+    public function testClientValidateAttributeWithCustomClientScriptAndUseJqueryFalse(): void
+    {
+        Yii::$app->useJquery = false;
+
+        $modelValidator = new FakedValidationModel();
+
+        $validator = new NumberValidator(
+            [
+                'clientScript' => ['class' => NumberValidatorJqueryClientScript::class],
+            ],
+        );
+
+        self::assertInstanceOf(
+            ClientValidatorScriptInterface::class,
+            $validator->clientScript,
+            'Should instantiate custom clientScript array config via Yii::createObject even when useJquery is false.',
+        );
+        self::assertInstanceOf(
+            NumberValidatorJqueryClientScript::class,
+            $validator->clientScript,
+            'Should be an instance of NumberValidatorJqueryClientScript.',
         );
     }
 

--- a/tests/framework/jquery/validators/NumberValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/NumberValidatorJqueryClientScriptTest.php
@@ -1,25 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\NumberValidator;
+use yii\validators\ValidationAsset;
 use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see NumberValidator} client validation script.
  */
-final class NumberValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class NumberValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,34 +42,36 @@ final class NumberValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new NumberValidator();
 
         $modelValidator->attrA = 123.45;
 
-        $this->assertSame(
-            'yii.validation.number(value, messages, {"pattern":/^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$/,' .
-            '"message":"attrA must be a number.","skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        $validator = new NumberValidator();
+
+        self::assertSame(
+            <<<JS
+            yii.validation.number(value, messages, {"pattern":/^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$/,"message":"attrA must be a number.","skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
 
         $clientOptions['pattern'] = (string) ($clientOptions['pattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'pattern' => $validator->numberPattern,
                 'message' => 'attrA must be a number.',
                 'skipOnEmpty' => 1,
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('invalid-number', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be a number.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -83,16 +89,25 @@ final class NumberValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'max' => 10,
             ],
         );
+
         $model = new FakedValidationModel();
 
         $js = $val->clientValidateAttribute(
             $model,
             'attr_number',
-            new View(['assetBundles' => ['yii\validators\ValidationAsset' => true]]),
+            new View(['assetBundles' => [ValidationAsset::class => true]]),
         );
 
-        $this->assertStringContainsString('"min":5', $js);
-        $this->assertStringContainsString('"max":10', $js);
+        self::assertStringContainsString(
+            '"min":5',
+            $js,
+            "Failed asserting that the generated client validation script contains the expected 'min' value.",
+        );
+        self::assertStringContainsString(
+            '"max":10',
+            $js,
+            "Failed asserting that the generated client validation script contains the expected 'max' value.",
+        );
 
         $val = new NumberValidator(
             [
@@ -105,11 +120,19 @@ final class NumberValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         $js = $val->clientValidateAttribute(
             $model,
             'attr_number',
-            new View(['assetBundles' => ['yii\validators\ValidationAsset' => true]]),
+            new View(['assetBundles' => [ValidationAsset::class => true]]),
         );
 
-        $this->assertStringContainsString('"min":5', $js);
-        $this->assertStringContainsString('"max":10', $js);
+        self::assertStringContainsString(
+            '"min":5',
+            $js,
+            "Failed asserting that the generated client validation script contains the expected 'min' value.",
+        );
+        self::assertStringContainsString(
+            '"max":10',
+            $js,
+            "Failed asserting that the generated client validation script contains the expected 'max' value.",
+        );
 
         $val = new NumberValidator(
             [
@@ -122,11 +145,19 @@ final class NumberValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         $js = $val->clientValidateAttribute(
             $model,
             'attr_number',
-            new View(['assetBundles' => ['yii\validators\ValidationAsset' => true]]),
+            new View(['assetBundles' => [ValidationAsset::class => true]]),
         );
 
-        $this->assertStringContainsString('"min":5.65', $js);
-        $this->assertStringContainsString('"max":13.37', $js);
+        self::assertStringContainsString(
+            '"min":5.65',
+            $js,
+            "Failed asserting that the generated client validation script contains the expected 'min' value.",
+        );
+        self::assertStringContainsString(
+            '"max":13.37',
+            $js,
+            "Failed asserting that the generated client validation script contains the expected 'max' value.",
+        );
 
         $val = new NumberValidator(
             [
@@ -139,11 +170,19 @@ final class NumberValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         $js = $val->clientValidateAttribute(
             $model,
             'attr_number',
-            new View(['assetBundles' => ['yii\validators\ValidationAsset' => true]]),
+            new View(['assetBundles' => [ValidationAsset::class => true]]),
         );
 
-        $this->assertStringContainsString('"min":5.65', $js);
-        $this->assertStringContainsString('"max":13.37', $js);
+        self::assertStringContainsString(
+            '"min":5.65',
+            $js,
+            "Failed asserting that the generated client validation script contains the expected 'min' value.",
+        );
+        self::assertStringContainsString(
+            '"max":13.37',
+            $js,
+            "Failed asserting that the generated client validation script contains the expected 'max' value.",
+        );
     }
 
     public function testClientValidateAttributeWithUseJqueryFalse(): void
@@ -151,6 +190,9 @@ final class NumberValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 50;
+
         $validator = new NumberValidator(
             [
                 'min' => 10,
@@ -158,24 +200,22 @@ final class NumberValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 50;
-
-        $this->assertNull(
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validate(5, $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be no less than 10.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/jquery/validators/RangeValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/RangeValidatorJqueryClientScriptTest.php
@@ -1,25 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\RangeValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see RangeValidator} client validation script.
  */
-final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class RangeValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,6 +40,9 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'apple';
+
         $validator = new RangeValidator(
             [
                 'range' => [
@@ -48,15 +53,14 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'apple';
-
-        $this->assertSame(
-            'yii.validation.range(value, messages, {"range":["apple","banana","cherry"],"not":false,' .
-            '"message":"attrA is invalid.","skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.range(value, messages, {"range":["apple","banana","cherry"],"not":false,"message":"attrA is invalid.","skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'range' => ['apple', 'banana', 'cherry'],
                 'not' => false,
@@ -64,12 +68,12 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is invalid.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -79,6 +83,9 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithAllowArray(): void
     {
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = ['red', 'blue'];
+
         $validator = new RangeValidator(
             [
                 'range' => [
@@ -90,15 +97,14 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = ['red', 'blue'];
-
-        $this->assertSame(
-            'yii.validation.range(value, messages, {"range":["blue","green","red"],"not":false,' .
-            '"message":"attrA is invalid.","skipOnEmpty":1,"allowArray":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.range(value, messages, {"range":["blue","green","red"],"not":false,"message":"attrA is invalid.","skipOnEmpty":1,"allowArray":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'range' => [
                     'blue',
@@ -111,7 +117,7 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'allowArray' => 1,
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate(
@@ -122,7 +128,7 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             $errorMessage,
         );
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is invalid.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -132,6 +138,9 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithClosureRange(): void
     {
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'dynamic1';
+
         $validator = new RangeValidator(
             [
                 'range' => static fn(): array => [
@@ -142,15 +151,14 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'dynamic1';
-
-        $this->assertSame(
-            'yii.validation.range(value, messages, {"range":["dynamic1","dynamic2","dynamic3"],"not":false,' .
-            '"message":"attrA is invalid.","skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.range(value, messages, {"range":["dynamic1","dynamic2","dynamic3"],"not":false,"message":"attrA is invalid.","skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'range' => [
                     'dynamic1',
@@ -162,12 +170,12 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is invalid.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -179,6 +187,9 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'option1';
+
         $validator = new RangeValidator(
             [
                 'range' => [
@@ -190,24 +201,22 @@ final class RangeValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'option1';
-
-        $this->assertNull(
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is invalid.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/jquery/validators/RegularExpressionValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/RegularExpressionValidatorJqueryClientScriptTest.php
@@ -1,25 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\RegularExpressionValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see RegularExpressionValidator} client validation script.
  */
-final class RegularExpressionValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class RegularExpressionValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,22 +40,24 @@ final class RegularExpressionValidatorJqueryClientScriptTest extends \yiiunit\Te
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new RegularExpressionValidator(['pattern' => '/^[a-zA-Z0-9]+$/']);
 
         $modelValidator->attrA = 'apple';
 
-        $this->assertSame(
-            'yii.validation.regularExpression(value, messages, {"pattern":/^[a-zA-Z0-9]+$/,"not":false,' .
-            '"message":"attrA is invalid.","skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        $validator = new RegularExpressionValidator(['pattern' => '/^[a-zA-Z0-9]+$/']);
+
+        self::assertSame(
+            <<<JS
+            yii.validation.regularExpression(value, messages, {"pattern":/^[a-zA-Z0-9]+$/,"not":false,"message":"attrA is invalid.","skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
 
         $clientOptions['pattern'] = (string) ($clientOptions['pattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'pattern' => '/^[a-zA-Z0-9]+$/',
                 'not' => false,
@@ -61,12 +65,12 @@ final class RegularExpressionValidatorJqueryClientScriptTest extends \yiiunit\Te
                 'skipOnEmpty' => 1,
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue!', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is invalid.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -78,26 +82,27 @@ final class RegularExpressionValidatorJqueryClientScriptTest extends \yiiunit\Te
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
-        $validator = new RegularExpressionValidator(['pattern' => '/^[a-zA-Z0-9]+$/']);
 
         $modelValidator->attrA = 'option1';
 
-        $this->assertNull(
+        $validator = new RegularExpressionValidator(['pattern' => '/^[a-zA-Z0-9]+$/']);
+
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validate('someIncorrectValue!', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is invalid.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/jquery/validators/RequiredValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/RequiredValidatorJqueryClientScriptTest.php
@@ -1,25 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\RequiredValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see RequiredValidator} client validation script.
  */
-final class RequireValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class RequiredValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,24 +40,27 @@ final class RequireValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new RequiredValidator();
 
         $modelValidator->attrA = 'test_value';
 
-        $this->assertSame(
-            'yii.validation.required(value, messages, {"message":"attrA cannot be blank."});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        $validator = new RequiredValidator();
+
+        self::assertSame(
+            <<<JS
+            yii.validation.required(value, messages, {"message":"attrA cannot be blank."});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             ['message' => 'attrA cannot be blank.'],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value cannot be blank.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -65,28 +70,30 @@ final class RequireValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithRequiredValue(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new RequiredValidator(['requiredValue' => 'expected_value']);
 
         $modelValidator->attrA = 'expected_value';
 
-        $this->assertSame(
-            'yii.validation.required(value, messages, {"message":"attrA must be \u0022expected_value\u0022.",' .
-            '"requiredValue":"expected_value"});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        $validator = new RequiredValidator(['requiredValue' => 'expected_value']);
+
+        self::assertSame(
+            <<<JS
+            yii.validation.required(value, messages, {"message":"attrA must be \u0022expected_value\u0022.","requiredValue":"expected_value"});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'message' => 'attrA must be "expected_value".',
                 'requiredValue' => 'expected_value',
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be "expected_value".',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -96,27 +103,30 @@ final class RequireValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithStrictMode(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new RequiredValidator(['strict' => true]);
 
         $modelValidator->attrA = 'test_value';
 
-        $this->assertSame(
-            'yii.validation.required(value, messages, {"message":"attrA cannot be blank.","strict":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        $validator = new RequiredValidator(['strict' => true]);
+
+        self::assertSame(
+            <<<JS
+            yii.validation.required(value, messages, {"message":"attrA cannot be blank.","strict":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'message' => 'attrA cannot be blank.',
                 'strict' => 1,
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate(null, $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value cannot be blank.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -128,6 +138,9 @@ final class RequireValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'test_value';
+
         $validator = new RequiredValidator(
             [
                 'requiredValue' => 'test_value',
@@ -135,24 +148,22 @@ final class RequireValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'test_value';
-
-        $this->assertNull(
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value must be "test_value".',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/jquery/validators/StringValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/StringValidatorJqueryClientScriptTest.php
@@ -1,25 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\StringValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see StringValidator} client validation script.
  */
-final class StringValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class StringValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,6 +40,9 @@ final class StringValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'test';
+
         $validator = new StringValidator(
             [
                 'min' => 3,
@@ -45,16 +50,14 @@ final class StringValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'test';
-
-        $this->assertSame(
-            'yii.validation.string(value, messages, {"message":"attrA must be a string.","min":3,' .
-            '"tooShort":"attrA should contain at least 3 characters.","max":10,' .
-            '"tooLong":"attrA should contain at most 10 characters.","skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.string(value, messages, {"message":"attrA must be a string.","min":3,"tooShort":"attrA should contain at least 3 characters.","max":10,"tooLong":"attrA should contain at most 10 characters.","skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'message' => 'attrA must be a string.',
                 'min' => 3,
@@ -64,12 +67,12 @@ final class StringValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('so', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value should contain at least 3 characters.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -79,17 +82,19 @@ final class StringValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithLength(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new StringValidator(['length' => 5]);
 
         $modelValidator->attrA = 'hello';
 
-        $this->assertSame(
-            'yii.validation.string(value, messages, {"message":"attrA must be a string.","is":5,' .
-            '"notEqual":"attrA should contain 5 characters.","skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        $validator = new StringValidator(['length' => 5]);
+
+        self::assertSame(
+            <<<JS
+            yii.validation.string(value, messages, {"message":"attrA must be a string.","is":5,"notEqual":"attrA should contain 5 characters.","skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'message' => 'attrA must be a string.',
                 'is' => 5,
@@ -97,12 +102,12 @@ final class StringValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value should contain 5 characters.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -114,6 +119,9 @@ final class StringValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'test';
+
         $validator = new StringValidator(
             [
                 'min' => 3,
@@ -121,24 +129,22 @@ final class StringValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'test';
-
-        $this->assertNull(
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validate('so', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value should contain at least 3 characters.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/jquery/validators/TrimValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/TrimValidatorJqueryClientScriptTest.php
@@ -1,25 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\TrimValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
- * @group validators
+ * Unit tests for {@see TrimValidator} client validation script.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 2.2
  */
-final class TrimValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class TrimValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -38,29 +43,31 @@ final class TrimValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new TrimValidator();
 
         $modelValidator->attrA = '  test value  ';
 
-        $this->assertSame(
-            'value = yii.validation.trim($form, attribute, {"skipOnArray":false,"skipOnEmpty":false,' .
-            '"chars":false}, value);',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        $validator = new TrimValidator();
+
+        self::assertSame(
+            <<<JS
+            value = yii.validation.trim(\$form, attribute, {"skipOnArray":false,"skipOnEmpty":false,"chars":false}, value);
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'skipOnArray' => false,
                 'skipOnEmpty' => false,
                 'chars' => false,
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validateAttribute($modelValidator, 'attrA');
 
-        $this->assertSame(
+        self::assertSame(
             'test value',
             $modelValidator->attrA,
             'Should trim the attribute value.',
@@ -70,31 +77,28 @@ final class TrimValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithSkipOnArray(): void
     {
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = ['  test  ', '  value  '];
+
         $validator = new TrimValidator(['skipOnArray' => true]);
 
-        $modelValidator->attrA = [
-            '  test  ',
-            '  value  ',
-        ];
-
-        $this->assertEmpty(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return empty string when 'skipOnArray' is 'true' and  value " .
-            'is array.',
+        self::assertEmpty(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return empty string when 'skipOnArray' is 'true' and value is array.",
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'skipOnArray' => true,
                 'skipOnEmpty' => false,
                 'chars' => false,
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validateAttribute($modelValidator, 'attrA');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 '  test  ',
                 '  value  ',
@@ -109,26 +113,27 @@ final class TrimValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
-        $validator = new TrimValidator(['chars' => '/-']);
 
         $modelValidator->attrA = '//test-value--';
 
-        $this->assertNull(
+        $validator = new TrimValidator(['chars' => '/-']);
+
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validateAttribute($modelValidator, 'attrA');
 
-        $this->assertSame(
+        self::assertSame(
             'test-value',
             $modelValidator->attrA,
             'Should trim custom characters from the attribute value.',

--- a/tests/framework/jquery/validators/UrlValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/UrlValidatorJqueryClientScriptTest.php
@@ -1,24 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\jquery\validators;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\UrlValidator;
-use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\TestCase;
 
 /**
- * @group jquery
+ * Unit tests for {@see UrlValidator} client validation script.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 2.2
  */
-final class UrlValidatorJqueryClientScriptTest extends \yiiunit\TestCase
+#[Group('jquery')]
+#[Group('validators')]
+final class UrlValidatorJqueryClientScriptTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -37,23 +43,24 @@ final class UrlValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttribute(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new UrlValidator();
 
         $modelValidator->attrA = 'https://www.example.com';
 
-        $this->assertSame(
-            'yii.validation.url(value, messages, {' .
-            '"pattern":/^(http|https):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(?::\d{1,5})?(?:$|[?\/#])/i,' .
-            '"message":"attrA is not a valid URL.","enableIDN":false,"skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        $validator = new UrlValidator();
+
+        self::assertSame(
+            <<<JS
+            yii.validation.url(value, messages, {"pattern":/^(http|https):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(?::\d{1,5})?(?:$|[?\/#])/i,"message":"attrA is not a valid URL.","enableIDN":false,"skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
 
         $clientOptions['pattern'] = (string) ($clientOptions['pattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'pattern' => '/^(http|https):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(?::\d{1,5})?(?:$|[?\/#])/i',
                 'message' => 'attrA is not a valid URL.',
@@ -61,12 +68,12 @@ final class UrlValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is not a valid URL.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -76,22 +83,24 @@ final class UrlValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithCustomPattern(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new UrlValidator(['pattern' => '/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)/i']);
 
         $modelValidator->attrA = 'example.com';
 
-        $this->assertSame(
-            'yii.validation.url(value, messages, {"pattern":/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)/i,' .
-            '"message":"attrA is not a valid URL.","enableIDN":false,"skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        $validator = new UrlValidator(['pattern' => '/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)/i']);
+
+        self::assertSame(
+            <<<JS
+            yii.validation.url(value, messages, {"pattern":/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)/i,"message":"attrA is not a valid URL.","enableIDN":false,"skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
 
         $clientOptions['pattern'] = (string) ($clientOptions['pattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'pattern' => '/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)/i',
                 'message' => 'attrA is not a valid URL.',
@@ -99,12 +108,12 @@ final class UrlValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is not a valid URL.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -114,23 +123,24 @@ final class UrlValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithDefaultScheme(): void
     {
         $modelValidator = new FakedValidationModel();
-        $validator = new UrlValidator(['defaultScheme' => 'https']);
 
         $modelValidator->attrA = 'www.example.com';
 
-        $this->assertSame(
-            'yii.validation.url(value, messages, {' .
-            '"pattern":/^(http|https):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(?::\d{1,5})?(?:$|[?\/#])/i,' .
-            '"message":"attrA is not a valid URL.","enableIDN":false,"skipOnEmpty":1,"defaultScheme":"https"});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        $validator = new UrlValidator(['defaultScheme' => 'https']);
+
+        self::assertSame(
+            <<<JS
+            yii.validation.url(value, messages, {"pattern":/^(http|https):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(?::\d{1,5})?(?:$|[?\/#])/i,"message":"attrA is not a valid URL.","enableIDN":false,"skipOnEmpty":1,"defaultScheme":"https"});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
 
         $clientOptions['pattern'] = (string) ($clientOptions['pattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'pattern' => '/^(http|https):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(?::\d{1,5})?(?:$|[?\/#])/i',
                 'message' => 'attrA is not a valid URL.',
@@ -139,12 +149,12 @@ final class UrlValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'defaultScheme' => 'https',
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is not a valid URL.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -154,21 +164,22 @@ final class UrlValidatorJqueryClientScriptTest extends \yiiunit\TestCase
     public function testClientValidateAttributeWithEnableIDN(): void
     {
         $modelValidator = new FakedValidationModel();
+
         $validator = new UrlValidator(['enableIDN' => true]);
 
-        $this->assertSame(
-            'yii.validation.url(value, messages, {' .
-            '"pattern":/^(http|https):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(?::\d{1,5})?(?:$|[?\/#])/i,' .
-            '"message":"attrA is not a valid URL.","enableIDN":true,"skipOnEmpty":1});',
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return correct validation script.",
+        self::assertSame(
+            <<<JS
+            yii.validation.url(value, messages, {"pattern":/^(http|https):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(?::\d{1,5})?(?:$|[?\/#])/i,"message":"attrA is not a valid URL.","enableIDN":true,"skipOnEmpty":1});
+            JS,
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            'Should return correct validation script.',
         );
 
         $clientOptions = $validator->getClientOptions($modelValidator, 'attrA');
 
         $clientOptions['pattern'] = (string) ($clientOptions['pattern'] ?? '');
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'pattern' => '/^(http|https):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(?::\d{1,5})?(?:$|[?\/#])/i',
                 'message' => 'attrA is not a valid URL.',
@@ -176,12 +187,12 @@ final class UrlValidatorJqueryClientScriptTest extends \yiiunit\TestCase
                 'skipOnEmpty' => 1,
             ],
             $clientOptions,
-            "'getClientOptions()' method should return correct options array.",
+            'Should return correct options array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is not a valid URL.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',
@@ -193,6 +204,9 @@ final class UrlValidatorJqueryClientScriptTest extends \yiiunit\TestCase
         Yii::$app->useJquery = false;
 
         $modelValidator = new FakedValidationModel();
+
+        $modelValidator->attrA = 'https://www.example.com';
+
         $validator = new UrlValidator(
             [
                 'validSchemes' => [
@@ -204,24 +218,22 @@ final class UrlValidatorJqueryClientScriptTest extends \yiiunit\TestCase
             ],
         );
 
-        $modelValidator->attrA = 'https://www.example.com';
-
-        $this->assertNull(
+        self::assertNull(
             $validator->clientScript,
-            "'ClientScript' property should be 'null' when 'useJquery' is 'false'.",
+            "Should be 'null' when 'useJquery' is 'false'.",
         );
-        $this->assertNull(
-            $validator->clientValidateAttribute($modelValidator, 'attrA', new View()),
-            "'clientValidateAttribute()' method should return 'null' value.",
+        self::assertNull(
+            $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
+            "Should return 'null' value.",
         );
-        $this->assertEmpty(
+        self::assertEmpty(
             $validator->getClientOptions($modelValidator, 'attrA'),
-            "'getClientOptions()' method should return an empty array.",
+            'Should return an empty array.',
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
 
-        $this->assertSame(
+        self::assertSame(
             'the input value is not a valid URL.',
             $errorMessage,
             'Failed asserting that the generated error message matches the expected one.',

--- a/tests/framework/validators/BooleanValidatorTest.php
+++ b/tests/framework/validators/BooleanValidatorTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yiiunit\framework\validators;
 
 use yii\validators\BooleanValidator;
+use yii\web\View;
 use yiiunit\data\validators\models\FakedValidationModel;
 use yiiunit\TestCase;
 
@@ -73,5 +74,25 @@ class BooleanValidatorTest extends TestCase
         $this->assertFalse($obj->hasErrors('attrB'));
         $val->validateAttribute($obj, 'attrD');
         $this->assertTrue($obj->hasErrors('attrD'));
+    }
+
+    public function testClientValidateAttributeReturnsNullWithoutJquery(): void
+    {
+        $this->destroyApplication();
+
+        $validator = new BooleanValidator(
+            [
+                'trueValue' => true,
+                'falseValue' => false,
+                'strict' => true,
+            ],
+        );
+        $obj = new FakedValidationModel();
+        $obj->attrB = '1';
+
+        self::assertNull(
+            $validator->clientValidateAttribute($obj, 'attrB', new View()),
+            "Should return 'null' when no application context exists.",
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

Related: #20582
