### PR TITLE
Fix composite `IN`/`NOT` IN conditions generate `IS NULL`/`IS NOT NULL` instead of literal `NULL` comparisons.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -43,7 +43,7 @@ Yii Framework 2 Change Log
 - Bug: Fix `Controller::getActionArgsHelp()` crashing on PHP `8.2+` DNF/intersection types in console `Controller` class (terabytesoftw)
 - Chg: Remove deprecated APIs in `Security`, `View`, and `UniqueValidator`, delete deprecated migration template `createJunctionMigration.php`, and clean related validator tests (terabytesoftw)
 - Enh: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
-
+- Chg: Type `InCondition` / `InConditionBuilder` APIs and generate `IS NULL` / `IS NOT NULL` for composite `IN` / `NOT IN` `NULL` comparisons (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -43,7 +43,7 @@ Yii Framework 2 Change Log
 - Bug: Fix `Controller::getActionArgsHelp()` crashing on PHP `8.2+` DNF/intersection types in console `Controller` class (terabytesoftw)
 - Chg: Remove deprecated APIs in `Security`, `View`, and `UniqueValidator`, delete deprecated migration template `createJunctionMigration.php`, and clean related validator tests (terabytesoftw)
 - Enh: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
-- Chg: Type `InCondition` / `InConditionBuilder` APIs and generate `IS NULL` / `IS NOT NULL` for composite `IN` / `NOT IN` `NULL` comparisons (terabytesoftw)
+- Bug #10073: Type `InCondition` / `InConditionBuilder` APIs and generate `IS NULL` / `IS NOT NULL` for composite `IN` / `NOT IN` `NULL` comparisons (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -1,6 +1,6 @@
 # Upgrading Instructions for Yii Framework 22.x
 
-This file contains the upgrade notes for the Yii Framework `22.x` line. These notes highlight changes that break 
+This file contains the upgrade notes for the Yii Framework `22.x` line. These notes highlight changes that break
 backwards compatibility from the `2.0.x` line and that require action when upgrading an application.
 
 For the historical `2.0.x` upgrade notes see [`UPGRADE.md`](UPGRADE.md).
@@ -9,8 +9,8 @@ For the historical `2.0.x` upgrade notes see [`UPGRADE.md`](UPGRADE.md).
 
 ### General upgrade notes
 
-* Raised minimum supported PHP version to `8.3`.
-* All methods that were previously deprecated have been removed. If your application still uses any deprecated methods,
+- Raised minimum supported PHP version to `8.3`.
+- All methods that were previously deprecated have been removed. If your application still uses any deprecated methods,
   you must update your code before upgrading.
 
 ### ActiveField label, radio, and checkbox enhancements
@@ -72,28 +72,28 @@ not available in PHP >= `8.0`, so the dual-mode `$useApcu` property has been rem
 'cache' => [
     'class' => 'yii\caching\ApcuCache',
 ],
-```  
+```
 
 ### Bootstrap CSS class defaults removed
 
 Bootstrap-specific CSS class defaults have been removed from widget properties. The framework is now CSS-agnostic; no
 CSS framework is required or assumed. The following property defaults have changed:
 
-| Class                      | Property              | Old default                                                    | New default                                           |
-|----------------------------|-----------------------|----------------------------------------------------------------|-------------------------------------------------------|
-| `yii\widgets\ActiveField`  | `$options`            | `['class' => 'form-group']`                                    | `[]`                                                  |
-| `yii\widgets\ActiveField`  | `$inputOptions`       | `['class' => 'form-control']`                                  | `[]`                                                  |
-| `yii\widgets\ActiveField`  | `$errorOptions`       | `['class' => 'help-block']`                                    | `['class' => 'field-error']`                          |
-| `yii\widgets\ActiveField`  | `$labelOptions`       | `['class' => 'control-label']`                                 | `[]`                                                  |
-| `yii\widgets\ActiveForm`   | `$errorCssClass`      | `'has-error'`                                                  | `''`                                                  |
-| `yii\widgets\ActiveForm`   | `$successCssClass`    | `'has-success'`                                                | `''`                                                  |
-| `yii\grid\GridView`        | `$tableOptions`       | `['class' => 'table table-striped table-bordered']`            | `[]`                                                  |
-| `yii\grid\GridView`        | `$filterErrorOptions` | `['class' => 'help-block']`                                    | `['class' => 'field-error']`                          |
-| `yii\grid\DataColumn`      | `$filterInputOptions` | `['class' => 'form-control', 'id' => null]`                    | `['id' => null]`                                      |
-| `yii\widgets\DetailView`   | `$options`            | `['class' => 'table table-striped table-bordered detail-view']`| `['class' => 'detail-view']`                          |
-| `yii\widgets\Breadcrumbs`  | `$options`            | `['class' => 'breadcrumb']`                                    | `[]`                                                  |
-| `yii\widgets\LinkPager`    | `$options`            | `['class' => 'pagination']`                                    | `[]`                                                  |
-| `yii\captcha\Captcha`      | `$options`            | `['class' => 'form-control']`                                  | `[]`                                                  |
+| Class                     | Property              | Old default                                                     | New default                  |
+| ------------------------- | --------------------- | --------------------------------------------------------------- | ---------------------------- |
+| `yii\widgets\ActiveField` | `$options`            | `['class' => 'form-group']`                                     | `[]`                         |
+| `yii\widgets\ActiveField` | `$inputOptions`       | `['class' => 'form-control']`                                   | `[]`                         |
+| `yii\widgets\ActiveField` | `$errorOptions`       | `['class' => 'help-block']`                                     | `['class' => 'field-error']` |
+| `yii\widgets\ActiveField` | `$labelOptions`       | `['class' => 'control-label']`                                  | `[]`                         |
+| `yii\widgets\ActiveForm`  | `$errorCssClass`      | `'has-error'`                                                   | `''`                         |
+| `yii\widgets\ActiveForm`  | `$successCssClass`    | `'has-success'`                                                 | `''`                         |
+| `yii\grid\GridView`       | `$tableOptions`       | `['class' => 'table table-striped table-bordered']`             | `[]`                         |
+| `yii\grid\GridView`       | `$filterErrorOptions` | `['class' => 'help-block']`                                     | `['class' => 'field-error']` |
+| `yii\grid\DataColumn`     | `$filterInputOptions` | `['class' => 'form-control', 'id' => null]`                     | `['id' => null]`             |
+| `yii\widgets\DetailView`  | `$options`            | `['class' => 'table table-striped table-bordered detail-view']` | `['class' => 'detail-view']` |
+| `yii\widgets\Breadcrumbs` | `$options`            | `['class' => 'breadcrumb']`                                     | `[]`                         |
+| `yii\widgets\LinkPager`   | `$options`            | `['class' => 'pagination']`                                     | `[]`                         |
+| `yii\captcha\Captcha`     | `$options`            | `['class' => 'form-control']`                                   | `[]`                         |
 
 `yii\grid\ActionColumn::initDefaultButton()` no longer falls back to `glyphicon glyphicon-$iconName` markup when an
 icon name is not present in `$icons`. It now renders the icon name as plain text.
@@ -103,8 +103,8 @@ For `ActiveField`:
 
 ```php
 $form->field(
-    $model, 
-    'username', 
+    $model,
+    'username',
     [
         'options'      => ['class' => 'form-group'],
         'inputOptions' => ['class' => 'form-control'],
@@ -125,19 +125,47 @@ $form = ActiveForm::begin(
 );
 ```
 
-**Note on `yii.activeForm.js` compatibility.** `ActiveField::$errorOptions` now defaults to `['class' => 'field-error']` 
-instead of `['class' => 'help-block']`. The client-side validation JavaScript in `yiisoft/yii2-jquery` still defaults 
+**Note on `yii.activeForm.js` compatibility.** `ActiveField::$errorOptions` now defaults to `['class' => 'field-error']`
+instead of `['class' => 'help-block']`. The client-side validation JavaScript in `yiisoft/yii2-jquery` still defaults
 its error selector to `.help-block`, but `ActiveFormJqueryClientScript::getClientOptions()` passes the per-field `error`
-selector in the payload that overrides the JS default at runtime, so client-side validation keeps working against 
+selector in the payload that overrides the JS default at runtime, so client-side validation keeps working against
 `.field-error` with no manual configuration.
 
-### CUBRID database support removed
+### Database
+
+#### CUBRID database support removed
 
 Yii `22.x` no longer includes support for the CUBRID database driver. Applications that still depend on CUBRID must
 migrate to a supported database engine before upgrading to Yii `22.x`.
 
 There is no compatibility layer for CUBRID in this release. The framework no longer ships CUBRID-specific database
 classes, configuration entries, fixtures, or test coverage.
+
+### `InCondition` and `InConditionBuilder` typing + composite `NULL` handling
+
+`yii\db\conditions\InCondition` now uses typed constructor parameters and typed return values:
+
+- `__construct(array|string|ExpressionInterface|Traversable $column, string $operator, array|int|string|ExpressionInterface|Traversable $values)`
+- `getOperator(): string`
+- `getColumn(): array|string|ExpressionInterface`
+- `getValues(): array|int|string|ExpressionInterface`
+- `fromArrayDefinition(...): static`
+
+`Traversable` values passed as `$column` or `$values` are normalized to arrays on first access in `getColumn()` /
+`getValues()` and cached for subsequent calls.
+
+`yii\db\conditions\InConditionBuilder` protected methods now declare parameter and return types. If you extend this
+builder (or DB-specific builders that inherit it), update overridden method signatures accordingly.
+
+Composite `IN` / `NOT IN` generation has changed: the builder now decomposes composite comparisons into boolean
+expressions and uses `IS NULL` / `IS NOT NULL` instead of literal `NULL` comparisons.
+
+Example:
+
+- Before: `([[id]], [[name]]) IN ((:p0, NULL))`
+- After: `(([[id]] = :p0 AND [[name]] IS NULL))`
+
+If your tests assert exact SQL strings for composite `IN` / `NOT IN`, update expected SQL.
 
 ### HHVM support removed
 
@@ -148,7 +176,7 @@ All HHVM-specific code has been removed from the framework. Yii `22.x` targets P
 - `yii\base\ErrorHandler` no longer registers a HHVM-specific error handler when `HHVM_VERSION` is defined.
 - HHVM-specific test skips and workarounds have been removed.
 
-If your application references `ErrorException::E_HHVM_FATAL_ERROR` or `ErrorHandler::handleHhvmError()`, remove those 
+If your application references `ErrorException::E_HHVM_FATAL_ERROR` or `ErrorHandler::handleHhvmError()`, remove those
 references when upgrading.
 
 ### jQuery client scripts moved to `yiisoft/yii2-jquery`
@@ -258,10 +286,10 @@ The default implementations now delegate to the configured `$clientScript` handl
 `POS_READY` or `POS_LOAD`, and `View::wrapReadyScript()` / `wrapLoadScript()` now emit vanilla JavaScript event
 listeners instead of jQuery wrappers:
 
-| Position    | Old wrapper                                            | New wrapper                                                                            |
-|-------------|--------------------------------------------------------|----------------------------------------------------------------------------------------|
-| `POS_READY` | `jQuery(function ($) { ... });`                        | `document.addEventListener('DOMContentLoaded', function (event) { ... });`             |
-| `POS_LOAD`  | `jQuery(window).on('load', function () { ... });`      | `window.addEventListener('load', function (event) { ... });`                           |
+| Position    | Old wrapper                                       | New wrapper                                                                |
+| ----------- | ------------------------------------------------- | -------------------------------------------------------------------------- |
+| `POS_READY` | `jQuery(function ($) { ... });`                   | `document.addEventListener('DOMContentLoaded', function (event) { ... });` |
+| `POS_LOAD`  | `jQuery(window).on('load', function () { ... });` | `window.addEventListener('load', function (event) { ... });`               |
 
 This is a behaviour change for applications that passed JavaScript fragments relying on `$` being bound inside the
 wrapper, for example:
@@ -274,15 +302,15 @@ In 22.0 that code runs inside a `DOMContentLoaded` listener where `$` is **not**
 
 1. Wrap your own code explicitly, letting the jQuery plugin define `$`:
 
-   ```php
-   $this->registerJs("jQuery(function ($) { $('#foo').click(function () { ... }); });");
-   ```
+    ```php
+    $this->registerJs("jQuery(function ($) { $('#foo').click(function () { ... }); });");
+    ```
 
 2. Replace the jQuery call with vanilla DOM APIs:
 
-   ```php
-   $this->registerJs("document.getElementById('foo').addEventListener('click', function () { ... });");
-   ```
+    ```php
+    $this->registerJs("document.getElementById('foo').addEventListener('click', function () { ... });");
+    ```
 
 Option 1 keeps working transparently as long as `yiisoft/yii2-jquery` is installed and `JqueryAsset` (or any asset
 bundle that depends on it) has been registered somewhere in the request.
@@ -314,7 +342,7 @@ All framework classes are now loaded exclusively by Composer:
 
 #### What you must do
 
-1. Remove any code that writes to `Yii::$classMap` or calls `Yii::autoload()`. Both no longer exist and will produce a 
+1. Remove any code that writes to `Yii::$classMap` or calls `Yii::autoload()`. Both no longer exist and will produce a
    fatal error.
 2. Make sure every class your application uses is reachable through Composer autoload. Declare it under one of:
     - `autoload.psr-4` namespace mapping (preferred for application code).
@@ -323,12 +351,12 @@ All framework classes are now loaded exclusively by Composer:
     - `autoload-dev` development and test-only classes.
 3. Regenerate the autoload files after editing `composer.json`:
 
-   ```bash
-   composer dump-autoload -o
-   ```
+    ```bash
+    composer dump-autoload -o
+    ```
 
-   Use `-o` (or `--classmap-authoritative`) in production for the same performance benefit that
-   `framework/classes.php` used to provide.
+    Use `-o` (or `--classmap-authoritative`) in production for the same performance benefit that
+    `framework/classes.php` used to provide.
 
 #### Migration example: registering a new class
 
@@ -355,7 +383,7 @@ registration is required.
 
 #### Migration example: overriding a framework class
 
-The most common reason for writing to `Yii::$classMap` was to *replace* a framework class with a custom implementation, 
+The most common reason for writing to `Yii::$classMap` was to _replace_ a framework class with a custom implementation,
 for example swapping `yii\web\Request`. The Composer equivalent uses `classmap` together with `exclude-from-classmap`.
 
 Before (runtime override via `$classMap`, no longer supported):
@@ -373,12 +401,8 @@ After (in the application's `composer.json`):
         "psr-4": {
             "app\\": "src/"
         },
-        "classmap": [
-            "src/overrides/Request.php"
-        ],
-        "exclude-from-classmap": [
-            "vendor/yiisoft/yii2/web/Request.php"
-        ]
+        "classmap": ["src/overrides/Request.php"],
+        "exclude-from-classmap": ["vendor/yiisoft/yii2/web/Request.php"]
     }
 }
 ```
@@ -401,13 +425,13 @@ Then run `composer dump-autoload -o`. Composer loads the override from `src/over
 skips the vendor file thanks to `exclude-from-classmap`. The override survives optimized and
 authoritative classmaps because it is resolved at autoload-generation time, not at runtime.
 
