### PR TITLE
Fix: CVE-2026-39850, Isolate internal variables in `View::renderPhpFile()` and `ErrorHandler::renderFile()` to prevent parameter collisions from overriding included file paths

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.55 under development
 ------------------------
 
+- Bug: CVE-2026-39850, Isolate internal variables in `View::renderPhpFile()` and `ErrorHandler::renderFile()` to prevent parameter collisions from overriding included file paths (samdark)
 - Bug #20705: Replace `$this` with `self` in generics in Psalm annotations (mspirkov)
 - Bug #20715: Adjust `JSON` helper error message assertions for `PHP 8.6` compatibility in `JsonTest` class (terabytesoftw)
 - Enh #20714: Allow overriding the `yii\grid\GridView`'s default `filterSelector`, allow using `Closure`s for `filterSelector` (chriscpty)

--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -348,7 +348,7 @@ class View extends Component implements DynamicContentAwareInterface
         ob_start();
         ob_implicit_flush(false);
         try {
-            $_renderer_($_file_, $_params_);
+            call_user_func_array($_renderer_, [$_file_, $_params_]);
             return ob_get_clean();
         } catch (\Exception $e) {
             while (ob_get_level() > $_obInitialLevel_) {

--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -341,11 +341,14 @@ class View extends Component implements DynamicContentAwareInterface
     public function renderPhpFile($_file_, $_params_ = [])
     {
         $_obInitialLevel_ = ob_get_level();
+        $_renderer_ = function () {
+            extract(func_get_arg(1), EXTR_OVERWRITE);
+            require func_get_arg(0);
+        };
         ob_start();
         ob_implicit_flush(false);
-        extract($_params_, EXTR_OVERWRITE);
         try {
-            require $_file_;
+            $_renderer_($_file_, $_params_);
             return ob_get_clean();
         } catch (\Exception $e) {
             while (ob_get_level() > $_obInitialLevel_) {

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -259,10 +259,13 @@ class ErrorHandler extends \yii\base\ErrorHandler
     {
         $_params_['handler'] = $this;
         if ($this->exception instanceof ErrorException || !Yii::$app->has('view')) {
+            $_renderer_ = function () {
+                extract(func_get_arg(1), EXTR_OVERWRITE);
+                require Yii::getAlias(func_get_arg(0));
+            };
             ob_start();
             ob_implicit_flush(false);
-            extract($_params_, EXTR_OVERWRITE);
-            require Yii::getAlias($_file_);
+            $_renderer_($_file_, $_params_);
 
             return ob_get_clean();
         }

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -265,7 +265,7 @@ class ErrorHandler extends \yii\base\ErrorHandler
             };
             ob_start();
             ob_implicit_flush(false);
-            $_renderer_($_file_, $_params_);
+            call_user_func_array($_renderer_, [$_file_, $_params_]);
 
             return ob_get_clean();
         }

--- a/tests/framework/base/ViewTest.php
+++ b/tests/framework/base/ViewTest.php
@@ -108,6 +108,19 @@ PHP
         $this->assertSame($subViewContent, $view->render('@testviews/base'));
     }
 
+    public function testRenderFileDoesNotAllowInternalFileOverride(): void
+    {
+        $view = new View();
+
+        $viewFile = $this->testViewPath . DIRECTORY_SEPARATOR . 'safe.php';
+        file_put_contents($viewFile, '<?php echo "safe view";');
+
+        $secretFile = $this->testViewPath . DIRECTORY_SEPARATOR . 'secret.txt';
+        file_put_contents($secretFile, 'secret data');
+
+        $this->assertSame('safe view', $view->renderFile($viewFile, ['_file_' => $secretFile]));
+    }
+
     public function testAfterRender(): void
     {
         $view = new View();

--- a/tests/framework/web/ErrorHandlerTest.php
+++ b/tests/framework/web/ErrorHandlerTest.php
@@ -10,6 +10,7 @@ namespace yiiunit\framework\web;
 
 use Exception;
 use yii\BaseYii;
+use yii\base\ErrorException;
 use yii\web\Application;
 use Yii;
 use yii\web\NotFoundHttpException;
@@ -178,6 +179,28 @@ Exception: yii\web\NotFoundHttpException', $out);
 
         $this->assertSame($expected, $handler->htmlEncode($text));
     }
+
+    public function testRenderFileDoesNotAllowInternalFileOverride(): void
+    {
+        $viewFile = tempnam(sys_get_temp_dir(), 'yii2-error-view-');
+        $secretFile = tempnam(sys_get_temp_dir(), 'yii2-error-secret-');
+
+        file_put_contents($viewFile, '<?php echo "safe error view";');
+        file_put_contents($secretFile, 'secret data');
+
+        try {
+            /** @var ErrorHandler $handler */
+            $handler = Yii::$app->getErrorHandler();
+
+            $this->assertSame(
+                'safe error view',
+                $handler->renderFileForException($viewFile, ['_file_' => $secretFile], new ErrorException('test'))
+            );
+        } finally {
+            @unlink($viewFile);
+            @unlink($secretFile);
+        }
+    }
 }
 
 class ErrorHandler extends \yii\web\ErrorHandler
@@ -188,5 +211,12 @@ class ErrorHandler extends \yii\web\ErrorHandler
     protected function shouldRenderSimpleHtml()
     {
         return false;
+    }
+
+    public function renderFileForException($file, array $params, \Throwable $exception): string
+    {
+        $this->exception = $exception;
+
+        return $this->renderFile($file, $params);
     }
 }


### PR DESCRIPTION
Isolate internal variables in `View::renderPhpFile()` and `ErrorHandler::renderFile()` to prevent parameter collisions from overriding included file paths.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | CVE-2026-39850
