### PR TITLE
Refactor Oracle pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; Oracle `12.1+` is now required for `yii\db\oci\QueryBuilder` pagination.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -46,6 +46,7 @@ Yii Framework 2 Change Log
 - Bug #10073: Type `InCondition` / `InConditionBuilder` APIs and generate `IS NULL` / `IS NOT NULL` for composite `IN` / `NOT IN` `NULL` comparisons (terabytesoftw)
 - Bug: Fix MSSQL `buildWithQueries()` to omit unsupported `RECURSIVE` keyword in SQL Server CTEs (terabytesoftw)
 - Bug: Fix Oracle `buildWithQueries()` to omit unsupported `RECURSIVE` keyword in Oracle CTEs (terabytesoftw)
+- Chg: Refactor Oracle pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; Oracle `12.1+` is now required for `yii\db\oci\QueryBuilder` pagination (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -141,7 +141,7 @@ migrate to a supported database engine before upgrading to Yii `22.x`.
 There is no compatibility layer for CUBRID in this release. The framework no longer ships CUBRID-specific database
 classes, configuration entries, fixtures, or test coverage.
 
-### `InCondition` and `InConditionBuilder` typing + composite `NULL` handling
+#### `InCondition` and `InConditionBuilder` typing + composite `NULL` handling
 
 `yii\db\conditions\InCondition` now uses typed constructor parameters and typed return values:
 
@@ -166,6 +166,21 @@ Example:
 - After: `(([[id]] = :p0 AND [[name]] IS NULL))`
 
 If your tests assert exact SQL strings for composite `IN` / `NOT IN`, update expected SQL.
+
+#### Oracle pagination now uses `OFFSET ... FETCH` (`12.1+`)
+
+`yii\db\oci\QueryBuilder::buildOrderByAndLimit()` now emits SQL using Oracle's native row-limiting clause:
+
+- `OFFSET <n> ROWS` is emitted only when an offset is set.
+- `FETCH NEXT <n> ROWS ONLY` is emitted only when a limit is set.
+- No synthetic `ORDER BY (SELECT NULL)` is added when the user did not specify an `ORDER BY`.
+
+The previous legacy `ROWNUM`/CTE pagination SQL has been removed. Oracle versions earlier than `12.1` are no longer
+supported for Yii-generated pagination SQL in the OCI QueryBuilder.
+
+If you rely on paginated results without specifying `orderBy()`, note that Oracle returns rows in an unspecified order,
+so `OFFSET`/`FETCH` results may vary between executions. Always specify `orderBy()` when you need deterministic
+pagination.
 
 ### HHVM support removed
 

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -17,7 +19,7 @@ use yii\helpers\StringHelper;
 use yii\db\ExpressionInterface;
 
 /**
- * QueryBuilder is the query builder for Oracle databases.
+ * QueryBuilder is the query builder for Oracle databases (version 12.1 and above).
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -69,29 +71,20 @@ class QueryBuilder extends \yii\db\QueryBuilder
     public function buildOrderByAndLimit($sql, $orderBy, $limit, $offset)
     {
         $orderBy = $this->buildOrderBy($orderBy);
+
         if ($orderBy !== '') {
-            $sql .= $this->separator . $orderBy;
+            $sql .= "{$this->separator}{$orderBy}";
         }
 
-        $filters = [];
         if ($this->hasOffset($offset)) {
-            $filters[] = 'rowNumId > ' . $offset;
-        }
-        if ($this->hasLimit($limit)) {
-            $filters[] = 'rownum <= ' . $limit;
-        }
-        if (empty($filters)) {
-            return $sql;
+            $sql .= "{$this->separator}OFFSET {$offset} ROWS";
         }
 
-        $filter = implode(' AND ', $filters);
-        return <<<EOD
-WITH USER_SQL AS ($sql),
-    PAGINATION AS (SELECT USER_SQL.*, rownum as rowNumId FROM USER_SQL)
-SELECT *
-FROM PAGINATION
-WHERE $filter
-EOD;
+        if ($this->hasLimit($limit)) {
+            $sql .= "{$this->separator}FETCH NEXT {$limit} ROWS ONLY";
+        }
+
+        return $sql;
     }
 
     /**

--- a/tests/framework/db/oci/QueryBuilderTest.php
+++ b/tests/framework/db/oci/QueryBuilderTest.php
@@ -14,6 +14,7 @@ use Closure;
 use Exception;
 use PHPUnit\Framework\Attributes\Group;
 use yii\base\NotSupportedException;
+use yii\db\Query;
 use yii\db\oci\QueryBuilder;
 use yii\db\oci\Schema;
 use yiiunit\data\base\TraversableObject;
@@ -78,6 +79,140 @@ final class QueryBuilderTest extends BaseQueryBuilder
         $result = parent::indexesProvider();
         $result['drop'][0] = 'DROP INDEX [[CN_constraints_2_single]]';
         return $result;
+    }
+
+    public function testBuildOrderByAndLimitWithOffsetAndLimit(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(10)
+            ->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            'OFFSET and LIMIT should generate OFFSET x ROWS FETCH NEXT y ROWS ONLY.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'OFFSET/LIMIT query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithLimitOnly(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(10);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" FETCH NEXT 10 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            'LIMIT without OFFSET should generate FETCH NEXT y ROWS ONLY.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'LIMIT-only query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithOffsetOnly(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->offset(10);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" OFFSET 10 ROWS
+            SQL,
+            $actualQuerySql,
+            'OFFSET without LIMIT should generate OFFSET x ROWS without FETCH clause.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'OFFSET-only query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithoutOffsetAndLimit(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example');
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example"
+            SQL,
+            $actualQuerySql,
+            'Query without OFFSET/LIMIT should not contain OFFSET or FETCH clauses.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'Query without OFFSET/LIMIT should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithExplicitOrderBy(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->orderBy('id')
+            ->limit(10)
+            ->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" ORDER BY "id" OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            'Explicit ORDER BY should be preserved alongside OFFSET/FETCH clauses.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'Query with explicit ORDER BY should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithOrderByWithoutPagination(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->orderBy('id');
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" ORDER BY "id"
+            SQL,
+            $actualQuerySql,
+            'ORDER BY without OFFSET/LIMIT should not contain OFFSET or FETCH clauses.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'ORDER BY without pagination should have no bound parameters.',
+        );
     }
 
     public function testCommentColumn(): void
@@ -186,25 +321,13 @@ final class QueryBuilderTest extends BaseQueryBuilder
                 3 => 'MERGE INTO "T_upsert" USING (SELECT :qp0 AS "email", :qp1 AS "address", :qp2 AS "status", :qp3 AS "profile_id" FROM "DUAL") "EXCLUDED" ON ("T_upsert"."email"="EXCLUDED"."email") WHEN NOT MATCHED THEN INSERT ("email", "address", "status", "profile_id") VALUES ("EXCLUDED"."email", "EXCLUDED"."address", "EXCLUDED"."status", "EXCLUDED"."profile_id")',
             ],
             'query' => [
-                3 => 'MERGE INTO "T_upsert" USING (WITH USER_SQL AS (SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0),
-    PAGINATION AS (SELECT USER_SQL.*, rownum as rowNumId FROM USER_SQL)
-SELECT *
-FROM PAGINATION
-WHERE rownum <= 1) "EXCLUDED" ON ("T_upsert"."email"="EXCLUDED"."email") WHEN MATCHED THEN UPDATE SET "status"="EXCLUDED"."status" WHEN NOT MATCHED THEN INSERT ("email", "status") VALUES ("EXCLUDED"."email", "EXCLUDED"."status")'
+                3 => 'MERGE INTO "T_upsert" USING (SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0 FETCH NEXT 1 ROWS ONLY) "EXCLUDED" ON ("T_upsert"."email"="EXCLUDED"."email") WHEN MATCHED THEN UPDATE SET "status"="EXCLUDED"."status" WHEN NOT MATCHED THEN INSERT ("email", "status") VALUES ("EXCLUDED"."email", "EXCLUDED"."status")'
             ],
             'query with update part' => [
-                3 => 'MERGE INTO "T_upsert" USING (WITH USER_SQL AS (SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0),
-    PAGINATION AS (SELECT USER_SQL.*, rownum as rowNumId FROM USER_SQL)
-SELECT *
-FROM PAGINATION
-WHERE rownum <= 1) "EXCLUDED" ON ("T_upsert"."email"="EXCLUDED"."email") WHEN MATCHED THEN UPDATE SET "address"=:qp1, "status"=:qp2, "orders"=T_upsert.orders + 1 WHEN NOT MATCHED THEN INSERT ("email", "status") VALUES ("EXCLUDED"."email", "EXCLUDED"."status")'
+                3 => 'MERGE INTO "T_upsert" USING (SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0 FETCH NEXT 1 ROWS ONLY) "EXCLUDED" ON ("T_upsert"."email"="EXCLUDED"."email") WHEN MATCHED THEN UPDATE SET "address"=:qp1, "status"=:qp2, "orders"=T_upsert.orders + 1 WHEN NOT MATCHED THEN INSERT ("email", "status") VALUES ("EXCLUDED"."email", "EXCLUDED"."status")'
             ],
             'query without update part' => [
-                3 => 'MERGE INTO "T_upsert" USING (WITH USER_SQL AS (SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0),
-    PAGINATION AS (SELECT USER_SQL.*, rownum as rowNumId FROM USER_SQL)
-SELECT *
-FROM PAGINATION
-WHERE rownum <= 1) "EXCLUDED" ON ("T_upsert"."email"="EXCLUDED"."email") WHEN NOT MATCHED THEN INSERT ("email", "status") VALUES ("EXCLUDED"."email", "EXCLUDED"."status")'
+                3 => 'MERGE INTO "T_upsert" USING (SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0 FETCH NEXT 1 ROWS ONLY) "EXCLUDED" ON ("T_upsert"."email"="EXCLUDED"."email") WHEN NOT MATCHED THEN INSERT ("email", "status") VALUES ("EXCLUDED"."email", "EXCLUDED"."status")'
             ],
             'values and expressions' => [
                 3 => 'INSERT INTO {{%T_upsert}} ({{%T_upsert}}.[[email]], [[ts]]) VALUES (:qp0, now())',

--- a/tests/framework/db/oci/QueryTest.php
+++ b/tests/framework/db/oci/QueryTest.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\db\oci;
 
+use PHPUnit\Framework\Attributes\Group;
 use yii\db\Query;
 use yiiunit\base\db\BaseQuery;
-
 
 /**
  * Unit test for {@see \yii\db\Query} with Oracle driver.
@@ -20,7 +20,6 @@ use yiiunit\base\db\BaseQuery;
 #[Group('db')]
 #[Group('oci')]
 #[Group('query')]
-
 class QueryTest extends BaseQuery
 {
     protected $driverName = 'oci';

--- a/tests/framework/db/oci/QueryTest.php
+++ b/tests/framework/db/oci/QueryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,15 +10,85 @@
 
 namespace yiiunit\framework\db\oci;
 
+use yii\db\Query;
 use yiiunit\base\db\BaseQuery;
 
+
 /**
- * @group db
- * @group oci
+ * Unit test for {@see \yii\db\Query} with Oracle driver.
  */
+#[Group('db')]
+#[Group('oci')]
+#[Group('query')]
+
 class QueryTest extends BaseQuery
 {
     protected $driverName = 'oci';
+
+    public function testLimitOffsetExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id', 'name'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(1)
+            ->offset(1)
+            ->all($db);
+
+        self::assertCount(
+            1,
+            $rows,
+            "LIMIT '1' OFFSET '1' should return exactly one row.",
+        );
+        self::assertSame(
+            2,
+            (int) $rows[0]['id'],
+            "OFFSET '1' should skip the first row and start at 'id=2'.",
+        );
+        self::assertSame(
+            'user2',
+            $rows[0]['name'],
+            "Row at OFFSET '1' should correspond to 'user2'.",
+        );
+    }
+
+    public function testOffsetExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->offset(1)
+            ->column($db);
+
+        self::assertSame(
+            [2, 3],
+            array_map('intval', $rows),
+            "OFFSET '1' without LIMIT should return remaining rows starting at 'id=2'.",
+        );
+    }
+
+    public function testLimitExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(2)
+            ->column($db);
+
+        self::assertSame(
+            [1, 2],
+            array_map('intval', $rows),
+            "LIMIT '2' without OFFSET should return the first two rows.",
+        );
+    }
 
     public function testUnion(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #18639

### Summary

This PR addresses the Oracle part of #18639 by switching OCI pagination SQL generation to Oracle's native row-limiting clause.

`yii\db\oci\QueryBuilder::buildOrderByAndLimit()` now emits:

- `OFFSET <n> ROWS`
- `FETCH NEXT <n> ROWS ONLY`

instead of the legacy `ROWNUM`/CTE pagination wrapper.