### PR TITLE
Fix #20261: Preserve modification time when rotating log files

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 Change Log
 - Bug #20878: Fix `@var` annotation for `yii\db\Query::$from` (mspirkov)
 - Enh #7616: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
 - Enh #20884: Add `application/x-rar` as an alias of `application/x-rar-compressed` in MIME aliases (WarLikeLaux)
+- Enh #20888: Preserve the modification time of a log file when it is rotated by copy in `yii\log\FileTarget` (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/log/FileTarget.php
+++ b/framework/log/FileTarget.php
@@ -195,10 +195,11 @@ class FileTarget extends Target
     private function rotateByCopy($rotateFile, $newFile)
     {
         $mtime = @filemtime($rotateFile);
-        @copy($rotateFile, $newFile);
-        if ($mtime !== false) {
+
+        if (@copy($rotateFile, $newFile) && $mtime !== false) {
             @touch($newFile, $mtime);
         }
+
         if ($this->fileMode !== null) {
             @chmod($newFile, $this->fileMode);
         }

--- a/framework/log/FileTarget.php
+++ b/framework/log/FileTarget.php
@@ -194,7 +194,11 @@ class FileTarget extends Target
      */
     private function rotateByCopy($rotateFile, $newFile)
     {
+        $mtime = @filemtime($rotateFile);
         @copy($rotateFile, $newFile);
+        if ($mtime !== false) {
+            @touch($newFile, $mtime);
+        }
         if ($this->fileMode !== null) {
             @chmod($newFile, $this->fileMode);
         }

--- a/tests/framework/log/FileTargetTest.php
+++ b/tests/framework/log/FileTargetTest.php
@@ -113,6 +113,43 @@ class FileTargetTest extends TestCase
         $this->assertFileDoesNotExist($logFile . '.4');
     }
 
+    public function testRotatePreservesMtime(): void
+    {
+        $logFile = Yii::getAlias('@yiiunit/runtime/log/filetargettest.log');
+        FileHelper::removeDirectory(dirname($logFile));
+        mkdir(dirname($logFile), 0777, true);
+
+        $logger = new Logger();
+        $dispatcher = new Dispatcher([
+            'logger' => $logger,
+            'targets' => [
+                'file' => [
+                    'class' => 'yii\log\FileTarget',
+                    'logFile' => $logFile,
+                    'levels' => ['warning'],
+                    'maxFileSize' => 1,
+                    'maxLogFiles' => 1,
+                    'logVars' => [],
+                ],
+            ],
+        ]);
+
+        $logger->log(str_repeat('x', 2048), Logger::LEVEL_WARNING);
+        $logger->flush(true);
+
+        $expectedMtime = time() - 7200;
+        touch($logFile, $expectedMtime);
+        clearstatcache();
+
+        $logger->log('y', Logger::LEVEL_WARNING);
+        $logger->flush(true);
+
+        clearstatcache();
+
+        $this->assertFileExists($logFile . '.1');
+        $this->assertSame($expectedMtime, filemtime($logFile . '.1'));
+    }
+
     public function testLogEmptyStrings(): void
     {
         $logFile = Yii::getAlias('@yiiunit/runtime/log/filetargettest.log');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #20261

## What does this PR do?

Preserves the modification time of a log file when `yii\log\FileTarget` rotates it by copy, so the rotated file's mtime reflects when the log was last written instead of when rotation happened. Implementation reads `filemtime()` of the source file before `copy()` and calls `touch()` on the destination with that value.
