### PR TITLE
Relax `yii\base\Action` constructor to accept `null` id; standalone action dispatch now uses unified DI without positional args.

### DIFF
--- a/docs/guide/tutorial-standalone-actions.md
+++ b/docs/guide/tutorial-standalone-actions.md
@@ -106,6 +106,93 @@ A request whose route resolves to `health` runs `HealthAction::run()` directly. 
 action's `behaviors()` (such as [[yii\filters\AccessControl]] or [[yii\filters\VerbFilter]]) participate in the lifecycle
 the same way they do on a controller.
 
+### Dependency injection in standalone actions
+
+Standalone actions dispatched via `actionMap` or `actionNamespace` support dependency injection in **two places**:
+
+1. **Constructor injection** — typed parameters on `__construct()` are resolved through the DI container before the
+   action runs. Use this for long-lived collaborators (database connections, repositories, services) that the action
+   needs across all invocations.
+2. **`run()` method injection** — typed parameters on `run()` are resolved per-invocation through
+   [[\yii\di\Container::resolveCallableDependencies()]]. Use this for the request itself ([[yii\web\Response]],
+   [[yii\web\Request]]) and for route-bound scalars (`int $id` from the URL, etc.).
+
+Both paths coexist. A common pattern injects services through the constructor and request-scoped values through
+`run()`:
+
+```php
+namespace app\controllers;
+
+use yii\db\Connection;
+use yii\web\Action;
+use yii\web\Response;
+
+final class HealthAction extends Action
+{
+    // Long-lived service: resolved once at construction by the DI container.
+    public function __construct(private readonly Connection $db)
+    {
+    }
+
+    // Per-invocation: $response comes from the application; route scalars (none here) would land alongside it.
+    public function run(Response $response): Response
+    {
+        $response->format = Response::FORMAT_JSON;
+        $response->data = ['db' => $this->db->open() ? 'ok' : 'down'];
+
+        return $response;
+    }
+}
+```
+
+The constructor uses PHP `8.x` promoted properties (`private readonly Connection $db`) to assign the typed parameter
+to a property in one step. Promoted properties are syntactic sugar — a plain assignment is equivalent:
+
+```php
+private readonly Connection $db;
+
+public function __construct(Connection $db)
+{
+    $this->db = $db;
+}
+```
+
+#### Choosing constructor vs `run()` injection
+
+| Inject in the constructor when                                             | Inject in `run()` when                                                                     |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| The dependency is the same on every call (DB, mailer, cache, repository).  | The dependency is the request-scoped artifact ([[yii\web\Request]], [[yii\web\Response]]). |
+| You want it usable from `behaviors()`, `init()`, or other lifecycle hooks. | You want it scoped to the single dispatch.                                                 |
+| You want the type signature to document the action's collaborators.        | The value is a route parameter (`int $id`, `string $slug`).                                |
+
+Route scalars on `run()` (such as `int $id`) get HTTP-aware coercion through [[yii\web\Action::resolveStandaloneParams()]]
+when the action extends [[yii\web\Action]]. Non-HTTP standalone actions (extending [[yii\base\Action]]) get the same
+DI but skip the scalar coercion.
+
+#### Lifecycle and `parent::__construct()`
+
+The dispatcher calls `Yii::createObject()` on the action class with no positional arguments and assigns
+[[yii\base\Action::$id]] afterwards. Modern actions do **not** need to call `parent::__construct()` — the parent
+constructor accepts a `null` id by default.
+
+If your action relies on [[yii\base\Action::init()]] (because you attach behaviors there or run setup that depends on
+the parent's state), call `parent::__construct()` explicitly to trigger it:
+
+```php
+public function __construct(private readonly Connection $db)
+{
+    parent::__construct();
+}
+```
+
+Note: when `init()` runs through `parent::__construct()`, [[yii\base\Action::$id]] is still `null` — the dispatcher
+assigns it after the constructor returns. Logic that depends on the action ID belongs in `behaviors()` event handlers
+(which fire on `EVENT_BEFORE_ACTION` / `EVENT_AFTER_ACTION` after id assignment), not in `init()`.
+
+Controllers and actions registered through [[yii\base\Controller::actions()]] keep the historical positional
+contract `__construct($id, $controller, $config)` — this DI-friendly dispatch path only applies to standalone
+actions resolved through `actionMap` or `actionNamespace`.
+
 For projects that prefer a separate root for standalone actions (vertical slices, use cases, ports/adapters layout), set
 `actionNamespace` to the desired namespace:
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -54,6 +54,7 @@ Yii Framework 2 Change Log
 - Chg: Remove PostgreSQL `< 13.0` dead code; drop `oldUpsert()` CTE workaround for `< 9.5` and identity column version branch in `Schema::findColumns()` for `< 12.0`; minimum supported version is now PostgreSQL `13.0` (terabytesoftw)
 - Chg #18639: Refactor PostgreSQL pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; PostgreSQL `13+` is now required for `yii\db\pgsql\QueryBuilder` pagination (terabytesoftw)
 - Chg: Add `Module::$actionMap`, `Module::$actionNamespace`, and `yii\web\Action` for standalone action dispatch with HTTP-aware param binding (terabytesoftw)
+- Chg: Relax `yii\base\Action` constructor to accept `null` id; standalone action dispatch now uses unified DI without positional args (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -474,9 +474,9 @@ declared on the action participate in its lifecycle (`AccessControl`, `VerbFilte
 The convention-based file placement mirrors controllers, only the suffix and parent class differ:
 
 ```
-app/controllers/PostController.php          (existing controller, unchanged)
-app/controllers/post/IndexAction.php        (standalone action, route post/index)
-app/controllers/post/ViewAction.php         (standalone action, route post/view)
+app/controllers/PostController.php           (existing controller, unchanged)
+app/controllers/post/IndexAction.php         (standalone action, route post/index)
+app/controllers/post/ViewAction.php          (standalone action, route post/view)
 app/controllers/admin/posts/CreateAction.php (standalone action, route admin/posts/create)
 ```
 
@@ -541,6 +541,104 @@ final class HealthAction extends Action
 Reserve `yii\base\Action` for non-HTTP standalone contexts (queue jobs, scheduled tasks, console-side dispatch). It
 keeps the simpler `yii\di\Container::resolveCallableDependencies()` resolution which autowires typed services but
 does not coerce or validate scalar parameters.
+
+#### Standalone action constructor and dependency injection
+
+`yii\base\Action::__construct()` now accepts `null` for both `$id` and `$controller`:
+
+```php
+// Before (2.0.x)
+public function __construct($id, $controller = null, $config = [])
+
+// 22.0
+public function __construct($id = null, $controller = null, $config = [])
+```
+
+This relaxation enables two coexisting DI paths for actions dispatched through `Module::$actionMap` or
+`Module::$actionNamespace`:
+
+1. **Constructor injection** — typed parameters (with or without PHP `8.x` promoted properties) are autowired by the
+   DI container. Use this for long-lived collaborators (database connections, repositories, services).
+2. **`run()` method injection** — typed parameters on `run()` are resolved per-invocation through
+   `Container::resolveCallableDependencies()`. Use this for the request itself (`yii\web\Response`,
+   `yii\web\Request`) and for route-bound scalars (`int $id`, `string $slug`).
+
+Both forms compose:
+
+```php
+namespace app\controllers;
+
+use yii\db\Connection;
+use yii\web\Action;
+use yii\web\Response;
+
+final class HealthAction extends Action
+{
+    public function __construct(private readonly Connection $db)
+    {
+    }
+
+    public function run(Response $response): Response
+    {
+        $response->format = Response::FORMAT_JSON;
+        $response->data = ['db' => $this->db->open() ? 'ok' : 'down'];
+
+        return $response;
+    }
+}
+```
+
+##### Dispatch contract change for standalone actions
+
+`Module::runMappedAction()` and `Module::createStandaloneAction()` now build the action through
+`Yii::createObject($definition)` with **no positional arguments** and assign `Action::$id` afterwards. In 2.0.x the
+dispatcher passed `[$id, null]` positionally, so the constructor (and any code running inside `init()`) saw the route
+segment ID immediately.
+
+**Behavior change**: when a standalone action declares a legacy positional constructor
+(`__construct($id, $controller = null, $config = [])` calling `parent::__construct(...)`), the constructor now
+receives `$id === null`, and `Action::init()` runs with `$this->id === null`. The dispatcher assigns the real ID
+**after** the constructor returns, so `$this->id` is correct by the time the action's lifecycle events
+(`EVENT_BEFORE_ACTION`, `EVENT_AFTER_ACTION`) and `run()` execute.
+
+This affects only standalone actions registered in `actionMap` or discovered through `actionNamespace`. Actions
+registered through `Controller::actions()` keep the historical positional contract `[$id, $this]` unchanged, and
+their `init()` continues to see the ID during construction.
+
+##### Migration
+
+If your standalone action overrides `init()` and reads `$this->id` (for example to register an alias, set a logger
+category, or compute a cache key), move that logic to a `behaviors()` event handler attached to
+`EVENT_BEFORE_ACTION`. Event handlers fire after the dispatcher has assigned the ID:
+
+```php
+// Before
+public function init()
+{
+    parent::init();
+
+    \Yii::setAlias('@action-' . $this->id, '@runtime/' . $this->id);  // sees null in 22.0
+}
+
+// After
+public function behaviors(): array
+{
+    return [
+        'aliases' => [
+            'class' => \yii\base\Behavior::class,
+            'on ' . self::EVENT_BEFORE_ACTION => function () {
+                \Yii::setAlias('@action-' . $this->owner->id, '@runtime/' . $this->owner->id);
+            },
+        ],
+    ];
+}
+```
+
+Modern constructors do not need to call `parent::__construct()` — the parent constructor accepts `null` and is a no-op
+for identity. Call it explicitly only if your action depends on `Action::init()` for behavior attachment or other
+parent-side setup, and in that case understand that `$this->id` will be `null` inside `init()`.
+
+##### Other related changes
 
 `yii\filters\AccessRule::matchController()` now accepts `null` for the controller argument. When a rule declares a
 non-empty `controllers` constraint and the action runs as a standalone action, the rule does not match. To keep the

--- a/framework/base/Action.php
+++ b/framework/base/Action.php
@@ -68,11 +68,12 @@ class Action extends Component
     /**
      * Constructor.
      *
-     * @param string $id The ID of this action.
+     * @param string|null $id The ID of this action, or `null` when the action is instantiated through the DI container
+     * and the ID is assigned afterwards by the dispatcher.
      * @param T|null $controller The controller that owns this action, or `null` for standalone handlers.
      * @param array<string, mixed> $config name-value pairs that will be used to initialize the object properties.
      */
-    public function __construct($id, $controller = null, $config = [])
+    public function __construct($id = null, $controller = null, $config = [])
     {
         $this->id = $id;
         $this->controller = $controller;

--- a/framework/base/Action.php
+++ b/framework/base/Action.php
@@ -49,7 +49,8 @@ use function get_class;
 class Action extends Component
 {
     /**
-     * @var string ID of the action
+     * @var string|null ID of the action; `null` between construction and dispatcher post-assignment for standalone
+     * actions resolved through {@see Module::$actionMap} or {@see Module::$actionNamespace}.
      */
     public $id;
     /**

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -675,9 +675,9 @@ class Module extends ServiceLocator
     /**
      * Runs a standalone action registered in [[actionMap]].
      *
-     * The action is instantiated via [[\Yii::createObject()]] with `[$id, null]` as positional constructor arguments,
-     * allowing the DI container to autowire any extra typed dependencies declared after `$controller`. The lifecycle is
-     * then delegated to [[runStandaloneAction()]].
+     * The action is instantiated via [[\Yii::createObject()]] with no positional constructor arguments, allowing the
+     * DI container to autowire typed dependencies declared on the action's constructor. The dispatcher assigns
+     * [[Action::$id]] after construction and then delegates lifecycle to [[runStandaloneAction()]].
      *
      * @param string $id The action ID present in [[actionMap]].
      * @param array $params The parameters to be matched against the action's `run()` signature.

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -689,7 +689,9 @@ class Module extends ServiceLocator
     protected function runMappedAction(string $id, array $params): mixed
     {
         /** @var Action $action */
-        $action = Yii::createObject($this->actionMap[$id], [$id, null]);
+        $action = Yii::createObject($this->actionMap[$id]);
+
+        $action->id = $id;
 
         $action->setModule($this);
 
@@ -774,7 +776,10 @@ class Module extends ServiceLocator
         }
 
         /** @var Action $action */
-        $action = Yii::createObject($className, [$route, null]);
+        $action = Yii::createObject($className);
+
+        $action->id = $route;
+
         $action->setModule($this);
 
         return $action;

--- a/tests/framework/base/ModuleActionMapTest.php
+++ b/tests/framework/base/ModuleActionMapTest.php
@@ -17,6 +17,8 @@ use yii\base\InvalidRouteException;
 use yii\base\Module;
 use yiiunit\framework\base\stub\actionmap\PingAction;
 use yiiunit\framework\base\stub\actionmap\PingController;
+use yiiunit\framework\base\stub\actions\HealthAction;
+use yiiunit\framework\base\stub\standalone\ActionTestService;
 use yiiunit\framework\base\stub\standalone\LegacyConstructorAction;
 use yiiunit\framework\base\stub\standalone\LegacyConstructorBehaviorAction;
 use yiiunit\TestCase;
@@ -237,7 +239,7 @@ final class ModuleActionMapTest extends TestCase
         );
     }
 
-    public function testLegacyConstructorActionReceivesRouteIdInsideTheConstructor(): void
+    public function testLegacyConstructorActionReceivesNullIdFromDispatcher(): void
     {
         $module = new Module('mymod');
 
@@ -252,10 +254,9 @@ final class ModuleActionMapTest extends TestCase
             $action,
             'Resolved action must be the legacy stub.',
         );
-        self::assertSame(
-            'legacy',
+        self::assertNull(
             $action->idSeenInConstructor,
-            'Route segment ID must arrive positionally.',
+            "ID must be 'null' during construction.",
         );
         self::assertNull(
             $action->controllerSeenInConstructor,
@@ -263,7 +264,7 @@ final class ModuleActionMapTest extends TestCase
         );
     }
 
-    public function testLegacyConstructorActionInitObservesRouteId(): void
+    public function testLegacyConstructorActionInitObservesNullIdAndDispatcherAssignsAfterwards(): void
     {
         $module = new Module('mymod');
 
@@ -278,10 +279,14 @@ final class ModuleActionMapTest extends TestCase
             $action,
             'Resolved action must be the legacy stub.',
         );
+        self::assertNull(
+            $action->idSeenInInit,
+            "Identity must be 'null' during 'init'.",
+        );
         self::assertSame(
             'legacy',
-            $action->idSeenInInit,
-            'Identity must be set before lifecycle hooks run.',
+            $action->id,
+            'Dispatcher must assign the route ID post-construction.',
         );
         self::assertSame(
             'mymod/legacy',
@@ -326,10 +331,9 @@ final class ModuleActionMapTest extends TestCase
             $action,
             'Resolved action must be the legacy stub.',
         );
-        self::assertSame(
-            'legacy',
+        self::assertNull(
             $action->idSeenInInit,
-            'Identity must survive nested dispatch.',
+            "Identity must be 'null' during 'init' even under nested dispatch.",
         );
         self::assertSame(
             'parent/child/legacy',
@@ -348,5 +352,24 @@ final class ModuleActionMapTest extends TestCase
         );
 
         $module->runAction('missing');
+    }
+
+    public function testActionMapResolvesPromotedConstructorAction(): void
+    {
+        Yii::$container->setSingleton(ActionTestService::class, ActionTestService::class);
+
+        $module = new Module('mymod');
+
+        $module->actionMap = ['promoted' => HealthAction::class];
+
+        $result = $module->runAction('promoted');
+
+        Yii::$container->clear(ActionTestService::class);
+
+        self::assertSame(
+            'health-svc',
+            $result,
+            'Action with promoted constructor must receive its dependency through the DI container.',
+        );
     }
 }

--- a/tests/framework/base/ModuleActionNamespaceTest.php
+++ b/tests/framework/base/ModuleActionNamespaceTest.php
@@ -16,6 +16,7 @@ use yii\base\InvalidConfigException;
 use yii\base\InvalidRouteException;
 use yii\base\Module;
 use yiiunit\framework\base\stub\actions\LegacyDiscoverableAction;
+use yiiunit\framework\base\stub\standalone\ActionTestService;
 use yiiunit\TestCase;
 
 /**
@@ -217,7 +218,7 @@ final class ModuleActionNamespaceTest extends TestCase
         $module->runAction('does-not-exist');
     }
 
-    public function testLegacyConstructorActionDiscoveredByNamespaceReceivesRouteIdInsideTheConstructor(): void
+    public function testLegacyConstructorActionDiscoveredByNamespaceReceivesNullIdFromDispatcher(): void
     {
         $module = new Module(
             'mymod',
@@ -239,14 +240,13 @@ final class ModuleActionNamespaceTest extends TestCase
             $action,
             'Resolved action must be the legacy stub.',
         );
-        self::assertSame(
-            'legacy-discoverable',
+        self::assertNull(
             $action->idSeenInConstructor,
-            'Route segment ID must arrive positionally.',
+            "ID must be 'null' during construction.",
         );
     }
 
-    public function testLegacyConstructorActionDiscoveredByNamespaceObservesRouteIdInInit(): void
+    public function testLegacyConstructorActionDiscoveredByNamespaceObservesNullIdInInit(): void
     {
         $module = new Module(
             'mymod',
@@ -262,15 +262,40 @@ final class ModuleActionNamespaceTest extends TestCase
             $action,
             'Resolved action must be the legacy stub.',
         );
+        self::assertNull(
+            $action->idSeenInInit,
+            "Identity must be 'null' during 'init'.",
+        );
         self::assertSame(
             'legacy-discoverable',
-            $action->idSeenInInit,
-            'Identity must be set before lifecycle hooks run.',
+            $action->id,
+            'Dispatcher must assign the route ID post-construction.',
         );
         self::assertSame(
             'mymod/legacy-discoverable',
             $action->getUniqueId(),
             'Unique ID must combine the module ID and the discovered route segment.',
+        );
+    }
+
+    public function testStandaloneActionWithPromotedConstructorResolvedByConvention(): void
+    {
+        Yii::$container->setSingleton(ActionTestService::class, ActionTestService::class);
+
+        $module = new Module(
+            'mymod',
+            null,
+            ['controllerNamespace' => self::FIXTURE_NAMESPACE],
+        );
+
+        $result = $module->runAction('health');
+
+        Yii::$container->clear(ActionTestService::class);
+
+        self::assertSame(
+            'health-svc',
+            $result,
+            'Convention-based action with promoted constructor must receive its dependency through the DI container.',
         );
     }
 }

--- a/tests/framework/base/stub/actions/HealthAction.php
+++ b/tests/framework/base/stub/actions/HealthAction.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\actions;
+
+use yii\base\Action;
+use yiiunit\framework\base\stub\standalone\ActionTestService;
+
+/**
+ * Action used for testing convention-based discovery of a standalone action that uses a PHP `8.x` promoted constructor
+ * for dependency injection.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class HealthAction extends Action
+{
+    public function __construct(private readonly ActionTestService $service)
+    {
+    }
+
+    public function run(): string
+    {
+        return 'health-' . $this->service->name();
+    }
+}

--- a/tests/framework/web/WebActionTest.php
+++ b/tests/framework/web/WebActionTest.php
@@ -85,7 +85,7 @@ final class WebActionTest extends TestCase
         );
     }
 
-    public function testLegacyConstructorWebActionReceivesRouteIdInsideTheConstructor(): void
+    public function testLegacyConstructorWebActionReceivesNullIdFromDispatcher(): void
     {
         $module = new Module('mymod', Yii::$app);
 
@@ -100,14 +100,13 @@ final class WebActionTest extends TestCase
             $action,
             'Resolved action must be the legacy web stub.',
         );
-        self::assertSame(
-            'legacy',
+        self::assertNull(
             $action->idSeenInConstructor,
-            'Route segment ID must arrive positionally.',
+            "ID must be 'null' during construction.",
         );
     }
 
-    public function testLegacyConstructorWebActionInitObservesRouteId(): void
+    public function testLegacyConstructorWebActionObservesNullIdInInit(): void
     {
         $module = new Module('mymod', Yii::$app);
 
@@ -122,10 +121,14 @@ final class WebActionTest extends TestCase
             $action,
             'Resolved action must be the legacy web stub.',
         );
+        self::assertNull(
+            $action->idSeenInInit,
+            "Identity must be 'null' during 'init'.",
+        );
         self::assertSame(
             'legacy',
-            $action->idSeenInInit,
-            'Identity must be set before lifecycle hooks run.',
+            $action->id,
+            'Dispatcher must assign the route ID post-construction.',
         );
         self::assertSame(
             'mymod/legacy',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
