### PR TITLE
 Add `Module::$actionMap`, `Module::$actionNamespace`, and `yii\web\Action` for standalone action dispatch with HTTP-aware param binding.

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -176,6 +176,7 @@ Special Topics
 * [Mailing](tutorial-mailing.md)
 * [Performance Tuning](tutorial-performance-tuning.md)
 * [Shared Hosting Environment](tutorial-shared-hosting.md)
+* [Standalone Actions](tutorial-standalone-actions.md)
 * [Template Engines](tutorial-template-engines.md)
 * [Working with Third-Party Code](tutorial-yii-integration.md)
 * [Using Yii as a micro framework](tutorial-yii-as-micro-framework.md)

--- a/docs/guide/tutorial-standalone-actions.md
+++ b/docs/guide/tutorial-standalone-actions.md
@@ -37,7 +37,7 @@ class.
 
 Default file placement (no configuration required, because `$actionNamespace` defaults to `$controllerNamespace`):
 
-```
+```text
 app/controllers/PostController.php           (existing controller, unchanged)
 app/controllers/post/IndexAction.php         (route post/index)
 app/controllers/post/ViewAction.php          (route post/view)
@@ -47,14 +47,27 @@ app/controllers/admin/posts/CreateAction.php (route admin/posts/create)
 The hyphen-to-CamelCase rule applies to the last route segment (`view-summary` resolves to `ViewSummaryAction`);
 preceding segments form a sub-namespace prefix verbatim.
 
+### Choosing the right base class
+
+Yii ships two action base classes for standalone dispatch:
+
+- **[[yii\web\Action]]** — for HTTP endpoints. Reuses [[yii\web\Controller::bindActionParams()]] semantics: scalar
+  coercion (`'7'` → `int 7`), [[yii\web\BadRequestHttpException]] on type mismatches and missing required
+  parameters, and the same DI resolution as web controllers (module components, module DI, container).
+- **[[yii\base\Action]]** — for non-HTTP contexts (queue jobs, scheduled tasks, console-side dispatch). Resolves
+  typed parameters through [[\yii\di\Container::resolveCallableDependencies()]] without HTTP-specific filtering.
+
+For every example below that handles an HTTP request, the action extends `yii\web\Action`. Reserve `yii\base\Action`
+for actions that should not pay HTTP-specific costs nor surface `BadRequestHttpException` on bad scalars.
+
 A realistic example is a health-check endpoint that verifies database connectivity. With the default configuration, drop
 the file at `app/controllers/HealthAction.php`:
 
 ```php
 namespace app\controllers;
 
-use yii\base\Action;
 use yii\db\Connection;
+use yii\web\Action;
 use yii\web\Response;
 
 final class HealthAction extends Action
@@ -147,7 +160,7 @@ The same example could be built with one `PostController` and six `actionXxx` me
 
 ### Folder layout
 
-```
+```text
 app/
     UseCase/
         post/
@@ -292,8 +305,8 @@ final class PostForm extends Model
 
 ### 4. The actions
 
-Each action is a [[yii\base\Action]] subclass that owns its `run()` method. Dependencies are injected by the DI
-container.
+Each action extends [[yii\web\Action]] (HTTP endpoints) and owns its `run()` method. Typed parameters are coerced and
+validated through the same binder as web controllers.
 
 #### `IndexAction` — list with pagination
 
@@ -303,8 +316,8 @@ container.
 namespace app\UseCase\post;
 
 use app\models\Post;
-use yii\base\Action;
 use yii\data\ActiveDataProvider;
+use yii\web\Action;
 
 final class IndexAction extends Action
 {
@@ -338,7 +351,7 @@ when the action is hosted by a controller). Rendering goes through the module's 
 namespace app\UseCase\post;
 
 use app\models\Post;
-use yii\base\Action;
+use yii\web\Action;
 use yii\web\NotFoundHttpException;
 
 final class ViewAction extends Action
@@ -360,8 +373,9 @@ final class ViewAction extends Action
 }
 ```
 
-The `int $id` parameter is filled from the route. The DI container resolves typed scalars from the
-parameters passed to `runAction()` and typed services from the container.
+The `int $id` parameter is filled from the route and coerced by [[yii\web\Action]]'s binder; passing `?id=abc`
+raises [[yii\web\BadRequestHttpException]] (HTTP 400) instead of a `TypeError`. Typed services are resolved from
+module components and the DI container.
 
 #### `CreateAction` — POST with form validation
 
@@ -372,9 +386,9 @@ namespace app\UseCase\post;
 
 use app\models\Post;
 use Yii;
-use yii\base\Action;
 use yii\filters\AccessControl;
 use yii\filters\VerbFilter;
+use yii\web\Action;
 use yii\web\Request;
 use yii\web\Response;
 use yii\web\User;
@@ -530,8 +544,9 @@ wherever `actionNamespace` points). Routing is deterministic:
 4. The controller pipeline tries to resolve a `<X>Controller` with a matching `actionXxx` method.
 5. If no controller method matches, the standalone-action pipeline tries `<X>Action` under `actionNamespace`.
 
-Because controllers always win when both could handle the same route, existing applications can adopt the pattern
-feature by feature. Migrate one slice; leave the rest on controllers. There is no global switch.
+Because ambiguous matches now raise `InvalidConfigException`, existing applications can still adopt the pattern
+feature by feature, but overlapping controller/standalone routes must be disambiguated explicitly. There is no global
+switch.
 
 ## Scaling to N slices
 

