### PR TITLE
Fix #18661: Add sendRaw property to yii\web\Cookie for raw cookie values

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Enh #20878: Add `@param-out` annotation for `$models` in `yii\db\BaseActiveRecord::loadRelationsFor()` (mspirkov)
 - Bug #20878: Fix `@var` annotation for `yii\db\Query::$from` (mspirkov)
 - Enh #7616: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
+- Enh #20887: Add `yii\web\Cookie::$sendRaw` to send cookie values without URL encoding via `setrawcookie()` (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/web/Cookie.php
+++ b/framework/web/Cookie.php
@@ -88,12 +88,12 @@ class Cookie extends \yii\base\BaseObject
      * [[setrawcookie()]] instead of [[setcookie()]].
      *
      * Set this to `true` when the value is already encoded the way the application expects and you
-     * want to avoid an extra URL-encoding pass. Note that values containing characters that are not
-     * allowed in a `Set-Cookie` header (such as spaces, commas or semicolons) must not be sent raw.
+     * want to avoid an extra URL-encoding pass. Values must not contain characters disallowed in a
+     * `Set-Cookie` header (spaces, commas, semicolons, tabs and line breaks).
      *
-     * Combining `sendRaw = true` with [[yii\web\Request::$enableCookieValidation]] may produce
-     * values that are not round-trippable, since the hashed value contains `+` characters that
-     * the browser will decode back to spaces on its next request.
+     * Raw cookies bypass [[yii\web\Request::$enableCookieValidation]]: the value is written as-is
+     * without the hash prefix, and the framework will not validate it on the next request. Read
+     * such cookies via `$_COOKIE` directly instead of `Yii::$app->request->cookies`.
      *
      * @see https://www.php.net/manual/en/function.setrawcookie.php
      * @since 2.0.56

--- a/framework/web/Cookie.php
+++ b/framework/web/Cookie.php
@@ -83,6 +83,22 @@ class Cookie extends \yii\base\BaseObject
      * @since 2.0.21
      */
     public $sameSite = self::SAME_SITE_LAX;
