### PR TITLE
Refactor PostgreSQL pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; PostgreSQL `13+` is now required for `yii\db\pgsql\QueryBuilder` pagination.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -52,6 +52,7 @@ Yii Framework 2 Change Log
 - Chg #18639: Refactor MariaDB pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; MariaDB `10.6+` is now required for `yii\db\mysql\QueryBuilder` MariaDB pagination (terabytesoftw)
 - Chg #18639: Refactor SQLite offset-only pagination SQL to use documented `LIMIT -1 OFFSET ...`; SQLite continues to use `LIMIT` / `OFFSET` because `OFFSET ... FETCH` is unsupported (terabytesoftw)
 - Chg: Remove PostgreSQL `< 13.0` dead code; drop `oldUpsert()` CTE workaround for `< 9.5` and identity column version branch in `Schema::findColumns()` for `< 12.0`; minimum supported version is now PostgreSQL `13.0` (terabytesoftw)
+- Chg #18639: Refactor PostgreSQL pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; PostgreSQL `13+` is now required for `yii\db\pgsql\QueryBuilder` pagination (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -302,29 +302,47 @@ pagination.
 > AI Database `26ai` (released January `2026` on-premises) is the newest LTS, with premier support through December
 > 31, `2031`. The `12.1+` floor matches the earliest release with native row-limiting syntax.
 
-#### PostgreSQL dead code removal (minimum `13.0+`)
+#### PostgreSQL
 
-The minimum supported PostgreSQL version is now **`13.0+`**. Every legacy version branch in the PostgreSQL driver
+##### Dead code removal (minimum `13+`)
+
+The minimum supported PostgreSQL version is now **`13+`**. Every legacy version branch in the PostgreSQL driver
 collapses under this floor, and the following dead code has been removed:
 
 - `yii\db\pgsql\QueryBuilder::oldUpsert()` — CTE-based upsert workaround for PostgreSQL `< 9.5`. The `ON CONFLICT`
   syntax (available since PostgreSQL `9.5`) is now used unconditionally.
-- `yii\db\pgsql\QueryBuilder::newUpsert()` — inlined directly into `upsert()` since the version branch is gone.
+- `yii\db\pgsql\QueryBuilder::newUpsert()` — removed; its logic is now inlined into `upsert()`.
 - The `version_compare(..., '9.5', '<')` check in `QueryBuilder::upsert()`.
 - The `version_compare(..., '12.0', '>=')` branch in `Schema::findColumns()` for identity column detection
   (`attidentity != ''`). The identity column clause is now always emitted in the catalogue query.
 
-If your application extends `\yii\db\pgsql\QueryBuilder` and overrides or calls `oldUpsert()` or `newUpsert()`,
-remove those references. The upsert logic now lives directly in `upsert()` using the `ON CONFLICT` syntax.
+If your application extends `\yii\db\pgsql\QueryBuilder` and overrides or calls `oldUpsert()` or `newUpsert()`, remove
+those references. The upsert logic now lives directly in `upsert()` using the `ON CONFLICT` syntax.
+
+##### Pagination now uses `OFFSET ... FETCH` (`13+`)
+
+`yii\db\pgsql\QueryBuilder::buildLimit()` now emits SQL using PostgreSQL's standard row-limiting clause:
+
+- `OFFSET <n> ROWS` is emitted only when an offset is set.
+- `FETCH NEXT <n> ROWS ONLY` is emitted whenever a limit is set, including `limit(0)`.
+- Raw `Expression` values are wrapped in parentheses, for example `FETCH NEXT (1 + 1) ROWS ONLY`.
+- No synthetic `ORDER BY` is added when the user did not specify an `ORDER BY`.
+
+If your tests assert exact SQL strings for PostgreSQL paginated queries, replace expected `LIMIT` / `OFFSET` clauses
+with `OFFSET ... ROWS` / `FETCH NEXT ... ROWS ONLY`.
+
+If you rely on paginated results without specifying `orderBy()`, note that PostgreSQL returns rows in an unspecified
+order, so `OFFSET` / `FETCH` results may vary between executions. Always specify `orderBy()` when you need
+deterministic pagination.
 
 > [!NOTE]
 > **Lifecycle:** PostgreSQL releases one major version per year, each supported for five years. PostgreSQL `13` was
 > released on September 24, `2020` and reached community EOL on November 13, `2025`. Supported majors include
 > PostgreSQL `14` (through November 12, `2026`), `15` (through November 11, `2027`), `16` (through November 9, `2028`),
 > `17` (through November 8, `2029`), and `18` (released September 25, `2025`; through November 14, `2030`).