-> Important: because the original `yii\web\Request` file is excluded from the classmap, the FQCN `yii\web\Request` is 
-> now defined exclusively by your override file. You **cannot** write `class Request extends \yii\web\Request` inside 
-> `namespace yii\web;` that would be self-inheritance and PHP will reject it. You must reimplement the full public 
+> Important: because the original `yii\web\Request` file is excluded from the classmap, the FQCN `yii\web\Request` is
+> now defined exclusively by your override file. You **cannot** write `class Request extends \yii\web\Request` inside
+> `namespace yii\web;` that would be self-inheritance and PHP will reject it. You must reimplement the full public
 > surface of the original class.
 >
-> If you only need to *extend* the framework class, do **not** use `exclude-from-classmap`. Instead, declare a subclass 
-> under a different FQCN (for example `app\components\Request extends \yii\web\Request`) and point the `request` 
+> If you only need to _extend_ the framework class, do **not** use `exclude-from-classmap`. Instead, declare a subclass
+> under a different FQCN (for example `app\components\Request extends \yii\web\Request`) and point the `request`
 > application component at the new class via the application configuration:
 >
 > ```php
@@ -418,15 +442,15 @@ authoritative classmaps because it is resolved at autoload-generation time, not 
 
 #### Installing Yii from an archive file (non-Composer install)
 
-Yii 2 can still be installed from a downloadable archive file as documented in the [installation guide](../docs/guide/start-installation.md). 
-The archive published at `yiiframework.com/download/` ships a prebuilt `vendor/` directory generated with 
+Yii 2 can still be installed from a downloadable archive file as documented in the [installation guide](../docs/guide/start-installation.md).
+The archive published at `yiiframework.com/download/` ships a prebuilt `vendor/` directory generated with
 `composer install`, so it already contains `vendor/autoload.php`. The standard application templates (`basic`, `advanced`)
-require `vendor/autoload.php` from their entry scripts (`web/index.php`, `yii`) before any framework class is referenced, 
+require `vendor/autoload.php` from their entry scripts (`web/index.php`, `yii`) before any framework class is referenced,
 so the archive-install path keeps working unchanged with this release.
 
-What is **no longer supported** is bootstrapping the framework by requiring `framework/Yii.php` (or the legacy 
-`framework/classes.php`) *without* having Composer's autoloader active. There is no runtime fallback anymore: 
-`vendor/autoload.php` MUST be loaded first. If you maintain a custom entry script that historically skipped Composer's 
+What is **no longer supported** is bootstrapping the framework by requiring `framework/Yii.php` (or the legacy
+`framework/classes.php`) _without_ having Composer's autoloader active. There is no runtime fallback anymore:
+`vendor/autoload.php` MUST be loaded first. If you maintain a custom entry script that historically skipped Composer's
 autoloader, add `require __DIR__ . '/vendor/autoload.php';` before any reference to `Yii` or `yii\…` classes.
 
 #### Adding test-only classes

--- a/framework/db/conditions/InCondition.php
+++ b/framework/db/conditions/InCondition.php
@@ -38,7 +38,9 @@ class InCondition implements ConditionInterface
     }
 
     /**
-     * @return string
+     * Returns the comparison operator.
+     *
+     * @return string operator (for example, `IN` or `NOT IN`).
      */
     public function getOperator(): string
     {
@@ -46,7 +48,12 @@ class InCondition implements ConditionInterface
     }
 
     /**
-     * @return array|string|ExpressionInterface
+     * Returns the column(s) being matched.
+     *
+     * Normalizes `Traversable` input to an array on first access and caches the result for subsequent calls.
+     *
+     * @return array|string|ExpressionInterface column name, list of column names for composite conditions, or an
+     * expression.
      */
     public function getColumn(): array|string|ExpressionInterface
     {
@@ -58,7 +65,11 @@ class InCondition implements ConditionInterface
     }
 
     /**
-     * @return array|int|string|ExpressionInterface
+     * Returns the value(s) to match against.
+     *
+     * Normalizes `Traversable` input to an array on first access and caches the result for subsequent calls.
+     *
+     * @return array|int|string|ExpressionInterface value list, scalar, or expression used for the comparison.
      */
     public function getValues(): array|int|string|ExpressionInterface
     {

--- a/framework/db/conditions/InCondition.php
+++ b/framework/db/conditions/InCondition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,79 +10,71 @@
 
 namespace yii\db\conditions;
 
+use Traversable;
 use yii\base\InvalidArgumentException;
 use yii\db\ExpressionInterface;
 
 /**
- * Class InCondition represents `IN` condition.
+ * Represents `IN` condition.
  *
  * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
  * @since 2.0.14
- * @phpcs:disable Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore
  */
 class InCondition implements ConditionInterface
 {
     /**
-     * @var string $operator the operator to use (e.g. `IN` or `NOT IN`)
+     * @param array|string|ExpressionInterface|Traversable $column the column name. If it is an array, a composite `IN`
+     * condition will be generated.
+     * @param string $operator the operator to use (e.g. `IN` or `NOT IN`).
+     * @param array|int|string|ExpressionInterface|Traversable $values an array of values that [[column]] value should
+     * be among. If it is an empty array the generated expression will be a `false` value if [[operator]] is `IN` and
+     * empty if operator is `NOT IN`.
      */
-    private $operator;
-    /**
-     * @var string|string[] the column name. If it is an array, a composite `IN` condition
-     * will be generated.
-     */
-    private $column;
-    /**
-     * @var ExpressionInterface[]|string[]|int[] an array of values that [[column]] value should be among.
-     * If it is an empty array the generated expression will be a `false` value if
-     * [[operator]] is `IN` and empty if operator is `NOT IN`.
-     */
-    private $values;
-
-
-    /**
-     * SimpleCondition constructor
-     *
-     * @param string|string[] $column the column name. If it is an array, a composite `IN` condition
-     * will be generated.
-     * @param string $operator the operator to use (e.g. `IN` or `NOT IN`)
-     * @param array $values an array of values that [[column]] value should be among. If it is an empty array the generated
-     * expression will be a `false` value if [[operator]] is `IN` and empty if operator is `NOT IN`.
-     */
-    public function __construct($column, $operator, $values)
-    {
-        $this->column = $column;
-        $this->operator = $operator;
-        $this->values = $values;
+    public function __construct(
+        private array|string|ExpressionInterface|Traversable $column,
+        private string $operator,
+        private array|int|string|ExpressionInterface|Traversable $values
+    ) {
     }
 
     /**
      * @return string
      */
-    public function getOperator()
+    public function getOperator(): string
     {
         return $this->operator;
     }
 
     /**
-     * @return mixed
+     * @return array|string|ExpressionInterface
      */
-    public function getColumn()
+    public function getColumn(): array|string|ExpressionInterface
     {
+        if ($this->column instanceof Traversable && !$this->column instanceof ExpressionInterface) {
+            $this->column = iterator_to_array($this->column);
+        }
+
         return $this->column;
     }
 
     /**
-     * @return ExpressionInterface[]|string[]|int[]
+     * @return array|int|string|ExpressionInterface
      */
-    public function getValues()
+    public function getValues(): array|int|string|ExpressionInterface
     {
+        if ($this->values instanceof Traversable && !$this->values instanceof ExpressionInterface) {
+            $this->values = iterator_to_array($this->values);
+        }
+
         return $this->values;
     }
+
     /**
      * {@inheritdoc}
+     *
      * @throws InvalidArgumentException if wrong number of operands have been given.
      */
-    public static function fromArrayDefinition($operator, $operands)
+    public static function fromArrayDefinition($operator, $operands): static
     {
         if (!isset($operands[0], $operands[1])) {
             throw new InvalidArgumentException("Operator '$operator' requires two operands.");

--- a/framework/db/conditions/InConditionBuilder.php
+++ b/framework/db/conditions/InConditionBuilder.php
@@ -198,14 +198,18 @@ class InConditionBuilder implements ExpressionBuilderInterface
 
             foreach ($columns as $i => $_) {
                 $columnKey = $columnKeys[$i];
+                $columnValue = null;
 
                 if (
                     (is_array($value) || $value instanceof ArrayAccess)
                     && $columnKey !== null
-                    && isset($value[$columnKey])
                 ) {
-                    $columnValue = $value[$columnKey];
+                    $columnValue = $value[$columnKey] ?? null;
+                }
 
+                if ($columnValue === null) {
+                    $vs[] = $quotedColumns[$i] . ($operator === 'IN' ? ' IS' : ' IS NOT') . ' NULL';
+                } else {
                     if ($columnValue instanceof ExpressionInterface) {
                         $placeholder = $this->queryBuilder->buildExpression($columnValue, $params);
                     } else {
@@ -213,8 +217,6 @@ class InConditionBuilder implements ExpressionBuilderInterface
                     }
 
                     $vs[] = $quotedColumns[$i] . ($operator === 'IN' ? ' = ' : " {$notEqualOperator} ") . $placeholder;
-                } else {
-                    $vs[] = $quotedColumns[$i] . ($operator === 'IN' ? ' IS' : ' IS NOT') . ' NULL';
                 }
             }
 
@@ -327,7 +329,7 @@ class InConditionBuilder implements ExpressionBuilderInterface
     private function normalizeColumn(string|ExpressionInterface $column, array &$params): string
     {
         if ($column instanceof Expression) {
-            return $this->quoteColumn($column->expression);
+            return $this->quoteColumn($this->queryBuilder->buildExpression($column, $params));
         }
 
         if ($column instanceof ExpressionInterface) {

--- a/framework/db/conditions/InConditionBuilder.php
+++ b/framework/db/conditions/InConditionBuilder.php
@@ -55,7 +55,7 @@ class InConditionBuilder implements ExpressionBuilderInterface
 
         if (!is_array($values)) {
             // ensure values is an array
-            $values = (array) $values;
+            $values = [$values];
         }
 
         if (is_array($column)) {

--- a/framework/db/conditions/InConditionBuilder.php
+++ b/framework/db/conditions/InConditionBuilder.php
@@ -241,11 +241,13 @@ class InConditionBuilder implements ExpressionBuilderInterface
     }
 
     /**
-     * Builds is null/is not null condition for column based on operator
+     * Builds `IS NULL` / `IS NOT NULL` condition for a scalar column based on the operator.
      *
-     * @param string $operator
-     * @param string $column
-     * @return string is null or is not null condition
+     * @param string $operator operator in uppercase.
+     * @param string $column column to be matched.
+     *
+     * @return string null condition SQL.
+     *
      * @since 2.0.31
      */
     protected function getNullCondition(string $operator, string $column): string

--- a/framework/db/conditions/InConditionBuilder.php
+++ b/framework/db/conditions/InConditionBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,14 +10,18 @@
 
 namespace yii\db\conditions;
 
+use ArrayAccess;
 use yii\db\Expression;
 use yii\db\ExpressionBuilderInterface;
 use yii\db\ExpressionBuilderTrait;
 use yii\db\ExpressionInterface;
 use yii\db\Query;
 
+use function count;
+use function is_array;
+
 /**
- * Class InConditionBuilder builds objects of [[InCondition]]
+ * Builds objects of [[InCondition]].
  *
  * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
  * @since 2.0.14
@@ -24,16 +30,15 @@ class InConditionBuilder implements ExpressionBuilderInterface
 {
     use ExpressionBuilderTrait;
 
-
     /**
-     * Method builds the raw SQL from the $expression that will not be additionally
-     * escaped or quoted.
+     * Builds raw SQL from the expression.
      *
      * @param ExpressionInterface|InCondition $expression the expression to be built.
      * @param array $params the binding parameters.
+     *
      * @return string the raw SQL that will not be additionally escaped or quoted.
      */
-    public function build(ExpressionInterface $expression, array &$params = [])
+    public function build(ExpressionInterface $expression, array &$params = []): string
     {
         $operator = strtoupper($expression->getOperator());
         $column = $expression->getColumn();
@@ -48,7 +53,7 @@ class InConditionBuilder implements ExpressionBuilderInterface
             return $this->buildSubqueryInCondition($operator, $column, $values, $params);
         }
 
-        if (!is_array($values) && !$values instanceof \Traversable) {
+        if (!is_array($values)) {
             // ensure values is an array
             $values = (array) $values;
         }
@@ -60,74 +65,60 @@ class InConditionBuilder implements ExpressionBuilderInterface
             $column = reset($column);
         }
 
-        if ($column instanceof \Traversable) {
-            if (iterator_count($column) > 1) {
-                return $this->buildCompositeInCondition($operator, $column, $values, $params);
-            }
-            $column->rewind();
-            $column = $column->current();
-        }
-
         if ($column instanceof Expression) {
             $column = $column->expression;
         }
 
-        if (is_array($values)) {
-            $rawValues = $values;
-        } elseif ($values instanceof \Traversable) {
-            $rawValues = $this->getRawValuesFromTraversableObject($values);
-        }
-
+        $rawValues = $values;
         $nullCondition = null;
         $nullConditionOperator = null;
+
         if (isset($rawValues) && in_array(null, $rawValues, true)) {
             $nullCondition = $this->getNullCondition($operator, $column);
             $nullConditionOperator = $operator === 'IN' ? 'OR' : 'AND';
         }
 
         $sqlValues = $this->buildValues($expression, $values, $params);
-        if (empty($sqlValues)) {
+
+        if ($sqlValues === []) {
             if ($nullCondition === null) {
                 return $operator === 'IN' ? '0=1' : '';
             }
+
             return $nullCondition;
         }
 
-        if (strpos($column, '(') === false) {
-            $column = $this->queryBuilder->db->quoteColumnName($column);
-        }
+        $column = $this->quoteColumn($column);
+
         if (count($sqlValues) > 1) {
             $sql = "$column $operator (" . implode(', ', $sqlValues) . ')';
         } else {
             $operator = $operator === 'IN' ? '=' : '<>';
-            $sql = $column . $operator . reset($sqlValues);
+            $sql = "{$column}{$operator}" . reset($sqlValues);
         }
 
         return $nullCondition !== null && $nullConditionOperator !== null
-            ? sprintf('%s %s %s', $sql, $nullConditionOperator, $nullCondition)
+            ? "{$sql} {$nullConditionOperator} {$nullCondition}"
             : $sql;
     }
 
     /**
-     * Builds $values to be used in [[InCondition]]
+     * Builds values to be used in [[InCondition]].
      *
-     * @param ConditionInterface|InCondition $condition
-     * @param array $values
-     * @param array $params the binding parameters
-     * @return array of prepared for SQL placeholders
+     * @param ConditionInterface|InCondition $condition the condition to be built.
+     * @param array $values the values to bind.
+     * @param array $params the binding parameters.
+     *
+     * @return array prepared SQL placeholders.
      */
-    protected function buildValues(ConditionInterface $condition, $values, &$params)
+    protected function buildValues(ConditionInterface $condition, array $values, array &$params): array
     {
         $sqlValues = [];
+
         $column = $condition->getColumn();
 
         if (is_array($column)) {
             $column = reset($column);
-        }
-
-        if ($column instanceof \Traversable) {
-            $column->rewind();
-            $column = $column->current();
         }
 
         if ($column instanceof Expression) {
@@ -135,9 +126,10 @@ class InConditionBuilder implements ExpressionBuilderInterface
         }
 
         foreach ($values as $i => $value) {
-            if (is_array($value) || $value instanceof \ArrayAccess) {
-                $value = isset($value[$column]) ? $value[$column] : null;
+            if (is_array($value) || $value instanceof ArrayAccess) {
+                $value = $value[$column] ?? null;
             }
+
             if ($value === null) {
                 continue;
             } elseif ($value instanceof ExpressionInterface) {
@@ -153,24 +145,28 @@ class InConditionBuilder implements ExpressionBuilderInterface
     /**
      * Builds SQL for IN condition.
      *
-     * @param string $operator
-     * @param array|string $columns
-     * @param Query $values
-     * @param array $params
-     * @return string SQL
+     * @param string $operator operator in uppercase.
+     * @param array|string|ExpressionInterface $columns the columns to be matched.
+     * @param Query $values subquery values.
+     * @param array $params the binding parameters.
+     *
+     * @return string SQL for IN condition.
      */
-    protected function buildSubqueryInCondition($operator, $columns, $values, &$params)
-    {
+    protected function buildSubqueryInCondition(
+        string $operator,
+        array|string|ExpressionInterface $columns,
+        Query $values,
+        array &$params
+    ): string {
         $sql = $this->queryBuilder->buildExpression($values, $params);
 
         if (is_array($columns)) {
-            foreach ($columns as $i => $col) {
-                if ($col instanceof Expression) {
-                    $col = $col->expression;
+            foreach ($columns as $i => $column) {
+                if ($column instanceof Expression) {
+                    $column = $column->expression;
                 }
-                if (strpos($col, '(') === false) {
-                    $columns[$i] = $this->queryBuilder->db->quoteColumnName($col);
-                }
+
+                $columns[$i] = $this->quoteColumn($column);
             }
 
             return '(' . implode(', ', $columns) . ") $operator $sql";
@@ -179,53 +175,74 @@ class InConditionBuilder implements ExpressionBuilderInterface
         if ($columns instanceof Expression) {
             $columns = $columns->expression;
         }
-        if (strpos($columns, '(') === false) {
-            $columns = $this->queryBuilder->db->quoteColumnName($columns);
-        }
 
-        return "$columns $operator $sql";
+        return $this->quoteColumn($columns) . " $operator $sql";
     }
 
     /**
-     * Builds SQL for IN condition.
+     * Builds SQL for composite IN condition.
      *
-     * @param string $operator
-     * @param array|\Traversable $columns
-     * @param array $values
-     * @param array $params
-     * @return string SQL
+     * @param string $operator operator in uppercase.
+     * @param array $columns columns to be matched.
+     * @param array $values row values.
+     * @param array $params the binding parameters.
+     *
+     * @return string SQL for composite IN condition.
      */
-    protected function buildCompositeInCondition($operator, $columns, $values, &$params)
-    {
-        $vss = [];
-        foreach ($values as $value) {
-            $vs = [];
-            foreach ($columns as $column) {
-                if ($column instanceof Expression) {
-                    $column = $column->expression;
-                }
-                if (isset($value[$column])) {
-                    $vs[] = $this->queryBuilder->bindParam($value[$column], $params);
-                } else {
-                    $vs[] = 'NULL';
-                }
-            }
-            $vss[] = '(' . implode(', ', $vs) . ')';
-        }
+    protected function buildCompositeInCondition(
+        string $operator,
+        array $columns,
+        array $values,
+        array &$params
+    ): string {
+        $quotedColumns = [];
 
-        if (empty($vss)) {
-            return $operator === 'IN' ? '0=1' : '';
-        }
-
-        $sqlColumns = [];
         foreach ($columns as $i => $column) {
             if ($column instanceof Expression) {
                 $column = $column->expression;
             }
-            $sqlColumns[] = strpos($column, '(') === false ? $this->queryBuilder->db->quoteColumnName($column) : $column;
+
+            $quotedColumns[$i] = $this->quoteColumn($column);
         }
 
-        return '(' . implode(', ', $sqlColumns) . ") $operator (" . implode(', ', $vss) . ')';
+        $vss = [];
+        $notEqualOperator = $this->getNotEqualOperator();
+
+        foreach ($values as $value) {
+            $vs = [];
+
+            foreach ($columns as $i => $column) {
+                if ($column instanceof Expression) {
+                    $column = $column->expression;
+                }
+
+                if (isset($value[$column])) {
+                    $placeholder = $this->queryBuilder->bindParam($value[$column], $params);
+
+                    $vs[] = $quotedColumns[$i] . ($operator === 'IN' ? ' = ' : " {$notEqualOperator} ") . $placeholder;
+                } else {
+                    $vs[] = $quotedColumns[$i] . ($operator === 'IN' ? ' IS' : ' IS NOT') . ' NULL';
+                }
+            }
+
+            $vss[] = '(' . implode($operator === 'IN' ? ' AND ' : ' OR ', $vs) . ')';
+        }
+
+        if ($vss === []) {
+            return $operator === 'IN' ? '0=1' : '';
+        }
+
+        return '(' . implode($operator === 'IN' ? ' OR ' : ' AND ', $vss) . ')';
+    }
+
+    /**
+     * Returns inequality operator for decomposed `NOT IN` conditions.
+     *
+     * @return string inequality operator.
+     */
+    protected function getNotEqualOperator(): string
+    {
+        return '<>';
     }
 
     /**
@@ -236,31 +253,24 @@ class InConditionBuilder implements ExpressionBuilderInterface
      * @return string is null or is not null condition
      * @since 2.0.31
      */
-    protected function getNullCondition($operator, $column)
+    protected function getNullCondition(string $operator, string $column): string
     {
         $column = $this->queryBuilder->db->quoteColumnName($column);
-        if ($operator === 'IN') {
-            return sprintf('%s IS NULL', $column);
-        }
-        return sprintf('%s IS NOT NULL', $column);
+
+        return $column . ($operator === 'IN' ? ' IS NULL' : ' IS NOT NULL');
     }
 
     /**
-     * @param \Traversable $traversableObject
-     * @return array raw values
-     * @since 2.0.31
+     * Quotes column name if needed.
+     *
+     * @param string $column the column name.
+     *
+     * @return string quoted column name.
      */
-    protected function getRawValuesFromTraversableObject(\Traversable $traversableObject)
+    private function quoteColumn(string $column): string
     {
-        $rawValues = [];
-        foreach ($traversableObject as $value) {
-            if (is_array($value)) {
-                $values = array_values($value);
-                $rawValues = array_merge($rawValues, $values);
-            } else {
-                $rawValues[] = $value;
-            }
-        }
-        return $rawValues;
+        return strpos($column, '(') === false
+            ? $this->queryBuilder->db->quoteColumnName($column)
+            : $column;
     }
 }

--- a/framework/db/conditions/InConditionBuilder.php
+++ b/framework/db/conditions/InConditionBuilder.php
@@ -19,6 +19,7 @@ use yii\db\Query;
 
 use function count;
 use function is_array;
+use function is_string;
 
 /**
  * Builds objects of [[InCondition]].
@@ -65,11 +66,10 @@ class InConditionBuilder implements ExpressionBuilderInterface
             $column = reset($column);
         }
 
-        $rawValues = $values;
         $nullCondition = null;
         $nullConditionOperator = null;
 
-        if (isset($rawValues) && in_array(null, $rawValues, true)) {
+        if ($this->hasNullValue($column, $values)) {
             $nullCondition = $this->buildNullCondition($operator, $column, $params);
 
             $nullConditionOperator = $operator === 'IN' ? 'OR' : 'AND';
@@ -269,6 +269,31 @@ class InConditionBuilder implements ExpressionBuilderInterface
         }
 
         return $this->getNullCondition($operator, $column);
+    }
+
+    /**
+     * Checks whether condition values include null after row extraction.
+     *
+     * @param string|ExpressionInterface $column column to be matched.
+     * @param array $values the values to inspect.
+     *
+     * @return bool whether values include null.
+     */
+    private function hasNullValue(string|ExpressionInterface $column, array $values): bool
+    {
+        $columnKey = $this->resolveColumnKey($column);
+
+        foreach ($values as $value) {
+            if (is_array($value) || $value instanceof ArrayAccess) {
+                $value = $columnKey !== null ? ($value[$columnKey] ?? null) : null;
+            }
+
+            if ($value === null) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/framework/db/conditions/InConditionBuilder.php
+++ b/framework/db/conditions/InConditionBuilder.php
@@ -65,16 +65,13 @@ class InConditionBuilder implements ExpressionBuilderInterface
             $column = reset($column);
         }
 
-        if ($column instanceof Expression) {
-            $column = $column->expression;
-        }
-
         $rawValues = $values;
         $nullCondition = null;
         $nullConditionOperator = null;
 
         if (isset($rawValues) && in_array(null, $rawValues, true)) {
-            $nullCondition = $this->getNullCondition($operator, $column);
+            $nullCondition = $this->buildNullCondition($operator, $column, $params);
+
             $nullConditionOperator = $operator === 'IN' ? 'OR' : 'AND';
         }
 
@@ -88,7 +85,7 @@ class InConditionBuilder implements ExpressionBuilderInterface
             return $nullCondition;
         }
 
-        $column = $this->quoteColumn($column);
+        $column = $this->normalizeColumn($column, $params);
 
         if (count($sqlValues) > 1) {
             $sql = "$column $operator (" . implode(', ', $sqlValues) . ')';
@@ -121,13 +118,11 @@ class InConditionBuilder implements ExpressionBuilderInterface
             $column = reset($column);
         }
 
-        if ($column instanceof Expression) {
-            $column = $column->expression;
-        }
+        $columnKey = $this->resolveColumnKey($column);
 
         foreach ($values as $i => $value) {
             if (is_array($value) || $value instanceof ArrayAccess) {
-                $value = $value[$column] ?? null;
+                $value = $columnKey !== null ? ($value[$columnKey] ?? null) : null;
             }
 
             if ($value === null) {
@@ -162,21 +157,13 @@ class InConditionBuilder implements ExpressionBuilderInterface
 
         if (is_array($columns)) {
             foreach ($columns as $i => $column) {
-                if ($column instanceof Expression) {
-                    $column = $column->expression;
-                }
-
-                $columns[$i] = $this->quoteColumn($column);
+                $columns[$i] = $this->normalizeColumn($column, $params);
             }
 
             return '(' . implode(', ', $columns) . ") $operator $sql";
         }
 
-        if ($columns instanceof Expression) {
-            $columns = $columns->expression;
-        }
-
-        return $this->quoteColumn($columns) . " $operator $sql";
+        return $this->normalizeColumn($columns, $params) . " $operator $sql";
     }
 
     /**
@@ -196,13 +183,11 @@ class InConditionBuilder implements ExpressionBuilderInterface
         array &$params
     ): string {
         $quotedColumns = [];
+        $columnKeys = [];
 
         foreach ($columns as $i => $column) {
-            if ($column instanceof Expression) {
-                $column = $column->expression;
-            }
-
-            $quotedColumns[$i] = $this->quoteColumn($column);
+            $quotedColumns[$i] = $this->normalizeColumn($column, $params);
+            $columnKeys[$i] = $this->resolveColumnKey($column);
         }
 
         $vss = [];
@@ -211,13 +196,21 @@ class InConditionBuilder implements ExpressionBuilderInterface
         foreach ($values as $value) {
             $vs = [];
 
-            foreach ($columns as $i => $column) {
-                if ($column instanceof Expression) {
-                    $column = $column->expression;
-                }
+            foreach ($columns as $i => $_) {
+                $columnKey = $columnKeys[$i];
 
-                if (isset($value[$column])) {
-                    $placeholder = $this->queryBuilder->bindParam($value[$column], $params);
+                if (
+                    (is_array($value) || $value instanceof ArrayAccess)
+                    && $columnKey !== null
+                    && isset($value[$columnKey])
+                ) {
+                    $columnValue = $value[$columnKey];
+
+                    if ($columnValue instanceof ExpressionInterface) {
+                        $placeholder = $this->queryBuilder->buildExpression($columnValue, $params);
+                    } else {
+                        $placeholder = $this->queryBuilder->bindParam($columnValue, $params);
+                    }
 
                     $vs[] = $quotedColumns[$i] . ($operator === 'IN' ? ' = ' : " {$notEqualOperator} ") . $placeholder;
                 } else {
@@ -258,6 +251,65 @@ class InConditionBuilder implements ExpressionBuilderInterface
         $column = $this->queryBuilder->db->quoteColumnName($column);
 
         return $column . ($operator === 'IN' ? ' IS NULL' : ' IS NOT NULL');
+    }
+
+    /**
+     * Builds null condition for scalar and expression columns.
+     *
+     * @param string $operator operator in uppercase.
+     * @param string|ExpressionInterface $column column to be matched.
+     * @param array $params the binding parameters.
+     *
+     * @return string null condition SQL.
+     */
+    private function buildNullCondition(string $operator, string|ExpressionInterface $column, array &$params): string
+    {
+        if ($column instanceof ExpressionInterface) {
+            return $this->normalizeColumn($column, $params) . ($operator === 'IN' ? ' IS NULL' : ' IS NOT NULL');
+        }
+
+        return $this->getNullCondition($operator, $column);
+    }
+
+    /**
+     * Resolves array lookup key for column values.
+     *
+     * @param string|ExpressionInterface $column column to be matched.
+     *
+     * @return string|null lookup key for row arrays.
+     */
+    private function resolveColumnKey(string|ExpressionInterface $column): ?string
+    {
+        if (is_string($column)) {
+            return $column;
+        }
+
+        if ($column instanceof Expression) {
+            return $column->expression;
+        }
+
+        return null;
+    }
+
+    /**
+     * Normalizes column to SQL fragment.
+     *
+     * @param string|ExpressionInterface $column column to be matched.
+     * @param array $params the binding parameters.
+     *
+     * @return string SQL fragment for column.
+     */
+    private function normalizeColumn(string|ExpressionInterface $column, array &$params): string
+    {
+        if ($column instanceof Expression) {
+            return $this->quoteColumn($column->expression);
+        }
+
+        if ($column instanceof ExpressionInterface) {
+            return $this->queryBuilder->buildExpression($column, $params);
+        }
+
+        return $this->quoteColumn($column);
     }
 
     /**

--- a/framework/db/mssql/conditions/InConditionBuilder.php
+++ b/framework/db/mssql/conditions/InConditionBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -9,7 +11,8 @@
 namespace yii\db\mssql\conditions;
 
 use yii\base\NotSupportedException;
-use yii\db\Expression;
+use yii\db\ExpressionInterface;
+use yii\db\Query;
 
 /**
  * {@inheritdoc}
@@ -23,8 +26,12 @@ class InConditionBuilder extends \yii\db\conditions\InConditionBuilder
      * {@inheritdoc}
      * @throws NotSupportedException if `$columns` is an array
      */
-    protected function buildSubqueryInCondition($operator, $columns, $values, &$params)
-    {
+    protected function buildSubqueryInCondition(
+        string $operator,
+        array|string|ExpressionInterface $columns,
+        Query $values,
+        array &$params
+    ): string {
         if (is_array($columns)) {
             throw new NotSupportedException(__METHOD__ . ' is not supported by MSSQL.');
         }
@@ -35,32 +42,8 @@ class InConditionBuilder extends \yii\db\conditions\InConditionBuilder
     /**
      * {@inheritdoc}
      */
-    protected function buildCompositeInCondition($operator, $columns, $values, &$params)
+    protected function getNotEqualOperator(): string
     {
-        $quotedColumns = [];
-        foreach ($columns as $i => $column) {
-            if ($column instanceof Expression) {
-                $column = $column->expression;
-            }
-            $quotedColumns[$i] = strpos($column, '(') === false ? $this->queryBuilder->db->quoteColumnName($column) : $column;
-        }
-        $vss = [];
-        foreach ($values as $value) {
-            $vs = [];
-            foreach ($columns as $i => $column) {
-                if ($column instanceof Expression) {
-                    $column = $column->expression;
-                }
-                if (isset($value[$column])) {
-                    $phName = $this->queryBuilder->bindParam($value[$column], $params);
-                    $vs[] = $quotedColumns[$i] . ($operator === 'IN' ? ' = ' : ' != ') . $phName;
-                } else {
-                    $vs[] = $quotedColumns[$i] . ($operator === 'IN' ? ' IS' : ' IS NOT') . ' NULL';
-                }
-            }
-            $vss[] = '(' . implode($operator === 'IN' ? ' AND ' : ' OR ', $vs) . ')';
-        }
-
-        return '(' . implode($operator === 'IN' ? ' OR ' : ' AND ', $vss) . ')';
+        return '!=';
     }
 }

--- a/framework/db/oci/conditions/InConditionBuilder.php
+++ b/framework/db/oci/conditions/InConditionBuilder.php
@@ -51,7 +51,7 @@ class InConditionBuilder extends \yii\db\conditions\InConditionBuilder
      */
     protected function splitCondition(InCondition $condition, array &$params): ?string
     {
-        $operator = $condition->getOperator();
+        $operator = strtoupper($condition->getOperator());
         $values = $condition->getValues();
         $column = $condition->getColumn();
 

--- a/framework/db/oci/conditions/InConditionBuilder.php
+++ b/framework/db/oci/conditions/InConditionBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -10,6 +12,10 @@ namespace yii\db\oci\conditions;
 
 use yii\db\conditions\InCondition;
 use yii\db\ExpressionInterface;
+
+use function array_slice;
+use function count;
+use function is_array;
 
 /**
  * {@inheritdoc}
@@ -24,9 +30,10 @@ class InConditionBuilder extends \yii\db\conditions\InConditionBuilder
      * @param array $params the binding parameters.
      * @return string the raw SQL that will not be additionally escaped or quoted.
      */
-    public function build(ExpressionInterface $expression, array &$params = [])
+    public function build(ExpressionInterface $expression, array &$params = []): string
     {
         $splitCondition = $this->splitCondition($expression, $params);
+
         if ($splitCondition !== null) {
             return $splitCondition;
         }
@@ -38,34 +45,40 @@ class InConditionBuilder extends \yii\db\conditions\InConditionBuilder
      * Oracle DBMS does not support more than 1000 parameters in `IN` condition.
      * This method splits long `IN` condition into series of smaller ones.
      *
-     * @param ExpressionInterface|InCondition $condition the expression to be built.
+     * @param InCondition $condition the expression to be built.
      * @param array $params the binding parameters.
      * @return string|null null when split is not required. Otherwise - built SQL condition.
      */
-    protected function splitCondition(InCondition $condition, &$params)
+    protected function splitCondition(InCondition $condition, array &$params): ?string
     {
         $operator = $condition->getOperator();
         $values = $condition->getValues();
         $column = $condition->getColumn();
-
-        if ($values instanceof \Traversable) {
-            $values = iterator_to_array($values);
-        }
 
         if (!is_array($values)) {
             return null;
         }
 
         $maxParameters = 1000;
+
         $count = count($values);
+
         if ($count <= $maxParameters) {
             return null;
         }
 
         $slices = [];
+
         for ($i = 0; $i < $count; $i += $maxParameters) {
-            $slices[] = $this->queryBuilder->createConditionFromArray([$operator, $column, array_slice($values, $i, $maxParameters)]);
+            $slices[] = $this->queryBuilder->createConditionFromArray(
+                [
+                    $operator,
+                    $column,
+                    array_slice($values, $i, $maxParameters),
+                ],
+            );
         }
+
         array_unshift($slices, ($operator === 'IN') ? 'OR' : 'AND');
 
         return $this->queryBuilder->buildCondition($slices, $params);

--- a/framework/db/sqlite/conditions/InConditionBuilder.php
+++ b/framework/db/sqlite/conditions/InConditionBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -9,7 +11,10 @@
 namespace yii\db\sqlite\conditions;
 
 use yii\base\NotSupportedException;
-use yii\db\Expression;
+use yii\db\ExpressionInterface;
+use yii\db\Query;
+
+use function is_array;
 
 /**
  * {@inheritdoc}
@@ -23,8 +28,12 @@ class InConditionBuilder extends \yii\db\conditions\InConditionBuilder
      * {@inheritdoc}
      * @throws NotSupportedException if `$columns` is an array
      */
-    protected function buildSubqueryInCondition($operator, $columns, $values, &$params)
-    {
+    protected function buildSubqueryInCondition(
+        string $operator,
+        array|string|ExpressionInterface $columns,
+        Query $values,
+        array &$params
+    ): string {
         if (is_array($columns)) {
             throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');
         }
@@ -35,32 +44,8 @@ class InConditionBuilder extends \yii\db\conditions\InConditionBuilder
     /**
      * {@inheritdoc}
      */
-    protected function buildCompositeInCondition($operator, $columns, $values, &$params)
+    protected function getNotEqualOperator(): string
     {
-        $quotedColumns = [];
-        foreach ($columns as $i => $column) {
-            if ($column instanceof Expression) {
-                $column = $column->expression;
-            }
-            $quotedColumns[$i] = strpos($column, '(') === false ? $this->queryBuilder->db->quoteColumnName($column) : $column;
-        }
-        $vss = [];
-        foreach ($values as $value) {
-            $vs = [];
-            foreach ($columns as $i => $column) {
-                if ($column instanceof Expression) {
-                    $column = $column->expression;
-                }
-                if (isset($value[$column])) {
-                    $phName = $this->queryBuilder->bindParam($value[$column], $params);
-                    $vs[] = $quotedColumns[$i] . ($operator === 'IN' ? ' = ' : ' != ') . $phName;
-                } else {
-                    $vs[] = $quotedColumns[$i] . ($operator === 'IN' ? ' IS' : ' IS NOT') . ' NULL';
-                }
-            }
-            $vss[] = '(' . implode($operator === 'IN' ? ' AND ' : ' OR ', $vs) . ')';
-        }
-
-        return '(' . implode($operator === 'IN' ? ' OR ' : ' AND ', $vss) . ')';
+        return '!=';
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -301,18 +301,6 @@ parameters:
 			path: framework/db/conditions/HashConditionBuilder.php
 
 		-
-			message: '#^Call to an undefined method Traversable\:\:current\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: framework/db/conditions/InConditionBuilder.php
-
-		-
-			message: '#^Call to an undefined method Traversable\:\:rewind\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: framework/db/conditions/InConditionBuilder.php
-
-		-
 			message: '#^Call to an undefined method yii\\db\\ExpressionInterface\:\:getColumn\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -401,12 +389,6 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: framework/db/mysql/JsonExpressionBuilder.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$condition with type yii\\db\\ExpressionInterface is not subtype of native type yii\\db\\conditions\\InCondition\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: framework/db/oci/conditions/InConditionBuilder.php
 
 		-
 			message: '#^Call to an undefined method yii\\db\\ExpressionInterface\:\:getDimension\(\)\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -325,12 +325,6 @@ parameters:
 			path: framework/db/conditions/InConditionBuilder.php
 
 		-
-			message: '#^Variable \$rawValues in isset\(\) always exists and is not nullable\.$#'
-			identifier: isset.variable
-			count: 1
-			path: framework/db/conditions/InConditionBuilder.php
-
-		-
 			message: '#^Call to an undefined method yii\\db\\ExpressionInterface\:\:getColumn\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/tests/base/db/conditions/InConditionTest.php
+++ b/tests/base/db/conditions/InConditionTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace yiiunit\base\db\conditions;
 
+use Generator;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use yii\db\ArrayExpression;
@@ -81,5 +82,48 @@ final class InConditionTest extends TestCase
             $values->getDimension(),
             'Unexpected values expression dimension.',
         );
+    }
+
+    public function testGetColumnConvertsGeneratorToArray(): void
+    {
+        $condition = new InCondition(self::generatorFrom(['id', 'name']), 'IN', [1, 2]);
+
+        $column = $condition->getColumn();
+        $columnAgain = $condition->getColumn();
+
+        self::assertSame(
+            ['id', 'name'],
+            $column,
+            'Column traversable should normalize to array.',
+        );
+        self::assertSame(
+            ['id', 'name'],
+            $columnAgain,
+            'Column normalization should be stable across calls.',
+        );
+    }
+
+    public function testGetValuesConvertsGeneratorToArray(): void
+    {
+        $condition = new InCondition('id', 'IN', self::generatorFrom([1, 2, 3]));
+
+        $values = $condition->getValues();
+        $valuesAgain = $condition->getValues();
+
+        self::assertSame(
+            [1, 2, 3],
+            $values,
+            'Values traversable should normalize to array.',
+        );
+        self::assertSame(
+            [1, 2, 3],
+            $valuesAgain,
+            'Values normalization should be stable across calls.',
+        );
+    }
+
+    private static function generatorFrom(array $items): Generator
+    {
+        yield from $items;
     }
 }

--- a/tests/base/db/conditions/InConditionTest.php
+++ b/tests/base/db/conditions/InConditionTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use yii\db\ArrayExpression;
 use yii\db\conditions\InCondition;
+use yii\db\JsonExpression;
 
 /**
  * Unit tests for {@see InCondition}.
@@ -81,6 +82,52 @@ final class InConditionTest extends TestCase
             1,
             $values->getDimension(),
             'Unexpected values expression dimension.',
+        );
+    }
+
+    public function testGetColumnPreservesJsonExpression(): void
+    {
+        $jsonExpression = new JsonExpression(['id' => 1]);
+        $condition = new InCondition($jsonExpression, 'IN', [1]);
+
+        $column = $condition->getColumn();
+
+        self::assertInstanceOf(
+            JsonExpression::class,
+            $column,
+            'Unexpected JSON column expression type.',
+        );
+        self::assertSame(
+            ['id' => 1],
+            $column->getValue(),
+            'Unexpected JSON column expression value.',
+        );
+        self::assertNull(
+            $column->getType(),
+            'Unexpected JSON column expression type name.',
+        );
+    }
+
+    public function testGetValuesPreservesJsonExpression(): void
+    {
+        $jsonExpression = new JsonExpression(['id' => 1]);
+        $condition = new InCondition('id', 'IN', $jsonExpression);
+
+        $values = $condition->getValues();
+
+        self::assertInstanceOf(
+            JsonExpression::class,
+            $values,
+            'Unexpected JSON values expression type.',
+        );
+        self::assertSame(
+            ['id' => 1],
+            $values->getValue(),
+            'Unexpected JSON values expression value.',
+        );
+        self::assertNull(
+            $values->getType(),
+            'Unexpected JSON values expression type name.',
         );
     }
 

--- a/tests/base/db/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/base/db/conditions/providers/InConditionBuilderProvider.php
@@ -146,6 +146,20 @@ class InConditionBuilderProvider
                 SQL,
                 [':qp0' => 1, ':qp1' => 2],
             ],
+            'composite in (just one column) with null row value' => [
+                ['in', ['id'], [['id' => null, 'name' => 'Name1']]],
+                <<<SQL
+                [[id]] IS NULL
+                SQL,
+                [],
+            ],
+            'composite not in (just one column) with null row value' => [
+                ['not in', ['id'], [['id' => null, 'name' => 'Name1']]],
+                <<<SQL
+                [[id]] IS NOT NULL
+                SQL,
+                [],
+            ],
             'composite in using array objects (just one column)' => [
                 ['in', new TraversableObject(['id']), new TraversableObject([
                     ['id' => 1, 'name' => 'Name1'],

--- a/tests/base/db/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/base/db/conditions/providers/InConditionBuilderProvider.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace yiiunit\base\db\conditions\providers;
 
+use Generator;
 use yii\db\conditions\InCondition;
 use yii\db\Expression;
 use yii\db\Query;
@@ -78,9 +79,58 @@ class InConditionBuilderProvider
             'composite in' => [
                 ['in', ['id', 'name'], [['id' => 1, 'name' => 'oy']]],
                 <<<SQL
-                ([[id]], [[name]]) IN ((:qp0, :qp1))
+                (([[id]] = :qp0 AND [[name]] = :qp1))
                 SQL,
                 [':qp0' => 1, ':qp1' => 'oy'],
+            ],
+            'composite in with multiple rows' => [
+                ['in', ['id', 'name'], [['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']]],
+                <<<SQL
+                (([[id]] = :qp0 AND [[name]] = :qp1) OR ([[id]] = :qp2 AND [[name]] = :qp3))
+                SQL,
+                [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'],
+            ],
+            'composite in with expression column' => [
+                ['in', [new Expression('id'), 'name'], [['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']]],
+                <<<SQL
+                (([[id]] = :qp0 AND [[name]] = :qp1) OR ([[id]] = :qp2 AND [[name]] = :qp3))
+                SQL,
+                [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'],
+            ],
+            'composite in with null' => [
+                ['in', ['id', 'name'], [['id' => 1, 'name' => null]]],
+                <<<SQL
+                (([[id]] = :qp0 AND [[name]] IS NULL))
+                SQL,
+                [':qp0' => 1],
+            ],
+            'composite not in' => [
+                ['not in', ['id', 'name'], [['id' => 1, 'name' => 'oy']]],
+                <<<SQL
+                (([[id]] <> :qp0 OR [[name]] <> :qp1))
+                SQL,
+                [':qp0' => 1, ':qp1' => 'oy'],
+            ],
+            'composite not in with multiple rows' => [
+                ['not in', ['id', 'name'], [['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']]],
+                <<<SQL
+                (([[id]] <> :qp0 OR [[name]] <> :qp1) AND ([[id]] <> :qp2 OR [[name]] <> :qp3))
+                SQL,
+                [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'],
+            ],
+            'composite not in with expression column' => [
+                ['not in', [new Expression('id'), 'name'], [['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']]],
+                <<<SQL
+                (([[id]] <> :qp0 OR [[name]] <> :qp1) AND ([[id]] <> :qp2 OR [[name]] <> :qp3))
+                SQL,
+                [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'],
+            ],
+            'composite not in with null' => [
+                ['not in', ['id', 'name'], [['id' => 1, 'name' => null]]],
+                <<<SQL
+                (([[id]] <> :qp0 OR [[name]] IS NOT NULL))
+                SQL,
+                [':qp0' => 1],
             ],
             'composite in (just one column)' => [
                 ['in', ['id'], [['id' => 1, 'name' => 'Name1'], ['id' => 2, 'name' => 'Name2']]],
@@ -168,9 +218,27 @@ class InConditionBuilderProvider
                     ['id' => 2, 'name' => 'yo'],
                 ])],
                 <<<SQL
-                ([[id]], [[name]]) IN ((:qp0, :qp1), (:qp2, :qp3))
+                (([[id]] = :qp0 AND [[name]] = :qp1) OR ([[id]] = :qp2 AND [[name]] = :qp3))
                 SQL,
                 [':qp0' => 1, ':qp1' => 'oy', ':qp2' => 2, ':qp3' => 'yo'],
+            ],
+            'composite in with generator columns' => [
+                new InCondition(
+                    self::generatorFrom(['id', 'name']),
+                    'in',
+                    [['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']],
+                ),
+                <<<SQL
+                (([[id]] = :qp0 AND [[name]] = :qp1) OR ([[id]] = :qp2 AND [[name]] = :qp3))
+                SQL,
+                [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'],
+            ],
+            'in with generator values' => [
+                new InCondition('id', 'in', self::generatorFrom([1, 2, 3])),
+                <<<SQL
+                [[id]] IN (:qp0, :qp1, :qp2)
+                SQL,
+                [':qp0' => 1, ':qp1' => 2, ':qp2' => 3],
             ],
             'in condition object with scalar' => [
                 new InCondition('id', 'in', 1),
@@ -222,5 +290,10 @@ class InConditionBuilderProvider
                 [':qp0' => 1, ':qp1' => 2],
             ],
         ];
+    }
+
+    private static function generatorFrom(array $items): Generator
+    {
+        yield from $items;
     }
 }

--- a/tests/base/db/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/base/db/conditions/providers/InConditionBuilderProvider.php
@@ -254,6 +254,13 @@ class InConditionBuilderProvider
                 SQL,
                 [':qp0' => 1],
             ],
+            'in condition object with expression value' => [
+                new InCondition('id', 'in', new Expression('42')),
+                <<<SQL
+                [[id]]=42
+                SQL,
+                [],
+            ],
             'in condition object with expression column and scalar' => [
                 new InCondition(new Expression('id'), 'in', 1),
                 <<<SQL

--- a/tests/base/db/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/base/db/conditions/providers/InConditionBuilderProvider.php
@@ -97,6 +97,13 @@ class InConditionBuilderProvider
                 SQL,
                 [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'],
             ],
+            'composite in with expression value' => [
+                ['in', ['id', 'name'], [['id' => new Expression('42'), 'name' => 'foo']]],
+                <<<SQL
+                (([[id]] = 42 AND [[name]] = :qp0))
+                SQL,
+                [':qp0' => 'foo'],
+            ],
             'composite in with null' => [
                 ['in', ['id', 'name'], [['id' => 1, 'name' => null]]],
                 <<<SQL
@@ -251,6 +258,13 @@ class InConditionBuilderProvider
                 new InCondition(new Expression('id'), 'in', 1),
                 <<<SQL
                 [[id]]=:qp0
+                SQL,
+                [':qp0' => 1],
+            ],
+            'in condition object with query column and scalar' => [
+                new InCondition((new Query())->select('id')->from('users'), 'in', 1),
+                <<<SQL
+                (SELECT [[id]] FROM [[users]])=:qp0
                 SQL,
                 [':qp0' => 1],
             ],

--- a/tests/base/db/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/base/db/conditions/providers/InConditionBuilderProvider.php
@@ -114,6 +114,20 @@ class InConditionBuilderProvider
                 SQL,
                 [':qp0' => 1],
             ],
+            'issue 10073 composite in with all null row values' => [
+                ['in', ['category', 'name'], [['category' => null, 'name' => null]]],
+                <<<SQL
+                (([[category]] IS NULL AND [[name]] IS NULL))
+                SQL,
+                [],
+            ],
+            'issue 10073 composite not in with all null row values' => [
+                ['not in', ['category', 'name'], [['category' => null, 'name' => null]]],
+                <<<SQL
+                (([[category]] IS NOT NULL OR [[name]] IS NOT NULL))
+                SQL,
+                [],
+            ],
             'composite in with array access null value' => [
                 ['in', ['id', 'name'], [new class (['id' => 1, 'name' => null]) extends ArrayAccessObject {
                     public function offsetExists($offset): bool

--- a/tests/base/db/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/base/db/conditions/providers/InConditionBuilderProvider.php
@@ -14,7 +14,10 @@ use Generator;
 use yii\db\conditions\InCondition;
 use yii\db\Expression;
 use yii\db\Query;
+use yiiunit\data\base\ArrayAccessObject;
 use yiiunit\data\base\TraversableObject;
+
+use function array_key_exists;
 
 /**
  * Data provider for IN/NOT IN condition builder test cases.
@@ -111,6 +114,18 @@ class InConditionBuilderProvider
                 SQL,
                 [':qp0' => 1],
             ],
+            'composite in with array access null value' => [
+                ['in', ['id', 'name'], [new class (['id' => 1, 'name' => null]) extends ArrayAccessObject {
+                    public function offsetExists($offset): bool
+                    {
+                        return array_key_exists($offset, $this->data);
+                    }
+                }]],
+                <<<SQL
+                (([[id]] = :qp0 AND [[name]] IS NULL))
+                SQL,
+                [':qp0' => 1],
+            ],
             'composite not in' => [
                 ['not in', ['id', 'name'], [['id' => 1, 'name' => 'oy']]],
                 <<<SQL
@@ -134,6 +149,18 @@ class InConditionBuilderProvider
             ],
             'composite not in with null' => [
                 ['not in', ['id', 'name'], [['id' => 1, 'name' => null]]],
+                <<<SQL
+                (([[id]] <> :qp0 OR [[name]] IS NOT NULL))
+                SQL,
+                [':qp0' => 1],
+            ],
+            'composite not in with array access null value' => [
+                ['not in', ['id', 'name'], [new class (['id' => 1, 'name' => null]) extends ArrayAccessObject {
+                    public function offsetExists($offset): bool
+                    {
+                        return array_key_exists($offset, $this->data);
+                    }
+                }]],
                 <<<SQL
                 (([[id]] <> :qp0 OR [[name]] IS NOT NULL))
                 SQL,
@@ -281,6 +308,17 @@ class InConditionBuilderProvider
                 [[id]]=:qp0
                 SQL,
                 [':qp0' => 1],
+            ],
+            'in condition object with expression column params and scalar' => [
+                new InCondition(
+                    new Expression('COALESCE(id, :fallback)', [':fallback' => 0]),
+                    'in',
+                    1,
+                ),
+                <<<SQL
+                COALESCE(id, :fallback)=:qp0
+                SQL,
+                [':qp0' => 1, ':fallback' => 0],
             ],
             'in condition object with query column and scalar' => [
                 new InCondition((new Query())->select('id')->from('users'), 'in', 1),

--- a/tests/framework/db/mssql/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/framework/db/mssql/conditions/providers/InConditionBuilderProvider.php
@@ -58,6 +58,39 @@ final class InConditionBuilderProvider extends \yiiunit\base\db\conditions\provi
                 SQL,
                 [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'],
             ],
+            'composite not in' => [
+                [
+                    'not in',
+                    ['id', 'name'],
+                    [['id' => 1, 'name' => 'oy']],
+                ],
+                <<<SQL
+                (([id] != :qp0 OR [name] != :qp1))
+                SQL,
+                [':qp0' => 1, ':qp1' => 'oy'],
+            ],
+            'composite not in with expression column' => [
+                [
+                    'not in',
+                    [new Expression('id'), 'name'],
+                    [['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']],
+                ],
+                <<<SQL
+                (([id] != :qp0 OR [name] != :qp1) AND ([id] != :qp2 OR [name] != :qp3))
+                SQL,
+                [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'],
+            ],
+            'composite not in with null' => [
+                [
+                    'not in',
+                    ['id', 'name'],
+                    [['id' => 1, 'name' => null]],
+                ],
+                <<<SQL
+                (([id] != :qp0 OR [name] IS NOT NULL))
+                SQL,
+                [':qp0' => 1],
+            ],
             'composite in' => [
                 [
                     'in',

--- a/tests/framework/db/mssql/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/framework/db/mssql/conditions/providers/InConditionBuilderProvider.php
@@ -11,7 +11,10 @@ declare(strict_types=1);
 namespace yiiunit\framework\db\mssql\conditions\providers;
 
 use yii\db\Expression;
+use yiiunit\data\base\ArrayAccessObject;
 use yiiunit\data\base\TraversableObject;
+
+use function array_key_exists;
 
 /**
  * Data provider for MSSQL IN/NOT IN condition builder test cases.
@@ -91,6 +94,22 @@ final class InConditionBuilderProvider extends \yiiunit\base\db\conditions\provi
                 SQL,
                 [':qp0' => 1],
             ],
+            'composite not in with array access null value' => [
+                [
+                    'not in',
+                    ['id', 'name'],
+                    [new class (['id' => 1, 'name' => null]) extends ArrayAccessObject {
+                        public function offsetExists($offset): bool
+                        {
+                            return array_key_exists($offset, $this->data);
+                        }
+                    }],
+                ],
+                <<<SQL
+                (([id] != :qp0 OR [name] IS NOT NULL))
+                SQL,
+                [':qp0' => 1],
+            ],
             'composite in' => [
                 [
                     'in',
@@ -101,6 +120,22 @@ final class InConditionBuilderProvider extends \yiiunit\base\db\conditions\provi
                 (([id] = :qp0 AND [name] = :qp1))
                 SQL,
                 [':qp0' => 1, ':qp1' => 'oy'],
+            ],
+            'composite in with array access null value' => [
+                [
+                    'in',
+                    ['id', 'name'],
+                    [new class (['id' => 1, 'name' => null]) extends ArrayAccessObject {
+                        public function offsetExists($offset): bool
+                        {
+                            return array_key_exists($offset, $this->data);
+                        }
+                    }],
+                ],
+                <<<SQL
+                (([id] = :qp0 AND [name] IS NULL))
+                SQL,
+                [':qp0' => 1],
             ],
             'composite in using array objects' => [
                 [

--- a/tests/framework/db/mysql/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/framework/db/mysql/conditions/providers/InConditionBuilderProvider.php
@@ -12,6 +12,7 @@ namespace yiiunit\framework\db\mysql\conditions\providers;
 
 use yii\db\conditions\InCondition;
 use yii\db\Expression;
+use yii\db\JsonExpression;
 use yii\db\Query;
 
 /**
@@ -50,6 +51,20 @@ final class InConditionBuilderProvider extends \yiiunit\base\db\conditions\provi
                 ([[id]], [[name]]) NOT IN (SELECT [[id]], [[name]] FROM [[users]] WHERE [[active]]=:qp0)
                 SQL,
                 [':qp0' => 1],
+            ],
+            'composite in with json expression value' => [
+                ['in', ['id', 'name'], [['id' => new JsonExpression(['x' => 1]), 'name' => 'foo']]],
+                <<<SQL
+                (([[id]] = :qp0 AND [[name]] = :qp1))
+                SQL,
+                [':qp0' => '{"x":1}', ':qp1' => 'foo'],
+            ],
+            'in condition object with json expression column and scalar' => [
+                new InCondition(new JsonExpression(['a' => 1]), 'in', 1),
+                <<<SQL
+                :qp1=:qp0
+                SQL,
+                [':qp0' => 1, ':qp1' => '{"a":1}'],
             ],
         ];
     }

--- a/tests/framework/db/oci/conditions/InConditionBuilderTest.php
+++ b/tests/framework/db/oci/conditions/InConditionBuilderTest.php
@@ -61,7 +61,11 @@ final class InConditionBuilderTest extends DatabaseTestCase
 
         [$sql, $params] = $db->getQueryBuilder()->build($query);
 
-        $expectedSql = 'SELECT * WHERE ("id" IN (' . implode(', ', self::buildPlaceholders(0, 999)) . ')) OR ("id"=:qp1000)';
+        $placeholders = implode(', ', self::buildPlaceholders(0, 999));
+
+        $expectedSql = <<<SQL
+        SELECT * WHERE ("id" IN ({$placeholders})) OR ("id"=:qp1000)
+        SQL;
 
         self::assertSame(
             $expectedSql,
@@ -83,7 +87,11 @@ final class InConditionBuilderTest extends DatabaseTestCase
 
         [$sql, $params] = $db->getQueryBuilder()->build($query);
 
-        $expectedSql = 'SELECT * WHERE ("id" NOT IN (' . implode(', ', self::buildPlaceholders(0, 999)) . ')) AND ("id"<>:qp1000)';
+        $placeholders = implode(', ', self::buildPlaceholders(0, 999));
+
+        $expectedSql = <<<SQL
+        SELECT * WHERE ("id" NOT IN ({$placeholders})) AND ("id"<>:qp1000)
+        SQL;
 
         self::assertSame(
             $expectedSql,

--- a/tests/framework/db/oci/conditions/InConditionBuilderTest.php
+++ b/tests/framework/db/oci/conditions/InConditionBuilderTest.php
@@ -53,11 +53,77 @@ final class InConditionBuilderTest extends DatabaseTestCase
         );
     }
 
+    public function testBuildConditionSplitsInWhenValueCountExceedsOracleLimit(): void
+    {
+        $query = (new Query())->where(new InCondition('id', 'in', range(1, 1001)));
+
+        $db = $this->getConnection(true, false);
+
+        [$sql, $params] = $db->getQueryBuilder()->build($query);
+
+        $expectedSql = 'SELECT * WHERE ("id" IN (' . implode(', ', self::buildPlaceholders(0, 999)) . ')) OR ("id"=:qp1000)';
+
+        self::assertSame(
+            $expectedSql,
+            $sql,
+            'Split IN SQL should match expected chunked SQL.',
+        );
+        self::assertSame(
+            self::buildExpectedParams(1001),
+            $params,
+            'Split IN SQL should match expected bound parameters.',
+        );
+    }
+
+    public function testBuildConditionSplitsNotInWhenValueCountExceedsOracleLimit(): void
+    {
+        $query = (new Query())->where(new InCondition('id', 'not in', range(1, 1001)));
+
+        $db = $this->getConnection(true, false);
+
+        [$sql, $params] = $db->getQueryBuilder()->build($query);
+
+        $expectedSql = 'SELECT * WHERE ("id" NOT IN (' . implode(', ', self::buildPlaceholders(0, 999)) . ')) AND ("id"<>:qp1000)';
+
+        self::assertSame(
+            $expectedSql,
+            $sql,
+            'Split NOT IN SQL should match expected chunked SQL.',
+        );
+        self::assertSame(
+            self::buildExpectedParams(1001),
+            $params,
+            'Split NOT IN SQL should match expected bound parameters.',
+        );
+    }
+
     public function testThrowInvalidArgumentExceptionWhenFromArrayDefinitionHasMissingOperands(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Operator 'IN' requires two operands.");
 
         InCondition::fromArrayDefinition('IN', []);
+    }
+
+    private static function buildPlaceholders(int $from, int $to): array
+    {
+        $placeholders = [];
+
+        for ($i = $from; $i <= $to; ++$i) {
+            $placeholders[] = ":qp$i";
+        }
+
+        return $placeholders;
+    }
+
+    private static function buildExpectedParams(int $count): array
+    {
+        $params = [];
+
+        for ($i = 0; $i < $count; ++$i) {
+            $params[":qp$i"] = $i + 1;
+        }
+
+        return $params;
     }
 }

--- a/tests/framework/db/pgsql/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/framework/db/pgsql/conditions/providers/InConditionBuilderProvider.php
@@ -10,8 +10,10 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\db\pgsql\conditions\providers;
 
+use yii\db\ArrayExpression;
 use yii\db\conditions\InCondition;
 use yii\db\Expression;
+use yii\db\JsonExpression;
 use yii\db\Query;
 
 /**
@@ -50,6 +52,34 @@ final class InConditionBuilderProvider extends \yiiunit\base\db\conditions\provi
                 ([[id]], [[name]]) NOT IN (SELECT [[id]], [[name]] FROM [[users]] WHERE [[active]]=:qp0)
                 SQL,
                 [':qp0' => 1],
+            ],
+            'composite in with json expression value' => [
+                ['in', ['id', 'name'], [['id' => new JsonExpression(['x' => 1]), 'name' => 'foo']]],
+                <<<SQL
+                (([[id]] = :qp0 AND [[name]] = :qp1))
+                SQL,
+                [':qp0' => '{"x":1}', ':qp1' => 'foo'],
+            ],
+            'composite in with array expression value' => [
+                ['in', ['id', 'name'], [['id' => new ArrayExpression([1], 'integer'), 'name' => 'foo']]],
+                <<<SQL
+                (([[id]] = ARRAY[:qp0]::integer[] AND [[name]] = :qp1))
+                SQL,
+                [':qp0' => 1, ':qp1' => 'foo'],
+            ],
+            'in condition object with json expression column and scalar' => [
+                new InCondition(new JsonExpression(['a' => 1]), 'in', 1),
+                <<<SQL
+                :qp1=:qp0
+                SQL,
+                [':qp0' => 1, ':qp1' => '{"a":1}'],
+            ],
+            'in condition object with array expression column and scalar' => [
+                new InCondition(new ArrayExpression([1, 2], 'integer'), 'in', 1),
+                <<<SQL
+                ARRAY[:qp1, :qp2]::integer[]=:qp0
+                SQL,
+                [':qp0' => 1, ':qp1' => 1, ':qp2' => 2],
             ],
         ];
     }

--- a/tests/framework/db/sqlite/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/framework/db/sqlite/conditions/providers/InConditionBuilderProvider.php
@@ -58,6 +58,39 @@ final class InConditionBuilderProvider extends \yiiunit\base\db\conditions\provi
                 SQL,
                 [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'],
             ],
+            'composite not in' => [
+                [
+                    'not in',
+                    ['id', 'name'],
+                    [['id' => 1, 'name' => 'oy']],
+                ],
+                <<<SQL
+                (([[id]] != :qp0 OR [[name]] != :qp1))
+                SQL,
+                [':qp0' => 1, ':qp1' => 'oy'],
+            ],
+            'composite not in with expression column' => [
+                [
+                    'not in',
+                    [new Expression('id'), 'name'],
+                    [['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']],
+                ],
+                <<<SQL
+                (([[id]] != :qp0 OR [[name]] != :qp1) AND ([[id]] != :qp2 OR [[name]] != :qp3))
+                SQL,
+                [':qp0' => 1, ':qp1' => 'foo', ':qp2' => 2, ':qp3' => 'bar'],
+            ],
+            'composite not in with null' => [
+                [
+                    'not in',
+                    ['id', 'name'],
+                    [['id' => 1, 'name' => null]],
+                ],
+                <<<SQL
+                (([[id]] != :qp0 OR [[name]] IS NOT NULL))
+                SQL,
+                [':qp0' => 1],
+            ],
             'composite in' => [
                 [
                     'in',

--- a/tests/framework/db/sqlite/conditions/providers/InConditionBuilderProvider.php
+++ b/tests/framework/db/sqlite/conditions/providers/InConditionBuilderProvider.php
@@ -11,7 +11,10 @@ declare(strict_types=1);
 namespace yiiunit\framework\db\sqlite\conditions\providers;
 
 use yii\db\Expression;
+use yiiunit\data\base\ArrayAccessObject;
 use yiiunit\data\base\TraversableObject;
+
+use function array_key_exists;
 
 /**
  * Data provider for SQLite IN/NOT IN condition builder test cases.
@@ -91,6 +94,22 @@ final class InConditionBuilderProvider extends \yiiunit\base\db\conditions\provi
                 SQL,
                 [':qp0' => 1],
             ],
+            'composite not in with array access null value' => [
+                [
+                    'not in',
+                    ['id', 'name'],
+                    [new class (['id' => 1, 'name' => null]) extends ArrayAccessObject {
+                        public function offsetExists($offset): bool
+                        {
+                            return array_key_exists($offset, $this->data);
+                        }
+                    }],
+                ],
+                <<<SQL
+                (([[id]] != :qp0 OR [[name]] IS NOT NULL))
+                SQL,
+                [':qp0' => 1],
+            ],
             'composite in' => [
                 [
                     'in',
@@ -101,6 +120,22 @@ final class InConditionBuilderProvider extends \yiiunit\base\db\conditions\provi
                 (([[id]] = :qp0 AND [[name]] = :qp1))
                 SQL,
                 [':qp0' => 1, ':qp1' => 'oy'],
+            ],
+            'composite in with array access null value' => [
+                [
+                    'in',
+                    ['id', 'name'],
+                    [new class (['id' => 1, 'name' => null]) extends ArrayAccessObject {
+                        public function offsetExists($offset): bool
+                        {
+                            return array_key_exists($offset, $this->data);
+                        }
+                    }],
+                ],
+                <<<SQL
+                (([[id]] = :qp0 AND [[name]] IS NULL))
+                SQL,
+                [':qp0' => 1],
             ],
             'composite in using array objects' => [
                 [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️

### Summary

Fixes [#10073](https://github.com/yiisoft/yii2/issues/10073) (reported 2015-11-02): composite `IN` / `NOT IN` conditions emitted literal `NULL` inside tuple comparisons, producing SQL that is always `UNKNOWN` under three-valued logic and never matches rows with genuine `NULL` values.

### Root cause

`QueryBuilder::buildCompositeInCondition` rendered rows with missing values as `([[col]], [[col]]) IN ((:p0, NULL))`. In SQL, comparing any value to `NULL` yields `UNKNOWN`, so this predicate never matches including the rows the caller intended to select.

### Fix

`InConditionBuilder` now decomposes composite comparisons into boolean expressions and uses `IS NULL` / `IS NOT NULL` instead of literal `NULL` comparisons.