### PR TITLE
Fix Oracle `DbSession` writes to BLOB-backed `data` columns by converting string `PdoValue` LOB payloads to Oracle BLOB expressions.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -62,6 +62,7 @@ Yii Framework 2 Change Log
 - Chg: Remove legacy `apc_delete_file()` call in `yii\rbac\PhpManager::invalidateScriptCache()` (terabytesoftw)
 - Chg: Replace MSSQL `INSTEAD OF` triggers in `yii\rbac\DbManager` with native FK `ON DELETE` / `ON UPDATE CASCADE` (the `auth_item_child.child` FK stays `NO ACTION` due to MSSQL's multi-path constraint and is handled in PHP via the new `requiresSoftCascade()` hook) (terabytesoftw)
 - Bug: Fix Oracle BLOB string inserts by wrapping BLOB string values in `TO_BLOB(UTL_RAW.CAST_TO_RAW(...))` expressions (terabytesoftw)
+- Bug #15900, #16468: Fix Oracle `DbSession` writes to BLOB-backed `data` columns by converting string `PdoValue` LOB payloads to Oracle BLOB expressions (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/db/oci/ColumnSchema.php
+++ b/framework/db/oci/ColumnSchema.php
@@ -35,19 +35,35 @@ class ColumnSchema extends \yii\db\ColumnSchema
     {
         if ($this->type === Schema::TYPE_BINARY && $this->dbType === 'BLOB') {
             if ($value instanceof PdoValue) {
+                if ($value->getType() === \PDO::PARAM_LOB && is_string($value->getValue())) {
+                    return $this->createBlobExpression($value->getValue());
+                }
+
                 return parent::dbTypecast($value);
             }
 
             if (is_string($value)) {
-                $placeholder = 'qp' . str_replace('.', '', uniqid('', true));
-
-                return new Expression(
-                    'TO_BLOB(UTL_RAW.CAST_TO_RAW(:' . $placeholder . '))',
-                    [':' . $placeholder => $value]
-                );
+                return $this->createBlobExpression($value);
             }
         }
 
         return parent::dbTypecast($value);
+    }
+
+    /**
+     * Creates an Oracle BLOB expression for a PHP `string` value.
+     *
+     * @param string $value Value to bind.
+     *
+     * @return Expression Oracle BLOB expression.
+     */
+    private function createBlobExpression(string $value): Expression
+    {
+        $placeholder = 'qp' . str_replace('.', '', uniqid('', true));
+
+        return new Expression(
+            "TO_BLOB(UTL_RAW.CAST_TO_RAW(:{$placeholder}))",
+            [":{$placeholder}" => $value],
+        );
     }
 }

--- a/tests/base/web/session/BaseDbSession.php
+++ b/tests/base/web/session/BaseDbSession.php
@@ -133,7 +133,8 @@ abstract class BaseDbSession extends TestCase
             ->update(
                 'session',
                 ['expire' => time() - 100],
-                '[[id]] = :id', ['id' => 'expire'],
+                '[[id]] = :id',
+                ['id' => 'expire'],
             )
             ->execute();
         $deleted = $session->gcSession(1);

--- a/tests/base/web/session/BaseDbSession.php
+++ b/tests/base/web/session/BaseDbSession.php
@@ -130,7 +130,11 @@ abstract class BaseDbSession extends TestCase
         $session->writeSession('expire', 'expire data');
 
         $session->db->createCommand()
-            ->update('session', ['expire' => time() - 100], 'id = :id', ['id' => 'expire'])
+            ->update(
+                'session',
+                ['expire' => time() - 100],
+                '[[id]] = :id', ['id' => 'expire'],
+            )
             ->execute();
         $deleted = $session->gcSession(1);
 

