### PR TITLE
Honor `beforeRun()` and `afterRun()` hooks in `yii\base\InlineAction::runWithParams()` so inline actions follow the same lifecycle as standalone actions.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -56,6 +56,7 @@ Yii Framework 2 Change Log
 - Chg: Add `Module::$actionMap`, `Module::$actionNamespace`, and `yii\web\Action` for standalone action dispatch with HTTP-aware param binding (terabytesoftw)
 - Chg: Relax `yii\base\Action` constructor to accept `null` id; standalone action dispatch now uses unified DI without positional args (terabytesoftw)
 - Enh: Add `#[\SensitiveParameter]` attribute to secret-bearing parameters in `Security`, `User`, and `IdentityInterface` to redact values from stack traces (terabytesoftw)
+- Enh #18467: Honor `beforeRun()` and `afterRun()` hooks in `yii\base\InlineAction::runWithParams()` so inline actions follow the same lifecycle as standalone actions (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/base/InlineAction.php
+++ b/framework/base/InlineAction.php
@@ -12,6 +12,9 @@ namespace yii\base;
 
 use Yii;
 
+use function call_user_func_array;
+use function get_class;
+
 /**
  * InlineAction represents an action that is defined as a controller method.
  *
@@ -51,18 +54,38 @@ class InlineAction extends Action
 
     /**
      * Runs this action with the specified parameters.
+     *
      * This method is mainly invoked by the controller.
-     * @param array $params action parameters
-     * @return mixed the result of the action
+     *
+     * Since version 22.0, the controller method is wrapped in the same {@see Action::beforeRun()} / {@see afterRun()}
+     * guard as standalone {@see Action::runWithParams()}, so subclasses overriding `beforeRun()` to short-circuit the
+     * action also short-circuit inline action methods.
+     *
+     * @param array $params Action parameters.
+     *
+     * @return mixed The result of the action, or `null` if {@see beforeRun()} returned `false`.
      */
-    public function runWithParams($params)
+    public function runWithParams($params): mixed
     {
         $args = $this->controller->bindActionParams($this, $params);
-        Yii::debug('Running action: ' . get_class($this->controller) . '::' . $this->actionMethod . '()', __METHOD__);
+
+        Yii::debug(
+            'Running action: ' . get_class($this->controller) . '::' . $this->actionMethod . '()',
+            __METHOD__,
+        );
+
         if (Yii::$app->requestedParams === null) {
             Yii::$app->requestedParams = $args;
         }
 
-        return call_user_func_array([$this->controller, $this->actionMethod], $args);
+        if ($this->beforeRun()) {
+            $result = call_user_func_array([$this->controller, $this->actionMethod], $args);
+
+            $this->afterRun();
+
+            return $result;
+        }
+
+        return null;
     }
 }

--- a/tests/framework/base/InlineActionTest.php
+++ b/tests/framework/base/InlineActionTest.php
@@ -35,6 +35,8 @@ final class InlineActionTest extends TestCase
         parent::setUp();
 
         $this->mockApplication();
+
+        PingController::$callLog = [];
     }
 
     public function testBeforeRunReturningFalseShortCircuitsControllerMethod(): void
@@ -49,13 +51,10 @@ final class InlineActionTest extends TestCase
             $result,
             "Inline action must return 'null' when 'beforeRun' returns 'false'.",
         );
-        self::assertFalse(
-            $controller->methodInvoked,
-            "Controller method must not be invoked when 'beforeRun' returns 'false'.",
-        );
-        self::assertFalse(
-            $action->afterRunCalled,
-            "afterRun must not be invoked when 'beforeRun' returns 'false'.",
+        self::assertSame(
+            ['beforeRunFalse'],
+            PingController::$callLog,
+            "No hook beyond 'beforeRun' must run when it returns 'false'.",
         );
     }
 
@@ -72,17 +71,14 @@ final class InlineActionTest extends TestCase
             $result,
             "Controller method result must propagate when beforeRun returns 'true'.",
         );
