### PR TITLE
Remove legacy `apc_delete_file()` call in `yii\rbac\PhpManager::invalidateScriptCache()`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -59,6 +59,7 @@ Yii Framework 2 Change Log
 - Enh #18467: Honor `beforeRun()` and `afterRun()` hooks in `yii\base\InlineAction::runWithParams()` so inline actions follow the same lifecycle as standalone actions (terabytesoftw)
 - Bug: Move MSSQL `varbinary` type-casting from `yii\db\mssql\QueryBuilder::normalizeTableRowData()` to `yii\db\mssql\ColumnSchema::dbTypecast()` (terabytesoftw)
 - Bug: Remove `yii\db\mssql\QueryBuilder::normalizeTableRowData()` and the `update()` override (terabytesoftw)
+- Chg: Remove legacy `apc_delete_file()` call in `yii\rbac\PhpManager::invalidateScriptCache()` (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/rbac/PhpManager.php
+++ b/framework/rbac/PhpManager.php
@@ -815,9 +815,6 @@ class PhpManager extends BaseManager
         if (function_exists('opcache_invalidate')) {
             opcache_invalidate($file, true);
         }
-        if (function_exists('apc_delete_file')) {
-            @apc_delete_file($file);
-        }
     }
 
     /**

--- a/framework/rbac/PhpManager.php
+++ b/framework/rbac/PhpManager.php
@@ -177,7 +177,7 @@ class PhpManager extends BaseManager
         }
 
         if ($parent->name === $child->name) {
-            throw new InvalidArgumentException("Cannot add '{$parent->name} ' as a child of itself.");
+            throw new InvalidArgumentException("Cannot add '{$parent->name}' as a child of itself.");
         }
         if ($parent instanceof Permission && $child instanceof Role) {
             throw new InvalidArgumentException('Cannot add a role as a child of a permission.');

--- a/framework/rbac/PhpManager.php
+++ b/framework/rbac/PhpManager.php
@@ -806,7 +806,7 @@ class PhpManager extends BaseManager
     }
 
     /**
-     * Invalidates precompiled script cache (such as OPCache or APC) for the given file.
+     * Invalidates precompiled script cache (OPcache) for the given file.
      * @param string $file the file path.
      * @since 2.0.9
      */

--- a/tests/framework/filters/AccessRuleTest.php
+++ b/tests/framework/filters/AccessRuleTest.php
@@ -21,7 +21,7 @@ use yii\web\Request;
 use yii\web\User;
 use yiiunit\framework\filters\stubs\MockAuthManager;
 use yiiunit\framework\filters\stubs\UserIdentity;