--- a/docs/guide/tutorial-standalone-actions.md
+++ b/docs/guide/tutorial-standalone-actions.md
@@ -1,0 +1,634 @@
+# Standalone Actions
+
+> Available since version 22.0.
+
+This tutorial introduces the standalone-action support added in Yii 22.0. A standalone action is a [[yii\base\Action]]
+subclass that handles a route directly, without a hosting controller. There are two mechanisms both optional, both
+additive and they mirror the two mechanisms Yii has always offered for controllers:
+
+- [[yii\base\Module::$actionNamespace]] — convention-based discovery, parallel to
+  [[yii\base\Module::$controllerNamespace]]. Defaults to the value of `$controllerNamespace`, so by default
+  standalone actions live under the same root as controllers.
+- [[yii\base\Module::$actionMap]] — explicit registration, parallel to [[yii\base\Module::$controllerMap]]. Use it for
+  endpoints that do not follow the convention.
+
+The tutorial walks through both, plus a complete CRUD example backed by ActiveRecord.
+
+## The traditional controller approach is unchanged
+
+Everything you already know keeps working in 22.0:
+
+- `app\controllers\PostController` extending [[yii\web\Controller]] with `actionIndex()`, `actionCreate()`,
+  `actionUpdate()`, `actionDelete()` methods.
+- `Controller::actions()` registering reusable [[yii\base\Action]] subclasses such as [[yii\rest\IndexAction]],
+  [[yii\web\ErrorAction]], or your own.
+- `Module::$controllerMap` and namespace-based controller discovery.
+- All filters, behaviors, and CSRF/auth components attached at the controller level.
+
+The new feature is purely additive. Existing applications upgrade without code changes; you only opt in where you want
+the new pattern.
+
+## What 22.0 adds
+
+The headline mechanism is **convention**. Drop a class named `<X>Action` (extending [[yii\base\Action]], not
+[[yii\base\Controller]]) in the right folder, and a route resolves to it. Route segments map to sub-namespaces just as
+they do for controllers; the only differences are the class suffix (`Action` instead of `Controller`) and the parent
+class.
+
+Default file placement (no configuration required, because `$actionNamespace` defaults to `$controllerNamespace`):
+
+```
+app/controllers/PostController.php           (existing controller, unchanged)
+app/controllers/post/IndexAction.php         (route post/index)
+app/controllers/post/ViewAction.php          (route post/view)
+app/controllers/admin/posts/CreateAction.php (route admin/posts/create)
+```
+
+The hyphen-to-CamelCase rule applies to the last route segment (`view-summary` resolves to `ViewSummaryAction`);
+preceding segments form a sub-namespace prefix verbatim.
+
+A realistic example is a health-check endpoint that verifies database connectivity. With the default configuration, drop
+the file at `app/controllers/HealthAction.php`:
+
+```php
+namespace app\controllers;
+
+use yii\base\Action;
+use yii\db\Connection;
+use yii\web\Response;
+
+final class HealthAction extends Action
+{
+    public function run(Connection $db, Response $response): Response
+    {
+        $checks = ['database' => 'unknown'];
+        $statusCode = 200;
+
+        try {
+            $db->createCommand('SELECT 1')->queryScalar();
+
+            $checks['database'] = 'ok';
+        } catch (\Throwable $e) {
+            $checks['database'] = 'failed';
+            $statusCode = 503;
+        }
+
+        $response->format = Response::FORMAT_JSON;
+
+        $response->statusCode = $statusCode;
+
+        $response->data = [
+            'status' => $statusCode === 200 ? 'ok' : 'degraded',
+            'checks' => $checks,
+        ];
+
+        return $response;
+    }
+}
+```
+
+A request whose route resolves to `health` runs `HealthAction::run()` directly. No controller class is instantiated, no
+`actionXxx` method is called, and `Yii::$app->controller` is not set. The action's dependencies (`Connection $db`,
+`Response $response`) are resolved by the DI container based on the typed parameters of `run()`. Filters declared in the
+action's `behaviors()` (such as [[yii\filters\AccessControl]] or [[yii\filters\VerbFilter]]) participate in the lifecycle
+the same way they do on a controller.
+
+For projects that prefer a separate root for standalone actions (vertical slices, use cases, ports/adapters layout), set
+`actionNamespace` to the desired namespace:
+
+```php
+// config/web.php
+return [
+    // ...
+    'actionNamespace' => 'app\\UseCase',
+];
+```
+
+With the line above, controllers continue to live at `app/controllers/PostController.php` (untouched), and standalone
+actions live at `app/UseCase/post/IndexAction.php`, `app/UseCase/admin/posts/CreateAction.php`, etc. Routes resolve
+under `actionNamespace` instead of `controllerNamespace`.
+
+When a route does not follow the convention (custom ID, third-party class, two slices that need disambiguation), use
+[[yii\base\Module::$actionMap]] for explicit registration:
+
+```php
+'actionMap' => [
+    'health' => app\actions\HealthCheckAction::class,
+],
+```
+
+`actionMap` is parallel to `controllerMap` and takes precedence over both `controllerMap` and the convention. It is
+rarely needed in practice; the convention covers most cases.
+
+## When to use which
+
+Use the **traditional controller approach** when:
+
+- Several actions naturally share state, filters, or layout (typical CRUD on a single resource where the controller's
+  `behaviors()` cover all actions).
+- You rely on `view` rendering helpers from [[yii\web\Controller::render()]].
+- You are extending an existing controller-based code base and consistency matters more than slicing.
+
+Use **standalone actions** (convention or `actionMap`) when:
+
+- Each endpoint has its own dependencies, behaviors, or filters and you want them owned by the action.
+- You organize an application as vertical slices or use cases, with each slice in its own folder.
+- The endpoint is single-purpose: webhooks, health checks, integrations, one-shot operations.
+
+Both styles can coexist. A controller can have most of its `actionXxx` methods, and a standalone `<X>Action.php` file
+can fill in a specific action that the controller does **not** implement. If both a controller method and a standalone
+Action class match the same route, `Module::runAction()` throws `InvalidConfigException` so the developer
+disambiguates instead of silently shadowing one or the other.
+
+## A complete CRUD example
+
+The rest of this tutorial builds a `posts` resource with six endpoints organized as a vertical slice under `app/UseCase`.
+The same example could be built with one `PostController` and six `actionXxx` methods; the patterns coexist.
+
+### Folder layout
+
+```
+app/
+    UseCase/
+        post/
+            IndexAction.php
+            ViewAction.php
+            CreateAction.php
+            UpdateAction.php
+            DeleteAction.php
+            SearchAction.php
+            PostForm.php
+            views/
+                index.php
+                view.php
+                form.php
+    models/
+        Post.php
+    migrations/
+        m250101_000000_create_post_table.php
+config/
+    web.php
+```
+
+The folder name `post` (lowercase) is the route segment. Each `*Action.php` file is one HTTP endpoint.
+The form model and views live next to the actions because they are part of the same slice.
+
+### 1. Migration
+
+Migrations are unchanged. Use `safeUp()` and `safeDown()` per Yii conventions:
+
+```php
+use yii\db\Migration;
+
+final class m250101_000000_create_post_table extends Migration
+{
+    public function safeUp(): void
+    {
+        $this->createTable(
+            '{{%post}}',
+            [
+                'id' => $this->primaryKey(),
+                'title' => $this->string(180)->notNull(),
+                'body' => $this->text()->notNull(),
+                'status' => $this->string(20)->notNull()->defaultValue('draft'),
+                'author_id' => $this->integer()->notNull(),
+                'created_at' => $this->integer()->notNull(),
+                'updated_at' => $this->integer()->notNull(),
+            ],
+        );
+        $this->createIndex('idx-post-status', '{{%post}}', 'status');
+        $this->createIndex('idx-post-author_id', '{{%post}}', 'author_id');
+    }
+
+    public function safeDown(): void
+    {
+        $this->dropTable('{{%post}}');
+    }
+}
+```
+
+### 2. ActiveRecord model
+
+`app/models/Post.php` follows standard Yii conventions:
+
+```php
+namespace app\models;
+
+use yii\behaviors\TimestampBehavior;
+use yii\db\ActiveRecord;
+
+final class Post extends ActiveRecord
+{
+    public static function tableName(): string
+    {
+        return '{{%post}}';
+    }
+
+    public function rules(): array
+    {
+        return [
+            [['title', 'body', 'author_id'], 'required'],
+            [['title'], 'string', 'max' => 180],
+            [['body'], 'string'],
+            [['status'], 'in', 'range' => ['draft', 'published', 'archived']],
+            [['author_id'], 'integer'],
+        ];
+    }
+
+    public function attributeLabels(): array
+    {
+        return [
+            'id' => 'ID',
+            'title' => 'Title',
+            'body' => 'Body',
+            'status' => 'Status',
+            'author_id' => 'Author',
+        ];
+    }
+
+    public function behaviors(): array
+    {
+        return [TimestampBehavior::class];
+    }
+}
+```
+
+### 3. Form model (input validation)
+
+`app/UseCase/post/PostForm.php` is a form-only model used by Create and Update. Keeping it separate from the
+ActiveRecord lets you change the table without touching the input contract:
+
+```php
+namespace app\UseCase\post;
+
+use yii\base\Model;
+
+final class PostForm extends Model
+{
+    public string $title = '';
+    public string $body = '';
+    public string $status = 'draft';
+
+    public function rules(): array
+    {
+        return [
+            [['title', 'body'], 'required'],
+            [['title'], 'string', 'max' => 180],
+            [['body'], 'string'],
+            [['status'], 'in', 'range' => ['draft', 'published', 'archived']],
+        ];
+    }
+
+    public function attributeLabels(): array
+    {
+        return [
+            'title' => 'Title',
+            'body' => 'Body',
+            'status' => 'Status',
+        ];
+    }
+}
+```
+
+### 4. The actions
+
+Each action is a [[yii\base\Action]] subclass that owns its `run()` method. Dependencies are injected by the DI
+container.
+
+#### `IndexAction` — list with pagination
+
+`app/UseCase/post/IndexAction.php`:
+
+```php
+namespace app\UseCase\post;
+
+use app\models\Post;
+use yii\base\Action;
+use yii\data\ActiveDataProvider;
+
+final class IndexAction extends Action
+{
+    public function run(): string
+    {
+        $provider = new ActiveDataProvider(
+            [
+                'query' => Post::find()->orderBy(['created_at' => SORT_DESC]),
+                'pagination' => ['pageSize' => 20],
+            ],
+        );
+
+        return $this->getModule()->view->render(
+            '@app/UseCase/post/views/index',
+            ['provider' => $provider],
+            $this,
+        );
+    }
+}
+```
+
+`$this->getModule()` returns the owning module when the action runs standalone (it falls back to the controller's module
+when the action is hosted by a controller). Rendering goes through the module's view component; you can equally inject
+[[yii\web\Response]] and return JSON without touching views.
+
+#### `ViewAction` — show one record
+
+`app/UseCase/post/ViewAction.php`:
+
+```php
+namespace app\UseCase\post;
+
+use app\models\Post;
+use yii\base\Action;
+use yii\web\NotFoundHttpException;
+
+final class ViewAction extends Action
+{
+    public function run(int $id): string
+    {
+        $post = Post::findOne($id);
+
+        if ($post === null) {
+            throw new NotFoundHttpException('Post not found.');
+        }
+
+        return $this->getModule()->view->render(
+            '@app/UseCase/post/views/view',
+            ['post' => $post],
+            $this,
+        );
+    }
+}
+```
+
+The `int $id` parameter is filled from the route. The DI container resolves typed scalars from the
+parameters passed to `runAction()` and typed services from the container.
+
+#### `CreateAction` — POST with form validation
+
+`app/UseCase/post/CreateAction.php`:
+
+```php
+namespace app\UseCase\post;
+
+use app\models\Post;
+use Yii;
+use yii\base\Action;
+use yii\filters\AccessControl;
+use yii\filters\VerbFilter;
+use yii\web\Request;
+use yii\web\Response;
+use yii\web\User;
+
+final class CreateAction extends Action
+{
+    public function behaviors(): array
+    {
+        return [
+            'access' => [
+                'class' => AccessControl::class,
+                'rules' => [['allow' => true, 'roles' => ['@']]],
+            ],
+            'verbs' => [
+                'class' => VerbFilter::class,
+                'actions' => ['create' => ['POST']],
+            ],
+        ];
+    }
+
+    public function run(Request $request, Response $response, User $user, PostForm $form): Response|string
+    {
+        if (!$form->load($request->post()) || !$form->validate()) {
+            $response->statusCode = 422;
+
+            return $this->getModule()->view->render(
+                '@app/UseCase/post/views/form',
+                ['form' => $form],
+                $this,
+            );
+        }
+
+        $post = new Post();
+
+        $post->setAttributes($form->getAttributes());
+        $post->author_id = (int) $user->getId();
+
+        if (!$post->save()) {
+            throw new \RuntimeException('Failed to persist post: ' . print_r($post->errors, true));
+        }
+
+        Yii::$app->session->setFlash('success', 'Post created.');
+
+        return $response->redirect(['post/view', 'id' => $post->id]);
+    }
+}
+```
+
+Three things to notice:
+
+1. `behaviors()` is declared on the action itself. `AccessControl` and `VerbFilter` attach to the action's
+   `EVENT_BEFORE_ACTION` and run before `run()`.
+2. `Request`, `Response`, `User`, and `PostForm` are typed parameters; the DI container resolves each of them.
+   `Request`, `Response`, and `User` are application components (resolved by name), while `PostForm` is autowired by
+   class.
+3. The form is _separate_ from the ActiveRecord. Validation runs on `PostForm`, then attributes are copied to a `Post`
+   instance. This keeps input validation independent of the persistence schema.
+
+#### `UpdateAction`, `DeleteAction`, `SearchAction`
+
+These follow the same pattern. Update is a copy of Create with a leading lookup:
+
+```php
+public function run(int $id, Request $request, Response $response, PostForm $form): Response|string
+{
+    $post = Post::findOne($id) ?? throw new NotFoundHttpException('Post not found.');
+
+    $form->setAttributes($post->getAttributes());
+
+    if ($request->isPut || $request->isPatch) {
+        if ($form->load($request->post()) && $form->validate()) {
+            $post->setAttributes($form->getAttributes());
+            $post->save(false);
+
+            return $response->redirect(
+                [
+                    'post/view',
+                    'id' => $post->id,
+                ],
+            );
+        }
+    }
+
+    return $this->getModule()->view->render(
+        '@app/UseCase/post/views/form',
+        ['form' => $form],
+        $this,
+    );
+}
+```
+
+Delete is even smaller and only needs `VerbFilter` plus an `AccessControl` rule for the destroyer role.
+Search is read-only and accepts `string $q` plus pagination parameters.
+
+### 5. URL configuration
+
+Yii's [[yii\web\UrlManager]] is unchanged; you just point clean URLs at the conventional route strings.
+Verb-prefixed rules give you proper REST routing:
+
+```php
+'urlManager' => [
+    'enablePrettyUrl' => true,
+    'showScriptName' => false,
+    'rules' => [
+        'GET,HEAD posts'           => 'post/index',
+        'GET posts/search'         => 'post/search',
+        'POST posts'               => 'post/create',
+        'GET posts/<id:\d+>'       => 'post/view',
+        'PUT,PATCH posts/<id:\d+>' => 'post/update',
+        'DELETE posts/<id:\d+>'    => 'post/delete',
+    ],
+],
+```
+
+The right-hand side of each rule is a route string. Yii resolves the route by following the standard order: `actionMap`,
+`controllerMap`, sub-modules, controllers by namespace, then standalone actions by namespace. With the layout above,
+`post/index` resolves to `app\UseCase\post\IndexAction` because `actionNamespace` is set to `app\UseCase`. Placeholders
+like `<id:\d+>` are captured and passed to `run()` as named parameters.
+
+### 6. The configuration
+
+The whole vertical slice needs only one configuration line for routing to work — the namespace pointer:
+
+```php
+return [
+    // ...
+    'actionNamespace' => 'app\\UseCase',
+    'urlManager' => [/* rules above */],
+];
+```
+
+There is no per-action registration. Adding a new action is dropping the file at the right path; the next request finds
+it.
+
+If a single action needs a custom ID or different namespace from the rest, register it explicitly through `actionMap`:
+
+```php
+'actionMap' => [
+    'webhooks-stripe' => app\Integrations\Stripe\WebhookHandler::class,
+],
+```
+
+`actionMap` and `actionNamespace` coexist with no conflict; explicit entries take precedence.
+
+### 7. Coexistence with controllers
+
+The same application can declare controllers (in `app/controllers/`) and standalone actions (in `app/UseCase/` or
+wherever `actionNamespace` points). Routing is deterministic:
+
+1. `actionMap` is checked first.
+2. `controllerMap` is checked next.
+3. Sub-modules are matched on the first segment.
+4. The controller pipeline tries to resolve a `<X>Controller` with a matching `actionXxx` method.
+5. If no controller method matches, the standalone-action pipeline tries `<X>Action` under `actionNamespace`.
+
+Because controllers always win when both could handle the same route, existing applications can adopt the pattern
+feature by feature. Migrate one slice; leave the rest on controllers. There is no global switch.
+
+## Scaling to N slices
+
+The convention scales linearly because the resolver is route-driven, not slice-driven. Ten slices look like ten folders
+under `actionNamespace`:
+
+```text
+app/UseCase/
+    post/
+        IndexAction.php
+        ViewAction.php
+        CreateAction.php
+    user/
+        IndexAction.php
+        ProfileAction.php
+        UpdateAction.php
+    order/
+        IndexAction.php
+        ViewAction.php
+        FulfillAction.php
+    product/
+        ...
+    invoice/
+        ...
+    cart/
+        ...
+    checkout/
+        ...
+    notification/
+        ...
+    audit/
+        ...
+    integration/
+        StripeWebhookAction.php
+```
+
+The configuration stays a single line: `'actionNamespace' => 'app\\UseCase'`. Each request performs a single class
+lookup. Route `post/index` only tries `app\UseCase\post\IndexAction`; the resolver does not iterate over the other
+slices, and adding the eleventh slice is dropping a folder. Performance is the same as a controller lookup of equivalent
+depth.
+
+If two slices need entirely different roots (rare), register one of them through a sub-module that has its own
+`actionNamespace`. Sub-modules are an existing Yii2 mechanism; nothing about standalone actions changes how they work.
+
+## Frequently asked questions
+
+**"Is the request really running without any controller?"**
+
+Yes, by design. `Module::runAction()` dispatches the action directly: it builds the [[yii\base\Action]] instance (either
+from `actionMap`, the `actionNamespace` convention, or a user-provided class), fires module before-action events, fires
+the action's own `EVENT_BEFORE_ACTION` (so behaviors like `AccessControl` and `VerbFilter` attach), invokes `run()`
+with arguments resolved through the DI container, then fires the after-action events. No `Controller` subclass is
+instantiated, no `actionXxx` method is called, and `Yii::$app->controller` is not mutated.
+
+**"Where do shared concerns live without a controller?"**
+
+In three places, all of which were already there:
+
+- _Application-wide._ `Yii::$app->components` (session, db, mailer, log, urlManager, …) and bootstrap components are
+  unchanged. They are read by typed parameters in the action's `run()` or pulled directly from `Yii::$app`.
+- _Per route._ The action's own `behaviors()` declares filters (`AccessControl`, `VerbFilter`, `ContentNegotiator`, rate
+  limiting, …). They attach to the action's `EVENT_BEFORE_ACTION` and run before `run()`.
+- _Per module._ `EVENT_BEFORE_ACTION` and `EVENT_AFTER_ACTION` still fire on every ancestor module. Use these for
+  cross-cutting policies like auditing, feature flags, or request logging.
+
+**"Should we migrate every controller to standalone actions?"**
+
+No. Standalone actions pay off when an endpoint has its own dependencies and behaviors that do not need to be shared
+with siblings — webhooks, health checks, integrations, single-purpose use cases, vertical slices. For traditional CRUD
+where four to six methods naturally share filters, layouts, and helper state, a controller remains the simpler choice
+and the standard Yii pattern. Adopt the new pattern feature by feature where it pays off; leave the rest on controllers.
+
+**"What about REST resources and existing `Action` subclasses?"**
+
+[[yii\rest\ActiveController]] and the REST action set ([[yii\rest\IndexAction]], [[yii\rest\ViewAction]], …) keep
+working through `Controller::actions()` exactly as before. They are controller-based by design because they share
+filters and serializer state. Standalone actions are complementary, not a replacement.
+
+**"How do I test a standalone action?"**
+
+The same way you would test any class. Instantiate it with `new YourAction('id', null)`, call `runWithParams([...])`
+with the route parameters, and assert against the result. The DI container resolves typed parameters; for unit tests,
+register stubs in `Yii::$container` before invoking. See `tests/framework/base/StandaloneActionTest.php` and
+`tests/framework/base/ModuleActionNamespaceTest.php` in the framework for working examples.
+
+## Things to keep in mind
+
+- `yii\base\Action::$controller` is `null` for standalone actions. Action classes that read `$this->controller` directly
+  are not standalone-compatible. The framework documents this on [[yii\web\ViewAction]], [[yii\web\ErrorAction]], and
+  [[yii\base\InlineAction]].
+- `yii\filters\AccessRule::matchController()` accepts `null`. A rule with a non-empty `controllers` constraint does not
+  match a standalone action. Leave `controllers` empty (or omit the constraint) when the rule should apply to standalone
+  actions.
+- `Yii::$app->controller` is **not** mutated when a standalone action runs. Code that reads `Yii::$app->controller`
+  mid-request still sees whatever value was set previously (typically `null`).
+- CSRF, session, and authentication components are application-level. They keep working unchanged; nothing about
+  standalone actions disables them.
+- When a controller method AND a standalone Action class both match the same route, `Module::runAction()` throws
+  `InvalidConfigException` so the developer disambiguates explicitly. Existing applications upgrade with no behavioral
+  change because before this release a class file at the convention path was never resolved.

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -53,6 +53,7 @@ Yii Framework 2 Change Log
 - Chg #18639: Refactor SQLite offset-only pagination SQL to use documented `LIMIT -1 OFFSET ...`; SQLite continues to use `LIMIT` / `OFFSET` because `OFFSET ... FETCH` is unsupported (terabytesoftw)
 - Chg: Remove PostgreSQL `< 13.0` dead code; drop `oldUpsert()` CTE workaround for `< 9.5` and identity column version branch in `Schema::findColumns()` for `< 12.0`; minimum supported version is now PostgreSQL `13.0` (terabytesoftw)
 - Chg #18639: Refactor PostgreSQL pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; PostgreSQL `13+` is now required for `yii\db\pgsql\QueryBuilder` pagination (terabytesoftw)