-> PostgreSQL `12` reached community EOL on November 14, `2024` and is no longer covered by Yii. The `13.0+` floor
-> consolidates the `ON CONFLICT` upsert syntax (PostgreSQL `9.5+`) and `GENERATED AS IDENTITY` columns
-> (PostgreSQL `12+`) under a single code path.
+> PostgreSQL `12` reached community EOL on November 14, `2024` and is no longer covered by Yii. The `13+` floor lets
+> Yii use `ON CONFLICT` upsert (`9.5+`) and `GENERATED AS IDENTITY` columns (`12+`) unconditionally, without runtime
+> version branching.
 
 ### HHVM support removed
 

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -20,7 +20,7 @@ use yii\helpers\StringHelper;
 use function is_bool;
 
 /**
- * QueryBuilder is the query builder for PostgreSQL databases.
+ * QueryBuilder is the query builder for PostgreSQL databases (version 13 and above).
  *
  * @author Gevik Babakhani <gevikb@gmail.com>
  * @since 2.0
@@ -103,6 +103,46 @@ class QueryBuilder extends \yii\db\QueryBuilder
             'yii\db\ArrayExpression' => 'yii\db\pgsql\ArrayExpressionBuilder',
             'yii\db\JsonExpression' => 'yii\db\pgsql\JsonExpressionBuilder',
         ]);
+    }
+
+    /**
+     * Builds the LIMIT and OFFSET clauses for a SELECT query using the PostgreSQL `OFFSET ... FETCH` syntax.
+     *
+     * @param int|\yii\db\ExpressionInterface|null $limit the LIMIT value. `null` or a non-positive integer means no limit.
+     * @param int|\yii\db\ExpressionInterface|null $offset the OFFSET value. `null` or `0` means no offset.
+     * @return string the LIMIT and OFFSET clauses built for PostgreSQL `13+`.
+     */
+    public function buildLimit($limit, $offset)
+    {
+        $sql = '';
+
+        if ($this->hasOffset($offset)) {
+            $sql = 'OFFSET ' . $this->buildLimitOffsetValue($offset) . ' ROWS';
+        }
+
+        if ($this->hasLimit($limit)) {
+            $sql .= ($sql !== '' ? ' ' : '') . 'FETCH NEXT ' . $this->buildLimitOffsetValue($limit) . ' ROWS ONLY';
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Builds a PostgreSQL row-limiting value.
+     *
+     * PostgreSQL allows non-standard expressions in `OFFSET` and `FETCH`, but arithmetic expressions must be enclosed
+     * in parentheses to avoid syntax ambiguity.
+     *
+     * @param int|ExpressionInterface $value The row-limiting value.
+     * @return string The value SQL.
+     */
+    protected function buildLimitOffsetValue($value)
+    {
+        if ($value instanceof Expression) {
+            return '(' . (string) $value . ')';
+        }
+
+        return (string) $value;
     }
 
     /**

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -107,7 +107,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
     /**
      * Builds the LIMIT and OFFSET clauses for a SELECT query using the PostgreSQL `OFFSET ... FETCH` syntax.
      *
-     * @param int|ExpressionInterface|null $limit the LIMIT value. `null` or a non-positive integer means no limit.
+     * @param int|ExpressionInterface|null $limit the LIMIT value. `null` or a negative value means no limit; `0` is
+     * valid and emits `FETCH NEXT 0 ROWS ONLY`.
      * @param int|ExpressionInterface|null $offset the OFFSET value. `null` or `0` means no offset.
      * @return string the LIMIT and OFFSET clauses built for PostgreSQL `13+`.
      */

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -80,7 +80,6 @@ class QueryBuilder extends \yii\db\QueryBuilder
         Schema::TYPE_JSON => 'jsonb',
     ];
 
-
     /**
      * {@inheritdoc}
      */
@@ -108,8 +107,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
     /**
      * Builds the LIMIT and OFFSET clauses for a SELECT query using the PostgreSQL `OFFSET ... FETCH` syntax.
      *
-     * @param int|\yii\db\ExpressionInterface|null $limit the LIMIT value. `null` or a non-positive integer means no limit.
-     * @param int|\yii\db\ExpressionInterface|null $offset the OFFSET value. `null` or `0` means no offset.
+     * @param int|ExpressionInterface|null $limit the LIMIT value. `null` or a non-positive integer means no limit.
+     * @param int|ExpressionInterface|null $offset the OFFSET value. `null` or `0` means no offset.
      * @return string the LIMIT and OFFSET clauses built for PostgreSQL `13+`.
      */
     public function buildLimit($limit, $offset)
@@ -128,12 +127,16 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
-     * Builds a PostgreSQL row-limiting value.
+     * Builds a PostgreSQL row-limiting value for `OFFSET` / `FETCH` clauses.
      *
-     * PostgreSQL allows non-standard expressions in `OFFSET` and `FETCH`, but arithmetic expressions must be enclosed
-     * in parentheses to avoid syntax ambiguity.
+     * PostgreSQL allows scalar expressions in `OFFSET` and `FETCH`, but arithmetic expressions must be enclosed in
+     * parentheses to avoid syntax ambiguity (for example, `FETCH NEXT (1 + 1) ROWS ONLY`).
      *
-     * @param int|ExpressionInterface $value The row-limiting value.
+     * Only `int` and {@see Expression} are supported. Other {@see ExpressionInterface} implementations
+     * ({@see \yii\db\JsonExpression}, {@see \yii\db\ArrayExpression}, {@see PdoValue}) are not valid row-count values
+     * and are not handled here; passing them produces undefined SQL.
+     *
+     * @param int|Expression $value The row-limiting value.
      * @return string The value SQL.
      */
     protected function buildLimitOffsetValue($value)

--- a/tests/framework/db/pgsql/QueryBuilderTest.php
+++ b/tests/framework/db/pgsql/QueryBuilderTest.php
@@ -33,6 +33,185 @@ final class QueryBuilderTest extends BaseQueryBuilder
     public $driverName = 'pgsql';
     protected static string $driverNameStatic = 'pgsql';
 
+    public function testBuildOrderByAndLimitWithOffsetAndLimit(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(10)
+            ->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            'OFFSET and LIMIT should generate OFFSET x ROWS FETCH NEXT y ROWS ONLY.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'OFFSET/LIMIT query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithLimitOnly(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(10);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" FETCH NEXT 10 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            'LIMIT without OFFSET should generate FETCH NEXT y ROWS ONLY.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'LIMIT-only query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithOffsetOnly(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->offset(10);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" OFFSET 10 ROWS
+            SQL,
+            $actualQuerySql,
+            'OFFSET without LIMIT should generate OFFSET x ROWS without FETCH clause.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'OFFSET-only query should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithoutOffsetAndLimit(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example');
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example"
+            SQL,
+            $actualQuerySql,
+            'Query without OFFSET/LIMIT should not contain pagination clauses.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'Query without OFFSET/LIMIT should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithOrderByWithoutPagination(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->orderBy('id');
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" ORDER BY "id"
+            SQL,
+            $actualQuerySql,
+            'ORDER BY without OFFSET/LIMIT should not contain pagination clauses.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'ORDER BY without pagination should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithZeroLimit(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(0);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" FETCH NEXT 0 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            "Limit '0' must emit FETCH NEXT '0' ROWS ONLY.",
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            "Limit '0' query should have no bound parameters.",
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithExplicitOrderBy(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->orderBy('id')
+            ->limit(10)
+            ->offset(5);
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" ORDER BY "id" OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            'Explicit ORDER BY should be preserved alongside OFFSET/FETCH clauses.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'Query with explicit ORDER BY should have no bound parameters.',
+        );
+    }
+
+    public function testBuildOrderByAndLimitWithExpressionLimitAndOffset(): void
+    {
+        $query = (new Query())
+            ->select('id')
+            ->from('example')
+            ->limit(new Expression('1 + 1'))
+            ->offset(new Expression('1'));
+
+        [$actualQuerySql, $actualQueryParams] = $this->getQueryBuilder()->build($query);
+
+        self::assertSame(
+            <<<SQL
+            SELECT "id" FROM "example" OFFSET (1) ROWS FETCH NEXT (1 + 1) ROWS ONLY
+            SQL,
+            $actualQuerySql,
+            'Expression LIMIT/OFFSET values should be wrapped in parentheses for PostgreSQL OFFSET/FETCH.',
+        );
+        self::assertEmpty(
+            $actualQueryParams,
+            'Pagination query with expressions should have no bound parameters.',
+        );
+    }
+
     public function columnTypes()
     {
         $columns = [
@@ -335,13 +514,13 @@ final class QueryBuilderTest extends BaseQueryBuilder
                 ],
             ],
             'query' => [
-                3 => 'INSERT INTO "T_upsert" ("email", "status") SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0 LIMIT 1 ON CONFLICT ("email") DO UPDATE SET "status"=EXCLUDED."status"',
+                3 => 'INSERT INTO "T_upsert" ("email", "status") SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0 FETCH NEXT 1 ROWS ONLY ON CONFLICT ("email") DO UPDATE SET "status"=EXCLUDED."status"',
             ],
             'query with update part' => [
-                3 => 'INSERT INTO "T_upsert" ("email", "status") SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0 LIMIT 1 ON CONFLICT ("email") DO UPDATE SET "address"=:qp1, "status"=:qp2, "orders"=T_upsert.orders + 1',
+                3 => 'INSERT INTO "T_upsert" ("email", "status") SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0 FETCH NEXT 1 ROWS ONLY ON CONFLICT ("email") DO UPDATE SET "address"=:qp1, "status"=:qp2, "orders"=T_upsert.orders + 1',
             ],
             'query without update part' => [
-                3 => 'INSERT INTO "T_upsert" ("email", "status") SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0 LIMIT 1 ON CONFLICT DO NOTHING',
+                3 => 'INSERT INTO "T_upsert" ("email", "status") SELECT "email", 2 AS "status" FROM "customer" WHERE "name"=:qp0 FETCH NEXT 1 ROWS ONLY ON CONFLICT DO NOTHING',
             ],
             'values and expressions' => [
                 3 => 'INSERT INTO {{%T_upsert}} ({{%T_upsert}}.[[email]], [[ts]]) VALUES (:qp0, now())',

--- a/tests/framework/db/pgsql/QueryTest.php
+++ b/tests/framework/db/pgsql/QueryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,16 +10,104 @@
 
 namespace yiiunit\framework\db\pgsql;
 
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\Expression;
 use yii\db\Query;
 use yiiunit\base\db\BaseQuery;
 
 /**
- * @group db
- * @group pgsql
+ * Unit test for {@see \yii\db\Query} with PostgreSQL driver.
  */
+#[Group('db')]
+#[Group('pgsql')]
+#[Group('query')]
 class QueryTest extends BaseQuery
 {
-    public $driverName = 'pgsql';
+    protected $driverName = 'pgsql';
+
+    public function testLimitOffsetExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id', 'name'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(1)
+            ->offset(1)
+            ->all($db);
+
+        self::assertCount(
+            1,
+            $rows,
+            "LIMIT '1' OFFSET '1' should return exactly one row.",
+        );
+        self::assertSame(
+            2,
+            $rows[0]['id'],
+            "OFFSET '1' should skip the first row and start at 'id=2'.",
+        );
+        self::assertSame(
+            'user2',
+            $rows[0]['name'],
+            "Row at OFFSET '1' should correspond to 'user2'.",
+        );
+    }
+
+    public function testOffsetExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->offset(1)
+            ->column($db);
+
+        self::assertSame(
+            [2, 3],
+            $rows,
+            "OFFSET '1' without LIMIT should return remaining rows starting at 'id=2'.",
+        );
+    }
+
+    public function testLimitExecution(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(2)
+            ->column($db);
+
+        self::assertSame(
+            [1, 2],
+            $rows,
+            "LIMIT '2' without OFFSET should return the first two rows.",
+        );
+    }
+
+    public function testLimitOffsetWithExpression(): void
+    {
+        $db = $this->getConnection();
+
+        $rows = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(new Expression('1 + 1'))
+            ->offset(new Expression('1'))
+            ->column($db);
+
+        self::assertSame(
+            [2, 3],
+            $rows,
+            "Expression LIMIT '1 + 1' OFFSET '1' should return rows with 'id=2' and 'id=3'.",
+        );
+    }
 
     public function testBooleanValues(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #18639

### Summary

This PR addresses the PostgreSQL part of #18639 by switching PostgreSQL pagination SQL generation to PostgreSQL standard row-limiting clause.

`yii\db\pgsql\QueryBuilder::buildLimit()` is now overridden in the PostgreSQL driver and emits:

- `OFFSET <n> ROWS` (only when `offset()` is set, omitted when just `limit()` is used, since PostgreSQL does not require an `OFFSET` clause to appear with `FETCH NEXT`).
- `FETCH NEXT <n> ROWS ONLY` (emitted whenever `limit()` is set, including `limit(0)`).
- Raw `Expression` values are wrapped in parentheses via the new `buildLimitOffsetValue()` helper, for example `FETCH NEXT (1 + 1) ROWS ONLY`, since PostgreSQL requires arithmetic expressions inside `OFFSET` / `FETCH` to be parenthesized.
- No synthetic `ORDER BY` is added when the user did not specify an `orderBy()`, as PostgreSQL does not require `ORDER BY` to accompany `OFFSET` / `FETCH` (results without an explicit `orderBy()` are unordered, same as `LIMIT` / `OFFSET`).