--- a/tests/framework/db/oci/type/BlobTest.php
+++ b/tests/framework/db/oci/type/BlobTest.php
@@ -20,15 +20,7 @@ use yii\db\oci\ColumnSchema;
 use yiiunit\framework\db\DatabaseTestCase;
 
 /**
- * Tests Oracle BLOB column type-casting.
- *
- * Test coverage.
- *
- * - String BLOB values are wrapped in Oracle-compatible SQL expressions.
- * - Explicit `PdoValue` LOB bindings are preserved.
- * - String BLOB values round-trip through insert and update commands.
- *
- * @see ColumnSchema
+ * Unit test for {@see \yii\db\oci\ColumnSchema} with Oracle BLOB type.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 22.0
@@ -46,46 +38,36 @@ final class BlobTest extends DatabaseTestCase
 
         $result = $this->makeBlobColumn()->dbTypecast($value);
 
-        self::assertInstanceOf(
-            Expression::class,
-            $result,
-            'BLOB strings must be wrapped in an Oracle BLOB expression.',
-        );
-
-        $placeholder = array_key_first($result->params);
-
-        self::assertIsString(
-            $placeholder,
-            'BLOB expression must define a named placeholder.',
-        );
-        self::assertStringStartsWith(
-            ':qp',
-            $placeholder,
-            'BLOB expression placeholder must use the query parameter prefix.',
-        );
-        self::assertSame(
-            'TO_BLOB(UTL_RAW.CAST_TO_RAW(' . $placeholder . '))',
-            (string) $result,
-            'BLOB expression SQL must wrap the generated placeholder.',
-        );
-        self::assertSame(
-            [$placeholder => $value],
-            $result->params,
-            'BLOB expression params must contain the original string value.',
-        );
+        $this->assertBlobExpression($result, $value);
     }
 
-    public function testDbTypecastPreservesPdoValue(): void
+    public function testDbTypecastReturnsExpressionForPdoValueStringLob(): void
     {
-        $pdoValue = new PdoValue('binary content', PDO::PARAM_LOB);
+        $value = 'binary content';
+
+        $result = $this->makeBlobColumn()->dbTypecast(new PdoValue($value, PDO::PARAM_LOB));
+
+        $this->assertBlobExpression($result, $value);
+    }
+
+    public function testDbTypecastPreservesPdoValueResource(): void
+    {
+        $resource = fopen('php://memory', 'rb+');
+
+        fwrite($resource, 'binary content');
+        rewind($resource);
+
+        $pdoValue = new PdoValue($resource, PDO::PARAM_LOB);
 
         $result = $this->makeBlobColumn()->dbTypecast($pdoValue);
 
         self::assertSame(
             $pdoValue,
             $result,
-            'Explicit PdoValue instances must be delegated without unwrapping.',
+            'Explicit PdoValue resource instances must be delegated without unwrapping.',
         );
+
+        fclose($resource);
     }
 
     public function testBlob(): void
@@ -151,5 +133,36 @@ final class BlobTest extends DatabaseTestCase
         $column->allowNull = true;
 
         return $column;
+    }
+
+    private function assertBlobExpression(mixed $result, string $value): void
+    {
+        self::assertInstanceOf(
+            Expression::class,
+            $result,
+            'BLOB strings must be wrapped in an Oracle BLOB expression.',
+        );
+
+        $placeholder = array_key_first($result->params);
+
+        self::assertIsString(
+            $placeholder,
+            'BLOB expression must define a named placeholder.',
+        );
+        self::assertStringStartsWith(
+            ':qp',
+            $placeholder,
+            'BLOB expression placeholder must use the query parameter prefix.',
+        );
+        self::assertSame(
+            'TO_BLOB(UTL_RAW.CAST_TO_RAW(' . $placeholder . '))',
+            (string) $result,
+            'BLOB expression SQL must wrap the generated placeholder.',
+        );
+        self::assertSame(
+            [$placeholder => $value],
+            $result->params,
+            'BLOB expression params must contain the original string value.',
+        );
     }
 }

--- a/tests/framework/web/session/oci/DbSessionTest.php
+++ b/tests/framework/web/session/oci/DbSessionTest.php
@@ -11,7 +11,10 @@ declare(strict_types=1);
 namespace yiiunit\framework\web\session\oci;
 
 use PHPUnit\Framework\Attributes\Group;
+use stdClass;
 use yiiunit\base\web\session\BaseDbSession;
+
+use function str_repeat;
 
 /**
  * Unit test for {@see \yii\web\DbSession} with Oracle driver.
@@ -30,5 +33,16 @@ final class DbSessionTest extends BaseDbSession
     protected function getDriverNames()
     {
         return ['oci'];
+    }
+
+    protected function buildObjectForSerialization(): stdClass
+    {
+        $object = parent::buildObjectForSerialization();
+
+        // Oracle `UTL_RAW.CAST_TO_RAW()` is limited by the `RAW` maximum size. With `MAX_STRING_SIZE=STANDARD`,
+        // that limit is `2000` bytes, so this Oracle-specific fixture keeps both serialized writes under it.
+        $object->textValue = str_repeat('QweåßƒТест', 94);
+
+        return $object;
     }
 }

--- a/tests/framework/web/session/oci/DbSessionTest.php
+++ b/tests/framework/web/session/oci/DbSessionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\web\session\oci;
+
+use PHPUnit\Framework\Attributes\Group;
+use yiiunit\base\web\session\BaseDbSession;
+
+/**
+ * Unit test for {@see \yii\web\DbSession} with Oracle driver.
+ *
+ * @see https://github.com/yiisoft/yii2/issues/15900
+ * @see https://github.com/yiisoft/yii2/issues/16468
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('db')]
+#[Group('db-session')]
+#[Group('oci')]
+final class DbSessionTest extends BaseDbSession
+{
+    protected function getDriverNames()
+    {
+        return ['oci'];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #15900, #16468