-use yiiunit\framework\rbac\AuthorRule;
+use yiiunit\framework\rbac\stub\AuthorRule;
 
 /**
  * @group filters

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,14 +10,24 @@
 
 namespace yiiunit\framework\rbac;
 
+use ReflectionClass;
+use stdClass;
 use Yii;
 use yii\base\InvalidArgumentException;
+use yii\base\InvalidCallException;
+use yii\base\InvalidConfigException;
+use yii\base\InvalidValueException;
 use yii\rbac\BaseManager;
 use yii\rbac\Item;
 use yii\rbac\ManagerInterface;
 use yii\rbac\Permission;
 use yii\rbac\Role;
+use yii\rbac\Rule;
+use yiiunit\framework\rbac\stub\ActionRule;
+use yiiunit\framework\rbac\stub\AuthorRule;
 use yiiunit\TestCase;
+
+use function count;
 
 /**
  * ManagerTestCase.
@@ -35,45 +47,95 @@ abstract class ManagerTestCase extends TestCase
     public function testCreateRole(): void
     {
         $role = $this->auth->createRole('admin');
-        $this->assertInstanceOf(Role::class, $role);
-        $this->assertEquals(Item::TYPE_ROLE, $role->type);
-        $this->assertEquals('admin', $role->name);
+
+        self::assertInstanceOf(
+            Role::class,
+            $role,
+            'Returned object must be a Role.',
+        );
+        self::assertSame(
+            Item::TYPE_ROLE,
+            $role->type,
+            "Type must be 'TYPE_ROLE'.",
+        );
+        self::assertSame(
+            'admin',
+            $role->name,
+            'Name must round-trip from the factory argument.',
+        );
     }
 
     public function testCreatePermission(): void
     {
         $permission = $this->auth->createPermission('edit post');
-        $this->assertInstanceOf(Permission::class, $permission);
-        $this->assertEquals(Item::TYPE_PERMISSION, $permission->type);
-        $this->assertEquals('edit post', $permission->name);
+
+        self::assertInstanceOf(
+            Permission::class,
+            $permission,
+            'Returned object must be a Permission.',
+        );
+        self::assertSame(
+            Item::TYPE_PERMISSION,
+            $permission->type,
+            "Type must be 'TYPE_PERMISSION'.",
+        );
+        self::assertSame(
+            'edit post',
+            $permission->name,
+            'Name must round-trip from the factory argument.',
+        );
     }
 
     public function testAdd(): void
     {
         $role = $this->auth->createRole('admin');
+
         $role->description = 'administrator';
-        $this->assertTrue($this->auth->add($role));
+
+        self::assertTrue(
+            $this->auth->add($role),
+            "Adding a Role must report 'true'.",
+        );
 
         $permission = $this->auth->createPermission('edit post');
+
         $permission->description = 'edit a post';
-        $this->assertTrue($this->auth->add($permission));
+
+        self::assertTrue(
+            $this->auth->add($permission),
+            "Adding a Permission must report 'true'.",
+        );
 
         $rule = new AuthorRule(['name' => 'is author', 'reallyReally' => true]);
-        $this->assertTrue($this->auth->add($rule));
 
-        // todo: check duplication of name
+        self::assertTrue(
+            $this->auth->add($rule),
+            "Adding a Rule must report 'true'.",
+        );
     }
 
     public function testGetChildren(): void
     {
         $user = $this->auth->createRole('user');
+
         $this->auth->add($user);
-        $this->assertCount(0, $this->auth->getChildren($user->name));
+
+        self::assertCount(
+            0,
+            $this->auth->getChildren($user->name),
+            'Fresh role must have no children.',
+        );
 
         $changeName = $this->auth->createPermission('changeName');
+
         $this->auth->add($changeName);
         $this->auth->addChild($user, $changeName);
-        $this->assertCount(1, $this->auth->getChildren($user->name));
+
+        self::assertCount(
+            1,
+            $this->auth->getChildren($user->name),
+            "Children count must reflect a single 'addChild'.",
+        );
     }
 
     public function testGetRule(): void
@@ -81,11 +143,24 @@ abstract class ManagerTestCase extends TestCase
         $this->prepareData();
 
         $rule = $this->auth->getRule('isAuthor');
-        $this->assertInstanceOf('yii\rbac\Rule', $rule);
-        $this->assertEquals('isAuthor', $rule->name);
+
+        self::assertInstanceOf(
+            Rule::class,
+            $rule,
+            'Existing rule must be returned as a Rule instance.',
+        );
+        self::assertSame(
+            'isAuthor',
+            $rule->name,
+            'Rule name must match the persisted value.',
+        );
 
         $rule = $this->auth->getRule('nonExisting');
-        $this->assertNull($rule);
+
+        self::assertNull(
+            $rule,
+            "Unknown rule name must yield 'null'.",
+        );
     }
 
     public function testAddRule(): void
@@ -93,12 +168,22 @@ abstract class ManagerTestCase extends TestCase
         $this->prepareData();
 
         $ruleName = 'isReallyReallyAuthor';
+
         $rule = new AuthorRule(['name' => $ruleName, 'reallyReally' => true]);
+
         $this->auth->add($rule);
 
         $rule = $this->auth->getRule($ruleName);
-        $this->assertEquals($ruleName, $rule->name);
-        $this->assertTrue($rule->reallyReally);
+
+        self::assertSame(
+            $ruleName,
+            $rule->name,
+            'Rule name must round-trip after add.',
+        );
+        self::assertTrue(
+            $rule->reallyReally,
+            'Custom property must be persisted.',
+        );
     }
 
     public function testUpdateRule(): void
@@ -106,32 +191,62 @@ abstract class ManagerTestCase extends TestCase
         $this->prepareData();
 
         $rule = $this->auth->getRule('isAuthor');
+
         $rule->name = 'newName';
         $rule->reallyReally = false;
+
         $this->auth->update('isAuthor', $rule);
 
         $rule = $this->auth->getRule('isAuthor');
-        $this->assertNull($rule);
+
+        self::assertNull(
+            $rule,
+            'Old rule name must no longer resolve after rename.',
+        );
 
         $rule = $this->auth->getRule('newName');
-        $this->assertEquals('newName', $rule->name);
-        $this->assertFalse($rule->reallyReally);
+
+        self::assertSame(
+            'newName',
+            $rule->name,
+            'New rule name must resolve after rename.',
+        );
+        self::assertFalse(
+            $rule->reallyReally,
+            'Custom property update must persist.',
+        );
 
         $rule->reallyReally = true;
+
         $this->auth->update('newName', $rule);
 
         $rule = $this->auth->getRule('newName');
-        $this->assertTrue($rule->reallyReally);
+
+        self::assertTrue(
+            $rule->reallyReally,
+            'Subsequent property update must persist.',
+        );
 
         $item = $this->auth->getPermission('createPost');
+
         $item->name = 'new createPost';
+
         $this->auth->update('createPost', $item);
 
         $item = $this->auth->getPermission('createPost');
-        $this->assertNull($item);
+
+        self::assertNull(
+            $item,
+            'Old permission name must no longer resolve after rename.',
+        );
 
         $item = $this->auth->getPermission('new createPost');
-        $this->assertEquals('new createPost', $item->name);
+
+        self::assertSame(
+            'new createPost',
+            $item->name,
+            'New permission name must resolve after rename.',
+        );
     }
 
     public function testGetRules(): void
@@ -139,17 +254,27 @@ abstract class ManagerTestCase extends TestCase
         $this->prepareData();
 
         $rule = new AuthorRule(['name' => 'isReallyReallyAuthor', 'reallyReally' => true]);
+
         $this->auth->add($rule);
 
         $rules = $this->auth->getRules();
 
         $ruleNames = [];
+
         foreach ($rules as $rule) {
             $ruleNames[] = $rule->name;
         }
 
-        $this->assertContains('isReallyReallyAuthor', $ruleNames);
-        $this->assertContains('isAuthor', $ruleNames);
+        self::assertContains(
+            'isReallyReallyAuthor',
+            $ruleNames,
+            'Newly added rule must appear in the list.',
+        );
+        self::assertContains(
+            'isAuthor',
+            $ruleNames,
+            'Pre-existing fixture rule must remain in the list.',
+        );
     }
 
     public function testRemoveRule(): void
@@ -157,13 +282,22 @@ abstract class ManagerTestCase extends TestCase
         $this->prepareData();
 
         $this->auth->remove($this->auth->getRule('isAuthor'));
+
         $rules = $this->auth->getRules();
 
-        $this->assertEmpty($rules);
+        self::assertEmpty(
+            $rules,
+            'Removing the only rule must leave the rule set empty.',
+        );
 
         $this->auth->remove($this->auth->getPermission('createPost'));
+
         $item = $this->auth->getPermission('createPost');
-        $this->assertNull($item);
+
+        self::assertNull(
+            $item,
+            'Removed permission must no longer resolve.',
+        );
     }
 
     public function testCheckAccess(): void
@@ -210,14 +344,1062 @@ abstract class ManagerTestCase extends TestCase
 
         foreach ($testSuites as $user => $tests) {
             foreach ($tests as $permission => $result) {
-                $this->assertEquals($result, $this->auth->checkAccess($user, $permission, $params), "Checking $user can $permission");
+                self::assertSame(
+                    $result,
+                    $this->auth->checkAccess($user, $permission, $params),
+                    "Access decision must match expected for '{$user}' / '{$permission}'.",
+                );
             }
         }
     }
 
-    protected function prepareData()
+    public function testGetPermissionsByRole(): void
+    {
+        $this->prepareData();
+
+        $permissions = $this->auth->getPermissionsByRole('admin');
+        $expectedPermissions = ['createPost', 'updatePost', 'readPost', 'updateAnyPost'];
+
+        self::assertCount(
+            count($expectedPermissions),
+            $permissions,
+            'Permission count must match the role hierarchy.',
+        );
+
+        foreach ($expectedPermissions as $permissionName) {
+            self::assertInstanceOf(
+                Permission::class,
+                $permissions[$permissionName],
+                "Entry '{$permissionName}' must be a Permission instance.",
+            );
+        }
+    }
+
+    public function testGetPermissionsByUser(): void
+    {
+        $this->prepareData();
+
+        $permissions = $this->auth->getPermissionsByUser('author B');
+
+        $expectedPermissions = ['deletePost', 'createPost', 'updatePost', 'readPost'];
+
+        self::assertCount(
+            count($expectedPermissions),
+            $permissions,
+            'Permission count must match the user assignments.',
+        );
+
+        foreach ($expectedPermissions as $permissionName) {
+            self::assertInstanceOf(
+                Permission::class,
+                $permissions[$permissionName],
+                "Entry '{$permissionName}' must be a Permission instance.",
+            );
+        }
+    }
+
+    public function testGetRole(): void
+    {
+        $this->prepareData();
+
+        $author = $this->auth->getRole('author');
+
+        self::assertEquals(
+            Item::TYPE_ROLE,
+            $author->type,
+            "Type must be 'TYPE_ROLE'.",
+        );
+        self::assertSame(
+            'author',
+            $author->name,
+            'Name must round-trip from storage.',
+        );
+        self::assertSame(
+            'authorData',
+            $author->data,
+            'Custom data must round-trip from storage.',
+        );
+    }
+
+    public function testGetPermission(): void
+    {
+        $this->prepareData();
+        $createPost = $this->auth->getPermission('createPost');
+
+        self::assertEquals(
+            Item::TYPE_PERMISSION,
+            $createPost->type,
+            "Type must be `TYPE_PERMISSION'.",
+        );
+        self::assertSame(
+            'createPost',
+            $createPost->name,
+            'Name must round-trip from storage.',
+        );
+        self::assertSame(
+            'createPostData',
+            $createPost->data,
+            'Custom data must round-trip from storage.',
+        );
+    }
+
+    public function testGetRolesByUser(): void
+    {
+        $this->prepareData();
+
+        $reader = $this->auth->getRole('reader');
+
+        $this->auth->assign($reader, 0);
+        $this->auth->assign($reader, 123);
+
+        $roles = $this->auth->getRolesByUser('reader A');
+
+        self::assertInstanceOf(
+            Role::class,
+            reset($roles),
+            'String user id must yield Role instances.',
+        );
+        self::assertSame(
+            'reader',
+            $roles['reader']->name,
+            'Role name must match assignment.',
+        );
+
+        $roles = $this->auth->getRolesByUser(0);
+
+        self::assertInstanceOf(
+            Role::class,
+            reset($roles),
+            "User id '0' must yield Role instances.",
+        );
+        self::assertSame(
+            'reader',
+            $roles['reader']->name,
+            "Role name must match assignment for '0'.",
+        );
+
+        $roles = $this->auth->getRolesByUser(123);
+
+        self::assertInstanceOf(
+            Role::class,
+            reset($roles),
+            "User id '123' must yield Role instances.",
+        );
+        self::assertSame(
+            'reader',
+            $roles['reader']->name,
+            "Role name must match assignment for '123'.",
+        );
+        self::assertContains(
+            'myDefaultRole',
+            array_keys($roles),
+            'Default role must be merged into the result.',
+        );
+    }
+
+    public function testGetChildRoles(): void
+    {
+        $this->prepareData();
+
+        $roles = $this->auth->getChildRoles('withoutChildren');
+
+        self::assertCount(
+            1,
+            $roles,
+            'Childless role must produce a single-entry result.',
+        );
+        self::assertInstanceOf(
+            Role::class,
+            reset($roles),
+            'Entry must be a Role instance.',
+        );
+        self::assertSame(
+            'withoutChildren',
+            reset($roles)->name,
+            'Single entry must be the role itself.',
+        );
+
+        $roles = $this->auth->getChildRoles('reader');
+
+        self::assertCount(
+            1,
+            $roles,
+            'Reader has no child roles, only itself.',
+        );
+        self::assertInstanceOf(
+            Role::class,
+            reset($roles),
+            'Entry must be a Role instance.',
+        );
+        self::assertSame(
+            'reader',
+            reset($roles)->name,
+            'Single entry must be the role itself.',
+        );
+
+        $roles = $this->auth->getChildRoles('author');
+
+        self::assertCount(
+            2,
+            $roles,
+            "Author must include itself and 'reader'.",
+        );
+        self::assertArrayHasKey(
+            'author',
+            $roles,
+            'Result must include the queried role.',
+        );
+        self::assertArrayHasKey(
+            'reader',
+            $roles,
+            'Result must include nested child role.',
+        );
+
+        $roles = $this->auth->getChildRoles('admin');
+
+        self::assertCount(
+            3,
+            $roles,
+            "Admin must include itself, 'author' and 'reader'.",
+        );
+        self::assertArrayHasKey(
+            'admin',
+            $roles,
+            'Result must include the queried role.',
+        );
+        self::assertArrayHasKey(
+            'author',
+            $roles,
+            'Result must include direct child role.',
+        );
+        self::assertArrayHasKey(
+            'reader',
+            $roles,
+            'Result must include transitive child role.',
+        );
+    }
+
+    public function testAssignMultipleRoles(): void
+    {
+        $this->prepareData();
+
+        $reader = $this->auth->getRole('reader');
+        $author = $this->auth->getRole('author');
+
+        $this->auth->assign($reader, 'readingAuthor');
+        $this->auth->assign($author, 'readingAuthor');
+        $this->auth = $this->createManager();
+
+        $roles = $this->auth->getRolesByUser('readingAuthor');
+
+        $roleNames = [];
+
+        foreach ($roles as $role) {
+            $roleNames[] = $role->name;
+        }
+
+        self::assertContains(
+            'reader',
+            $roleNames,
+            "Result must include 'reader'. Got: " . implode(', ', $roleNames),
+        );
+        self::assertContains(
+            'author',
+            $roleNames,
+            "Result must include 'author'. Got: " . implode(', ', $roleNames),
+        );
+    }
+
+    public function testAssignmentsToIntegerId(): void
+    {
+        $this->prepareData();
+
+        $reader = $this->auth->getRole('reader');
+        $author = $this->auth->getRole('author');
+
+        $this->auth->assign($reader, 42);
+        $this->auth->assign($author, 1337);
+        $this->auth->assign($reader, 1337);
+
+        $this->auth = $this->createManager();
+
+        self::assertCount(
+            0,
+            $this->auth->getAssignments(0),
+            'User without assignments must yield empty result.',
+        );
+        self::assertCount(
+            1,
+            $this->auth->getAssignments(42),
+            'Single assignment must round-trip for integer id.',
+        );
+        self::assertCount(
+            2,
+            $this->auth->getAssignments(1337),
+            'Two assignments must round-trip for integer id.',
+        );
+    }
+
+    public function testGetAssignmentsByRole(): void
+    {
+        $this->prepareData();
+
+        $reader = $this->auth->getRole('reader');
+
+        $this->auth->assign($reader, 123);
+
+        $this->auth = $this->createManager();
+
+        self::assertSame(
+            [],
+            $this->auth->getUserIdsByRole('nonexisting'),
+            'Unknown role must yield an empty array.',
+        );
+        self::assertSame(
+            ['reader A', '123'],
+            $this->auth->getUserIdsByRole('reader'),
+            'User ids must include both string and numeric ids.',
+        );
+        self::assertSame(
+            ['author B'],
+            $this->auth->getUserIdsByRole('author'),
+            'Author must list a single user.',
+        );
+        self::assertSame(
+            ['admin C'],
+            $this->auth->getUserIdsByRole('admin'),
+            'Admin must list a single user.',
+        );
+    }
+
+    public function testCanAddChild(): void
+    {
+        $this->prepareData();
+
+        $author = $this->auth->createRole('author');
+        $reader = $this->auth->createRole('reader');
+
+        self::assertTrue(
+            $this->auth->canAddChild($author, $reader),
+            'Author may legally adopt reader as child.',
+        );
+        self::assertFalse(
+            $this->auth->canAddChild($reader, $author),
+            'Reader adopting author would create a loop.',
+        );
+    }
+
+    public function testRemoveAllRules(): void
+    {
+        $this->prepareData();
+
+        $this->auth->removeAllRules();
+
+        self::assertEmpty(
+            $this->auth->getRules(),
+            'Rule set must be cleared.',
+        );
+        self::assertNotEmpty(
+            $this->auth->getRoles(),
+            'Roles must remain untouched.',
+        );
+        self::assertNotEmpty(
+            $this->auth->getPermissions(),
+            'Permissions must remain untouched.',
+        );
+    }
+
+    public function testRemoveAllRoles(): void
+    {
+        $this->prepareData();
+
+        $this->auth->removeAllRoles();
+
+        self::assertEmpty(
+            $this->auth->getRoles(),
+            'Role set must be cleared.',
+        );
+        self::assertNotEmpty(
+            $this->auth->getRules(),
+            'Rules must remain untouched.',
+        );
+        self::assertNotEmpty(
+            $this->auth->getPermissions(),
+            'Permissions must remain untouched.',
+        );
+    }
+
+    public function testRemoveAllPermissions(): void
+    {
+        $this->prepareData();
+
+        $this->auth->removeAllPermissions();
+
+        self::assertEmpty(
+            $this->auth->getPermissions(),
+            'Permission set must be cleared.',
+        );
+        self::assertNotEmpty(
+            $this->auth->getRules(),
+            'Rules must remain untouched.',
+        );
+        self::assertNotEmpty(
+            $this->auth->getRoles(),
+            'Roles must remain untouched.',
+        );
+    }
+
+    /**
+     * @dataProvider RBACItemsProvider
+     * @param mixed $RBACItemType
+     */
+    public function testAssignRule($RBACItemType): void
+    {
+        $auth = $this->auth;
+
+        $userId = 3;
+
+        $auth->removeAll();
+
+        $item = $this->createRBACItem($RBACItemType, 'Admin');
+
+        $auth->add($item);
+        $auth->assign($item, $userId);
+
+        self::assertTrue(
+            $auth->checkAccess($userId, 'Admin'),
+            'Item without a rule must grant access.',
+        );
+
+        // with normal register rule
+        $auth->removeAll();
+
+        $rule = new ActionRule();
+
+        $auth->add($rule);
+
+        $item = $this->createRBACItem($RBACItemType, 'Reader');
+
+        $item->ruleName = $rule->name;
+
+        $auth->add($item);
+        $auth->assign($item, $userId);
+
+        self::assertTrue(
+            $auth->checkAccess($userId, 'Reader', ['action' => 'read']),
+            'Rule must allow `read` action.',
+        );
+        self::assertFalse(
+            $auth->checkAccess($userId, 'Reader', ['action' => 'write']),
+            'Rule must deny non-`read` action.',
+        );
+
+        // using rule class name
+        $auth->removeAll();
+
+        $item = $this->createRBACItem($RBACItemType, 'Reader');
+
+        $item->ruleName = 'yiiunit\framework\rbac\stub\ActionRule';
+
+        $auth->add($item);
+        $auth->assign($item, $userId);
+
+        self::assertTrue(
+            $auth->checkAccess($userId, 'Reader', ['action' => 'read']),
+            "Class-name rule must allow 'read' action.",
+        );
+        self::assertFalse(
+            $auth->checkAccess($userId, 'Reader', ['action' => 'write']),
+            "Class-name rule must deny 'write' action.",
+        );
+
+        // using DI
+        Yii::$container->set(
+            'write_rule',
+            ['class' => 'yiiunit\framework\rbac\stub\ActionRule',
+            'action' => 'write'],
+        );
+        Yii::$container->set(
+            'delete_rule',
+            ['class' => 'yiiunit\framework\rbac\stub\ActionRule',
+            'action' => 'delete'],
+        );
+        Yii::$container->set(
+            'all_rule',
+            ['class' => 'yiiunit\framework\rbac\stub\ActionRule',
+            'action' => 'all'],
+        );
+
+        $item = $this->createRBACItem($RBACItemType, 'Writer');
+
+        $item->ruleName = 'write_rule';
+
+        $auth->add($item);
+        $auth->assign($item, $userId);
+
+        self::assertTrue(
+            $auth->checkAccess($userId, 'Writer', ['action' => 'write']),
+            "DI-registered rule must allow 'write' action.",
+        );
+        self::assertFalse(
+            $auth->checkAccess($userId, 'Writer', ['action' => 'update']),
+            "DI-registered rule must deny 'update' action.",
+        );
+
+        $item = $this->createRBACItem($RBACItemType, 'Deleter');
+
+        $item->ruleName = 'delete_rule';
+
+        $auth->add($item);
+        $auth->assign($item, $userId);
+
+        self::assertTrue(
+            $auth->checkAccess($userId, 'Deleter', ['action' => 'delete']),
+            "DI-registered rule must allow 'delete' action.",
+        );
+        self::assertFalse(
+            $auth->checkAccess($userId, 'Deleter', ['action' => 'update']),
+            "DI-registered rule must deny 'update' action.",
+        );
+
+        $item = $this->createRBACItem($RBACItemType, 'Author');
+
+        $item->ruleName = 'all_rule';
+
+        $auth->add($item);
+        $auth->assign($item, $userId);
+
+        self::assertTrue(
+            $auth->checkAccess($userId, 'Author', ['action' => 'update']),
+            'Wildcard rule must allow any action.',
+        );
+
+        // update role and rule
+        $item = $this->getRBACItem($RBACItemType, 'Reader');
+
+        $item->name = 'AdminPost';
+        $item->ruleName = 'all_rule';
+
+        $auth->update('Reader', $item);
+
+        self::assertTrue(
+            $auth->checkAccess($userId, 'AdminPost', ['action' => 'print']),
+            'Renamed item with wildcard rule must allow access.',
+        );
+    }
+
+    /**
+     * @dataProvider RBACItemsProvider
+     * @param mixed $RBACItemType
+     */
+    public function testRevokeRule($RBACItemType): void
+    {
+        $userId = 3;
+
+        $auth = $this->auth;
+
+        $auth->removeAll();
+
+        $item = $this->createRBACItem($RBACItemType, 'Admin');
+
+        $auth->add($item);
+        $auth->assign($item, $userId);
+
+        self::assertTrue(
+            $auth->revoke($item, $userId),
+            "Revoke of an existing assignment must report 'true'.",
+        );
+        self::assertFalse(
+            $auth->checkAccess($userId, 'Admin'),
+            'Access must be denied after revoke.',
+        );
+
+        $auth->removeAll();
+
+        $rule = new ActionRule();
+
+        $auth->add($rule);
+
+        $item = $this->createRBACItem($RBACItemType, 'Reader');
+
+        $item->ruleName = $rule->name;
+
+        $auth->add($item);
+        $auth->assign($item, $userId);
+
+        self::assertTrue(
+            $auth->revoke($item, $userId),
+            "Revoke of a rule-bound assignment must report 'true'.",
+        );
+        self::assertFalse(
+            $auth->checkAccess($userId, 'Reader', ['action' => 'read']),
+            'Access must be denied after revoke even if the rule would allow.',
+        );
+        self::assertFalse(
+            $auth->checkAccess($userId, 'Reader', ['action' => 'write']),
+            'Access must be denied after revoke for any action.',
+        );
+    }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/10176
+     * @see https://github.com/yiisoft/yii2/issues/12681
+     */
+    public function testRuleWithPrivateFields(): void
+    {
+        $auth = $this->auth;
+
+        $auth->removeAll();
+
+        $rule = new ActionRule();
+
+        $auth->add($rule);
+
+        /** @var ActionRule $rule */
+        $rule = $this->auth->getRule('action_rule');
+
+        self::assertInstanceOf(
+            ActionRule::class,
+            $rule,
+            'Rule with private fields must round-trip via storage.',
+        );
+    }
+
+    public function testDefaultRolesWithClosureReturningNonArrayValue(): void
+    {
+        $this->expectException(InvalidValueException::class);
+        $this->expectExceptionMessage(
+            'Default roles closure must return an array',
+        );
+
+        $this->auth->defaultRoles = fn() => 'test';
+    }
+
+    public function testDefaultRolesWithNonArrayValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Default roles must be either an array or a callable',
+        );
+
+        $this->auth->defaultRoles = 'test';
+    }
+
+    public function testHasChild(): void
+    {
+        $this->prepareData();
+
+        $author = $this->auth->getRole('author');
+        $createPost = $this->auth->getPermission('createPost');
+        $deletePost = $this->auth->getPermission('deletePost');
+
+        self::assertTrue(
+            $this->auth->hasChild($author, $createPost),
+            'Existing parent-child link must be detected.',
+        );
+        self::assertFalse(
+            $this->auth->hasChild($author, $deletePost),
+            "Missing parent-child link must report 'false'.",
+        );
+    }
+
+    public function testRemoveChild(): void
+    {
+        $this->prepareData();
+
+        $author = $this->auth->getRole('author');
+        $createPost = $this->auth->getPermission('createPost');
+
+        self::assertTrue(
+            $this->auth->removeChild($author, $createPost),
+            "Existing pair must be removed and report 'true'.",
+        );
+        self::assertFalse(
+            $this->auth->hasChild($author, $createPost),
+            'Pair must no longer be present after removal.',
+        );
+        self::assertFalse(
+            $this->auth->removeChild($author, $createPost),
+            "Removing an already-removed pair must report 'false'.",
+        );
+    }
+
+    public function testRemoveChildren(): void
+    {
+        $this->prepareData();
+
+        $author = $this->auth->getRole('author');
+
+        self::assertNotEmpty(
+            $this->auth->getChildren($author->name),
+            'Fixture must populate children.',
+        );
+        self::assertTrue(
+            $this->auth->removeChildren($author),
+            "Removing children must report 'true'.",
+        );
+        self::assertEmpty(
+            $this->auth->getChildren($author->name),
+            'Children must be cleared after removal.',
+        );
+        self::assertFalse(
+            $this->auth->removeChildren($author),
+            "Second call without children must report 'false'.",
+        );
+    }
+
+    public function testRevokeAll(): void
+    {
+        $this->prepareData();
+
+        self::assertTrue(
+            $this->auth->revokeAll('author B'),
+            "Revoking assignments of an assigned user must report 'true'.",
+        );
+        self::assertEmpty(
+            $this->auth->getAssignments('author B'),
+            'Assignments must be cleared after revokeAll.',
+        );
+        self::assertFalse(
+            $this->auth->revokeAll('user-never-assigned'),
+            "Revoking on a user that was never assigned must report 'false'.",
+        );
+    }
+
+    public function testGetAssignmentReturnsNullForUnknownPair(): void
+    {
+        $this->prepareData();
+
+        self::assertNull(
+            $this->auth->getAssignment('admin', 'nobody'),
+            "Unknown user must yield 'null'.",
+        );
+        self::assertNull(
+            $this->auth->getAssignment('nonExistentRole', 'reader A'),
+            "Unknown role must yield 'null'.",
+        );
+    }
+
+    public function testRemoveAllAssignments(): void
+    {
+        $this->prepareData();
+
+        $this->auth->removeAllAssignments();
+
+        self::assertEmpty(
+            $this->auth->getAssignments('reader A'),
+            'No assignments must remain for any user.',
+        );
+        self::assertEmpty(
+            $this->auth->getAssignments('author B'),
+            'No assignments must remain for any user.',
+        );
+        self::assertEmpty(
+            $this->auth->getAssignments('admin C'),
+            'No assignments must remain for any user.',
+        );
+    }
+
+    public function testCheckAccessReturnsFalseForUserWithoutAssignments(): void
+    {
+        $this->prepareData();
+
+        $this->auth->defaultRoles = [];
+
+        self::assertFalse(
+            $this->auth->checkAccess('user-without-any-assignment', 'createPost'),
+            'User without assignments and no default roles must be denied.',
+        );
+    }
+
+    public function testGetPermissionsByRoleReturnsEmptyForRoleWithoutChildren(): void
+    {
+        $this->prepareData();
+
+        self::assertSame(
+            [],
+            $this->auth->getPermissionsByRole('withoutChildren'),
+            'Role without children must yield an empty array.',
+        );
+    }
+
+    public function testGetPermissionsByUserReturnsEmptyForRoleWithoutChildren(): void
+    {
+        $this->prepareData();
+
+        $this->auth->assign($this->auth->getRole('withoutChildren'), 'lonely-user');
+
+        self::assertSame(
+            [],
+            $this->auth->getPermissionsByUser('lonely-user'),
+            'User assigned only to a childless role must yield no permissions.',
+        );
+    }
+
+    public function testGetUserIdsByRoleReturnsEmptyForBlankName(): void
+    {
+        $this->prepareData();
+
+        self::assertSame(
+            [],
+            $this->auth->getUserIdsByRole(''),
+            'Blank role name must yield an empty array.',
+        );
+    }
+
+    public function testGetDefaultRolesReturnsConfiguredArray(): void
+    {
+        $this->auth->defaultRoles = ['guest', 'observer'];
+
+        self::assertSame(
+            ['guest', 'observer'],
+            $this->auth->getDefaultRoles(),
+            'Configured default roles must round-trip.',
+        );
+    }
+
+    public function testSetDefaultRolesAcceptsClosureReturningArray(): void
+    {
+        $this->auth->defaultRoles = static fn(): array => ['viewer', 'editor'];
+
+        self::assertSame(
+            ['viewer', 'editor'],
+            $this->auth->getDefaultRoles(),
+            'Closure must populate default roles.',
+        );
+    }
+
+    public function testGetRoleReturnsNullForPermissionName(): void
+    {
+        $this->prepareData();
+
+        self::assertNull(
+            $this->auth->getRole('createPost'),
+            'Permission name must not resolve to a role.',
+        );
+    }
+
+    public function testGetPermissionReturnsNullForRoleName(): void
+    {
+        $this->prepareData();
+
+        self::assertNull(
+            $this->auth->getPermission('admin'),
+            'Role name must not resolve to a permission.',
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenAddChildIsItself(): void
+    {
+        $role = $this->auth->createRole('cycle-target');
+
+        $this->auth->add($role);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            "Cannot add 'cycle-target' as a child of itself.",
+        );
+
+        $this->auth->addChild($role, $role);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenAddChildPermissionParentsRole(): void
+    {
+        $perm = $this->auth->createPermission('do-stuff');
+        $role = $this->auth->createRole('staff');
+
+        $this->auth->add($perm);
+        $this->auth->add($role);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Cannot add a role as a child of a permission.',
+        );
+
+        $this->auth->addChild($perm, $role);
+    }
+
+    public function testThrowInvalidCallExceptionWhenAddChildCreatesLoop(): void
+    {
+        $a = $this->auth->createRole('loop-a');
+        $b = $this->auth->createRole('loop-b');
+
+        $this->auth->add($a);
+        $this->auth->add($b);
+        $this->auth->addChild($a, $b);
+
+        $this->expectException(InvalidCallException::class);
+        $this->expectExceptionMessage(
+            "Cannot add 'loop-a' as a child of 'loop-b'. A loop has been detected.",
+        );
+
+        $this->auth->addChild($b, $a);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenGetChildRolesUnknownRole(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Role "no-such-role" not found.',
+        );
+
+        $this->auth->getChildRoles('no-such-role');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenAddUnsupportedObject(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Adding unsupported object type.',
+        );
+
+        $this->auth->add(new stdClass());
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenRemoveUnsupportedObject(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Removing unsupported object type.',
+        );
+
+        $this->auth->remove(new stdClass());
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenUpdateUnsupportedObject(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Updating unsupported object type.',
+        );
+
+        $this->auth->update('any', new stdClass());
+    }
+
+    public function testRevokeReturnsFalseForUnassignedRole(): void
+    {
+        $this->prepareData();
+
+        $admin = $this->auth->getRole('admin');
+
+        self::assertFalse(
+            $this->auth->revoke($admin, 'never-was-admin'),
+            "Revoking a role from a user that was never assigned must report 'false'.",
+        );
+    }
+
+    public function testRemoveAllRolesIsIdempotentOnEmptyManager(): void
+    {
+        $this->auth->removeAll();
+        $this->auth->removeAllRoles();
+
+        self::assertSame(
+            [],
+            $this->auth->getRoles(),
+            "No roles must remain after empty 'removeAllRoles'.",
+        );
+    }
+
+    public function testRemoveAllPermissionsIsIdempotentOnEmptyManager(): void
+    {
+        $this->auth->removeAll();
+        $this->auth->removeAllPermissions();
+
+        self::assertSame(
+            [],
+            $this->auth->getPermissions(),
+            "No permissions must remain after empty 'removeAllPermissions'.",
+        );
+    }
+
+    public function testUpdateItemRenameWithChildrenAndAssignments(): void
+    {
+        $this->prepareData();
+
+        $author = $this->auth->getRole('author');
+
+        $author->name = 'newAuthor';
+
+        self::assertTrue(
+            $this->auth->update('author', $author),
+            'Rename of an item with children and assignments must succeed.',
+        );
+        self::assertNull(
+            $this->auth->getRole('author'),
+            'Old name must no longer resolve to a role.',
+        );
+        self::assertNotNull(
+            $this->auth->getRole('newAuthor'),
+            'New name must resolve to a role.',
+        );
+    }
+
+    public function testUpdateAutoCreatesRuleWhenItemReferencesAnUnknownRuleClass(): void
+    {
+        $perm = $this->auth->createPermission('audited-action');
+
+        $this->auth->add($perm);
+
+        // Update with a ruleName that resolves to an instantiable Rule class but is not yet registered.
+        $perm->ruleName = AuthorRule::class;
+        $this->auth->update('audited-action', $perm);
+
+        self::assertNotNull(
+            $this->auth->getRule(AuthorRule::class),
+            'Update must auto-register the rule referenced by the item.',
+        );
+    }
+
+    public function testThrowInvalidConfigExceptionWhenExecuteRuleCannotResolveRuleName(): void
     {
         $rule = new AuthorRule();
+
+        $perm = $this->auth->createPermission('rule-locked');
+
+        $perm->ruleName = $rule->name;
+
+        $this->auth->add($rule);
+        $this->auth->add($perm);
+        $this->auth->assign($perm, 'user-z');
+
+        // warm up the in-memory snapshot so subsequent checkAccess() calls do not reload from cache.
+        $this->auth->checkAccess('user-z', 'rule-locked', ['authorID' => 'user-z']);
+
+        // force the in-memory rule registry to drop the rule while the item keeps its `ruleName`, simulating a corrupt
+        // persisted state that bypasses the framework's normal cleanup.
+        $reflection = new ReflectionClass($this->auth);
+        $rulesProperty = $reflection->getProperty('rules');
+        $rules = (array) ($rulesProperty->getValue($this->auth) ?? [$rule->name => $rule]);
+
+        unset($rules[$rule->name]);
+
+        $rulesProperty->setValue($this->auth, $rules);
+
+        // reset the per-user assignment cache (DbManager only) so the next call re-reads assignments fresh.
+        if ($reflection->hasProperty('checkAccessAssignments')) {
+            $reflection->getProperty('checkAccessAssignments')->setValue($this->auth, []);
+        }
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage(
+            "Rule not found: {$rule->name}",
+        );
+
+        $this->auth->checkAccess('user-z', 'rule-locked', ['authorID' => 'user-z']);
+    }
+
+    public static function RBACItemsProvider(): array
+    {
+        return [
+            [Item::TYPE_ROLE],
+            [Item::TYPE_PERMISSION],
+        ];
+    }
+
+    protected function prepareData(): void
+    {
+        $rule = new AuthorRule();
+
         $this->auth->add($rule);
 
         $uniqueTrait = $this->auth->createPermission('Fast Metabolism');
@@ -273,317 +1455,15 @@ abstract class ManagerTestCase extends TestCase
         $this->auth->assign($admin, 'admin C');
     }
 
-    public function testGetPermissionsByRole(): void
-    {
-        $this->prepareData();
-        $permissions = $this->auth->getPermissionsByRole('admin');
-        $expectedPermissions = ['createPost', 'updatePost', 'readPost', 'updateAnyPost'];
-        $this->assertEquals(count($expectedPermissions), count($permissions));
-        foreach ($expectedPermissions as $permissionName) {
-            $this->assertInstanceOf(Permission::class, $permissions[$permissionName]);
-        }
-    }
-
-    public function testGetPermissionsByUser(): void
-    {
-        $this->prepareData();
-        $permissions = $this->auth->getPermissionsByUser('author B');
-        $expectedPermissions = ['deletePost', 'createPost', 'updatePost', 'readPost'];
-        $this->assertEquals(count($expectedPermissions), count($permissions));
-        foreach ($expectedPermissions as $permissionName) {
-            $this->assertInstanceOf(Permission::class, $permissions[$permissionName]);
-        }
-    }
-
-    public function testGetRole(): void
-    {
-        $this->prepareData();
-        $author = $this->auth->getRole('author');
-        $this->assertEquals(Item::TYPE_ROLE, $author->type);
-        $this->assertEquals('author', $author->name);
-        $this->assertEquals('authorData', $author->data);
-    }
-
-    public function testGetPermission(): void
-    {
-        $this->prepareData();
-        $createPost = $this->auth->getPermission('createPost');
-        $this->assertEquals(Item::TYPE_PERMISSION, $createPost->type);
-        $this->assertEquals('createPost', $createPost->name);
-        $this->assertEquals('createPostData', $createPost->data);
-    }
-
-    public function testGetRolesByUser(): void
-    {
-        $this->prepareData();
-        $reader = $this->auth->getRole('reader');
-        $this->auth->assign($reader, 0);
-        $this->auth->assign($reader, 123);
-
-        $roles = $this->auth->getRolesByUser('reader A');
-        $this->assertInstanceOf(Role::class, reset($roles));
-        $this->assertEquals($roles['reader']->name, 'reader');
-
-        $roles = $this->auth->getRolesByUser(0);
-        $this->assertInstanceOf(Role::class, reset($roles));
-        $this->assertEquals($roles['reader']->name, 'reader');
-
-        $roles = $this->auth->getRolesByUser(123);
-        $this->assertInstanceOf(Role::class, reset($roles));
-        $this->assertEquals($roles['reader']->name, 'reader');
-
-        $this->assertContains('myDefaultRole', array_keys($roles));
-    }
-
-    public function testGetChildRoles(): void
-    {
-        $this->prepareData();
-
-        $roles = $this->auth->getChildRoles('withoutChildren');
-        $this->assertCount(1, $roles);
-        $this->assertInstanceOf(Role::class, reset($roles));
-        $this->assertSame(reset($roles)->name, 'withoutChildren');
-
-        $roles = $this->auth->getChildRoles('reader');
-        $this->assertCount(1, $roles);
-        $this->assertInstanceOf(Role::class, reset($roles));
-        $this->assertSame(reset($roles)->name, 'reader');
-
-        $roles = $this->auth->getChildRoles('author');
-        $this->assertCount(2, $roles);
-        $this->assertArrayHasKey('author', $roles);
-        $this->assertArrayHasKey('reader', $roles);
-
-        $roles = $this->auth->getChildRoles('admin');
-        $this->assertCount(3, $roles);
-        $this->assertArrayHasKey('admin', $roles);
-        $this->assertArrayHasKey('author', $roles);
-        $this->assertArrayHasKey('reader', $roles);
-    }
-
-    public function testAssignMultipleRoles(): void
-    {
-        $this->prepareData();
-
-        $reader = $this->auth->getRole('reader');
-        $author = $this->auth->getRole('author');
-        $this->auth->assign($reader, 'readingAuthor');
-        $this->auth->assign($author, 'readingAuthor');
-
-        $this->auth = $this->createManager();
-
-        $roles = $this->auth->getRolesByUser('readingAuthor');
-        $roleNames = [];
-        foreach ($roles as $role) {
-            $roleNames[] = $role->name;
-        }
-
-        $this->assertContains(
-            'reader',
-            $roleNames,
-            'Roles should contain reader. Currently it has: ' . implode(', ', $roleNames)
-        );
-        $this->assertContains(
-            'author',
-            $roleNames,
-            'Roles should contain author. Currently it has: ' . implode(', ', $roleNames)
-        );
-    }
-
-    public function testAssignmentsToIntegerId(): void
-    {
-        $this->prepareData();
-
-        $reader = $this->auth->getRole('reader');
-        $author = $this->auth->getRole('author');
-        $this->auth->assign($reader, 42);
-        $this->auth->assign($author, 1337);
-        $this->auth->assign($reader, 1337);
-
-        $this->auth = $this->createManager();
-
-        $this->assertCount(0, $this->auth->getAssignments(0));
-        $this->assertCount(1, $this->auth->getAssignments(42));
-        $this->assertCount(2, $this->auth->getAssignments(1337));
-    }
-
-    public function testGetAssignmentsByRole(): void
-    {
-        $this->prepareData();
-        $reader = $this->auth->getRole('reader');
-        $this->auth->assign($reader, 123);
-
-        $this->auth = $this->createManager();
-
-        $this->assertEquals([], $this->auth->getUserIdsByRole('nonexisting'));
-        $this->assertEquals(['reader A', '123'], $this->auth->getUserIdsByRole('reader'), '');
-        $this->assertEquals(['author B'], $this->auth->getUserIdsByRole('author'));
-        $this->assertEquals(['admin C'], $this->auth->getUserIdsByRole('admin'));
-    }
-
-    public function testCanAddChild(): void
-    {
-        $this->prepareData();
-
-        $author = $this->auth->createRole('author');
-        $reader = $this->auth->createRole('reader');
-
-        $this->assertTrue($this->auth->canAddChild($author, $reader));
-        $this->assertFalse($this->auth->canAddChild($reader, $author));
-    }
-
-    public function testRemoveAllRules(): void
-    {
-        $this->prepareData();
-
-        $this->auth->removeAllRules();
-
-        $this->assertEmpty($this->auth->getRules());
-
-        $this->assertNotEmpty($this->auth->getRoles());
-        $this->assertNotEmpty($this->auth->getPermissions());
-    }
-
-    public function testRemoveAllRoles(): void
-    {
-        $this->prepareData();
-
-        $this->auth->removeAllRoles();
-
-        $this->assertEmpty($this->auth->getRoles());
-
-        $this->assertNotEmpty($this->auth->getRules());
-        $this->assertNotEmpty($this->auth->getPermissions());
-    }
-
-    public function testRemoveAllPermissions(): void
-    {
-        $this->prepareData();
-
-        $this->auth->removeAllPermissions();
-
-        $this->assertEmpty($this->auth->getPermissions());
-
-        $this->assertNotEmpty($this->auth->getRules());
-        $this->assertNotEmpty($this->auth->getRoles());
-    }
-
-    public static function RBACItemsProvider(): array
-    {
-        return [
-            [Item::TYPE_ROLE],
-            [Item::TYPE_PERMISSION],
-        ];
-    }
-
-    /**
-     * @dataProvider RBACItemsProvider
-     * @param mixed $RBACItemType
-     */
-    public function testAssignRule($RBACItemType): void
-    {
-        $auth = $this->auth;
-        $userId = 3;
-
-        $auth->removeAll();
-        $item = $this->createRBACItem($RBACItemType, 'Admin');
-        $auth->add($item);
-        $auth->assign($item, $userId);
-        $this->assertTrue($auth->checkAccess($userId, 'Admin'));
-
-        // with normal register rule
-        $auth->removeAll();
-        $rule = new ActionRule();
-        $auth->add($rule);
-        $item = $this->createRBACItem($RBACItemType, 'Reader');
-        $item->ruleName = $rule->name;
-        $auth->add($item);
-        $auth->assign($item, $userId);
-        $this->assertTrue($auth->checkAccess($userId, 'Reader', ['action' => 'read']));
-        $this->assertFalse($auth->checkAccess($userId, 'Reader', ['action' => 'write']));
-
-        // using rule class name
-        $auth->removeAll();
-        $item = $this->createRBACItem($RBACItemType, 'Reader');
-        $item->ruleName = 'yiiunit\framework\rbac\ActionRule';
-        $auth->add($item);
-        $auth->assign($item, $userId);
-        $this->assertTrue($auth->checkAccess($userId, 'Reader', ['action' => 'read']));
-        $this->assertFalse($auth->checkAccess($userId, 'Reader', ['action' => 'write']));
-
-        // using DI
-        Yii::$container->set('write_rule', ['class' => 'yiiunit\framework\rbac\ActionRule', 'action' => 'write']);
-        Yii::$container->set('delete_rule', ['class' => 'yiiunit\framework\rbac\ActionRule', 'action' => 'delete']);
-        Yii::$container->set('all_rule', ['class' => 'yiiunit\framework\rbac\ActionRule', 'action' => 'all']);
-
-        $item = $this->createRBACItem($RBACItemType, 'Writer');
-        $item->ruleName = 'write_rule';
-        $auth->add($item);
-        $auth->assign($item, $userId);
-        $this->assertTrue($auth->checkAccess($userId, 'Writer', ['action' => 'write']));
-        $this->assertFalse($auth->checkAccess($userId, 'Writer', ['action' => 'update']));
-
-        $item = $this->createRBACItem($RBACItemType, 'Deleter');
-        $item->ruleName = 'delete_rule';
-        $auth->add($item);
-        $auth->assign($item, $userId);
-        $this->assertTrue($auth->checkAccess($userId, 'Deleter', ['action' => 'delete']));
-        $this->assertFalse($auth->checkAccess($userId, 'Deleter', ['action' => 'update']));
-
-        $item = $this->createRBACItem($RBACItemType, 'Author');
-        $item->ruleName = 'all_rule';
-        $auth->add($item);
-        $auth->assign($item, $userId);
-        $this->assertTrue($auth->checkAccess($userId, 'Author', ['action' => 'update']));
-
-        // update role and rule
-        $item = $this->getRBACItem($RBACItemType, 'Reader');
-        $item->name = 'AdminPost';
-        $item->ruleName = 'all_rule';
-        $auth->update('Reader', $item);
-        $this->assertTrue($auth->checkAccess($userId, 'AdminPost', ['action' => 'print']));
-    }
-
-    /**
-     * @dataProvider RBACItemsProvider
-     * @param mixed $RBACItemType
-     */
-    public function testRevokeRule($RBACItemType): void
-    {
-        $userId = 3;
-        $auth = $this->auth;
-
-        $auth->removeAll();
-        $item = $this->createRBACItem($RBACItemType, 'Admin');
-        $auth->add($item);
-        $auth->assign($item, $userId);
-
-        $this->assertTrue($auth->revoke($item, $userId));
-        $this->assertFalse($auth->checkAccess($userId, 'Admin'));
-
-        $auth->removeAll();
-        $rule = new ActionRule();
-        $auth->add($rule);
-        $item = $this->createRBACItem($RBACItemType, 'Reader');
-        $item->ruleName = $rule->name;
-        $auth->add($item);
-        $auth->assign($item, $userId);
-
-        $this->assertTrue($auth->revoke($item, $userId));
-        $this->assertFalse($auth->checkAccess($userId, 'Reader', ['action' => 'read']));
-        $this->assertFalse($auth->checkAccess($userId, 'Reader', ['action' => 'write']));
-    }
-
     /**
      * Create Role or Permission RBAC item.
-     * @param int $RBACItemType
-     * @return Permission|Role
      */
     private function createRBACItem(int $RBACItemType, string $name)
     {
         if ($RBACItemType === Item::TYPE_ROLE) {
             return $this->auth->createRole($name);
         }
+
         if ($RBACItemType === Item::TYPE_PERMISSION) {
             return $this->auth->createPermission($name);
         }
@@ -593,50 +1473,17 @@ abstract class ManagerTestCase extends TestCase
 
     /**
      * Get Role or Permission RBAC item.
-     * @param int $RBACItemType
-     * @return Permission|Role
      */
     private function getRBACItem(int $RBACItemType, string $name)
     {
         if ($RBACItemType === Item::TYPE_ROLE) {
             return $this->auth->getRole($name);
         }
+
         if ($RBACItemType === Item::TYPE_PERMISSION) {
             return $this->auth->getPermission($name);
         }
 
         throw new InvalidArgumentException();
-    }
-
-    /**
-     * @see https://github.com/yiisoft/yii2/issues/10176
-     * @see https://github.com/yiisoft/yii2/issues/12681
-     */
-    public function testRuleWithPrivateFields(): void
-    {
-        $auth = $this->auth;
-
-        $auth->removeAll();
-
-        $rule = new ActionRule();
-        $auth->add($rule);
-
-        /** @var ActionRule $rule */
-        $rule = $this->auth->getRule('action_rule');
-        $this->assertInstanceOf(ActionRule::class, $rule);
-    }
-
-    public function testDefaultRolesWithClosureReturningNonArrayValue(): void
-    {
-        $this->expectException('yii\base\InvalidValueException');
-        $this->expectExceptionMessage('Default roles closure must return an array');
-        $this->auth->defaultRoles = fn() => 'test';
-    }
-
-    public function testDefaultRolesWithNonArrayValue(): void
-    {
-        $this->expectException('yii\base\InvalidArgumentException');
-        $this->expectExceptionMessage('Default roles must be either an array or a callable');
-        $this->auth->defaultRoles = 'test';
     }
 }

--- a/tests/framework/rbac/PhpManagerTest.php
+++ b/tests/framework/rbac/PhpManagerTest.php
@@ -1,45 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-namespace yii\rbac;
-
-/**
- * Mock for the filemtime() function for rbac classes. Avoid random test fails.
- * @param string $file
- * @return int
- */
-function filemtime($file)
-{
-    return \yiiunit\framework\rbac\PhpManagerTest::$filemtime ?: \filemtime($file);
-}
-
-/**
- * Mock for the time() function for rbac classes. Avoid random test fails.
- * @return int
- */
-function time()
-{
-    return \yiiunit\framework\rbac\PhpManagerTest::$time ?: \time();
-}
-
 namespace yiiunit\framework\rbac;
 
+use PHPUnit\Framework\Attributes\Group;
+use Xepozz\InternalMocker\MockerState;
 use Yii;
+use yiiunit\framework\rbac\stub\AuthorRule;
+use yiiunit\framework\rbac\stub\ExposedPhpManager;
 
 /**
- * @group rbac
- * @property ExposedPhpManager $auth
+ * Unit test for {@see \yii\rbac\PhpManager}.
  */
-class PhpManagerTest extends ManagerTestCase
+#[Group('rbac')]
+#[Group('rbac-php')]
+final class PhpManagerTest extends ManagerTestCase
 {
-    public static $filemtime;
-    public static $time;
-
     protected function getItemFile()
     {
         return Yii::$app->getRuntimePath() . '/rbac-items.php';
@@ -67,51 +50,72 @@ class PhpManagerTest extends ManagerTestCase
      */
     protected function createManager()
     {
-        return new ExposedPhpManager([
-            'itemFile' => $this->getItemFile(),
-            'assignmentFile' => $this->getAssignmentFile(),
-            'ruleFile' => $this->getRuleFile(),
-            'defaultRoles' => ['myDefaultRole'],
-        ]);
+        return new ExposedPhpManager(
+            [
+                'itemFile' => $this->getItemFile(),
+                'assignmentFile' => $this->getAssignmentFile(),
+                'ruleFile' => $this->getRuleFile(),
+                'defaultRoles' => ['myDefaultRole'],
+            ],
+        );
     }
 
     protected function setUp(): void
     {
-        static::$filemtime = null;
-        static::$time = null;
         parent::setUp();
 
         $this->mockApplication();
         $this->removeDataFiles();
+
         $this->auth = $this->createManager();
     }
 
     protected function tearDown(): void
     {
         $this->removeDataFiles();
-        static::$filemtime = null;
-        static::$time = null;
         parent::tearDown();
     }
 
     public function testSaveLoad(): void
     {
-        static::$time = static::$filemtime = \time();
+        $now = \time();
+
+        MockerState::addCondition('yii\rbac', 'time', [], $now, true);
+        MockerState::addCondition('yii\rbac', 'filemtime', [], $now, true);
 
         $this->prepareData();
+
         $items = $this->auth->items;
         $children = $this->auth->children;
         $assignments = $this->auth->assignments;
         $rules = $this->auth->rules;
+
         $this->auth->save();
 
         $this->auth = $this->createManager();
+
         $this->auth->load();
 
-        $this->assertEquals($items, $this->auth->items);
-        $this->assertEquals($children, $this->auth->children);
-        $this->assertEquals($assignments, $this->auth->assignments);
-        $this->assertEquals($rules, $this->auth->rules);
+        self::assertEquals(
+            $items,
+            $this->auth->items,
+            'Items must round-trip identically.',
+        );
+        self::assertEquals(
+            $children,
+            $this->auth->children,
+            'Children must round-trip identically.',
+        );
+        self::assertEquals(
+            $assignments,
+            $this->auth->assignments,
+            'Assignments must round-trip identically.',
+        );
+        self::assertEquals(
+            $rules,
+            $this->auth->rules,
+            'Rules must round-trip identically.',
+        );
     }
 
     public function testUpdateItemName(): void
@@ -119,18 +123,31 @@ class PhpManagerTest extends ManagerTestCase
         $this->prepareData();
 
         $name = 'readPost';
+
         $permission = $this->auth->getPermission($name);
+
         $permission->name = 'UPDATED-NAME';
-        $this->assertTrue($this->auth->update($name, $permission), 'You should be able to update name.');
+
+        self::assertTrue(
+            $this->auth->update($name, $permission),
+            "Rename must report 'true'.",
+        );
     }
 
     public function testUpdateDescription(): void
     {
         $this->prepareData();
+
         $name = 'readPost';
+
         $permission = $this->auth->getPermission($name);
+
         $permission->description = 'UPDATED-DESCRIPTION';
-        $this->assertTrue($this->auth->update($name, $permission), 'You should be able to save w/o changing name.');
+
+        self::assertTrue(
+            $this->auth->update($name, $permission),
+            "Description-only update must report 'true'.",
+        );
     }
 
     public function testOverwriteName(): void
@@ -138,10 +155,15 @@ class PhpManagerTest extends ManagerTestCase
         $this->prepareData();
 
         $name = 'readPost';
+
         $permission = $this->auth->getPermission($name);
+
         $permission->name = 'createPost';
 
         $this->expectException(\yii\base\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            "Unable to change the item name. The name 'createPost' is already used by another item.",
+        );
 
         $this->auth->update($name, $permission);
     }
@@ -149,14 +171,110 @@ class PhpManagerTest extends ManagerTestCase
     public function testSaveAssignments(): void
     {
         $this->auth->removeAll();
+
         $role = $this->auth->createRole('Admin');
+
         $this->auth->add($role);
         $this->auth->assign($role, 13);
-        $this->assertStringContainsString('Admin', file_get_contents($this->getAssignmentFile()));
+
+        self::assertStringContainsString(
+            'Admin',
+            file_get_contents($this->getAssignmentFile()),
+            'Initial assignment must persist the role name.',
+        );
+
         $role->name = 'NewAdmin';
+
         $this->auth->update('Admin', $role);
-        $this->assertStringContainsString('NewAdmin', file_get_contents($this->getAssignmentFile()));
+
+        self::assertStringContainsString(
+            'NewAdmin',
+            file_get_contents($this->getAssignmentFile()),
+            'Renamed role must persist with the new name.',
+        );
+
         $this->auth->remove($role);
-        $this->assertStringNotContainsString('NewAdmin', file_get_contents($this->getAssignmentFile()));
+
+        self::assertStringNotContainsString(
+            'NewAdmin',
+            file_get_contents($this->getAssignmentFile()),
+            'Removed role must not appear in the persistence file.',
+        );
+    }
+
+    public function testRemoveItemReturnsFalseForUnknownItem(): void
+    {
+        $orphan = $this->auth->createRole('never-added');
+
+        self::assertFalse(
+            $this->auth->remove($orphan),
+            "Removing an item that was never added must report 'false'.",
+        );
+    }
+
+    public function testRemoveRuleReturnsFalseForUnknownRule(): void
+    {
+        $rule = new AuthorRule(['name' => 'never-saved']);
+
+        self::assertFalse(
+            $this->auth->remove($rule),
+            "Removing a rule that was never added must report 'false'.",
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenAddChildItemNotInItems(): void
+    {
+        $orphanParent = $this->auth->createRole('orphan-parent');
+        $orphanChild = $this->auth->createPermission('orphan-child');
+
+        $this->expectException(\yii\base\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            "Either 'orphan-parent' or 'orphan-child' does not exist.",
+        );
+
+        $this->auth->addChild($orphanParent, $orphanChild);
+    }
+
+    public function testThrowInvalidCallExceptionWhenAddChildAlreadyExists(): void
+    {
+        $role = $this->auth->createRole('manager');
+        $perm = $this->auth->createPermission('act');
+
+        $this->auth->add($role);
+        $this->auth->add($perm);
+        $this->auth->addChild($role, $perm);
+
+        $this->expectException(\yii\base\InvalidCallException::class);
+        $this->expectExceptionMessage(
+            "The item 'manager' already has a child 'act'.",
+        );
+
+        $this->auth->addChild($role, $perm);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenAssignUnknownRole(): void
+    {
+        $role = $this->auth->createRole('ghost-role');
+
+        $this->expectException(\yii\base\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            "Unknown role 'ghost-role'.",
+        );
+
+        $this->auth->assign($role, 'user-1');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenAssignAlreadyAssigned(): void
+    {
+        $role = $this->auth->createRole('member');
+        $this->auth->add($role);
+        $this->auth->assign($role, 'user-2');
+
+        $this->expectException(\yii\base\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            "Authorization item 'member' has already been assigned to user 'user-2'.",
+        );
+
+        $this->auth->assign($role, 'user-2');
     }
 }

--- a/tests/framework/rbac/stub/ActionRule.php
+++ b/tests/framework/rbac/stub/ActionRule.php
@@ -1,19 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-namespace yiiunit\framework\rbac;
+namespace yiiunit\framework\rbac\stub;
 
 use yii\rbac\Rule;
 
 /**
  * Description of ActionRule.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
  */
-class ActionRule extends Rule
+final class ActionRule extends Rule
 {
     public $name = 'action_rule';
     public $action = 'read';

--- a/tests/framework/rbac/stub/AuthorRule.php
+++ b/tests/framework/rbac/stub/AuthorRule.php
@@ -1,19 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-namespace yiiunit\framework\rbac;
+namespace yiiunit\framework\rbac\stub;
 
 use yii\rbac\Rule;
 
 /**
  * Checks if authorID matches userID passed via params.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
  */
-class AuthorRule extends Rule
+final class AuthorRule extends Rule
 {
     public $name = 'isAuthor';
     public $reallyReally = false;

--- a/tests/framework/rbac/stub/ExposedPhpManager.php
+++ b/tests/framework/rbac/stub/ExposedPhpManager.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
  * @license https://www.yiiframework.com/license/
  */
 
-namespace yiiunit\framework\rbac;
+namespace yiiunit\framework\rbac\stub;
 
 use yii\rbac\Item;
 use yii\rbac\Assignment;
@@ -15,8 +17,11 @@ use yii\rbac\PhpManager;
 
 /**
  * Exposes protected properties and methods to inspect from outside.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
  */
-class ExposedPhpManager extends PhpManager
+final class ExposedPhpManager extends PhpManager
 {
     /**
      * @var Item[]

--- a/tests/support/MockerExtension.php
+++ b/tests/support/MockerExtension.php
@@ -60,6 +60,14 @@ final class MockerExtension implements Extension
                 'namespace' => 'yii\caching',
                 'name' => 'extension_loaded',
             ],
+            [
+                'namespace' => 'yii\rbac',
+                'name' => 'filemtime',
+            ],
+            [
+                'namespace' => 'yii\rbac',
+                'name' => 'time',
+            ],
         ];
 
         $mocker = new Mocker();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
