### PR TITLE
Harden `yii\i18n\PhpMessageSource` category path handling to reject `..` segments, absolute paths, and stream-wrapper categories.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Enh #20890: Harden `yii\i18n\PhpMessageSource` category path handling to reject `..` segments, absolute paths, and stream-wrapper categories (terabytesoftw)
 
 
 2.0.55 May 09, 2026

--- a/framework/i18n/PhpMessageSource.php
+++ b/framework/i18n/PhpMessageSource.php
@@ -11,6 +11,9 @@ namespace yii\i18n;
 use Yii;
 use yii\base\InvalidArgumentException;
 
+use function sprintf;
+use function str_replace;
+
 /**
  * PhpMessageSource represents a message source that stores translated messages in PHP scripts.
  *
@@ -128,9 +131,14 @@ class PhpMessageSource extends MessageSource
     /**
      * Returns message file path for the specified language and category.
      *
+     * The category may use `/` or `\` as namespace separators (for example, `app/error`). Categories that contain `..`
+     * segments, an absolute path, or a stream-wrapper scheme (such as `php://`) are rejected so the resolved path
+     * cannot escape [[basePath]].
+     *
      * @param string $category the message category
      * @param string $language the target language
      * @return string path to message file
+     * @throws InvalidArgumentException if the language code is invalid, or the category resolves to an unsafe path.
      */
     protected function getMessageFilePath($category, $language)
     {
@@ -142,7 +150,15 @@ class PhpMessageSource extends MessageSource
         if (isset($this->fileMap[$category])) {
             $messageFile .= $this->fileMap[$category];
         } else {
-            $messageFile .= str_replace('\\', '/', $category) . '.php';
+            $normalizedCategory = str_replace('\\', '/', (string) $category);
+
+            if (!preg_match('~^\w(?:(?!\/\.{0,2}\/)[\w\/\-\.])*$~', $normalizedCategory)) {
+                throw new InvalidArgumentException(
+                    sprintf('Invalid message category: "%s".', (string) $category),
+                );
+            }
+
+            $messageFile .= "{$normalizedCategory}.php";
         }
 
         return $messageFile;

--- a/framework/i18n/PhpMessageSource.php
+++ b/framework/i18n/PhpMessageSource.php
@@ -152,7 +152,7 @@ class PhpMessageSource extends MessageSource
         } else {
             $normalizedCategory = str_replace('\\', '/', (string) $category);
 
-            if (preg_match('~^[A-Za-z]:/|(?:^|/)\.{0,2}(?:/|$)~', $normalizedCategory)) {
+            if (preg_match('~(?:^|/)\.\.(?:/|$)|^/|^[A-Za-z]:/|^[A-Za-z][A-Za-z0-9+.\-]*://~', $normalizedCategory)) {
                 throw new InvalidArgumentException(
                     sprintf('Invalid message category: "%s".', (string) $category),
                 );

--- a/framework/i18n/PhpMessageSource.php
+++ b/framework/i18n/PhpMessageSource.php
@@ -152,7 +152,7 @@ class PhpMessageSource extends MessageSource
         } else {
             $normalizedCategory = str_replace('\\', '/', (string) $category);
 
-            if (!preg_match('~^\w(?:(?!\/\.{0,2}\/)[\w\/\-\.])*$~', $normalizedCategory)) {
+            if (preg_match('~^[A-Za-z]:|(?:^|/)\.{0,2}(?:/|$)~', $normalizedCategory)) {
                 throw new InvalidArgumentException(
                     sprintf('Invalid message category: "%s".', (string) $category),
                 );

--- a/framework/i18n/PhpMessageSource.php
+++ b/framework/i18n/PhpMessageSource.php
@@ -152,7 +152,7 @@ class PhpMessageSource extends MessageSource
         } else {
             $normalizedCategory = str_replace('\\', '/', (string) $category);
 
-            if (preg_match('~^[A-Za-z]:|(?:^|/)\.{0,2}(?:/|$)~', $normalizedCategory)) {
+            if (preg_match('~^[A-Za-z]:/|(?:^|/)\.{0,2}(?:/|$)~', $normalizedCategory)) {
                 throw new InvalidArgumentException(
                     sprintf('Invalid message category: "%s".', (string) $category),
                 );

--- a/tests/framework/i18n/PhpMessageSourceTest.php
+++ b/tests/framework/i18n/PhpMessageSourceTest.php
@@ -72,8 +72,8 @@ final class PhpMessageSourceTest extends TestCase
     /**
      * Provides categories outside the traversal threat model that must remain accepted.
      *
-     * Leading `.`/`-`, non-ASCII names, and spaces resolve under `basePath` and predate the hardening; rejecting
-     * them would be a backward-compatibility break wider than the documented threat model.
+     * Leading `.`/`-`, a `letter:` prefix, non-ASCII names, and spaces resolve under `basePath` and predate the
+     * hardening; rejecting them would be a backward-compatibility break wider than the documented threat model.
      *
      * @return array<string, array{string, string}> input category and resolved relative path.
      */
@@ -82,6 +82,7 @@ final class PhpMessageSourceTest extends TestCase
         return [
             'leading dot' => ['.messages', '.messages'],
             'leading hyphen' => ['-foo', '-foo'],
+            'letter colon prefix' => ['a:foo', 'a:foo'],
             'non-ascii accented' => ['café', 'café'],
             'non-ascii cyrillic' => ['модуль', 'модуль'],
             'whitespace in name' => ['My Category', 'My Category'],

--- a/tests/framework/i18n/PhpMessageSourceTest.php
+++ b/tests/framework/i18n/PhpMessageSourceTest.php
@@ -38,14 +38,19 @@ final class PhpMessageSourceTest extends TestCase
     public function unsafeCategoryProvider(): array
     {
         return [
-            'parent traversal' => ['../../etc/passwd'],
-            'leading traversal segment' => ['../secret'],
-            'embedded traversal segment' => ['app/../../config/db'],
-            'current-dir segment' => ['app/./db'],
             'absolute unix path' => ['/etc/passwd'],
-            'windows absolute path' => ['C:\\Windows\\system32'],
-            'php stream wrapper' => ['php://filter/resource=config/db'],
+            'bare current-dir segment' => ['.'],
+            'bare parent segment' => ['..'],
+            'double slash' => ['app//error'],
+            'embedded current-dir segment' => ['app/./db'],
+            'embedded traversal segment' => ['app/../../config/db'],
+            'leading current-dir segment' => ['./config'],
+            'leading traversal segment' => ['../secret'],
+            'parent traversal' => ['../../etc/passwd'],
             'phar stream wrapper' => ['phar://archive.phar/config'],
+            'php stream wrapper' => ['php://filter/resource=config/db'],
+            'trailing traversal segment' => ['app/..'],
+            'windows absolute path' => ['C:\\Windows\\system32'],
         ];
     }
 
@@ -57,10 +62,29 @@ final class PhpMessageSourceTest extends TestCase
     public function safeCategoryProvider(): array
     {
         return [
-            'simple' => ['app', 'app'],
-            'slash namespace' => ['app/error', 'app/error'],
             'backslash namespace' => ['modules\\users\\validation', 'modules/users/validation'],
             'dashes and dots' => ['app-name/sub.module', 'app-name/sub.module'],
+            'simple' => ['app', 'app'],
+            'slash namespace' => ['app/error', 'app/error'],
+        ];
+    }
+
+    /**
+     * Provides categories outside the traversal threat model that must remain accepted.
+     *
+     * Leading `.`/`-`, non-ASCII names, and spaces resolve under `basePath` and predate the hardening; rejecting
+     * them would be a backward-compatibility break wider than the documented threat model.
+     *
+     * @return array<string, array{string, string}> input category and resolved relative path.
+     */
+    public function benignCategoryProvider(): array
+    {
+        return [
+            'leading dot' => ['.messages', '.messages'],
+            'leading hyphen' => ['-foo', '-foo'],
+            'non-ascii accented' => ['café', 'café'],
+            'non-ascii cyrillic' => ['модуль', 'модуль'],
+            'whitespace in name' => ['My Category', 'My Category'],
         ];
     }
 
@@ -94,6 +118,26 @@ final class PhpMessageSourceTest extends TestCase
             $expected,
             $source->exposeMessageFilePath($category, 'en'),
             'Namespace separators must be preserved under basePath.',
+        );
+    }
+
+    /**
+     * @dataProvider benignCategoryProvider
+     */
+    public function testReturnExpectedPathForBenignCategory(string $category, string $expectedRelative): void
+    {
+        $source = new ExposedPhpMessageSource(
+            [
+                'basePath' => '@yiiunit/data/i18n/messages',
+            ],
+        );
+
+        $expected = Yii::getAlias('@yiiunit/data/i18n/messages') . '/en/' . $expectedRelative . '.php';
+
+        $this->assertSame(
+            $expected,
+            $source->exposeMessageFilePath($category, 'en'),
+            'Non-traversal category must resolve under basePath.',
         );
     }
 

--- a/tests/framework/i18n/PhpMessageSourceTest.php
+++ b/tests/framework/i18n/PhpMessageSourceTest.php
@@ -39,12 +39,8 @@ final class PhpMessageSourceTest extends TestCase
     {
         return [
             'absolute unix path' => ['/etc/passwd'],
-            'bare current-dir segment' => ['.'],
             'bare parent segment' => ['..'],
-            'double slash' => ['app//error'],
-            'embedded current-dir segment' => ['app/./db'],
             'embedded traversal segment' => ['app/../../config/db'],
-            'leading current-dir segment' => ['./config'],
             'leading traversal segment' => ['../secret'],
             'parent traversal' => ['../../etc/passwd'],
             'phar stream wrapper' => ['phar://archive.phar/config'],
@@ -86,6 +82,23 @@ final class PhpMessageSourceTest extends TestCase
             'non-ascii accented' => ['café', 'café'],
             'non-ascii cyrillic' => ['модуль', 'модуль'],
             'whitespace in name' => ['My Category', 'My Category'],
+        ];
+    }
+
+    /**
+     * Provides non-canonical but in-bounds categories that must remain accepted.
+     *
+     * Current-directory (`.`) segments and duplicate separators (`//`) still resolve under `basePath`; the documented
+     * threat model only covers `..`, absolute paths, and stream wrappers, so rejecting them would break compatibility.
+     *
+     * @return array<string, array{string, string}> input category and resolved relative path.
+     */
+    public function inBoundsNonCanonicalCategoryProvider(): array
+    {
+        return [
+            'double slash' => ['app//error', 'app//error'],
+            'embedded current-dir segment' => ['app/./db', 'app/./db'],
+            'leading current-dir segment' => ['./config', './config'],
         ];
     }
 
@@ -139,6 +152,26 @@ final class PhpMessageSourceTest extends TestCase
             $expected,
             $source->exposeMessageFilePath($category, 'en'),
             'Non-traversal category must resolve under basePath.',
+        );
+    }
+
+    /**
+     * @dataProvider inBoundsNonCanonicalCategoryProvider
+     */
+    public function testReturnExpectedPathForInBoundsNonCanonicalCategory(string $category, string $expectedRelative): void
+    {
+        $source = new ExposedPhpMessageSource(
+            [
+                'basePath' => '@yiiunit/data/i18n/messages',
+            ],
+        );
+
+        $expected = Yii::getAlias('@yiiunit/data/i18n/messages') . '/en/' . $expectedRelative . '.php';
+
+        $this->assertSame(
+            $expected,
+            $source->exposeMessageFilePath($category, 'en'),
+            'Non-canonical in-bounds category must be accepted.',
         );
     }
 

--- a/tests/framework/i18n/PhpMessageSourceTest.php
+++ b/tests/framework/i18n/PhpMessageSourceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
+namespace yiiunit\framework\i18n;
+
+use Yii;
+use yii\base\InvalidArgumentException;
+use yiiunit\framework\i18n\stubs\ExposedPhpMessageSource;
+use yiiunit\TestCase;
+
+/**
+ * Unit tests for {@see \yii\i18n\PhpMessageSource} category path-traversal hardening.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 2.0.56
+ * @group i18n
+ */
+final class PhpMessageSourceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockApplication();
+    }
+
+    /**
+     * Provides categories that resolve outside [[PhpMessageSource::basePath]] and must be rejected.
+     *
+     * @return array<string, array{string}> traversal, absolute, and stream-wrapper category inputs.
+     */
+    public function unsafeCategoryProvider(): array
+    {
+        return [
+            'parent traversal' => ['../../etc/passwd'],
+            'leading traversal segment' => ['../secret'],
+            'embedded traversal segment' => ['app/../../config/db'],
+            'current-dir segment' => ['app/./db'],
+            'absolute unix path' => ['/etc/passwd'],
+            'windows absolute path' => ['C:\\Windows\\system32'],
+            'php stream wrapper' => ['php://filter/resource=config/db'],
+            'phar stream wrapper' => ['phar://archive.phar/config'],
+        ];
+    }
+
+    /**
+     * Provides valid categories paired with their expected `basePath`-relative file name.
+     *
+     * @return array<string, array{string, string}> input category and resolved relative path.
+     */
+    public function safeCategoryProvider(): array
+    {
+        return [
+            'simple' => ['app', 'app'],
+            'slash namespace' => ['app/error', 'app/error'],
+            'backslash namespace' => ['modules\\users\\validation', 'modules/users/validation'],
+            'dashes and dots' => ['app-name/sub.module', 'app-name/sub.module'],
+        ];
+    }
+
+    /**
+     * @dataProvider unsafeCategoryProvider
+     */
+    public function testThrowInvalidArgumentExceptionForUnsafeCategory(string $category): void
+    {
+        $source = new ExposedPhpMessageSource(['basePath' => '@yiiunit/data/i18n/messages']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid message category:');
+
+        $source->exposeMessageFilePath($category, 'en');
+    }
+
+    /**
+     * @dataProvider safeCategoryProvider
+     */
+    public function testReturnExpectedPathForSafeCategory(string $category, string $expectedRelative): void
+    {
+        $source = new ExposedPhpMessageSource(
+            [
+                'basePath' => '@yiiunit/data/i18n/messages',
+            ],
+        );
+
+        $expected = Yii::getAlias('@yiiunit/data/i18n/messages') . '/en/' . $expectedRelative . '.php';
+
+        $this->assertSame(
+            $expected,
+            $source->exposeMessageFilePath($category, 'en'),
+            'Namespace separators must be preserved under basePath.',
+        );
+    }
+
+    public function testReturnFileMapPathForMappedCategory(): void
+    {
+        $source = new ExposedPhpMessageSource(
+            [
+                'basePath' => '@yiiunit/data/i18n/messages',
+                'fileMap' => ['weird/../category' => 'safe.php'],
+            ],
+        );
+
+        $expected = Yii::getAlias('@yiiunit/data/i18n/messages') . '/en/safe.php';
+
+        $this->assertSame(
+            $expected,
+            $source->exposeMessageFilePath('weird/../category', 'en'),
+            'fileMap entry must bypass category validation.',
+        );
+    }
+}

--- a/tests/framework/i18n/stubs/ExposedPhpMessageSource.php
+++ b/tests/framework/i18n/stubs/ExposedPhpMessageSource.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\i18n\stubs;
+
+use yii\i18n\PhpMessageSource;
+
+/**
+ * Test double exposing the protected {@see PhpMessageSource::getMessageFilePath()} for direct assertions.
+ */
+class ExposedPhpMessageSource extends PhpMessageSource
+{
+    public function exposeMessageFilePath($category, $language): string
+    {
+        return $this->getMessageFilePath($category, $language);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20890 