+- Chg: Add `Module::$actionMap` and `Module::$actionNamespace` for standalone action dispatch parallel to controllers (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -53,7 +53,7 @@ Yii Framework 2 Change Log
 - Chg #18639: Refactor SQLite offset-only pagination SQL to use documented `LIMIT -1 OFFSET ...`; SQLite continues to use `LIMIT` / `OFFSET` because `OFFSET ... FETCH` is unsupported (terabytesoftw)
 - Chg: Remove PostgreSQL `< 13.0` dead code; drop `oldUpsert()` CTE workaround for `< 9.5` and identity column version branch in `Schema::findColumns()` for `< 12.0`; minimum supported version is now PostgreSQL `13.0` (terabytesoftw)
 - Chg #18639: Refactor PostgreSQL pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; PostgreSQL `13+` is now required for `yii\db\pgsql\QueryBuilder` pagination (terabytesoftw)
-- Chg: Add `Module::$actionMap` and `Module::$actionNamespace` for standalone action dispatch parallel to controllers (terabytesoftw)
+- Chg: Add `Module::$actionMap`, `Module::$actionNamespace`, and `yii\web\Action` for standalone action dispatch with HTTP-aware param binding (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -457,6 +457,75 @@ compatibility:
 The default implementations now delegate to the configured `$clientScript` handler. Subclasses that call
 `parent::clientValidateAttribute()` or `parent::getClientOptions()` are not affected.
 
+### Standalone actions (`Module::$actionMap` and `Module::$actionNamespace`)
+
+`yii\base\Action::$controller` is now nullable, and two new `yii\base\Module` properties enable routing directly to a
+standalone `yii\base\Action` subclass without a hosting `Controller`:
+
+- `Module::$actionMap` explicit registration, parallel to `Module::$controllerMap`. Each entry maps an ID (the first
+  route segment) to an `Action` class configuration accepted by `Yii::createObject()`.
+- `Module::$actionNamespace` convention-based lookup, parallel to `Module::$controllerNamespace`. Defaults to the
+  value of `controllerNamespace` during `init()`, so by default standalone actions live next to controllers under the
+  same root.
+
+Standalone actions receive constructor and method-level dependencies through the DI container, and `behaviors()`
+declared on the action participate in its lifecycle (`AccessControl`, `VerbFilter`, and similar filters).
+
+The convention-based file placement mirrors controllers, only the suffix and parent class differ:
+
+```
+app/controllers/PostController.php          (existing controller, unchanged)
+app/controllers/post/IndexAction.php        (standalone action, route post/index)
+app/controllers/post/ViewAction.php         (standalone action, route post/view)
+app/controllers/admin/posts/CreateAction.php (standalone action, route admin/posts/create)
+```
+
+The same hyphen-to-CamelCase rule applies to the last route segment (`view-summary` resolves to `ViewSummaryAction`),
+and preceding segments form a sub-namespace prefix verbatim.
+
+For projects that prefer a separate root (vertical slices, use cases, ports/adapters layout), set `actionNamespace`
+explicitly:
+
+```php
+// config/web.php
+return [
+    // ...
+    'actionNamespace' => 'app\\UseCase',
+];
+```
+
+With the example above, route `posts/index` resolves to `app\UseCase\posts\IndexAction`. Controllers remain at
+`app/controllers/` and continue to be discovered through `controllerNamespace`.
+
+Resolution order in `Module::runAction()`: explicit `actionMap` and `controllerMap` entries are checked first, then
+sub-modules, then controllers by namespace, and finally standalone actions by namespace. **If a controller method and a
+standalone Action class both match the same route, `Module::runAction()` throws `InvalidConfigException`** so the
+developer disambiguates instead of silently shadowing one or the other. Existing applications upgrade with no
+behavioral change because before this release a class file at the convention path was never resolved.
+
+Minimal `actionMap` example for an endpoint that does not follow the convention (custom ID or external class):
+
+```php
+// config/web.php
+return [
+    // ...
+    'actionMap' => [
+        'health' => app\actions\HealthCheckAction::class,
+    ],
+];
+```
+
+The feature is purely additive: drop a `<X>Action.php` in the right folder (or register it in `actionMap`) and the
+route works. Routes that match neither a controller nor a standalone action throw `InvalidRouteException` as before.
+
+`yii\filters\AccessRule::matchController()` now accepts `null` for the controller argument. When a rule declares a
+non-empty `controllers` constraint and the action runs as a standalone action, the rule does not match. To keep the
+previous behavior, leave `controllers` empty.
+
+The following actions are not standalone-compatible because they require controller-level rendering or layout
+resolution: `yii\web\ViewAction`, `yii\web\ErrorAction`, `yii\base\InlineAction`. Continue to register them through
+`Controller::actions()`.
+
 ### `View::registerJs()` no longer assumes jQuery
 
 `yii\web\View::registerJs()` no longer calls `JqueryAsset::register($this)` automatically when the script position is

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -518,6 +518,30 @@ return [
 The feature is purely additive: drop a `<X>Action.php` in the right folder (or register it in `actionMap`) and the
 route works. Routes that match neither a controller nor a standalone action throw `InvalidRouteException` as before.
 
+#### HTTP-aware param binding: `yii\web\Action`
+
+For HTTP endpoints, extend `yii\web\Action` (new in 22.0) instead of `yii\base\Action`. `yii\web\Action::resolveStandaloneParams()`
+delegates to `yii\web\Controller::bindActionParamsToCallable()` so the action receives the same scalar coercion, type
+validation, and DI resolution as a controller-bound action: `'7'` is coerced to `int 7`, invalid scalars raise
+`yii\web\BadRequestHttpException`, missing required parameters also raise `BadRequestHttpException`, and typed services
+resolve through module components, module DI, and the global container in that order.
+
+```php
+namespace app\controllers;
+
+use yii\web\Action;
+use yii\web\Response;
+
+final class HealthAction extends Action
+{
+    public function run(int $id, Response $response): Response { ... }
+}
+```
+
+Reserve `yii\base\Action` for non-HTTP standalone contexts (queue jobs, scheduled tasks, console-side dispatch). It
+keeps the simpler `yii\di\Container::resolveCallableDependencies()` resolution which autowires typed services but
+does not coerce or validate scalar parameters.
+
 `yii\filters\AccessRule::matchController()` now accepts `null` for the controller argument. When a rule declares a
 non-empty `controllers` constraint and the action runs as a standalone action, the rule does not match. To keep the
 previous behavior, leave `controllers` empty.

--- a/framework/base/Action.php
+++ b/framework/base/Action.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -10,16 +12,21 @@ namespace yii\base;
 
 use Yii;
 
+use function call_user_func_array;
+use function get_class;
+
 /**
  * Action is the base class for all controller action classes.
  *
- * Action provides a way to reuse action method code. An action method in an Action
- * class can be used in multiple controllers or in different projects.
+ * Action provides a way to reuse action method code. An action method in an Action class can be used in multiple
+ * controllers or in different projects.
  *
- * Derived classes must implement a method named `run()`. This method
- * will be invoked by the controller when the action is requested.
- * The `run()` method can have parameters which will be filled up
- * with user input values automatically according to their names.
+ * Derived classes must implement a method named `run()`. This method will be invoked by the controller when the action
+ * is requested.
+ *
+ * The `run()` method can have parameters which will be filled up with user input values automatically according to
+ * their names.
+ *
  * For example, if the `run()` method is declared as follows:
  *
  * ```
@@ -27,6 +34,7 @@ use Yii;
  * ```
  *
  * And the parameters provided for the action are: `['id' => 1]`.
+ *
  * Then the `run()` method will be invoked as `run(1)` automatically.
  *
  * For more details and usage information on Action, see the [guide article on actions](guide:structure-controllers).
@@ -45,61 +53,152 @@ class Action extends Component
      */
     public $id;
     /**
-     * @var T the controller that owns this action
+     * @var T|null the controller that owns this action, or `null` when the action runs standalone.
+     * via {@see Module::$actionMap}
      */
     public $controller;
 
+    /**
+     * This action when invoked standalone (without a controller).
+     *
+     * @since 22.0
+     */
+    private Module|null $_module = null;
 
     /**
      * Constructor.
      *
-     * @param string $id the ID of this action
-     * @param T $controller the controller that owns this action
-     * @param array<string, mixed> $config name-value pairs that will be used to initialize the object properties
+     * @param string $id The ID of this action.
+     * @param T|null $controller The controller that owns this action, or `null` for standalone handlers.
+     * @param array<string, mixed> $config name-value pairs that will be used to initialize the object properties.
      */
-    public function __construct($id, $controller, $config = [])
+    public function __construct($id, $controller = null, $config = [])
     {
         $this->id = $id;
         $this->controller = $controller;
+
         parent::__construct($config);
     }
 
     /**
      * Returns the unique ID of this action among the whole application.
      *
-     * @return string the unique ID of this action among the whole application.
+     * When the action is hosted by a controller, the ID is composed of the controller's unique ID and the action ID.
+     *
+     * For standalone handlers (no controller), the ID falls back to the owning module's unique ID, or to the action ID
+     * alone when no module is attached.
+     *
+     * @return string The unique ID of this action among the whole application.
      */
     public function getUniqueId()
     {
-        return $this->controller->getUniqueId() . '/' . $this->id;
+        if ($this->controller !== null) {
+            return $this->controller->getUniqueId() . '/' . $this->id;
+        }
+
+        $module = $this->getModule();
+        $moduleId = $module !== null ? $module->getUniqueId() : '';
+
+        return $moduleId === '' ? $this->id : $moduleId . '/' . $this->id;
+    }
+
+    /**
+     * Returns the module that owns this action when invoked standalone.
+     *
+     * Falls back to the controller's module when a controller hosts the action.
+     *
+     * @return Module|null The owning module, or `null` if neither a module nor a controller is attached.
+     *
+     * @since 22.0
+     */
+    public function getModule(): Module|null
+    {
+        if ($this->_module !== null) {
+            return $this->_module;
+        }
+
+        return $this->controller?->module;
+    }
+
+    /**
+     * Sets the module that owns this action when invoked standalone.
+     *
+     * Used by {@see Module::runAction()} when dispatching a handler registered in {@see Module::$actionMap}.
+     *
+     * @param Module|null $module The owning module, or `null` to detach.
+     *
+     * @since 22.0
+     */
+    public function setModule(Module|null $module): void
+    {
+        $this->_module = $module;
     }
 
     /**
      * Runs this action with the specified parameters.
-     * This method is mainly invoked by the controller.
      *
-     * @param array $params the parameters to be bound to the action's run() method.
-     * @return mixed the result of the action
-     * @throws InvalidConfigException if the action class does not have a run() method
+     * When a controller hosts the action, parameter binding is delegated to {@see Controller::bindActionParams()}.
+     *
+     * For standalone handlers the typed parameters of `run()` are resolved through the DI container via
+     * {@see resolveStandaloneParams()}.
+     *
+     * @param array $params The parameters to be bound to the action's `run()` method.
+     *
+     * @throws InvalidConfigException if the action class does not have a `run()` method.
+     *
+     * @return mixed The result of the action.
      */
-    public function runWithParams($params)
+    public function runWithParams(array $params)
     {
         if (!method_exists($this, 'run')) {
             throw new InvalidConfigException(get_class($this) . ' must define a "run()" method.');
         }
-        $args = $this->controller->bindActionParams($this, $params);
-        Yii::debug('Running action: ' . get_class($this) . '::run(), invoked by ' . get_class($this->controller), __METHOD__);
+
+        if ($this->controller !== null) {
+            $args = $this->controller->bindActionParams($this, $params);
+
+            Yii::debug(
+                'Running action: ' . get_class($this) . '::run(), invoked by ' . get_class($this->controller),
+                __METHOD__,
+            );
+        } else {
+            $args = $this->resolveStandaloneParams($params);
+
+            Yii::debug(
+                'Running standalone action: ' . get_class($this) . '::run()',
+                __METHOD__,
+            );
+        }
+
         if (Yii::$app->requestedParams === null) {
             Yii::$app->requestedParams = $args;
         }
+
         if ($this->beforeRun()) {
             $result = call_user_func_array([$this, 'run'], $args);
+
             $this->afterRun();
 
             return $result;
         }
 
         return null;
+    }
+
+    /**
+     * Resolves typed parameters of `run()` when the action is invoked without a hosting controller.
+     *
+     * Delegates to {@see \yii\di\Container::resolveCallableDependencies()} so that route parameters are matched by name
+     * and class-typed parameters are autowired from the DI container.
+     *
+     * @param array $params Route parameters to be matched by name against `run()`'s signature.
+     * @return array<array-key, mixed> The resolved positional argument list for `run()`.
+     *
+     * @since 22.0
+     */
+    protected function resolveStandaloneParams($params): array
+    {
+        return Yii::$container->resolveCallableDependencies([$this, 'run'], $params);
     }
 
     /**

--- a/framework/base/InlineAction.php
+++ b/framework/base/InlineAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -13,10 +15,13 @@ use Yii;
 /**
  * InlineAction represents an action that is defined as a controller method.
  *
- * The name of the controller method is available via [[actionMethod]] which
- * is set by the [[controller]] who creates this action.
+ * The name of the controller method is available via [[actionMethod]] which is set by the [[controller]] who creates
+ * this action.
  *
  * For more details and usage information on InlineAction, see the [guide article on actions](guide:structure-controllers).
+ *
+ * Not standalone-compatible: by definition InlineAction targets a controller method, so it cannot be registered in
+ * [[\yii\base\Module::$actionMap]] and is always created with a non-`null` controller.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -27,10 +32,9 @@ use Yii;
 class InlineAction extends Action
 {
     /**
-     * @var string the controller method that this inline action is associated with
+     * @var string The controller method that this inline action is associated with.
      */
-    public $actionMethod;
-
+    public string $actionMethod = '';
 
     /**
      * @param string $id the ID of this action
@@ -41,6 +45,7 @@ class InlineAction extends Action
     public function __construct($id, $controller, $actionMethod, $config = [])
     {
         $this->actionMethod = $actionMethod;
+
         parent::__construct($id, $controller, $config);
     }
 

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -610,7 +610,7 @@ class Module extends ServiceLocator
     {
         $normalizedRoute = trim((string) $route, '/');
 
-        if ($normalizedRoute !== '' && !empty($this->actionMap)) {
+        if ($normalizedRoute !== '' && $this->actionMap !== []) {
             $separator = strpos($normalizedRoute, '/');
             $actionId = $separator === false ? $normalizedRoute : substr($normalizedRoute, 0, $separator);
 

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -11,22 +13,21 @@ namespace yii\base;
 use Yii;
 use yii\di\ServiceLocator;
 
+use function is_array;
+
 /**
  * Module is the base class for module and application classes.
  *
- * A module represents a sub-application which contains MVC elements by itself, such as
- * models, views, controllers, etc.
+ * A module represents a sub-application which contains MVC elements by itself, such as models, views, controllers, etc.
  *
  * A module may consist of [[modules|sub-modules]].
  *
- * [[components|Components]] may be registered with the module so that they are globally
- * accessible within the module.
+ * [[components|Components]] may be registered with the module so that they are globally accessible within the module.
  *
  * For more details and usage information on Module, see the [guide article on modules](guide:structure-modules).
  *
- * @property-write array $aliases List of path aliases to be defined. The array keys are alias names (must
- * start with `@`) and the array values are the corresponding paths or aliases. See [[setAliases()]] for an
- * example.
+ * @property-write array $aliases List of path aliases to be defined. The array keys are alias names (must start with
+ * `@`) and the array values are the corresponding paths or aliases. See [[setAliases()]] for an example.
  * @property string $basePath The root directory of the module.
  * @property string $controllerPath The directory that contains the controller classes.
  * @property string $layoutPath The root directory of layout files. Defaults to "[[viewPath]]/layouts".
@@ -89,6 +90,30 @@ class Module extends ServiceLocator
      */
     public $controllerMap = [];
     /**
+     * @var array<string, class-string|array<string, mixed>> mapping from action IDs to standalone {@see Action} class
+     * configurations. Mapped actions are dispatched by {@see runAction()} without requiring a hosting controller, in
+     * parallel to {@see $controllerMap}.
+     *
+     * Each entry maps an ID (the first route segment) to either a fully qualified class name or an array configuration
+     * accepted by {@see \Yii::createObject()}. The class must extend {@see Action}.
+     *
+     * Usage example:
+     *
+     * ```php
+     * [
+     *     'webhooks-stripe' => app\actions\StripeWebhookAction::class,
+     *     'health'          => ['class' => app\actions\HealthCheckAction::class],
+     * ]
+     * ```
+     *
+     * Action IDs in this map take precedence over IDs in {@see $controllerMap} and over module/controller resolution.
+     *
+     * Routes whose first segment is not present here fall through to the legacy controller pipeline unchanged.
+     *
+     * @since 22.0
+     */
+    public array $actionMap = [];
+    /**
      * @var string|null the namespace that controller classes are in.
      * This namespace will be used to load controller classes by prepending it to the controller
      * class name.
@@ -101,6 +126,32 @@ class Module extends ServiceLocator
      * defining namespaces and how classes are loaded.
      */
     public $controllerNamespace;
+    /**
+     * The namespace where standalone {@see Action} subclasses are located for convention-based discovery, parallel to
+     * {@see $controllerNamespace} for controllers.
+     *
+     * If not set, defaults to the value of {@see $controllerNamespace} during {@see init()}, so standalone actions can
+     * live next to controllers under the same root. Set this property to a different namespace to organize standalone
+     * actions in their own folder (for example, vertical slices under `app\UseCase`):
+     *
+     * Usage example:
+     *
+     * ```php
+     * 'actionNamespace' => 'app\\UseCase',
+     * ```
+     *
+     * With the example above, route `posts/index` resolves to `app\UseCase\posts\IndexAction`, route
+     * `posts/view-summary` resolves to `app\UseCase\posts\ViewSummaryAction`, and so on. The same hyphen, slash, and
+     * CamelCase rules apply as for controllers (see {@see createControllerByID()}).
+     *
+     * Resolution order in {@see runAction()}: explicit {@see $controllerMap}/{@see $actionMap} entries are checked
+     * first, then sub-modules, then controllers by namespace, and finally standalone actions by namespace. When a
+     * controller method AND a standalone Action class both match the same route, {@see runAction()} throws
+     * {@see InvalidConfigException} so the developer disambiguates instead of silently shadowing one or the other.
+     *
+     * @since 22.0
+     */
+    public string|null $actionNamespace = null;
     /**
      * @var string the default route of this module. Defaults to `default`.
      * The route may consist of child module ID, controller ID, and/or action ID.
@@ -147,7 +198,6 @@ class Module extends ServiceLocator
      */
     private $_version;
 
-
     /**
      * Constructor.
      * @param string $id the ID of this module.
@@ -190,9 +240,9 @@ class Module extends ServiceLocator
     /**
      * Initializes the module.
      *
-     * This method is called after the module is created and initialized with property values
-     * given in configuration. The default implementation will initialize [[controllerNamespace]]
-     * if it is not set.
+     * This method is called after the module is created and initialized with property values given in configuration.
+     *
+     * The default implementation will initialize [[controllerNamespace]] if it is not set.
      *
      * If you override this method, please make sure you call the parent implementation.
      */
@@ -200,9 +250,14 @@ class Module extends ServiceLocator
     {
         if ($this->controllerNamespace === null) {
             $class = get_class($this);
+
             if (($pos = strrpos($class, '\\')) !== false) {
                 $this->controllerNamespace = substr($class, 0, $pos) . '\\controllers';
             }
+        }
+
+        if ($this->actionNamespace === null) {
+            $this->actionNamespace = $this->controllerNamespace;
         }
     }
 
@@ -530,31 +585,275 @@ class Module extends ServiceLocator
 
     /**
      * Runs a controller action specified by a route.
+     *
      * This method parses the specified route and creates the corresponding child module(s), controller and action
      * instances. It then calls [[Controller::runAction()]] to run the action with the given parameters.
+     *
      * If the route is empty, the method will use [[defaultRoute]].
-     * @param string $route the route that specifies the action.
-     * @param array $params the parameters to be passed to the action
-     * @return mixed the result of the action.
+     *
+     * Since version 22.0, when the first segment of the route matches a key in [[actionMap]], the action is dispatched
+     * as a standalone action via [[runMappedAction()]], without resolving a controller. When no controller resolves the
+     * route either, the method falls back to convention-based standalone action lookup under [[actionNamespace]] via
+     * [[createStandaloneAction()]]. When a controller method AND a standalone Action class both match the same route,
+     * the method throws [[InvalidConfigException]] so the developer disambiguates instead of silently shadowing one or
+     * the other.
+     *
+     * @param string $route The route that specifies the action.
+     * @param array $params The parameters to be passed to the action.
+     *
+     * @throws InvalidConfigException if a controller method and a standalone Action class both match the same route.
      * @throws InvalidRouteException if the requested route cannot be resolved into an action successfully.
+     *
+     * @return mixed The result of the action.
      */
     public function runAction($route, $params = [])
     {
-        $parts = $this->createController($route);
-        if (is_array($parts)) {
-            list($controller, $actionID) = $parts;
-            $oldController = Yii::$app->controller;
-            Yii::$app->controller = $controller;
-            $result = $controller->runAction($actionID, $params);
-            if ($oldController !== null) {
-                Yii::$app->controller = $oldController;
-            }
+        $normalizedRoute = trim((string) $route, '/');
 
-            return $result;
+        if ($normalizedRoute !== '' && !empty($this->actionMap)) {
+            $separator = strpos($normalizedRoute, '/');
+            $actionId = $separator === false ? $normalizedRoute : substr($normalizedRoute, 0, $separator);
+
+            if (isset($this->actionMap[$actionId])) {
+                return $this->runMappedAction($actionId, $params);
+            }
+        }
+
+        $parts = $this->createController($route);
+
+        $controller = null;
+        $actionID = null;
+
+        if (is_array($parts)) {
+            [$controller, $actionID] = $parts;
+            $resolvedActionID = $actionID === '' ? $controller->defaultAction : $actionID;
+
+            if ($controller->createAction($resolvedActionID) !== null) {
+                if ($this->createStandaloneAction($route) !== null) {
+                    $id = $this->getUniqueId();
+
+                    throw new InvalidConfigException(
+                        'Route "'
+                        . ($id === '' ? $route : "{$id}/{$route}")
+                        . '" matches both a controller action and a standalone Action class. '
+                        . 'Remove one to disambiguate.',
+                    );
+                }
+
+                $oldController = Yii::$app->controller;
+                Yii::$app->controller = $controller;
+
+                $result = $controller->runAction($actionID, $params);
+
+                if ($oldController !== null) {
+                    Yii::$app->controller = $oldController;
+                }
+
+                return $result;
+            }
+        }
+
+        $action = $this->createStandaloneAction($route);
+
+        if ($action !== null) {
+            return $this->runStandaloneAction($action, $params);
+        }
+
+        if ($controller !== null) {
+            throw new InvalidRouteException(
+                'Unable to resolve the request: ' . $controller->getUniqueId() . '/' . $actionID
+            );
         }
 
         $id = $this->getUniqueId();
-        throw new InvalidRouteException('Unable to resolve the request "' . ($id === '' ? $route : $id . '/' . $route) . '".');
+
+        throw new InvalidRouteException(
+            'Unable to resolve the request "' . ($id === '' ? $route : "{$id}/{$route}") . '".',
+        );
+    }
+
+    /**
+     * Runs a standalone action registered in [[actionMap]].
+     *
+     * The action is instantiated via [[\Yii::createObject()]] with `[$id, null]` as positional constructor arguments,
+     * allowing the DI container to autowire any extra typed dependencies declared after `$controller`. The lifecycle is
+     * then delegated to [[runStandaloneAction()]].
+     *
+     * @param string $id The action ID present in [[actionMap]].
+     * @param array $params The parameters to be matched against the action's `run()` signature.
+     *
+     * @return mixed the action result, or `null` if execution was canceled by a before-action listener.
+     *
+     * @since 22.0
+     */
+    protected function runMappedAction(string $id, array $params): mixed
+    {
+        /** @var Action $action */
+        $action = Yii::createObject($this->actionMap[$id], [$id, null]);
+
+        $action->setModule($this);
+
+        return $this->runStandaloneAction($action, $params);
+    }
+
+    /**
+     * Resolves a route to a standalone {@see Action} class through convention-based discovery under
+     * [[actionNamespace]].
+     *
+     * Recurses through registered sub-modules using their first-segment ID, matching the pattern of
+     * {@see createController()}. When the route does not match a sub-module, the last segment is converted to a
+     * CamelCased class name with an `Action` suffix, the preceding segments form a sub-namespace prefix, and the result
+     * is looked up under the owning module's [[actionNamespace]].
+     *
+     * The resolved class must extend [[Action]] and must NOT extend [[Controller]]; otherwise this method returns
+     * `null` and the caller falls through to the controller pipeline (or to `InvalidRouteException`).
+     *
+     * @param string $route The route relative to this module.
+     *
+     * @return Action|null A resolved standalone action ready for dispatch, or `null` when no class matches.
+     *
+     * @since 22.0
+     */
+    protected function createStandaloneAction(string $route): Action|null
+    {
+        if ($route === '') {
+            $route = $this->defaultRoute;
+        }
+
+        $route = trim($route, '/');
+
+        if ($route === '' || strpos($route, '//') !== false) {
+            return null;
+        }
+
+        $firstSlash = strpos($route, '/');
+        $firstSegment = $firstSlash === false ? $route : substr($route, 0, $firstSlash);
+
+        $module = $this->getModule($firstSegment);
+
+        if ($module !== null) {
+            $remainder = $firstSlash === false ? '' : substr($route, $firstSlash + 1);
+
+            return $module->createStandaloneAction($remainder);
+        }
+
+        if ($this->actionNamespace === null || $this->actionNamespace === '') {
+            return null;
+        }
+
+        $lastSlash = strrpos($route, '/');
+
+        if ($lastSlash === false) {
+            $prefix = '';
+            $idPart = $route;
+        } else {
+            $prefix = substr($route, 0, $lastSlash + 1);
+            $idPart = substr($route, $lastSlash + 1);
+        }
+
+        if ($idPart === '' || $this->isIncorrectClassNameOrPrefix($idPart, $prefix)) {
+            return null;
+        }
+
+        $className = preg_replace_callback(
+            '%-([a-z0-9_])%i',
+            fn($matches): string => ucfirst($matches[1]),
+            ucfirst($idPart),
+        ) . 'Action';
+        $className = ltrim(
+            "{$this->actionNamespace}\\" . str_replace('/', '\\', $prefix) . $className,
+            '\\',
+        );
+
+        if (strpos($className, '-') !== false || !class_exists($className)) {
+            return null;
+        }
+
+        if (!is_subclass_of($className, Action::class) || is_subclass_of($className, Controller::class)) {
+            return null;
+        }
+
+        /** @var Action $action */
+        $action = Yii::createObject($className, [$route, null]);
+        $action->setModule($this);
+
+        return $action;
+    }
+
+    /**
+     * Runs a standalone {@see Action} instance through the standard module/action event lifecycle.
+     *
+     * Module ancestors fire [[EVENT_BEFORE_ACTION]] outer-to-inner before execution and [[EVENT_AFTER_ACTION]]
+     * inner-to-outer afterwards, mirroring [[Controller::runAction()]]. The action itself also fires
+     * [[Controller::EVENT_BEFORE_ACTION]] and [[Controller::EVENT_AFTER_ACTION]] so behaviors attached via the action's
+     * [[behaviors()]] (for example [[\yii\filters\AccessControl]] or [[\yii\filters\VerbFilter]]) participate in the
+     * lifecycle.
+     *
+     * Setting [[ActionEvent::isValid]] to `false` in any before-action listener cancels the action and returns `null`.
+     *
+     * @param Action $action The action to run.
+     * @param array $params The parameters to be matched against the action's `run()` signature.
+     *
+     * @return mixed The action result, or `null` if execution was canceled by a before-action listener.
+     *
+     * @since 22.0
+     */
+    protected function runStandaloneAction(Action $action, array $params): mixed
+    {
+        if (Yii::$app->requestedAction === null) {
+            Yii::$app->requestedAction = $action;
+        }
+
+        $modulesOuterToInner = [$this];
+        $ancestor = $this->module;
+
+        while ($ancestor !== null) {
+            array_unshift($modulesOuterToInner, $ancestor);
+
+            $ancestor = $ancestor->module;
+        }
+
+        $modulesInnerToOuter = [];
+        $runAction = true;
+
+        foreach ($modulesOuterToInner as $module) {
+            if ($module->beforeAction($action)) {
+                array_unshift($modulesInnerToOuter, $module);
+            } else {
+                $runAction = false;
+
+                break;
+            }
+        }
+
+        if ($runAction) {
+            $beforeEvent = new ActionEvent($action);
+            $action->trigger(Controller::EVENT_BEFORE_ACTION, $beforeEvent);
+
+            if (!$beforeEvent->isValid) {
+                $runAction = false;
+            }
+        }
+
+        $result = null;
+
+        if ($runAction) {
+            $result = $action->runWithParams($params);
+
+            $afterEvent = new ActionEvent($action);
+
+            $afterEvent->result = $result;
+
+            $action->trigger(Controller::EVENT_AFTER_ACTION, $afterEvent);
+
+            $result = $afterEvent->result;
+
+            foreach ($modulesInnerToOuter as $module) {
+                $result = $module->afterAction($action, $result);
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/framework/filters/AccessRule.php
+++ b/framework/filters/AccessRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -161,7 +163,6 @@ class AccessRule extends Component
      */
     public $denyCallback;
 
-
     /**
      * Checks whether the Web user is allowed to perform the specified action.
      * @param Action $action the action to be performed
@@ -195,8 +196,10 @@ class AccessRule extends Component
     }
 
     /**
-     * @param Controller $controller the controller
-     * @return bool whether the rule applies to the controller
+     * @param Controller|null $controller The controller, or `null` when the action runs as a standalone action
+     * dispatched by [[\yii\base\Module::$actionMap]] (since 22.0).
+     *
+     * @return bool Whether the rule applies to the controller.
      */
     protected function matchController($controller)
     {
@@ -204,7 +207,12 @@ class AccessRule extends Component
             return true;
         }
 
+        if ($controller === null) {
+            return false;
+        }
+
         $id = $controller->getUniqueId();
+
         foreach ($this->controllers as $pattern) {
             if (StringHelper::matchWildcard($pattern, $id)) {
                 return true;

--- a/framework/web/Action.php
+++ b/framework/web/Action.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yii\web;
+
+use ReflectionMethod;
+use Yii;
+use yii\base\Action as BaseAction;
+
+/**
+ * Base class for HTTP standalone actions dispatched without a hosting controller.
+ *
+ * Use this class instead of [[\yii\base\Action]] when an action handles an HTTP request and should benefit from the
+ * same parameter-binding semantics as web controller actions: scalar coercion, [[BadRequestHttpException]] on type
+ * mismatches and missing required parameters, and DI resolution of typed services through module components,
+ * module DI definitions, and the global container.
+ *
+ * Standalone actions extending [[\yii\base\Action]] still receive DI-based parameter resolution, but skip the
+ * HTTP-specific scalar filtering and exception mapping. Reserve that base class for non-HTTP contexts (console actions,
+ * queue jobs, scheduled tasks).
+ *
+ * Usage example:
+ *
+ * ```php
+ * namespace app\controllers;
+ *
+ * use yii\web\Action;
+ * use yii\web\Response;
+ *
+ * final class HealthAction extends Action
+ * {
+ *     public function run(int $id, Response $response): Response
+ *     {
+ *         // 'abc' for $id throws BadRequestHttpException, '7' is coerced to int 7.
+ *         return $response;
+ *     }
+ * }
+ * ```
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+class Action extends BaseAction
+{
+    /**
+     * Resolves the parameters of {@see run()} using the same HTTP-aware binder as [[Controller::bindActionParams()]].
+     *
+     * Delegates to [[Controller::bindActionParamsToCallable()]] so scalar parameters are coerced and validated,
+     * required parameters raise [[BadRequestHttpException]], and typed services are autowired from the module and
+     * the global container.
+     *
+     * Populates [[\yii\base\Application::$requestedParams]] with the merged action and injected parameter descriptions,
+     * mirroring the controller-bound dispatch.
+     *
+     * @param array $params Route parameters to be bound to {@see run()}.
+     * @return array The positional argument list for the action's {@see run()} method.
+     */
+    protected function resolveStandaloneParams($params): array
+    {
+        $method = new ReflectionMethod($this, 'run');
+
+        [$args, $actionParams, $requestedParams] = Controller::bindActionParamsToCallable(
+            $method,
+            $params,
+            $this->getModule(),
+        );
+
+        if (Yii::$app->requestedParams === null) {
+            Yii::$app->requestedParams = [
+                ...$actionParams,
+                ...$requestedParams,
+            ];
+        }
+
+        return $args;
+    }
+}

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -186,9 +186,9 @@ class Controller extends BaseController
      * @since 22.0
      */
     public static function bindActionParamsToCallable(
-        \ReflectionMethod $method,
+        ReflectionMethod $method,
         array $params,
-        ?Module $module = null
+        Module|null $module = null
     ): array {
         $args = [];
         $missing = [];

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,6 +10,9 @@
 
 namespace yii\web;
 
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionUnionType;
 use Yii;
 use yii\base\Exception;
 use yii\base\InlineAction;
@@ -15,6 +20,10 @@ use yii\helpers\Url;
 use yii\base\Action;
 use yii\base\Controller as BaseController;
 use yii\base\Module;
+
+use function array_key_exists;
+use function get_class;
+use function is_array;
 
 /**
  * Controller is the base class of web controllers.
@@ -42,7 +51,6 @@ class Controller extends BaseController
      * @var array the parameters bound to the current action.
      */
     public $actionParams = [];
-
 
     /**
      * Renders a view in response to an AJAX request.
@@ -118,40 +126,87 @@ class Controller extends BaseController
 
     /**
      * Binds the parameters to the action.
+     *
      * This method is invoked by [[Action]] when it begins to run with the given parameters.
-     * This method will check the parameter names that the action requires and return
-     * the provided parameters according to the requirement. If there is any missing parameter,
-     * an exception will be thrown.
-     * @param Action<static> $action the action to be bound with parameters
-     * @param array<array-key, mixed> $params the parameters to be bound to the action
-     * @return mixed[] the valid parameters that the action can run with.
+     *
+     * This method will check the parameter names that the action requires and return the provided parameters according
+     * to the requirement. If there is any missing parameter, an exception will be thrown.
+     *
+     * @param Action<static> $action The action to be bound with parameters.
+     * @param array<array-key, mixed> $params The parameters to be bound to the action.
+     *
      * @throws BadRequestHttpException if there are missing or invalid parameters.
+     *
+     * @return mixed[] The valid parameters that the action can run with.
      *
      * @phpstan-param Action<static> $action
      * @psalm-param Action<self> $action
      */
     public function bindActionParams($action, $params)
     {
-        if ($action instanceof InlineAction) {
-            $method = new \ReflectionMethod($this, $action->actionMethod);
-        } else {
-            $method = new \ReflectionMethod($action, 'run');
+        $method = $action instanceof InlineAction
+            ? new ReflectionMethod($this, $action->actionMethod)
+            : new ReflectionMethod($action, 'run');
+
+        [$args, $actionParams, $requestedParams] = self::bindActionParamsToCallable($method, $params, $this->module);
+
+        $this->actionParams = $actionParams;
+
+        // we use a different array here, specifically one that doesn't contain service instances but descriptions
+        // instead.
+        if (Yii::$app->requestedParams === null) {
+            Yii::$app->requestedParams = [
+                ...$actionParams,
+                ...$requestedParams,
+            ];
         }
 
+        return $args;
+    }
+
+    /**
+     * Resolves the parameters for an action's invokable callable using the same scalar coercion, type validation,
+     * and DI rules as [[bindActionParams()]].
+     *
+     * Standalone actions extending [[Action]] use this static entry point so they get the exact same
+     * HTTP-aware parameter handling as controller-hosted actions.
+     *
+     * @param \ReflectionMethod $method The reflected `run()` (or controller method) whose parameters are being bound.
+     * @param array $params Route parameters available for binding (typically `$_GET`/`$_POST`-derived).
+     * @param Module|null $module The module that should be queried for components and DI definitions when resolving
+     * non-builtin typed parameters. May be `null` for standalone resolution outside a module context.
+     *
+     * @throws BadRequestHttpException if a scalar parameter fails type coercion or a required parameter is missing.
+     * @throws ServerErrorHttpException if a typed dependency cannot be resolved by the container.
+     *
+     * @return array A tuple `[positional args, named action params, named requested params]` where the first item is
+     * passed to the callable, the second mirrors the controller's `actionParams`, and the third is a description map
+     * for `Yii::$app->requestedParams`.
+     *
+     * @since 22.0
+     */
+    public static function bindActionParamsToCallable(
+        \ReflectionMethod $method,
+        array $params,
+        ?Module $module = null
+    ): array {
         $args = [];
         $missing = [];
         $actionParams = [];
         $requestedParams = [];
+
         foreach ($method->getParameters() as $param) {
             $name = $param->getName();
             if (array_key_exists($name, $params)) {
                 $isValid = true;
+
                 $type = $param->getType();
+
                 if ($type instanceof \ReflectionNamedType) {
-                    [$result, $isValid] = $this->filterSingleTypeActionParam($params[$name], $type);
+                    [$result, $isValid] = self::filterSingleTypeActionParam($params[$name], $type);
                     $params[$name] = $result;
                 } elseif ($type instanceof \ReflectionUnionType) {
-                    [$result, $isValid] = $this->filterUnionTypeActionParam($params[$name], $type);
+                    [$result, $isValid] = self::filterUnionTypeActionParam($params[$name], $type);
                     $params[$name] = $result;
                 }
 
@@ -160,7 +215,9 @@ class Controller extends BaseController
                         Yii::t('yii', 'Invalid data received for parameter "{param}".', ['param' => $name])
                     );
                 }
+
                 $args[] = $actionParams[$name] = $params[$name];
+
                 unset($params[$name]);
             } elseif (
                 ($type = $param->getType()) !== null
@@ -168,7 +225,7 @@ class Controller extends BaseController
                 && !$type->isBuiltin()
             ) {
                 try {
-                    $this->bindInjectedParams($type, $name, $args, $requestedParams);
+                    self::resolveInjectedParam($type, $name, $args, $requestedParams, $module);
                 } catch (HttpException $e) {
                     throw $e;
                 } catch (Exception $e) {
@@ -187,30 +244,79 @@ class Controller extends BaseController
             );
         }
 
-        $this->actionParams = $actionParams;
-
-        // We use a different array here, specifically one that doesn't contain service instances but descriptions instead.
-        if (Yii::$app->requestedParams === null) {
-            Yii::$app->requestedParams = array_merge($actionParams, $requestedParams);
-        }
-
-        return $args;
+        return [$args, $actionParams, $requestedParams];
     }
 
     /**
-     * The logic for [[bindActionParam]] to validate whether a given parameter matches the action's typing
-     * if the function parameter has a single named type.
+     * Static counterpart of [[\yii\base\Controller::bindInjectedParams()]] used by [[bindActionParamsToCallable()]].
+     *
+     * Resolves a typed non-builtin parameter from the module's components, the module's DI definitions, and finally the
+     * global container, mirroring the controller-bound resolution order.
+     *
+     * @param ReflectionNamedType $type The non-builtin reflection type for the parameter.
+     * @param string $name The parameter name.
+     * @param array $args The positional argument list being built (mutated in place).
+     * @param array $requestedParams The description map for [[\yii\base\Application::$requestedParams]] (mutated).
+     * @param Module|null $module The module to query for components and DI definitions, or `null` to skip module
+     * lookups and consult only the global container.
+     *
+     * @throws Exception if the dependency cannot be resolved and the parameter is not nullable.
+     *
+     * @since 22.0
+     */
+    private static function resolveInjectedParam(
+        ReflectionNamedType $type,
+        string $name,
+        array &$args,
+        array &$requestedParams,
+        ?Module $module
+    ): void {
+        $typeName = $type->getName();
+
+        if ($module !== null && ($component = $module->get($name, false)) instanceof $typeName) {
+            $args[] = $component;
+            $requestedParams[$name] = 'Component: ' . get_class($component) . " \$$name";
+        } elseif (
+            $module !== null
+            && $module->has($typeName)
+            && ($service = $module->get($typeName)) instanceof $typeName
+        ) {
+            $args[] = $service;
+            $requestedParams[$name] = 'Module ' . get_class($module) . " DI: $typeName \$$name";
+        } elseif (
+            Yii::$container->has($typeName)
+            && ($service = Yii::$container->get($typeName)) instanceof $typeName
+        ) {
+            $args[] = $service;
+            $requestedParams[$name] = "Container DI: $typeName \$$name";
+        } elseif ($type->allowsNull()) {
+            $args[] = null;
+            $requestedParams[$name] = "Unavailable service: $name";
+        } else {
+            throw new Exception('Could not load required service: ' . $name);
+        }
+    }
+
+    /**
+     * The logic for [[bindActionParam]] to validate whether a given parameter matches the action's typing if the
+     * function parameter has a single named type.
+     *
      * @param mixed $param The parameter value.
-     * @param \ReflectionNamedType $type
+     *
+     * @param ReflectionNamedType $type The parameter's reflected named type.
+     *
      * @return array{mixed, bool} The resulting parameter value and a boolean indicating whether the value is valid.
      */
-    private function filterSingleTypeActionParam($param, $type)
+    private static function filterSingleTypeActionParam($param, $type)
     {
         $isArray = $type->getName() === 'array';
+
         if ($isArray) {
             return [(array)$param, true];
         }
+
         $isMixed = $type->getName() === 'mixed';
+
         if ($isMixed) {
             return [$param, true];
         }
@@ -235,22 +341,29 @@ class Controller extends BaseController
             if ($typeName === 'string') {
                 return [$param, true];
             }
-            $filterResult = $this->filterParamByType($param, $typeName);
+
+            $filterResult = self::filterParamByType($param, $typeName);
+
             return [$filterResult, $filterResult !== null];
         }
+
         return [$param, true];
     }
 
     /**
-     * The logic for [[bindActionParam]] to validate whether a given parameter matches the action's typing
-     * if the function parameter has a union type.
+     * The logic for [[bindActionParam]] to validate whether a given parameter matches the action's typing if the
+     * function parameter has a union type.
+     *
      * @param mixed $param The parameter value.
-     * @param \ReflectionUnionType $type
+     *
+     * @param ReflectionUnionType $type The parameter's reflected union type.
+     *
      * @return array{mixed, bool} The resulting parameter value and a boolean indicating whether the value is valid.
      */
-    private function filterUnionTypeActionParam($param, $type)
+    private static function filterUnionTypeActionParam($param, $type)
     {
         $types = $type->getTypes();
+
         if ($param === '' && $type->allowsNull()) {
             // check if type can be string for old string behavior compatibility
             foreach ($types as $partialType) {
@@ -268,11 +381,13 @@ class Controller extends BaseController
             }
             return [null, true];
         }
+
         // if we found a built-in type but didn't return out, its validation failed
         $foundBuiltinType = false;
         // we save returning out an array or string for later because other types should take precedence
         $canBeArray = false;
         $canBeString = false;
+
         foreach ($types as $partialType) {
             if (
                 $partialType === null
@@ -281,10 +396,14 @@ class Controller extends BaseController
             ) {
                 continue;
             }
+
             $foundBuiltinType = true;
+
             $typeName = $partialType->getName();
+
             $canBeArray |= $typeName === 'array';
             $canBeString |= $typeName === 'string';
+
             if (is_array($param)) {
                 if ($canBeArray) {
                     break;
@@ -292,37 +411,40 @@ class Controller extends BaseController
                 continue;
             }
 
-            $filterResult = $this->filterParamByType($param, $typeName);
+            $filterResult = self::filterParamByType($param, $typeName);
+
             if ($filterResult !== null) {
                 return [$filterResult, true];
             }
         }
+
         if (!is_array($param) && $canBeString) {
             return [$param, true];
         }
+
         if ($canBeArray) {
             return [(array)$param, true];
         }
+
         return [$param, $canBeString || !$foundBuiltinType];
     }
 
     /**
      * Run the according filter_var logic for teh given type.
-     * @param string $param The value to filter.
+     *
+     * @param mixed $param The value to filter.
      * @param string $typeName The type name.
-     * @return mixed|null The resulting value, or null if validation failed or the type can't be validated.
+     *
+     * @return mixed|null The resulting value, or `null` if validation failed or the type can't be validated.
      */
-    private function filterParamByType(string $param, string $typeName)
+    private static function filterParamByType(mixed $param, string $typeName): mixed
     {
-        switch ($typeName) {
-            case 'int':
-                return filter_var($param, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
-            case 'float':
-                return filter_var($param, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
-            case 'bool':
-                return filter_var($param, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-        }
-        return null;
+        return match ($typeName) {
+            'int' => filter_var($param, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE),
+            'float' => filter_var($param, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE),
+            'bool' => filter_var($param, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
+            default => null,
+        };
     }
 
     /**

--- a/framework/web/ErrorAction.php
+++ b/framework/web/ErrorAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -18,8 +20,8 @@ use yii\base\UserException;
  *
  * To use ErrorAction, you need to do the following steps:
  *
- * First, declare an action of ErrorAction type in the `actions()` method of your `SiteController`
- * class (or whatever controller you prefer), like the following:
+ * First, declare an action of ErrorAction type in the `actions()` method of your `SiteController` class (or whatever
+ * controller you prefer), like the following:
  *
  * ```
  * public function actions()
@@ -30,8 +32,8 @@ use yii\base\UserException;
  * }
  * ```
  *
- * Then, create a view file for this action. If the route of your error action is `site/error`, then
- * the view file should be `views/site/error.php`. In this view file, the following variables are available:
+ * Then, create a view file for this action. If the route of your error action is `site/error`, then the view file
+ * should be `views/site/error.php`. In this view file, the following variables are available:
  *
  * - `$name`: the error name
  * - `$message`: the error message
@@ -44,6 +46,10 @@ use yii\base\UserException;
  *     'errorAction' => 'site/error',
  * ]
  * ```
+ *
+ * Not standalone-compatible: this action requires a hosting controller because rendering, layout resolution, and `view`
+ * aliases are performed through the controller. Register it via [[\yii\base\Controller::actions()]] rather than
+ * [[\yii\base\Module::$actionMap]].
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @author Dmitry Naumenko <d.naumenko.a@gmail.com>

--- a/framework/web/ViewAction.php
+++ b/framework/web/ViewAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -16,14 +18,19 @@ use yii\base\ViewNotFoundException;
  * ViewAction represents an action that displays a view according to a user-specified parameter.
  *
  * By default, the view being displayed is specified via the `view` GET parameter.
+ *
  * The name of the GET parameter can be customized via [[viewParam]].
  *
- * Users specify a view in the format of `path/to/view`, which translates to the view name
- * `ViewPrefix/path/to/view` where `ViewPrefix` is given by [[viewPrefix]]. The view will then
- * be rendered by the [[\yii\base\Controller::render()|render()]] method of the currently active controller.
+ * Users specify a view in the format of `path/to/view`, which translates to the view name `ViewPrefix/path/to/view`
+ * where `ViewPrefix` is given by [[viewPrefix]]. The view will then be rendered by the
+ * [[\yii\base\Controller::render()|render()]] method of the currently active controller.
  *
- * Note that the user-specified view name must start with a word character and can only contain
- * word characters, forward slashes, dots and dashes.
+ * Note that the user-specified view name must start with a word character and can only contain word characters, forward
+ * slashes, dots and dashes.
+ *
+ * Not standalone-compatible: this action requires a hosting controller because rendering and layout resolution are
+ * performed through the controller. Register it via [[\yii\base\Controller::actions()]] rather than
+ * [[\yii\base\Module::$actionMap]].
  *
  * @author Alexander Makarov <sam@rmcreative.ru>
  * @author Qiang Xue <qiang.xue@gmail.com>
@@ -60,7 +67,6 @@ class ViewAction extends Action
      * If false, no layout will be applied.
      */
     public $layout;
-
 
     /**
      * Runs the action.

--- a/tests/framework/base/ModuleActionMapTest.php
+++ b/tests/framework/base/ModuleActionMapTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base;
+
+use PHPUnit\Framework\Attributes\Group;
+use Yii;
+use yii\base\ActionEvent;
+use yii\base\InvalidRouteException;
+use yii\base\Module;
+use yiiunit\framework\base\stub\actionmap\PingAction;
+use yiiunit\framework\base\stub\actionmap\PingController;
+use yiiunit\TestCase;
+
+/**
+ * Unit tests for {@see \yii\base\Module} dispatch of standalone actions via `Module::$actionMap`.
+ *
+ * Verifies that registering a standalone {@see \yii\base\Action} subclass under `actionMap` causes
+ * {@see \yii\base\Module::runAction()} to invoke it without a hosting controller, that lifecycle events on the module
+ * chain still fire in order, and that legacy controller-based dispatch remains unaffected for unmapped IDs.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('base')]
+final class ModuleActionMapTest extends TestCase
+{
+    public static array $events = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockApplication();
+
+        self::$events = [];
+    }
+
+    public function testActionMapResolvesAndRuns(): void
+    {
+        $module = new Module('mymod');
+
+        $module->actionMap = ['ping' => PingAction::class];
+
+        $result = $module->runAction('ping', ['name' => 'world']);
+
+        self::assertSame(
+            'pong-world',
+            $result,
+            'Mapped action must execute and receive params from the route.',
+        );
+    }
+
+    public function testActionMapTakesPrecedenceOverControllerMap(): void
+    {
+        $module = new Module('mymod');
+
+        $module->controllerMap = ['ping' => PingController::class];
+        $module->actionMap = ['ping' => PingAction::class];
+
+        $result = $module->runAction('ping', ['name' => 'first']);
+
+        self::assertSame(
+            'pong-first',
+            $result,
+            "'actionMap' lookup must run before 'controllerMap' resolution.",
+        );
+    }
+
+    public function testActionNotInMapFallsThroughToControllerPipeline(): void
+    {
+        $module = new Module('mymod');
+
+        $module->controllerMap = ['legacy' => PingController::class];
+        $module->actionMap = ['ping' => PingAction::class];
+
+        $result = $module->runAction('legacy/echo');
+
+        self::assertSame(
+            'legacy:hello',
+            $result,
+            'Routes outside `actionMap` must reach the controller pipeline.',
+        );
+    }
+
+    public function testModuleEventBeforeActionFiresForMappedAction(): void
+    {
+        $module = new Module('mymod');
+
+        $module->actionMap = ['ping' => PingAction::class];
+
+        $module->on(
+            Module::EVENT_BEFORE_ACTION,
+            static function (ActionEvent $e): void {
+                ModuleActionMapTest::$events[] = 'module-before:' . $e->action->getUniqueId();
+            },
+        );
+
+        $module->runAction('ping', ['name' => 'evt']);
+
+        self::assertContains(
+            'module-before:mymod/ping',
+            self::$events,
+            'Before-action should observe the action.',
+        );
+    }
+
+    public function testModuleEventAfterActionFiresForMappedAction(): void
+    {
+        $module = new Module('mymod');
+
+        $module->actionMap = ['ping' => PingAction::class];
+
+        $module->on(
+            Module::EVENT_AFTER_ACTION,
+            static function (ActionEvent $e): void {
+                ModuleActionMapTest::$events[] = "module-after:{$e->result}";
+            },
+        );
+
+        $module->runAction('ping', ['name' => 'evt']);
+
+        self::assertContains(
+            'module-after:pong-evt',
+            self::$events,
+            'After-action event should observe the result.',
+        );
+    }
+
+    public function testNestedModuleEventsFireForMappedActionInOrder(): void
+    {
+        $parent = new Module('parent');
+        $child = new Module('child', $parent);
+
+        $child->actionMap = ['ping' => PingAction::class];
+
+        $parent->on(
+            Module::EVENT_BEFORE_ACTION,
+            static function (): void {
+                ModuleActionMapTest::$events[] = 'parent-before';
+            },
+        );
+        $child->on(
+            Module::EVENT_BEFORE_ACTION,
+            static function (): void {
+                ModuleActionMapTest::$events[] = 'child-before';
+            },
+        );
+        $parent->on(
+            Module::EVENT_AFTER_ACTION,
+            static function (): void {
+                ModuleActionMapTest::$events[] = 'parent-after';
+            },
+        );
+        $child->on(
+            Module::EVENT_AFTER_ACTION,
+            static function (): void {
+                ModuleActionMapTest::$events[] = 'child-after';
+            },
+        );
+
+        $child->runAction('ping', ['name' => 'nest']);
+
+        self::assertSame(
+            ['parent-before', 'child-before', 'child-after', 'parent-after'],
+            self::$events,
+            'Module ancestors fire before-actions outer-to-inner and after-actions inner-to-outer.',
+        );
+    }
+
+    public function testActionEventCanCancelMappedActionExecution(): void
+    {
+        $module = new Module('mymod');
+
+        $module->actionMap = ['ping' => PingAction::class];
+
+        $module->on(
+            Module::EVENT_BEFORE_ACTION,
+            static function (ActionEvent $e): void {
+                $e->isValid = false;
+            },
+        );
+
+        $result = $module->runAction('ping', ['name' => 'blocked']);
+
+        self::assertNull(
+            $result,
+            "Setting 'isValid' to 'false' in module before-action must cancel the action.",
+        );
+    }
+
+    public function testMappedActionSetsRequestedActionOnApplication(): void
+    {
+        $module = new Module('mymod', Yii::$app);
+
+        $module->actionMap = ['ping' => PingAction::class];
+
+        Yii::$app->requestedAction = null;
+
+        $module->runAction('ping', ['name' => 'tracker']);
+
+        self::assertNotNull(
+            Yii::$app->requestedAction,
+            'Action must populate \'Yii::$app->requestedAction\' once.',
+        );
+
+        $requested = Yii::$app->requestedAction;
+
+        self::assertSame(
+            'mymod/ping',
+            $requested->getUniqueId(),
+            'Requested action must be the mapped action.',
+        );
+    }
+
+    public function testThrowInvalidRouteExceptionWhenRouteResolvesToNeitherMap(): void
+    {
+        $module = new Module('mymod');
+
+        $this->expectException(InvalidRouteException::class);
+        $this->expectExceptionMessage(
+            'Unable to resolve the request "mymod/missing".',
+        );
+
+        $module->runAction('missing');
+    }
+}

--- a/tests/framework/base/ModuleActionNamespaceTest.php
+++ b/tests/framework/base/ModuleActionNamespaceTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base;
+
+use PHPUnit\Framework\Attributes\Group;
+use yii\base\InvalidConfigException;
+use yii\base\InvalidRouteException;
+use yii\base\Module;
+use yiiunit\TestCase;
+
+/**
+ * Unit tests for {@see \yii\base\Module} convention-based standalone action discovery via `Module::$actionNamespace`.
+ *
+ * Verifies the parallel between controllers and standalone actions: `actionNamespace` defaults to
+ * `controllerNamespace`, supports hyphen and sub-namespace prefixes in routes, recurses through sub-modules, yields
+ * precedence to controllers when both could match a route, and rejects classes with the `Action` suffix that are
+ * actually `Controller` subclasses.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('base')]
+final class ModuleActionNamespaceTest extends TestCase
+{
+    private const string FIXTURE_NAMESPACE = 'yiiunit\\framework\\base\\stub\\actions';
+    private const string USECASE_NAMESPACE = 'yiiunit\\framework\\base\\stub\\usecase';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockApplication();
+    }
+
+    public function testActionNamespaceDefaultsToControllerNamespaceAfterInit(): void
+    {
+        $module = new Module(
+            'mymod',
+            null,
+            ['controllerNamespace' => self::FIXTURE_NAMESPACE],
+        );
+
+        self::assertSame(
+            self::FIXTURE_NAMESPACE,
+            $module->actionNamespace,
+            "'actionNamespace' should default to 'controllerNamespace' when not configured.",
+        );
+    }
+
+    public function testActionNamespaceHonorsExplicitConfiguration(): void
+    {
+        $module = new Module(
+            'mymod',
+            null,
+            [
+                'controllerNamespace' => self::FIXTURE_NAMESPACE,
+                'actionNamespace' => self::USECASE_NAMESPACE,
+            ],
+        );
+
+        self::assertSame(
+            self::USECASE_NAMESPACE,
+            $module->actionNamespace,
+            "Explicitly configured 'actionNamespace' must override the default.",
+        );
+    }
+
+    public function testStandaloneActionResolvedByConvention(): void
+    {
+        $module = new Module(
+            'mymod',
+            null,
+            ['controllerNamespace' => self::FIXTURE_NAMESPACE],
+        );
+
+        $result = $module->runAction('post/index');
+
+        self::assertSame(
+            'post-index',
+            $result,
+            "Convention should resolve route to '<ns>\\post\\IndexAction'.",
+        );
+    }
+
+    public function testStandaloneActionResolvedWithHyphenInSegment(): void
+    {
+        $module = new Module(
+            'mymod',
+            null,
+            ['controllerNamespace' => self::FIXTURE_NAMESPACE],
+        );
+
+        $result = $module->runAction('post/view-details');
+
+        self::assertSame(
+            'view-details',
+            $result,
+            'Hyphenated last segment must resolve to CamelCased class name.',
+        );
+    }
+
+    public function testStandaloneActionResolvedWithSubNamespacePrefix(): void
+    {
+        $module = new Module(
+            'mymod',
+            null,
+            ['controllerNamespace' => self::FIXTURE_NAMESPACE],
+        );
+
+        $result = $module->runAction('admin/posts/view');
+
+        self::assertSame(
+            'admin-posts-view',
+            $result,
+            'Multi-segment route must traverse sub-namespaces.',
+        );
+    }
+
+    public function testActionNamespaceOverrideRoutesToCustomRoot(): void
+    {
+        $module = new Module(
+            'mymod',
+            null,
+            [
+                'controllerNamespace' => self::FIXTURE_NAMESPACE,
+                'actionNamespace' => self::USECASE_NAMESPACE,
+            ],
+        );
+
+        $result = $module->runAction('orders/create');
+
+        self::assertSame(
+            'usecase-orders-create',
+            $result,
+            "Custom 'actionNamespace' must root standalone-action lookup outside 'controllerNamespace'.",
+        );
+    }
+
+    public function testStandaloneActionRecursesIntoSubModule(): void
+    {
+        $parent = new Module(
+            'parent',
+            null,
+            ['controllerNamespace' => self::FIXTURE_NAMESPACE],
+        );
+
+        $parent->setModule(
+            'admin',
+            [
+                'class' => Module::class,
+                'controllerNamespace' => self::FIXTURE_NAMESPACE . '\\admin',
+            ],
+        );
+
+        $result = $parent->runAction('admin/posts/view');
+
+        self::assertSame(
+            'admin-posts-view',
+            $result,
+            'Sub-module must resolve standalone action through recursion.',
+        );
+    }
+
+    public function testStandaloneActionRejectsControllerSubclass(): void
+    {
+        $module = new Module(
+            'mymod',
+            null,
+            ['controllerNamespace' => self::FIXTURE_NAMESPACE],
+        );
+
+        $this->expectException(InvalidRouteException::class);
+
+        $module->runAction('sub/foo');
+    }
+
+    public function testThrowInvalidConfigExceptionWhenControllerActionAndStandaloneActionShadow(): void
+    {
+        $module = new Module(
+            'mymod',
+            null,
+            ['controllerNamespace' => self::FIXTURE_NAMESPACE],
+        );
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage(
+            'Route "mymod/post/view" matches both a controller action and a standalone Action class. '
+            . 'Remove one to disambiguate.',
+        );
+
+        $module->runAction('post/view');
+    }
+
+    public function testThrowInvalidRouteExceptionWhenNoControllerNorActionMatches(): void
+    {
+        $module = new Module(
+            'mymod',
+            null,
+            ['controllerNamespace' => self::FIXTURE_NAMESPACE],
+        );
+
+        $this->expectException(InvalidRouteException::class);
+        $this->expectExceptionMessage(
+            'Unable to resolve the request "mymod/does-not-exist".',
+        );
+
+        $module->runAction('does-not-exist');
+    }
+}

--- a/tests/framework/base/StandaloneActionTest.php
+++ b/tests/framework/base/StandaloneActionTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base;
+
+use Yii;
+use yii\base\ActionEvent;
+use yii\base\Controller;
+use yii\base\InvalidConfigException;
+use yii\base\Module;
+use yiiunit\framework\base\stub\standalone\ActionTestService;
+use yiiunit\framework\base\stub\standalone\BehaviorAction;
+use yiiunit\framework\base\stub\standalone\CancelingAction;
+use yiiunit\framework\base\stub\standalone\GreetAction;
+use yiiunit\framework\base\stub\standalone\InjectingAction;
+use yiiunit\framework\base\stub\standalone\MethodInjectingAction;
+use yiiunit\framework\base\stub\standalone\NoRunAction;
+use yiiunit\framework\base\stub\standalone\StubController;
+use yiiunit\framework\base\stub\standalone\TrackingFilter;
+use yiiunit\TestCase;
+
+/**
+ * Unit tests for {@see \yii\base\Action} when invoked standalone (without a hosting controller).
+ *
+ * Covers the nullable `$controller` contract, module-aware {@see \yii\base\Action::getUniqueId()} fallback,
+ * DI-based parameter resolution on `run()` via {@see \yii\di\Container::resolveCallableDependencies()}, the
+ * `beforeRun()` cancellation hook, and behavior attachment via the action's own event triggers.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ *
+ * @group base
+ */
+final class StandaloneActionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockApplication();
+
+        Yii::$container->setSingleton(ActionTestService::class, ActionTestService::class);
+
+        TrackingFilter::$beforeCalls = [];
+    }
+
+    protected function tearDown(): void
+    {
+        Yii::$container->clear(ActionTestService::class);
+
+        parent::tearDown();
+    }
+
+    public function testRunWithoutController(): void
+    {
+        $action = new GreetAction('greet', null);
+
+        $result = $action->runWithParams(['name' => 'world']);
+
+        self::assertSame(
+            'hello world',
+            $result,
+            "Standalone action should execute 'run()' with provided params.",
+        );
+    }
+
+    public function testGetUniqueIdFallsBackToModuleWhenControllerIsNull(): void
+    {
+        $module = new Module('mymod');
+
+        $action = new GreetAction('greet', null);
+
+        $action->setModule($module);
+
+        self::assertSame(
+            'mymod/greet',
+            $action->getUniqueId(),
+            'Unique ID should combine module ID and action ID.',
+        );
+    }
+
+    public function testGetUniqueIdReturnsIdWhenNoControllerAndNoModule(): void
+    {
+        $action = new GreetAction('orphan', null);
+
+        self::assertSame(
+            'orphan',
+            $action->getUniqueId(),
+            'Unique ID should fall back to action ID alone.',
+        );
+    }
+
+    public function testGetUniqueIdStillWorksWithController(): void
+    {
+        $controller = new StubController('stub', Yii::$app);
+
+        $action = new GreetAction('greet', $controller);
+
+        self::assertSame(
+            'stub/greet',
+            $action->getUniqueId(),
+            'Existing controller-bound path must remain intact.',
+        );
+    }
+
+    public function testTypedParamInjectionViaContainer(): void
+    {
+        $action = new MethodInjectingAction('inject', null);
+
+        $result = $action->runWithParams(['id' => 7]);
+
+        self::assertSame(
+            'svc-7',
+            $result,
+            'Service should be autowired and scalar param taken from request.',
+        );
+    }
+
+    public function testConstructorParamInjectionViaContainer(): void
+    {
+        $action = Yii::createObject(InjectingAction::class, ['inject', null]);
+
+        self::assertInstanceOf(
+            InjectingAction::class,
+            $action,
+            'Container must instantiate action with deps.',
+        );
+        self::assertSame(
+            'svc',
+            $action->runWithParams([]),
+            "Constructor injected service should reach 'run()'.",
+        );
+    }
+
+    public function testBeforeRunReturningFalseCancelsExecution(): void
+    {
+        $action = new CancelingAction('cancel', null);
+
+        $result = $action->runWithParams([]);
+
+        self::assertNull(
+            $result,
+            "Before run returning 'false' must short-circuit execution.",
+        );
+        self::assertFalse(
+            $action->ran,
+            "run() must not be invoked when beforeRun returns 'false'.",
+        );
+    }
+
+    public function testBehaviorAttachesAndFiresOnAction(): void
+    {
+        $action = new BehaviorAction('tracked', null);
+
+        $event = new ActionEvent($action);
+
+        $action->trigger(Controller::EVENT_BEFORE_ACTION, $event);
+
+        self::assertTrue(
+            $event->isValid,
+            'Tracking filter must keep the action valid by default.',
+        );
+        self::assertSame(
+            ['tracked'],
+            TrackingFilter::$beforeCalls,
+            'Behavior must observe the standalone action ID.',
+        );
+    }
+
+    public function testStandaloneRunResolvesParamsViaContainer(): void
+    {
+        $action = new MethodInjectingAction('inject', null);
+
+        $result = $action->runWithParams(['id' => 42]);
+
+        self::assertSame(
+            'svc-42',
+            $result,
+            'Method level DI must combine container service and route params.',
+        );
+    }
+
+    public function testThrowInvalidConfigExceptionWhenActionHasNoRunMethod(): void
+    {
+        $action = new NoRunAction('broken', null);
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage(
+            'must define a "run()" method',
+        );
+
+        $action->runWithParams([]);
+    }
+}

--- a/tests/framework/base/stub/actionmap/PingAction.php
+++ b/tests/framework/base/stub/actionmap/PingAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\actionmap;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing {@see \yii\base\Module::$actionMap}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class PingAction extends Action
+{
+    public function run(string $name): string
+    {
+        return "pong-{$name}";
+    }
+}

--- a/tests/framework/base/stub/actionmap/PingController.php
+++ b/tests/framework/base/stub/actionmap/PingController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\actionmap;
+
+use yii\base\Controller;
+
+/**
+ * Controller used for testing {@see \yii\base\Module::$actionMap}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class PingController extends Controller
+{
+    public function actionEcho(): string
+    {
+        return 'legacy:hello';
+    }
+}

--- a/tests/framework/base/stub/actions/PostController.php
+++ b/tests/framework/base/stub/actions/PostController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\actions;
+
+use yii\base\Controller;
+
+/**
+ * Controller used for testing {@see \yii\base\Module::actions()}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class PostController extends Controller
+{
+    public function actionView(): string
+    {
+        return 'controller-view';
+    }
+}

--- a/tests/framework/base/stub/actions/admin/posts/ViewAction.php
+++ b/tests/framework/base/stub/actions/admin/posts/ViewAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\actions\admin\posts;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing {@see \yii\base\Module::actions()}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class ViewAction extends Action
+{
+    public function run(): string
+    {
+        return 'admin-posts-view';
+    }
+}

--- a/tests/framework/base/stub/actions/post/IndexAction.php
+++ b/tests/framework/base/stub/actions/post/IndexAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\actions\post;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing {@see \yii\base\Module::actions()}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class IndexAction extends Action
+{
+    public function run(): string
+    {
+        return 'post-index';
+    }
+}

--- a/tests/framework/base/stub/actions/post/ViewAction.php
+++ b/tests/framework/base/stub/actions/post/ViewAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\actions\post;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing {@see \yii\base\Module::actions()}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class ViewAction extends Action
+{
+    public function run(): string
+    {
+        return 'action-view';
+    }
+}

--- a/tests/framework/base/stub/actions/post/ViewDetailsAction.php
+++ b/tests/framework/base/stub/actions/post/ViewDetailsAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\actions\post;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing {@see \yii\base\Module::actions()}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class ViewDetailsAction extends Action
+{
+    public function run(): string
+    {
+        return 'view-details';
+    }
+}

--- a/tests/framework/base/stub/actions/sub/FooAction.php
+++ b/tests/framework/base/stub/actions/sub/FooAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\actions\sub;
+
+use yii\base\Controller;
+
+/**
+ * Intentionally extends Controller (not Action) to assert that the standalone resolver rejects classes with the Action
+ * suffix that are actually Controller subclasses.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class FooAction extends Controller
+{
+    public function actionIndex(): string
+    {
+        return 'unreachable';
+    }
+}

--- a/tests/framework/base/stub/standalone/ActionTestService.php
+++ b/tests/framework/base/stub/standalone/ActionTestService.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\standalone;
+
+/**
+ * Service used for testing standalone action resolver.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class ActionTestService
+{
+    public function name(): string
+    {
+        return 'svc';
+    }
+}

--- a/tests/framework/base/stub/standalone/BehaviorAction.php
+++ b/tests/framework/base/stub/standalone/BehaviorAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\standalone;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing standalone action resolver with behaviors.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class BehaviorAction extends Action
+{
+    public function behaviors(): array
+    {
+        return [
+            'tracker' => TrackingFilter::class,
+        ];
+    }
+
+    public function run(): string
+    {
+        return 'ok';
+    }
+}

--- a/tests/framework/base/stub/standalone/CancelingAction.php
+++ b/tests/framework/base/stub/standalone/CancelingAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\standalone;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing that returning false from {@see \yii\base\Action::beforeRun()} prevents the action from
+ * running.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class CancelingAction extends Action
+{
+    public bool $ran = false;
+
+    public function run(): string
+    {
+        $this->ran = true;
+
+        return 'should-not-reach';
+    }
+
+    protected function beforeRun(): bool
+    {
+        return false;
+    }
+}

--- a/tests/framework/base/stub/standalone/GreetAction.php
+++ b/tests/framework/base/stub/standalone/GreetAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\standalone;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing standalone action resolver.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class GreetAction extends Action
+{
+    public function run(string $name): string
+    {
+        return "hello {$name}";
+    }
+}

--- a/tests/framework/base/stub/standalone/InjectingAction.php
+++ b/tests/framework/base/stub/standalone/InjectingAction.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\standalone;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing standalone action resolver with constructor injection.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class InjectingAction extends Action
+{
+    public ActionTestService $service;
+
+    public function __construct($id, $controller, ActionTestService $service, $config = [])
+    {
+        $this->service = $service;
+
+        parent::__construct($id, $controller, $config);
+    }
+
+    public function run(): string
+    {
+        return $this->service->name();
+    }
+}

--- a/tests/framework/base/stub/standalone/MethodInjectingAction.php
+++ b/tests/framework/base/stub/standalone/MethodInjectingAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\standalone;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing standalone action resolver with method injection.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class MethodInjectingAction extends Action
+{
+    public function run(ActionTestService $service, int $id): string
+    {
+        return $service->name() . '-' . $id;
+    }
+}

--- a/tests/framework/base/stub/standalone/NoRunAction.php
+++ b/tests/framework/base/stub/standalone/NoRunAction.php
@@ -13,8 +13,8 @@ namespace yiiunit\framework\base\stub\standalone;
 use yii\base\Action;
 
 /**
- * Action used for testing that an action that does not implement {@see \yii\base\Action::run()} can be resolved and
- * executed without error.
+ * Action used for testing that resolving an action without {@see \yii\base\Action::run()} leads to
+ * {@see \yii\base\InvalidConfigException} on execution.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 22.0

--- a/tests/framework/base/stub/standalone/NoRunAction.php
+++ b/tests/framework/base/stub/standalone/NoRunAction.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\standalone;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing that an action that does not implement {@see \yii\base\Action::run()} can be resolved and
+ * executed without error.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class NoRunAction extends Action
+{
+}

--- a/tests/framework/base/stub/standalone/StubController.php
+++ b/tests/framework/base/stub/standalone/StubController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\standalone;
+
+use yii\base\Controller;
+
+/**
+ * Controller used for testing standalone action resolver.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class StubController extends Controller
+{
+}

--- a/tests/framework/base/stub/standalone/TrackingFilter.php
+++ b/tests/framework/base/stub/standalone/TrackingFilter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\standalone;
+
+use yii\base\ActionFilter;
+
+/**
+ * Action filter used for testing that filters can be applied to standalone actions.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class TrackingFilter extends ActionFilter
+{
+    public static array $beforeCalls = [];
+
+    public function beforeAction($action): bool
+    {
+        self::$beforeCalls[] = $action->getUniqueId();
+
+        return true;
+    }
+}

--- a/tests/framework/base/stub/usecase/orders/CreateAction.php
+++ b/tests/framework/base/stub/usecase/orders/CreateAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\usecase\orders;
+
+use yii\base\Action;
+
+/**
+ * Action used for testing that a standalone action can be resolved and executed when the action ID contains a dash.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class CreateAction extends Action
+{
+    public function run(): string
+    {
+        return 'usecase-orders-create';
+    }
+}

--- a/tests/framework/web/WebActionTest.php
+++ b/tests/framework/web/WebActionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\web;
+
+use PHPUnit\Framework\Attributes\Group;
+use yii\web\BadRequestHttpException;
+use yiiunit\framework\web\stub\standalone\CoerceIntAction;
+use yiiunit\TestCase;
+
+/**
+ * Unit tests for {@see \yii\web\Action} HTTP-aware standalone parameter binding.
+ *
+ * Verifies that standalone HTTP actions get the same scalar coercion, type validation, and missing-parameter handling
+ * as controller-bound actions, mirroring {@see \yii\web\Controller::bindActionParams()}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('web')]
+final class WebActionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockWebApplication();
+    }
+
+    public function testWebActionCoercesScalarParam(): void
+    {
+        $action = new CoerceIntAction('coerce', null);
+
+        $result = $action->runWithParams(['id' => '7']);
+
+        self::assertSame(
+            7,
+            $result,
+            "Scalar string '7' should be coerced to int 7 by HTTP-aware binder.",
+        );
+    }
+
+    public function testThrowBadRequestHttpExceptionWhenScalarParamFailsTypeCoercion(): void
+    {
+        $action = new CoerceIntAction('coerce', null);
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('Invalid data received for parameter "id".');
+
+        $action->runWithParams(['id' => 'abc']);
+    }
+
+    public function testThrowBadRequestHttpExceptionWhenRequiredParamMissing(): void
+    {
+        $action = new CoerceIntAction('coerce', null);
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('Missing required parameters: id');
+
+        $action->runWithParams([]);
+    }
+}

--- a/tests/framework/web/stub/standalone/CoerceIntAction.php
+++ b/tests/framework/web/stub/standalone/CoerceIntAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\web\stub\standalone;
+
+use yii\web\Action;
+
+/**
+ * Action used for testing scalar coercion in {@see \yii\web\Action::resolveStandaloneParams()}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class CoerceIntAction extends Action
+{
+    public function run(int $id): int
+    {
+        return $id;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #20840
