### PR TITLE
Fix the types in the PHPDoc annotations for `JsonParser`, `Request`, and `RequestParserInterface`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,8 @@ Yii Framework 2 Change Log
 - Bug #20878: Fix `@var` annotation for `yii\db\Query::$from` (mspirkov)
 - Enh #7616: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
 - Enh #20884: Add `application/x-rar` as an alias of `application/x-rar-compressed` in MIME aliases (WarLikeLaux)
+- Bug #20891: Fix `@return` annotation in `RequestParserInterface::parse()`, `JsonParser::parse()`, and `Request::post()` (mspirkov)
+- Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 
 
 2.0.55 May 09, 2026

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,8 +13,9 @@ Yii Framework 2 Change Log
 - Bug #20878: Fix `@var` annotation for `yii\db\Query::$from` (mspirkov)
 - Enh #7616: Add `yii\web\ErrorHandler::EVENT_AFTER_RENDER` and `yii\web\ErrorHandlerRenderEvent` to post-process rendered HTML error output (terabytesoftw)
 - Enh #20884: Add `application/x-rar` as an alias of `application/x-rar-compressed` in MIME aliases (WarLikeLaux)
-- Bug #20891: Fix `@return` annotation in `RequestParserInterface::parse()`, `JsonParser::parse()`, and `Request::post()` (mspirkov)
+- Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
+- Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
 
 
 2.0.55 May 09, 2026

--- a/framework/web/JsonParser.php
+++ b/framework/web/JsonParser.php
@@ -43,7 +43,7 @@ class JsonParser implements RequestParserInterface
      * Parses a HTTP request body.
      * @param string $rawBody the raw HTTP request body.
      * @param string $contentType the content type specified for the request body.
-     * @return array|\stdClass parameters parsed from the request body
+     * @return mixed parameters parsed from the request body
      * @throws BadRequestHttpException if the body contains invalid json and [[throwException]] is `true`.
      */
     public function parse($rawBody, $contentType)

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -41,8 +41,7 @@ use yii\validators\IpValidator;
  * @property-read string|null $authUser The username sent via HTTP authentication, `null` if the username is
  * not given.
  * @property string $baseUrl The relative URL for the application.
- * @property array|object $bodyParams The request parameters given in the request body. Note that the type of
- * this property differs in getter and setter. See [[getBodyParams()]] and [[setBodyParams()]] for details.
+ * @property mixed $bodyParams The request parameters given in the request body.
  * @property-read string $contentType Request content-type. Empty string is returned if this information is
  * not available.
  * @property-read CookieCollection $cookies The cookie collection.

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -41,7 +41,8 @@ use yii\validators\IpValidator;
  * @property-read string|null $authUser The username sent via HTTP authentication, `null` if the username is
  * not given.
  * @property string $baseUrl The relative URL for the application.
- * @property array|object $bodyParams The request parameters given in the request body.
+ * @property array|object $bodyParams The request parameters given in the request body. Note that the type of
+ * this property differs in getter and setter. See [[getBodyParams()]] and [[setBodyParams()]] for details.
  * @property-read string $contentType Request content-type. Empty string is returned if this information is
  * not available.
  * @property-read CookieCollection $cookies The cookie collection.
@@ -592,7 +593,7 @@ class Request extends \yii\base\Request
      * Request parameters are determined using the parsers configured in [[parsers]] property.
      * If no parsers are configured for the current [[contentType]] it uses the PHP function `mb_parse_str()`
      * to parse the [[rawBody|request body]].
-     * @return array|object the request parameters given in the request body.
+     * @return mixed the request parameters given in the request body.
      * @throws \yii\base\InvalidConfigException if a registered parser does not implement the [[RequestParserInterface]].
      * @see getMethod()
      * @see getBodyParam()

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -583,7 +583,7 @@ class Request extends \yii\base\Request
         $this->_rawBody = $rawBody;
     }
 
-    /** @var array|object */
+    /** @var mixed */
     private $_bodyParams;
 
     /**
@@ -642,7 +642,7 @@ class Request extends \yii\base\Request
     /**
      * Sets the request body parameters.
      *
-     * @param array|object $values the request body parameters (name-value pairs)
+     * @param mixed $values the request body parameters (name-value pairs)
      * @see getBodyParams()
      */
     public function setBodyParams($values)
@@ -682,7 +682,7 @@ class Request extends \yii\base\Request
      *
      * @param string|null $name the parameter name
      * @param mixed $defaultValue the default parameter value if the parameter does not exist.
-     * @return ($name is null ? array|object : mixed)
+     * @return mixed
      */
     public function post($name = null, $defaultValue = null)
     {

--- a/framework/web/RequestParserInterface.php
+++ b/framework/web/RequestParserInterface.php
@@ -20,7 +20,7 @@ interface RequestParserInterface
      * Parses a HTTP request body.
      * @param string $rawBody the raw HTTP request body.
      * @param string $contentType the content type specified for the request body.
-     * @return array|object parameters parsed from the request body
+     * @return mixed parameters parsed from the request body
      */
     public function parse($rawBody, $contentType);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
