### PR TITLE
Fix #19468: Split `SELECT` columns on top-level commas only

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Bug #20900: Split `SELECT` columns on top-level commas in `Query::normalizeSelect()` so commas inside expressions like `COALESCE()` keep the column intact (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -685,7 +685,7 @@ PATTERN;
         if ($columns instanceof ExpressionInterface) {
             $columns = [$columns];
         } elseif (!is_array($columns)) {
-            $columns = preg_split('/\s*,\s*/', trim((string)$columns), -1, PREG_SPLIT_NO_EMPTY);
+            $columns = $this->splitColumnsIntoParts((string)$columns);
         }
         $select = [];
         foreach ($columns as $columnAlias => $columnDefinition) {
@@ -714,6 +714,46 @@ PATTERN;
             $select[] = $columnDefinition;
         }
         return $select;
+    }
+
+    /**
+     * Splits a comma-separated list of columns into individual definitions.
+     *
+     * Commas enclosed in parentheses are ignored, so DB expressions such as `COALESCE(a, b)` are kept
+     * intact instead of being split on their inner commas. Nested parentheses are handled as well.
+     *
+     * @param string $columns the comma-separated columns.
+     * @return string[] the column definitions with surrounding whitespace trimmed and empty parts removed.
+     * @since 2.0.56
+     */
+    private function splitColumnsIntoParts($columns)
+    {
+        $parts = [];
+        $part = '';
+        $depth = 0;
+        $length = strlen($columns);
+        for ($i = 0; $i < $length; $i++) {
+            $char = $columns[$i];
+            if ($char === '(') {
+                $depth++;
+            } elseif ($char === ')') {
+                if ($depth > 0) {
+                    $depth--;
+                }
+            } elseif ($char === ',' && $depth === 0) {
+                if (trim($part) !== '') {
+                    $parts[] = trim($part);
+                }
+                $part = '';
+                continue;
+            }
+            $part .= $char;
+        }
+        if (trim($part) !== '') {
+            $parts[] = trim($part);
+        }
+
+        return $parts;
     }
 
     /**

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -107,6 +107,27 @@ abstract class QueryTest extends DatabaseTestCase
         $this->assertEquals(['DISTINCT ON(tour_dates.date_from) tour_dates.date_from', 'tour_dates.id' => 'tour_dates.id'], $query->select);
     }
 
+    public static function dataProviderSelectExpressionWithCommaInParentheses(): array
+    {
+        return [
+            ['p.id, COALESCE(p.id, 0)', ['p.id' => 'p.id', 'COALESCE(p.id, 0)']],
+            ['a, COALESCE(IF(1, 2, 3), IF(4, 5, 6))', ['a' => 'a', 'COALESCE(IF(1, 2, 3), IF(4, 5, 6))']],
+            ['name, SUM(votes) AS total', ['name' => 'name', 'total' => 'SUM(votes)']],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderSelectExpressionWithCommaInParentheses
+     * @see https://github.com/yiisoft/yii2/issues/19468
+     *
+     * @param string $columns
+     * @param array $expected
+     */
+    public function testSelectExpressionWithCommaInParentheses($columns, $expected): void
+    {
+        $this->assertSame($expected, (new Query())->select($columns)->select);
+    }
+
     public function testFrom(): void
     {
         $query = new Query();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #19468

## What does this PR do?

Makes `Query::normalizeSelect()` split a string column list only on top-level commas, so a comma inside a parenthesised expression like `COALESCE(p.id, 0)` is no longer treated as a column separator and mis-quoted.

For example, `select('p.id, COALESCE(p.id, 0)')` used to build:

```sql
SELECT `p`.`id`, COALESCE(`p`.`id`, `0)`
```

The inner comma split the expression, so `0)` became its own quoted column. The split now tracks parenthesis depth (nested parentheses included), which is the paren-aware approach @samdark approved in the issue. The regex he initially blessed breaks on nested calls like `COALESCE(IF(1,2,3), IF(4,5,6))`, so depth counting is used instead.

Only string input to `select()`/`addSelect()` is affected, and only column strings that contain a parenthesised comma, which already produced broken SQL. Array-form columns and plain `'id, name'` lists are unchanged, so existing behavior holds.
