### PR TITLE
Refactor MSSQL pagination SQL to use standard `ORDER BY ... OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; SQL Server `2019+` is now required for `yii\db\mssql\QueryBuilder` pagination.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -46,7 +46,8 @@ Yii Framework 2 Change Log
 - Bug #10073: Type `InCondition` / `InConditionBuilder` APIs and generate `IS NULL` / `IS NOT NULL` for composite `IN` / `NOT IN` `NULL` comparisons (terabytesoftw)
 - Bug: Fix MSSQL `buildWithQueries()` to omit unsupported `RECURSIVE` keyword in SQL Server CTEs (terabytesoftw)
 - Bug: Fix Oracle `buildWithQueries()` to omit unsupported `RECURSIVE` keyword in Oracle CTEs (terabytesoftw)
-- Chg: Refactor Oracle pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; Oracle `12.1+` is now required for `yii\db\oci\QueryBuilder` pagination (terabytesoftw)
+- Chg #18639: Refactor Oracle pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; Oracle `12.1+` is now required for `yii\db\oci\QueryBuilder` pagination (terabytesoftw)
+- Chg #18639: Refactor MSSQL pagination SQL to use standard `ORDER BY ... OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; SQL Server `2019+` is now required for `yii\db\mssql\QueryBuilder` pagination (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -171,8 +171,9 @@ If your tests assert exact SQL strings for composite `IN` / `NOT IN`, update exp
 
 `yii\db\mssql\QueryBuilder::buildOrderByAndLimit()` now emits SQL using SQL Server's native row-limiting clause:
 
-- `ORDER BY` is always present for paginated MSSQL queries. If no `orderBy()` is specified, Yii emits
-  `ORDER BY (SELECT NULL)` because SQL Server requires an `ORDER BY` clause with `OFFSET`/`FETCH`.
+- `ORDER BY` is always present for paginated MSSQL queries. If no `orderBy()` is specified, Yii emits `ORDER BY 1`
+  (references the first select-list item) because SQL Server requires an `ORDER BY` clause with `OFFSET`/`FETCH`. The
+  ordinal form is used instead of `ORDER BY (SELECT NULL)` so it remains valid when the query uses `SELECT DISTINCT`.
 - `OFFSET <n> ROWS` is emitted for paginated queries. For `limit()` without explicit `offset()`, Yii emits
   `OFFSET 0 ROWS`.
 - `FETCH NEXT <n> ROWS ONLY` is emitted only when a limit is set.

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -178,12 +178,11 @@ Generated SQL:
   `orderBy()` is set).
 - `OFFSET <n> ROWS` is always emitted for paginated queries (`OFFSET 0 ROWS` when only `limit()` is set).
 - `FETCH NEXT <n> ROWS ONLY` is emitted only when `limit(n)` with `n >= 1`.
+- `limit(0)` wraps the query as `SELECT * FROM (...) sub WHERE 1=0` (returns zero rows, consistent with
+  MySQL/PostgreSQL/SQLite/Oracle).
 
 Behavioral notes:
 
-- `limit(0)`: SQL Server requires `FETCH >= 1`, so Yii treats `limit(0)` as "no limit applied" and returns all rows.
-  Diverges from MySQL/PostgreSQL/SQLite where `LIMIT 0` returns zero rows. Use `where('1=0')` to force an empty
-  result set.
 - `DISTINCT` + unorderable column types: the `ORDER BY 1` fallback cannot sort `text`, `ntext`, `image`, `xml`,
   `geography`, or `geometry`. Add an explicit `orderBy()` when the first selected column has one of those types and
   `DISTINCT` is required.

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -167,6 +167,24 @@ Example:
 
 If your tests assert exact SQL strings for composite `IN` / `NOT IN`, update expected SQL.
 
+#### MSSQL pagination now uses `OFFSET ... FETCH` (`2019+`)
+
+`yii\db\mssql\QueryBuilder::buildOrderByAndLimit()` now emits SQL using SQL Server's native row-limiting clause:
+
+- `ORDER BY` is always present for paginated MSSQL queries. If no `orderBy()` is specified, Yii emits
+  `ORDER BY (SELECT NULL)` because SQL Server requires an `ORDER BY` clause with `OFFSET`/`FETCH`.
+- `OFFSET <n> ROWS` is emitted for paginated queries. For `limit()` without explicit `offset()`, Yii emits
+  `OFFSET 0 ROWS`.
+- `FETCH NEXT <n> ROWS ONLY` is emitted only when a limit is set.
+
+The legacy pre-`OFFSET` pagination fallback for old SQL Server versions has been removed from
+`yii\db\mssql\QueryBuilder`. SQL Server versions earlier than `2019` are no longer supported for Yii-generated
+pagination SQL in the MSSQL QueryBuilder.
+
+If you rely on paginated results without specifying `orderBy()`, note that SQL Server returns rows in an unspecified
+order, so pagination results may vary between executions. Always specify `orderBy()` when you need deterministic
+pagination.
+
 #### Oracle pagination now uses `OFFSET ... FETCH` (`12.1+`)
 
 `yii\db\oci\QueryBuilder::buildOrderByAndLimit()` now emits SQL using Oracle's native row-limiting clause:

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -169,29 +169,34 @@ If your tests assert exact SQL strings for composite `IN` / `NOT IN`, update exp
 
 #### MSSQL pagination now uses `OFFSET ... FETCH` (`2019+`)
 