+    /**
+     * @var bool whether the cookie value should be sent without URL-encoding by using
+     * [[setrawcookie()]] instead of [[setcookie()]].
+     *
+     * Set this to `true` when the value is already encoded the way the application expects and you
+     * want to avoid an extra URL-encoding pass. Note that values containing characters that are not
+     * allowed in a `Set-Cookie` header (such as spaces, commas or semicolons) must not be sent raw.
+     *
+     * Combining `sendRaw = true` with [[yii\web\Request::$enableCookieValidation]] may produce
+     * values that are not round-trippable, since the hashed value contains `+` characters that
+     * the browser will decode back to spaces on its next request.
+     *
+     * @see https://www.php.net/manual/en/function.setrawcookie.php
+     * @since 2.0.56
+     */
+    public $sendRaw = false;
 
 
     /**

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -430,7 +430,7 @@ class Response extends \yii\base\Response
                 if (!is_null($cookie->sameSite)) {
                     $cookiePath .= '; samesite=' . $cookie->sameSite;
                 }
-                $setCookie($cookie->name, $value, $expire, $cookiePath, $cookie->domain, $cookie->secure, $cookie->httpOnly);
+                setcookie($cookie->name, $value, $expire, $cookiePath, $cookie->domain, $cookie->secure, $cookie->httpOnly);
             }
         }
     }

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -413,8 +413,9 @@ class Response extends \yii\base\Response
             if ($expire != 1 && isset($validationKey)) {
                 $value = Yii::$app->getSecurity()->hashData(serialize([$cookie->name, $value]), $validationKey);
             }
+            $setCookie = $cookie->sendRaw ? 'setrawcookie' : 'setcookie';
             if (PHP_VERSION_ID >= 70300) {
-                setcookie($cookie->name, $value, [
+                $setCookie($cookie->name, $value, [
                     'expires' => $expire,
                     'path' => $cookie->path,
                     'domain' => $cookie->domain,
@@ -429,7 +430,7 @@ class Response extends \yii\base\Response
                 if (!is_null($cookie->sameSite)) {
                     $cookiePath .= '; samesite=' . $cookie->sameSite;
                 }
-                setcookie($cookie->name, $value, $expire, $cookiePath, $cookie->domain, $cookie->secure, $cookie->httpOnly);
+                $setCookie($cookie->name, $value, $expire, $cookiePath, $cookie->domain, $cookie->secure, $cookie->httpOnly);
             }
         }
     }

--- a/framework/web/Response.php
+++ b/framework/web/Response.php
@@ -410,7 +410,7 @@ class Response extends \yii\base\Response
             if ($expire === null || $expire === false) {
                 $expire = 0;
             }
-            if ($expire != 1 && isset($validationKey)) {
+            if ($expire != 1 && isset($validationKey) && !$cookie->sendRaw) {
                 $value = Yii::$app->getSecurity()->hashData(serialize([$cookie->name, $value]), $validationKey);
             }
             $setCookie = $cookie->sendRaw ? 'setrawcookie' : 'setcookie';

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -503,12 +503,12 @@ class ResponseTest extends TestCase
             $this->markTestSkipped('Xdebug is required to inspect raw Set-Cookie headers.');
         }
 
-        $this->assertTrue(Yii::$app->request->enableCookieValidation);
+        Yii::$app->request->enableCookieValidation = true;
         $rawValue = 'untouched-by-hash';
 
         $response = new Response();
         $response->cookies->add(new Cookie([
-            'name' => 'rawCookie',
+            'name' => 'rawValidatedCookie',
             'value' => $rawValue,
             'sendRaw' => true,
         ]));
@@ -519,13 +519,13 @@ class ResponseTest extends TestCase
 
         $rawHeader = null;
         foreach (xdebug_get_headers() as $header) {
-            if (strpos($header, 'Set-Cookie: rawCookie=') === 0) {
+            if (strpos($header, 'Set-Cookie: rawValidatedCookie=') === 0) {
                 $rawHeader = $header;
                 break;
             }
         }
 
-        $this->assertStringContainsString('rawCookie=' . $rawValue . ';', $rawHeader);
+        $this->assertStringContainsString('rawValidatedCookie=' . $rawValue . ';', $rawHeader);
     }
 
     /**

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -493,6 +493,42 @@ class ResponseTest extends TestCase
     }
 
     /**
+     * Raw cookies must bypass the validation hash even when cookie validation is enabled,
+     * otherwise the hashed payload's semicolons make setrawcookie() reject the value.
+     * @see https://github.com/yiisoft/yii2/issues/18661
+     */
+    public function testSendRawCookieBypassesValidationHash(): void
+    {
+        if (!function_exists('xdebug_get_headers')) {
+            $this->markTestSkipped('Xdebug is required to inspect raw Set-Cookie headers.');
+        }
+
+        $this->assertTrue(Yii::$app->request->enableCookieValidation);
+        $rawValue = 'untouched-by-hash';
+
+        $response = new Response();
+        $response->cookies->add(new Cookie([
+            'name' => 'rawCookie',
+            'value' => $rawValue,
+            'sendRaw' => true,
+        ]));
+
+        ob_start();
+        $response->send();
+        ob_end_clean();
+
+        $rawHeader = null;
+        foreach (xdebug_get_headers() as $header) {
+            if (strpos($header, 'Set-Cookie: rawCookie=') === 0) {
+                $rawHeader = $header;
+                break;
+            }
+        }
+
+        $this->assertStringContainsString('rawCookie=' . $rawValue . ';', $rawHeader);
+    }
+
+    /**
      * Tries to parse cookies set in the response headers.
      * When running PHP on the CLI headers are not available (the `headers_list()` function always returns an
      * empty array). If possible use xDebug: http://xdebug.org/docs/all_functions#xdebug_get_headers

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -460,6 +460,7 @@ class ResponseTest extends TestCase
             $this->markTestSkipped('Xdebug is required to inspect raw Set-Cookie headers.');
         }
 
+        Yii::$app->request->enableCookieValidation = false;
         $rawValue = 'plus+slash/equals=';
 
         $response = new Response();

--- a/tests/framework/web/ResponseTest.php
+++ b/tests/framework/web/ResponseTest.php
@@ -452,6 +452,46 @@ class ResponseTest extends TestCase
     }
 
     /**
+     * @see https://github.com/yiisoft/yii2/issues/18661
+     */
+    public function testSendRawCookie(): void
+    {
+        if (!function_exists('xdebug_get_headers')) {
+            $this->markTestSkipped('Xdebug is required to inspect raw Set-Cookie headers.');
+        }
+
+        $rawValue = 'plus+slash/equals=';
+
+        $response = new Response();
+        $response->cookies->add(new Cookie([
+            'name' => 'rawCookie',
+            'value' => $rawValue,
+            'sendRaw' => true,
+        ]));
+        $response->cookies->add(new Cookie([
+            'name' => 'encodedCookie',
+            'value' => $rawValue,
+        ]));
+
+        ob_start();
+        $response->send();
+        ob_end_clean();
+
+        $rawHeader = null;
+        $encodedHeader = null;
+        foreach (xdebug_get_headers() as $header) {
+            if (strpos($header, 'Set-Cookie: rawCookie=') === 0) {
+                $rawHeader = $header;
+            } elseif (strpos($header, 'Set-Cookie: encodedCookie=') === 0) {
+                $encodedHeader = $header;
+            }
+        }
+
+        $this->assertStringContainsString('rawCookie=' . $rawValue . ';', $rawHeader);
+        $this->assertStringContainsString('encodedCookie=plus%2Bslash%2Fequals%3D;', $encodedHeader);
+    }
+
+    /**
      * Tries to parse cookies set in the response headers.
      * When running PHP on the CLI headers are not available (the `headers_list()` function always returns an
      * empty array). If possible use xDebug: http://xdebug.org/docs/all_functions#xdebug_get_headers


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #18661

## What does this PR do?

Adds `yii\web\Cookie::$sendRaw` (default `false`). When `true`, `Response::sendCookies()` uses `setrawcookie()` instead of `setcookie()` and skips the validation hash (same pattern already used for delete cookies with `expire=1`). PHPDoc notes that raw cookies bypass validation and should be read via `$_COOKIE`.

Two tests in `ResponseTest`, both skipping without `xdebug_get_headers`:
- `testSendRawCookie` — raw header preserved with `sendRaw=true`, URL-encoded otherwise.
- `testSendRawCookieBypassesValidationHash` — validation enabled, raw value reaches the header un-hashed.
