### PR TITLE
Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -42,6 +42,7 @@ Yii Framework 2 Change Log
 - Chg: Extract jQuery integration to `yiisoft/yii2-jquery` extension, make framework CSS-agnostic, and switch `View` ready/load wrappers to vanilla JS event listeners (terabytesoftw)
 - Bug: Fix `Controller::getActionArgsHelp()` crashing on PHP `8.2+` DNF/intersection types in console `Controller` class (terabytesoftw)
 - Chg: Remove deprecated APIs in `Security`, `View`, and `UniqueValidator`, delete deprecated migration template `createJunctionMigration.php`, and clean related validator tests (terabytesoftw)
+- Enh: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
 
 
 2.0.55 under development

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -35,8 +35,9 @@ use function is_string;
 class ErrorHandler extends \yii\base\ErrorHandler
 {
     /**
-     * @event ErrorHandlerRenderEvent an event that is triggered after HTML error content is rendered.
-     * Event handlers may modify [[ErrorHandlerRenderEvent::$output]].
+     * {@see ErrorHandlerRenderEvent} an event that is triggered after HTML error content is rendered.
+     *
+     * Event handlers may modify {@see ErrorHandlerRenderEvent::$output}.
      *
      * @since 22.0
      */

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -8,11 +8,14 @@
 
 namespace yii\web;
 
+use Throwable;
 use Yii;
 use yii\base\ErrorException;
 use yii\base\Exception;
 use yii\base\UserException;
 use yii\helpers\VarDumper;
+
+use function is_string;
 
 /**
  * ErrorHandler handles uncaught PHP errors and exceptions.
@@ -31,6 +34,14 @@ use yii\helpers\VarDumper;
  */
 class ErrorHandler extends \yii\base\ErrorHandler
 {
+    /**
+     * @event ErrorHandlerRenderEvent an event that is triggered after HTML error content is rendered.
+     * Event handlers may modify [[ErrorHandlerRenderEvent::$output]].
+     *
+     * @since 22.0
+     */
+    public const string EVENT_AFTER_RENDER = 'afterRender';
+
     /**
      * @var int maximum number of source code lines to be displayed. Defaults to 19.
      */
@@ -136,6 +147,14 @@ class ErrorHandler extends \yii\base\ErrorHandler
             $response->data = $this->convertExceptionToArray($exception);
         }
 
+        if ($response->format === Response::FORMAT_HTML) {
+            if (is_string($response->data)) {
+                $response->data = $this->triggerAfterRender($exception, $response->data);
+            } elseif (is_string($response->content)) {
+                $response->content = $this->triggerAfterRender($exception, $response->content);
+            }
+        }
+
         $response->send();
     }
 
@@ -184,6 +203,32 @@ class ErrorHandler extends \yii\base\ErrorHandler
     public function htmlEncode($text)
     {
         return htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
+    }
+
+    /**
+     * Triggers [[EVENT_AFTER_RENDER]] and returns final HTML content.
+     *
+     * @param Throwable $exception the exception being rendered.
+     * @param string $output the rendered HTML output.
+     *
+     * @return string the final HTML output.
+     *
+     * @since 22.0
+     */
+    protected function triggerAfterRender(Throwable $exception, string $output)
+    {
+        if ($this->hasEventHandlers(self::EVENT_AFTER_RENDER)) {
+            $event = new ErrorHandlerRenderEvent();
+
+            $event->exception = $exception;
+            $event->output = $output;
+
+            $this->trigger(self::EVENT_AFTER_RENDER, $event);
+
+            return $event->output;
+        }
+
+        return $output;
     }
 
     /**

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -207,7 +207,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
     }
 
     /**
-     * Triggers [[EVENT_AFTER_RENDER]] and returns final HTML content.
+     * Triggers {@see EVENT_AFTER_RENDER} and returns final HTML content.
      *
      * @param Throwable $exception the exception being rendered.
      * @param string $output the rendered HTML output.

--- a/framework/web/ErrorHandlerRenderEvent.php
+++ b/framework/web/ErrorHandlerRenderEvent.php
@@ -14,7 +14,7 @@ use Throwable;
 use yii\base\Event;
 
 /**
- * ErrorHandlerRenderEvent represents events triggered by [[ErrorHandler]].
+ * Represents events triggered by {@see ErrorHandler}.
  *
  * @since 22.0
  */

--- a/framework/web/ErrorHandlerRenderEvent.php
+++ b/framework/web/ErrorHandlerRenderEvent.php
@@ -27,6 +27,5 @@ class ErrorHandlerRenderEvent extends Event
     /**
      * Rendered HTML output.
      */
-    public string $output = "";
+    public string $output = '';
 }
-

