### PR TITLE
 Fix `CompareValidator` client-side closure `compareValue` resolution to pass `($model, $attribute)` and avoid mutating validator state.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -37,6 +37,7 @@ Yii Framework 2 Change Log
 - Chg #20808: Rename `ApcCache` to `ApcuCache` and remove legacy APC extension support (terabytesoftw)
 - Bug: Fix `ActiveField::generateLabel()` to strip `label`/`for` attributes for custom tags and preserve prior label in `radio()`/`checkbox()` (terabytesoftw)
 - Bug: Fix `clientScript` not being instantiated in validators when a custom array config is set and `useJquery` is `false` (terabytesoftw)
+- Bug: Fix `CompareValidator` client-side closure `compareValue` resolution to pass `($model, $attribute)` and avoid mutating validator state (terabytesoftw)
 
 
 2.0.55 under development

--- a/framework/jquery/validators/CompareValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/CompareValidatorJqueryClientScript.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yii\jquery\validators;
 
+use Closure;
 use yii\base\Model;
 use yii\helpers\Html;
 use yii\helpers\Json;
@@ -19,8 +20,10 @@ use yii\validators\ValidationAsset;
 use yii\validators\Validator;
 use yii\web\View;
 
+use function call_user_func;
+
 /**
- * CompareValidatorJqueryClientScript provides client-side validation script generation for attribute comparison.
+ * Provides client-side validation script generation for attribute comparison.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for comparison validation in Yii2 forms using jQuery.
@@ -29,20 +32,26 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 2.2
  */
 class CompareValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {
     public function getClientOptions(Validator $validator, Model $model, string $attribute): array
     {
+        $resolvedCompareValue = $validator->compareValue;
+
+        if ($resolvedCompareValue instanceof Closure) {
+            $resolvedCompareValue = call_user_func($resolvedCompareValue, $model, $attribute);
+        }
+
         $options = [
             'operator' => $validator->operator,
             'type' => $validator->type,
         ];
 
-        if ($validator->compareValue !== null) {
-            $options['compareValue'] = $validator->compareValue;
-            $compareLabel = $compareValue = $compareValueOrAttribute = $validator->compareValue;
+        if ($resolvedCompareValue !== null) {
+            $options['compareValue'] = $resolvedCompareValue;
+            $compareLabel = $compareValue = $compareValueOrAttribute = $resolvedCompareValue;
         } else {
             $compareAttribute = $validator->compareAttribute === null ? $attribute . '_repeat' : $validator->compareAttribute;
 
@@ -71,10 +80,6 @@ class CompareValidatorJqueryClientScript implements ClientValidatorScriptInterfa
 
     public function register(Validator $validator, Model $model, string $attribute, View $view): string
     {
-        if ($validator->compareValue != null && $validator->compareValue instanceof \Closure) {
-            $validator->compareValue = call_user_func($validator->compareValue);
-        }
-
         ValidationAsset::register($view);
 
         $options = $this->getClientOptions($validator, $model, $attribute);

--- a/tests/framework/jquery/validators/CompareValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/CompareValidatorJqueryClientScriptTest.php
@@ -83,13 +83,13 @@ final class CompareValidatorJqueryClientScriptTest extends TestCase
     {
         $modelValidator = new FakedValidationModel();
 
-        $validator = new CompareValidator(
-            [
-                'compareValue' => static fn(): string => 'closure_value',
-                'operator' => '==',
-                'type' => CompareValidator::TYPE_STRING,
-            ],
-        );
+        $closureConfig = [
+            'compareValue' => static fn(FakedValidationModel $model, string $attribute): string => 'closure_value',
+            'operator' => '==',
+            'type' => CompareValidator::TYPE_STRING,
+        ];
+
+        $validator = new CompareValidator($closureConfig);
 
         self::assertSame(
             <<<JS
@@ -98,6 +98,9 @@ final class CompareValidatorJqueryClientScriptTest extends TestCase
             $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
             'Should return correct validation script.',
         );
+
+        $validator = new CompareValidator($closureConfig);
+
         self::assertSame(
             [
                 'operator' => '==',
@@ -108,6 +111,14 @@ final class CompareValidatorJqueryClientScriptTest extends TestCase
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
             'Should return correct options array.',
+        );
+
+        $validator = new CompareValidator(
+            [
+                'compareValue' => static fn(): string => 'closure_value',
+                'operator' => '==',
+                'type' => CompareValidator::TYPE_STRING,
+            ],
         );
 
         $validator->validate('someIncorrectValue', $errorMessage);
@@ -128,7 +139,6 @@ final class CompareValidatorJqueryClientScriptTest extends TestCase
 
         $validator = new CompareValidator(
             [
-                'compareAttribute' => 'attrA_repeat',
                 'operator' => '==',
                 'type' => CompareValidator::TYPE_STRING,
             ],

--- a/tests/framework/jquery/validators/CompareValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/CompareValidatorJqueryClientScriptTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\jquery\validators;
 
+use Closure;
 use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\validators\CompareValidator;
@@ -81,8 +82,6 @@ final class CompareValidatorJqueryClientScriptTest extends TestCase
 
     public function testClientValidateAttributeWithClosureCompareValue(): void
     {
-        $modelValidator = new FakedValidationModel();
-
         $closureConfig = [
             'compareValue' => static fn(FakedValidationModel $model, string $attribute): string => 'closure_value',
             'operator' => '==',
@@ -91,6 +90,13 @@ final class CompareValidatorJqueryClientScriptTest extends TestCase
 
         $validator = new CompareValidator($closureConfig);
 
+        $modelValidator = new FakedValidationModel();
+
+        self::assertInstanceOf(
+            Closure::class,
+            $validator->compareValue,
+            'Should start as Closure before client validation.',
+        );
         self::assertSame(
             <<<JS
             yii.validation.compare(value, messages, {"operator":"==","type":"string","compareValue":"closure_value","skipOnEmpty":1,"message":"attrA must be equal to \u0022closure_value\u0022."}, \$form);
@@ -98,8 +104,19 @@ final class CompareValidatorJqueryClientScriptTest extends TestCase
             $validator->clientValidateAttribute($modelValidator, 'attrA', Yii::$app->view),
             'Should return correct validation script.',
         );
+        self::assertInstanceOf(
+            Closure::class,
+            $validator->compareValue,
+            'Should not resolve compareValue in-place.',
+        );
 
         $validator = new CompareValidator($closureConfig);
+
+        self::assertInstanceOf(
+            Closure::class,
+            $validator->compareValue,
+            'Should start as Closure before client validation.',
+        );
 
         self::assertSame(
             [
@@ -111,6 +128,11 @@ final class CompareValidatorJqueryClientScriptTest extends TestCase
             ],
             $validator->getClientOptions($modelValidator, 'attrA'),
             'Should return correct options array.',
+        );
+        self::assertInstanceOf(
+            Closure::class,
+            $validator->compareValue,
+            'Should not resolve compareValue in-place.',
         );
 
         $validator = new CompareValidator(

--- a/tests/framework/validators/CompareValidatorTest.php
+++ b/tests/framework/validators/CompareValidatorTest.php
@@ -199,8 +199,9 @@ final class CompareValidatorTest extends TestCase
         $validator = new CompareValidator(
             [
                 'compareValue' => 10,
-                'type' => CompareValidator::TYPE_NUMBER],
-            );
+                'type' => CompareValidator::TYPE_NUMBER,
+            ],
+        );
 
         self::assertTrue(
             $validator->validate(10),
@@ -266,9 +267,21 @@ final class CompareValidatorTest extends TestCase
     {
         $expectedValue = 42;
         $closureExecuted = false;
+        $receivedModel = null;
+        $receivedAttribute = null;
 
-        $closure = static function () use ($expectedValue, &$closureExecuted): int {
+        $closure = static function (
+            FakedValidationModel $model,
+            string $attribute,
+        ) use (
+            $expectedValue,
+            &$closureExecuted,
+            &$receivedModel,
+            &$receivedAttribute,
+        ): int {
             $closureExecuted = true;
+            $receivedModel = $model;
+            $receivedAttribute = $attribute;
 
             return $expectedValue;
         };
@@ -288,6 +301,16 @@ final class CompareValidatorTest extends TestCase
         self::assertTrue(
             $closureExecuted,
             'Closure should be executed during validation.',
+        );
+        self::assertSame(
+            $model,
+            $receivedModel,
+            'Closure should receive the model as first parameter.',
+        );
+        self::assertSame(
+            'attr_test',
+            $receivedAttribute,
+            'Closure should receive the attribute as second parameter.',
         );
         self::assertFalse(
             $model->hasErrors('attr_test'),
@@ -768,7 +791,7 @@ final class CompareValidatorTest extends TestCase
     public function testClientValidateAttributeWithClosureCompareValue(): void
     {
         $closureConfig = [
-            'compareValue' => static fn(): string => 'closure_value',
+            'compareValue' => static fn(FakedValidationModel $model, string $attribute): string => 'closure_value',
             'operator' => '==',
             'type' => CompareValidator::TYPE_STRING,
         ];
@@ -799,7 +822,13 @@ final class CompareValidatorTest extends TestCase
             'Should return correct options array.',
         );
 
-        $validator3 = new CompareValidator($closureConfig);
+        $validator3 = new CompareValidator(
+            [
+                'compareValue' => static fn(): string => 'closure_value',
+                'operator' => '==',
+                'type' => CompareValidator::TYPE_STRING,
+            ],
+        );
 
         $errorMessage = null;
 

--- a/tests/framework/validators/CompareValidatorTest.php
+++ b/tests/framework/validators/CompareValidatorTest.php
@@ -795,34 +795,32 @@ final class CompareValidatorTest extends TestCase
     public function testClientValidateAttributeWithClosureCompareValue(): void
     {
         $closureConfig = [
-            'compareValue' => static fn(FakedValidationModel $model, string $attribute): string => 'closure_value',
+            'compareValue' => static fn(FakedValidationModel $model, string $attribute): string => "{$attribute}_value",
             'operator' => '==',
             'type' => CompareValidator::TYPE_STRING,
         ];
 
-        $validator1 = new CompareValidator($closureConfig);
+        $validator = new CompareValidator($closureConfig);
 
         $model = new FakedValidationModel();
 
         self::assertSame(
             <<<JS
-            yii.validation.compare(value, messages, {"operator":"==","type":"string","compareValue":"closure_value","skipOnEmpty":1,"message":"attrA must be equal to \u0022closure_value\u0022."}, \$form);
+            yii.validation.compare(value, messages, {"operator":"==","type":"string","compareValue":"attrA_value","skipOnEmpty":1,"message":"attrA must be equal to \u0022attrA_value\u0022."}, \$form);
             JS,
-            $validator1->clientValidateAttribute($model, 'attrA', Yii::$app->getView()),
+            $validator->clientValidateAttribute($model, 'attrA', Yii::$app->getView()),
             'Should return correct validation script.',
         );
-
-        $validator2 = new CompareValidator($closureConfig);
 
         self::assertSame(
             [
                 'operator' => '==',
                 'type' => 'string',
-                'compareValue' => 'closure_value',
+                'compareValue' => 'attrB_value',
                 'skipOnEmpty' => 1,
-                'message' => 'attrA must be equal to "closure_value".',
+                'message' => 'attrB must be equal to "attrB_value".',
             ],
-            $validator2->getClientOptions($model, 'attrA'),
+            $validator->getClientOptions($model, 'attrB'),
             'Should return correct options array.',
         );
 

--- a/tests/framework/validators/CompareValidatorTest.php
+++ b/tests/framework/validators/CompareValidatorTest.php
@@ -491,6 +491,8 @@ final class CompareValidatorTest extends TestCase
             "'getClientOptions()' should return correct options array.",
         );
 
+        $errorMessage = null;
+
         $validator->validate('someIncorrectValue', $errorMessage);
 
         self::assertSame(
@@ -558,6 +560,8 @@ final class CompareValidatorTest extends TestCase
                 'compareValue' => 'expected',
             ],
         );
+
+        $error = null;
 
         $validator->validate('wrong', $error);
 

--- a/tests/framework/validators/CompareValidatorTest.php
+++ b/tests/framework/validators/CompareValidatorTest.php
@@ -1,31 +1,37 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\validators;
 
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\validators\CompareValidator;
 use yiiunit\data\validators\models\FakedValidationModel;
+use yiiunit\framework\validators\providers\CompareValidatorProvider;
 use yiiunit\TestCase;
 
 /**
- * @group validators
+ * Unit test for {@see CompareValidator}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 2.2
  */
-class CompareValidatorTest extends TestCase
+#[Group('validators')]
+final class CompareValidatorTest extends TestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->mockApplication();
+        $this->mockWebApplication();
     }
 
     protected function tearDown(): void
@@ -37,364 +43,807 @@ class CompareValidatorTest extends TestCase
 
     public function testValidateValueException(): void
     {
-        $this->expectException('yii\base\InvalidConfigException');
-        $val = new CompareValidator();
-        $val->validate('val');
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('CompareValidator::compareValue must be set.');
+
+        $validator = new CompareValidator();
+
+        $validator->validate('val');
     }
 
-    public function testValidateValue(): void
-    {
-        $value = 18449;
-        // default config
-        $val = new CompareValidator(['compareValue' => $value]);
-        $this->assertTrue($val->validate($value));
-        $this->assertTrue($val->validate((string) $value));
-        $this->assertFalse($val->validate($value + 1));
+    #[DataProviderExternal(CompareValidatorProvider::class, 'validateValue')]
+    public function testValidateValue(
+        array $validatorConfig,
+        mixed $inputValue,
+        bool $expectedResult,
+        string $expectedMessage,
+    ): void {
+        $validator = new CompareValidator($validatorConfig);
 
-        // Using a closure for compareValue
-        $val = new CompareValidator(['compareValue' => function () use ($value) {
-            return $value;
-        }]);
-        $this->assertTrue($val->validate($value));
-        $this->assertTrue($val->validate((string) $value));
-        $this->assertFalse($val->validate($value + 1));
+        self::assertSame(
+            $expectedResult,
+            $validator->validate($inputValue),
+            $expectedMessage,
+        );
+    }
 
-        foreach ($this->getOperationTestData($value) as $op => $tests) {
-            $val = new CompareValidator(['compareValue' => $value]);
-            $val->operator = $op;
-            foreach ($tests as $test) {
-                $this->assertEquals($test[1], $val->validate($test[0]), "Testing $op");
-            }
+    #[DataProviderExternal(CompareValidatorProvider::class, 'validateAttribute')]
+    public function testValidateAttribute(
+        array $validatorConfig,
+        array $attributes,
+        string $validateAttribute,
+        bool $expectedHasErrors,
+        string $expectedMessage,
+        array $additionalErrors = [],
+    ): void {
+        $validator = new CompareValidator($validatorConfig);
+
+        $model = FakedValidationModel::createWithAttributes($attributes);
+
+        foreach ($additionalErrors as $attr => $error) {
+            $model->addError($attr, $error);
         }
+
+        $validator->validateAttribute($model, $validateAttribute);
+
+        self::assertSame(
+            $expectedHasErrors,
+            $model->hasErrors($validateAttribute),
+            $expectedMessage,
+        );
     }
 
-    /**
-     * @phpstan-return array<string, array<int, array{mixed, bool}>>
-     */
-    protected function getOperationTestData(int $value): array
+    public function testValidateAttributeWithArrayValue(): void
     {
-        return [
-            '===' => [
-                [$value, true],
-                [(string) $value, true],
-                [(float) $value, true],
-                [$value + 1, false],
-            ],
-            '!=' => [
-                [$value, false],
-                [(string) $value, false],
-                [(float) $value, false],
-                [$value + 0.00001, true],
-                [false, true],
-            ],
-            '!==' => [
-                [$value, false],
-                [(string) $value, false],
-                [(float) $value, false],
-                [false, true],
-            ],
-            '>' => [
-                [$value, false],
-                [$value + 1, true],
-                [$value - 1, false],
-            ],
-            '>=' => [
-                [$value, true],
-                [$value + 1, true],
-                [$value - 1, false],
-            ],
-            '<' => [
-                [$value, false],
-                [$value + 1, false],
-                [$value - 1, true],
-            ],
-            '<=' => [
-                [$value, true],
-                [$value + 1, false],
-                [$value - 1, true],
-            ],
-            /*'non-op' => [
-                [$value, false],
-                [$value + 1, false],
-                [$value - 1, false],
-            ],*/
-        ];
-    }
+        $validator = new CompareValidator();
 
-    public function testValidateAttribute(): void
-    {
-        // invalid-array
-        $val = new CompareValidator();
         $model = new FakedValidationModel();
+
         $model->attr = ['test_val'];
-        $val->validateAttribute($model, 'attr');
-        $this->assertTrue($model->hasErrors('attr'));
-        $val = new CompareValidator(['compareValue' => 'test-string']);
-        $model = new FakedValidationModel();
-        $model->attr_test = 'test-string';
-        $val->validateAttribute($model, 'attr_test');
-        $this->assertFalse($model->hasErrors('attr_test'));
-        $val = new CompareValidator(['compareAttribute' => 'attr_test_val']);
-        $model = new FakedValidationModel();
-        $model->attr_test = 'test-string';
-        $model->attr_test_val = 'test-string';
-        $val->validateAttribute($model, 'attr_test');
-        $this->assertFalse($model->hasErrors('attr_test'));
-        $this->assertFalse($model->hasErrors('attr_test_val'));
-        $val = new CompareValidator(['compareAttribute' => 'attr_test_val']);
-        $model = new FakedValidationModel();
-        $model->attr_test = 'test-string';
-        $model->attr_test_val = 'test-string-false';
-        $val->validateAttribute($model, 'attr_test');
-        $this->assertTrue($model->hasErrors('attr_test'));
-        $this->assertFalse($model->hasErrors('attr_test_val'));
-        // assume: _repeat
-        $val = new CompareValidator();
-        $model = new FakedValidationModel();
-        $model->attr_test = 'test-string';
-        $model->attr_test_repeat = 'test-string';
-        $val->validateAttribute($model, 'attr_test');
-        $this->assertFalse($model->hasErrors('attr_test'));
-        $this->assertFalse($model->hasErrors('attr_test_repeat'));
-        $val = new CompareValidator();
-        $model = new FakedValidationModel();
-        $model->attr_test = 'test-string';
-        $model->attr_test_repeat = 'test-string2';
-        $val->validateAttribute($model, 'attr_test');
-        $this->assertTrue($model->hasErrors('attr_test'));
-        $this->assertFalse($model->hasErrors('attr_test_repeat'));
-        // not existing op
-        $val = new CompareValidator();
-        $val->operator = '<>';
-        $model = FakedValidationModel::createWithAttributes(['attr_o' => 5, 'attr_o_repeat' => 5]);
-        $val->validateAttribute($model, 'attr_o');
-        $this->assertTrue($model->hasErrors('attr_o'));
-        // compareAttribute has validation error
-        $val = new CompareValidator(['compareAttribute' => 'attr_x', 'skipOnError' => false]);
-        $model = FakedValidationModel::createWithAttributes(['attr_x' => 10, 'attr_y' => 10]);
-        $model->addError('attr_x', 'invalid value');
-        $val->validateAttribute($model, 'attr_y');
-        $this->assertTrue($model->hasErrors('attr_x'));
-        $this->assertTrue($model->hasErrors('attr_y'));
-        // compareAttribute has validation error but rule has skipOnError
-        $val = new CompareValidator(['compareAttribute' => 'attr_x', 'skipOnError' => true]);
-        $model = FakedValidationModel::createWithAttributes(['attr_x' => 10, 'attr_y' => 10]);
-        $model->addError('attr_x', 'invalid value');
-        $val->validateAttribute($model, 'attr_y');
-        $this->assertTrue($model->hasErrors('attr_x'));
-        $this->assertFalse($model->hasErrors('attr_y'));
+
+        $validator->validateAttribute($model, 'attr');
+
+        self::assertTrue(
+            $model->hasErrors('attr'),
+            'Validation should fail when attribute value is an array.',
+        );
     }
 
-    public function testAttributeErrorMessages(): void
-    {
-        $model = FakedValidationModel::createWithAttributes([
-            'attr1' => 1,
-            'attr2' => 2,
-            'attrN' => 2,
-        ]);
+    #[DataProviderExternal(CompareValidatorProvider::class, 'attributeErrorMessages')]
+    public function testAttributeErrorMessages(
+        string $attribute,
+        string $operator,
+        int|string $compareTarget,
+        string $expectedError,
+        string $compareProperty,
+    ): void {
+        $validator = new CompareValidator();
 
-        foreach ($this->getTestDataForMessages() as $data) {
-            $model->clearErrors($data[0]);
-            $model->clearErrors($data[2]);
-            $validator = new CompareValidator();
-            $validator->operator = $data[1];
-            $validator->message = null;
-            $validator->init(); // reload messages
-            $validator->{$data[4]} = $data[2];
-            $validator->validateAttribute($model, $data[0]);
-            $error = $model->getErrors($data[0])[0];
-            $this->assertEquals($data[3], $error);
-        }
+        $validator->operator = $operator;
+        $validator->message = null;
+
+        $model = FakedValidationModel::createWithAttributes(
+            [
+                'attr1' => 1,
+                'attr2' => 2,
+                'attrN' => 2,
+            ],
+        );
+
+        $validator->init();
+
+        $validator->{$compareProperty} = $compareTarget;
+
+        $validator->validateAttribute($model, $attribute);
+
+        $errors = $model->getErrors($attribute);
+
+        self::assertNotEmpty(
+            $errors,
+            "Validation should produce an error for operator '{$operator}'.",
+        );
+        self::assertSame(
+            $expectedError,
+            $errors[0],
+            "Error message should match expected format for operator '{$operator}'.",
+        );
     }
 
-    /**
-     * @phpstan-return array<array-key, array{string, string, int|string, string, string}>
-     */
-    protected function getTestDataForMessages(): array
-    {
-        return [
-            ['attr1', '==', 2, 'attr1 must be equal to "2".', 'compareValue'],
-            ['attr1', '===', 2, 'attr1 must be equal to "2".', 'compareValue'],
-            ['attrN', '!=', 2, 'attrN must not be equal to "2".', 'compareValue'],
-            ['attrN', '!==', 2, 'attrN must not be equal to "2".', 'compareValue'],
-            ['attr1', '>', 2, 'attr1 must be greater than "2".', 'compareValue'],
-            ['attr1', '>=', 2, 'attr1 must be greater than or equal to "2".', 'compareValue'],
-            ['attr2', '<', 1, 'attr2 must be less than "1".', 'compareValue'],
-            ['attr2', '<=', 1, 'attr2 must be less than or equal to "1".', 'compareValue'],
+    #[DataProviderExternal(CompareValidatorProvider::class, 'validateAttributeOperators')]
+    public function testValidateAttributeOperators(
+        string $operator,
+        mixed $inputValue,
+        int $compareValue,
+        bool $expectedValid,
+    ): void {
+        $validator = new CompareValidator(
+            [
+                'operator' => $operator,
+                'compareValue' => $compareValue,
+            ],
+        );
 
-            ['attr1', '==', 'attr2', 'attr1 must be equal to "attr2".', 'compareAttribute'],
-            ['attr1', '===', 'attr2', 'attr1 must be equal to "attr2".', 'compareAttribute'],
-            ['attrN', '!=', 'attr2', 'attrN must not be equal to "attr2".', 'compareAttribute'],
-            ['attrN', '!==', 'attr2', 'attrN must not be equal to "attr2".', 'compareAttribute'],
-            ['attr1', '>', 'attr2', 'attr1 must be greater than "attr2".', 'compareAttribute'],
-            ['attr1', '>=', 'attr2', 'attr1 must be greater than or equal to "attr2".', 'compareAttribute'],
-            ['attr2', '<', 'attr1', 'attr2 must be less than "attr1".', 'compareAttribute'],
-            ['attr2', '<=', 'attr1', 'attr2 must be less than or equal to "attr1".', 'compareAttribute'],
-        ];
-    }
+        $model = new FakedValidationModel();
 
-    public function testValidateAttributeOperators(): void
-    {
-        $value = 55;
-        foreach ($this->getOperationTestData($value) as $operator => $tests) {
-            $val = new CompareValidator(['operator' => $operator, 'compareValue' => $value]);
-            foreach ($tests as $test) {
-                $model = new FakedValidationModel();
-                $model->attr_test = $test[0];
-                $val->validateAttribute($model, 'attr_test');
-                $this->assertEquals($test[1], !$model->hasErrors('attr_test'));
-            }
-        }
+        $model->attr_test = $inputValue;
+
+        $validator->validateAttribute($model, 'attr_test');
+
+        self::assertSame(
+            $expectedValid,
+            !$model->hasErrors('attr_test'),
+            "Operator '{$operator}' with value '{$inputValue}' against '{$compareValue}'.",
+        );
     }
 
     public function testEnsureMessageSetOnInit(): void
     {
-        foreach ($this->getOperationTestData(1337) as $operator => $tests) {
-            $val = new CompareValidator(['operator' => $operator]);
-            $this->assertTrue(strlen($val->message) > 1);
-        }
-        try {
-            new CompareValidator(['operator' => '<>']);
-        } catch (InvalidConfigException) {
-            return;
-        } catch (Exception $e) {
-            $this->fail('InvalidConfigException expected' . $e::class . 'received');
+        $operators = ['===', '!=', '!==', '>', '>=', '<', '<='];
 
-            return;
+        foreach ($operators as $operator) {
+            $validator = new CompareValidator(['operator' => $operator]);
+
+            self::assertTrue(
+                strlen($validator->message) > 1,
+                "Message should be set on 'init' for operator '{$operator}'.",
+            );
         }
-        $this->fail('InvalidConfigException expected none received');
+
+        $this->expectException(InvalidConfigException::class);
+
+        new CompareValidator(['operator' => '<>']);
     }
 
     public function testValidateValueWithTypeNumber(): void
     {
-        $val = new CompareValidator(['compareValue' => 10, 'type' => CompareValidator::TYPE_NUMBER]);
-        $this->assertTrue($val->validate(10));
-        $this->assertTrue($val->validate('10'));
-        $this->assertTrue($val->validate(10.0));
-        $this->assertFalse($val->validate(11));
+        $validator = new CompareValidator(
+            [
+                'compareValue' => 10,
+                'type' => CompareValidator::TYPE_NUMBER],
+            );
+
+        self::assertTrue(
+            $validator->validate(10),
+            "Integer '10' should equal compareValue '10'.",
+        );
+        self::assertTrue(
+            $validator->validate('10'),
+            "String '10' should equal compareValue '10'.",
+        );
+        self::assertTrue(
+            $validator->validate(10.0),
+            "Float '10.0' should equal compareValue '10'.",
+        );
+        self::assertFalse(
+            $validator->validate(11),
+            "Integer '11' should not equal compareValue '10'.",
+        );
     }
 
     public function testCompareValuesWithTypeNumber(): void
     {
-        $val = new CompareValidator(['compareValue' => 100, 'type' => CompareValidator::TYPE_NUMBER, 'operator' => '>']);
-        $this->assertTrue($val->validate(101));
-        $this->assertFalse($val->validate(100));
-        $this->assertFalse($val->validate(99));
+        $validator = new CompareValidator(
+            [
+                'compareValue' => 100,
+                'type' => CompareValidator::TYPE_NUMBER,
+                'operator' => '>',
+            ],
+        );
 
-        $val->operator = '<';
-        $val->message = null;
-        $val->init();
-        $this->assertTrue($val->validate(99));
-        $this->assertFalse($val->validate(100));
-        $this->assertFalse($val->validate(101));
+        self::assertTrue(
+            $validator->validate(101),
+            "Integer '101' should be greater than '100'.",
+        );
+        self::assertFalse(
+            $validator->validate(100),
+            "Integer '100' should not be greater than '100'.",
+        );
+        self::assertFalse(
+            $validator->validate(99),
+            "Integer '99' should not be greater than '100'.",
+        );
+
+        $validator->operator = '<';
+        $validator->message = null;
+
+        $validator->init();
+
+        self::assertTrue(
+            $validator->validate(99),
+            "'99' should be less than '100'.",
+        );
+        self::assertFalse(
+            $validator->validate(100),
+            "'100' should not be less than '100'.",
+        );
+        self::assertFalse(
+            $validator->validate(101),
+            "'101' should not be less than '100'.",
+        );
     }
 
     public function testValidateAttributeWithClosure(): void
     {
-        $val = new CompareValidator([
-            'compareValue' => function ($model, $attribute) {
-                return $model->attr_test_val;
-            },
-        ]);
-        $model = FakedValidationModel::createWithAttributes([
-            'attr_test' => 'hello',
-            'attr_test_val' => 'hello',
-        ]);
-        $val->validateAttribute($model, 'attr_test');
-        $this->assertFalse($model->hasErrors('attr_test'));
+        $expectedValue = 42;
+        $closureExecuted = false;
 
-        $model = FakedValidationModel::createWithAttributes([
-            'attr_test' => 'hello',
-            'attr_test_val' => 'world',
-        ]);
-        $val = new CompareValidator([
-            'compareValue' => function ($model, $attribute) {
-                return $model->attr_test_val;
-            },
-        ]);
-        $val->validateAttribute($model, 'attr_test');
-        $this->assertTrue($model->hasErrors('attr_test'));
+        $closure = static function () use ($expectedValue, &$closureExecuted): int {
+            $closureExecuted = true;
+
+            return $expectedValue;
+        };
+
+        $validator = new CompareValidator(
+            [
+                'compareValue' => $closure,
+            ],
+        );
+
+        $model = new FakedValidationModel();
+
+        $model->attr_test = $expectedValue;
+
+        $validator->validateAttribute($model, 'attr_test');
+
+        self::assertTrue(
+            $closureExecuted,
+            'Closure should be executed during validation.',
+        );
+        self::assertFalse(
+            $model->hasErrors('attr_test'),
+            'Validation should pass when values match.',
+        );
     }
 
-    public function testValidateValueWithClosure(): void
+    public function testGetClientOptionsWithCompareValue(): void
     {
-        $val = new CompareValidator(['compareValue' => function () {
-            return 42;
-        }]);
-        $this->assertTrue($val->validate(42));
-        $this->assertFalse($val->validate(43));
+        $validator = new CompareValidator(
+            [
+                'compareValue' => 'expected',
+            ],
+        );
+
+        $model = new FakedValidationModel();
+
+        $model->attr_test = 'test';
+
+        $options = $validator->getClientOptions($model, 'attr_test');
+
+        self::assertSame(
+            '==',
+            $options['operator'],
+            "Operator should default to '=='.",
+        );
+        self::assertSame(
+            'string',
+            $options['type'],
+            "Type should default to 'string'.",
+        );
+        self::assertSame(
+            'expected',
+            $options['compareValue'],
+            'CompareValue should be present in client options.',
+        );
+        self::assertArrayNotHasKey(
+            'compareAttribute',
+            $options,
+            'CompareAttribute should not be present.',
+        );
+        self::assertArrayHasKey(
+            'message',
+            $options,
+            'Message should be present in client options.',
+        );
     }
 
-    public static function defaultMessagePerOperatorProvider(): array
+    public function testGetClientOptionsWithCompareAttribute(): void
     {
-        return [
-            ['==', 'equal to'],
-            ['===', 'equal to'],
-            ['!=', 'not be equal'],
-            ['!==', 'not be equal'],
-            ['>', 'greater than'],
-            ['>=', 'greater than or equal'],
-            ['<', 'less than'],
-            ['<=', 'less than or equal'],
-        ];
+        $validator = new CompareValidator(
+            [
+                'compareAttribute' => 'attr_test_val',
+            ],
+        );
+
+        $model = new FakedValidationModel();
+
+        $model->attr_test = 'test';
+        $model->attr_test_val = 'test';
+
+        $options = $validator->getClientOptions($model, 'attr_test');
+
+        self::assertArrayHasKey(
+            'compareAttribute',
+            $options,
+            'CompareAttribute should be present.',
+        );
+        self::assertArrayHasKey(
+            'compareAttributeName',
+            $options,
+            'CompareAttributeName should be present.',
+        );
+        self::assertArrayNotHasKey(
+            'compareValue',
+            $options,
+            'CompareValue should not be present.',
+        );
     }
 
-    /**
-     * @dataProvider defaultMessagePerOperatorProvider
-     */
+    public function testGetClientOptionsDefaultCompareAttribute(): void
+    {
+        $validator = new CompareValidator();
+
+        $model = new FakedValidationModel();
+
+        $model->attr_test = 'test';
+        $model->attr_test_repeat = 'test';
+
+        $options = $validator->getClientOptions($model, 'attr_test');
+
+        self::assertArrayHasKey(
+            'compareAttribute',
+            $options,
+            'Default compareAttribute should be present.',
+        );
+        self::assertStringContainsString(
+            'attr_test_repeat',
+            $options['compareAttributeName'],
+            "Default compareAttributeName should contain 'attr_test_repeat'.",
+        );
+    }
+
+    public function testGetClientOptionsWithSkipOnEmpty(): void
+    {
+        $validator = new CompareValidator(
+            [
+                'compareValue' => 'test',
+                'skipOnEmpty' => true,
+            ],
+        );
+
+        $model = new FakedValidationModel();
+
+        $model->attr_test = 'test';
+
+        $options = $validator->getClientOptions($model, 'attr_test');
+
+        self::assertSame(
+            1,
+            $options['skipOnEmpty'],
+            'SkipOnEmpty should be 1 when enabled.',
+        );
+    }
+
+    public function testGetClientOptionsWithoutSkipOnEmpty(): void
+    {
+        $validator = new CompareValidator(
+            [
+                'compareValue' => 'test',
+                'skipOnEmpty' => false,
+            ],
+        );
+
+        $model = new FakedValidationModel();
+
+        $model->attr_test = 'test';
+
+        $options = $validator->getClientOptions($model, 'attr_test');
+
+        self::assertArrayNotHasKey(
+            'skipOnEmpty',
+            $options,
+            'SkipOnEmpty should not be present when disabled.',
+        );
+    }
+
+    public function testClientValidateAttribute(): void
+    {
+        $validator = new CompareValidator(
+            [
+                'compareValue' => 'test_value',
+                'operator' => '==',
+                'type' => CompareValidator::TYPE_STRING,
+            ],
+        );
+
+        $model = new FakedValidationModel();
+
+        $model->attrA = 'test_value';
+
+        self::assertSame(
+            <<<JS
+            yii.validation.compare(value, messages, {"operator":"==","type":"string","compareValue":"test_value","skipOnEmpty":1,"message":"attrA must be equal to \u0022test_value\u0022."}, \$form);
+            JS,
+            $validator->clientValidateAttribute($model, 'attrA', Yii::$app->getView()),
+            "'clientValidateAttribute()' should return correct validation script.",
+        );
+        self::assertSame(
+            [
+                'operator' => '==',
+                'type' => 'string',
+                'compareValue' => 'test_value',
+                'skipOnEmpty' => 1,
+                'message' => 'attrA must be equal to "test_value".',
+            ],
+            $validator->getClientOptions($model, 'attrA'),
+            "'getClientOptions()' should return correct options array.",
+        );
+
+        $validator->validate('someIncorrectValue', $errorMessage);
+
+        self::assertSame(
+            'the input value must be equal to "test_value".',
+            $errorMessage,
+            'Error message should match expected format.',
+        );
+    }
+
+    #[DataProviderExternal(CompareValidatorProvider::class, 'defaultMessagePerOperator')]
     public function testDefaultMessagePerOperator(string $operator, string $expectedSubstring): void
     {
-        $val = new CompareValidator(['operator' => $operator, 'compareValue' => 1]);
-        $this->assertStringContainsString($expectedSubstring, $val->message);
+        $validator = new CompareValidator(
+            [
+                'operator' => $operator,
+                'compareValue' => 1,
+            ],
+        );
+
+        self::assertStringContainsString(
+            $expectedSubstring,
+            $validator->message,
+            "Default message for operator '{$operator}' should contain '{$expectedSubstring}'.",
+        );
     }
 
     public function testValidateAttributeCompareAttributeHasErrorMessage(): void
     {
-        $val = new CompareValidator(['compareAttribute' => 'attr_x', 'skipOnError' => false]);
-        $model = FakedValidationModel::createWithAttributes(['attr_x' => 10, 'attr_y' => 10]);
+        $validator = new CompareValidator(
+            [
+                'compareAttribute' => 'attr_x',
+                'skipOnError' => false,
+            ],
+        );
+
+        $model = FakedValidationModel::createWithAttributes(
+            [
+                'attr_x' => 10,
+                'attr_y' => 10,
+            ],
+        );
+
         $model->addError('attr_x', 'invalid');
-        $val->validateAttribute($model, 'attr_y');
+
+        $validator->validateAttribute($model, 'attr_y');
+
         $errors = $model->getErrors('attr_y');
-        $this->assertStringContainsString('attr_x', $errors[0]);
-        $this->assertStringContainsString('is invalid', $errors[0]);
+
+        self::assertStringContainsString(
+            'attr_x',
+            $errors[0],
+            'Error message should reference the compare attribute.',
+        );
+        self::assertStringContainsString(
+            'is invalid',
+            $errors[0],
+            'Error message should indicate the compare attribute is invalid.',
+        );
     }
 
     public function testValidateValueErrorContainsCompareValue(): void
     {
-        $val = new CompareValidator(['compareValue' => 'expected']);
-        $val->validate('wrong', $error);
-        $this->assertStringContainsString('expected', $error);
+        $validator = new CompareValidator(
+            [
+                'compareValue' => 'expected',
+            ],
+        );
+
+        $validator->validate('wrong', $error);
+
+        self::assertStringContainsString(
+            'expected',
+            $error,
+            'Validation error should contain the compare value.',
+        );
+    }
+
+    public function testGetClientOptionsMessageContainsCompareValue(): void
+    {
+        $validator = new CompareValidator(
+            [
+                'compareValue' => 'target',
+            ],
+        );
+
+        $model = new FakedValidationModel();
+
+        $model->attr_test = 'test';
+
+        $options = $validator->getClientOptions($model, 'attr_test');
+
+        self::assertStringContainsString(
+            'target',
+            $options['message'],
+            'Client options message should contain the compare value.',
+        );
     }
 
     public function testTypeNumberCastsToFloat(): void
     {
-        $val = new CompareValidator([
-            'compareValue' => '10',
-            'type' => CompareValidator::TYPE_NUMBER,
-            'operator' => '===',
-        ]);
-        $this->assertTrue($val->validate('10'));
-        $this->assertTrue($val->validate(10));
-        $this->assertTrue($val->validate(10.0));
+        $validator = new CompareValidator(
+            [
+                'compareValue' => '10',
+                'type' => CompareValidator::TYPE_NUMBER,
+                'operator' => '===',
+            ],
+        );
+
+        self::assertTrue(
+            $validator->validate('10'),
+            "String '10' should equal after float cast.",
+        );
+        self::assertTrue(
+            $validator->validate(10),
+            "Integer '10' should equal after float cast.",
+        );
+        self::assertTrue(
+            $validator->validate(10.0),
+            "Float '10.0' should equal after float cast.",
+        );
     }
 
     public function testCompareAttributeErrorEarlyReturn(): void
     {
-        $val = new CompareValidator(['compareAttribute' => 'attr_x', 'skipOnError' => false]);
-        $model = FakedValidationModel::createWithAttributes(['attr_x' => 5, 'attr_y' => 99]);
-        $model->addError('attr_x', 'bad value');
-        $val->validateAttribute($model, 'attr_y');
+        $validator = new CompareValidator(
+            [
+                'compareAttribute' => 'attr_x',
+                'skipOnError' => false,
+            ],
+        );
 
+        $model = FakedValidationModel::createWithAttributes(
+            [
+                'attr_x' => 5,
+                'attr_y' => 99,
+            ],
+        );
+
+        $model->addError('attr_x', 'bad value');
+        $validator->validateAttribute($model, 'attr_y');
         $errors = $model->getErrors('attr_y');
-        $this->assertCount(1, $errors);
-        $this->assertStringContainsString('is invalid', $errors[0]);
+
+        self::assertCount(
+            1,
+            $errors,
+            'Should produce exactly one error on early return.',
+        );
+        self::assertStringContainsString(
+            'is invalid',
+            $errors[0] ?? '',
+            'Error should indicate the compare attribute is invalid.',
+        );
+    }
+
+    public function testGetClientOptionsMessageContainsAttributeLabel(): void
+    {
+        $validator = new CompareValidator(
+            [
+                'compareValue' => 'x',
+            ],
+        );
+
+        $model = new FakedValidationModel();
+
+        $model->attr_test = 'test';
+
+        $options = $validator->getClientOptions($model, 'attr_test');
+
+        self::assertStringContainsString(
+            'attr_test',
+            $options['message'],
+            'Client options message should contain the attribute label.',
+        );
     }
 
     public function testDefaultOperatorFallsThrough(): void
     {
-        $val = new CompareValidator(['compareValue' => 5]);
-        $val->operator = '<>';
-        $this->assertFalse($val->validate(5));
-        $this->assertFalse($val->validate(999));
+        $validator = new CompareValidator(
+            [
+                'compareValue' => 5,
+            ],
+        );
+
+        $validator->operator = '<>';
+
+        self::assertFalse(
+            $validator->validate(5),
+            "Unknown operator should always return 'false'.",
+        );
+        self::assertFalse(
+            $validator->validate(999),
+            "Unknown operator should always return 'false'.",
+        );
+    }
+
+    #[DataProviderExternal(CompareValidatorProvider::class, 'numericTypeConversionProvider')]
+    public function testValidateAttributeWithNumericTypeConversion(
+        array $validatorConfig,
+        int|string $attributeValue,
+        string|null $compareAttributeValue,
+        bool $expectedValidation,
+        string $expectedMessage,
+    ): void {
+        $validator = new CompareValidator($validatorConfig);
+
+        $model = new FakedValidationModel();
+
+        $model->attr_test = $attributeValue;
+
+        if ($compareAttributeValue !== null) {
+            $model->attr_compare = $compareAttributeValue;
+        }
+
+        $validator->validateAttribute($model, 'attr_test');
+
+        self::assertSame(
+            $expectedValidation,
+            $model->hasErrors('attr_test'),
+            $expectedMessage,
+        );
+    }
+
+    #[DataProviderExternal(CompareValidatorProvider::class, 'numericValueConversionProvider')]
+    public function testValidateValueWithNumericTypeConversion(
+        array $validatorConfig,
+        float|int|string $attributeValue,
+        bool $expectedResult,
+        string $expectedMessage,
+    ): void {
+        $validator = new CompareValidator($validatorConfig);
+
+        $result = $validator->validate($attributeValue);
+
+        self::assertSame(
+            $expectedResult,
+            $result,
+            $expectedMessage,
+        );
+    }
+
+    public function testValidateAttributeWithClosureFailure(): void
+    {
+        $expectedValue = 100;
+        $actualValue = 50;
+
+        $validator = new CompareValidator(
+            [
+                'compareValue' => static fn(): int => $expectedValue,
+            ],
+        );
+
+        $model = new FakedValidationModel();
+
+        $model->attr_test = $actualValue;
+
+        $validator->validateAttribute($model, 'attr_test');
+
+        self::assertTrue(
+            $model->hasErrors('attr_test'),
+            'Validation should fail when values do not match.',
+        );
+    }
+
+    public function testValidateAttributeWithClosureAndOperator(): void
+    {
+        $compareValue = 75;
+
+        $validator = new CompareValidator(
+            [
+                'compareValue' => static fn(): int => $compareValue,
+                'operator' => '>',
+            ],
+        );
+
+        $model = new FakedValidationModel();
+
+        $model->attr_test = 100;
+
+        $validator->validateAttribute($model, 'attr_test');
+
+        self::assertFalse(
+            $model->hasErrors('attr_test'),
+            "Validation should pass when '100' > '75'.",
+        );
+
+        $model2 = new FakedValidationModel();
+
+        $model2->attr_test = 50;
+
+        $validator->validateAttribute($model2, 'attr_test');
+
+        self::assertTrue(
+            $model2->hasErrors('attr_test'),
+            "Validation should fail when '50' is not > '75'.",
+        );
+    }
+
+    public function testClientValidateAttributeWithClosureCompareValue(): void
+    {
+        $closureConfig = [
+            'compareValue' => static fn(): string => 'closure_value',
+            'operator' => '==',
+            'type' => CompareValidator::TYPE_STRING,
+        ];
+
+        $validator1 = new CompareValidator($closureConfig);
+
+        $model = new FakedValidationModel();
+
+        self::assertSame(
+            <<<JS
+            yii.validation.compare(value, messages, {"operator":"==","type":"string","compareValue":"closure_value","skipOnEmpty":1,"message":"attrA must be equal to \u0022closure_value\u0022."}, \$form);
+            JS,
+            $validator1->clientValidateAttribute($model, 'attrA', Yii::$app->getView()),
+            'Should return correct validation script.',
+        );
+
+        $validator2 = new CompareValidator($closureConfig);
+
+        self::assertSame(
+            [
+                'operator' => '==',
+                'type' => 'string',
+                'compareValue' => 'closure_value',
+                'skipOnEmpty' => 1,
+                'message' => 'attrA must be equal to "closure_value".',
+            ],
+            $validator2->getClientOptions($model, 'attrA'),
+            'Should return correct options array.',
+        );
+
+        $validator3 = new CompareValidator($closureConfig);
+
+        $errorMessage = null;
+
+        $validator3->validate('someIncorrectValue', $errorMessage);
+
+        self::assertSame(
+            'the input value must be equal to "closure_value".',
+            $errorMessage,
+            'Error message should match expected format.',
+        );
+    }
+
+    public function testClientValidateAttributeWithNullCompareAttribute(): void
+    {
+        $validator = new CompareValidator(
+            [
+                'operator' => '==',
+                'type' => CompareValidator::TYPE_STRING,
+            ],
+        );
+
+        $model = new FakedValidationModel();
+
+        $model->attrA = 'test';
+        $model->attrA_repeat = 'test';
+
+        self::assertSame(
+            <<<JS
+            yii.validation.compare(value, messages, {"operator":"==","type":"string","compareAttribute":"fakedvalidationmodel-attra_repeat","compareAttributeName":"FakedValidationModel[attrA_repeat]","skipOnEmpty":1,"message":"attrA must be equal to \u0022attrA_repeat\u0022."}, \$form);
+            JS,
+            $validator->clientValidateAttribute($model, 'attrA', Yii::$app->getView()),
+            'Should return correct validation script.',
+        );
+        self::assertSame(
+            [
+                'operator' => '==',
+                'type' => 'string',
+                'compareAttribute' => 'fakedvalidationmodel-attra_repeat',
+                'compareAttributeName' => 'FakedValidationModel[attrA_repeat]',
+                'skipOnEmpty' => 1,
+                'message' => 'attrA must be equal to "attrA_repeat".',
+            ],
+            $validator->getClientOptions($model, 'attrA'),
+            'Should return correct options array.',
+        );
     }
 }

--- a/tests/framework/validators/providers/CompareValidatorProvider.php
+++ b/tests/framework/validators/providers/CompareValidatorProvider.php
@@ -1,35 +1,657 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\validators\providers;
 
 use yii\validators\CompareValidator;
 
 /**
- * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * Data provider for {@see \yiiunit\framework\validators\CompareValidatorTest} test cases.
  *
- * @since 2.2.0
+ * Provides representative input/output pairs for validation, attribute comparison, error messages, operator behavior,
+ * and numeric type conversion scenarios.
+ *
+ * @copyright Copyright (c) 2008 Yii Software LLC.
+ * @license https://www.yiiframework.com/license/
  */
 final class CompareValidatorProvider
 {
-    /**
-     * Provides test cases for numeric type conversion and comparison.
-     *
-     * This provider supplies scenarios for validating numeric comparisons, including type coercion between strings,
-     * integers, and floats, strict and loose operators, closure-based compare values, and edge cases such as zero and
-     * negative numbers. It ensures that CompareValidator correctly handles numeric type conversion and operator logic.
-     *
-     * @return array test data for numeric type conversion and comparison.
-     *
-     * @phpstan-return array<string, array{array<string, mixed>, int|string, string|null, bool, string}>
-     */
+    public static function validateValue(): array
+    {
+        $value = 18449;
+
+        return [
+            'closure equal different value' => [
+                ['compareValue' => static fn(): int => $value],
+                $value + 1,
+                false,
+                'Closure returning different value should not validate as equal.',
+            ],
+            'closure equal same int' => [
+                ['compareValue' => static fn(): int => $value],
+                $value, true,
+                'Closure returning same value should validate as equal.',
+            ],
+            'closure equal same string' => [
+                ['compareValue' => static fn(): int => $value],
+                (string) $value, true,
+                'Closure returning same value as string should validate as equal.',
+            ],
+            'default equal different value' => [
+                ['compareValue' => $value],
+                $value + 1, false,
+                'Different value should not validate as equal.',
+            ],
+            'default equal same int' => [
+                ['compareValue' => $value],
+                $value, true,
+                'Same integer value should validate as equal.',
+            ],
+            'default equal same string' => [
+                ['compareValue' => $value],
+                (string) $value, true,
+                'String cast of integer should validate as equal.',
+            ],
+            'greater than higher value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '>',
+                ],
+                $value + 1, true,
+                'Greater than with higher value should pass.',
+            ],
+            'greater than lower value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '>',
+                ],
+                $value - 1, false,
+                'Greater than with lower value should fail.',
+            ],
+            'greater than or equal higher value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '>=',
+                ],
+                $value + 1,
+                true,
+                'Greater than or equal with higher value should pass.',
+            ],
+            'greater than or equal lower value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '>=',
+                ],
+                $value - 1,
+                false,
+                'Greater than or equal with lower value should fail.',
+            ],
+            'greater than or equal same value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '>=',
+                ],
+                $value,
+                true,
+                'Greater than or equal with same value should pass.',
+            ],
+            'greater than same value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '>',
+                ],
+                $value,
+                false,
+                'Greater than with same value should fail.',
+            ],
+            'less than higher value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '<',
+                ],
+                $value + 1,
+                false,
+                'Less than with higher value should fail.',
+            ],
+            'less than lower value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '<',
+                ],
+                $value - 1,
+                true,
+                'Less than with lower value should pass.',
+            ],
+            'less than or equal higher value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '<=',
+                ],
+                $value + 1,
+                false,
+                'Less than or equal with higher value should fail.',
+            ],
+            'less than or equal lower value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '<=',
+                ],
+                $value - 1,
+                true,
+                'Less than or equal with lower value should pass.',
+            ],
+            'less than or equal same value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '<=',
+                ],
+                $value,
+                true,
+                'Less than or equal with same value should pass.',
+            ],
+            'less than same value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '<',
+                ],
+                $value,
+                false,
+                'Less than with same value should fail.',
+            ],
+            'not equal same float' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '!=',
+                ],
+                (float) $value,
+                false,
+                'Not equal with float cast should fail.',
+            ],
+            'not equal same int' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '!=',
+                ],
+                $value,
+                false,
+                'Not equal with same value should fail.',
+            ],
+            'not equal same string' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '!=',
+                ],
+                (string) $value,
+                false,
+                'Not equal with string cast should fail.',
+            ],
+            'not equal slightly different' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '!=',
+                ],
+                $value + 0.00001,
+                true,
+                'Not equal with slightly different value should pass.',
+            ],
+            'not equal with false' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '!=',
+                ],
+                false,
+                true,
+                'Not equal with `false` should pass.',
+            ],
+            'strict equal different value' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '===',
+                ],
+                $value + 1,
+                false,
+                'Strict equal with different value should fail.',
+            ],
+            'strict equal same float' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '===',
+                ],
+                (float) $value,
+                true,
+                'Strict equal with float cast should pass (both cast to string).',
+            ],
+            'strict equal same int' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '===',
+                ],
+                $value,
+                true,
+                'Strict equal with same integer should pass.',
+            ],
+            'strict equal same string' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '===',
+                ],
+                (string) $value,
+                true,
+                'Strict equal with string cast should pass (both cast to string).',
+            ],
+            'strict not equal same float' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '!==',
+                ],
+                (float) $value,
+                false,
+                'Strict not equal with float cast should fail.',
+            ],
+            'strict not equal same int' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '!==',
+                ],
+                $value,
+                false,
+                'Strict not equal with same value should fail.',
+            ],
+            'strict not equal same string' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '!==',
+                ],
+                (string) $value,
+                false,
+                'Strict not equal with string cast should fail.',
+            ],
+            'strict not equal with false' => [
+                [
+                    'compareValue' => $value,
+                    'operator' => '!==',
+                ],
+                false,
+                true,
+                'Strict not equal with `false` should pass.',
+            ],
+        ];
+    }
+
+    public static function validateAttribute(): array
+    {
+        return [
+            'compareAttribute equal match' => [
+                ['compareAttribute' => 'attr_test_val'],
+                [
+                    'attr_test' => 'test-string',
+                    'attr_test_val' => 'test-string',
+                ],
+                'attr_test',
+                false,
+                'Validation should pass when attribute matches compareAttribute.',
+            ],
+            'compareAttribute not equal' => [
+                ['compareAttribute' => 'attr_test_val'],
+                [
+                    'attr_test' => 'test-string',
+                    'attr_test_val' => 'test-string-false',
+                ],
+                'attr_test',
+                true,
+                'Validation should fail when attribute does not match compareAttribute.',
+            ],
+            'compareAttribute with error and skipOnError false' => [
+                ['compareAttribute' => 'attr_x', 'skipOnError' => false],
+                ['attr_x' => 10, 'attr_y' => 10],
+                'attr_y',
+                true,
+                'Validation should fail when compareAttribute has errors and skipOnError is `false`.',
+                ['attr_x' => 'invalid value']
+            ],
+            'compareAttribute with error and skipOnError true' => [
+                ['compareAttribute' => 'attr_x', 'skipOnError' => true],
+                ['attr_x' => 10, 'attr_y' => 10],
+                'attr_y',
+                false,
+                'Validation should be skipped when compareAttribute has errors and skipOnError is `true`.',
+                ['attr_x' => 'invalid value']
+            ],
+            'compareValue equal match' => [
+                ['compareValue' => 'test-string'],
+                ['attr_test' => 'test-string'],
+                'attr_test',
+                false,
+                'Validation should pass when attribute matches compareValue.'
+            ],
+            'default _repeat attribute match' => [
+                [],
+                ['attr_test' => 'test-string', 'attr_test_repeat' => 'test-string'],
+                'attr_test',
+                false,
+                'Validation should pass when attribute matches default _repeat attribute.'
+            ],
+            'default _repeat attribute mismatch' => [
+                [],
+                ['attr_test' => 'test-string', 'attr_test_repeat' => 'test-string2'],
+                'attr_test',
+                true,
+                'Validation should fail when attribute does not match _repeat attribute.'
+            ],
+        ];
+    }
+
+    public static function attributeErrorMessages(): array
+    {
+        return [
+            'equal compareAttribute' => [
+                'attr1',
+                '==',
+                'attr2',
+                'attr1 must be equal to "attr2".', 'compareAttribute',
+            ],
+            'equal compareValue' => [
+                'attr1',
+                '==',
+                2,
+                'attr1 must be equal to "2".',
+                'compareValue',
+            ],
+            'greater than compareAttribute' => [
+                'attr1',
+                '>',
+                'attr2',
+                'attr1 must be greater than "attr2".',
+                'compareAttribute',
+            ],
+            'greater than compareValue' => [
+                'attr1',
+                '>',
+                2,
+                'attr1 must be greater than "2".',
+                'compareValue',
+            ],
+            'greater than or equal compareAttribute' => [
+                'attr1',
+                '>=',
+                'attr2',
+                'attr1 must be greater than or equal to "attr2".',
+                'compareAttribute',
+            ],
+            'greater than or equal compareValue' => [
+                'attr1',
+                '>=',
+                2,
+                'attr1 must be greater than or equal to "2".',
+                'compareValue',
+            ],
+            'less than compareAttribute' => [
+                'attr2',
+                '<',
+                'attr1',
+                'attr2 must be less than "attr1".',
+                'compareAttribute',
+            ],
+            'less than compareValue' => [
+                'attr2',
+                '<',
+                1,
+                'attr2 must be less than "1".', 'compareValue',
+            ],
+            'less than or equal compareAttribute' => [
+                'attr2',
+                '<=',
+                'attr1',
+                'attr2 must be less than or equal to "attr1".', 'compareAttribute',
+            ],
+            'less than or equal compareValue' => [
+                'attr2',
+                '<=',
+                1,
+                'attr2 must be less than or equal to "1".', 'compareValue',
+            ],
+            'not equal compareAttribute' => [
+                'attrN',
+                '!=',
+                'attr2',
+                'attrN must not be equal to "attr2".', 'compareAttribute',
+            ],
+            'not equal compareValue' => [
+                'attrN',
+                '!=',
+                2,
+                'attrN must not be equal to "2".', 'compareValue',
+            ],
+            'strict equal compareAttribute' => [
+                'attr1',
+                '===',
+                'attr2',
+                'attr1 must be equal to "attr2".', 'compareAttribute',
+            ],
+            'strict equal compareValue' => [
+                'attr1',
+                '===',
+                2,
+                'attr1 must be equal to "2".', 'compareValue',
+            ],
+            'strict not equal compareAttribute' => [
+                'attrN',
+                '!==',
+                'attr2',
+                'attrN must not be equal to "attr2".', 'compareAttribute',
+            ],
+            'strict not equal compareValue' => [
+                'attrN',
+                '!==',
+                2,
+                'attrN must not be equal to "2".', 'compareValue',
+            ],
+        ];
+    }
+
+    public static function validateAttributeOperators(): array
+    {
+        $value = 55;
+
+        return [
+            'greater than higher' => [
+                '>',
+                $value + 1,
+                $value,
+                true,
+            ],
+            'greater than lower' => [
+                '>',
+                $value - 1,
+                $value,
+                false,
+            ],
+            'greater than or equal higher' => [
+                '>=',
+                $value + 1,
+                $value,
+                true,
+            ],
+            'greater than or equal lower' => [
+                '>=',
+                $value - 1,
+                $value,
+                false,
+            ],
+            'greater than or equal same' => [
+                '>=',
+                $value,
+                $value,
+                true,
+            ],
+            'greater than same' => [
+                '>',
+                $value,
+                $value,
+                false,
+            ],
+            'less than higher' => [
+                '<',
+                $value + 1,
+                $value,
+                false,
+            ],
+            'less than lower' => [
+                '<',
+                $value - 1,
+                $value,
+                true,
+            ],
+            'less than or equal higher' => [
+                '<=',
+                $value + 1,
+                $value,
+                false,
+            ],
+            'less than or equal lower' => [
+                '<=',
+                $value - 1,
+                $value,
+                true,
+            ],
+            'less than or equal same' => [
+                '<=',
+                $value,
+                $value,
+                true,
+            ],
+            'less than same' => [
+                '<',
+                $value,
+                $value,
+                false,
+            ],
+            'not equal same float' => [
+                '!=',
+                (float) $value,
+                $value,
+                false,
+            ],
+            'not equal same int' => [
+                '!=',
+                $value,
+                $value,
+                false,
+            ],
+            'not equal same string' => [
+                '!=',
+                (string) $value,
+                $value,
+                false,
+            ],
+            'not equal slightly different' => [
+                '!=',
+                $value + 0.00001,
+                $value,
+                true,
+            ],
+            'not equal with false' => [
+                '!=',
+                false,
+                $value,
+                true,
+            ],
+            'strict equal different' => [
+                '===',
+                $value + 1,
+                $value,
+                false,
+            ],
+            'strict equal same float' => [
+                '===',
+                (float) $value,
+                $value,
+                true,
+            ],
+            'strict equal same int' => [
+                '===',
+                $value,
+                $value,
+                true,
+            ],
+            'strict equal same string' => [
+                '===',
+                (string) $value,
+                $value,
+                true,
+            ],
+            'strict not equal same float' => [
+                '!==',
+                (float) $value,
+                $value,
+                false,
+            ],
+            'strict not equal same int' => [
+                '!==',
+                $value,
+                $value,
+                false,
+            ],
+            'strict not equal same string' => [
+                '!==',
+                (string) $value,
+                $value,
+                false,
+            ],
+            'strict not equal with false' => [
+                '!==',
+                false,
+                $value,
+                true,
+            ],
+        ];
+    }
+
+    public static function defaultMessagePerOperator(): array
+    {
+        return [
+            'equal' => [
+                '==',
+                'equal to',
+            ],
+            'greater than or equal' => [
+                '>=',
+                'greater than or equal',
+            ],
+            'greater than' => [
+                '>',
+                'greater than',
+            ],
+            'less than or equal' => [
+                '<=',
+                'less than or equal',
+            ],
+            'less than' => [
+                '<',
+                'less than',
+            ],
+            'not equal' => [
+                '!=',
+                'not be equal',
+            ],
+            'strict equal' => [
+                '===',
+                'equal to',
+            ],
+            'strict not equal' => [
+                '!==',
+                'not be equal',
+            ],
+        ];
+    }
+
     public static function numericTypeConversionProvider(): array
     {
         return [
@@ -97,7 +719,7 @@ final class CompareValidatorProvider
                 '100',
                 null,
                 false,
-                'Less than or equal operator should work with numeric conversion.'
+                'Less than or equal operator should work with numeric conversion.',
             ],
             'valid negative numbers comparison' => [
                 [
@@ -157,18 +779,6 @@ final class CompareValidatorProvider
         ];
     }
 
-    /**
-     * Provides test cases for numeric value conversion and comparison.
-     *
-     * This data provider covers scenarios involving numeric type coercion, strict and loose comparison operators,
-     * closure-based compare values, string-to-float conversion, negative numbers, zero, and edge cases for
-     * CompareValidator with TYPE_NUMBER. It ensures that numeric values are properly converted and compared according
-     * to the specified operator, including strict equality, inequality, and relational operators.
-     *
-     * @return array test data for numeric value conversion and comparison.
-     *
-     * @phpstan-return array<string, array{array<string, mixed>, float|int|string, bool, string}>
-     */
     public static function numericValueConversionProvider(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

Related: #20582
