### PR TITLE
Fix #20497: Add alias for application/x-rar-compressed (#20884)

### DIFF
--- a/build/controllers/MimeTypeController.php
+++ b/build/controllers/MimeTypeController.php
@@ -47,6 +47,7 @@ class MimeTypeController extends Controller
         'application/bmp' => 'image/bmp',
         'application/x-bmp' => 'image/bmp',
         'application/x-win-bitmap' => 'image/bmp',
+        'application/x-rar' => 'application/x-rar-compressed',
     ];
 
     /**

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Enh #20878: Add `@param-out` annotation for `$models` in `yii\db\BaseActiveRecord::loadRelationsFor()` (mspirkov)
 - Bug #20878: Fix `@var` annotation for `yii\db\Query::$from` (mspirkov)
 - Enh #7616: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
+- Enh #20884: Add `application/x-rar` as an alias of `application/x-rar-compressed` in MIME aliases (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/helpers/mimeAliases.php
+++ b/framework/helpers/mimeAliases.php
@@ -23,4 +23,5 @@ return [
     'application/bmp' => 'image/bmp',
     'application/x-bmp' => 'image/bmp',
     'application/x-win-bitmap' => 'image/bmp',
+    'application/x-rar' => 'application/x-rar-compressed',
 ];

--- a/tests/framework/helpers/FileHelperTest.php
+++ b/tests/framework/helpers/FileHelperTest.php
@@ -1342,7 +1342,9 @@ class FileHelperTest extends TestCase
             ['application/json', false, 'json'],
             ['image/jpeg', true, 'jpg'],
             ['image/jpeg', false, 'jpeg'],
+            ['application/x-rar-compressed', true, 'rar'],
             ['application/x-rar-compressed', false, 'rar'],
+            ['application/x-rar', true, 'rar'],
             ['application/x-rar', false, 'rar'],
         ];
     }

--- a/tests/framework/helpers/FileHelperTest.php
+++ b/tests/framework/helpers/FileHelperTest.php
@@ -1308,6 +1308,18 @@ class FileHelperTest extends TestCase
                     'pjpeg',
                 ],
             ],
+            [
+                'application/x-rar-compressed',
+                [
+                    'rar',
+                ],
+            ],
+            [
+                'application/x-rar',
+                [
+                    'rar',
+                ],
+            ],
         ];
     }
 
@@ -1330,6 +1342,8 @@ class FileHelperTest extends TestCase
             ['application/json', false, 'json'],
             ['image/jpeg', true, 'jpg'],
             ['image/jpeg', false, 'jpeg'],
+            ['application/x-rar-compressed', false, 'rar'],
+            ['application/x-rar', false, 'rar'],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #20497

## What does this PR do?

Adds `application/x-rar` as an alias for `application/x-rar-compressed` so `FileHelper::getExtensionsByMimeType()` resolves both variants returned by PHP's `finfo`.

`framework/helpers/mimeAliases.php` gets the new entry; the same line is mirrored in `build/controllers/MimeTypeController::$_aliases` (regeneration source of truth). Regression cases for `application/x-rar` and `application/x-rar-compressed` added to `FileHelperTest::getExtensionsByMimeTypeProvider` and `getExtensionByMimeTypeProvider`.
