### PR TITLE
Fix #15401: Render array input value as empty in `BaseHtml::input()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Bug #20894: Render an empty value instead of throwing when an array is passed as an input value in `yii\helpers\BaseHtml::input()` (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -577,6 +577,10 @@ class BaseHtml
             $options['type'] = $type;
         }
         $options['name'] = $name;
+        // https://github.com/yiisoft/yii2/issues/15401
+        if (is_array($value)) {
+            $value = '';
+        }
         $options['value'] = $value === null ? null : (string) $value;
         return static::tag('input', '', $options);
     }

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1521,6 +1521,25 @@ EOD;
         $this->assertEquals($expectedHtml, Html::activeTextInput($model, 'name', $options));
     }
 
+    public static function dataProviderActiveInputArrayValue(): array
+    {
+        return [
+            'text' => ['activeTextInput', '<input type="text" id="htmltestmodel-name" name="HtmlTestModel[name]" value="">'],
+            'password' => ['activePasswordInput', '<input type="password" id="htmltestmodel-name" name="HtmlTestModel[name]" value="">'],
+            'hidden' => ['activeHiddenInput', '<input type="hidden" id="htmltestmodel-name" name="HtmlTestModel[name]" value="">'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderActiveInputArrayValue
+     */
+    public function testActiveInputRendersEmptyForArrayValue($method, $expectedHtml): void
+    {
+        $model = new HtmlTestModel();
+        $model->setAttributes(['name' => ['tampered@example.com']], false);
+        $this->assertSame($expectedHtml, Html::$method($model, 'name'));
+    }
+
     /**
      * Data provider for [[testActiveTextInputMaxLength]].
      * @return array test data

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -1540,6 +1540,14 @@ EOD;
         $this->assertSame($expectedHtml, Html::$method($model, 'name'));
     }
 
+    public function testInputRendersEmptyForArrayValue(): void
+    {
+        $this->assertSame(
+            '<input type="text" name="n" value="">',
+            Html::input('text', 'n', ['tampered@example.com'])
+        );
+    }
+
     /**
      * Data provider for [[testActiveTextInputMaxLength]].
      * @return array test data


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #15401

## What does this PR do?

Renders an empty value instead of throwing a 500 error when an array reaches `BaseHtml::input()` as the value.

A tampered request such as `Form[email][]=x` loads the model attribute as an array. Rendering the field then reaches `input()`, where `(string) $value` triggers an `Array to string conversion` error and an HTTP 500. Following the approach discussed in the issue (render as empty), `input()` now resets an array value to `''`, so the field renders `value=""`. Scalars and objects with `__toString()` keep going through the cast, so their output is unchanged; methods that expect arrays (list box, checkbox/radio list) do not pass through this branch.

### Coverage

3 tests added (text, password, hidden active inputs). Mutation coverage of the changed lines: MSI 100% (2/2 mutants killed).
