### PR TITLE
Fix #18952: Export arrow functions in `VarDumper::export()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Bug #20897: Support arrow functions in `yii\helpers\BaseVarDumper::export()` (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/helpers/BaseVarDumper.php
+++ b/framework/helpers/BaseVarDumper.php
@@ -251,21 +251,28 @@ class BaseVarDumper
         $closureTokens = [];
         $pendingParenthesisCount = 0;
         foreach ($tokens as $token) {
-            if (isset($token[0]) && $token[0] === T_FUNCTION) {
+            if (isset($token[0]) && in_array($token[0], [T_FUNCTION, T_FN], true)) {
                 $closureTokens[] = $token[1];
                 continue;
             }
-            if ($closureTokens !== []) {
-                $closureTokens[] = isset($token[1]) ? $token[1] : $token;
-                if ($token === '}') {
-                    $pendingParenthesisCount--;
+            if ($closureTokens === []) {
+                continue;
+            }
+            if (is_string($token)) {
+                if ($token === '{' || $token === '[' || $token === '(') {
+                    $pendingParenthesisCount++;
+                } elseif ($token === '}' || $token === ']' || $token === ')') {
                     if ($pendingParenthesisCount === 0) {
                         break;
                     }
-                } elseif ($token === '{') {
-                    $pendingParenthesisCount++;
+                    $pendingParenthesisCount--;
+                } elseif ($token === ',' || $token === ';') {
+                    if ($pendingParenthesisCount === 0) {
+                        break;
+                    }
                 }
             }
+            $closureTokens[] = isset($token[1]) ? $token[1] : $token;
         }
 
         return implode('', $closureTokens);

--- a/tests/framework/helpers/VarDumperTest.php
+++ b/tests/framework/helpers/VarDumperTest.php
@@ -159,6 +159,15 @@ RESULT;
         }';
         $data[] = [$var, $expectedResult];
 
+        $var = fn () => 2;
+        $data[] = [$var, 'fn () => 2'];
+
+        $var = fn ($x) => $x + 10;
+        $data[] = [$var, 'fn ($x) => $x + 10'];
+
+        $var = fn ($a, $b) => ($a + $b) * 2;
+        $data[] = [$var, 'fn ($a, $b) => ($a + $b) * 2'];
+
         return $data;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #18952

## What does this PR do?

`VarDumper::export()` now exports arrow functions instead of producing broken output for them.

`exportClosure()` only began capturing at a `T_FUNCTION` token and tracked `{}` braces to find the end. An arrow function starts with `T_FN` and has no braces, so it was never captured. The token loop now also starts at `T_FN` and tracks parenthesis/bracket depth, ending the arrow function at the enclosing `,`, `;` or closing bracket. Regular closures are captured exactly as before.
