### PR TITLE
Refactor MariaDB pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; MariaDB `10.6+` is now required for `yii\db\mysql\QueryBuilder` MariaDB pagination.

### DIFF
--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -47,7 +47,7 @@ jobs:
       database-image: mariadb
       database-port: "3306"
       database-type: mysql
-      database-versions: '["10.5","latest"]'
+      database-versions: '["10.6","latest"]'
       extensions: curl, intl, pdo, pdo_mysql
       os: '["ubuntu-22.04"]'
       php-version: '["8.5"]'

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -49,6 +49,7 @@ Yii Framework 2 Change Log
 - Chg #18639: Refactor Oracle pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; Oracle `12.1+` is now required for `yii\db\oci\QueryBuilder` pagination (terabytesoftw)
 - Chg #18639: Refactor MSSQL pagination SQL to use standard `ORDER BY ... OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; SQL Server `2019+` is now required for `yii\db\mssql\QueryBuilder` pagination (terabytesoftw)
 - Chg: Remove MySQL `< 8.0` dead code and deprecated integer display width from MySQL type map (`int(11)` → `int`, `bigint(20)` → `bigint`, etc.); `tinyint(1)` for `TYPE_BOOLEAN` is preserved (terabytesoftw)
+- Chg #18639: Refactor MariaDB pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; MariaDB `10.6+` is now required for `yii\db\mysql\QueryBuilder` MariaDB pagination (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -169,8 +169,8 @@ If your tests assert exact SQL strings for composite `IN` / `NOT IN`, update exp
 
 #### MariaDB pagination now uses `OFFSET ... FETCH` (`10.6+`)
 
-`yii\db\mysql\QueryBuilder::buildOrderByAndLimit()` now emits SQL using MariaDB's standard row-limiting clause when the
-connected server is MariaDB:
+`yii\db\mysql\QueryBuilder::buildLimit()` now delegates to `buildOffsetFetch()` and emits SQL using MariaDB's standard
+row-limiting clause when the connected server is MariaDB:
 
 - `OFFSET <n> ROWS` is emitted only when an offset is set.
 - `FETCH NEXT <n> ROWS ONLY` is emitted whenever a limit is set, including `limit(0)`.

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -183,6 +183,14 @@ If you rely on paginated results without specifying `orderBy()`, note that Maria
 so `OFFSET`/`FETCH` results may vary between executions. Always specify `orderBy()` when you need deterministic
 pagination.
 
+> [!NOTE]
+> **Lifecycle:** MariaDB `10.6` LTS was released on July 6, `2021` and introduced the standard
+> `SELECT ... OFFSET ... FETCH` row-limiting clause. Community support for `10.6` ends on July 6, `2026`. Newer LTS
+> releases are `10.11` (released February 16, `2023`; community support through February 16, `2028`), `11.4` (released
+> May 29, `2024`; community support through May 29, `2029`), and `11.8` (released June 4, `2025`; community support
+> through June 4, `2028`). MariaDB `10.5` LTS reached community support EOL on June 24, `2025` and is no longer covered
+> by Yii. The `10.6+` floor matches the earliest MariaDB release with the standard `OFFSET ... FETCH` syntax.
+
 #### MSSQL pagination now uses `OFFSET ... FETCH` (`2019+`)
 
 `yii\db\mssql\QueryBuilder::buildOrderByAndLimit()` now emits SQL using SQL Server's native row-limiting clause. SQL

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -167,6 +167,22 @@ Example:
 
 If your tests assert exact SQL strings for composite `IN` / `NOT IN`, update expected SQL.
 
+#### MariaDB pagination now uses `OFFSET ... FETCH` (`10.6+`)
+
+`yii\db\mysql\QueryBuilder::buildOrderByAndLimit()` now emits SQL using MariaDB's standard row-limiting clause when the
+connected server is MariaDB:
+
+- `OFFSET <n> ROWS` is emitted only when an offset is set.
+- `FETCH NEXT <n> ROWS ONLY` is emitted whenever a limit is set, including `limit(0)`.
+- No synthetic `ORDER BY` is added when the user did not specify an `ORDER BY`.
+
+MariaDB versions earlier than `10.6` are no longer supported for Yii-generated pagination SQL. MySQL continues to use
+`LIMIT` / `LIMIT ... OFFSET ...` because MySQL's `SELECT` syntax does not support `OFFSET ... FETCH`.
+
+If you rely on paginated results without specifying `orderBy()`, note that MariaDB returns rows in an unspecified order,
+so `OFFSET`/`FETCH` results may vary between executions. Always specify `orderBy()` when you need deterministic
+pagination.
+
 #### MSSQL pagination now uses `OFFSET ... FETCH` (`2019+`)
 
 `yii\db\mssql\QueryBuilder::buildOrderByAndLimit()` now emits SQL using SQL Server's native row-limiting clause. SQL
