### PR TITLE
Fix #18423: Fix bug in jQuery selector for empty error classes in `ActiveForm`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Enh #20878: Add `@param-out` annotation for `$models` in `yii\db\BaseActiveRecord::loadRelationsFor()` (mspirkov)
 - Bug #20878: Fix `@var` annotation for `yii\db\Query::$from` (mspirkov)
 - Enh #7616: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
+- Bug #20885: Fix invalid jQuery selector built from empty `yii\widgets\ActiveForm::$errorSummaryCssClass` and `yii\widgets\ActiveField::$errorOptions['class']` (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -859,7 +859,7 @@ class ActiveField extends Component
             $options['error'] = $this->selectors['error'];
         } elseif (isset($this->errorOptions['class'])) {
             $errorClasses = preg_split('/\s+/', (string) $this->errorOptions['class'], -1, PREG_SPLIT_NO_EMPTY);
-            $options['error'] = empty($errorClasses) ? '' : '.' . implode('.', $errorClasses);
+            $options['error'] = $errorClasses === [] ? '' : '.' . implode('.', $errorClasses);
         } else {
             $options['error'] = isset($this->errorOptions['tag']) ? $this->errorOptions['tag'] : 'span';
         }

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -858,7 +858,8 @@ class ActiveField extends Component
         if (isset($this->selectors['error'])) {
             $options['error'] = $this->selectors['error'];
         } elseif (isset($this->errorOptions['class'])) {
-            $options['error'] = '.' . implode('.', preg_split('/\s+/', $this->errorOptions['class'], -1, PREG_SPLIT_NO_EMPTY));
+            $errorClasses = preg_split('/\s+/', (string) $this->errorOptions['class'], -1, PREG_SPLIT_NO_EMPTY);
+            $options['error'] = empty($errorClasses) ? '' : '.' . implode('.', $errorClasses);
         } else {
             $options['error'] = isset($this->errorOptions['tag']) ? $this->errorOptions['tag'] : 'span';
         }

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -255,7 +255,7 @@ class ActiveForm extends Widget
         $errorSummaryClasses = preg_split('/\s+/', (string) $this->errorSummaryCssClass, -1, PREG_SPLIT_NO_EMPTY);
         $options = [
             'encodeErrorSummary' => $this->encodeErrorSummary,
-            'errorSummary' => empty($errorSummaryClasses) ? '' : '.' . implode('.', $errorSummaryClasses),
+            'errorSummary' => $errorSummaryClasses === [] ? '' : '.' . implode('.', $errorSummaryClasses),
             'validateOnSubmit' => $this->validateOnSubmit,
             'errorCssClass' => $this->errorCssClass,
             'successCssClass' => $this->successCssClass,

--- a/framework/widgets/ActiveForm.php
+++ b/framework/widgets/ActiveForm.php
@@ -252,9 +252,10 @@ class ActiveForm extends Widget
      */
     protected function getClientOptions()
     {
+        $errorSummaryClasses = preg_split('/\s+/', (string) $this->errorSummaryCssClass, -1, PREG_SPLIT_NO_EMPTY);
         $options = [
             'encodeErrorSummary' => $this->encodeErrorSummary,
-            'errorSummary' => '.' . implode('.', preg_split('/\s+/', $this->errorSummaryCssClass, -1, PREG_SPLIT_NO_EMPTY)),
+            'errorSummary' => empty($errorSummaryClasses) ? '' : '.' . implode('.', $errorSummaryClasses),
             'validateOnSubmit' => $this->validateOnSubmit,
             'errorCssClass' => $this->errorCssClass,
             'successCssClass' => $this->successCssClass,

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -428,6 +428,27 @@ EOD;
         $this->assertSame($expectedEnableAjaxValidation, $actualValue['enableAjaxValidation']);
     }
 
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/18423
+     */
+    public function testGetClientOptionsErrorSelector(): void
+    {
+        $this->activeField->setClientOptionsEmpty(false);
+        $this->activeField->model->addRule($this->attributeName, 'yiiunit\framework\widgets\TestValidator');
+
+        $this->activeField->errorOptions = ['class' => ''];
+        $options = $this->activeField->getClientOptions();
+        $this->assertSame('', $options['error']);
+
+        $this->activeField->errorOptions = ['class' => '   '];
+        $options = $this->activeField->getClientOptions();
+        $this->assertSame('', $options['error']);
+
+        $this->activeField->errorOptions = ['class' => 'foo bar'];
+        $options = $this->activeField->getClientOptions();
+        $this->assertSame('.foo.bar', $options['error']);
+    }
+
     public function testGetClientOptionsValidatorWhenClientSet(): void
     {
         $this->activeField->setClientOptionsEmpty(false);

--- a/tests/framework/widgets/ActiveFormTest.php
+++ b/tests/framework/widgets/ActiveFormTest.php
@@ -170,6 +170,37 @@ HTML,
     }
 
     /**
+     * @see https://github.com/yiisoft/yii2/issues/18423
+     */
+    public function testGetClientOptionsErrorSummary(): void
+    {
+        ob_start();
+        $form = ActiveForm::begin(['action' => '/something', 'enableClientScript' => false]);
+        ActiveForm::end();
+        ob_end_clean();
+
+        $form->errorSummaryCssClass = '';
+        $options = $this->invokeMethod($form, 'getClientOptions');
+        $this->assertSame('', $options['errorSummary']);
+
+        $form->errorSummaryCssClass = '   ';
+        $options = $this->invokeMethod($form, 'getClientOptions');
+        $this->assertSame('', $options['errorSummary']);
+
+        $form->errorSummaryCssClass = false;
+        $options = $this->invokeMethod($form, 'getClientOptions');
+        $this->assertSame('', $options['errorSummary']);
+
+        $form->errorSummaryCssClass = 'foo bar';
+        $options = $this->invokeMethod($form, 'getClientOptions');
+        $this->assertSame('.foo.bar', $options['errorSummary']);
+
+        $form->errorSummaryCssClass = 'error-summary';
+        $options = $this->invokeMethod($form, 'getClientOptions');
+        $this->assertArrayNotHasKey('errorSummary', $options);
+    }
+
+    /**
      * @see https://github.com/yiisoft/yii2/issues/15476
      * @see https://github.com/yiisoft/yii2/issues/16892
      */

--- a/tests/framework/widgets/ActiveFormTest.php
+++ b/tests/framework/widgets/ActiveFormTest.php
@@ -187,10 +187,6 @@ HTML,
         $options = $this->invokeMethod($form, 'getClientOptions');
         $this->assertSame('', $options['errorSummary']);
 
-        $form->errorSummaryCssClass = false;
-        $options = $this->invokeMethod($form, 'getClientOptions');
-        $this->assertSame('', $options['errorSummary']);
-
         $form->errorSummaryCssClass = 'foo bar';
         $options = $this->invokeMethod($form, 'getClientOptions');
         $this->assertSame('.foo.bar', $options['errorSummary']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #18423

## What does this PR do?

Fixes the invalid jQuery selector `.` generated by `ActiveForm::getClientOptions()` when `errorSummaryCssClass` is empty, which caused `Syntax error, unrecognized expression: .` on form interaction. Same fix applied to `ActiveField::getClientOptions()` for `errorOptions['class']` — same `'.' . implode(...)` pattern was present there.

Both call sites now pre-split the class string and return an empty `error`/`errorSummary` selector when there are no classes, instead of a bare dot. Added `testGetClientOptionsErrorSummary` to `ActiveFormTest` and `testGetClientOptionsErrorSelector` to `ActiveFieldTest` covering empty, whitespace-only, multi-class and default cases.
