### PR TITLE
Fix `Controller::getActionArgsHelp()` crashing on PHP `8.2+` DNF/intersection types in console `Controller` class.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -40,6 +40,7 @@ Yii Framework 2 Change Log
 - Bug: Fix `CompareValidator` client-side closure `compareValue` resolution to pass `($model, $attribute)` and avoid mutating validator state (terabytesoftw)
 - Bug: Moved `declare(strict_types=1)` before the license docblock and standardized PHPDoc headers across framework and test files (terabytesoftw)
 - Chg: Extract jQuery integration to `yiisoft/yii2-jquery` extension, make framework CSS-agnostic, and switch `View` ready/load wrappers to vanilla JS event listeners (terabytesoftw)
+- Bug: Fix `Controller::getActionArgsHelp()` crashing on PHP `8.2+` DNF/intersection types in console `Controller` class (terabytesoftw)
 
 
 2.0.55 under development

--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -8,6 +8,11 @@
 
 namespace yii\console;
 
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionParameter;
+use ReflectionType;
+use ReflectionUnionType;
 use Yii;
 use yii\base\Action;
 use yii\base\InlineAction;
@@ -561,21 +566,20 @@ class Controller extends BaseController
     /**
      * Returns the help information for the anonymous arguments for the action.
      *
-     * The returned value should be an array. The keys are the argument names, and the values are
-     * the corresponding help information. Each value must be an array of the following structure:
+     * The returned value should be an array. The keys are the argument names, and the values are the corresponding help
+     * information. Each value must be an array of the following structure:
      *
-     * - required: bool, whether this argument is required
-     * - type: string|null, the PHP type(s) of this argument
-     * - default: mixed, the default value of this argument
-     * - comment: string, the description of this argument
+     * - required: bool, whether this argument is required.
+     * - type: string|null, the PHP type(s) of this argument.
+     * - default: mixed, the default value of this argument.
+     * - comment: string, the description of this argument.
      *
-     * The default implementation will return the help information extracted from the Reflection or
-     * DocBlock of the parameters corresponding to the action method.
+     * The default implementation will return the help information extracted from the Reflection or DocBlock of the
+     * parameters corresponding to the action method.
      *
      * @param Action<static> $action the action instance
      * @return array the help information of the action arguments
      *
-     * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function getActionArgsHelp($action)
@@ -595,17 +599,12 @@ class Controller extends BaseController
 
         $args = [];
 
-        /** @var \ReflectionParameter $parameter */
+        /** @var ReflectionParameter $parameter */
         foreach ($method->getParameters() as $i => $parameter) {
             $type = null;
             $comment = '';
             if ($parameter->hasType()) {
-                $reflectionType = $parameter->getType();
-                $types = method_exists($reflectionType, 'getTypes') ? $reflectionType->getTypes() : [$reflectionType];
-                foreach ($types as $key => $reflectionType) {
-                    $types[$key] = $reflectionType->getName();
-                }
-                $type = implode('|', $types);
+                $type = $this->stringifyReflectionType($parameter->getType());
             }
             // find PhpDoc tag by property name or position
             $key = isset($phpDocParams[$parameter->name]) ? $parameter->name : (isset($phpDocParams[$i]) ? $i : null);
@@ -697,6 +696,50 @@ class Controller extends BaseController
         }
 
         return $options;
+    }
+
+    /**
+     * Converts a {@see ReflectionType} to its string representation.
+     *
+     * Handles named, nullable, union, intersection, and DNF (Disjunctive Normal Form) types.
+     *
+     * @param ReflectionType $type the reflection type to stringify.
+     *
+     * @return string the string representation of the type.
+     */
+    private function stringifyReflectionType(ReflectionType $type): string
+    {
+        if ($type instanceof ReflectionNamedType) {
+            return $type->getName();
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            $parts = array_map(
+                function (ReflectionType $nestedType): string {
+                    $str = $this->stringifyReflectionType($nestedType);
+
+                    if ($nestedType instanceof ReflectionIntersectionType) {
+                        return "({$str})";
+                    }
+
+                    return $str;
+                },
+                $type->getTypes(),
+            );
+
+            return implode('|', $parts);
+        }
+
+        if ($type instanceof ReflectionIntersectionType) {
+            $parts = array_map(
+                fn(ReflectionType $nestedType): string => $this->stringifyReflectionType($nestedType),
+                $type->getTypes(),
+            );
+
+            return implode('&', $parts);
+        }
+
+        return (string) $type;
     }
 
     private $_reflections = [];

--- a/tests/framework/console/ControllerTest.php
+++ b/tests/framework/console/ControllerTest.php
@@ -8,6 +8,9 @@
 
 namespace yiiunit\framework\console;
 
+use PHPUnit\Framework\Attributes\Group;
+use ReflectionMethod;
+use ReflectionType;
 use yii\data\ArrayDataProvider;
 use RuntimeException;
 use Yii;
@@ -21,9 +24,7 @@ use yii\helpers\Console;
 use yiiunit\framework\console\stubs\DummyService;
 use yiiunit\TestCase;
 
