### PR TITLE
Fix #19657: Stop treating an array as empty in `StringValidator`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Bug #20901: Stop treating an array as empty in `yii\validators\StringValidator` so an array assigned to a string attribute is reported as invalid instead of being saved as `"Array"` (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -51,6 +51,15 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to follow the instructions
 for both A and B.
 
+Upgrade from Yii 2.0.55
+-----------------------
+
+* `yii\validators\StringValidator` no longer treats an array as an empty value. Previously, assigning an array to a
+  string attribute while `skipOnEmpty` was enabled skipped validation, and the array could reach the database as the
+  literal string `"Array"`. Such a value is now reported as invalid (`{attribute} must be a string.`). If you relied on
+  the old behavior, pass a custom `isEmpty` callback to the validator.
+
+
 Upgrade from Yii 2.0.53
 -----------------------
 

--- a/framework/validators/StringValidator.php
+++ b/framework/validators/StringValidator.php
@@ -108,6 +108,24 @@ class StringValidator extends Validator
 
     /**
      * {@inheritdoc}
+     *
+     * Unlike the base implementation, an array is not treated as empty. This way an array assigned to a
+     * string attribute is reported as invalid instead of being skipped when [[skipOnEmpty]] is enabled and
+     * later cast to the literal string `"Array"`.
+     *
+     * @since 2.0.56
+     */
+    public function isEmpty($value)
+    {
+        if ($this->isEmpty !== null) {
+            return call_user_func($this->isEmpty, $value);
+        }
+
+        return $value === null || $value === '';
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function validateAttribute($model, $attribute)
     {

--- a/tests/framework/validators/StringValidatorTest.php
+++ b/tests/framework/validators/StringValidatorTest.php
@@ -111,6 +111,46 @@ class StringValidatorTest extends TestCase
         $this->assertTrue($model->hasErrors('attr_str'));
     }
 
+    public static function dataProviderIsEmpty(): array
+    {
+        return [
+            [null, true],
+            ['', true],
+            ['0', false],
+            [[], false],
+            [['abc'], false],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderIsEmpty
+     *
+     * @param mixed $value
+     * @param bool $expected
+     */
+    public function testIsEmpty($value, $expected): void
+    {
+        $this->assertSame($expected, (new StringValidator())->isEmpty($value));
+    }
+
+    public function testEmptyArrayIsValidatedInsteadOfSkipped(): void
+    {
+        $val = new StringValidator(['attributes' => ['attr_string']]);
+        $model = new FakedValidationModel();
+        $model->attr_string = [];
+        $val->validateAttributes($model);
+        $this->assertTrue($model->hasErrors('attr_string'));
+    }
+
+    public function testIsEmptyUsesCustomCallback(): void
+    {
+        $val = new StringValidator(['isEmpty' => static function ($value) {
+            return $value === 'skip';
+        }]);
+        $this->assertTrue($val->isEmpty('skip'));
+        $this->assertFalse($val->isEmpty(''));
+    }
+
     public function testEnsureMessagesOnInit(): void
     {
         $val = new StringValidator(['min' => 1, 'max' => 2]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #19657

## What does this PR do?

Overrides `isEmpty()` in `yii\validators\StringValidator` so an array is no longer treated as an empty value.

Before, `Validator::isEmpty()` reported `[]` as empty, so a `StringValidator` with `skipOnEmpty` enabled skipped an array assigned to a string attribute. Validation never ran, and the array reached the database cast to the literal string `"Array"`. The attribute is now reported as invalid (`{attribute} must be a string.`) instead.

This is the direction @samdark approved in the issue ("in case of arrays in string fields it makes sense"), confirmed by @bizley. The override is scoped to `StringValidator`, so the shared `Validator::isEmpty()` and every other validator keep the current `[]`-is-empty behavior. A custom `isEmpty` callback still takes precedence.

`null` and `''` stay empty, so only an array value changes outcome.

### Breaks BC

A string attribute that received an array with `skipOnEmpty` enabled now fails validation instead of passing silently. Noted in `UPGRADE.md`; the workaround is a custom `isEmpty` callback.
