### PR TITLE
Fix Oracle `buildWithQueries()` to omit unsupported `RECURSIVE` keyword in Oracle CTEs.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -45,6 +45,7 @@ Yii Framework 2 Change Log
 - Enh: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
 - Bug #10073: Type `InCondition` / `InConditionBuilder` APIs and generate `IS NULL` / `IS NOT NULL` for composite `IN` / `NOT IN` `NULL` comparisons (terabytesoftw)
 - Bug: Fix MSSQL `buildWithQueries()` to omit unsupported `RECURSIVE` keyword in SQL Server CTEs (terabytesoftw)
+- Bug: Fix Oracle `buildWithQueries()` to omit unsupported `RECURSIVE` keyword in Oracle CTEs (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -95,6 +95,25 @@ EOD;
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * Oracle does not support the `RECURSIVE` keyword for CTEs. Recursion is implicit when a CTE references itself.
+     */
+    public function buildWithQueries($withs, &$params)
+    {
+        if ($withs === null || $withs === []) {
+            return '';
+        }
+
+        foreach ($withs as $i => $with) {
+            $with['recursive'] = false;
+            $withs[$i] = $with;
+        }
+
+        return parent::buildWithQueries($withs, $params);
+    }
+
+    /**
      * Builds a SQL statement for renaming a DB table.
      *
      * @param string $table the table to be renamed. The name will be properly quoted by the method.

--- a/tests/framework/db/oci/QueryBuilderUnionTest.php
+++ b/tests/framework/db/oci/QueryBuilderUnionTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yiiunit\framework\db\oci;
 
 use PHPUnit\Framework\Attributes\Group;
+use yii\db\Query;
 use yiiunit\base\db\BaseQueryBuilderUnion;
 
 /**
@@ -26,4 +27,38 @@ class QueryBuilderUnionTest extends BaseQueryBuilderUnion
 {
     protected $driverName = 'oci';
     protected static string $driverNameStatic = 'oci';
+
+    /**
+     * Oracle does not support the `RECURSIVE` keyword. Recursion is implicit when a CTE references itself.
+     */
+    public function testBuildWithQueryRecursive(): void
+    {
+        $db = $this->getConnection(true, false);
+
+        $with1Query = (new Query())
+            ->select('id')
+            ->from('t1')
+            ->where('expr = 1');
+        $query = (new Query())
+            ->withQuery($with1Query, 'a1', true)
+            ->from('a1');
+
+        $expectedQuerySql = $this->replaceQuotes(
+            <<<SQL
+            WITH a1 AS (SELECT [[id]] FROM [[t1]] WHERE expr = 1) SELECT * FROM [[a1]]
+            SQL
+        );
+
+        [$actualQuerySql, $queryParams] = $db->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            $expectedQuerySql,
+            $actualQuerySql,
+            'Oracle WITH query should omit RECURSIVE keyword.',
+        );
+        self::assertEmpty(
+            $queryParams,
+            'WITH query should have no bound parameters.',
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

### Summary

Oracle does not support the `RECURSIVE` keyword in Common Table Expressions (CTEs). Recursion is implicit when a CTE references itself. However, the shared `QueryBuilder::buildWithQueries()` method emits `WITH RECURSIVE ...`, and the Oracle `QueryBuilder` does  not override this method.

As a result, `testBuildWithQueryRecursive()` in `BaseQueryBuilderUnion` will produce invalid SQL syntax when run against the Oracle driver (`driverName = 'oci'`).