-/**
- * @group console
- */
+#[Group('console')]
 class ControllerTest extends TestCase
 {
     /**
@@ -283,13 +284,157 @@ class ControllerTest extends TestCase
     public function testGetActionArgsHelp(): void
     {
         $controller = new FakeController('fake', Yii::$app);
+
         $help = $controller->getActionArgsHelp($controller->createAction('aksi2'));
 
-        $this->assertArrayHasKey('values', $help);
-        $this->assertEquals('array', $help['values']['type']);
-        $this->assertArrayHasKey('value', $help);
+        self::assertArrayHasKey(
+            'values',
+            $help,
+            "Expected help to expose the 'values' argument.",
+        );
+        self::assertSame(
+            'array',
+            $help['values']['type'],
+            "Declared 'array' type should be reported for the 'values' argument.",
+        );
+        self::assertArrayHasKey(
+            'value',
+            $help,
+            "Expected help to expose the 'value' argument.",
+        );
         // PHPDoc type
-        $this->assertEquals('string', $help['value']['type']);
+        self::assertSame(
+            'string',
+            $help['value']['type'],
+            "PHPDoc 'string' type should be reported for the 'value' argument.",
+        );
+    }
+
+    public function testGetActionArgsHelpWithUnionType(): void
+    {
+        $controller = new FakeController('fake', Yii::$app);
+
+        $help = $controller->getActionArgsHelp($controller->createAction('union-type'));
+
+        self::assertArrayHasKey(
+            'param',
+            $help,
+            "Expected help to expose the 'param' argument for the union-typed action.",
+        );
+        self::assertSame(
+            'string|int',
+            $help['param']['type'],
+            "Union type 'string|int' should be rendered for the 'param' argument.",
+        );
+        self::assertTrue(
+            $help['param']['required'],
+            'Argument without a default value must be reported as required.',
+        );
+    }
+
+    public function testGetActionArgsHelpWithIntersectionType(): void
+    {
+        $controller = new FakeController('fake', Yii::$app);
+
+        $help = $controller->getActionArgsHelp($controller->createAction('intersection-type'));
+
+        self::assertArrayHasKey(
+            'param',
+            $help,
+            "Expected help to expose the 'param' argument for the intersection-typed action.",
+        );
+        self::assertSame(
+            'Countable&Iterator',
+            $help['param']['type'],
+            "Intersection type 'Countable&Iterator' should be rendered for the 'param' argument.",
+        );
+        self::assertTrue(
+            $help['param']['required'],
+            'Argument without a default value must be reported as required.',
+        );
+    }
+
+    public function testGetActionArgsHelpWithDnfType(): void
+    {
+        $controller = new FakeController('fake', Yii::$app);
+
+        $help = $controller->getActionArgsHelp($controller->createAction('dnf-type'));
+
+        self::assertArrayHasKey(
+            'param',
+            $help,
+            "Expected help to expose the 'param' argument for the DNF-typed action.",
+        );
+        self::assertSame(
+            '(Countable&Iterator)|null',
+            $help['param']['type'],
+            "DNF type '(Countable&Iterator)|null' should be rendered with parenthesized intersection.",
+        );
+        self::assertFalse(
+            $help['param']['required'],
+            'Argument with a default value must be reported as optional.',
+        );
+    }
+
+    public function testGetActionArgsHelpWithNullableType(): void
+    {
+        $controller = new FakeController('fake', Yii::$app);
+
+        $help = $controller->getActionArgsHelp($controller->createAction('nullable-type'));
+
+        self::assertArrayHasKey(
+            'param',
+            $help,
+            "Expected help to expose the 'param' argument for the nullable-typed action.",
+        );
+        self::assertSame(
+            'int',
+            $help['param']['type'],
+            "Nullable named type '?int' should render as 'int' (matching 'ReflectionNamedType::getName()').",
+        );
+        self::assertFalse(
+            $help['param']['required'],
+            'Argument with a default value must be reported as optional.',
+        );
+    }
+
+    public function testGetActionArgsHelpWithUnionNullableType(): void
+    {
+        $controller = new FakeController('fake', Yii::$app);
+
+        $help = $controller->getActionArgsHelp($controller->createAction('union-nullable-type'));
+
+        self::assertArrayHasKey(
+            'param',
+            $help,
+            "Expected help to expose the 'param' argument for the union-nullable-typed action.",
+        );
+        self::assertSame(
+            'string|int|null',
+            $help['param']['type'],
+            "Union type with 'null' should render every member including 'null'.",
+        );
+        self::assertFalse(
+            $help['param']['required'],
+            'Argument with a default value must be reported as optional.',
+        );
+    }
+
+    public function testStringifyReflectionTypeWithUnknownSubclass(): void
+    {
+        $controller = new FakeController('fake', Yii::$app);
+
+        $mockType = $this->createMock(ReflectionType::class);
+
+        $mockType->method('__toString')->willReturn('unknown');
+
+        $method = new ReflectionMethod($controller, 'stringifyReflectionType');
+
+        self::assertSame(
+            'unknown',
+            $method->invoke($controller, $mockType),
+            "Unknown 'ReflectionType' subclasses should fall back to string casting.",
+        );
     }
 
     public function testGetActionHelpSummaryOnNull(): void

--- a/tests/framework/console/FakeController.php
+++ b/tests/framework/console/FakeController.php
@@ -110,4 +110,29 @@ class FakeController extends Controller
     {
         return [$foo, $bar, $baz];
     }
+
+    public function actionUnionType(int|string $param): int|string
+    {
+        return $param;
+    }
+
+    public function actionIntersectionType(\Countable&\Iterator $param): \Countable&\Iterator
+    {
+        return $param;
+    }
+
+    public function actionDnfType((\Countable&\Iterator)|null $param = null): (\Countable&\Iterator)|null
+    {
+        return $param;
+    }
+
+    public function actionNullableType(?int $param = null): ?int
+    {
+        return $param;
+    }
+
+    public function actionUnionNullableType(int|string|null $param = null): int|string|null
+    {
+        return $param;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
