### PR TITLE
Moved `declare(strict_types=1)` before the license docblock and standardized PHPDoc headers across framework and test files.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -38,6 +38,7 @@ Yii Framework 2 Change Log
 - Bug: Fix `ActiveField::generateLabel()` to strip `label`/`for` attributes for custom tags and preserve prior label in `radio()`/`checkbox()` (terabytesoftw)
 - Bug: Fix `clientScript` not being instantiated in validators when a custom array config is set and `useJquery` is `false` (terabytesoftw)
 - Bug: Fix `CompareValidator` client-side closure `compareValue` resolution to pass `($model, $attribute)` and avoid mutating validator state (terabytesoftw)
+- Bug: Moved `declare(strict_types=1)` before the license docblock and standardized PHPDoc headers across framework and test files (terabytesoftw)
 
 
 2.0.55 under development

--- a/framework/caching/ApcuCache.php
+++ b/framework/caching/ApcuCache.php
@@ -33,7 +33,7 @@ use function is_array;
  * For more details and usage information on Cache, see the [guide article on caching](guide:caching-overview).
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2
+ * @since 22.0
  */
 class ApcuCache extends Cache
 {

--- a/framework/console/Application.php
+++ b/framework/console/Application.php
@@ -84,7 +84,7 @@ class Application extends \yii\base\Application
      *
      * When enabled, jQuery assets will be registered for validators and widgets that require it.
      *
-     * @since 2.2.0
+     * @since 22.0
      */
     public bool $useJquery = false;
 

--- a/framework/jquery/grid/CheckboxColumnJqueryClientScript.php
+++ b/framework/jquery/grid/CheckboxColumnJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\grid;
 
@@ -17,7 +17,7 @@ use yii\web\client\ClientScriptInterface;
 use yii\web\View;
 
 /**
- * CheckboxColumnJqueryClientScript provides client-side script registration for gridview checkbox columns.
+ * Provides client-side script registration for gridview checkbox columns.
  *
  * This class implements {@see ClientScriptInterface} to supply client-side options and register the corresponding
  * JavaScript code for checkbox selection columns in Yii2 gridviews using jQuery.
@@ -26,7 +26,7 @@ use yii\web\View;
  * @implements ClientScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class CheckboxColumnJqueryClientScript implements ClientScriptInterface
 {

--- a/framework/jquery/grid/GridViewJqueryClientScript.php
+++ b/framework/jquery/grid/GridViewJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\grid;
 
@@ -22,7 +22,7 @@ use yii\web\View;
 use function array_merge;
 
 /**
- * GridViewJqueryClientScript provides client-side script registration for GridView widgets using jQuery.
+ * Provides client-side script registration for GridView widgets using jQuery.
  *
  * This class implements {@see ClientScriptInterface} to supply client-side options and register the corresponding
  * JavaScript code for GridView widgets in Yii2 applications using jQuery.
@@ -31,7 +31,7 @@ use function array_merge;
  * @implements ClientScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class GridViewJqueryClientScript implements ClientScriptInterface
 {

--- a/framework/jquery/validators/BooleanValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/BooleanValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -19,7 +19,7 @@ use yii\validators\Validator;
 use yii\web\View;
 
 /**
- * BooleanValidatorJqueryClientScript provides client-side validation script generation for boolean attributes.
+ * Provides client-side validation script generation for boolean attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for boolean validation in Yii2 forms using jQuery.
@@ -28,7 +28,7 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class BooleanValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {

--- a/framework/jquery/validators/CompareValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/CompareValidatorJqueryClientScript.php
@@ -32,7 +32,7 @@ use function call_user_func;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2
+ * @since 22.0
  */
 class CompareValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {

--- a/framework/jquery/validators/EmailValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/EmailValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -21,7 +21,7 @@ use yii\web\JsExpression;
 use yii\web\View;
 
 /**
- * EmailValidatorJqueryClientScript provides client-side validation script generation for email attributes.
+ * Provides client-side validation script generation for email attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for email validation in Yii2 forms using jQuery.
@@ -30,7 +30,7 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class EmailValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {

--- a/framework/jquery/validators/FileValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/FileValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -23,7 +23,7 @@ use yii\web\JsExpression;
 use yii\web\View;
 
 /**
- * FileValidatorJqueryClientScript provides client-side validation script generation for file attributes.
+ * Provides client-side validation script generation for file attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for file validation in Yii2 forms using jQuery.
@@ -32,7 +32,7 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class FileValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {

--- a/framework/jquery/validators/ImageValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/ImageValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -15,7 +15,7 @@ use yii\validators\ImageValidator;
 use yii\validators\Validator;
 
 /**
- * ImageValidatorJqueryClientScript provides client-side validation script generation for image attributes.
+ * Provides client-side validation script generation for image attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for image validation in Yii2 forms using jQuery.
@@ -23,7 +23,7 @@ use yii\validators\Validator;
  * @extends FileValidatorJqueryClientScript<ImageValidator>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class ImageValidatorJqueryClientScript extends FileValidatorJqueryClientScript
 {

--- a/framework/jquery/validators/IpValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/IpValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -21,7 +21,7 @@ use yii\web\JsExpression;
 use yii\web\View;
 
 /**
- * IpValidatorJqueryClientScript provides client-side validation script generation for IP address attributes.
+ * Provides client-side validation script generation for IP address attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for IP address validation in Yii2 forms using jQuery.
@@ -30,7 +30,7 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class IpValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {

--- a/framework/jquery/validators/NumberValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/NumberValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -20,7 +20,7 @@ use yii\web\JsExpression;
 use yii\web\View;
 
 /**
- * NumberValidatorJqueryClientScript provides client-side validation script generation for number attributes.
+ * Provides client-side validation script generation for number attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for number validation in Yii2 forms using jQuery.
@@ -29,7 +29,7 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class NumberValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {

--- a/framework/jquery/validators/RangeValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/RangeValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -19,7 +19,7 @@ use yii\validators\Validator;
 use yii\web\View;
 
 /**
- * RangeValidatorJqueryClientScript provides client-side validation script generation for range attributes.
+ * Provides client-side validation script generation for range attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for range validation in Yii2 forms using jQuery.
@@ -28,7 +28,7 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class RangeValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {

--- a/framework/jquery/validators/RegularExpressionValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/RegularExpressionValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -21,8 +21,7 @@ use yii\web\JsExpression;
 use yii\web\View;
 
 /**
- * RegularExpressionValidatorJqueryClientScript provides client-side validation script generation for regular
- * expression attributes.
+ * Provides client-side validation script generation for regular expression attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for regular expression validation in Yii2 forms using jQuery.
@@ -31,7 +30,7 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class RegularExpressionValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {

--- a/framework/jquery/validators/RequiredValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/RequiredValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -19,7 +19,7 @@ use yii\validators\Validator;
 use yii\web\View;
 
 /**
- * RequiredValidatorJqueryClientScript provides client-side validation script generation for required attributes.
+ * Provides client-side validation script generation for required attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for required value validation in Yii2 forms using jQuery.
@@ -28,7 +28,7 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class RequiredValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {

--- a/framework/jquery/validators/StringValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/StringValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -19,7 +19,7 @@ use yii\validators\Validator;
 use yii\web\View;
 
 /**
- * StringValidatorJqueryClientScript provides client-side validation script generation for string attributes.
+ * Provides client-side validation script generation for string attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for string validation in Yii2 forms using jQuery.
@@ -28,7 +28,7 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class StringValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {

--- a/framework/jquery/validators/TrimValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/TrimValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -19,7 +19,7 @@ use yii\validators\Validator;
 use yii\web\View;
 
 /**
- * TrimValidatorJqueryClientScript provides client-side validation script generation for trimming attributes.
+ * Provides client-side validation script generation for trimming attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for trim validation in Yii2 forms using jQuery.
@@ -28,7 +28,7 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class TrimValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {
@@ -41,10 +41,10 @@ class TrimValidatorJqueryClientScript implements ClientValidatorScriptInterface
         ];
     }
 
-    public function register(Validator $validator, Model $model, string $attribute, View $view): string
+    public function register(Validator $validator, Model $model, string $attribute, View $view): string|null
     {
         if ($validator->skipOnArray && is_array($model->$attribute)) {
-            return '';
+            return null;
         }
 
         ValidationAsset::register($view);

--- a/framework/jquery/validators/UrlValidatorJqueryClientScript.php
+++ b/framework/jquery/validators/UrlValidatorJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\validators;
 
@@ -21,7 +21,7 @@ use yii\web\JsExpression;
 use yii\web\View;
 
 /**
- * UrlValidatorJqueryClientScript provides client-side validation script generation for URL attributes.
+ * Provides client-side validation script generation for URL attributes.
  *
  * This class implements {@see ClientValidatorScriptInterface} to supply client-side validation options and register the
  * corresponding JavaScript code for URL validation in Yii2 forms using jQuery.
@@ -30,7 +30,7 @@ use yii\web\View;
  * @implements ClientValidatorScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class UrlValidatorJqueryClientScript implements ClientValidatorScriptInterface
 {

--- a/framework/jquery/widgets/ActiveFormJqueryClientScript.php
+++ b/framework/jquery/widgets/ActiveFormJqueryClientScript.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\jquery\widgets;
 
@@ -27,7 +27,7 @@ use function in_array;
 use function preg_split;
 
 /**
- * ActiveFormJqueryClientScript provides jQuery-based client script integration for ActiveForm and ActiveField widgets.
+ * Provides jQuery-based client script integration for ActiveForm and ActiveField widgets.
  *
  * This class is responsible for generating and registering client-side validation options and scripts for Yii2
  * ActiveForm and ActiveField widgets, enabling AJAX and client validation via the `yii.activeForm` jQuery plugin.
@@ -36,7 +36,7 @@ use function preg_split;
  * @implements ClientScriptInterface<T>
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 class ActiveFormJqueryClientScript implements ClientScriptInterface
 {

--- a/framework/validators/Validator.php
+++ b/framework/validators/Validator.php
@@ -486,13 +486,11 @@ class Validator extends Component
      * parameters.
      *
      * @param string $message the message template to be formatted
-     * @param array $params the parameters to be inserted into the message
+     * @param array<string, mixed> $params the parameters to be inserted into the message
      *
      * @return string the formatted validation message
      *
-     * @phpstan-param array<string, mixed> $params
-     *
-     * @since 2.2.0
+     * @since 22.0
      */
     public function getFormattedClientMessage(string $message, array $params): string
     {

--- a/framework/validators/client/ClientValidatorScriptInterface.php
+++ b/framework/validators/client/ClientValidatorScriptInterface.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\validators\client;
 
@@ -15,7 +15,7 @@ use yii\validators\Validator;
 use yii\web\View;
 
 /**
- * ClientValidatorScriptInterface defines the contract for client-side validator script generation.
+ * Defines the contract for client-side validator script generation.
  *
  * Classes implementing this interface provide methods for retrieving client-side validation options and registering the
  * corresponding JavaScript code for a given validator, model, and attribute.
@@ -23,35 +23,30 @@ use yii\web\View;
  * @template T of Validator
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 interface ClientValidatorScriptInterface
 {
     /**
      * Returns client-side validation options for the specified validator, model, and attribute.
      *
-     * @param Validator $validator the validator instance.
+     * @param T $validator the validator instance.
      * @param Model $model the data model being validated.
      * @param string $attribute the attribute name being validated.
      *
-     * @return array client-side validation options.
-     *
-     * @phpstan-param T $validator
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed> client-side validation options.
      */
     public function getClientOptions(Validator $validator, Model $model, string $attribute): array;
 
     /**
      * Registers the client-side validation script for the specified validator, model, and attribute in the view.
      *
-     * @param Validator $validator the validator instance.
+     * @param T $validator the validator instance.
      * @param Model $model the data model being validated.
      * @param string $attribute the attribute name being validated.
      * @param View $view the view instance where the script will be registered.
      *
-     * @return string the JavaScript code for client-side validation.
-     *
-     * @phpstan-param T $validator
+     * @return string|null The client-side validation script, or `null` if not supported.
      */
-    public function register(Validator $validator, Model $model, string $attribute, View $view): string;
+    public function register(Validator $validator, Model $model, string $attribute, View $view): string|null;
 }

--- a/framework/web/Application.php
+++ b/framework/web/Application.php
@@ -65,7 +65,7 @@ class Application extends \yii\base\Application
      *
      * Set to `false` to disable automatic jQuery inclusion for these features.
      *
-     * @since 2.2.0
+     * @since 22.0
      */
     public bool $useJquery = true;
 

--- a/framework/web/View.php
+++ b/framework/web/View.php
@@ -163,7 +163,7 @@ class View extends \yii\base\View
      * When `true` (default), maintains backward compatibility by using jQuery wrappers.
      * When `false`, uses vanilla JavaScript equivalents.
      *
-     * @since 2.2.0
+     * @since 22.0
      */
     public bool $useJquery = true;
 
@@ -728,7 +728,7 @@ class View extends \yii\base\View
      *
      * @return string the wrapped script
      *
-     * @since 2.2.0
+     * @since 22.0
      */
     protected function wrapReadyScript(string $script): string
     {
@@ -748,7 +748,7 @@ class View extends \yii\base\View
      *
      * @return string the wrapped script
      *
-     * @since 2.2.0
+     * @since 22.0
      */
     protected function wrapLoadScript(string $script): string
     {

--- a/framework/web/client/ClientScriptInterface.php
+++ b/framework/web/client/ClientScriptInterface.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yii\web\client;
 
@@ -14,7 +14,7 @@ use yii\base\BaseObject;
 use yii\web\View;
 
 /**
- * ClientScriptInterface defines the contract for registering client-side scripts for widgets and components.
+ * Defines the contract for registering client-side scripts for widgets and components.
  *
  * Classes implementing this interface are responsible for providing client options and registering scripts in the
  * context of Yii2 widgets and views.
@@ -22,7 +22,7 @@ use yii\web\View;
  * @template T of BaseObject
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2.0
+ * @since 22.0
  */
 interface ClientScriptInterface
 {
@@ -31,14 +31,10 @@ interface ClientScriptInterface
      *
      * This method is used to retrieve the options that will be passed to the client-side script.
      *
-     * @param BaseObject $object the object for which to get the client options.
-     * @param array $options additional options that may influence the client options returned.
+     * @param T $object the object for which to get the client options.
+     * @param array<string, mixed> $options additional options that may influence the client options returned.
      *
-     * @return array the client options for the widget or component.
-     *
-     * @phpstan-param T $object
-     * @phpstan-param array<string, mixed> $options
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed> the client options for the widget or component.
      */
     public function getClientOptions(BaseObject $object, array $options = []): array;
 
@@ -47,14 +43,9 @@ interface ClientScriptInterface
      *
      * This method is used to register the necessary client-side scripts for the widget in the given view.
      *
-     * @param BaseObject $object the object whose client script is to be registered.
+     * @param T $object the object whose client script is to be registered.
      * @param View $view the view in which the client script should be registered.
-     * @param array $options additional options that may influence the script registration process.
-     *
-     * @return void
-     *
-     * @phpstan-param T $object
-     * @phpstan-param array<string, mixed> $options
+     * @param array<string, mixed> $options additional options that may influence the script registration process.
      */
     public function register(BaseObject $object, View $view, array $options = []): void;
 }

--- a/tests/IsOneOfAssert.php
+++ b/tests/IsOneOfAssert.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit;
 

--- a/tests/data/ar/Animal.php
+++ b/tests/data/ar/Animal.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\ar;
 

--- a/tests/data/ar/Cat.php
+++ b/tests/data/ar/Cat.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\ar;
 

--- a/tests/data/ar/Customer.php
+++ b/tests/data/ar/Customer.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\ar;
 

--- a/tests/data/ar/CustomerQuery.php
+++ b/tests/data/ar/CustomerQuery.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\ar;
 

--- a/tests/data/ar/CustomerWithConstructor.php
+++ b/tests/data/ar/CustomerWithConstructor.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\ar;
 

--- a/tests/data/ar/Dog.php
+++ b/tests/data/ar/Dog.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\ar;
 

--- a/tests/data/ar/NoAutoLabels.php
+++ b/tests/data/ar/NoAutoLabels.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\ar;
 

--- a/tests/data/ar/OrderItemWithConstructor.php
+++ b/tests/data/ar/OrderItemWithConstructor.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\ar;
 

--- a/tests/data/ar/OrderWithConstructor.php
+++ b/tests/data/ar/OrderWithConstructor.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\ar;
 

--- a/tests/data/ar/ProfileWithConstructor.php
+++ b/tests/data/ar/ProfileWithConstructor.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\ar;
 

--- a/tests/data/base/ArrayAccessObject.php
+++ b/tests/data/base/ArrayAccessObject.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\base;
 

--- a/tests/data/base/Speaker.php
+++ b/tests/data/base/Speaker.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\base;
 

--- a/tests/data/base/TraversableObject.php
+++ b/tests/data/base/TraversableObject.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\base;
 

--- a/tests/data/console/controllers/fixtures/DependentActiveFixture.php
+++ b/tests/data/console/controllers/fixtures/DependentActiveFixture.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\console\controllers\fixtures;
 

--- a/tests/data/console/controllers/fixtures/FirstFixture.php
+++ b/tests/data/console/controllers/fixtures/FirstFixture.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\console\controllers\fixtures;
 

--- a/tests/data/console/controllers/fixtures/FirstIndependentActiveFixture.php
+++ b/tests/data/console/controllers/fixtures/FirstIndependentActiveFixture.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\console\controllers\fixtures;
 

--- a/tests/data/console/controllers/fixtures/FixtureStorage.php
+++ b/tests/data/console/controllers/fixtures/FixtureStorage.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\console\controllers\fixtures;
 

--- a/tests/data/console/controllers/fixtures/GlobalFixture.php
+++ b/tests/data/console/controllers/fixtures/GlobalFixture.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\console\controllers\fixtures;
 

--- a/tests/data/console/controllers/fixtures/SecondFixture.php
+++ b/tests/data/console/controllers/fixtures/SecondFixture.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\console\controllers\fixtures;
 

--- a/tests/data/console/controllers/fixtures/SecondIndependentActiveFixture.php
+++ b/tests/data/console/controllers/fixtures/SecondIndependentActiveFixture.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\console\controllers\fixtures;
 

--- a/tests/data/console/controllers/fixtures/subdir/FirstFixture.php
+++ b/tests/data/console/controllers/fixtures/subdir/FirstFixture.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\console\controllers\fixtures\subdir;
 

--- a/tests/data/console/controllers/fixtures/subdir/SecondFixture.php
+++ b/tests/data/console/controllers/fixtures/subdir/SecondFixture.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\console\controllers\fixtures\subdir;
 

--- a/tests/data/controllers/TestController.php
+++ b/tests/data/controllers/TestController.php
@@ -2,6 +2,12 @@
 
 declare(strict_types=1);
 
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
 namespace yiiunit\data\controllers;
 
 use yii\web\Controller;

--- a/tests/data/modules/magic/controllers/ETagController.php
+++ b/tests/data/modules/magic/controllers/ETagController.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\modules\magic\controllers;
 

--- a/tests/data/modules/magic/controllers/subFolder/SubController.php
+++ b/tests/data/modules/magic/controllers/subFolder/SubController.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\modules\magic\controllers\subFolder;
 

--- a/tests/data/validators/TestValidator.php
+++ b/tests/data/validators/TestValidator.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\data\validators;
 

--- a/tests/framework/ChangeLogTest.php
+++ b/tests/framework/ChangeLogTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework;
 

--- a/tests/framework/base/ActionFilterTest.php
+++ b/tests/framework/base/ActionFilterTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/ApplicationTest.php
+++ b/tests/framework/base/ApplicationTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/ArrayableTraitTest.php
+++ b/tests/framework/base/ArrayableTraitTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/BaseObjectTest.php
+++ b/tests/framework/base/BaseObjectTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/BehaviorTest.php
+++ b/tests/framework/base/BehaviorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/ComponentTest.php
+++ b/tests/framework/base/ComponentTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/ControllerTest.php
+++ b/tests/framework/base/ControllerTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/DynamicModelTest.php
+++ b/tests/framework/base/DynamicModelTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/ErrorExceptionTest.php
+++ b/tests/framework/base/ErrorExceptionTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/EventTest.php
+++ b/tests/framework/base/EventTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/ModelTest.php
+++ b/tests/framework/base/ModelTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/ModuleTest.php
+++ b/tests/framework/base/ModuleTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/SecurityTest.php
+++ b/tests/framework/base/SecurityTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/StaticInstanceTraitTest.php
+++ b/tests/framework/base/StaticInstanceTraitTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/ThemeTest.php
+++ b/tests/framework/base/ThemeTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/base/ViewTest.php
+++ b/tests/framework/base/ViewTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 

--- a/tests/framework/behaviors/AttributeBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeBehaviorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\behaviors;
 

--- a/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\behaviors;
 

--- a/tests/framework/behaviors/AttributesBehaviorTest.php
+++ b/tests/framework/behaviors/AttributesBehaviorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\behaviors;
 

--- a/tests/framework/behaviors/BlameableBehaviorConsoleTest.php
+++ b/tests/framework/behaviors/BlameableBehaviorConsoleTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\behaviors;
 

--- a/tests/framework/behaviors/BlameableBehaviorTest.php
+++ b/tests/framework/behaviors/BlameableBehaviorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\behaviors;
 

--- a/tests/framework/behaviors/OptimisticLockBehaviorTest.php
+++ b/tests/framework/behaviors/OptimisticLockBehaviorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\behaviors;
 

--- a/tests/framework/caching/ApcuCacheTest.php
+++ b/tests/framework/caching/ApcuCacheTest.php
@@ -21,7 +21,7 @@ use yii\caching\ApcuCache;
  * Requires `apc.enable_cli=1` in `php.ini` for CLI execution.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2
+ * @since 22.0
  */
 #[Group('caching')]
 #[Group('apcu')]

--- a/tests/framework/db/sqlite/conditions/InconditionBuilderTest.php
+++ b/tests/framework/db/sqlite/conditions/InconditionBuilderTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\db\sqlite\conditions;
 

--- a/tests/framework/grid/SerialColumnTest.php
+++ b/tests/framework/grid/SerialColumnTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\grid;
 

--- a/tests/framework/jquery/grid/CheckboxColumnJqueryClientScriptTest.php
+++ b/tests/framework/jquery/grid/CheckboxColumnJqueryClientScriptTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\jquery\grid;
 

--- a/tests/framework/jquery/grid/GridViewJqueryClientScriptTest.php
+++ b/tests/framework/jquery/grid/GridViewJqueryClientScriptTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\jquery\grid;
 

--- a/tests/framework/jquery/validators/TrimValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/TrimValidatorJqueryClientScriptTest.php
@@ -20,7 +20,7 @@ use yiiunit\TestCase;
  * Unit tests for {@see TrimValidator} client validation script.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2
+ * @since 22.0
  */
 #[Group('jquery')]
 #[Group('validators')]

--- a/tests/framework/jquery/validators/UrlValidatorJqueryClientScriptTest.php
+++ b/tests/framework/jquery/validators/UrlValidatorJqueryClientScriptTest.php
@@ -20,7 +20,7 @@ use yiiunit\TestCase;
  * Unit tests for {@see UrlValidator} client validation script.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2
+ * @since 22.0
  */
 #[Group('jquery')]
 #[Group('validators')]

--- a/tests/framework/validators/CompareValidatorTest.php
+++ b/tests/framework/validators/CompareValidatorTest.php
@@ -22,7 +22,7 @@ use yiiunit\TestCase;
  * Unit test for {@see CompareValidator}.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2
+ * @since 22.0
  */
 #[Group('validators')]
 final class CompareValidatorTest extends TestCase

--- a/tests/framework/validators/EachValidatorTest.php
+++ b/tests/framework/validators/EachValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\validators;
 

--- a/tests/framework/validators/EmailValidatorTest.php
+++ b/tests/framework/validators/EmailValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\validators;
 

--- a/tests/framework/validators/FileValidatorTest.php
+++ b/tests/framework/validators/FileValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\validators;
 

--- a/tests/framework/validators/IpValidatorTest.php
+++ b/tests/framework/validators/IpValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\validators;
 

--- a/tests/framework/validators/NumberValidatorTest.php
+++ b/tests/framework/validators/NumberValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\validators;
 

--- a/tests/framework/validators/RangeValidatorTest.php
+++ b/tests/framework/validators/RangeValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\validators;
 

--- a/tests/framework/validators/RegularExpressionValidatorTest.php
+++ b/tests/framework/validators/RegularExpressionValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\validators;
 

--- a/tests/framework/validators/RequiredValidatorTest.php
+++ b/tests/framework/validators/RequiredValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\validators;
 

--- a/tests/framework/validators/StringValidatorTest.php
+++ b/tests/framework/validators/StringValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\validators;
 

--- a/tests/framework/validators/UrlValidatorTest.php
+++ b/tests/framework/validators/UrlValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\validators;
 

--- a/tests/framework/validators/ValidatorTest.php
+++ b/tests/framework/validators/ValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\validators;
 

--- a/tests/framework/validators/providers/EmailValidatorProvider.php
+++ b/tests/framework/validators/providers/EmailValidatorProvider.php
@@ -1,19 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\validators\providers;
 
 /**
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  *
- * @since 2.2.0
+ * @since 22.0
  */
 final class EmailValidatorProvider
 {

--- a/tests/framework/validators/providers/FileValidatorProvider.php
+++ b/tests/framework/validators/providers/FileValidatorProvider.php
@@ -1,19 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\validators\providers;
 
 /**
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  *
- * @since 2.2.0
+ * @since 22.0
  */
 final class FileValidatorProvider
 {

--- a/tests/framework/validators/stub/EmailValidatorMockeryFunctionsTrait.php
+++ b/tests/framework/validators/stub/EmailValidatorMockeryFunctionsTrait.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-declare(strict_types=1);
-
 namespace yiiunit\framework\validators\stub;
 
 /**
+ * Trait that provides mockery functions for the {@see \yii\validators\EmailValidator} test cases.
+ *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  *
- * @since 2.2.0
+ * @since 22.0
  */
 trait EmailValidatorMockeryFunctionsTrait
 {

--- a/tests/framework/widgets/ActiveFormTest.php
+++ b/tests/framework/widgets/ActiveFormTest.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
-
-declare(strict_types=1);
 
 namespace yiiunit\framework\widgets;
 

--- a/tests/framework/widgets/providers/ActiveFieldProvider.php
+++ b/tests/framework/widgets/providers/ActiveFieldProvider.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * Provides representative input/output pairs for label, hint, radio, and checkbox attributes.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2
+ * @since 22.0
  */
 
 namespace yiiunit\framework\widgets\providers;

--- a/tests/support/MockerExtension.php
+++ b/tests/support/MockerExtension.php
@@ -25,7 +25,7 @@ use Xepozz\InternalMocker\MockerState;
  * PHPUnit extension that registers internal-function mocks for test execution.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
- * @since 2.2
+ * @since 22.0
  */
 final class MockerExtension implements Extension
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
