### PR TITLE
Fix `Sort::createUrl()` and `Pagination::createUrl()` to fall back when no controller is active, supporting standalone actions discovered through `Module::$actionNamespace`.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1426,11 +1426,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.54",
+            "version": "2.1.55",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
-                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9eaac3826ed5e9b8427350a43cac825eeca3f566",
+                "reference": "9eaac3826ed5e9b8427350a43cac825eeca3f566",
                 "shasum": ""
             },
             "require": {
@@ -1475,7 +1475,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-29T13:31:09+00:00"
+            "time": "2026-05-18T11:57:34+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -71,6 +71,7 @@ Yii Framework 2 Change Log
 - Chg: Refactor MSSQL `QueryBuilder::insert()`: drop dead SQL Server `< 2005` branch; throw on unknown table (terabytesoftw)
 - Chg: Drop dead SQL Server `< 2017` branches from MSSQL `Schema::loadColumnSchema()` (terabytesoftw)
 - Chg: Drop dead SQL Server `< 2005` branches from MSSQL `Schema::insert()` (terabytesoftw)
+- Bug: Fix `Sort::createUrl()` and `Pagination::createUrl()` to fall back when no controller is active, supporting standalone actions discovered through `Module::$actionNamespace` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/data/Pagination.php
+++ b/framework/data/Pagination.php
@@ -10,6 +10,7 @@ namespace yii\data;
 
 use Yii;
 use yii\base\BaseObject;
+use yii\base\InvalidConfigException;
 use yii\web\Link;
 use yii\web\Linkable;
 use yii\web\Request;
@@ -249,10 +250,14 @@ class Pagination extends BaseObject implements Linkable
     /**
      * Creates the URL suitable for pagination with the specified page number.
      * This method is mainly called by pagers when creating URLs used to perform pagination.
+     *
+     * The target route is determined by [[resolveRoute()]] when [[route]] is not configured.
+     *
      * @param int $page the zero-based page number that the URL should point to.
      * @param int|null $pageSize the number of items on each page. If not set, the value of [[pageSize]] will be used.
      * @param bool $absolute whether to create an absolute URL. Defaults to `false`.
      * @return string the created URL
+     * @throws InvalidConfigException if [[resolveRoute()]] cannot determine a route.
      * @see params
      * @see forcePageParam
      */
@@ -277,13 +282,44 @@ class Pagination extends BaseObject implements Linkable
         } else {
             unset($params[$this->pageSizeParam]);
         }
-        $params[0] = $this->route === null ? Yii::$app->controller->getRoute() : $this->route;
+
+        $params[0] = $this->resolveRoute();
+
         $urlManager = $this->urlManager === null ? Yii::$app->getUrlManager() : $this->urlManager;
         if ($absolute) {
             return $urlManager->createAbsoluteUrl($params);
         }
 
         return $urlManager->createUrl($params);
+    }
+
+    /**
+     * Resolves the target route from [[route]], the active controller, or [[\yii\base\Application::$requestedRoute]].
+     *
+     * The `requestedRoute` fallback supports standalone actions where no controller is hosting the request.
+     *
+     * @return string The resolved route.
+     * @throws InvalidConfigException if no route can be resolved.
+     */
+    protected function resolveRoute(): string
+    {
+        if ($this->route !== null) {
+            return $this->route;
+        }
+
+        if (Yii::$app->controller !== null) {
+            return Yii::$app->controller->getRoute();
+        }
+
+        $requestedRoute = Yii::$app->requestedRoute;
+
+        if ($requestedRoute !== null && $requestedRoute !== '') {
+            return $requestedRoute;
+        }
+
+        throw new InvalidConfigException(
+            'Unable to determine the route. Configure "Pagination::$route" explicitly.',
+        );
     }
 
     /**

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -414,10 +414,13 @@ class Sort extends BaseObject
      * This method will consider the current sorting status given by [[attributeOrders]].
      * For example, if the current page already sorts the data by the specified attribute in ascending order,
      * then the URL created will lead to a page that sorts the data by the specified attribute in descending order.
+     *
+     * The target route is determined by [[resolveRoute()]] when [[route]] is not configured.
+     *
      * @param string $attribute the attribute name
      * @param bool $absolute whether to create an absolute URL. Defaults to `false`.
      * @return string the URL for sorting. False if the attribute is invalid.
-     * @throws InvalidConfigException if the attribute is unknown
+     * @throws InvalidConfigException if the attribute is unknown, or if [[resolveRoute()]] cannot determine a route.
      * @see attributeOrders
      * @see params
      */