--- a/framework/web/ErrorHandlerRenderEvent.php
+++ b/framework/web/ErrorHandlerRenderEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yii\web;
+
+use Throwable;
+use yii\base\Event;
+
+/**
+ * ErrorHandlerRenderEvent represents events triggered by [[ErrorHandler]].
+ *
+ * @since 22.0
+ */
+class ErrorHandlerRenderEvent extends Event
+{
+    /**
+     * Exception being rendered.
+     */
+    public Throwable|null $exception = null;
+    /**
+     * Rendered HTML output.
+     */
+    public string $output = "";
+}
+

--- a/tests/framework/web/ErrorHandlerTest.php
+++ b/tests/framework/web/ErrorHandlerTest.php
@@ -183,7 +183,8 @@ Exception: yii\web\NotFoundHttpException', $out);
         ob_get_clean();
 
         self::assertSame(
-            $exception, $actualException,
+            $exception,
+            $actualException,
             "Exception passed to the 'afterRender' event should be the same as the one rendered."
         );
         self::assertStringContainsString(

--- a/tests/framework/web/ErrorHandlerTest.php
+++ b/tests/framework/web/ErrorHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -9,13 +11,21 @@
 namespace yiiunit\framework\web;
 
 use Exception;
+use PHPUnit\Framework\Attributes\Group;
 use yii\BaseYii;
+use yii\base\ErrorException;
 use yii\web\Application;
 use Yii;
+use yii\web\ErrorHandlerRenderEvent;
 use yii\web\NotFoundHttpException;
 use yii\web\View;
 use yiiunit\TestCase;
 
+/**
+ * Unit test for {@see \yii\web\ErrorHandler}.
+ */
+#[Group('web')]
+#[Group('error-handler')]
 class ErrorHandlerTest extends TestCase
 {
     protected function setUp(): void
@@ -116,6 +126,97 @@ Exception: yii\web\NotFoundHttpException', $out);
         ob_get_clean();
         $out = Yii::$app->response->data;
         $this->assertStringNotContainsString('<script', $out);
+    }
+
+    public function testAfterRenderEventCanModifyOutput(): void
+    {
+        $handler = Yii::$app->getErrorHandler();
+
+        $exception = new Exception('Some Exception');
+
+        $actualException = null;
+
+        $handler->on(
+            ErrorHandler::EVENT_AFTER_RENDER,
+            static function (ErrorHandlerRenderEvent $event) use (&$actualException): void {
+                $actualException = $event->exception;
+                $event->output .= "\n<!--after-render-->";
+            }
+        );
+
+        ob_start(); // suppress response output
+        $this->invokeMethod($handler, 'renderException', [$exception]);
+        ob_get_clean();
+
+        self::assertSame(
+            $exception,
+            $actualException,
+            "Exception passed to the 'afterRender' event should be the same as the one rendered.",
+        );
+        self::assertStringContainsString(
+            '<!--after-render-->',
+            Yii::$app->response->data,
+            "Output modified in the 'afterRender' event should be present in the response.",
+        );
+    }
+
+    public function testAfterRenderEventCanModifyOutputInErrorActionView(): void
+    {
+        $handler = Yii::$app->getErrorHandler();
+
+        $handler->errorAction = 'test/error';
+
+        $exception = new NotFoundHttpException('Resource not found');
+
+        $actualException = null;
+
+        $handler->on(
+            ErrorHandler::EVENT_AFTER_RENDER,
+            static function (ErrorHandlerRenderEvent $event) use (&$actualException): void {
+                $actualException = $event->exception;
+                $event->output .= "\n<!--after-render-error-action-->";
+            }
+        );
+
+        ob_start(); // suppress response output
+        $this->invokeMethod($handler, 'renderException', [$exception]);
+        ob_get_clean();
+
+        self::assertSame(
+            $exception, $actualException,
+            "Exception passed to the 'afterRender' event should be the same as the one rendered."
+        );
+        self::assertStringContainsString(
+            '<!--after-render-error-action-->',
+            Yii::$app->response->data,
+            "Output modified in the 'afterRender' event should be present in the response."
+        );
+    }
+
+    public function testAfterRenderEventCanModifyOutputForPhpErrors(): void
+    {
+        $handler = Yii::$app->getErrorHandler();
+
+        $exception = new ErrorException('PHP Warning', E_WARNING, E_WARNING, __FILE__, __LINE__);
+
+        $handler->exception = $exception;
+
+        $handler->on(
+            ErrorHandler::EVENT_AFTER_RENDER,
+            static function (ErrorHandlerRenderEvent $event): void {
+                $event->output .= "\n<!--php-error-after-render-->";
+            }
+        );
+
+        ob_start(); // suppress response output
+        $this->invokeMethod($handler, 'renderException', [$exception]);
+        ob_get_clean();
+
+        self::assertStringContainsString(
+            '<!--php-error-after-render-->',
+            Yii::$app->response->data,
+            "Output modified in the 'afterRender' event should be present in the response."
+        );
     }
 
     public function testRenderCallStackItem(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #7616 
