### PR TITLE
Fix #20117: Avoid relating a record with key `0` to a `null` FK

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Bug #20893: Fix relational query populating a record with key `0` for models with a `null` foreign key in `yii\db\ActiveRelationTrait` (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -313,7 +313,7 @@ trait ActiveRelationTrait
                 }
             } else {
                 $key = $this->getModelKey($primaryModel, $link);
-                $value = isset($buckets[$key]) ? $buckets[$key] : ($this->multiple ? [] : null);
+                $value = $key !== false && isset($buckets[$key]) ? $buckets[$key] : ($this->multiple ? [] : null);
             }
             if ($primaryModel instanceof ActiveRecordInterface) {
                 $primaryModel->populateRelation($name, $value);

--- a/tests/data/ar/Customer.php
+++ b/tests/data/ar/Customer.php
@@ -36,6 +36,7 @@ use yiiunit\framework\db\ActiveRecordTest;
  * @property-read Item[] $orderItems
  * @property-read OrderItem[] $orderItems2
  * @property-read Item[] $items
+ * @property-read Customer[] $statusMates
  */
 class Customer extends ActiveRecord
 {
@@ -54,6 +55,16 @@ class Customer extends ActiveRecord
     public function getProfile()
     {
         return $this->hasOne(Profile::class, ['id' => 'profile_id']);
+    }
+
+    /**
+     * Links a nullable column (`profile_id`) to a non-primary-key column (`status`).
+     * Used to reproduce a null foreign key matching a zero link value.
+     * @see https://github.com/yiisoft/yii2/issues/20117
+     */
+    public function getStatusMates()
+    {
+        return $this->hasMany(Customer::class, ['status' => 'profile_id']);
     }
 
     public function getOrdersPlain()

--- a/tests/data/ar/Customer.php
+++ b/tests/data/ar/Customer.php
@@ -58,13 +58,12 @@ class Customer extends ActiveRecord
     }
 
     /**
-     * Links a nullable column (`profile_id`) to a non-primary-key column (`status`).
-     * Used to reproduce a null foreign key matching a zero link value.
+     * Customers sharing the same `status`.
      * @see https://github.com/yiisoft/yii2/issues/20117
      */
     public function getStatusMates()
     {
-        return $this->hasMany(Customer::class, ['status' => 'profile_id']);
+        return $this->hasMany(Customer::class, ['status' => 'status']);
     }
 
     public function getOrdersPlain()

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1787,6 +1787,23 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals('Some {{%updated}} address', $customer->address);
     }
 
+    public function testEagerLoadingWithNullForeignKeyDoesNotMatchZeroPrimaryKey(): void
+    {
+        ActiveRecord::$db->createCommand()->insert('profile', ['id' => 0, 'description' => 'profile zero'])->execute();
+
+        $zeroProfile = Profile::findOne(0);
+        if ($zeroProfile === null || (int) $zeroProfile->id !== 0) {
+            $this->markTestSkipped('Database does not store a zero primary key value.');
+        }
+
+        Customer::updateAll(['profile_id' => 0], ['id' => 1]);
+
+        $customers = Customer::find()->with('profile')->indexBy('id')->all();
+
+        $this->assertSame(0, (int) $customers[1]->profile->id);
+        $this->assertNull($customers[2]->profile);
+    }
+
     /**
      * Ensure no ambiguous column error occurs if ActiveQuery adds a JOIN.
      *

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1787,21 +1787,16 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals('Some {{%updated}} address', $customer->address);
     }
 
-    public function testEagerLoadingWithNullForeignKeyDoesNotMatchZeroPrimaryKey(): void
+    public function testEagerLoadingWithNullForeignKeyDoesNotMatchZeroLinkValue(): void
     {
-        ActiveRecord::$db->createCommand()->insert('profile', ['id' => 0, 'description' => 'profile zero'])->execute();
+        Customer::updateAll(['status' => 0], ['id' => 1]);
+        Customer::updateAll(['profile_id' => 0], ['id' => 3]);
 
-        $zeroProfile = Profile::findOne(0);
-        if ($zeroProfile === null || (int) $zeroProfile->id !== 0) {
-            $this->markTestSkipped('Database does not store a zero primary key value.');
-        }
+        $customers = Customer::find()->with('statusMates')->indexBy('id')->all();
 
-        Customer::updateAll(['profile_id' => 0], ['id' => 1]);
-
-        $customers = Customer::find()->with('profile')->indexBy('id')->all();
-
-        $this->assertSame(0, (int) $customers[1]->profile->id);
-        $this->assertNull($customers[2]->profile);
+        $this->assertCount(1, $customers[3]->statusMates);
+        $this->assertSame(1, (int) $customers[3]->statusMates[0]->id);
+        $this->assertSame([], $customers[2]->statusMates);
     }
 
     /**

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1790,12 +1790,12 @@ abstract class ActiveRecordTest extends DatabaseTestCase
     public function testEagerLoadingWithNullForeignKeyDoesNotMatchZeroLinkValue(): void
     {
         Customer::updateAll(['status' => 0], ['id' => 1]);
-        Customer::updateAll(['profile_id' => 0], ['id' => 3]);
+        Customer::updateAll(['status' => null], ['id' => 2]);
 
         $customers = Customer::find()->with('statusMates')->indexBy('id')->all();
 
-        $this->assertCount(1, $customers[3]->statusMates);
-        $this->assertSame(1, (int) $customers[3]->statusMates[0]->id);
+        $this->assertCount(1, $customers[1]->statusMates);
+        $this->assertSame(1, (int) $customers[1]->statusMates[0]->id);
         $this->assertSame([], $customers[2]->statusMates);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #20117

## What does this PR do?

During eager loading, a primary model with a `null` foreign key wrongly received a related record whose link value is `0`.

`getModelKey()` returns `false` when the link value is `null`. `populateRelation()` then looks up `isset($buckets[$key])`, and PHP treats `$buckets[false]` as `$buckets[0]` - the bucket of a related record whose key is `0`. So a model with a `null` foreign key picked up the record keyed by `0`. A `$key !== false` guard skips the lookup for those models.

### Coverage

1 regression test added. The test fails without the fix and passes with it.

The bug needs a related record whose link value is `0` while a primary model's link value is `null`. The natural way (a foreign key pointing at a record with primary key `0`) is not portable: MySQL and CUBRID reassign an explicit `0` on an auto-increment key, MSSQL rejects it on an identity column, and a real foreign key would also reject `0` when no such parent row exists.

To stay driver-independent, the test uses the `customer.status` column, which is nullable, has no foreign key, and can hold `0`. A `getStatusMates` relation links `status` to `status` (customers sharing a status). One customer gets `status = 0` and another `status = null`; the one with `null` must not pick up the one with `0`. This keeps the values on a plain column, so no zero primary key or foreign-key parent is needed and the test runs on every driver.