@@ -197,7 +213,7 @@ Behavioral notes:
 
 #### MySQL dead code removal and integer display width cleanup
 
-The minimum supported MySQL version is now **8.0+** (**MariaDB 10.5+**). The following dead code has been removed:
+The minimum supported MySQL version is now **8.0+** (**MariaDB 10.6+**). The following dead code has been removed:
 
 - `Schema::isOldMysql()` method and `$_oldMysql` property (checked for MySQL <= `5.1`, never called).
 - `QueryBuilder::supportsFractionalSeconds()` method (always `true` for MySQL `8.0+`).

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -16,7 +16,7 @@ use yii\db\Expression;
 use yii\db\Query;
 
 /**
- * QueryBuilder is the query builder for MySQL databases.
+ * QueryBuilder is the query builder for MySQL databases (MySQL 8.0+ and MariaDB 10.6+).
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -202,20 +202,63 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     public function buildLimit($limit, $offset)
     {
+        if (!$this->hasLimit($limit) && !$this->hasOffset($offset)) {
+            return '';
+        }
+
+        if ($this->isMariaDb()) {
+            return $this->buildOffsetFetch($limit, $offset);
+        }
+
         $sql = '';
+
         if ($this->hasLimit($limit)) {
-            $sql = 'LIMIT ' . $limit;
+            $sql = "LIMIT {$limit}";
+
             if ($this->hasOffset($offset)) {
-                $sql .= ' OFFSET ' . $offset;
+                $sql .= " OFFSET {$offset}";
             }
         } elseif ($this->hasOffset($offset)) {
             // limit is not optional in MySQL
             // https://stackoverflow.com/questions/255517/mysql-offset-infinite-rows/271650#271650
             // https://dev.mysql.com/doc/refman/5.7/en/select.html#idm46193796386608
-            $sql = "LIMIT $offset, 18446744073709551615"; // 2^64-1
+            $sql = "LIMIT {$offset}, 18446744073709551615"; // 2^64-1
         }
 
         return $sql;
+    }
+
+    /**
+     * Returns whether the connected server is MariaDB.
+     *
+     * @return bool whether the connected server is MariaDB.
+     */
+    public function isMariaDb()
+    {
+        return stripos($this->db->getServerVersion(), 'MariaDB') !== false;
+    }
+
+    /**
+     * Builds the OFFSET/FETCH clauses for MariaDB 10.6 or newer.
+     *
+     * @param int|Expression $limit The limit number. See [[Query::limit]] for more details.
+     * @param int|Expression $offset The offset number. See [[Query::offset]] for more details.
+     *
+     * @return string SQL statement for OFFSET/FETCH clauses.
+     */
+    protected function buildOffsetFetch($limit, $offset)
+    {
+        $parts = [];
+
+        if ($this->hasOffset($offset)) {
+            $parts[] = "OFFSET {$offset} ROWS";
+        }
+
+        if ($this->hasLimit($limit)) {
+            $parts[] = "FETCH NEXT {$limit} ROWS ONLY";
+        }
+
+        return implode(' ', $parts);
     }
 
     /**

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -28,6 +30,245 @@ final class QueryBuilderTest extends BaseQueryBuilder
 {
     protected $driverName = 'mysql';
     protected static string $driverNameStatic = 'mysql';
+
+    public function testBuildOrderByAndLimitWithOffsetAndLimit(): void
+    {
+        $qb = $this->getConnection(false)->getQueryBuilder();
+
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(10)
+            ->offset(5);
+
+        $expectedQuerySql = $qb->isMariaDb()
+            ? <<<SQL
+            SELECT `id` FROM `example` OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL
+            : <<<SQL
+            SELECT `id` FROM `example` LIMIT 10 OFFSET 5
+            SQL;
+
+        [$actualQuerySql, $actualQueryParams] = $qb->build($query);
+
+        self::assertSame(
+            $expectedQuerySql,
+            $actualQuerySql,
+            'OFFSET and LIMIT should generate the server-specific pagination syntax.',
+        );
+        self::assertSame(
+            [],
+            $actualQueryParams,
+            'OFFSET/LIMIT query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithLimitOnly(): void
+    {
+        $qb = $this->getConnection(false)->getQueryBuilder();
+
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(10);
+
+        $expectedQuerySql = $qb->isMariaDb()
+            ? <<<SQL
+            SELECT `id` FROM `example` FETCH NEXT 10 ROWS ONLY
+            SQL
+            : <<<SQL
+            SELECT `id` FROM `example` LIMIT 10
+            SQL;
+
+        [$actualQuerySql, $actualQueryParams] = $qb->build($query);
+
+        self::assertSame(
+            $expectedQuerySql,
+            $actualQuerySql,
+            'LIMIT without OFFSET should generate the server-specific limit syntax.',
+        );
+        self::assertSame(
+            [],
+            $actualQueryParams,
+            'LIMIT-only query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithOffsetOnly(): void
+    {
+        $qb = $this->getConnection(false)->getQueryBuilder();
+
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->offset(10);
+
+        $expectedQuerySql = $qb->isMariaDb()
+            ? <<<SQL
+            SELECT `id` FROM `example` OFFSET 10 ROWS
+            SQL
+            : <<<SQL
+            SELECT `id` FROM `example` LIMIT 10, 18446744073709551615
+            SQL;
+
+        [$actualQuerySql, $actualQueryParams] = $qb->build($query);
+
+        self::assertSame(
+            $expectedQuerySql,
+            $actualQuerySql,
+            'OFFSET without LIMIT should generate the server-specific offset syntax.',
+        );
+        self::assertSame(
+            [],
+            $actualQueryParams,
+            'OFFSET-only query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithoutOffsetAndLimit(): void
+    {
+        $qb = $this->getConnection(false)->getQueryBuilder();
+
+        $query = (new Query())
+            ->select('id')
+            ->from('example');
+
+        [$actualQuerySql, $actualQueryParams] = $qb->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT `id` FROM `example`
+            SQL,
+            $actualQuerySql,
+            'Query without OFFSET/LIMIT should not contain pagination clauses.',
+        );
+        self::assertSame(
+            [],
+            $actualQueryParams,
+            'Query without OFFSET/LIMIT should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithOrderByWithoutPagination(): void
+    {
+        $qb = $this->getConnection(false)->getQueryBuilder();
+
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->orderBy('id');
+
+        [$actualQuerySql, $actualQueryParams] = $qb->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT `id` FROM `example` ORDER BY `id`
+            SQL,
+            $actualQuerySql,
+            'ORDER BY without OFFSET/LIMIT should not contain pagination clauses.',
+        );
+        self::assertSame(
+            [],
+            $actualQueryParams,
+            'ORDER BY without pagination should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithZeroLimit(): void
+    {
+        $qb = $this->getConnection(false)->getQueryBuilder();
+
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(0);
+
+        $expectedQuerySql = $qb->isMariaDb()
+            ? <<<SQL
+            SELECT `id` FROM `example` FETCH NEXT 0 ROWS ONLY
+            SQL
+            : <<<SQL
+            SELECT `id` FROM `example` LIMIT 0
+            SQL;
+
+        [$actualQuerySql, $actualQueryParams] = $qb->build($query);
+
+        self::assertSame(
+            $expectedQuerySql,
+            $actualQuerySql,
+            "Limit '0' should generate the server-specific zero-limit syntax.",
+        );
+        self::assertSame(
+            [],
+            $actualQueryParams,
+            "Limit '0' query should have no bound parameters.",
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithExplicitOrderBy(): void
+    {
+        $qb = $this->getConnection(false)->getQueryBuilder();
+
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->orderBy('id')
+            ->limit(10)
+            ->offset(5);
+
+        $expectedQuerySql = $qb->isMariaDb()
+            ? <<<SQL
+            SELECT `id` FROM `example` ORDER BY `id` OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL
+            : <<<SQL
+            SELECT `id` FROM `example` ORDER BY `id` LIMIT 10 OFFSET 5
+            SQL;
+
+        [$actualQuerySql, $actualQueryParams] = $qb->build($query);
+
+        self::assertSame(
+            $expectedQuerySql,
+            $actualQuerySql,
+            'Explicit ORDER BY should be preserved alongside server-specific pagination clauses.',
+        );
+        self::assertSame(
+            [],
+            $actualQueryParams,
+            'Query with explicit ORDER BY should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithExpressionLimitAndOffset(): void
+    {
+        $qb = $this->getConnection(false)->getQueryBuilder();
+
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(new Expression('10'))
+            ->offset(new Expression('5'));
+
+        $expectedQuerySql = $qb->isMariaDb()
+            ? <<<SQL
+            SELECT `id` FROM `example` OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL
+            : <<<SQL
+            SELECT `id` FROM `example` LIMIT 10 OFFSET 5
+            SQL;
+
+        [$actualQuerySql, $actualQueryParams] = $qb->build($query);
+
+        self::assertSame(
+            $expectedQuerySql,
+            $actualQuerySql,
+            'Integer Expression values should generate server-specific pagination clauses.',
+        );
+        self::assertSame(
+            [],
+            $actualQueryParams,
+            'Pagination query with integer expressions should have no bound parameters.',
+        );
+    }
 
     /**
      * This is not used as a dataprovider for testGetColumnType to speed up the test
@@ -208,13 +449,22 @@ final class QueryBuilderTest extends BaseQueryBuilder
                 3 => 'INSERT INTO `T_upsert` (`email`, `address`, `status`, `profile_id`) VALUES (:qp0, :qp1, :qp2, :qp3) ON DUPLICATE KEY UPDATE `email`=`T_upsert`.`email`',
             ],
             'query' => [
-                3 => 'INSERT INTO `T_upsert` (`email`, `status`) SELECT `email`, 2 AS `status` FROM `customer` WHERE `name`=:qp0 LIMIT 1 ON DUPLICATE KEY UPDATE `status`=VALUES(`status`)',
+                3 => [
+                    'INSERT INTO `T_upsert` (`email`, `status`) SELECT `email`, 2 AS `status` FROM `customer` WHERE `name`=:qp0 LIMIT 1 ON DUPLICATE KEY UPDATE `status`=VALUES(`status`)',
+                    'INSERT INTO `T_upsert` (`email`, `status`) SELECT `email`, 2 AS `status` FROM `customer` WHERE `name`=:qp0 FETCH NEXT 1 ROWS ONLY ON DUPLICATE KEY UPDATE `status`=VALUES(`status`)',
+                ],
             ],
             'query with update part' => [
-                3 => 'INSERT INTO `T_upsert` (`email`, `status`) SELECT `email`, 2 AS `status` FROM `customer` WHERE `name`=:qp0 LIMIT 1 ON DUPLICATE KEY UPDATE `address`=:qp1, `status`=:qp2, `orders`=T_upsert.orders + 1',
+                3 => [
+                    'INSERT INTO `T_upsert` (`email`, `status`) SELECT `email`, 2 AS `status` FROM `customer` WHERE `name`=:qp0 LIMIT 1 ON DUPLICATE KEY UPDATE `address`=:qp1, `status`=:qp2, `orders`=T_upsert.orders + 1',
+                    'INSERT INTO `T_upsert` (`email`, `status`) SELECT `email`, 2 AS `status` FROM `customer` WHERE `name`=:qp0 FETCH NEXT 1 ROWS ONLY ON DUPLICATE KEY UPDATE `address`=:qp1, `status`=:qp2, `orders`=T_upsert.orders + 1',
+                ],
             ],
             'query without update part' => [
-                3 => 'INSERT INTO `T_upsert` (`email`, `status`) SELECT `email`, 2 AS `status` FROM `customer` WHERE `name`=:qp0 LIMIT 1 ON DUPLICATE KEY UPDATE `email`=`T_upsert`.`email`',
+                3 => [
+                    'INSERT INTO `T_upsert` (`email`, `status`) SELECT `email`, 2 AS `status` FROM `customer` WHERE `name`=:qp0 LIMIT 1 ON DUPLICATE KEY UPDATE `email`=`T_upsert`.`email`',
+                    'INSERT INTO `T_upsert` (`email`, `status`) SELECT `email`, 2 AS `status` FROM `customer` WHERE `name`=:qp0 FETCH NEXT 1 ROWS ONLY ON DUPLICATE KEY UPDATE `email`=`T_upsert`.`email`',
+                ],
             ],
             'values and expressions' => [
                 3 => 'INSERT INTO {{%T_upsert}} ({{%T_upsert}}.[[email]], [[ts]]) VALUES (:qp0, now())',

--- a/tests/framework/db/mysql/QueryTest.php
+++ b/tests/framework/db/mysql/QueryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,17 +10,85 @@
 
 namespace yiiunit\framework\db\mysql;
 
+use PHPUnit\Framework\Attributes\Group;
 use yii\db\Expression;
 use yii\db\Query;
 use yiiunit\base\db\BaseQuery;
 
 /**
- * @group db
- * @group mysql
+ * Unit test for {@see \yii\db\Query} with MySQL driver.
  */
