### PR TITLE
Fix #7616: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 Change Log
 - Bug #20785: Fix `@return` annotation for `yii\base\Model::getErrors()` (mspirkov)
 - Bug #20785: Fix `@var` annotation for `yii\validators\CompareValidator::$message` (mspirkov)
 - Enh #20785: Add `@param-out` annotation for `$error` in `yii\validators\Validator::validate()` (mspirkov)
+- Enh #7616: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
 
 
 2.0.55 May 09, 2026

--- a/framework/web/ErrorHandler.php
+++ b/framework/web/ErrorHandler.php
@@ -8,11 +8,14 @@
 
 namespace yii\web;
 
+use Throwable;
 use Yii;
 use yii\base\ErrorException;
 use yii\base\Exception;
 use yii\base\UserException;
 use yii\helpers\VarDumper;
+
+use function is_string;
 
 /**
  * ErrorHandler handles uncaught PHP errors and exceptions.
@@ -31,6 +34,15 @@ use yii\helpers\VarDumper;
  */
 class ErrorHandler extends \yii\base\ErrorHandler
 {
+    /**
+     * @event ErrorHandlerRenderEvent an event that is triggered after HTML error content is rendered.
+     *
+     * Event handlers may modify [[ErrorHandlerRenderEvent::$output]].
+     *
+     * @since 2.0.56
+     */
+    public const EVENT_AFTER_RENDER = 'afterRender';
+
     /**
      * @var int maximum number of source code lines to be displayed. Defaults to 19.
      */
@@ -136,6 +148,14 @@ class ErrorHandler extends \yii\base\ErrorHandler
             $response->data = $this->convertExceptionToArray($exception);
         }
 
+        if ($response->format === Response::FORMAT_HTML) {
+            if (is_string($response->data)) {
+                $response->data = $this->triggerAfterRender($exception, $response->data);
+            } elseif (is_string($response->content)) {
+                $response->content = $this->triggerAfterRender($exception, $response->content);
+            }
+        }
+
         $response->send();
     }
 
@@ -184,6 +204,25 @@ class ErrorHandler extends \yii\base\ErrorHandler
     public function htmlEncode($text)
     {
         return htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
+    }
+
+    /**
+     * Triggers [[EVENT_AFTER_RENDER]] and returns the final HTML content.
+     *
+     * @since 2.0.56
+     */
+    protected function triggerAfterRender(Throwable $exception, string $output): string
+    {
+        if ($this->hasEventHandlers(self::EVENT_AFTER_RENDER)) {
+            $event = new ErrorHandlerRenderEvent();
+            $event->exception = $exception;
+            $event->output = $output;
+            $this->trigger(self::EVENT_AFTER_RENDER, $event);
+
+            return $event->output;
+        }
+
+        return $output;
     }
 
     /**

--- a/framework/web/ErrorHandlerRenderEvent.php
+++ b/framework/web/ErrorHandlerRenderEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yii\web;
+
+use Throwable;
+use yii\base\Event;
+
+/**
+ * ErrorHandlerRenderEvent represents events triggered by [[ErrorHandler]].
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 2.0.56
+ */
+class ErrorHandlerRenderEvent extends Event
+{
+    /**
+     * @var \Throwable|null Exception being rendered.
+     */
+    public ?Throwable $exception = null;
+    /**
+     * @var string Rendered HTML output.
+     */
+    public string $output = '';
+}

--- a/tests/framework/web/ErrorHandlerTest.php
+++ b/tests/framework/web/ErrorHandlerTest.php
@@ -13,6 +13,7 @@ use yii\BaseYii;
 use yii\base\ErrorException;
 use yii\web\Application;
 use Yii;
+use yii\web\ErrorHandlerRenderEvent;
 use yii\web\NotFoundHttpException;
 use yii\web\View;
 use yiiunit\TestCase;
@@ -122,6 +123,80 @@ Exception: yii\web\NotFoundHttpException', $out);
         ob_get_clean();
         $out = Yii::$app->response->data;
         $this->assertStringNotContainsString('<script', $out);
+    }
+
+    public function testAfterRenderEventCanModifyOutput(): void
+    {
+        /** @var ErrorHandler $handler */
+        $handler = Yii::$app->getErrorHandler();
+
+        $exception = new Exception('Some Exception');
+
+        $actualException = null;
+
+        $handler->on(
+            ErrorHandler::EVENT_AFTER_RENDER,
+            static function (ErrorHandlerRenderEvent $event) use (&$actualException): void {
+                $actualException = $event->exception;
+                $event->output .= "\n<!--after-render-->";
+            }
+        );
+
+        ob_start(); // suppress response output
+        $this->invokeMethod($handler, 'renderException', [$exception]);
+        ob_get_clean();
+
+        $this->assertSame($exception, $actualException);
+        $this->assertStringContainsString('<!--after-render-->', Yii::$app->response->data);
+    }
+
+    public function testAfterRenderEventCanModifyOutputInErrorActionView(): void
+    {
+        /** @var ErrorHandler $handler */
+        $handler = Yii::$app->getErrorHandler();
+        $handler->errorAction = 'test/error';
+
+        $exception = new NotFoundHttpException('Resource not found');
+
+        $actualException = null;
+
+        $handler->on(
+            ErrorHandler::EVENT_AFTER_RENDER,
+            static function (ErrorHandlerRenderEvent $event) use (&$actualException): void {
+                $actualException = $event->exception;
+                $event->output .= "\n<!--after-render-error-action-->";
+            }
+        );
+
+        ob_start(); // suppress response output
+        $this->invokeMethod($handler, 'renderException', [$exception]);
+        ob_get_clean();
+
+        $this->assertSame($exception, $actualException);
+        $this->assertStringContainsString('<!--after-render-error-action-->', Yii::$app->response->data);
+    }
+
+    public function testAfterRenderEventCanModifyOutputForPhpErrors(): void
+    {
+        /** @var ErrorHandler $handler */
+        $handler = Yii::$app->getErrorHandler();
+
+        $exception = new ErrorException('PHP Warning', E_WARNING, E_WARNING, __FILE__, __LINE__);
+
+        $handler->exception = $exception;
+
+        $handler->on(
+            ErrorHandler::EVENT_AFTER_RENDER,
+            static function (ErrorHandlerRenderEvent $event): void {
+                $event->output .= "\n<!--php-error-after-render-->";
+            }
+        );
+
+        ob_start(); // suppress response output
+        $this->invokeMethod($handler, 'renderException', [$exception]);
+        ob_get_clean();
+
+        $this->assertStringContainsString('<!--php-error-after-render-->', Yii::$app->response->data);
     }
 
     public function testRenderCallStackItem(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #7616 