-        self::assertTrue(
-            $controller->methodInvoked,
-            'Controller method must be invoked.',
-        );
-        self::assertTrue(
-            $action->beforeRunCalled,
-            'beforeRun hook must be invoked before the controller method.',
-        );
-        self::assertTrue(
-            $action->afterRunCalled,
-            'afterRun hook must be invoked after the controller method.',
+        self::assertSame(
+            [
+                'beforeRun',
+                'actionPing',
+                'afterRun',
+            ],
+            PingController::$callLog,
+            "Hooks must wrap the controller method in order: 'beforeRun' → 'actionPing' → 'afterRun'.",
         );
     }
 }

--- a/tests/framework/base/InlineActionTest.php
+++ b/tests/framework/base/InlineActionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base;
+
+use PHPUnit\Framework\Attributes\Group;
+use Yii;
+use yiiunit\framework\base\stub\inline\CancelingInlineAction;
+use yiiunit\framework\base\stub\inline\PingController;
+use yiiunit\framework\base\stub\inline\TrackingInlineAction;
+use yiiunit\TestCase;
+
+/**
+ * Unit tests for {@see \yii\base\InlineAction} lifecycle wrapper around the controller method invocation.
+ *
+ * Verifies that since version 22.0, {@see \yii\base\InlineAction::runWithParams()} honors
+ * {@see \yii\base\Action::beforeRun()} and {@see \yii\base\Action::afterRun()} hooks, mirroring the behavior of
+ * standalone {@see \yii\base\Action::runWithParams()}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('base')]
+final class InlineActionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockApplication();
+    }
+
+    public function testBeforeRunReturningFalseShortCircuitsControllerMethod(): void
+    {
+        $controller = new PingController('ping', Yii::$app);
+
+        $action = new CancelingInlineAction('ping', $controller, 'actionPing');
+
+        $result = $action->runWithParams([]);
+
+        self::assertNull(
+            $result,
+            "Inline action must return 'null' when 'beforeRun' returns 'false'.",
+        );
+        self::assertFalse(
+            $controller->methodInvoked,
+            "Controller method must not be invoked when 'beforeRun' returns 'false'.",
+        );
+        self::assertFalse(
+            $action->afterRunCalled,
+            "afterRun must not be invoked when 'beforeRun' returns 'false'.",
+        );
+    }
+
+    public function testBeforeRunAndAfterRunWrapTheControllerMethod(): void
+    {
+        $controller = new PingController('ping', Yii::$app);
+
+        $action = new TrackingInlineAction('ping', $controller, 'actionPing');
+
+        $result = $action->runWithParams([]);
+
+        self::assertSame(
+            'pong',
+            $result,
+            "Controller method result must propagate when beforeRun returns 'true'.",
+        );
+        self::assertTrue(
+            $controller->methodInvoked,
+            'Controller method must be invoked.',
+        );
+        self::assertTrue(
+            $action->beforeRunCalled,
+            'beforeRun hook must be invoked before the controller method.',
+        );
+        self::assertTrue(
+            $action->afterRunCalled,
+            'afterRun hook must be invoked after the controller method.',
+        );
+    }
+}

--- a/tests/framework/base/stub/inline/CancelingInlineAction.php
+++ b/tests/framework/base/stub/inline/CancelingInlineAction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\inline;
+
+use yii\base\InlineAction;
+
+/**
+ * Inline action subclass whose {@see beforeRun()} returns `false` to verify that the controller method is short
+ * circuited.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class CancelingInlineAction extends InlineAction
+{
+    public bool $afterRunCalled = false;
+
+    protected function beforeRun(): bool
+    {
+        return false;
+    }
+
+    protected function afterRun(): void
+    {
+        $this->afterRunCalled = true;
+    }
+}

--- a/tests/framework/base/stub/inline/CancelingInlineAction.php
+++ b/tests/framework/base/stub/inline/CancelingInlineAction.php
@@ -16,20 +16,24 @@ use yii\base\InlineAction;
  * Inline action subclass whose {@see beforeRun()} returns `false` to verify that the controller method is short
  * circuited.
  *
+ * Records `beforeRunFalse` into {@see PingController::$callLog} when the cancellation hook fires; if {@see afterRun()}
+ * were ever invoked it would also record, so the test can assert the resulting log proves nothing else ran after the
+ * short-circuit.
+ *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 22.0
  */
 final class CancelingInlineAction extends InlineAction
 {
-    public bool $afterRunCalled = false;
-
     protected function beforeRun(): bool
     {
+        PingController::$callLog[] = 'beforeRunFalse';
+
         return false;
     }
 
     protected function afterRun(): void
     {
-        $this->afterRunCalled = true;
+        PingController::$callLog[] = 'afterRun';
     }
 }

