### PR TITLE
Add `#[\SensitiveParameter]` attribute to secret-bearing parameters in `Security`, `User`, and `IdentityInterface` to redact values from stack traces.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,6 +34,7 @@ install:
     - 7z x C:\tools\apcu.zip -oC:\tools\php\ext php_apcu.dll -y
     - echo extension=php_apcu.dll >> php.ini
     - echo apc.enable_cli=1 >> php.ini
+    - echo zend.exception_ignore_args=0 >> php.ini
     - IF NOT EXIST C:\tools\composer.phar (cd C:\tools && appveyor DownloadFile https://getcomposer.org/download/2.6.3/composer.phar)
 
 before_test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ concurrency:
 
 env:
   PHP_EXTENSIONS: apcu, curl, dom, imagick, intl, mbstring, mcrypt, memcached
-  PHP_INI_VALUES: apc.enabled=1,apc.shm_size=32M,apc.enable_cli=1, date.timezone='UTC'
+  PHP_INI_VALUES: apc.enabled=1,apc.shm_size=32M,apc.enable_cli=1, date.timezone='UTC', zend.exception_ignore_args=0
   PHPUNIT_EXCLUDE_GROUP: db wincache prod
 
 jobs:

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -55,6 +55,7 @@ Yii Framework 2 Change Log
 - Chg #18639: Refactor PostgreSQL pagination SQL to use standard `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY`; PostgreSQL `13+` is now required for `yii\db\pgsql\QueryBuilder` pagination (terabytesoftw)
 - Chg: Add `Module::$actionMap`, `Module::$actionNamespace`, and `yii\web\Action` for standalone action dispatch with HTTP-aware param binding (terabytesoftw)
 - Chg: Relax `yii\base\Action` constructor to accept `null` id; standalone action dispatch now uses unified DI without positional args (terabytesoftw)
+- Enh: Add `#[\SensitiveParameter]` attribute to secret-bearing parameters in `Security`, `User`, and `IdentityInterface` to redact values from stack traces (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -8,6 +8,7 @@
 
 namespace yii\base;
 
+use SensitiveParameter;
 use yii\helpers\StringHelper;
 
 /**
@@ -97,7 +98,7 @@ class Security extends Component
      * @see decryptByPassword()
      * @see encryptByKey()
      */
-    public function encryptByPassword($data, $password)
+    public function encryptByPassword($data, #[SensitiveParameter] $password)
     {
         return $this->encrypt($data, true, $password, null);
     }
@@ -116,7 +117,7 @@ class Security extends Component
      * @see decryptByKey()
      * @see encryptByPassword()
      */
-    public function encryptByKey($data, $inputKey, $info = null)
+    public function encryptByKey($data, #[\SensitiveParameter] $inputKey, $info = null)
     {
         return $this->encrypt($data, false, $inputKey, $info);
     }
@@ -128,7 +129,7 @@ class Security extends Component
      * @return bool|string the decrypted data or false on authentication failure
      * @see encryptByPassword()
      */
-    public function decryptByPassword($data, $password)
+    public function decryptByPassword($data, #[\SensitiveParameter] $password)
     {
         return $this->decrypt($data, true, $password, null);
     }
@@ -141,7 +142,7 @@ class Security extends Component
      * @return bool|string the decrypted data or false on authentication failure
      * @see encryptByKey()
      */
-    public function decryptByKey($data, $inputKey, $info = null)
+    public function decryptByKey($data, #[\SensitiveParameter] $inputKey, $info = null)
     {
         return $this->decrypt($data, false, $inputKey, $info);
     }
@@ -160,7 +161,7 @@ class Security extends Component
      * @throws Exception on OpenSSL error
      * @see decrypt()
      */
-    protected function encrypt($data, $passwordBased, $secret, $info)
+    protected function encrypt($data, $passwordBased, #[\SensitiveParameter] $secret, $info)
     {
         if (!extension_loaded('openssl')) {
             throw new InvalidConfigException('Encryption requires the OpenSSL PHP extension');
@@ -210,7 +211,7 @@ class Security extends Component
      * @throws Exception on OpenSSL error
      * @see encrypt()
      */
-    protected function decrypt($data, $passwordBased, $secret, $info)
+    protected function decrypt($data, $passwordBased, #[\SensitiveParameter] $secret, $info)
     {
         if (!extension_loaded('openssl')) {
             throw new InvalidConfigException('Encryption requires the OpenSSL PHP extension');
@@ -260,7 +261,7 @@ class Security extends Component
      * @throws InvalidArgumentException when HMAC generation fails.
      * @return string the derived key
      */
-    public function hkdf($algo, $inputKey, $salt = null, $info = null, $length = 0)
+    public function hkdf($algo, #[\SensitiveParameter] $inputKey, $salt = null, $info = null, $length = 0)
     {
         $outputKey = hash_hkdf((string)$algo, (string)$inputKey, $length, (string)$info, (string)$salt);
         if ($outputKey === false) {
@@ -284,7 +285,7 @@ class Security extends Component
      * @return string the derived key
      * @throws InvalidArgumentException when hash generation fails due to invalid params given.
      */
-    public function pbkdf2($algo, $password, $salt, $iterations, $length = 0)
+    public function pbkdf2($algo, #[\SensitiveParameter] $password, $salt, $iterations, $length = 0)
     {
         $outputKey = hash_pbkdf2($algo, $password, $salt, $iterations, $length, true);
 
@@ -311,7 +312,7 @@ class Security extends Component
      * @see hkdf()
      * @see pbkdf2()
      */
-    public function hashData($data, $key, $rawHash = false)
+    public function hashData($data, #[\SensitiveParameter] $key, $rawHash = false)
     {
         $hash = hash_hmac($this->macHash, $data, $key, $rawHash);
         if (!$hash) {
@@ -336,7 +337,7 @@ class Security extends Component
      * @throws InvalidConfigException when HMAC generation fails.
      * @see hashData()
      */
-    public function validateData($data, $key, $rawHash = false)
+    public function validateData($data, #[\SensitiveParameter] $key, $rawHash = false)
     {
         $test = @hash_hmac($this->macHash, '', '', $rawHash);
         if (!$test) {
@@ -434,7 +435,7 @@ class Security extends Component
      * @throws Exception on bad password parameter or cost parameter.
      * @see validatePassword()
      */
-    public function generatePasswordHash($password, $cost = null)
+    public function generatePasswordHash(#[\SensitiveParameter] $password, $cost = null)
     {
         if ($cost === null) {
             $cost = $this->passwordHashCost;
@@ -451,7 +452,7 @@ class Security extends Component
      * @throws InvalidArgumentException on bad password/hash parameters.
      * @see generatePasswordHash()
      */
-    public function validatePassword($password, $hash)
+    public function validatePassword(#[\SensitiveParameter] $password, $hash)
     {
         if (!is_string($password) || $password === '') {
             throw new InvalidArgumentException('Password must be a string and cannot be empty.');
@@ -496,7 +497,7 @@ class Security extends Component
      * @return string A masked token.
      * @since 2.0.12
      */
-    public function maskToken($token)
+    public function maskToken(#[\SensitiveParameter] $token)
     {
         // The number of bytes in a mask is always equal to the number of bytes in a token.
         $mask = $this->generateRandomKey(StringHelper::byteLength($token));
@@ -509,7 +510,7 @@ class Security extends Component
      * @return string An unmasked token, or an empty string in case of token format is invalid.
      * @since 2.0.12
      */
-    public function unmaskToken($maskedToken)
+    public function unmaskToken(#[\SensitiveParameter] $maskedToken)
     {
         $decoded = StringHelper::base64UrlDecode($maskedToken);
         $length = StringHelper::byteLength($decoded) / 2;

--- a/framework/base/Security.php
+++ b/framework/base/Security.php
@@ -117,7 +117,7 @@ class Security extends Component
      * @see decryptByKey()
      * @see encryptByPassword()
      */
-    public function encryptByKey($data, #[\SensitiveParameter] $inputKey, $info = null)
+    public function encryptByKey($data, #[SensitiveParameter] $inputKey, $info = null)
     {
         return $this->encrypt($data, false, $inputKey, $info);
     }
@@ -129,7 +129,7 @@ class Security extends Component
      * @return bool|string the decrypted data or false on authentication failure
      * @see encryptByPassword()
      */
-    public function decryptByPassword($data, #[\SensitiveParameter] $password)
+    public function decryptByPassword($data, #[SensitiveParameter] $password)
     {
         return $this->decrypt($data, true, $password, null);
     }
@@ -142,7 +142,7 @@ class Security extends Component
      * @return bool|string the decrypted data or false on authentication failure
      * @see encryptByKey()
      */
-    public function decryptByKey($data, #[\SensitiveParameter] $inputKey, $info = null)
+    public function decryptByKey($data, #[SensitiveParameter] $inputKey, $info = null)
     {
         return $this->decrypt($data, false, $inputKey, $info);
     }
@@ -161,7 +161,7 @@ class Security extends Component
      * @throws Exception on OpenSSL error
      * @see decrypt()
      */
-    protected function encrypt($data, $passwordBased, #[\SensitiveParameter] $secret, $info)
+    protected function encrypt($data, $passwordBased, #[SensitiveParameter] $secret, $info)
     {
         if (!extension_loaded('openssl')) {
             throw new InvalidConfigException('Encryption requires the OpenSSL PHP extension');
@@ -211,7 +211,7 @@ class Security extends Component
      * @throws Exception on OpenSSL error
      * @see encrypt()
      */
-    protected function decrypt($data, $passwordBased, #[\SensitiveParameter] $secret, $info)
+    protected function decrypt($data, $passwordBased, #[SensitiveParameter] $secret, $info)
     {
         if (!extension_loaded('openssl')) {
             throw new InvalidConfigException('Encryption requires the OpenSSL PHP extension');
@@ -261,7 +261,7 @@ class Security extends Component
      * @throws InvalidArgumentException when HMAC generation fails.
      * @return string the derived key
      */
-    public function hkdf($algo, #[\SensitiveParameter] $inputKey, $salt = null, $info = null, $length = 0)
+    public function hkdf($algo, #[SensitiveParameter] $inputKey, $salt = null, $info = null, $length = 0)
     {
         $outputKey = hash_hkdf((string)$algo, (string)$inputKey, $length, (string)$info, (string)$salt);
         if ($outputKey === false) {
@@ -285,7 +285,7 @@ class Security extends Component
      * @return string the derived key
      * @throws InvalidArgumentException when hash generation fails due to invalid params given.
      */
-    public function pbkdf2($algo, #[\SensitiveParameter] $password, $salt, $iterations, $length = 0)
+    public function pbkdf2($algo, #[SensitiveParameter] $password, $salt, $iterations, $length = 0)
     {
         $outputKey = hash_pbkdf2($algo, $password, $salt, $iterations, $length, true);
 
@@ -312,7 +312,7 @@ class Security extends Component
      * @see hkdf()
      * @see pbkdf2()
      */
-    public function hashData($data, #[\SensitiveParameter] $key, $rawHash = false)
+    public function hashData($data, #[SensitiveParameter] $key, $rawHash = false)
     {
         $hash = hash_hmac($this->macHash, $data, $key, $rawHash);
         if (!$hash) {
@@ -337,7 +337,7 @@ class Security extends Component
      * @throws InvalidConfigException when HMAC generation fails.
      * @see hashData()
      */
-    public function validateData($data, #[\SensitiveParameter] $key, $rawHash = false)
+    public function validateData($data, #[SensitiveParameter] $key, $rawHash = false)
     {
         $test = @hash_hmac($this->macHash, '', '', $rawHash);
         if (!$test) {
@@ -435,7 +435,7 @@ class Security extends Component
      * @throws Exception on bad password parameter or cost parameter.
      * @see validatePassword()
      */
-    public function generatePasswordHash(#[\SensitiveParameter] $password, $cost = null)
+    public function generatePasswordHash(#[SensitiveParameter] $password, $cost = null)
     {
         if ($cost === null) {
             $cost = $this->passwordHashCost;
@@ -452,7 +452,7 @@ class Security extends Component
      * @throws InvalidArgumentException on bad password/hash parameters.
      * @see generatePasswordHash()
      */
-    public function validatePassword(#[\SensitiveParameter] $password, $hash)
+    public function validatePassword(#[SensitiveParameter] $password, $hash)
     {
         if (!is_string($password) || $password === '') {
             throw new InvalidArgumentException('Password must be a string and cannot be empty.');
@@ -497,7 +497,7 @@ class Security extends Component
      * @return string A masked token.
      * @since 2.0.12
      */
-    public function maskToken(#[\SensitiveParameter] $token)
+    public function maskToken(#[SensitiveParameter] $token)
     {
         // The number of bytes in a mask is always equal to the number of bytes in a token.
         $mask = $this->generateRandomKey(StringHelper::byteLength($token));
@@ -510,7 +510,7 @@ class Security extends Component
      * @return string An unmasked token, or an empty string in case of token format is invalid.
      * @since 2.0.12
      */
-    public function unmaskToken(#[\SensitiveParameter] $maskedToken)
+    public function unmaskToken(#[SensitiveParameter] $maskedToken)
     {
         $decoded = StringHelper::base64UrlDecode($maskedToken);
         $length = StringHelper::byteLength($decoded) / 2;

--- a/framework/web/IdentityInterface.php
+++ b/framework/web/IdentityInterface.php
@@ -8,6 +8,8 @@
 
 namespace yii\web;
 
+use SensitiveParameter;
+
 /**
  * IdentityInterface is the interface that should be implemented by a class providing identity information.
  *
@@ -74,7 +76,7 @@ interface IdentityInterface
      * Null should be returned if such an identity cannot be found
      * or the identity is not in an active state (disabled, deleted, etc.)
      */
-    public static function findIdentityByAccessToken($token, $type = null);
+    public static function findIdentityByAccessToken(#[SensitiveParameter] $token, $type = null);
 
     /**
      * Returns an ID that can uniquely identify a user identity.

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -8,6 +8,7 @@
 
 namespace yii\web;
 
+use SensitiveParameter;
 use Yii;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
@@ -160,7 +161,6 @@ class User extends Component
 
     private $_access = [];
 
-
     /**
      * Initializes the application component.
      */
@@ -300,7 +300,7 @@ class User extends Component
      * @return T|null the identity associated with the given access token. Null is returned if
      * the access token is invalid or [[login()]] is unsuccessful.
      */
-    public function loginByAccessToken($token, $type = null)
+    public function loginByAccessToken(#[SensitiveParameter] $token, $type = null)
     {
         $class = $this->identityClass;
         $identity = $class::findIdentityByAccessToken($token, $type);

--- a/tests/framework/base/SensitiveParameterAttributionTest.php
+++ b/tests/framework/base/SensitiveParameterAttributionTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use ReflectionMethod;
+use SensitiveParameter;
+use SensitiveParameterValue;
+use Throwable;
+use ValueError;
+use yii\base\InvalidArgumentException;
+use yii\base\Security;
+use yiiunit\framework\base\provider\SensitiveParameterAttributionProvider;
+use yiiunit\TestCase;
+
+/**
+ * Unit tests for the `#[\SensitiveParameter]` attribution contract on secret-bearing parameters in
+ * {@see \yii\base\Security}, {@see \yii\web\User}, and {@see \yii\web\IdentityInterface}.
+ *
+ * Verifies the static contract via reflection and the runtime redaction performed by the PHP engine on
+ * {@see \Throwable::getTrace()} and {@see \Throwable::getTraceAsString()}.
+ *
+ * {@see SensitiveParameterAttributionProvider} for test case data providers.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('base')]
+final class SensitiveParameterAttributionTest extends TestCase
+{
+    #[DataProviderExternal(SensitiveParameterAttributionProvider::class, 'attributedParameters')]
+    public function testParameterCarriesSensitiveAttribute(string $class, string $method, string $parameterName): void
+    {
+        $reflection = new ReflectionMethod($class, $method);
+
+        $matched = null;
+
+        foreach ($reflection->getParameters() as $parameter) {
+            if ($parameter->getName() === $parameterName) {
+                $matched = $parameter;
+                break;
+            }
+        }
+
+        self::assertNotNull(
+            $matched,
+            "Parameter \${$parameterName} must exist on {$class}::{$method}().",
+        );
+        self::assertNotEmpty(
+            $matched->getAttributes(SensitiveParameter::class),
+            "Parameter \${$parameterName} must declare `#[\\SensitiveParameter]`.",
+        );
+    }
+
+    public function testValidatePasswordRedactsPasswordInExceptionTrace(): void
+    {
+        $sentinel = 'SENTINEL_PASSWORD_47A1';
+
+        $security = new Security();
+
+        try {
+            $security->validatePassword($sentinel, 'not-a-real-bcrypt-hash');
+
+            self::fail("Invalid hash must trigger an 'InvalidArgumentException'.");
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSentinelRedacted(
+                $exception,
+                Security::class,
+                'validatePassword',
+                $sentinel,
+            );
+        }
+    }
+
+    public function testPbkdf2RedactsPasswordInExceptionTrace(): void
+    {
+        $sentinel = 'SENTINEL_PBKDF2_9F22';
+
+        $security = new Security();
+
+        try {
+            $security->pbkdf2('not-a-real-algo', $sentinel, 'salt', 1, 0);
+
+            self::fail("Invalid algorithm must trigger a 'ValueError'.");
+        } catch (ValueError $exception) {
+            $this->assertSentinelRedacted(
+                $exception,
+                Security::class,
+                'pbkdf2',
+                $sentinel,
+            );
+        }
+    }
+
+    private function assertSentinelRedacted(
+        Throwable $exception,
+        string $class,
+        string $method,
+        string $sentinel,
+    ): void {
+        self::assertStringNotContainsString(
+            $sentinel,
+            $exception->getTraceAsString(),
+            'Sentinel must not appear in the trace string.',
+        );
+
+        $wrapped = false;
+
+        foreach ($exception->getTrace() as $frame) {
+            foreach ($frame['args'] ?? [] as $argument) {
+                self::assertNotSame(
+                    $sentinel,
+                    $argument,
+                    'Sentinel must not appear as a raw trace argument.',
+                );
+            }
+
+            if (($frame['class'] ?? null) !== $class || ($frame['function'] ?? null) !== $method) {
+                continue;
+            }
+
+            foreach ($frame['args'] ?? [] as $argument) {
+                if ($argument instanceof SensitiveParameterValue) {
+                    $wrapped = true;
+                    break 2;
+                }
+            }
+        }
+
+        self::assertTrue(
+            $wrapped,
+            "Sensitive arg must be wrapped in `SensitiveParameterValue` for {$class}::{$method}().",
+        );
+    }
+}

--- a/tests/framework/base/SensitiveParameterAttributionTest.php
+++ b/tests/framework/base/SensitiveParameterAttributionTest.php
@@ -107,13 +107,17 @@ final class SensitiveParameterAttributionTest extends TestCase
         string $method,
         string $sentinel,
     ): void {
+        if ((bool) ini_get('zend.exception_ignore_args')) {
+            self::markTestSkipped(
+                "'zend.exception_ignore_args' must be disabled ('0') for redaction assertions to work.",
+            );
+        }
+
         self::assertStringNotContainsString(
             $sentinel,
             $exception->getTraceAsString(),
             'Sentinel must not appear in the trace string.',
         );
-
-        $wrapped = false;
 
         foreach ($exception->getTrace() as $frame) {
             foreach ($frame['args'] ?? [] as $argument) {
@@ -123,7 +127,11 @@ final class SensitiveParameterAttributionTest extends TestCase
                     'Sentinel must not appear as a raw trace argument.',
                 );
             }
+        }
 
+        $wrapped = false;
+
+        foreach ($exception->getTrace() as $frame) {
             if (($frame['class'] ?? null) !== $class || ($frame['function'] ?? null) !== $method) {
                 continue;
             }

--- a/tests/framework/base/provider/SensitiveParameterAttributionProvider.php
+++ b/tests/framework/base/provider/SensitiveParameterAttributionProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\provider;
+
+use yii\base\Security;
+use yii\web\IdentityInterface;
+use yii\web\User;
+
+/**
+ * Data provider for {@see \yiiunit\framework\base\SensitiveParameterAttributionTest} test cases.
+ *
+ * Provides every `(class, method, parameterName)` triple in the framework whose formal parameter must carry the
+ * `#[\SensitiveParameter]` attribute so that secret values are redacted from stack traces.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class SensitiveParameterAttributionProvider
+{
+    /**
+     * @return array<int, array{class-string, string, string}>
+     */
+    public static function attributedParameters(): array
+    {
+        return [
+            [IdentityInterface::class, 'findIdentityByAccessToken', 'token'],
+            [Security::class, 'decrypt', 'secret'],
+            [Security::class, 'decryptByKey', 'inputKey'],
+            [Security::class, 'decryptByPassword', 'password'],
+            [Security::class, 'encrypt', 'secret'],
+            [Security::class, 'encryptByKey', 'inputKey'],
+            [Security::class, 'encryptByPassword', 'password'],
+            [Security::class, 'generatePasswordHash', 'password'],
+            [Security::class, 'hashData', 'key'],
+            [Security::class, 'hkdf', 'inputKey'],
+            [Security::class, 'maskToken', 'token'],
+            [Security::class, 'pbkdf2', 'password'],
+            [Security::class, 'unmaskToken', 'maskedToken'],
+            [Security::class, 'validateData', 'key'],
+            [Security::class, 'validatePassword', 'password'],
+            [User::class, 'loginByAccessToken', 'token'],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
