### PR TITLE
Fix #20902: Honor raw SQL of a `findBySql()` query used as a subquery in a condition

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Bug #20902: Honor raw SQL of a `findBySql()` query used as a subquery in a condition (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/db/QueryExpressionBuilder.php
+++ b/framework/db/QueryExpressionBuilder.php
@@ -30,6 +30,7 @@ class QueryExpressionBuilder implements ExpressionBuilderInterface
      */
     public function build(ExpressionInterface $expression, array &$params = [])
     {
+        // https://github.com/yiisoft/yii2/issues/19771
         if ($expression instanceof ActiveQuery && $expression->sql !== null) {
             $params = array_merge($params, $expression->params ?? []);
             return '(' . $expression->sql . ')';

--- a/framework/db/QueryExpressionBuilder.php
+++ b/framework/db/QueryExpressionBuilder.php
@@ -30,6 +30,11 @@ class QueryExpressionBuilder implements ExpressionBuilderInterface
      */
     public function build(ExpressionInterface $expression, array &$params = [])
     {
+        if ($expression instanceof ActiveQuery && $expression->sql !== null) {
+            $params = array_merge($params, $expression->params ?? []);
+            return '(' . $expression->sql . ')';
+        }
+
         list($sql, $params) = $this->queryBuilder->build($expression, $params);
 
         return "($sql)";

--- a/tests/framework/db/QueryBuilderTest.php
+++ b/tests/framework/db/QueryBuilderTest.php
@@ -28,6 +28,7 @@ use yii\db\Schema;
 use yii\db\SchemaBuilderTrait;
 use yii\db\sqlite\QueryBuilder as SqliteQueryBuilder;
 use yii\helpers\ArrayHelper;
+use yiiunit\data\ar\Customer;
 use yiiunit\data\base\TraversableObject;
 
 abstract class QueryBuilderTest extends DatabaseTestCase
@@ -1336,6 +1337,30 @@ abstract class QueryBuilderTest extends DatabaseTestCase
         list($sql, $params) = $this->getQueryBuilder()->build($query);
         $this->assertEquals('SELECT *' . (empty($expected) ? '' : ' WHERE ' . $this->replaceQuotes($expected)), $sql);
         $this->assertEquals($expectedParams, $params);
+    }
+
+    public function testBuildWhereWithRawSqlSubQuery(): void
+    {
+        $subQuery = Customer::findBySql('SELECT id FROM customer WHERE status = 2');
+        $query = (new Query())->from('customer')->where(['id' => $subQuery]);
+        list($sql, $params) = $this->getQueryBuilder()->build($query);
+        $this->assertSame(
+            $this->replaceQuotes('SELECT * FROM [[customer]] WHERE [[id]] IN (SELECT id FROM customer WHERE status = 2)'),
+            $sql
+        );
+        $this->assertSame([], $params);
+    }
+
+    public function testBuildWhereWithRawSqlSubQueryAndParams(): void
+    {
+        $subQuery = Customer::findBySql('SELECT id FROM customer WHERE status = :status', [':status' => 2]);
+        $query = (new Query())->from('customer')->where(['type' => 1])->andWhere(['id' => $subQuery]);
+        list($sql, $params) = $this->getQueryBuilder()->build($query);
+        $this->assertSame(
+            $this->replaceQuotes('SELECT * FROM [[customer]] WHERE ([[type]]=:qp0) AND ([[id]] IN (SELECT id FROM customer WHERE status = :status))'),
+            $sql
+        );
+        $this->assertSame([':qp0' => 1, ':status' => 2], $params);
     }
 
     public static function primaryKeysProvider(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #19771

## What does this PR do?

A query built with `findBySql()` used as a subquery in a condition was rebuilt from its parts instead of using its raw SQL:

```php
$sub = Customer::findBySql('SELECT id FROM customer WHERE status = 2');
Customer::find()->where(['id' => $sub])->count();
// was:  ... WHERE `id` IN (SELECT * FROM `customer`)
// now:  ... WHERE `id` IN (SELECT id FROM customer WHERE status = 2)
```

`QueryExpressionBuilder::build()` now returns the query's raw SQL when an `ActiveQuery` has it set, covering all drivers in one place (the per-driver `build()` overrides are left untouched).