--- a/tests/framework/base/stub/inline/PingController.php
+++ b/tests/framework/base/stub/inline/PingController.php
@@ -15,16 +15,19 @@ use yii\base\Controller;
 /**
  * Controller used for testing the inline action lifecycle wrapper.
  *
+ * Records each invocation step into a shared {@see $callLog} so test cases can assert the exact ordering of
+ * {@see InlineAction::beforeRun()}, the controller method, and {@see InlineAction::afterRun()}.
+ *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 22.0
  */
 final class PingController extends Controller
 {
-    public bool $methodInvoked = false;
+    public static array $callLog = [];
 
     public function actionPing(): string
     {
-        $this->methodInvoked = true;
+        self::$callLog[] = 'actionPing';
 
         return 'pong';
     }

--- a/tests/framework/base/stub/inline/PingController.php
+++ b/tests/framework/base/stub/inline/PingController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\inline;
+
+use yii\base\Controller;
+
+/**
+ * Controller used for testing the inline action lifecycle wrapper.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class PingController extends Controller
+{
+    public bool $methodInvoked = false;
+
+    public function actionPing(): string
+    {
+        $this->methodInvoked = true;
+
+        return 'pong';
+    }
+}

--- a/tests/framework/base/stub/inline/TrackingInlineAction.php
+++ b/tests/framework/base/stub/inline/TrackingInlineAction.php
@@ -13,26 +13,23 @@ namespace yiiunit\framework\base\stub\inline;
 use yii\base\InlineAction;
 
 /**
- * Inline action subclass that records {@see beforeRun()} and {@see afterRun()} invocations to verify the lifecycle
- * wrapper around the controller method call.
+ * Inline action subclass that appends a token into {@see PingController::$callLog} on each lifecycle hook so the test
+ * can assert the exact `beforeRun → controller method → afterRun` sequence.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 22.0
  */
 final class TrackingInlineAction extends InlineAction
 {
-    public bool $beforeRunCalled = false;
-    public bool $afterRunCalled = false;
-
     protected function beforeRun(): bool
     {
-        $this->beforeRunCalled = true;
+        PingController::$callLog[] = 'beforeRun';
 
         return true;
     }
 
     protected function afterRun(): void
     {
-        $this->afterRunCalled = true;
+        PingController::$callLog[] = 'afterRun';
     }
 }

--- a/tests/framework/base/stub/inline/TrackingInlineAction.php
+++ b/tests/framework/base/stub/inline/TrackingInlineAction.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\inline;
+
+use yii\base\InlineAction;
+
+/**
+ * Inline action subclass that records {@see beforeRun()} and {@see afterRun()} invocations to verify the lifecycle
+ * wrapper around the controller method call.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class TrackingInlineAction extends InlineAction
+{
+    public bool $beforeRunCalled = false;
+    public bool $afterRunCalled = false;
+
+    protected function beforeRun(): bool
+    {
+        $this->beforeRunCalled = true;
+
+        return true;
+    }
+
+    protected function afterRun(): void
+    {
+        $this->afterRunCalled = true;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #18467