-`yii\db\mssql\QueryBuilder::buildOrderByAndLimit()` now emits SQL using SQL Server's native row-limiting clause:
+`yii\db\mssql\QueryBuilder::buildOrderByAndLimit()` now emits SQL using SQL Server's native row-limiting clause. SQL
+Server versions earlier than `2019` are no longer supported (the legacy `ROW_NUMBER()` fallback was removed).
 
-- `ORDER BY` is always present for paginated MSSQL queries. If no `orderBy()` is specified, Yii emits `ORDER BY 1`
-  (references the first select-list item) because SQL Server requires an `ORDER BY` clause with `OFFSET`/`FETCH`. The
-  ordinal form is used instead of `ORDER BY (SELECT NULL)` so it remains valid when the query uses `SELECT DISTINCT`.
-- `OFFSET <n> ROWS` is emitted for paginated queries. For `limit()` without explicit `offset()`, Yii emits
-  `OFFSET 0 ROWS`.
-- `FETCH NEXT <n> ROWS ONLY` is emitted only when a limit is set.
+Generated SQL:
 
-The legacy pre-`OFFSET` pagination fallback for old SQL Server versions has been removed from
-`yii\db\mssql\QueryBuilder`. SQL Server versions earlier than `2019` are no longer supported for Yii-generated
-pagination SQL in the MSSQL QueryBuilder.
+- `ORDER BY` is always present (Yii adds `ORDER BY (SELECT NULL)`, or `ORDER BY 1` for `SELECT DISTINCT`, when no
+  `orderBy()` is set).
+- `OFFSET <n> ROWS` is always emitted for paginated queries (`OFFSET 0 ROWS` when only `limit()` is set).
+- `FETCH NEXT <n> ROWS ONLY` is emitted only when `limit(n)` with `n >= 1`.
 
-If you rely on paginated results without specifying `orderBy()`, note that SQL Server returns rows in an unspecified
-order, so pagination results may vary between executions. Always specify `orderBy()` when you need deterministic
-pagination.
+Behavioral notes:
+
+- `limit(0)`: SQL Server requires `FETCH >= 1`, so Yii treats `limit(0)` as "no limit applied" and returns all rows.
+  Diverges from MySQL/PostgreSQL/SQLite where `LIMIT 0` returns zero rows. Use `where('1=0')` to force an empty
+  result set.
+- `DISTINCT` + unorderable column types: the `ORDER BY 1` fallback cannot sort `text`, `ntext`, `image`, `xml`,
+  `geography`, or `geometry`. Add an explicit `orderBy()` when the first selected column has one of those types and
+  `DISTINCT` is required.
+- Always specify `orderBy()` for deterministic pagination; SQL Server returns rows in an unspecified order otherwise.
 
 #### Oracle pagination now uses `OFFSET ... FETCH` (`12.1+`)
 
 `yii\db\oci\QueryBuilder::buildOrderByAndLimit()` now emits SQL using Oracle's native row-limiting clause:
 
 - `OFFSET <n> ROWS` is emitted only when an offset is set.