@@ -428,13 +431,44 @@ class Sort extends BaseObject
             $params = $request instanceof Request ? $request->getQueryParams() : [];
         }
         $params[$this->sortParam] = $this->createSortParam($attribute);
-        $params[0] = $this->route === null ? Yii::$app->controller->getRoute() : $this->route;
+
+        $params[0] = $this->resolveRoute();
+
         $urlManager = $this->urlManager === null ? Yii::$app->getUrlManager() : $this->urlManager;
         if ($absolute) {
             return $urlManager->createAbsoluteUrl($params);
         }
 
         return $urlManager->createUrl($params);
+    }
+
+    /**
+     * Resolves the target route from [[route]], the active controller, or [[\yii\base\Application::$requestedRoute]].
+     *
+     * The `requestedRoute` fallback supports standalone actions where no controller is hosting the request.
+     *
+     * @return string The resolved route.
+     * @throws InvalidConfigException if no route can be resolved.
+     */
+    protected function resolveRoute()
+    {
+        if ($this->route !== null) {
+            return $this->route;
+        }
+
+        if (Yii::$app->controller !== null) {
+            return Yii::$app->controller->getRoute();
+        }
+
+        $requestedRoute = Yii::$app->requestedRoute;
+
+        if ($requestedRoute !== null && $requestedRoute !== '') {
+            return $requestedRoute;
+        }
+
+        throw new InvalidConfigException(
+            'Unable to determine the route. Configure "Sort::$route" explicitly.',
+        );
     }
 
     /**

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -450,7 +450,7 @@ class Sort extends BaseObject
      * @return string The resolved route.
      * @throws InvalidConfigException if no route can be resolved.
      */
-    protected function resolveRoute()
+    protected function resolveRoute(): string
     {
         if ($this->route !== null) {
             return $this->route;

--- a/tests/framework/data/PaginationTest.php
+++ b/tests/framework/data/PaginationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,13 +10,17 @@
 
 namespace yiiunit\framework\data;
 
+use PHPUnit\Framework\Attributes\Group;
+use Yii;
+use yii\base\InvalidConfigException;
 use yii\data\Pagination;
 use yii\web\Link;
 use yiiunit\TestCase;
 
 /**
- * @group data
+ * Unit test for {@see \yii\data\Pagination} class.
  */
+#[Group('data')]
 class PaginationTest extends TestCase
 {
     protected function setUp(): void
@@ -432,5 +438,59 @@ class PaginationTest extends TestCase
         } else {
             $this->assertArrayNotHasKey(Pagination::LINK_NEXT, $links);
         }
+    }
+
+    public function testCreateUrlFallsBackToRequestedRouteWhenControllerIsNull(): void
+    {
+        self::assertNull(
+            Yii::$app->controller,
+            'Mock must start with no active controller.',
+        );
+
+        Yii::$app->requestedRoute = 'user/index';
+
+        $pagination = new Pagination();
+
+        self::assertEquals(
+            '/index.php?r=user%2Findex&page=3',
+            $pagination->createUrl(2),
+            '`requestedRoute` must be used as the route segment.',
+        );
+    }
+
+    public function testCreateUrlPrefersExplicitRouteOverRequestedRoute(): void
+    {
+        Yii::$app->requestedRoute = 'user/index';
+
+        $pagination = new Pagination();
+
+        $pagination->route = 'admin/users';
+
+        self::assertEquals(
+            '/index.php?r=admin%2Fusers&page=3',
+            $pagination->createUrl(2),
+            'Explicit `$route` must win over `requestedRoute`.',
+        );
+    }
+
+    public function testThrowInvalidConfigExceptionWhenNoRouteIsAvailable(): void
+    {
+        self::assertNull(
+            Yii::$app->controller,
+            'Mock must start with no active controller.',
+        );
+        $this->assertEmpty(
+            Yii::$app->requestedRoute,
+            '`requestedRoute` must be empty for this scenario.',
+        );
+
+        $pagination = new Pagination();
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage(
+            'Unable to determine the route. Configure "Pagination::$route" explicitly.',
+        );
+
+        $pagination->createUrl(2);
     }
 }

