### PR TITLE
Refactor SQLite offset-only pagination SQL to use documented `LIMIT -1 OFFSET ...`; SQLite continues to use `LIMIT` / `OFFSET` because `OFFSET ... FETCH` is unsupported.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -50,6 +50,7 @@ Yii Framework 2 Change Log
 - Chg #18639: Refactor MSSQL pagination SQL to use standard `ORDER BY ... OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; SQL Server `2019+` is now required for `yii\db\mssql\QueryBuilder` pagination (terabytesoftw)
 - Chg: Remove MySQL `< 8.0` dead code and deprecated integer display width from MySQL type map (`int(11)` → `int`, `bigint(20)` → `bigint`, etc.); `tinyint(1)` for `TYPE_BOOLEAN` is preserved (terabytesoftw)
 - Chg #18639: Refactor MariaDB pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; MariaDB `10.6+` is now required for `yii\db\mysql\QueryBuilder` MariaDB pagination (terabytesoftw)
+- Chg #18639: Refactor SQLite offset-only pagination SQL to use documented `LIMIT -1 OFFSET ...`; SQLite continues to use `LIMIT` / `OFFSET` because `OFFSET ... FETCH` is unsupported (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -191,6 +191,30 @@ pagination.
 > through June 4, `2028`). MariaDB `10.5` LTS reached community support EOL on June 24, `2025` and is no longer covered
 > by Yii. The `10.6+` floor matches the earliest MariaDB release with the standard `OFFSET ... FETCH` syntax.
 