-- `FETCH NEXT <n> ROWS ONLY` is emitted only when a limit is set.
+- `FETCH NEXT <n> ROWS ONLY` is emitted whenever a limit is set, including `limit(0)`. Oracle accepts
+  `FETCH NEXT 0 ROWS ONLY` as valid syntax that returns zero rows, so `limit(0)` keeps the same semantics as in
+  MySQL/PostgreSQL/SQLite.
 - No synthetic `ORDER BY (SELECT NULL)` is added when the user did not specify an `ORDER BY`.
 
 The previous legacy `ROWNUM`/CTE pagination SQL has been removed. Oracle versions earlier than `12.1` are no longer

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -68,6 +68,12 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     public function buildOrderByAndLimit($sql, $orderBy, $limit, $offset)
     {
+        // Preserve limit(0) → zero rows semantics across drivers; SQL Server rejects FETCH NEXT `0`,
+        // so wrap with WHERE 1=0 (the optimizer constant-folds this into an empty scan).
+        if ((string) $limit === '0') {
+            return "SELECT * FROM ({$sql}) sub WHERE 1=0";
+        }
+
         $orderBy = $this->buildOrderBy($orderBy);
 
         if (!$this->hasOffset($offset) && !$this->hasLimit($limit)) {
@@ -91,17 +97,6 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         return $sql;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * SQL Server's `FETCH NEXT n ROWS ONLY` requires `n >= 1`, so `limit(0)` is treated as "no limit applied" instead
-     * of emitting invalid `FETCH NEXT 0 ROWS ONLY`.
-     */
-    protected function hasLimit($limit)
-    {
-        return parent::hasLimit($limit) && (string) $limit !== '0';
     }
 
     /**

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -15,7 +17,7 @@ use yii\db\Query;
 use yii\db\TableSchema;
 
 /**
- * QueryBuilder is the query builder for MS SQL Server databases (version 2008 and above).
+ * QueryBuilder is the query builder for MS SQL Server databases (version 2019 and above).
  *
  * @author Timur Ruziev <resurtm@gmail.com>
  * @since 2.0
@@ -66,73 +68,22 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     public function buildOrderByAndLimit($sql, $orderBy, $limit, $offset)
     {
+        $orderBy = $this->buildOrderBy($orderBy);
+
         if (!$this->hasOffset($offset) && !$this->hasLimit($limit)) {
-            $orderBy = $this->buildOrderBy($orderBy);
-            return $orderBy === '' ? $sql : $sql . $this->separator . $orderBy;
+            return $orderBy === '' ? $sql : "{$sql}{$this->separator}{$orderBy}";
         }
 
-        if (version_compare($this->db->getSchema()->getServerVersion(), '11', '<')) {
-            return $this->oldBuildOrderByAndLimit($sql, $orderBy, $limit, $offset);
-        }
-
-        return $this->newBuildOrderByAndLimit($sql, $orderBy, $limit, $offset);
-    }
-
-    /**
-     * Builds the ORDER BY/LIMIT/OFFSET clauses for SQL SERVER 2012 or newer.
-     * @param string $sql the existing SQL (without ORDER BY/LIMIT/OFFSET)
-     * @param array $orderBy the order by columns. See [[\yii\db\Query::orderBy]] for more details on how to specify this parameter.
-     * @param int $limit the limit number. See [[\yii\db\Query::limit]] for more details.
-     * @param int $offset the offset number. See [[\yii\db\Query::offset]] for more details.
-     * @return string the SQL completed with ORDER BY/LIMIT/OFFSET (if any)
-     */
-    protected function newBuildOrderByAndLimit($sql, $orderBy, $limit, $offset)
-    {
-        $orderBy = $this->buildOrderBy($orderBy);
         if ($orderBy === '') {
-            // ORDER BY clause is required when FETCH and OFFSET are in the SQL
-            $orderBy = 'ORDER BY (SELECT NULL)';
-        }
-        $sql .= $this->separator . $orderBy;
-
-        // https://technet.microsoft.com/en-us/library/gg699618.aspx
-        $offset = $this->hasOffset($offset) ? $offset : '0';
-        $sql .= $this->separator . "OFFSET $offset ROWS";
-        if ($this->hasLimit($limit)) {
-            $sql .= $this->separator . "FETCH NEXT $limit ROWS ONLY";
-        }
-
-        return $sql;
-    }
-
-    /**
-     * Builds the ORDER BY/LIMIT/OFFSET clauses for SQL SERVER 2005 to 2008.
-     * @param string $sql the existing SQL (without ORDER BY/LIMIT/OFFSET)
-     * @param array $orderBy the order by columns. See [[\yii\db\Query::orderBy]] for more details on how to specify this parameter.
-     * @param int|Expression $limit the limit number. See [[\yii\db\Query::limit]] for more details.
-     * @param int $offset the offset number. See [[\yii\db\Query::offset]] for more details.
-     * @return string the SQL completed with ORDER BY/LIMIT/OFFSET (if any)
-     */
-    protected function oldBuildOrderByAndLimit($sql, $orderBy, $limit, $offset)
-    {
-        $orderBy = $this->buildOrderBy($orderBy);
-        if ($orderBy === '') {
-            // ROW_NUMBER() requires an ORDER BY clause
+            // SQL Server requires ORDER BY when OFFSET/FETCH is used
             $orderBy = 'ORDER BY (SELECT NULL)';
         }
 
-        $sql = preg_replace('/^([\s(])*SELECT(\s+DISTINCT)?(?!\s*TOP\s*\()/i', "\\1SELECT\\2 rowNum = ROW_NUMBER() over ($orderBy),", $sql);
+        $offset = $this->hasOffset($offset) ? $offset : 0;
+        $sql .= "{$this->separator}{$orderBy}{$this->separator}OFFSET {$offset} ROWS";
 
         if ($this->hasLimit($limit)) {
-            if ($limit instanceof Expression) {
-                $limit = '(' . (string)$limit . ')';
-            }
-            $sql = "SELECT TOP $limit * FROM ($sql) sub";
-        } else {
-            $sql = "SELECT * FROM ($sql) sub";
-        }
-        if ($this->hasOffset($offset)) {
-            $sql .= $this->separator . "WHERE rowNum > $offset";
+            $sql .= "{$this->separator}FETCH NEXT {$limit} ROWS ONLY";
         }
 
         return $sql;
@@ -557,17 +508,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
         $on = $this->buildCondition($onCondition, $params);
         list(, $placeholders, $values, $params) = $this->prepareInsertValues($table, $insertColumns, $params);
 
-        /**
-         * Fix number of select query params for old MSSQL version that does not support offset correctly.
-         * @see QueryBuilder::oldBuildOrderByAndLimit
-         */
-        $insertNamesUsing = $insertNames;
-        if (strstr($values, 'rowNum = ROW_NUMBER()') !== false) {
-            $insertNamesUsing = array_merge(['[rowNum]'], $insertNames);
-        }
-
         $mergeSql = 'MERGE ' . $this->db->quoteTableName($table) . ' WITH (HOLDLOCK) '
-            . 'USING (' . (!empty($placeholders) ? 'VALUES (' . implode(', ', $placeholders) . ')' : ltrim($values, ' ')) . ') AS [EXCLUDED] (' . implode(', ', $insertNamesUsing) . ') '
+            . 'USING (' . (!empty($placeholders) ? 'VALUES (' . implode(', ', $placeholders) . ')' : ltrim($values, ' ')) . ') AS [EXCLUDED] (' . implode(', ', $insertNames) . ') '
             . "ON ($on)";
         $insertValues = [];
         foreach ($insertNames as $name) {

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -75,8 +75,9 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         if ($orderBy === '') {
-            // SQL Server requires ORDER BY when OFFSET/FETCH is used
-            $orderBy = 'ORDER BY (SELECT NULL)';
+            // SQL Server requires ORDER BY with OFFSET/FETCH; ORDER BY '1' references the first select-list item,
+            // which is also valid when SELECT DISTINCT is used (ORDER BY (SELECT NULL) is rejected with DISTINCT)
+            $orderBy = 'ORDER BY 1';
         }
 
         $offset = $this->hasOffset($offset) ? $offset : 0;
@@ -87,6 +88,17 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         return $sql;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * SQL Server's `FETCH NEXT n ROWS ONLY` requires `n >= 1`, so `limit(0)` is treated as "no limit applied" instead
+     * of emitting invalid `FETCH NEXT 0 ROWS ONLY`.
+     */
+    protected function hasLimit($limit)
+    {
+        return parent::hasLimit($limit) && (string) $limit !== '0';
     }
 
     /**

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -75,9 +75,12 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         if ($orderBy === '') {
-            // SQL Server requires ORDER BY with OFFSET/FETCH; ORDER BY '1' references the first select-list item,
-            // which is also valid when SELECT DISTINCT is used (ORDER BY (SELECT NULL) is rejected with DISTINCT)
-            $orderBy = 'ORDER BY 1';
+            // SELECT DISTINCT requires ORDER BY items to appear in the select list, so use ordinal `1`;
+            // otherwise `ORDER BY (SELECT NULL)` is preferred because it tolerates unorderable column types
+            // (`text`, `ntext`, `image`, `xml`, `geography`, `geometry`) which `ORDER BY 1` cannot sort.
+            $orderBy = str_starts_with($sql, 'SELECT DISTINCT')
+                ? 'ORDER BY 1'
+                : 'ORDER BY (SELECT NULL)';
         }
 
         $offset = $this->hasOffset($offset) ? $offset : 0;

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -90,6 +90,17 @@ class QueryBuilder extends \yii\db\QueryBuilder
     /**
      * {@inheritdoc}
      *
+     * Oracle's `FETCH NEXT n ROWS ONLY` requires `n >= 1`, so `limit(0)` is treated as "no limit applied" instead of
+     * emitting invalid `FETCH NEXT 0 ROWS ONLY`.
+     */
+    protected function hasLimit($limit)
+    {
+        return parent::hasLimit($limit) && (string) $limit !== '0';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * Oracle does not support the `RECURSIVE` keyword for CTEs. Recursion is implicit when a CTE references itself.
      */
     public function buildWithQueries($withs, &$params)

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -90,17 +90,6 @@ class QueryBuilder extends \yii\db\QueryBuilder
     /**
      * {@inheritdoc}
      *
-     * Oracle's `FETCH NEXT n ROWS ONLY` requires `n >= 1`, so `limit(0)` is treated as "no limit applied" instead of
-     * emitting invalid `FETCH NEXT 0 ROWS ONLY`.
-     */
-    protected function hasLimit($limit)
-    {
-        return parent::hasLimit($limit) && (string) $limit !== '0';
-    }
-
-    /**
-     * {@inheritdoc}
-     *
      * Oracle does not support the `RECURSIVE` keyword for CTEs. Recursion is implicit when a CTE references itself.
      */
     public function buildWithQueries($withs, &$params)

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -44,10 +44,10 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
         self::assertSame(
             <<<SQL
-            SELECT [id] FROM [example] ORDER BY 1 OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            SELECT [id] FROM [example] ORDER BY (SELECT NULL) OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
             SQL,
             $actualQuerySql,
-            'OFFSET and LIMIT should emit ORDER BY 1 with OFFSET and FETCH clauses.',
+            'OFFSET and LIMIT should emit ORDER BY (SELECT NULL) fallback with OFFSET and FETCH clauses.',
         );
         self::assertEmpty(
             $actualQueryParams,
@@ -65,10 +65,10 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
         self::assertSame(
             <<<SQL
-            SELECT [id] FROM [example] ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
+            SELECT [id] FROM [example] ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
             SQL,
             $actualQuerySql,
-            'LIMIT without OFFSET should emit ORDER BY 1 with OFFSET 0 ROWS and FETCH clause.',
+            "LIMIT without OFFSET should emit ORDER BY (SELECT NULL) fallback with OFFSET '0' ROWS and FETCH clause.",
         );
         self::assertEmpty(
             $actualQueryParams,
@@ -86,10 +86,10 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
         self::assertSame(
             <<<SQL
-            SELECT [id] FROM [example] ORDER BY 1 OFFSET 10 ROWS
+            SELECT [id] FROM [example] ORDER BY (SELECT NULL) OFFSET 10 ROWS
             SQL,
             $actualQuerySql,
-            'OFFSET without LIMIT should emit ORDER BY 1 with OFFSET clause and no FETCH.',
+            'OFFSET without LIMIT should emit ORDER BY (SELECT NULL) fallback with OFFSET clause and no FETCH.',
         );
         self::assertEmpty(
             $actualQueryParams,
@@ -173,11 +173,11 @@ final class QueryBuilderTest extends BaseQueryBuilder
             SELECT [id] FROM [example]
             SQL,
             $actualQuerySql,
-            'limit(0) must not emit FETCH NEXT 0 ROWS ONLY (invalid SQL Server syntax).',
+            "Limit '0' must not emit FETCH NEXT '0' ROWS ONLY (invalid SQL Server syntax).",
         );
         self::assertEmpty(
             $actualQueryParams,
-            'limit(0) query should have no bound parameters.',
+            "Limit '0' query should have no bound parameters.",
         );
     }
 
@@ -191,14 +191,14 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
         self::assertSame(
             <<<SQL
-            SELECT [id] FROM [example] ORDER BY 1 OFFSET 5 ROWS
+            SELECT [id] FROM [example] ORDER BY (SELECT NULL) OFFSET 5 ROWS
             SQL,
             $actualQuerySql,
-            'limit(0) with offset must emit OFFSET without FETCH (invalid SQL Server syntax otherwise).',
+            "Limit '0' with offset must emit OFFSET without FETCH (invalid SQL Server syntax otherwise).",
         );
         self::assertEmpty(
             $actualQueryParams,
-            'limit(0) with offset query should have no bound parameters.',
+            "Limit '0' with offset query should have no bound parameters.",
         );
     }
 
@@ -215,7 +215,7 @@ final class QueryBuilderTest extends BaseQueryBuilder
             SELECT DISTINCT [id] FROM [example] ORDER BY 1 OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
             SQL,
             $actualQuerySql,
-            'DISTINCT with pagination must use ORDER BY 1 (SQL Server rejects ORDER BY (SELECT NULL) with DISTINCT).',
+            "DISTINCT with pagination must use ORDER BY '1' (SQL Server rejects ORDER BY (SELECT NULL) with DISTINCT).",
         );
         self::assertEmpty(
             $actualQueryParams,
@@ -541,13 +541,13 @@ final class QueryBuilderTest extends BaseQueryBuilder
                 3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (VALUES (:qp0, :qp1, :qp2, :qp3)) AS [EXCLUDED] ([email], [address], [status], [profile_id]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN NOT MATCHED THEN INSERT ([email], [address], [status], [profile_id]) VALUES ([EXCLUDED].[email], [EXCLUDED].[address], [EXCLUDED].[status], [EXCLUDED].[profile_id]);',
             ],
             'query' => [
-                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN MATCHED THEN UPDATE SET [status]=[EXCLUDED].[status] WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
+                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN MATCHED THEN UPDATE SET [status]=[EXCLUDED].[status] WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
             ],
             'query with update part' => [
-                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN MATCHED THEN UPDATE SET [address]=:qp1, [status]=:qp2, [orders]=T_upsert.orders + 1 WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
+                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN MATCHED THEN UPDATE SET [address]=:qp1, [status]=:qp2, [orders]=T_upsert.orders + 1 WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
             ],
             'query without update part' => [
-                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
+                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
             ],
             'values and expressions' => [
                 3 => 'SET NOCOUNT ON;DECLARE @temporary_inserted TABLE ([id] int , [ts] int NULL, [email] varchar(128) , [recovery_email] varchar(128) NULL, [address] text NULL, [status] tinyint , [orders] int , [profile_id] int NULL);' .

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -223,6 +223,69 @@ final class QueryBuilderTest extends BaseQueryBuilder
         );
     }
 
+    public function testBuildOrderByAndLimitWithDistinctLimitOnly(): void
+    {
+        $query = new Query();
+
+        $query->select('id')->distinct()->from('example')->limit(10);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT DISTINCT [id] FROM [example] ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            "DISTINCT with LIMIT only must use ORDER BY '1' and default OFFSET to '0'.",
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'DISTINCT with LIMIT only should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithDistinctOffsetOnly(): void
+    {
+        $query = new Query();
+
+        $query->select('id')->distinct()->from('example')->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT DISTINCT [id] FROM [example] ORDER BY 1 OFFSET 5 ROWS
+            SQL,
+            $actualQuerySql,
+            "DISTINCT with OFFSET only must use ORDER BY '1' and omit FETCH.",
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'DISTINCT with OFFSET only should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithDistinctZeroLimit(): void
+    {
+        $query = new Query();
+
+        $query->select('id')->distinct()->from('example')->limit(0);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT DISTINCT [id] FROM [example]
+            SQL,
+            $actualQuerySql,
+            "DISTINCT with LIMIT '0' must take the early-return path (no pagination clauses).",
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            "DISTINCT with LIMIT '0' should have no bound parameters.",
+        );
+    }
+
     protected function getCommmentsFromTable($table)
     {
         $db = $this->getConnection(false, false);

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -36,50 +36,69 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
     public function testOffsetLimit(): void
     {
-        $expectedQuerySql = 'SELECT [id] FROM [example] ORDER BY (SELECT NULL) OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY';
-        $expectedQueryParams = [];
-
         $query = new Query();
+
         $query->select('id')->from('example')->limit(10)->offset(5);
 
         [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
 
-        $this->assertEquals($expectedQuerySql, $actualQuerySql);
-        $this->assertEquals($expectedQueryParams, $actualQueryParams);
+        self::assertSame(
+            <<<SQL
+            SELECT [id] FROM [example] ORDER BY 1 OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            'OFFSET and LIMIT should emit ORDER BY 1 with OFFSET and FETCH clauses.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'OFFSET and LIMIT query should have no bound parameters.',
+        );
     }
 
     public function testLimit(): void
     {
-        $expectedQuerySql = 'SELECT [id] FROM [example] ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY';
-        $expectedQueryParams = [];
-
         $query = new Query();
+
         $query->select('id')->from('example')->limit(10);
 
         [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
 
-        $this->assertEquals($expectedQuerySql, $actualQuerySql);
-        $this->assertEquals($expectedQueryParams, $actualQueryParams);
+        self::assertSame(
+            <<<SQL
+            SELECT [id] FROM [example] ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            'LIMIT without OFFSET should emit ORDER BY 1 with OFFSET 0 ROWS and FETCH clause.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'LIMIT-only query should have no bound parameters.',
+        );
     }
 
     public function testOffset(): void
     {
-        $expectedQuerySql = 'SELECT [id] FROM [example] ORDER BY (SELECT NULL) OFFSET 10 ROWS';
-        $expectedQueryParams = [];
-
         $query = new Query();
+
         $query->select('id')->from('example')->offset(10);
 
         [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
 
-        $this->assertEquals($expectedQuerySql, $actualQuerySql);
-        $this->assertEquals($expectedQueryParams, $actualQueryParams);
+        self::assertSame(
+            <<<SQL
+            SELECT [id] FROM [example] ORDER BY 1 OFFSET 10 ROWS
+            SQL,
+            $actualQuerySql,
+            'OFFSET without LIMIT should emit ORDER BY 1 with OFFSET clause and no FETCH.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'OFFSET-only query should have no bound parameters.',
+        );
     }
 
     public function testBuildOrderByAndLimitWithoutOffsetAndLimit(): void
     {
-        $expectedQueryParams = [];
-
         $query = new Query();
 
         $query->select('id')->from('example');
@@ -93,8 +112,7 @@ final class QueryBuilderTest extends BaseQueryBuilder
             $actualQuerySql,
             'Query without OFFSET/LIMIT should not contain OFFSET or FETCH clauses.',
         );
-        self::assertSame(
-            $expectedQueryParams,
+        self::assertEmpty(
             $actualQueryParams,
             'Query without OFFSET/LIMIT should have no bound parameters.',
         );
@@ -102,8 +120,6 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
     public function testBuildOrderByAndLimitWithExplicitOrderBy(): void
     {
-        $expectedQueryParams = [];
-
         $query = new Query();
 
         $query->select('id')->from('example')->orderBy('id')->limit(10)->offset(5);
@@ -117,8 +133,7 @@ final class QueryBuilderTest extends BaseQueryBuilder
             $actualQuerySql,
             'Explicit ORDER BY should be preserved alongside OFFSET/FETCH clauses.',
         );
-        self::assertSame(
-            $expectedQueryParams,
+        self::assertEmpty(
             $actualQueryParams,
             'Query with explicit ORDER BY should have no bound parameters.',
         );
@@ -126,8 +141,6 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
     public function testBuildOrderByAndLimitWithOrderByWithoutPagination(): void
     {
-        $expectedQueryParams = [];
-
         $query = new Query();
 
         $query->select('id')->from('example')->orderBy('id');
@@ -141,10 +154,72 @@ final class QueryBuilderTest extends BaseQueryBuilder
             $actualQuerySql,
             'ORDER BY without OFFSET/LIMIT should not contain OFFSET or FETCH clauses.',
         );
-        self::assertSame(
-            $expectedQueryParams,
+        self::assertEmpty(
             $actualQueryParams,
             'ORDER BY without pagination should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithZeroLimit(): void
+    {
+        $query = new Query();
+
+        $query->select('id')->from('example')->limit(0);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT [id] FROM [example]
+            SQL,
+            $actualQuerySql,
+            'limit(0) must not emit FETCH NEXT 0 ROWS ONLY (invalid SQL Server syntax).',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'limit(0) query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithZeroLimitAndOffset(): void
+    {
+        $query = new Query();
+
+        $query->select('id')->from('example')->limit(0)->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT [id] FROM [example] ORDER BY 1 OFFSET 5 ROWS
+            SQL,
+            $actualQuerySql,
+            'limit(0) with offset must emit OFFSET without FETCH (invalid SQL Server syntax otherwise).',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'limit(0) with offset query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithDistinctWithoutOrderBy(): void
+    {
+        $query = new Query();
+
+        $query->select('id')->distinct()->from('example')->limit(10)->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT DISTINCT [id] FROM [example] ORDER BY 1 OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            'DISTINCT with pagination must use ORDER BY 1 (SQL Server rejects ORDER BY (SELECT NULL) with DISTINCT).',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'DISTINCT pagination query should have no bound parameters.',
         );
     }
 
@@ -466,13 +541,13 @@ final class QueryBuilderTest extends BaseQueryBuilder
                 3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (VALUES (:qp0, :qp1, :qp2, :qp3)) AS [EXCLUDED] ([email], [address], [status], [profile_id]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN NOT MATCHED THEN INSERT ([email], [address], [status], [profile_id]) VALUES ([EXCLUDED].[email], [EXCLUDED].[address], [EXCLUDED].[status], [EXCLUDED].[profile_id]);',
             ],
             'query' => [
-                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN MATCHED THEN UPDATE SET [status]=[EXCLUDED].[status] WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
+                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN MATCHED THEN UPDATE SET [status]=[EXCLUDED].[status] WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
             ],
             'query with update part' => [
-                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN MATCHED THEN UPDATE SET [address]=:qp1, [status]=:qp2, [orders]=T_upsert.orders + 1 WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
+                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN MATCHED THEN UPDATE SET [address]=:qp1, [status]=:qp2, [orders]=T_upsert.orders + 1 WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
             ],
             'query without update part' => [
-                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
+                3 => 'MERGE [T_upsert] WITH (HOLDLOCK) USING (SELECT [email], 2 AS [status] FROM [customer] WHERE [name]=:qp0 ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [EXCLUDED] ([email], [status]) ON ([T_upsert].[email]=[EXCLUDED].[email]) WHEN NOT MATCHED THEN INSERT ([email], [status]) VALUES ([EXCLUDED].[email], [EXCLUDED].[status]);',
             ],
             'values and expressions' => [
                 3 => 'SET NOCOUNT ON;DECLARE @temporary_inserted TABLE ([id] int , [ts] int NULL, [email] varchar(128) , [recovery_email] varchar(128) NULL, [address] text NULL, [status] tinyint , [orders] int , [profile_id] int NULL);' .

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -76,6 +76,78 @@ final class QueryBuilderTest extends BaseQueryBuilder
         $this->assertEquals($expectedQueryParams, $actualQueryParams);
     }
 
+    public function testBuildOrderByAndLimitWithoutOffsetAndLimit(): void
+    {
+        $expectedQueryParams = [];
+
+        $query = new Query();
+
+        $query->select('id')->from('example');
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT [id] FROM [example]
+            SQL,
+            $actualQuerySql,
+            'Query without OFFSET/LIMIT should not contain OFFSET or FETCH clauses.',
+        );
+        self::assertSame(
+            $expectedQueryParams,
+            $actualQueryParams,
+            'Query without OFFSET/LIMIT should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithExplicitOrderBy(): void
+    {
+        $expectedQueryParams = [];
+
+        $query = new Query();
+
+        $query->select('id')->from('example')->orderBy('id')->limit(10)->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT [id] FROM [example] ORDER BY [id] OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            'Explicit ORDER BY should be preserved alongside OFFSET/FETCH clauses.',
+        );
+        self::assertSame(
+            $expectedQueryParams,
+            $actualQueryParams,
+            'Query with explicit ORDER BY should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithOrderByWithoutPagination(): void
+    {
+        $expectedQueryParams = [];
+
+        $query = new Query();
+
+        $query->select('id')->from('example')->orderBy('id');
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT [id] FROM [example] ORDER BY [id]
+            SQL,
+            $actualQuerySql,
+            'ORDER BY without OFFSET/LIMIT should not contain OFFSET or FETCH clauses.',
+        );
+        self::assertSame(
+            $expectedQueryParams,
+            $actualQueryParams,
+            'ORDER BY without pagination should have no bound parameters.',
+        );
+    }
+
     protected function getCommmentsFromTable($table)
     {
         $db = $this->getConnection(false, false);

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -170,10 +170,10 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
         self::assertSame(
             <<<SQL
-            SELECT [id] FROM [example]
+            SELECT * FROM (SELECT [id] FROM [example]) sub WHERE 1=0
             SQL,
             $actualQuerySql,
-            "Limit '0' must not emit FETCH NEXT '0' ROWS ONLY (invalid SQL Server syntax).",
+            "Limit '0' must wrap the query with WHERE 1=0 to return zero rows (portable semantics).",
         );
         self::assertEmpty(
             $actualQueryParams,
@@ -191,10 +191,10 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
         self::assertSame(
             <<<SQL
-            SELECT [id] FROM [example] ORDER BY (SELECT NULL) OFFSET 5 ROWS
+            SELECT * FROM (SELECT [id] FROM [example]) sub WHERE 1=0
             SQL,
             $actualQuerySql,
-            "Limit '0' with offset must emit OFFSET without FETCH (invalid SQL Server syntax otherwise).",
+            "Limit '0' with offset must still return zero rows (offset is irrelevant on empty result).",
         );
         self::assertEmpty(
             $actualQueryParams,
@@ -275,10 +275,10 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
         self::assertSame(
             <<<SQL
-            SELECT DISTINCT [id] FROM [example]
+            SELECT * FROM (SELECT DISTINCT [id] FROM [example]) sub WHERE 1=0
             SQL,
             $actualQuerySql,
-            "DISTINCT with LIMIT '0' must take the early-return path (no pagination clauses).",
+            "DISTINCT with LIMIT '0' must wrap with WHERE 1=0 to return zero rows.",
         );
         self::assertEmpty(
             $actualQueryParams,

--- a/tests/framework/db/mssql/QueryTest.php
+++ b/tests/framework/db/mssql/QueryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,16 +10,84 @@
 
 namespace yiiunit\framework\db\mssql;
 
+use PHPUnit\Framework\Attributes\Group;
 use yii\db\Query;
 use yiiunit\base\db\BaseQuery;
 
 /**
- * @group db
- * @group mssql
+ * Unit test for {@see \yii\db\Query} with MSSQL driver.
  */
+#[Group('db')]
+#[Group('mssql')]
+#[Group('query')]
 class QueryTest extends BaseQuery
 {
     protected $driverName = 'sqlsrv';
+
+    public function testLimitOffsetExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id', 'name'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(1)
+            ->offset(1)
+            ->all($db);
+
+        self::assertCount(
+            1,
+            $rows,
+            "LIMIT '1' OFFSET '1' should return exactly one row.",
+        );
+        self::assertSame(
+            '2',
+            $rows[0]['id'],
+            "OFFSET '1' should skip the first row and start at 'id=2'.",
+        );
+        self::assertSame(
+            'user2',
+            $rows[0]['name'],
+            "Row at OFFSET '1' should correspond to 'user2'.",
+        );
+    }
+
+    public function testOffsetExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->offset(1)
+            ->column($db);
+
+        self::assertSame(
+            ['2', '3'],
+            $rows,
+            "OFFSET '1' without LIMIT should return remaining rows starting at 'id=2'.",
+        );
+    }
+
+    public function testLimitExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(2)
+            ->column($db);
+
+        self::assertSame(
+            ['1', '2'],
+            $rows,
+            "LIMIT '2' without OFFSET should return the first two rows.",
+        );
+    }
 
     public function testUnion(): void
     {

--- a/tests/framework/db/oci/QueryBuilderTest.php
+++ b/tests/framework/db/oci/QueryBuilderTest.php
@@ -226,14 +226,14 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
         self::assertSame(
             <<<SQL
-            SELECT "id" FROM "example"
+            SELECT "id" FROM "example" FETCH NEXT 0 ROWS ONLY
             SQL,
             $actualQuerySql,
-            'limit(0) must not emit FETCH NEXT 0 ROWS ONLY (invalid Oracle syntax).',
+            "Limit '0' must emit FETCH NEXT '0' ROWS ONLY (valid Oracle syntax that returns zero rows).",
         );
         self::assertEmpty(
             $actualQueryParams,
-            'limit(0) query should have no bound parameters.',
+            "Limit '0' query should have no bound parameters.",
         );
     }
 
@@ -249,14 +249,14 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
         self::assertSame(
             <<<SQL
-            SELECT "id" FROM "example" OFFSET 5 ROWS
+            SELECT "id" FROM "example" OFFSET 5 ROWS FETCH NEXT 0 ROWS ONLY
             SQL,
             $actualQuerySql,
-            'limit(0) with offset must emit OFFSET without FETCH (invalid Oracle syntax otherwise).',
+            "Limit '0' with offset must emit OFFSET and FETCH NEXT '0' ROWS ONLY (valid Oracle syntax).",
         );
         self::assertEmpty(
             $actualQueryParams,
-            'limit(0) with offset query should have no bound parameters.',
+            "Limit '0' with offset query should have no bound parameters.",
         );
     }
 

--- a/tests/framework/db/oci/QueryBuilderTest.php
+++ b/tests/framework/db/oci/QueryBuilderTest.php
@@ -215,6 +215,51 @@ final class QueryBuilderTest extends BaseQueryBuilder
         );
     }
 
+    public function testBuildOrderByAndLimitWithZeroLimit(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(0);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example"
+            SQL,
+            $actualQuerySql,
+            'limit(0) must not emit FETCH NEXT 0 ROWS ONLY (invalid Oracle syntax).',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'limit(0) query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithZeroLimitAndOffset(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(0)
+            ->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" OFFSET 5 ROWS
+            SQL,
+            $actualQuerySql,
+            'limit(0) with offset must emit OFFSET without FETCH (invalid Oracle syntax otherwise).',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'limit(0) with offset query should have no bound parameters.',
+        );
+    }
+
     public function testCommentColumn(): void
     {
         $qb = $this->getQueryBuilder();

--- a/tests/framework/db/oci/QueryTest.php
+++ b/tests/framework/db/oci/QueryTest.php
@@ -42,8 +42,8 @@ class QueryTest extends BaseQuery
             "LIMIT '1' OFFSET '1' should return exactly one row.",
         );
         self::assertSame(
-            2,
-            (int) $rows[0]['id'],
+            '2',
+            $rows[0]['id'],
             "OFFSET '1' should skip the first row and start at 'id=2'.",
         );
         self::assertSame(
@@ -65,8 +65,8 @@ class QueryTest extends BaseQuery
             ->column($db);
 
         self::assertSame(
-            [2, 3],
-            array_map('intval', $rows),
+            ['2', '3'],
+            $rows,
             "OFFSET '1' without LIMIT should return remaining rows starting at 'id=2'.",
         );
     }
@@ -83,8 +83,8 @@ class QueryTest extends BaseQuery
             ->column($db);
 
         self::assertSame(
-            [1, 2],
-            array_map('intval', $rows),
+            ['1', '2'],
+            $rows,
             "LIMIT '2' without OFFSET should return the first two rows.",
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #18639

### Summary

This PR addresses the MSSQL part of #18639 by switching SQL Server pagination SQL generation to SQL Server's native row-limiting clause.

`yii\db\mssql\QueryBuilder::buildOrderByAndLimit()` now emits:

- `ORDER BY ...` (or `ORDER BY (SELECT NULL)` when no `orderBy()` is specified, as SQL Server requires `ORDER BY` with `OFFSET`/`FETCH`)
- `OFFSET <n> ROWS` (or `OFFSET 0 ROWS` when only `limit()` is set)
- `FETCH NEXT <n> ROWS ONLY`