### PR TITLE
Refactor controller tests to use new FakeInjectionController, FakeTypedParamsController, and FakeUnionTypesController; remove deprecated PHP `7.1` controller references.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1315,24 +1315,6 @@ parameters:
 			path: tests/framework/base/ComponentTest.php
 
 		-
-			message: '#^Property yiiunit\\framework\\console\\ControllerTest\:\:\$controller \(yiiunit\\framework\\console\\FakeController\) does not accept yiiunit\\framework\\console\\FakePhp71Controller\.$#'
-			identifier: assign.propertyType
-			count: 5
-			path: tests/framework/console/ControllerTest.php
-
-		-
-			message: '#^Parameter \$post of method yiiunit\\framework\\console\\FakePhp71Controller\:\:actionInjection\(\) has invalid type yiiunit\\framework\\base\\Post\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/framework/console/FakePhp71Controller.php
-
-		-
-			message: '#^Parameter \$post of method yiiunit\\framework\\console\\FakePhp71Controller\:\:actionNullableInjection\(\) has invalid type yiiunit\\framework\\base\\Post\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/framework/console/FakePhp71Controller.php
-
-		-
 			message: '#^Return type \(void\) of method yiiunit\\framework\\console\\controllers\\FixtureConsoledController\:\:stdout\(\) should be compatible with return type \(bool\|int\) of method yii\\console\\Controller\<yii\\console\\Application\>\:\:stdout\(\)$#'
 			identifier: method.childReturnType
 			count: 1

--- a/tests/framework/console/ControllerTest.php
+++ b/tests/framework/console/ControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -24,7 +26,11 @@ use yii\helpers\Console;
 use yiiunit\framework\console\stubs\DummyService;
 use yiiunit\TestCase;
 
+/**
+ * Unit test for {@see \yii\console\Controller}.
+ */
 #[Group('console')]
+#[Group('controller')]
 class ControllerTest extends TestCase
 {
     private FakeController|FakeInjectionController $controller;
@@ -32,7 +38,9 @@ class ControllerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->mockApplication();
+
         Yii::$app->controllerMap = [
             'fake' => 'yiiunit\framework\console\FakeController',
             'fake_witout_output' => 'yiiunit\framework\console\FakeHelpControllerWithoutOutput',
@@ -109,10 +117,16 @@ class ControllerTest extends TestCase
 
     public function testNullableInjectedActionParams(): void
     {
-        $this->controller = new FakeInjectionController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-        ]));
+        $this->controller = new FakeInjectionController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                ],
+            ),
+        );
+
         $this->mockApplication(['controller' => $this->controller]);
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionNullableInjection');
@@ -124,10 +138,16 @@ class ControllerTest extends TestCase
 
     public function testInjectionContainerException(): void
     {
-        $this->controller = new FakeInjectionController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-        ]));
+        $this->controller = new FakeInjectionController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                ],
+            ),
+        );
+
         $this->mockApplication(['controller' => $this->controller]);
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
@@ -143,10 +163,16 @@ class ControllerTest extends TestCase
 
     public function testUnknownInjection(): void
     {
-        $this->controller = new FakeInjectionController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-        ]));
+        $this->controller = new FakeInjectionController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                ],
+            ),
+        );
+
         $this->mockApplication(['controller' => $this->controller]);
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
@@ -159,10 +185,16 @@ class ControllerTest extends TestCase
 
     public function testInjectedActionParams(): void
     {
-        $this->controller = new FakeInjectionController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-        ]));
+        $this->controller = new FakeInjectionController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                ],
+            ),
+        );
+
         $this->mockApplication(['controller' => $this->controller]);
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
@@ -182,13 +214,21 @@ class ControllerTest extends TestCase
 
     public function testInjectedActionParamsFromModule(): void
     {
-        $module = new Module('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-        ]));
-        $module->set('yii\data\DataProviderInterface', [
-            'class' => ArrayDataProvider::class,
-        ]);
+        $module = new Module(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                ],
+            ),
+        );
+
+        $module->set(
+            'yii\data\DataProviderInterface',
+            ['class' => ArrayDataProvider::class],
+        );
+
         $this->controller = new FakeInjectionController('fake', $module);
         $this->mockWebApplication(['controller' => $this->controller]);
 