+#### SQLite offset-only pagination now uses `LIMIT -1 OFFSET`
+
+`yii\db\sqlite\QueryBuilder::buildLimit()` continues to emit SQLite's documented `LIMIT` / `OFFSET` syntax. SQLite does
+not support the SQL-standard `OFFSET ... FETCH` row-limiting clause.
+
+Offset-only queries now emit:
+
+```sql
+LIMIT -1 OFFSET <n>
+```
+
+instead of:
+
+```sql
+LIMIT 9223372036854775807 OFFSET <n>
+```
+
+SQLite treats a negative `LIMIT` expression as no upper bound, so the generated SQL remains equivalent while matching
+the documented SQLite behavior. If your tests assert exact SQL strings for SQLite offset-only queries, update the
+expected SQL.
+
+SQLite `LIMIT` and `OFFSET` clauses also accept scalar expressions, so raw `Expression` values such as `1 + 1` remain
+supported in Yii-generated pagination SQL.
+
 #### MSSQL pagination now uses `OFFSET ... FETCH` (`2019+`)
 
 `yii\db\mssql\QueryBuilder::buildOrderByAndLimit()` now emits SQL using SQL Server's native row-limiting clause. SQL

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -464,15 +466,16 @@ class QueryBuilder extends \yii\db\QueryBuilder
     public function buildLimit($limit, $offset)
     {
         $sql = '';
+
         if ($this->hasLimit($limit)) {
-            $sql = 'LIMIT ' . $limit;
+            $sql = "LIMIT {$limit}";
             if ($this->hasOffset($offset)) {
-                $sql .= ' OFFSET ' . $offset;
+                $sql .= " OFFSET {$offset}";
             }
         } elseif ($this->hasOffset($offset)) {
-            // limit is not optional in SQLite
-            // https://www.sqlite.org/syntaxdiagrams.html#select-stmt
-            $sql = "LIMIT 9223372036854775807 OFFSET $offset"; // 2^63-1
+            // LIMIT is not optional before OFFSET in SQLite, and a negative LIMIT means no upper bound.
+            // https://www.sqlite.org/lang_select.html#limitoffset
+            $sql = "LIMIT -1 OFFSET {$offset}";
         }
 
         return $sql;

--- a/tests/framework/db/sqlite/QueryBuilderTest.php
+++ b/tests/framework/db/sqlite/QueryBuilderTest.php
@@ -14,6 +14,8 @@ use Closure;
 use PDO;
 use PHPUnit\Framework\Attributes\Group;
 use yii\base\NotSupportedException;
+use yii\db\Expression;
+use yii\db\Query;
 use yii\db\Schema;
 use yii\db\sqlite\QueryBuilder;
 use yiiunit\base\db\BaseQueryBuilder;
@@ -30,6 +32,208 @@ final class QueryBuilderTest extends BaseQueryBuilder
     protected static string $driverNameStatic = 'sqlite';
 
     protected $likeEscapeCharSql = " ESCAPE '\\'";
+
+    public function testBuildOrderByAndLimitWithOffsetAndLimit(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(10)
+            ->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT `id` FROM `example` LIMIT 10 OFFSET 5
+            SQL,
+            $actualQuerySql,
+            'OFFSET and LIMIT should generate LIMIT x OFFSET y.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'OFFSET/LIMIT query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithLimitOnly(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(10);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT `id` FROM `example` LIMIT 10
+            SQL,
+            $actualQuerySql,
+            'LIMIT without OFFSET should generate LIMIT x.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'LIMIT-only query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithOffsetOnly(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->offset(10);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT `id` FROM `example` LIMIT -1 OFFSET 10
+            SQL,
+            $actualQuerySql,
+            "OFFSET without LIMIT should generate SQLite's documented negative LIMIT sentinel.",
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'OFFSET-only query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithoutOffsetAndLimit(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example');
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT `id` FROM `example`
+            SQL,
+            $actualQuerySql,
+            'Query without OFFSET/LIMIT should not contain pagination clauses.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'Query without OFFSET/LIMIT should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithOrderByWithoutPagination(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->orderBy('id');
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT `id` FROM `example` ORDER BY `id`
+            SQL,
+            $actualQuerySql,
+            'ORDER BY without OFFSET/LIMIT should not contain pagination clauses.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'ORDER BY without pagination should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithZeroLimit(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(0);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT `id` FROM `example` LIMIT 0
+            SQL,
+            $actualQuerySql,
+            "Limit '0' should generate LIMIT '0' and return zero rows.",
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            "Limit '0' query should have no bound parameters.",
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithZeroLimitAndOffset(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(0)
+            ->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT `id` FROM `example` LIMIT 0 OFFSET 5
+            SQL,
+            $actualQuerySql,
+            "Limit '0' with offset should still generate LIMIT '0' and return zero rows.",
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            "Limit '0' with offset query should have no bound parameters.",
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithExplicitOrderBy(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->orderBy('id')
+            ->limit(10)
+            ->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT `id` FROM `example` ORDER BY `id` LIMIT 10 OFFSET 5
+            SQL,
+            $actualQuerySql,
+            'Explicit ORDER BY should be preserved alongside LIMIT/OFFSET clauses.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'Query with explicit ORDER BY should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithExpressionLimitAndOffset(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(new Expression('1 + 1'))
+            ->offset(new Expression('1'));
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT `id` FROM `example` LIMIT 1 + 1 OFFSET 1
+            SQL,
+            $actualQuerySql,
+            'Scalar Expression values should generate LIMIT/OFFSET clauses.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'Pagination query with scalar expressions should have no bound parameters.',
+        );
+    }
 
     public function columnTypes()
     {

--- a/tests/framework/db/sqlite/QueryTest.php
+++ b/tests/framework/db/sqlite/QueryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,16 +10,84 @@
 
 namespace yiiunit\framework\db\sqlite;
 
+use PHPUnit\Framework\Attributes\Group;
 use yii\db\Query;
 use yiiunit\base\db\BaseQuery;
 
 /**
- * @group db
- * @group sqlite
+ * Unit test for {@see \yii\db\Query} with SQLite driver.
  */
+#[Group('db')]
+#[Group('sqlite')]
+#[Group('query')]
 class QueryTest extends BaseQuery
 {
     protected $driverName = 'sqlite';
+
+    public function testLimitOffsetExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id', 'name'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(1)
+            ->offset(1)
+            ->all($db);
+
+        self::assertCount(
+            1,
+            $rows,
+            "LIMIT '1' OFFSET '1' should return exactly one row.",
+        );
+        self::assertSame(
+            '2',
+            $rows[0]['id'],
+            "OFFSET '1' should skip the first row and start at 'id=2'.",
+        );
+        self::assertSame(
+            'user2',
+            $rows[0]['name'],
+            "Row at OFFSET '1' should correspond to 'user2'.",
+        );
+    }
+
+    public function testOffsetExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->offset(1)
+            ->column($db);
+
+        self::assertSame(
+            ['2', '3'],
+            $rows,
+            "OFFSET '1' without LIMIT should return remaining rows starting at 'id=2'.",
+        );
+    }
+
+    public function testLimitExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(2)
+            ->column($db);
+
+        self::assertSame(
+            ['1', '2'],
+            $rows,
+            "LIMIT '2' without OFFSET should return the first two rows.",
+        );
+    }
 
     public function testUnion(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #18639

### Summary

This PR addresses the SQLite part of #18639. Unlike the sibling drivers (Oracle, MSSQL, MariaDB), SQLite does **not** support the SQL-standard `OFFSET ... FETCH NEXT ... ROWS ONLY` clause, so SQLite continues to use its native `LIMIT` / `OFFSET` syntax. This PR aligns the offset-only branch with SQLite's documented "no upper bound" sentinel.

`yii\db\sqlite\QueryBuilder::buildLimit()` now emits:

- `LIMIT <n>` (when only `limit()` is set, including `limit(0)`).
- `LIMIT <n> OFFSET <m>` (when both `limit()` and `offset()` are set).
- `LIMIT -1 OFFSET <m>` (when only `offset()` is set, since `LIMIT` is not optional before `OFFSET` in SQLite, and a negative `LIMIT` means no upper bound per the SQLite docs).
- No synthetic `ORDER BY` is added when the user did not specify an `orderBy()`, since SQLite does not require `ORDER BY` to accompany `LIMIT` / `OFFSET`.

The previous magic number `9223372036854775807` (`2^63-1`, SQLite's max signed integer) is replaced by the documented sentinel `-1` (<https://www.sqlite.org/lang_select.html#limitoffset>). Both forms are semantically equivalent ("return all remaining rows"), but `-1` is the form blessed by SQLite documentation and is shorter, more readable in logs, and not coupled to SQLite's internal integer width.

No minimum SQLite version change is introduced. Negative `LIMIT` has been supported by SQLite since the feature was introduced, so the existing minimum (SQLite `3.7.11+` for batch insert; the broader Yii SQLite floor) is unchanged.