### PR TITLE
Move MSSQL `varbinary` type-casting from `yii\db\mssql\QueryBuilder::normalizeTableRowData()` to `yii\db\mssql\ColumnSchema::dbTypecast()`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -57,6 +57,7 @@ Yii Framework 2 Change Log
 - Chg: Relax `yii\base\Action` constructor to accept `null` id; standalone action dispatch now uses unified DI without positional args (terabytesoftw)
 - Enh: Add `#[\SensitiveParameter]` attribute to secret-bearing parameters in `Security`, `User`, and `IdentityInterface` to redact values from stack traces (terabytesoftw)
 - Enh #18467: Honor `beforeRun()` and `afterRun()` hooks in `yii\base\InlineAction::runWithParams()` so inline actions follow the same lifecycle as standalone actions (terabytesoftw)
+- Bug: Move MSSQL `varbinary` type-casting from `yii\db\mssql\QueryBuilder::normalizeTableRowData()` to `yii\db\mssql\ColumnSchema::dbTypecast()` (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/db/mssql/ColumnSchema.php
+++ b/framework/db/mssql/ColumnSchema.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -7,6 +9,11 @@
  */
 
 namespace yii\db\mssql;
+
+use yii\db\Expression;
+
+use function bin2hex;
+use function is_string;
 
 /**
  * Class ColumnSchema for MSSQL database
@@ -21,6 +28,29 @@ class ColumnSchema extends \yii\db\ColumnSchema
      */
     public $isComputed;
 
+    /**
+     * {@inheritdoc}
+     *
+     * Converts string values for `varbinary` columns to explicit `CONVERT(VARBINARY(MAX), 0x...)` expressions to avoid
+     * implicit `varchar` to `varbinary` conversion errors in SQL Server, particularly under `INSERT ... OUTPUT INTO`
+     * and `UPDATE`.
+     *
+     * @see https://github.com/yiisoft/yii2/issues/12599
+     */
+    public function dbTypecast($value)
+    {
+        if ($this->type === Schema::TYPE_BINARY && $this->dbType === 'varbinary') {
+            if (is_string($value)) {
+                return new Expression('CONVERT(VARBINARY(MAX), 0x' . bin2hex($value) . ')');
+            }
+
+            if ($value === null && $this->allowNull) {
+                return new Expression('CAST(NULL AS VARBINARY(MAX))');
+            }
+        }
+
+        return parent::dbTypecast($value);
+    }
 
     /**
      * Prepares default value and converts it according to [[phpType]]

--- a/tests/framework/db/mssql/type/VarbinaryTest.php
+++ b/tests/framework/db/mssql/type/VarbinaryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,30 +10,128 @@
 
 namespace yiiunit\framework\db\mssql\type;
 
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\Expression;
 use yii\db\Query;
+use yii\db\Schema;
+use yii\db\mssql\ColumnSchema;
 use yiiunit\framework\db\DatabaseTestCase;
+use yiiunit\framework\db\mssql\type\providers\VarbinaryProvider;
 
 /**
- * @group db
- * @group mssql
+ * Unit and integration tests for the MSSQL `varbinary` type.
+ *
+ * {@see VarbinaryProvider} for test case data providers.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
  */
-class VarbinaryTest extends DatabaseTestCase
+#[Group('db')]
+#[Group('mssql')]
+#[Group('column')]
+final class VarbinaryTest extends DatabaseTestCase
 {
     protected $driverName = 'sqlsrv';
+
+    public function testDbTypecastReturnsCastExpressionForNullOnNullableVarbinary(): void
+    {
+        $column = $this->makeVarbinary(true);
+
+        $result = $column->dbTypecast(null);
+
+        self::assertInstanceOf(
+            Expression::class,
+            $result,
+            'Nullable column must yield CAST expression.',
+        );
+        self::assertSame(
+            'CAST(NULL AS VARBINARY(MAX))',
+            (string) $result,
+            'SQL must be CAST NULL form.',
+        );
+    }
+
+    public function testDbTypecastDelegatesToParentForNullOnNonNullableVarbinary(): void
+    {
+        $column = $this->makeVarbinary(false);
+
+        $result = $column->dbTypecast(null);
+
+        self::assertNull(
+            $result,
+            'Non-nullable null must pass through unchanged.',
+        );
+    }
+
+    public function testDbTypecastDelegatesToParentForNonVarbinaryDbType(): void
+    {
+        $column = new ColumnSchema();
+
+        $column->type = Schema::TYPE_BINARY;
+
+        $column->phpType = 'resource';
+        $column->dbType = 'binary';
+
+        $result = $column->dbTypecast('hello');
+
+        self::assertNotInstanceOf(
+            Expression::class,
+            $result,
+            "'binary' dbType must not be wrapped.",
+        );
+    }
+
+    public function testDbTypecastDelegatesToParentForNonBinaryType(): void
+    {
+        $column = new ColumnSchema();
+
+        $column->type = Schema::TYPE_STRING;
+
+        $column->phpType = 'string';
+        $column->dbType = 'varchar';
+
+        $result = $column->dbTypecast('hello');
+
+        self::assertNotInstanceOf(
+            Expression::class,
+            $result,
+            'Non-binary type must not be wrapped.',
+        );
+    }
+
+    #[DataProviderExternal(VarbinaryProvider::class, 'varbinaryStringValue')]
+    public function testDbTypecastSqlMatchesLegacyNormalizeTableRowDataFormat(string $value): void
+    {
+        $column = $this->makeVarbinary(true);
+
+        $expected = 'CONVERT(VARBINARY(MAX), ' . ('0x' . bin2hex($value)) . ')';
+
+        $actual = (string) $column->dbTypecast($value);
+
+        self::assertSame(
+            $expected,
+            $actual,
+            'New SQL must match legacy normalizeTableRowData output.',
+        );
+    }
 
     public function testVarbinary(): void
     {
         $db = $this->getConnection();
 
         $db->createCommand()->delete('type')->execute();
-        $db->createCommand()->insert('type', [
-            'int_col' => $key = 1,
-            'char_col' => '',
-            'char_col2' => '6a3ce1a0bffe8eeb6fa986caf443e24c',
-            'float_col' => 0.0,
-            'blob_col' => 'a:1:{s:13:"template";s:1:"1";}',
-            'bool_col' => true,
-        ])->execute();
+        $db->createCommand()->insert(
+            'type',
+            [
+                'int_col' => $key = 1,
+                'char_col' => '',
+                'char_col2' => '6a3ce1a0bffe8eeb6fa986caf443e24c',
+                'float_col' => 0.0,
+                'blob_col' => 'a:1:{s:13:"template";s:1:"1";}',
+                'bool_col' => true,
+            ],
+        )->execute();
 
         $result = (new Query())
             ->select(['blob_col'])
@@ -40,6 +140,23 @@ class VarbinaryTest extends DatabaseTestCase
             ->createCommand($db)
             ->queryScalar();
 
-        $this->assertSame('a:1:{s:13:"template";s:1:"1";}', $result);
+        self::assertSame(
+            'a:1:{s:13:"template";s:1:"1";}',
+            $result,
+            'Round-trip must preserve serialized payload.',
+        );
+    }
+
+    private function makeVarbinary(bool $allowNull): ColumnSchema
+    {
+        $column = new ColumnSchema();
+
+        $column->type = Schema::TYPE_BINARY;
+
+        $column->phpType = 'resource';
+        $column->dbType = 'varbinary';
+        $column->allowNull = $allowNull;
+
+        return $column;
     }
 }

--- a/tests/framework/db/mssql/type/providers/VarbinaryProvider.php
+++ b/tests/framework/db/mssql/type/providers/VarbinaryProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mssql\type\providers;
+
+/**
+ * Data provider for {@see \yiiunit\framework\db\mssql\type\VarbinaryTest} test cases.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class VarbinaryProvider
+{
+    public static function varbinaryStringValue(): array
+    {
+        return [
+            'ascii' => ['hello'],
+            'binary nulls' => ["\x00\x01\x02"],
+            'empty string' => [''],
+            'multibyte' => ['héllo'],
+            'serialized payload' => ['a:1:{s:13:"template";s:1:"1";}'],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