--- a/tests/framework/console/ControllerTest.php
+++ b/tests/framework/console/ControllerTest.php
@@ -13,6 +13,7 @@ namespace yiiunit\framework\console;
 use PHPUnit\Framework\Attributes\Group;
 use ReflectionMethod;
 use ReflectionType;
+use yii\console\Controller;
 use yii\data\ArrayDataProvider;
 use RuntimeException;
 use Yii;
@@ -33,7 +34,7 @@ use yiiunit\TestCase;
 #[Group('controller')]
 class ControllerTest extends TestCase
 {
-    private FakeController|FakeInjectionController $controller;
+    private Controller $controller;
 
     protected function setUp(): void
     {

--- a/tests/framework/console/ControllerTest.php
+++ b/tests/framework/console/ControllerTest.php
@@ -112,8 +112,7 @@ class ControllerTest extends TestCase
 
     public function testNullableInjectedActionParams(): void
     {
-        // Use the PHP71 controller for this test
-        $this->controller = new FakePhp71Controller('fake', new Application([
+        $this->controller = new FakeInjectionController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
         ]));
@@ -128,8 +127,7 @@ class ControllerTest extends TestCase
 
     public function testInjectionContainerException(): void
     {
-        // Use the PHP71 controller for this test
-        $this->controller = new FakePhp71Controller('fake', new Application([
+        $this->controller = new FakeInjectionController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
         ]));
@@ -148,8 +146,7 @@ class ControllerTest extends TestCase
 
     public function testUnknownInjection(): void
     {
-        // Use the PHP71 controller for this test
-        $this->controller = new FakePhp71Controller('fake', new Application([
+        $this->controller = new FakeInjectionController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
         ]));
@@ -165,8 +162,7 @@ class ControllerTest extends TestCase
 
     public function testInjectedActionParams(): void
     {
-        // Use the PHP71 controller for this test
-        $this->controller = new FakePhp71Controller('fake', new Application([
+        $this->controller = new FakeInjectionController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
         ]));
@@ -196,8 +192,7 @@ class ControllerTest extends TestCase
         $module->set('yii\data\DataProviderInterface', [
             'class' => ArrayDataProvider::class,
         ]);
-        // Use the PHP71 controller for this test
-        $this->controller = new FakePhp71Controller('fake', $module);
+        $this->controller = new FakeInjectionController('fake', $module);
         $this->mockWebApplication(['controller' => $this->controller]);
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionModuleServiceInjection');

--- a/tests/framework/console/ControllerTest.php
+++ b/tests/framework/console/ControllerTest.php
@@ -27,10 +27,7 @@ use yiiunit\TestCase;
 #[Group('console')]
 class ControllerTest extends TestCase
 {
-    /**
-     * @var FakeController
-     */
-    private $controller;
+    private FakeController|FakeInjectionController $controller;
 
     protected function setUp(): void
     {

--- a/tests/framework/console/FakeInjectionController.php
+++ b/tests/framework/console/FakeInjectionController.php
@@ -6,27 +6,21 @@
  * @license https://www.yiiframework.com/license/
  */
 
-namespace yiiunit\framework\web;
+namespace yiiunit\framework\console;
 
 use yii\data\DataProviderInterface;
-use yii\web\Controller;
-use yii\web\Request;
-use yiiunit\framework\web\stubs\VendorImage;
-use yiiunit\framework\web\stubs\ModelBindingStub;
+use yiiunit\framework\console\stubs\DummyService;
+use yii\console\Controller;
+use yii\console\Request;
+use yiiunit\framework\base\Post;
 
-/**
- * @author Sam Mousa<sam@mousa.nl>
- * @since 2.0.36
- */
-class FakePhp71Controller extends Controller
+class FakeInjectionController extends Controller
 {
-    public $enableCsrfValidation = false;
-
     public function actionInjection(
         $before,
         Request $request,
         $between,
-        VendorImage $vendorImage,
+        DummyService $dummyService,
         ?Post $post,
         $after
     ) {
@@ -37,10 +31,6 @@ class FakePhp71Controller extends Controller
     }
 
     public function actionModuleServiceInjection(DataProviderInterface $dataProvider): void
-    {
-    }
-
-    public function actionModelBindingInjection(ModelBindingStub $model): void
     {
     }
 }

--- a/tests/framework/console/FakeInjectionController.php
+++ b/tests/framework/console/FakeInjectionController.php
@@ -12,7 +12,7 @@ use yii\data\DataProviderInterface;
 use yiiunit\framework\console\stubs\DummyService;
 use yii\console\Controller;
 use yii\console\Request;
-use yiiunit\framework\base\Post;
+use yiiunit\framework\web\Post;
 
 class FakeInjectionController extends Controller
 {

--- a/tests/framework/db/ColumnSchemaBackedEnumTest.php
+++ b/tests/framework/db/ColumnSchemaBackedEnumTest.php
@@ -8,9 +8,6 @@ use yiiunit\framework\db\stubs\IntBackedStatus;
 use yiiunit\framework\db\stubs\StringBackedStatus;
 use yiiunit\TestCase;
 
-/**
- * @requires PHP >= 8.1
- */
 class ColumnSchemaBackedEnumTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/framework/di/stubs/StaticMethodsWithIntersectionTypes.php
+++ b/tests/framework/di/stubs/StaticMethodsWithIntersectionTypes.php
@@ -2,7 +2,6 @@
 
 namespace yiiunit\framework\di\stubs;
 
-// Syntax valid only for PHP 8.1+
 class StaticMethodsWithIntersectionTypes
 {
     public static function withQuxInterfaceAndQuxAnotherIntersection(QuxInterface & QuxAnother $Qux): void

--- a/tests/framework/di/stubs/StaticMethodsWithUnionTypes.php
+++ b/tests/framework/di/stubs/StaticMethodsWithUnionTypes.php
@@ -2,7 +2,6 @@
 
 namespace yiiunit\framework\di\stubs;
 
-// Syntax valid only for PHP 8.0+
 class StaticMethodsWithUnionTypes
 {
     public static function withBetaUnion(string | Beta $beta): void

--- a/tests/framework/validators/EachValidatorTest.php
+++ b/tests/framework/validators/EachValidatorTest.php
@@ -218,8 +218,6 @@ class EachValidatorTest extends TestCase
      * of different type during validation.
      * (ie: public array $dummy; where $dummy is array of booleans,
      * validator will try to assign these booleans one by one to $dummy)
-     *
-     * @requires PHP >= 7.4
      */
     public function testTypedProperties(): void
     {

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -34,7 +34,7 @@ use yiiunit\TestCase;
 #[Group('controller')]
 class ControllerTest extends TestCase
 {
-    private FakeController|FakeInjectionController|FakeTypedParamsController|FakeUnionTypesController $controller;
+    private \yii\web\Controller $controller;
 
     protected function setUp(): void
     {

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -27,7 +27,7 @@ use yiiunit\TestCase;
  */
 class ControllerTest extends TestCase
 {
-    private \yiiunit\framework\web\FakeController|\yiiunit\framework\web\FakePhp71Controller|\yiiunit\framework\web\FakePhp7Controller|\yiiunit\framework\web\FakePhp80Controller $controller;
+    private \yiiunit\framework\web\FakeController|\yiiunit\framework\web\FakeInjectionController|\yiiunit\framework\web\FakeTypedParamsController|\yiiunit\framework\web\FakeUnionTypesController $controller;
 
     protected function setUp(): void
     {
@@ -66,8 +66,7 @@ class ControllerTest extends TestCase
 
     public function testNullableInjectedActionParams(): void
     {
-        // Use the PHP71 controller for this test
-        $this->controller = new FakePhp71Controller('fake', new Application([
+        $this->controller = new FakeInjectionController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
 
@@ -89,7 +88,7 @@ class ControllerTest extends TestCase
 
     public function testModelBindingHttpException(): void
     {
-        $this->controller = new FakePhp71Controller('fake', new Application([
+        $this->controller = new FakeInjectionController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
             'container' => [
@@ -118,8 +117,7 @@ class ControllerTest extends TestCase
 
     public function testInjectionContainerException(): void
     {
-        // Use the PHP71 controller for this test
-        $this->controller = new FakePhp71Controller('fake', new Application([
+        $this->controller = new FakeInjectionController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
 
@@ -146,8 +144,7 @@ class ControllerTest extends TestCase
 
     public function testUnknownInjection(): void
     {
-        // Use the PHP71 controller for this test
-        $this->controller = new FakePhp71Controller('fake', new Application([
+        $this->controller = new FakeInjectionController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
             'components' => [
@@ -170,8 +167,7 @@ class ControllerTest extends TestCase
 
     public function testInjectedActionParams(): void
     {
-        // Use the PHP71 controller for this test
-        $this->controller = new FakePhp71Controller('fake', new Application([
+        $this->controller = new FakeInjectionController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
             'components' => [
@@ -214,8 +210,7 @@ class ControllerTest extends TestCase
         $module->set('yii\data\DataProviderInterface', [
             'class' => ArrayDataProvider::class,
         ]);
-        // Use the PHP71 controller for this test
-        $this->controller = new FakePhp71Controller('fake', $module);
+        $this->controller = new FakeInjectionController('fake', $module);
         $this->mockWebApplication(['controller' => $this->controller]);
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionModuleServiceInjection');
@@ -229,8 +224,7 @@ class ControllerTest extends TestCase
      */
     public function testBindTypedActionParams(): void
     {
-        // Use the PHP7 controller for this test
-        $this->controller = new FakePhp7Controller('fake', new Application([
+        $this->controller = new FakeTypedParamsController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
             'components' => [
@@ -326,8 +320,7 @@ class ControllerTest extends TestCase
 
     public function testUnionBindingActionParams(): void
     {
-        // Use the PHP80 controller for this test
-        $this->controller = new FakePhp80Controller('fake', new Application([
+        $this->controller = new FakeUnionTypesController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
             'components' => [
@@ -358,8 +351,7 @@ class ControllerTest extends TestCase
 
     public function testUnionBindingActionParamsWithArray(): void
     {
-        // Use the PHP80 controller for this test
-        $this->controller = new FakePhp80Controller('fake', new Application([
+        $this->controller = new FakeUnionTypesController('fake', new Application([
             'id' => 'app',
             'basePath' => __DIR__,
             'components' => [

--- a/tests/framework/web/ControllerTest.php
+++ b/tests/framework/web/ControllerTest.php
@@ -8,7 +8,12 @@
 
 namespace yiiunit\framework\web;
 
+use PHPUnit\Framework\Attributes\Group;
 use yii\web\Application;
+use yiiunit\framework\web\FakeController;
+use yiiunit\framework\web\FakeInjectionController;
+use yiiunit\framework\web\FakeTypedParamsController;
+use yiiunit\framework\web\FakeUnionTypesController;
 use yiiunit\framework\web\stubs\ModelBindingStub;
 use yii\base\Module;
 use yii\data\ArrayDataProvider;
@@ -23,28 +28,36 @@ use yiiunit\framework\web\stubs\VendorImage;
 use yiiunit\TestCase;
 
 /**
- * @group web
+ * Unit test for {@see \yii\web\Controller}.
  */
+#[Group('web')]
+#[Group('controller')]
 class ControllerTest extends TestCase
 {
-    private \yiiunit\framework\web\FakeController|\yiiunit\framework\web\FakeInjectionController|\yiiunit\framework\web\FakeTypedParamsController|\yiiunit\framework\web\FakeUnionTypesController $controller;
+    private FakeController|FakeInjectionController|FakeTypedParamsController|FakeUnionTypesController $controller;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->mockWebApplication();
-        $this->controller = new FakeController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-            'components' => [
-                'request' => [
-                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
-                    'scriptFile' => __DIR__ . '/index.php',
-                    'scriptUrl' => '/index.php',
+
+        $this->controller = new FakeController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                    'components' => [
+                        'request' => [
+                            'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                            'scriptFile' => __DIR__ . '/index.php',
+                            'scriptUrl' => '/index.php',
+                        ],
+                    ],
                 ],
-            ],
-        ]));
+            ),
+        );
 
         Yii::$app->controller = $this->controller;
     }
@@ -66,18 +79,22 @@ class ControllerTest extends TestCase
 
     public function testNullableInjectedActionParams(): void
     {
-        $this->controller = new FakeInjectionController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-
-            'components' => [
-                'request' => [
-                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
-                    'scriptFile' => __DIR__ . '/index.php',
-                    'scriptUrl' => '/index.php',
+        $this->controller = new FakeInjectionController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                    'components' => [
+                        'request' => [
+                            'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                            'scriptFile' => __DIR__ . '/index.php',
+                            'scriptUrl' => '/index.php',
+                        ],
+                    ],
                 ],
-            ],
-        ]));
+            ),
+        );
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionNullableInjection');
         $params = [];
@@ -88,25 +105,31 @@ class ControllerTest extends TestCase
 
     public function testModelBindingHttpException(): void
     {
-        $this->controller = new FakeInjectionController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-            'container' => [
-                'definitions' => [
-                    ModelBindingStub::class => [
-                        ModelBindingStub::class,
-                        'build',
+        $this->controller = new FakeInjectionController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                    'container' => [
+                        'definitions' => [
+                            ModelBindingStub::class => [
+                                ModelBindingStub::class,
+                                'build',
+                            ],
+                        ],
+                    ],
+                    'components' => [
+                        'request' => [
+                            'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                            'scriptFile' => __DIR__ . '/index.php',
+                            'scriptUrl' => '/index.php',
+                        ],
                     ],
                 ],
-            ],
-            'components' => [
-                'request' => [
-                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
-                    'scriptFile' => __DIR__ . '/index.php',
-                    'scriptUrl' => '/index.php',
-                ],
-            ],
-        ]));
+            ),
+        );
+
         Yii::$container->set(VendorImage::class, VendorImage::class);
         $this->mockWebApplication(['controller' => $this->controller]);
         $injectionAction = new InlineAction('injection', $this->controller, 'actionModelBindingInjection');
@@ -117,18 +140,23 @@ class ControllerTest extends TestCase
 
     public function testInjectionContainerException(): void
     {
-        $this->controller = new FakeInjectionController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-
-            'components' => [
-                'request' => [
-                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
-                    'scriptFile' => __DIR__ . '/index.php',
-                    'scriptUrl' => '/index.php',
+        $this->controller = new FakeInjectionController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                    'components' => [
+                        'request' => [
+                            'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                            'scriptFile' => __DIR__ . '/index.php',
+                            'scriptUrl' => '/index.php',
+                        ],
+                    ],
                 ],
-            ],
-        ]));
+            ),
+        );
+
         $this->mockWebApplication(['controller' => $this->controller]);
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
@@ -144,17 +172,23 @@ class ControllerTest extends TestCase
 
     public function testUnknownInjection(): void
     {
-        $this->controller = new FakeInjectionController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-            'components' => [
-                'request' => [
-                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
-                    'scriptFile' => __DIR__ . '/index.php',
-                    'scriptUrl' => '/index.php',
+        $this->controller = new FakeInjectionController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                    'components' => [
+                        'request' => [
+                            'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                            'scriptFile' => __DIR__ . '/index.php',
+                            'scriptUrl' => '/index.php',
+                        ],
+                    ],
                 ],
-            ],
-        ]));
+            ),
+        );
+
         $this->mockWebApplication(['controller' => $this->controller]);
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
@@ -167,17 +201,22 @@ class ControllerTest extends TestCase
 
     public function testInjectedActionParams(): void
     {
-        $this->controller = new FakeInjectionController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-            'components' => [
-                'request' => [
-                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
-                    'scriptFile' => __DIR__ . '/index.php',
-                    'scriptUrl' => '/index.php',
+        $this->controller = new FakeInjectionController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                    'components' => [
+                        'request' => [
+                            'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                            'scriptFile' => __DIR__ . '/index.php',
+                            'scriptUrl' => '/index.php',
+                        ],
+                    ],
                 ],
-            ],
-        ]));
+            ),
+        );
 
         $injectionAction = new InlineAction('injection', $this->controller, 'actionInjection');
         $params = ['between' => 'test', 'after' => 'another', 'before' => 'test'];
@@ -196,17 +235,23 @@ class ControllerTest extends TestCase
 
     public function testInjectedActionParamsFromModule(): void
     {
-        $module = new Module('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-            'components' => [
-                'request' => [
-                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
-                    'scriptFile' => __DIR__ . '/index.php',
-                    'scriptUrl' => '/index.php',
+        $module = new Module(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                    'components' => [
+                        'request' => [
+                            'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                            'scriptFile' => __DIR__ . '/index.php',
+                            'scriptUrl' => '/index.php',
+                        ],
+                    ],
                 ],
-            ],
-        ]));
+            ),
+        );
+
         $module->set('yii\data\DataProviderInterface', [
             'class' => ArrayDataProvider::class,
         ]);
@@ -224,17 +269,23 @@ class ControllerTest extends TestCase
      */
     public function testBindTypedActionParams(): void
     {
-        $this->controller = new FakeTypedParamsController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-            'components' => [
-                'request' => [
-                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
-                    'scriptFile' => __DIR__ . '/index.php',
-                    'scriptUrl' => '/index.php',
+        $this->controller = new FakeTypedParamsController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                    'components' => [
+                        'request' => [
+                            'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                            'scriptFile' => __DIR__ . '/index.php',
+                            'scriptUrl' => '/index.php',
+                        ],
+                    ],
                 ],
-            ],
-        ]));
+            ),
+        );
+
         $this->mockWebApplication(['controller' => $this->controller]);
 
         $aksi1 = new InlineAction('aksi1', $this->controller, 'actionAksi1');
@@ -320,17 +371,22 @@ class ControllerTest extends TestCase
 
     public function testUnionBindingActionParams(): void
     {
-        $this->controller = new FakeUnionTypesController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-            'components' => [
-                'request' => [
-                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
-                    'scriptFile' => __DIR__ . '/index.php',
-                    'scriptUrl' => '/index.php',
+        $this->controller = new FakeUnionTypesController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                    'components' => [
+                        'request' => [
+                            'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                            'scriptFile' => __DIR__ . '/index.php',
+                            'scriptUrl' => '/index.php',
+                        ],
+                    ],
                 ],
-            ],
-        ]));
+            ),
+        );
 
         $this->mockWebApplication(['controller' => $this->controller]);
 
@@ -351,17 +407,22 @@ class ControllerTest extends TestCase
 
     public function testUnionBindingActionParamsWithArray(): void
     {
-        $this->controller = new FakeUnionTypesController('fake', new Application([
-            'id' => 'app',
-            'basePath' => __DIR__,
-            'components' => [
-                'request' => [
-                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
-                    'scriptFile' => __DIR__ . '/index.php',
-                    'scriptUrl' => '/index.php',
+        $this->controller = new FakeUnionTypesController(
+            'fake',
+            new Application(
+                [
+                    'id' => 'app',
+                    'basePath' => __DIR__,
+                    'components' => [
+                        'request' => [
+                            'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                            'scriptFile' => __DIR__ . '/index.php',
+                            'scriptUrl' => '/index.php',
+                        ],
+                    ],
                 ],
-            ],
-        ]));
+            ),
+        );
 
         $this->mockWebApplication(['controller' => $this->controller]);
 

--- a/tests/framework/web/FakeInjectionController.php
+++ b/tests/framework/web/FakeInjectionController.php
@@ -6,21 +6,27 @@
  * @license https://www.yiiframework.com/license/
  */
 
-namespace yiiunit\framework\console;
+namespace yiiunit\framework\web;
 
 use yii\data\DataProviderInterface;
-use yiiunit\framework\console\stubs\DummyService;
-use yii\console\Controller;
-use yii\console\Request;
-use yiiunit\framework\base\Post;
+use yii\web\Controller;
+use yii\web\Request;
+use yiiunit\framework\web\stubs\VendorImage;
+use yiiunit\framework\web\stubs\ModelBindingStub;
 
-class FakePhp71Controller extends Controller
+/**
+ * @author Sam Mousa<sam@mousa.nl>
+ * @since 2.0.36
+ */
+class FakeInjectionController extends Controller
 {
+    public $enableCsrfValidation = false;
+
     public function actionInjection(
         $before,
         Request $request,
         $between,
-        DummyService $dummyService,
+        VendorImage $vendorImage,
         ?Post $post,
         $after
     ) {
@@ -31,6 +37,10 @@ class FakePhp71Controller extends Controller
     }
 
     public function actionModuleServiceInjection(DataProviderInterface $dataProvider): void
+    {
+    }
+
+    public function actionModelBindingInjection(ModelBindingStub $model): void
     {
     }
 }

--- a/tests/framework/web/FakeTypedParamsController.php
+++ b/tests/framework/web/FakeTypedParamsController.php
@@ -14,7 +14,7 @@ use yii\web\Controller;
  * @author Brandon Kelly <branodn@craftcms.com>
  * @since 2.0.31
  */
-class FakePhp7Controller extends Controller
+class FakeTypedParamsController extends Controller
 {
     public $enableCsrfValidation = false;
 

--- a/tests/framework/web/FakeUnionTypesController.php
+++ b/tests/framework/web/FakeUnionTypesController.php
@@ -10,7 +10,7 @@ namespace yiiunit\framework\web;
 
 use yii\web\Controller;
 
-class FakePhp80Controller extends Controller
+class FakeUnionTypesController extends Controller
 {
     public $enableCsrfValidation = false;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
