### PR TITLE
Fix MSSQL `buildWithQueries()` to omit unsupported `RECURSIVE` keyword in SQL Server CTEs.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -44,6 +44,7 @@ Yii Framework 2 Change Log
 - Chg: Remove deprecated APIs in `Security`, `View`, and `UniqueValidator`, delete deprecated migration template `createJunctionMigration.php`, and clean related validator tests (terabytesoftw)
 - Enh: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
 - Bug #10073: Type `InCondition` / `InConditionBuilder` APIs and generate `IS NULL` / `IS NOT NULL` for composite `IN` / `NOT IN` `NULL` comparisons (terabytesoftw)
+- Bug: Fix MSSQL `buildWithQueries()` to omit unsupported `RECURSIVE` keyword in SQL Server CTEs (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -669,6 +669,24 @@ END";
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * SQL Server does not support the `RECURSIVE` keyword for CTEs. Recursion is implicit when a CTE references itself.
+     */
+    public function buildWithQueries($withs, &$params)
+    {
+        if ($withs === null || $withs === []) {
+            return '';
+        }
+
+        foreach ($withs as $i => $_with) {
+            $withs[$i]['recursive'] = false;
+        }
+
+        return parent::buildWithQueries($withs, $params);
+    }
+
+    /**
      * Drop all constraints before column delete
      * {@inheritdoc}
      */

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -679,8 +679,9 @@ END";
             return '';
         }
 
-        foreach ($withs as $i => $_with) {
-            $withs[$i]['recursive'] = false;
+        foreach ($withs as $i => $with) {
+            $with['recursive'] = false;
+            $withs[$i] = $with;
         }
 
         return parent::buildWithQueries($withs, $params);

--- a/tests/framework/db/mssql/QueryBuilderUnionTest.php
+++ b/tests/framework/db/mssql/QueryBuilderUnionTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yiiunit\framework\db\mssql;
 
 use PHPUnit\Framework\Attributes\Group;
+use yii\db\Query;
 use yiiunit\base\db\BaseQueryBuilderUnion;
 
 /**
@@ -26,4 +27,77 @@ class QueryBuilderUnionTest extends BaseQueryBuilderUnion
 {
     protected $driverName = 'sqlsrv';
     protected static string $driverNameStatic = 'sqlsrv';
+
+    /**
+     * Ensures `buildWithQueries()` joins multiple CTEs with commas.
+     */
+    public function testBuildWithQueryMultiple(): void
+    {
+        $db = $this->getConnection(true, false);
+
+        $with1Query = (new Query())
+            ->select('id')
+            ->from('t1')
+            ->where('expr = 1');
+        $with2Query = (new Query())
+            ->select('id')
+            ->from('t2')
+            ->where('expr = 2');
+        $query = (new Query())
+            ->withQuery($with1Query, 'a1')
+            ->withQuery($with2Query, 'a2')
+            ->from('a1');
+
+        $expectedQuerySql = $this->replaceQuotes(
+            <<<SQL
+            WITH a1 AS (SELECT [[id]] FROM [[t1]] WHERE expr = 1), a2 AS (SELECT [[id]] FROM [[t2]] WHERE expr = 2) SELECT * FROM [[a1]]
+            SQL
+        );
+
+        [$actualQuerySql, $queryParams] = $db->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            $expectedQuerySql,
+            $actualQuerySql,
+            'Multiple CTEs should be joined with commas.',
+        );
+        self::assertEmpty(
+            $queryParams,
+            'Multiple CTEs query should have no bound parameters.',
+        );
+    }
+
+    /**
+     * SQL Server does not support the `RECURSIVE` keyword. Recursion is implicit when a CTE references itself.
+     */
+    public function testBuildWithQueryRecursive(): void
+    {
+        $db = $this->getConnection(true, false);
+
+        $with1Query = (new Query())
+            ->select('id')
+            ->from('t1')
+            ->where('expr = 1');
+        $query = (new Query())
+            ->withQuery($with1Query, 'a1', true)
+            ->from('a1');
+
+        $expectedQuerySql = $this->replaceQuotes(
+            <<<SQL
+            WITH a1 AS (SELECT [[id]] FROM [[t1]] WHERE expr = 1) SELECT * FROM [[a1]]
+            SQL
+        );
+
+        [$actualQuerySql, $queryParams] = $db->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            $expectedQuerySql,
+            $actualQuerySql,
+            'MSSQL WITH query should omit RECURSIVE keyword.',
+        );
+        self::assertEmpty(
+            $queryParams,
+            'WITH query should have no bound parameters.',
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

### Summary

SQL Server (T-SQL) does not support the `RECURSIVE` keyword in Common Table Expressions (CTEs). Recursion is implicit when a CTE references itself. However, the shared `QueryBuilder::buildWithQueries()` method emits `WITH RECURSIVE ...`, and the MSSQL `QueryBuilder` does not override this method.

As a result, `testBuildWithQueryRecursive()` in `BaseQueryBuilderUnion` will produce invalid SQL syntax when run against the SQL Server driver (`driverName = 'sqlsrv'`).