### PR TITLE
Fix Oracle `DbCache` writes to BLOB-backed `data` columns using Oracle-native BLOB typecasting and stringified BLOB fetches.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -63,6 +63,7 @@ Yii Framework 2 Change Log
 - Chg: Replace MSSQL `INSTEAD OF` triggers in `yii\rbac\DbManager` with native FK `ON DELETE` / `ON UPDATE CASCADE` (the `auth_item_child.child` FK stays `NO ACTION` due to MSSQL's multi-path constraint and is handled in PHP via the new `requiresSoftCascade()` hook) (terabytesoftw)
 - Bug: Fix Oracle BLOB string inserts by wrapping BLOB string values in `TO_BLOB(UTL_RAW.CAST_TO_RAW(...))` expressions (terabytesoftw)
 - Bug #15900, #16468: Fix Oracle `DbSession` writes to BLOB-backed `data` columns by converting string `PdoValue` LOB payloads to Oracle BLOB expressions (terabytesoftw)
+- Bug: Fix Oracle `DbCache` writes to BLOB-backed `data` columns using Oracle-native BLOB typecasting and stringified BLOB fetches (terabytesoftw)
 
 2.0.55 under development
 ------------------------

--- a/framework/caching/DbCache.php
+++ b/framework/caching/DbCache.php
@@ -8,6 +8,7 @@
 
 namespace yii\caching;
 
+use PDO;
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\db\Connection;
@@ -322,11 +323,15 @@ class DbCache extends Cache
     }
 
     /**
-     * @return PdoValue PdoValue or direct $value for usage in MSSQL
+     * @return PdoValue|string PdoValue or direct $value for usage in MSSQL/Oracle.
      * @since 2.0.42
      */
     protected function getDataFieldValue($value)
     {
-        return $this->isVarbinaryDataField() ? $value : new PdoValue($value, \PDO::PARAM_LOB);
+        if ($this->isVarbinaryDataField() || $this->db->getDriverName() === 'oci') {
+            return $value;
+        }
+
+        return new PdoValue($value, PDO::PARAM_LOB);
     }
 }

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -728,7 +728,7 @@ class Connection extends Component
             }
         }
 
-        if ($this->getDriverName() === 'sqlite') {
+        if (in_array($this->getDriverName(), ['sqlite', 'oci'], true)) {
             $this->pdo->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
         }
 

--- a/tests/framework/caching/OciCacheTest.php
+++ b/tests/framework/caching/OciCacheTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\caching;
+
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\Connection;
+
+/**
+ * Unit test for {@see \yii\caching\DbCache} with Oracle driver.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('db')]
+#[Group('oci')]
+#[Group('caching')]
+class OciCacheTest extends DbCacheTest
+{
+    private ?Connection $_connection = null;
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pdo') || !extension_loaded('pdo_oci')) {
+            $this->markTestSkipped('pdo and pdo_oci extensions are required.');
+        }
+
+        $this->mockApplication();
+
+        $db = $this->getConnection();
+
+        if ($db->schema->getTableSchema('cache') !== null) {
+            $db->createCommand()->dropTable('cache')->execute();
+        }
+
+        $db->createCommand()->createTable(
+            'cache',
+            [
+                'id' => 'VARCHAR2(128) NOT NULL PRIMARY KEY',
+                'expire' => 'NUMBER(10)',
+                'data' => 'BLOB',
+            ],
+        )->execute();
+    }
+
+    /**
+     * @param bool $reset whether to clean up the test database
+     *
+     * @return Connection
+     */
+    public function getConnection($reset = true)
+    {
+        if ($this->_connection === null) {
+            $databases = self::getParam('databases');
+            $params = $databases['oci'];
+            $db = new Connection();
+            $db->dsn = $params['dsn'];
+            $db->username = $params['username'];
+            $db->password = $params['password'];
+            $db->open();
+
+            $this->_connection = $db;
+        }
+
+        return $this->_connection;
+    }
+}

--- a/tests/framework/caching/OciCacheTest.php
+++ b/tests/framework/caching/OciCacheTest.php
@@ -24,7 +24,7 @@ use yii\db\Connection;
 #[Group('caching')]
 class OciCacheTest extends DbCacheTest
 {
-    private ?Connection $_connection = null;
+    private Connection|null $_connection = null;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