+#[Group('db')]
+#[Group('mysql')]
+#[Group('query')]
 class QueryTest extends BaseQuery
 {
     protected $driverName = 'mysql';
+
+    public function testLimitOffsetExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id', 'name'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(1)
+            ->offset(1)
+            ->all($db);
+
+        self::assertCount(
+            1,
+            $rows,
+            "LIMIT '1' OFFSET '1' should return exactly one row.",
+        );
+        self::assertSame(
+            2,
+            $rows[0]['id'],
+            "OFFSET '1' should skip the first row and start at 'id=2'.",
+        );
+        self::assertSame(
+            'user2',
+            $rows[0]['name'],
+            "Row at OFFSET '1' should correspond to 'user2'.",
+        );
+    }
+
+    public function testOffsetExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->offset(1)
+            ->column($db);
+
+        self::assertSame(
+            [2, 3],
+            $rows,
+            "OFFSET '1' without LIMIT should return remaining rows starting at 'id=2'.",
+        );
+    }
+
+    public function testLimitExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(2)
+            ->column($db);
+
+        self::assertSame(
+            [1, 2],
+            $rows,
+            "LIMIT '2' without OFFSET should return the first two rows.",
+        );
+    }
 
     /**
      * Tests MySQL specific syntax for index hints.
@@ -36,7 +106,11 @@ class QueryTest extends BaseQuery
 
     public function testLimitOffsetWithExpression(): void
     {
-        $query = (new Query())->from('customer')->select('id')->orderBy('id');
+        $query = (new Query())
+            ->from('customer')
+            ->select('id')
+            ->orderBy('id');
+
         // In MySQL limit and offset arguments must both be nonnegative integer constant
         $query
             ->limit(new Expression('2'))
@@ -44,8 +118,15 @@ class QueryTest extends BaseQuery
 
         $result = $query->column($this->getConnection());
 
-        $this->assertCount(2, $result);
-        $this->assertNotContains(1, $result);
-        $this->assertEquals([2, 3], $result);
+        self::assertCount(
+            2,
+            $result,
+            "Expression LIMIT '2' OFFSET '1' should return exactly two rows.",
+        );
+        self::assertSame(
+            [2, 3],
+            $result,
+            "Expression LIMIT '2' OFFSET '1' should return rows with 'id=2' and 'id=3'.",
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #18639

### Summary

This PR addresses the MariaDB part of #18639 by switching MariaDB pagination SQL generation to MariaDB standard row-limiting clause.

`yii\db\mysql\QueryBuilder::buildLimit()` now detects MariaDB via `isMariaDb()` and routes to `buildOffsetFetch()`, which emits:

- `OFFSET <n> ROWS` (only when `offset()` is set, omitted when just `limit()` is used, since MariaDB does not require an `OFFSET` clause to appear with `FETCH NEXT`).
- `FETCH NEXT <n> ROWS ONLY` (emitted whenever `limit()` is set, including `limit(0)`).
- No synthetic `ORDER BY` is added when the user did not specify an `orderBy()`, as MariaDB does not require `ORDER BY` to accompany `OFFSET`/`FETCH`.

MariaDB `10.6+` is now required for `yii\db\mysql\QueryBuilder` MariaDB pagination. 