### PR TITLE
Fix #19785: Reset only changed-key relations on `refresh()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Bug #20896: Reset only relations whose foreign key changed on `yii\db\BaseActiveRecord::refresh()` instead of all (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -51,6 +51,14 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to follow the instructions
 for both A and B.
 
+Upgrade from Yii 2.0.55
+-----------------------
+
+* `yii\db\BaseActiveRecord::refresh()` now keeps already loaded relations whose foreign keys did not
+  change instead of resetting all of them. If your code relied on `refresh()` reloading related
+  records, unset the relation explicitly (e.g. `unset($model->relationName)`) to force a reload.
+
+
 Upgrade from Yii 2.0.53
 -----------------------
 

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1088,11 +1088,17 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
             return false;
         }
         foreach ($this->attributes() as $name) {
-            $this->_attributes[$name] = isset($record->_attributes[$name]) ? $record->_attributes[$name] : null;
+            $value = isset($record->_attributes[$name]) ? $record->_attributes[$name] : null;
+            // https://github.com/yiisoft/yii2/issues/19785
+            if (
+                !empty($this->_relationsDependencies[$name])
+                && (!array_key_exists($name, $this->_attributes) || $this->_attributes[$name] !== $value)
+            ) {
+                $this->resetDependentRelations($name);
+            }
+            $this->_attributes[$name] = $value;
         }
         $this->_oldAttributes = $record->_oldAttributes;
-        $this->_related = [];
-        $this->_relationsDependencies = [];
         $this->afterRefresh();
 
         return true;

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1098,6 +1098,17 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
             }
             $this->_attributes[$name] = $value;
         }
+        $trackedRelations = [];
+        foreach ($this->_relationsDependencies as $relationNames) {
+            foreach ($relationNames as $relationName) {
+                $trackedRelations[$relationName] = true;
+            }
+        }
+        foreach (array_keys($this->_related) as $name) {
+            if (!isset($trackedRelations[$name])) {
+                unset($this->_related[$name]);
+            }
+        }
         $this->_oldAttributes = $record->_oldAttributes;
         $this->afterRefresh();
 

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -1088,7 +1088,7 @@ abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
             return false;
         }
         foreach ($this->attributes() as $name) {
-            $value = isset($record->_attributes[$name]) ? $record->_attributes[$name] : null;
+            $value = array_key_exists($name, $record->_attributes) ? $record->_attributes[$name] : null;
             // https://github.com/yiisoft/yii2/issues/19785
             if (
                 !empty($this->_relationsDependencies[$name])

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1141,6 +1141,30 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals(1, $orderItem->item->id);
     }
 
+    public function testRefreshKeepsRelationWithUnchangedForeignKey(): void
+    {
+        $customer = Customer::findOne(1);
+        $profile = $customer->profile;
+        $this->assertTrue($customer->isRelationPopulated('profile'));
+
+        $this->assertTrue($customer->refresh());
+
+        $this->assertTrue($customer->isRelationPopulated('profile'));
+        $this->assertSame($profile, $customer->profile);
+    }
+
+    public function testRefreshResetsRelationWithChangedForeignKey(): void
+    {
+        $customer = Customer::findOne(1);
+        $this->assertEquals(1, $customer->profile->id);
+
+        Customer::updateAll(['profile_id' => 2], ['id' => 1]);
+        $this->assertTrue($customer->refresh());
+
+        $this->assertFalse($customer->isRelationPopulated('profile'));
+        $this->assertEquals(2, $customer->profile->id);
+    }
+
     public function testOutdatedCompositeKeyRelationsAreReset(): void
     {
         $dossier = Dossier::findOne([

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1165,6 +1165,18 @@ abstract class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals(2, $customer->profile->id);
     }
 
+    public function testRefreshResetsEagerlyLoadedRelation(): void
+    {
+        $customer = Customer::find()->where(['id' => 1])->with('profile')->one();
+        $this->assertTrue($customer->isRelationPopulated('profile'));
+
+        Customer::updateAll(['profile_id' => 2], ['id' => 1]);
+        $this->assertTrue($customer->refresh());
+
+        $this->assertFalse($customer->isRelationPopulated('profile'));
+        $this->assertEquals(2, $customer->profile->id);
+    }
+
     public function testOutdatedCompositeKeyRelationsAreReset(): void
     {
         $dossier = Dossier::findOne([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #19785

## What does this PR do?

`ActiveRecord::refresh()` no longer drops every loaded relation. It now resets only the relations whose foreign key actually changed during the refresh, matching the behavior documented for #13618 (relations are reset when the corresponding key fields change).

`refreshInternal()` cleared `$_related` and `$_relationsDependencies` unconditionally, so a relation loaded before `refresh()` was always unset, even when its foreign key was unchanged. Using it again ran another query for data that was already in memory. The fix mirrors the logic already used in `__set()`: while copying the freshly fetched attributes, a relation is reset only when its dependent foreign key value differs from the previous one.

This changes observable behavior: code that relied on `refresh()` reloading related records now keeps the cached relation when its foreign key is unchanged. The change is documented in `UPGRADE.md`.
