### PR TITLE
Remove MySQL `< 8.0` dead code and deprecated integer display width from MySQL type map (`int(11)` → `int`, `bigint(20)` → `bigint`, etc.); `tinyint(1)` for `TYPE_BOOLEAN` is preserved.

### DIFF
--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -47,7 +47,7 @@ jobs:
       database-image: mariadb
       database-port: "3306"
       database-type: mysql
-      database-versions: '["10.4","latest"]'
+      database-versions: '["10.5","latest"]'
       extensions: curl, intl, pdo, pdo_mysql
       os: '["ubuntu-22.04"]'
       php-version: '["8.5"]'

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -47,7 +47,7 @@ jobs:
       database-image: mysql
       database-port: "3306"
       database-type: mysql
-      database-versions: '["5.7","latest"]'
+      database-versions: '["8.0","latest"]'
       extensions: curl, intl, pdo, pdo_mysql
       os: '["ubuntu-22.04"]'
       php-version: '["8.5"]'

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -48,6 +48,7 @@ Yii Framework 2 Change Log
 - Bug: Fix Oracle `buildWithQueries()` to omit unsupported `RECURSIVE` keyword in Oracle CTEs (terabytesoftw)
 - Chg #18639: Refactor Oracle pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; Oracle `12.1+` is now required for `yii\db\oci\QueryBuilder` pagination (terabytesoftw)
 - Chg #18639: Refactor MSSQL pagination SQL to use standard `ORDER BY ... OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; SQL Server `2019+` is now required for `yii\db\mssql\QueryBuilder` pagination (terabytesoftw)
