### PR TITLE
Fix #18191: Read tag timestamps once per request when reusable

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Bug #20898: Honor the `reusable` flag in `yii\caching\TagDependency` so tag timestamps are read once per request (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/caching/TagDependency.php
+++ b/framework/caching/TagDependency.php
@@ -34,6 +34,12 @@ class TagDependency extends Dependency
      */
     public $tags = [];
 
+    /**
+     * @var array tag timestamps cached within the current request for reusable dependencies, indexed by cache key.
+     * @see $reusable
+     */
+    private static $_reusableTimestamps = [];
+
 
     /**
      * Generates the data needed to determine if dependency has been changed.
@@ -95,6 +101,11 @@ class TagDependency extends Dependency
             $items[$key] = $time;
         }
         $cache->multiSet($items);
+        foreach ($items as $key => $value) {
+            if (array_key_exists($key, self::$_reusableTimestamps)) {
+                self::$_reusableTimestamps[$key] = $value;
+            }
+        }
         return $items;
     }
 
@@ -115,6 +126,31 @@ class TagDependency extends Dependency
             $keys[] = $cache->buildKey([__CLASS__, $tag]);
         }
 
-        return $cache->multiGet($keys);
+        if (!$this->reusable) {
+            return $cache->multiGet($keys);
+        }
+
+        $missingKeys = array_diff($keys, array_keys(self::$_reusableTimestamps));
+        if (!empty($missingKeys)) {
+            foreach ($cache->multiGet($missingKeys) as $key => $value) {
+                self::$_reusableTimestamps[$key] = $value;
+            }
+        }
+
+        $timestamps = [];
+        foreach ($keys as $key) {
+            $timestamps[$key] = self::$_reusableTimestamps[$key];
+        }
+
+        return $timestamps;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function resetReusableData()
+    {
+        self::$_reusableTimestamps = [];
+        parent::resetReusableData();
     }
 }

--- a/tests/framework/caching/TagDependencyTest.php
+++ b/tests/framework/caching/TagDependencyTest.php
@@ -8,6 +8,7 @@
 
 namespace yiiunit\framework\caching;
 
+use yii\caching\ArrayCache;
 use yii\caching\FileCache;
 use yii\caching\TagDependency;
 use yiiunit\TestCase;
@@ -17,6 +18,25 @@ use yiiunit\TestCase;
  */
 class TagDependencyTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        TagDependency::resetReusableData();
+    }
+
+    private function createCountingCache()
+    {
+        return new class extends ArrayCache {
+            public $readKeys = [];
+
+            protected function getValue($key)
+            {
+                $this->readKeys[] = $key;
+                return parent::getValue($key);
+            }
+        };
+    }
+
     public function testInvalidate(): void
     {
         $cache = new FileCache(['cachePath' => '@yiiunit/runtime/cache']);
@@ -82,5 +102,44 @@ class TagDependencyTest extends TestCase
         $this->assertFalse($cache->get('a2'));
         $this->assertFalse($cache->get('b1'));
         $this->assertFalse($cache->get('b2'));
+    }
+
+    public function testReusableTagTimestampIsFetchedOncePerRequest(): void
+    {
+        $cache = $this->createCountingCache();
+        $dependency = new TagDependency(['tags' => 't1', 'reusable' => true]);
+        $dependency->evaluateDependency($cache);
+
+        TagDependency::resetReusableData();
+        $cache->readKeys = [];
+        $dependency->isChanged($cache);
+        $dependency->isChanged($cache);
+
+        $this->assertCount(1, $cache->readKeys);
+    }
+
+    public function testNonReusableTagTimestampIsFetchedEachTime(): void
+    {
+        $cache = $this->createCountingCache();
+        $dependency = new TagDependency(['tags' => 't1']);
+        $dependency->evaluateDependency($cache);
+
+        $cache->readKeys = [];
+        $dependency->isChanged($cache);
+        $dependency->isChanged($cache);
+
+        $this->assertCount(2, $cache->readKeys);
+    }
+
+    public function testReusableDependencyDetectsInvalidationWithinRequest(): void
+    {
+        $cache = new ArrayCache();
+        $cache->set('a', 'value', 0, new TagDependency(['tags' => 't1', 'reusable' => true]));
+
+        $this->assertSame('value', $cache->get('a'));
+
+        TagDependency::invalidate($cache, 't1');
+
+        $this->assertFalse($cache->get('a'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #18191

## What does this PR do?

`TagDependency` ignored the inherited `reusable` flag: its `isChanged()` override and `generateDependencyData()` both call `getTimestamps()`, which queried the cache backend on every call. So even with `reusable => true`, reusing one dependency for many cache reads in a single request hit the backend each time.

`getTimestamps()` now caches the fetched tag timestamps per request in a static property when `reusable` is set, so each tag is read from the backend only once. `touchKeys()` refreshes that cache for keys it writes, so an `invalidate()` in the same request is still detected. `resetReusableData()` clears it alongside the base data.

With `reusable => false` (the default) the method still queries the backend on every call, so existing behavior is unchanged.