--- a/tests/framework/data/PaginationTest.php
+++ b/tests/framework/data/PaginationTest.php
@@ -12,8 +12,10 @@ namespace yiiunit\framework\data;
 
 use PHPUnit\Framework\Attributes\Group;
 use Yii;
+use yii\base\Action;
 use yii\base\InvalidConfigException;
 use yii\data\Pagination;
+use yii\web\Controller;
 use yii\web\Link;
 use yiiunit\TestCase;
 
@@ -440,6 +442,23 @@ class PaginationTest extends TestCase
         }
     }
 
+    public function testCreateUrlUsesActiveControllerRouteWhenPaginationRouteIsNull(): void
+    {
+        $controller = new Controller('post', Yii::$app);
+
+        $controller->action = new Action('view', $controller);
+
+        Yii::$app->controller = $controller;
+
+        $pagination = new Pagination();
+
+        self::assertSame(
+            '/index.php?r=post%2Fview&page=3',
+            $pagination->createUrl(2),
+            "Active controller's `getRoute()` must be used as the route segment.",
+        );
+    }
+
     public function testCreateUrlFallsBackToRequestedRouteWhenControllerIsNull(): void
     {
         self::assertNull(
@@ -451,7 +470,7 @@ class PaginationTest extends TestCase
 
         $pagination = new Pagination();
 
-        self::assertEquals(
+        self::assertSame(
             '/index.php?r=user%2Findex&page=3',
             $pagination->createUrl(2),
             '`requestedRoute` must be used as the route segment.',
@@ -466,7 +485,7 @@ class PaginationTest extends TestCase
 
         $pagination->route = 'admin/users';
 
-        self::assertEquals(
+        self::assertSame(
             '/index.php?r=admin%2Fusers&page=3',
             $pagination->createUrl(2),
             'Explicit `$route` must win over `requestedRoute`.',

--- a/tests/framework/data/SortTest.php
+++ b/tests/framework/data/SortTest.php
@@ -12,8 +12,10 @@ namespace yiiunit\framework\data;
 
 use PHPUnit\Framework\Attributes\Group;
 use Yii;
+use yii\base\Action;
 use yii\base\InvalidConfigException;
 use yii\data\Sort;
+use yii\web\Controller;
 use yii\web\UrlManager;
 use yiiunit\TestCase;
 
@@ -397,6 +399,39 @@ class SortTest extends TestCase
         $this->assertEquals('[[last_name]] ASC NULLS FIRST', $orders[0]);
     }
 
+    public function testCreateUrlUsesActiveControllerRouteWhenSortRouteIsNull(): void
+    {
+        $this->mockWebApplication(
+            [
+                'components' => [
+                    'urlManager' => [
+                        'scriptUrl' => '/index.php',
+                    ],
+                ],
+            ],
+        );
+
+        $controller = new Controller('post', Yii::$app);
+
+        $controller->action = new Action('view', $controller);
+
+        Yii::$app->controller = $controller;
+
+        $sort = new Sort(
+            [
+                'attributes' => ['age'],
+                'params' => [],
+                'enableMultiSort' => true,
+            ],
+        );
+
+        self::assertSame(
+            '/index.php?r=post%2Fview&sort=age',
+            $sort->createUrl('age'),
+            "Active controller's `getRoute()` must be used as the route segment.",
+        );
+    }
+
     public function testCreateUrlFallsBackToRequestedRouteWhenControllerIsNull(): void
     {
         $this->mockWebApplication(
@@ -424,7 +459,7 @@ class SortTest extends TestCase
             ],
         );
 
-        $this->assertEquals(
+        self::assertSame(
             '/index.php?r=user%2Findex&sort=age',
             $sort->createUrl('age'),
             '`requestedRoute` must be used as the route segment.',
@@ -454,7 +489,7 @@ class SortTest extends TestCase
             ],
         );
 
-        self::assertEquals(
+        self::assertSame(
             '/index.php?r=admin%2Fusers&sort=age',
             $sort->createUrl('age'),
             'Explicit `$route` must win over `requestedRoute`.',

--- a/tests/framework/data/SortTest.php
+++ b/tests/framework/data/SortTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,16 +10,20 @@
 
 namespace yiiunit\framework\data;
 
+use PHPUnit\Framework\Attributes\Group;
+use Yii;
+use yii\base\InvalidConfigException;
 use yii\data\Sort;
 use yii\web\UrlManager;
 use yiiunit\TestCase;
 
 /**
+ * Unit test for {@see \yii\data\Sort} class.
+ *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
- *
- * @group data
  */
+#[Group('data')]
 class SortTest extends TestCase
 {
     protected function setUp(): void
@@ -389,6 +395,107 @@ class SortTest extends TestCase
         $orders = $sort->getOrders(true);
         $this->assertEquals(1, count($orders));
         $this->assertEquals('[[last_name]] ASC NULLS FIRST', $orders[0]);
+    }
+
+    public function testCreateUrlFallsBackToRequestedRouteWhenControllerIsNull(): void
+    {
+        $this->mockWebApplication(
+            [
+                'components' => [
+                    'urlManager' => [
+                        'scriptUrl' => '/index.php',
+                    ],
+                ],
+            ],
+        );
+
+        self::assertNull(
+            Yii::$app->controller,
+            'Mock must start with no active controller.',
+        );
+
+        Yii::$app->requestedRoute = 'user/index';
+
+        $sort = new Sort(
+            [
+                'attributes' => ['age'],
+                'params' => [],
+                'enableMultiSort' => true,
+            ],
+        );
+
+        $this->assertEquals(
+            '/index.php?r=user%2Findex&sort=age',
+            $sort->createUrl('age'),
+            '`requestedRoute` must be used as the route segment.',
+        );
+    }
+
+    public function testCreateUrlPrefersExplicitRouteOverRequestedRoute(): void
+    {
+        $this->mockWebApplication(
+            [
+                'components' => [
+                    'urlManager' => [
+                        'scriptUrl' => '/index.php',
+                    ],
+                ],
+            ],
+        );
+
+        Yii::$app->requestedRoute = 'user/index';
+
+        $sort = new Sort(
+            [
+                'attributes' => ['age'],
+                'params' => [],
+                'enableMultiSort' => true,
+                'route' => 'admin/users',
+            ],
+        );
+
+        self::assertEquals(
+            '/index.php?r=admin%2Fusers&sort=age',
+            $sort->createUrl('age'),
+            'Explicit `$route` must win over `requestedRoute`.',
+        );
+    }
+
+    public function testThrowInvalidConfigExceptionWhenNoRouteIsAvailable(): void
+    {
+        $this->mockWebApplication(
+            [
+                'components' => [
+                    'urlManager' => [
+                        'scriptUrl' => '/index.php',
+                    ],
+                ],
+            ],
+        );
+
+        self::assertNull(
+            Yii::$app->controller,
+            'Mock must start with no active controller.',
+        );
+        self::assertEmpty(
+            Yii::$app->requestedRoute,
+            '`requestedRoute` must be empty for this scenario.',
+        );
+
+        $sort = new Sort(
+            [
+                'attributes' => ['age'],
+                'params' => [],
+                'enableMultiSort' => true,
+            ],
+        );
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage(
+            'Unable to determine the route. Configure "Sort::$route" explicitly.',
+        );
+
+        $sort->createUrl('age');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