+- Chg: Remove MySQL `< 8.0` dead code and deprecated integer display width from MySQL type map (`int(11)` → `int`, `bigint(20)` → `bigint`, etc.); `tinyint(1)` for `TYPE_BOOLEAN` is preserved (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -188,6 +188,47 @@ Behavioral notes:
   `DISTINCT` is required.
 - Always specify `orderBy()` for deterministic pagination; SQL Server returns rows in an unspecified order otherwise.
 
+> [!NOTE]
+> **Lifecycle:** SQL Server `2019` was released on November 4, `2019`. Mainstream support ended on February 28, `2025`;
+> extended support (security-only) ends on January 8, `2030`. Although `OFFSET ... FETCH NEXT` has been available since
+> SQL Server `2012`, the `2019+` floor aligns with versions that still receive vendor security updates. SQL Server
+> `2017` remains in extended support until October 12, `2027`, but is no longer covered by Yii.
+
+#### MySQL dead code removal and integer display width cleanup
+
+The minimum supported MySQL version is now **8.0+** (**MariaDB 10.5+**). The following dead code has been removed:
+
+- `Schema::isOldMysql()` method and `$_oldMysql` property (checked for MySQL <= `5.1`, never called).
+- `QueryBuilder::supportsFractionalSeconds()` method (always `true` for MySQL `8.0+`).
+- `CacheInterface` / `DbCache` imports from `QueryBuilder` (only used by the removed method).
+- Version checks for MySQL < `5.6` / < `5.6.4` / < `5.7` in tests.
+
+**Integer display width** (`int(11)`, `bigint(20)`, `smallint(6)`, `tinyint(3)`) has been removed from the MySQL type
+map. MySQL `8.0.17+` deprecated display width for integer types and emits deprecation warnings. The new defaults are:
+
+| Before                | After             |
+| --------------------- | ----------------- |
+| `int(11)`             | `int`             |
+| `int(10) UNSIGNED`    | `int UNSIGNED`    |
+| `bigint(20)`          | `bigint`          |
+| `bigint(20) UNSIGNED` | `bigint UNSIGNED` |
+| `smallint(6)`         | `smallint`        |
+| `tinyint(3)`          | `tinyint`         |
+
+`tinyint(1)` for `TYPE_BOOLEAN` is preserved; MySQL uses it as the canonical boolean representation.
+
+Explicit integer sizes (for example, `$this->primaryKey(8)`) are now ignored; display width is no longer emitted.
+
+If your application or migrations rely on the exact SQL output of `QueryBuilder::getColumnType()` for integer types
+(for example, in string assertions or snapshot tests), update the expected values.
+
+> [!NOTE]
+> **Lifecycle:** MySQL `5.7` reached end of extended support on October 31, `2023`. MySQL `8.0` is the current LTS
+> release; premier support ended on April 30, `2025`, and extended support ends on April 30, `2026`. MariaDB `10.4`
+> reached community support EOL on June 18, `2024`, and MariaDB `10.5` reached community support EOL on June 24,
+> `2025`. The version floors catch up to releases that are at or near EOL; the dead code removed in this change
+> targeted MySQL branches already unsupported by the vendor.
+
 #### Oracle pagination now uses `OFFSET ... FETCH` (`12.1+`)
 
 `yii\db\oci\QueryBuilder::buildOrderByAndLimit()` now emits SQL using Oracle's native row-limiting clause:
@@ -204,6 +245,12 @@ supported for Yii-generated pagination SQL in the OCI QueryBuilder.
 If you rely on paginated results without specifying `orderBy()`, note that Oracle returns rows in an unspecified order,
 so `OFFSET`/`FETCH` results may vary between executions. Always specify `orderBy()` when you need deterministic
 pagination.
+
+> [!NOTE]
+> **Lifecycle:** Oracle Database `12.1` introduced the standard `OFFSET ... FETCH NEXT` row-limiting clause. Premier
+> support for `12.1` ended on July 31, `2018`; extended support ended on July 31, `2022`. Oracle currently recommends
+> `19c` (LTS, premier support through December 31, `2029`, extended support through December 31, `2032`) for all
+> production deployments. The `12.1+` floor matches the earliest release with native row-limiting syntax.
 
 ### HHVM support removed
 

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -223,9 +223,9 @@ If your application or migrations rely on the exact SQL output of `QueryBuilder:
 (for example, in string assertions or snapshot tests), update the expected values.
 
 > [!NOTE]
-> **Lifecycle:** MySQL `5.7` reached end of extended support on October 31, `2023`. MySQL `8.0` is the current LTS
-> release; premier support ended on April 30, `2025`, and extended support ends on April 30, `2026`. MariaDB `10.4`
-> reached community support EOL on June 18, `2024`, and MariaDB `10.5` reached community support EOL on June 24,
+> **Lifecycle:** MySQL `5.7` reached end of extended support on October 31, `2023`. MySQL `8.0` reaches end of extended
+> support on April 30, `2026`; MySQL `8.4` is the current LTS release (premier support through April `2029`). MariaDB
+> `10.4` reached community support EOL on June 18, `2024`, and MariaDB `10.5` reached community support EOL on June 24,
 > `2025`. The version floors catch up to releases that are at or near EOL; the dead code removed in this change
 > targeted MySQL branches already unsupported by the vendor.
 

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -191,8 +191,9 @@ Behavioral notes:
 > [!NOTE]
 > **Lifecycle:** SQL Server `2019` was released on November 4, `2019`. Mainstream support ended on February 28, `2025`;
 > extended support (security-only) ends on January 8, `2030`. Although `OFFSET ... FETCH NEXT` has been available since
-> SQL Server `2012`, the `2019+` floor aligns with versions that still receive vendor security updates. SQL Server
-> `2017` remains in extended support until October 12, `2027`, but is no longer covered by Yii.
+> SQL Server `2012`, Yii `22.x` raises its supported floor to `2019+` as a policy decision to reduce the legacy test
+> matrix; SQL Server `2017` remains in vendor extended support until October 12, `2027`, but is no longer covered by
+> Yii.
 
 #### MySQL dead code removal and integer display width cleanup
 
@@ -248,9 +249,10 @@ pagination.
 
 > [!NOTE]
 > **Lifecycle:** Oracle Database `12.1` introduced the standard `OFFSET ... FETCH NEXT` row-limiting clause. Premier
-> support for `12.1` ended on July 31, `2018`; extended support ended on July 31, `2022`. Oracle currently recommends
-> `19c` (LTS, premier support through December 31, `2029`, extended support through December 31, `2032`) for all
-> production deployments. The `12.1+` floor matches the earliest release with native row-limiting syntax.
+> support for `12.1` ended on July 31, `2018`; extended support ended on July 31, `2022`. Oracle Database `19c` remains
+> a supported LTS release (premier support through December 31, `2029`, extended through December 31, `2032`); Oracle
+> AI Database `26ai` (released January `2026` on-premises) is the newest LTS, with premier support through December
+> 31, `2031`. The `12.1+` floor matches the earliest release with native row-limiting syntax.
 
 ### HHVM support removed
 

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -9,8 +11,6 @@
 namespace yii\db\mysql;
 
 use yii\base\InvalidArgumentException;
-use yii\caching\CacheInterface;
-use yii\caching\DbCache;
 use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\Query;
@@ -27,17 +27,17 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * @var array mapping from abstract column types (keys) to physical column types (values).
      */
     public $typeMap = [
-        Schema::TYPE_PK => 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY',
-        Schema::TYPE_UPK => 'int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
-        Schema::TYPE_BIGPK => 'bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY',
-        Schema::TYPE_UBIGPK => 'bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
+        Schema::TYPE_PK => 'int NOT NULL AUTO_INCREMENT PRIMARY KEY',
+        Schema::TYPE_UPK => 'int UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
+        Schema::TYPE_BIGPK => 'bigint NOT NULL AUTO_INCREMENT PRIMARY KEY',
+        Schema::TYPE_UBIGPK => 'bigint UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
         Schema::TYPE_CHAR => 'char(1)',
         Schema::TYPE_STRING => 'varchar(255)',
         Schema::TYPE_TEXT => 'text',
-        Schema::TYPE_TINYINT => 'tinyint(3)',
-        Schema::TYPE_SMALLINT => 'smallint(6)',
-        Schema::TYPE_INTEGER => 'int(11)',
-        Schema::TYPE_BIGINT => 'bigint(20)',
+        Schema::TYPE_TINYINT => 'tinyint',
+        Schema::TYPE_SMALLINT => 'smallint',
+        Schema::TYPE_INTEGER => 'int',
+        Schema::TYPE_BIGINT => 'bigint',
         Schema::TYPE_FLOAT => 'float',
         Schema::TYPE_DOUBLE => 'double',
         Schema::TYPE_DECIMAL => 'decimal(10,0)',
@@ -56,7 +56,12 @@ class QueryBuilder extends \yii\db\QueryBuilder
     {
         parent::init();
 
-        $this->typeMap = array_merge($this->typeMap, $this->defaultTimeTypeMap());
+        $this->typeMap = [
+            ...$this->typeMap,
+            Schema::TYPE_DATETIME => 'datetime(0)',
+            Schema::TYPE_TIME => 'time(0)',
+            Schema::TYPE_TIMESTAMP => 'timestamp(0)',
+        ];
     }
 
     /**
@@ -260,7 +265,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * {@inheritdoc}
-     * @see https://downloads.mysql.com/docs/refman-5.1-en.pdf
+     * @see https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
      */
     public function upsert($table, $insertColumns, $updateColumns, &$params)
     {
@@ -378,59 +383,5 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         return null;
-    }
-
-    /**
-     * Checks the ability to use fractional seconds.
-     *
-     * @return bool
-     * @see https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html
-     */
-    private function supportsFractionalSeconds()
-    {
-        // use cache to prevent opening MySQL connection
-        // https://github.com/yiisoft/yii2/issues/13749#issuecomment-481657224
-        $key = [__METHOD__, $this->db->dsn];
-        $cache = null;
-        $schemaCache = (\Yii::$app && is_string($this->db->schemaCache)) ? \Yii::$app->get($this->db->schemaCache, false) : $this->db->schemaCache;
-        // If the `$schemaCache` is an instance of `DbCache` we don't use it to avoid a loop
-        if ($this->db->enableSchemaCache && $schemaCache instanceof CacheInterface && !($schemaCache instanceof DbCache)) {
-            $cache = $schemaCache;
-        }
-        $version = $cache ? $cache->get($key) : null;
-        if (!$version) {
-            $version = $this->db->getSlavePdo(true)->getAttribute(\PDO::ATTR_SERVER_VERSION);
-            if ($cache) {
-                $cache->set($key, $version, $this->db->schemaCacheDuration);
-            }
-        }
-
-        return version_compare($version, '5.6.4', '>=');
-    }
-
-    /**
-     * Returns the map for default time type.
-     * If the version of MySQL is lower than 5.6.4, then the types will be without fractional seconds,
-     * otherwise with fractional seconds.
-     *
-     * @return array
-     */
-    private function defaultTimeTypeMap()
-    {
-        $map = [
-            Schema::TYPE_DATETIME => 'datetime',
-            Schema::TYPE_TIMESTAMP => 'timestamp',
-            Schema::TYPE_TIME => 'time',
-        ];
-
-        if ($this->supportsFractionalSeconds()) {
-            $map = [
-                Schema::TYPE_DATETIME => 'datetime(0)',
-                Schema::TYPE_TIMESTAMP => 'timestamp(0)',
-                Schema::TYPE_TIME => 'time(0)',
-            ];
-        }
-
-        return $map;
     }
 }

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -9,13 +11,11 @@
 namespace yii\db\mysql;
 
 use Yii;
-use yii\base\InvalidConfigException;
 use yii\base\NotSupportedException;
 use yii\db\CheckConstraint;
 use yii\db\Constraint;
 use yii\db\ConstraintFinderInterface;
 use yii\db\ConstraintFinderTrait;
-use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\ForeignKeyConstraint;
 use yii\db\IndexConstraint;
@@ -24,7 +24,7 @@ use yii\helpers\ArrayHelper;
 use yii\db\Schema as BaseSchema;
 
 /**
- * Schema is the class for retrieving metadata from a MySQL database (version 4.1.x and 5.x).
+ * Schema is the class for retrieving metadata from a MySQL database (version 8.0 and later).
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -40,11 +40,6 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      * {@inheritdoc}
      */
     public $columnSchemaClass = 'yii\db\mysql\ColumnSchema';
-    /**
-     * @var bool whether MySQL used is older than 5.1.
-     */
-    private $_oldMysql;
-
 
     /**
      * @var array mapping from physical column types (keys) to abstract column types (values)
@@ -525,22 +520,6 @@ SQL;
     public function createColumnSchemaBuilder($type, $length = null)
     {
         return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length, $this->db]);
-    }
-
-    /**
-     * @return bool whether the version of the MySQL being used is older than 5.1.
-     * @throws InvalidConfigException
-     * @throws Exception
-     * @since 2.0.13
-     */
-    protected function isOldMysql()
-    {
-        if ($this->_oldMysql === null) {
-            $version = $this->db->getSlavePdo(true)->getAttribute(\PDO::ATTR_SERVER_VERSION);
-            $this->_oldMysql = version_compare($version, '5.1', '<=');
-        }
-
-        return $this->_oldMysql;
     }
 
     /**

--- a/tests/base/db/BaseQueryBuilder.php
+++ b/tests/base/db/BaseQueryBuilder.php
@@ -87,7 +87,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_BIGINT,
                 $this->bigInteger(),
                 [
-                    'mysql' => 'bigint(20)',
+                    'mysql' => 'bigint',
                     'pgsql' => 'bigint',
                     'sqlite' => 'bigint',
                     'oci' => 'NUMBER(20)',
@@ -98,7 +98,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_BIGINT . ' NOT NULL',
                 $this->bigInteger()->notNull(),
                 [
-                    'mysql' => 'bigint(20) NOT NULL',
+                    'mysql' => 'bigint NOT NULL',
                     'pgsql' => 'bigint NOT NULL',
                     'sqlite' => 'bigint NOT NULL',
                     'oci' => 'NUMBER(20) NOT NULL',
@@ -109,7 +109,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_BIGINT . ' CHECK (value > 5)',
                 $this->bigInteger()->check('value > 5'),
                 [
-                    'mysql' => 'bigint(20) CHECK (value > 5)',
+                    'mysql' => 'bigint CHECK (value > 5)',
                     'pgsql' => 'bigint CHECK (value > 5)',
                     'sqlite' => 'bigint CHECK (value > 5)',
                     'oci' => 'NUMBER(20) CHECK (value > 5)',
@@ -120,7 +120,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_BIGINT . '(8)',
                 $this->bigInteger(8),
                 [
-                    'mysql' => 'bigint(8)',
+                    'mysql' => 'bigint',
                     'pgsql' => 'bigint',
                     'sqlite' => 'bigint',
                     'oci' => 'NUMBER(8)',
@@ -131,7 +131,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_BIGINT . '(8) CHECK (value > 5)',
                 $this->bigInteger(8)->check('value > 5'),
                 [
-                    'mysql' => 'bigint(8) CHECK (value > 5)',
+                    'mysql' => 'bigint CHECK (value > 5)',
                     'pgsql' => 'bigint CHECK (value > 5)',
                     'sqlite' => 'bigint CHECK (value > 5)',
                     'oci' => 'NUMBER(8) CHECK (value > 5)',
@@ -142,7 +142,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_BIGPK,
                 $this->bigPrimaryKey(),
                 [
-                    'mysql' => 'bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY',
+                    'mysql' => 'bigint NOT NULL AUTO_INCREMENT PRIMARY KEY',
                     'pgsql' => 'bigserial NOT NULL PRIMARY KEY',
                     'sqlite' => 'integer PRIMARY KEY AUTOINCREMENT NOT NULL',
                 ],
@@ -453,7 +453,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_INTEGER . ' CHECK (value > 5)',
                 $this->integer()->check('value > 5'),
                 [
-                    'mysql' => 'int(11) CHECK (value > 5)',
+                    'mysql' => 'int CHECK (value > 5)',
                     'pgsql' => 'integer CHECK (value > 5)',
                     'sqlite' => 'integer CHECK (value > 5)',
                     'oci' => 'NUMBER(10) CHECK (value > 5)',
@@ -464,7 +464,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_INTEGER . ' NOT NULL',
                 $this->integer()->notNull(),
                 [
-                    'mysql' => 'int(11) NOT NULL',
+                    'mysql' => 'int NOT NULL',
                     'pgsql' => 'integer NOT NULL',
                     'sqlite' => 'integer NOT NULL',
                     'oci' => 'NUMBER(10) NOT NULL',
@@ -475,7 +475,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_INTEGER . '(8) CHECK (value > 5)',
                 $this->integer(8)->check('value > 5'),
                 [
-                    'mysql' => 'int(8) CHECK (value > 5)',
+                    'mysql' => 'int CHECK (value > 5)',
                     'pgsql' => 'integer CHECK (value > 5)',
                     'sqlite' => 'integer CHECK (value > 5)',
                     'oci' => 'NUMBER(8) CHECK (value > 5)',
@@ -486,7 +486,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_INTEGER . '(8)',
                 $this->integer(8),
                 [
-                    'mysql' => 'int(8)',
+                    'mysql' => 'int',
                     'pgsql' => 'integer',
                     'sqlite' => 'integer',
                     'oci' => 'NUMBER(8)',
@@ -497,7 +497,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_INTEGER,
                 $this->integer(),
                 [
-                    'mysql' => 'int(11)',
+                    'mysql' => 'int',
                     'pgsql' => 'integer',
                     'sqlite' => 'integer',
                     'oci' => 'NUMBER(10)',
@@ -563,7 +563,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_PK . ' CHECK (value > 5)',
                 $this->primaryKey()->check('value > 5'),
                 [
-                    'mysql' => 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY CHECK (value > 5)',
+                    'mysql' => 'int NOT NULL AUTO_INCREMENT PRIMARY KEY CHECK (value > 5)',
                     'pgsql' => 'serial NOT NULL PRIMARY KEY CHECK (value > 5)',
                     'sqlite' => 'integer PRIMARY KEY AUTOINCREMENT NOT NULL CHECK (value > 5)',
                     'oci' => 'NUMBER(10) NOT NULL PRIMARY KEY CHECK (value > 5)',
@@ -574,7 +574,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_PK . '(8) CHECK (value > 5)',
                 $this->primaryKey(8)->check('value > 5'),
                 [
-                    'mysql' => 'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY CHECK (value > 5)',
+                    'mysql' => 'int NOT NULL AUTO_INCREMENT PRIMARY KEY CHECK (value > 5)',
                     'oci' => 'NUMBER(8) NOT NULL PRIMARY KEY CHECK (value > 5)',
                 ],
             ],
@@ -582,7 +582,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_PK . '(8)',
                 $this->primaryKey(8),
                 [
-                    'mysql' => 'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY',
+                    'mysql' => 'int NOT NULL AUTO_INCREMENT PRIMARY KEY',
                     'oci' => 'NUMBER(8) NOT NULL PRIMARY KEY',
                 ],
             ],
@@ -590,7 +590,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_PK,
                 $this->primaryKey(),
                 [
-                    'mysql' => 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY',
+                    'mysql' => 'int NOT NULL AUTO_INCREMENT PRIMARY KEY',
                     'pgsql' => 'serial NOT NULL PRIMARY KEY',
                     'sqlite' => 'integer PRIMARY KEY AUTOINCREMENT NOT NULL',
                     'oci' => 'NUMBER(10) NOT NULL PRIMARY KEY',
@@ -601,7 +601,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_TINYINT . '(2)',
                 $this->tinyInteger(2),
                 [
-                    'mysql' => 'tinyint(2)',
+                    'mysql' => 'tinyint',
                     'pgsql' => 'smallint',
                     'sqlite' => 'tinyint',
                     'oci' => 'NUMBER(2)',
@@ -612,7 +612,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_TINYINT . ' UNSIGNED',
                 $this->tinyInteger()->unsigned(),
                 [
-                    'mysql' => 'tinyint(3) UNSIGNED',
+                    'mysql' => 'tinyint UNSIGNED',
                     'sqlite' => 'tinyint UNSIGNED',
                 ]
             ],
@@ -620,7 +620,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_TINYINT,
                 $this->tinyInteger(),
                 [
-                    'mysql' => 'tinyint(3)',
+                    'mysql' => 'tinyint',
                     'pgsql' => 'smallint',
                     'sqlite' => 'tinyint',
                     'oci' => 'NUMBER(3)',
@@ -631,7 +631,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_SMALLINT . '(8)',
                 $this->smallInteger(8),
                 [
-                    'mysql' => 'smallint(8)',
+                    'mysql' => 'smallint',
                     'pgsql' => 'smallint',
                     'sqlite' => 'smallint',
                     'oci' => 'NUMBER(8)',
@@ -642,7 +642,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_SMALLINT,
                 $this->smallInteger(),
                 [
-                    'mysql' => 'smallint(6)',
+                    'mysql' => 'smallint',
                     'pgsql' => 'smallint',
                     'sqlite' => 'smallint',
                     'oci' => 'NUMBER(5)',
@@ -876,7 +876,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_UPK,
                 $this->primaryKey()->unsigned(),
                 [
-                    'mysql' => 'int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
+                    'mysql' => 'int UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
                     'pgsql' => 'serial NOT NULL PRIMARY KEY',
                     'sqlite' => 'integer PRIMARY KEY AUTOINCREMENT NOT NULL',
                 ],
@@ -885,7 +885,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_UBIGPK,
                 $this->bigPrimaryKey()->unsigned(),
                 [
-                    'mysql' => 'bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
+                    'mysql' => 'bigint UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
                     'pgsql' => 'bigserial NOT NULL PRIMARY KEY',
                     'sqlite' => 'integer PRIMARY KEY AUTOINCREMENT NOT NULL',
                 ],
@@ -894,7 +894,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_INTEGER . " COMMENT 'test comment'",
                 $this->integer()->comment('test comment'),
                 [
-                    'mysql' => "int(11) COMMENT 'test comment'",
+                    'mysql' => "int COMMENT 'test comment'",
                     'sqlsrv' => 'int',
                 ],
                 [
@@ -905,7 +905,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_PK . " COMMENT 'test comment'",
                 $this->primaryKey()->comment('test comment'),
                 [
-                    'mysql' => "int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'test comment'",
+                    'mysql' => "int NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'test comment'",
                     'sqlsrv' => 'int IDENTITY PRIMARY KEY',
                 ],
                 [
@@ -916,7 +916,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_PK . ' FIRST',
                 $this->primaryKey()->first(),
                 [
-                    'mysql' => 'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
+                    'mysql' => 'int NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
                     'sqlsrv' => 'int IDENTITY PRIMARY KEY',
                 ],
                 [
@@ -928,7 +928,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_INTEGER . ' FIRST',
                 $this->integer()->first(),
                 [
-                    'mysql' => 'int(11) FIRST',
+                    'mysql' => 'int FIRST',
                     'sqlsrv' => 'int',
                 ],
                 [
@@ -953,7 +953,7 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 Schema::TYPE_INTEGER . ' NOT NULL FIRST',
                 $this->integer()->append('NOT NULL')->first(),
                 [
-                    'mysql' => 'int(11) NOT NULL FIRST',
+                    'mysql' => 'int NOT NULL FIRST',
                     'sqlsrv' => 'int NOT NULL',
                 ],
                 [

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -9,7 +9,6 @@
 namespace yiiunit\framework\db\mysql;
 
 use Closure;
-use PDO;
 use PHPUnit\Framework\Attributes\Group;
 use yii\base\DynamicModel;
 use yii\base\NotSupportedException;
@@ -40,42 +39,42 @@ final class QueryBuilderTest extends BaseQueryBuilder
             [
                 Schema::TYPE_PK . ' AFTER `col_before`',
                 $this->primaryKey()->after('col_before'),
-                'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER `col_before`',
+                'int NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER `col_before`',
             ],
             [
                 Schema::TYPE_PK . ' FIRST',
                 $this->primaryKey()->first(),
-                'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
+                'int NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
             ],
             [
                 Schema::TYPE_PK . ' FIRST',
                 $this->primaryKey()->first()->after('col_before'),
-                'int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
+                'int NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
             ],
             [
                 Schema::TYPE_PK . '(8) AFTER `col_before`',
                 $this->primaryKey(8)->after('col_before'),
-                'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER `col_before`',
+                'int NOT NULL AUTO_INCREMENT PRIMARY KEY AFTER `col_before`',
             ],
             [
                 Schema::TYPE_PK . '(8) FIRST',
                 $this->primaryKey(8)->first(),
-                'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
+                'int NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
             ],
             [
                 Schema::TYPE_PK . '(8) FIRST',
                 $this->primaryKey(8)->first()->after('col_before'),
-                'int(8) NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
+                'int NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST',
             ],
             [
                 Schema::TYPE_PK . " COMMENT 'test' AFTER `col_before`",
                 $this->primaryKey()->comment('test')->after('col_before'),
-                "int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'test' AFTER `col_before`",
+                "int NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'test' AFTER `col_before`",
             ],
             [
                 Schema::TYPE_PK . " COMMENT 'testing \'quote\'' AFTER `col_before`",
                 $this->primaryKey()->comment('testing \'quote\'')->after('col_before'),
-                "int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'testing \'quote\'' AFTER `col_before`",
+                "int NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'testing \'quote\'' AFTER `col_before`",
             ],
         ];
 
@@ -100,54 +99,34 @@ final class QueryBuilderTest extends BaseQueryBuilder
             [
                 Schema::TYPE_DATETIME . ' NOT NULL',
                 $this->dateTime()->notNull(),
-                'datetime NOT NULL',
+                'datetime(0) NOT NULL',
             ],
             [
                 Schema::TYPE_DATETIME,
                 $this->dateTime(),
-                'datetime',
+                'datetime(0)',
             ],
             [
                 Schema::TYPE_TIME . ' NOT NULL',
                 $this->time()->notNull(),
-                'time NOT NULL',
+                'time(0) NOT NULL',
             ],
             [
                 Schema::TYPE_TIME,
                 $this->time(),
-                'time',
+                'time(0)',
             ],
             [
                 Schema::TYPE_TIMESTAMP . ' NOT NULL',
                 $this->timestamp()->notNull(),
-                'timestamp NOT NULL',
+                'timestamp(0) NOT NULL',
             ],
             [
                 Schema::TYPE_TIMESTAMP . ' NULL DEFAULT NULL',
                 $this->timestamp()->defaultValue(null),
-                'timestamp NULL DEFAULT NULL',
+                'timestamp(0) NULL DEFAULT NULL',
             ],
         ];
-
-        /**
-         * @link https://github.com/yiisoft/yii2/issues/14367
-         */
-        $mysqlVersion = $this->getDb()->getSlavePdo(true)->getAttribute(PDO::ATTR_SERVER_VERSION);
-        $supportsFractionalSeconds = version_compare($mysqlVersion, '5.6.4', '>=');
-        if ($supportsFractionalSeconds) {
-            $expectedValues = [
-                'datetime(0) NOT NULL',
-                'datetime(0)',
-                'time(0) NOT NULL',
-                'time(0)',
-                'timestamp(0) NOT NULL',
-                'timestamp(0) NULL DEFAULT NULL',
-            ];
-
-            foreach ($expectedValues as $index => $expected) {
-                $columns[$index][2] = $expected;
-            }
-        }
 
         /**
          * @link https://github.com/yiisoft/yii2/issues/14834
@@ -163,7 +142,7 @@ final class QueryBuilderTest extends BaseQueryBuilder
             $columns[] = [
                 Schema::TYPE_TIMESTAMP,
                 $this->timestamp(),
-                $supportsFractionalSeconds ? 'timestamp(0)' : 'timestamp',
+                'timestamp(0)',
             ];
         }
 

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -15,19 +17,20 @@ use yii\db\mysql\Schema;
 use yiiunit\framework\db\AnyCaseValue;
 use yiiunit\base\db\BaseSchema;
 
+use function stripos;
+
 /**
- * @group db
- * @group mysql
+ * Unit test for {@see \yii\db\mysql\Schema} class.
  */
-class SchemaTest extends BaseSchema
+#[Group('db')]
+#[Group('mysql')]
+#[Group('schema')]
+final class SchemaTest extends BaseSchema
 {
     public $driverName = 'mysql';
 
     public function testLoadDefaultDatetimeColumn(): void
     {
-        if (!version_compare($this->getConnection()->pdo->getAttribute(PDO::ATTR_SERVER_VERSION), '5.6', '>=')) {
-            $this->markTestSkipped('Default datetime columns are supported since MySQL 5.6.');
-        }
         $sql = <<<SQL
 CREATE TABLE  IF NOT EXISTS `datetime_test`  (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -49,9 +52,6 @@ SQL;
 
     public function testDefaultDatetimeColumnWithMicrosecs(): void
     {
-        if (!version_compare($this->getConnection()->pdo->getAttribute(PDO::ATTR_SERVER_VERSION), '5.6.4', '>=')) {
-            $this->markTestSkipped('CURRENT_TIMESTAMP with microseconds as default column value is supported since MySQL 5.6.4.');
-        }
         $sql = <<<SQL
 CREATE TABLE  IF NOT EXISTS `current_timestamp_test`  (
   `dt` datetime(2) NOT NULL DEFAULT CURRENT_TIMESTAMP(2),
@@ -85,7 +85,6 @@ SQL;
         $result['1: check'][2][0]->expression = "`C_check` <> ''";
         $result['2: primary key'][2]->name = null;
 
-        // Work aroung bug in MySQL 5.1 - it creates only this table in lowercase. O_o
         $result['3: foreign key'][2][0]->foreignTableName = new AnyCaseValue('T_constraints_2');
 
         return $result;
@@ -260,110 +259,97 @@ SQL;
     {
         $version = $this->getConnection(false)->getServerVersion();
 
-        $columns = array_merge(
-            parent::getExpectedColumns(),
-            [
-                'int_col' => [
+        $columns = [
+            ...parent::getExpectedColumns(),
+            'int_col' => [
                     'type' => 'integer',
-                    'dbType' => 'int(11)',
+                    'dbType' => 'int',
                     'phpType' => 'integer',
                     'allowNull' => false,
                     'autoIncrement' => false,
                     'enumValues' => null,
-                    'size' => 11,
-                    'precision' => 11,
+                    'size' => null,
+                    'precision' => null,
                     'scale' => null,
                     'defaultValue' => null,
                 ],
                 'int_col2' => [
                     'type' => 'integer',
-                    'dbType' => 'int(11)',
+                    'dbType' => 'int',
                     'phpType' => 'integer',
                     'allowNull' => true,
                     'autoIncrement' => false,
                     'enumValues' => null,
-                    'size' => 11,
-                    'precision' => 11,
+                    'size' => null,
+                    'precision' => null,
                     'scale' => null,
                     'defaultValue' => 1,
                 ],
                 'int_col3' => [
                     'type' => 'integer',
-                    'dbType' => 'int(11) unsigned',
+                    'dbType' => 'int unsigned',
                     'phpType' => 'integer',
                     'allowNull' => true,
                     'autoIncrement' => false,
                     'enumValues' => null,
-                    'size' => 11,
-                    'precision' => 11,
+                    'size' => null,
+                    'precision' => null,
                     'scale' => null,
                     'defaultValue' => 1,
                 ],
                 'tinyint_col' => [
                     'type' => 'tinyint',
-                    'dbType' => 'tinyint(3)',
+                    'dbType' => 'tinyint',
                     'phpType' => 'integer',
                     'allowNull' => true,
                     'autoIncrement' => false,
                     'enumValues' => null,
-                    'size' => 3,
-                    'precision' => 3,
+                    'size' => null,
+                    'precision' => null,
                     'scale' => null,
                     'defaultValue' => 1,
                 ],
                 'smallint_col' => [
                     'type' => 'smallint',
-                    'dbType' =>  'smallint(1)',
+                    'dbType' => 'smallint',
                     'phpType' => 'integer',
                     'allowNull' => true,
                     'autoIncrement' => false,
                     'enumValues' => null,
-                    'size' => 1,
-                    'precision' => 1,
+                    'size' => null,
+                    'precision' => null,
                     'scale' => null,
                     'defaultValue' => 1,
                 ],
                 'bigint_col' => [
                     'type' => 'bigint',
-                    'dbType' => 'bigint(20) unsigned',
+                    'dbType' => 'bigint unsigned',
                     'phpType' => 'string',
                     'allowNull' => true,
                     'autoIncrement' => false,
                     'enumValues' => null,
-                    'size' => 20,
-                    'precision' => 20,
+                    'size' => null,
+                    'precision' => null,
                     'scale' => null,
                     'defaultValue' => null,
-                ],
-            ]
-        );
+                ]
+        ];
 
-        if (\version_compare($version, '8.0.17', '>') && \stripos($version, 'MariaDb') === false) {
-            $columns['int_col']['dbType'] = 'int';
-            $columns['int_col']['size'] = null;
-            $columns['int_col']['precision'] = null;
-            $columns['int_col2']['dbType'] = 'int';
-            $columns['int_col2']['size'] = null;
-            $columns['int_col2']['precision'] = null;
-            $columns['int_col3']['dbType'] = 'int unsigned';
-            $columns['int_col3']['size'] = null;
-            $columns['int_col3']['precision'] = null;
-            $columns['tinyint_col']['dbType'] = 'tinyint';
-            $columns['tinyint_col']['size'] = null;
-            $columns['tinyint_col']['precision'] = null;
-            $columns['smallint_col']['dbType'] = 'smallint';
-            $columns['smallint_col']['size'] = null;
-            $columns['smallint_col']['precision'] = null;
-            $columns['bigint_col']['dbType'] = 'bigint unsigned';
-            $columns['bigint_col']['size'] = null;
-            $columns['bigint_col']['precision'] = null;
-        }
+        if (stripos($version, 'MariaDb') !== false) {
+            $mariaDbOverrides = [
+                'int_col' => ['int(11)', 11],
+                'int_col2' => ['int(11)', 11],
+                'int_col3' => ['int(11) unsigned', 11],
+                'tinyint_col' => ['tinyint(3)', 3],
+                'smallint_col' => ['smallint(1)', 1],
+                'bigint_col' => ['bigint(20) unsigned', 20],
+            ];
 
-        if (version_compare($version, '5.7', '<') && \stripos($version, 'MariaDb') === false) {
-            $columns['int_col3']['phpType'] = 'string';
-            $columns['json_col']['type'] = 'text';
-            $columns['json_col']['dbType'] = 'longtext';
-            $columns['json_col']['phpType'] = 'string';
+            foreach ($mariaDbOverrides as $col => [$dbType, $size]) {
+                $columns[$col]['dbType'] = $dbType;
+                $columns[$col]['size'] = $size;
+                $columns[$col]['precision'] = $size;
+            }
         }
 
         return $columns;

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yiiunit\framework\db\mysql;
 
 use PDO;
+use PHPUnit\Framework\Attributes\Group;
 use yii\db\Expression;
 use yii\db\mysql\ColumnSchema;
 use yii\db\mysql\Schema;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
