### PR TITLE
Fix #11582: Add isValid() to Pagination and Sort

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Enh #20899: Add `isValid()` to `yii\data\Pagination` and `yii\data\Sort` to detect an out-of-range page or an undeclared sort attribute (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/data/Pagination.php
+++ b/framework/data/Pagination.php
@@ -203,6 +203,37 @@ class Pagination extends BaseObject implements Linkable
     }
 
     /**
+     * Returns whether the currently requested page is within the valid range.
+     *
+     * The page number is read from [[pageParam]] in [[params]] the same way as [[getPage()]], but it is
+     * not clamped to the available range. Use this to detect an out-of-range page and react explicitly,
+     * for example by responding with a 404 instead of silently falling back to the first or last page.
+     *
+     * The valid range is derived from [[pageCount]], so [[totalCount]] must be set correctly. When there
+     * are no items the first page is still considered valid. If [[validatePage]] is `false` the page is
+     * not range-checked and this method always returns `true`.
+     *
+     * @return bool whether the requested page is within the valid range.
+     * @since 2.0.56
+     */
+    public function isValid()
+    {
+        if (!$this->validatePage) {
+            return true;
+        }
+        $page = (int) $this->getQueryParam($this->pageParam, 1) - 1;
+        if ($page < 0) {
+            return false;
+        }
+        $pageCount = $this->getPageCount();
+        if ($pageCount === 0) {
+            return $page === 0;
+        }
+
+        return $page < $pageCount;
+    }
+
+    /**
      * Returns the number of items per page.
      * By default, this method will try to determine the page size by [[pageSizeParam]] in [[params]].
      * If the page size cannot be determined this way, [[defaultPageSize]] will be returned.

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -296,6 +296,49 @@ class Sort extends BaseObject
     }
 
     /**
+     * Returns whether the currently requested sort order is valid.
+     *
+     * The sort order is read from [[sortParam]] in [[params]] the same way as [[getAttributeOrders()]].
+     * The request is considered invalid when it references an attribute that is not listed in [[attributes]],
+     * or when more than one attribute is requested while [[enableMultiSort]] is `false`. When no sort is
+     * requested the order is considered valid, so that the [[defaultOrder]] can take over.
+     *
+     * Use this to detect a tampered or stale sort parameter and react explicitly, for example by responding
+     * with a 404 instead of silently dropping the unknown attributes.
+     *
+     * @return bool whether the requested sort order is valid.
+     * @since 2.0.56
+     */
+    public function isValid()
+    {
+        if (($params = $this->params) === null) {
+            $request = Yii::$app->getRequest();
+            $params = $request instanceof Request ? $request->getQueryParams() : [];
+        }
+        if (!isset($params[$this->sortParam])) {
+            return true;
+        }
+        $attributes = [];
+        foreach ($this->parseSortParam($params[$this->sortParam]) as $attribute) {
+            if (strncmp($attribute, '-', 1) === 0) {
+                $attribute = substr($attribute, 1);
+            }
+            if ($attribute === '') {
+                continue;
+            }
+            if (!isset($this->attributes[$attribute])) {
+                return false;
+            }
+            $attributes[] = $attribute;
+            if (!$this->enableMultiSort && count($attributes) > 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Parses the value of [[sortParam]] into an array of sort attributes.
      *
      * The format must be the attribute name only for ascending

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -265,10 +265,7 @@ class Sort extends BaseObject
     {
         if ($this->_attributeOrders === null || $recalculate) {
             $this->_attributeOrders = [];
-            if (($params = $this->params) === null) {
-                $request = Yii::$app->getRequest();
-                $params = $request instanceof Request ? $request->getQueryParams() : [];
-            }
+            $params = $this->resolveParams();
             if (isset($params[$this->sortParam])) {
                 foreach ($this->parseSortParam($params[$this->sortParam]) as $attribute) {
                     $descending = false;
@@ -296,6 +293,20 @@ class Sort extends BaseObject
     }
 
     /**
+     * Resolves the request parameters that carry the current sort information.
+     * @return array the parameters from [[params]], or the current request query parameters when [[params]] is not set.
+     */
+    private function resolveParams()
+    {
+        if ($this->params !== null) {
+            return $this->params;
+        }
+        $request = Yii::$app->getRequest();
+
+        return $request instanceof Request ? $request->getQueryParams() : [];
+    }
+
+    /**
      * Returns whether the currently requested sort order is valid.
      *
      * The sort order is read from [[sortParam]] in [[params]] the same way as [[getAttributeOrders()]].
@@ -311,10 +322,7 @@ class Sort extends BaseObject
      */
     public function isValid()
     {
-        if (($params = $this->params) === null) {
-            $request = Yii::$app->getRequest();
-            $params = $request instanceof Request ? $request->getQueryParams() : [];
-        }
+        $params = $this->resolveParams();
         if (!isset($params[$this->sortParam])) {
             return true;
         }
@@ -466,10 +474,7 @@ class Sort extends BaseObject
      */
     public function createUrl($attribute, $absolute = false)
     {
-        if (($params = $this->params) === null) {
-            $request = Yii::$app->getRequest();
-            $params = $request instanceof Request ? $request->getQueryParams() : [];
-        }
+        $params = $this->resolveParams();
         $params[$this->sortParam] = $this->createSortParam($attribute);
         $params[0] = $this->route === null ? Yii::$app->controller->getRoute() : $this->route;
         $urlManager = $this->urlManager === null ? Yii::$app->getUrlManager() : $this->urlManager;

--- a/tests/framework/data/PaginationTest.php
+++ b/tests/framework/data/PaginationTest.php
@@ -116,6 +116,42 @@ class PaginationTest extends TestCase
         $this->assertEquals(999, $pagination->getPage());
     }
 
+    public static function dataProviderIsValid(): array
+    {
+        return [
+            [['page' => '1'], 100, 10, true, true],
+            [['page' => '10'], 100, 10, true, true],
+            [['page' => '11'], 100, 10, true, false],
+            [['page' => '0'], 100, 10, true, false],
+            [['page' => '-5'], 100, 10, true, false],
+            [[], 100, 10, true, true],
+            [['page' => '1'], 0, 10, true, true],
+            [['page' => '2'], 0, 10, true, false],
+            [['page' => '999'], 100, 10, false, true],
+            [['page' => 'abc'], 100, 10, true, false],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderIsValid
+     *
+     * @param array $params
+     * @param int $totalCount
+     * @param int $pageSize
+     * @param bool $validatePage
+     * @param bool $expected
+     */
+    public function testIsValid($params, $totalCount, $pageSize, $validatePage, $expected): void
+    {
+        $pagination = new Pagination();
+        $pagination->validatePage = $validatePage;
+        $pagination->pageSize = $pageSize;
+        $pagination->totalCount = $totalCount;
+        $pagination->params = $params;
+
+        $this->assertSame($expected, $pagination->isValid());
+    }
+
     public static function dataProviderPageCount(): array
     {
         return [

--- a/tests/framework/data/SortTest.php
+++ b/tests/framework/data/SortTest.php
@@ -8,6 +8,7 @@
 
 namespace yiiunit\framework\data;
 
+use Yii;
 use yii\data\Sort;
 use yii\web\UrlManager;
 use yiiunit\TestCase;
@@ -379,6 +380,50 @@ class SortTest extends TestCase
         $orders = $sort->getOrders(true);
         $this->assertEquals(1, count($orders));
         $this->assertEquals('[[last_name]] ASC NULLS FIRST', $orders[0]);
+    }
+
+    public static function dataProviderIsValid(): array
+    {
+        return [
+            [false, ['sort' => 'age'], true],
+            [false, ['sort' => '-name'], true],
+            [true, ['sort' => 'age,-name'], true],
+            [false, ['sort' => 'age,-name'], false],
+            [false, ['sort' => 'unknown'], false],
+            [true, ['sort' => 'age,unknown'], false],
+            [false, [], true],
+            [false, ['sort' => ''], true],
+            [false, ['sort' => 'age,age'], false],
+            [true, ['sort' => ','], true],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderIsValid
+     *
+     * @param bool $enableMultiSort
+     * @param array $params
+     * @param bool $expected
+     */
+    public function testIsValid($enableMultiSort, $params, $expected): void
+    {
+        $sort = new Sort([
+            'attributes' => ['age', 'name'],
+            'enableMultiSort' => $enableMultiSort,
+            'params' => $params,
+        ]);
+
+        $this->assertSame($expected, $sort->isValid());
+    }
+
+    public function testIsValidReadsRequestWhenParamsNotSet(): void
+    {
+        $this->mockWebApplication();
+        Yii::$app->getRequest()->setQueryParams(['sort' => 'unknown']);
+
+        $sort = new Sort(['attributes' => ['age', 'name']]);
+
+        $this->assertFalse($sort->isValid());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #11582

## What does this PR do?

Adds `Pagination::isValid()` and `Sort::isValid()` so an application can detect an out-of-range page or a sort parameter referencing undeclared attributes and react explicitly (for example, respond with a 404) instead of silently falling back to the first/last page or dropping unknown attributes.

This is the additive approach suggested by @klimov-paul in the issue: rather than changing the default fallback behavior (a BC break), expose a check and let the application decide. Both methods are read-only, do not mutate cached state, and leave existing behavior untouched.

`Pagination::isValid()` reads the requested page the same way as `getPage()` but without clamping, and reports whether it is within `[1 .. pageCount]`. When there are no items the first page stays valid. With `validatePage = false` it returns `true`, matching the documented "range is not checked" contract.

`Sort::isValid()` reads `sortParam` the same way as `getAttributeOrders()` and returns `false` when a requested attribute is not declared in `attributes`, or when more than one attribute is requested while `enableMultiSort` is `false`.
