### PR TITLE
Fix `yii\helpers\Url::current()` and `yii\helpers\Url::canonical()` to fall back to `Application::$requestedRoute` when no controller is active, supporting standalone actions.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -72,6 +72,7 @@ Yii Framework 2 Change Log
 - Chg: Drop dead SQL Server `< 2017` branches from MSSQL `Schema::loadColumnSchema()` (terabytesoftw)
 - Chg: Drop dead SQL Server `< 2005` branches from MSSQL `Schema::insert()` (terabytesoftw)
 - Bug: Fix `Sort::createUrl()` and `Pagination::createUrl()` to fall back when no controller is active, supporting standalone actions discovered through `Module::$actionNamespace` (terabytesoftw)
+- Bug: Fix `yii\helpers\Url::current()` and `yii\helpers\Url::canonical()` to fall back to `Application::$requestedRoute` when no controller is active, supporting standalone actions (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -471,16 +471,28 @@ extension points (`removeItemSoftCascade()`, `removeItemManualCascade()`, `updat
 `updateRuleManualCascade()`, `removeRuleManualCascade()`, `removeAllRulesManualCascade()`) are available for finer
 overrides.
 
-### Standalone action dispatch incidental BC
+### Standalone actions
 
-Alongside the new standalone-action dispatch (additive feature), two incidental changes can break code that relied on
-prior behavior:
+Standalone-action dispatch (`Module::$actionMap`, `Module::$actionNamespace`, and `yii\web\Action`) is an additive
+feature. The notes below cover the incidental BC it introduces and a resolution-scope caveat to be aware of.
+
+#### Incidental BC
+
+Two incidental changes can break code that relied on prior behavior:
 
 - `yii\base\Action::$controller` is now nullable. Subclass overrides and any code that read `$action->controller`
   unchecked must add a `null` check.
 - `yii\filters\AccessRule::matchController()` accepts `null` and a rule with a non-empty `controllers` constraint
   no longer matches when the action runs standalone. To preserve the previous behavior of always matching, leave
   `controllers` empty on the rule.
+
+#### `actionMap` resolution scope
+
+`yii\base\Module::$actionMap` is consulted only by the module whose `runAction()` handles the route (typically the
+application). Unlike `Module::$controllerMap`, it is not resolved recursively across sub-modules during nested-route
+dispatch: `parent.runAction('child/ping')` does not match `child.actionMap['ping']`. To expose a standalone action
+under a sub-module, use convention-based discovery through `yii\base\Module::$actionNamespace` (which is resolved
+recursively), or register the action in the dispatching module's `actionMap`.
 
 ### View no longer assumes jQuery (`View::registerJs()`)
 

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -490,7 +490,7 @@ Two incidental changes can break code that relied on prior behavior:
 
 `yii\base\Module::$actionMap` is consulted only by the module whose `runAction()` handles the route (typically the
 application). Unlike `Module::$controllerMap`, it is not resolved recursively across sub-modules during nested-route
-dispatch: `parent.runAction('child/ping')` does not match `child.actionMap['ping']`. To expose a standalone action
+dispatch: `$parent->runAction('child/ping')` does not match `child.actionMap['ping']`. To expose a standalone action
 under a sub-module, use convention-based discovery through `yii\base\Module::$actionNamespace` (which is resolved
 recursively), or register the action in the dispatching module's `actionMap`.
 

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -110,6 +110,11 @@ class Module extends ServiceLocator
      *
      * Routes whose first segment is not present here fall through to the legacy controller pipeline unchanged.
      *
+     * Resolution scope: this map is consulted only by the module whose {@see runAction()} handles the route (typically
+     * the application). Unlike {@see $controllerMap}, it is NOT resolved recursively across sub-modules during
+     * nested-route dispatch. To expose a standalone action under a sub-module, rely on {@see $actionNamespace} (which
+     * IS resolved recursively), or register the action in the dispatching module's {@see $actionMap}.
+     *
      * @since 22.0
      */
     public array $actionMap = [];

--- a/framework/helpers/BaseUrl.php
+++ b/framework/helpers/BaseUrl.php
@@ -10,6 +10,7 @@ namespace yii\helpers;
 
 use Yii;
 use yii\base\InvalidArgumentException;
+use yii\base\InvalidConfigException;
 
 /**
  * BaseUrl provides concrete implementation for [[Url]].
@@ -337,12 +338,19 @@ class BaseUrl
      * $this->registerLinkTag(['rel' => 'canonical', 'href' => Url::canonical()]);
      * ```
      *
+     * When no controller is active (for example, a standalone action dispatched through
+     * [[\yii\base\Module::$actionMap]] or [[\yii\base\Module::$actionNamespace]]), the route falls back to
+     * [[\yii\base\Application::$requestedRoute]] and no action parameters are appended.
+     *
      * @return string the canonical URL of the currently requested page
      */
     public static function canonical()
     {
-        $params = Yii::$app->controller->actionParams;
-        $params[0] = Yii::$app->controller->getRoute();
+        $controller = Yii::$app->controller;
+
+        $params = $controller !== null ? $controller->actionParams : [];
+
+        $params[0] = static::resolveCurrentRoute();
 
         return static::getUrlManager()->createAbsoluteUrl($params);
     }
@@ -429,9 +437,40 @@ class BaseUrl
     public static function current(array $params = [], $scheme = false)
     {
         $currentParams = Yii::$app->getRequest()->getQueryParams();
-        $currentParams[0] = '/' . Yii::$app->controller->getRoute();
+        $currentParams[0] = '/' . static::resolveCurrentRoute();
         $route = array_replace_recursive($currentParams, $params);
         return static::toRoute($route, $scheme);
+    }
+
+    /**
+     * Resolves the route of the currently requested page.
+     *
+     * Returns the active controller's [[\yii\web\Controller::getRoute()|route]] when a controller is handling the
+     * request. For standalone actions dispatched without a hosting controller (through [[\yii\base\Module::$actionMap]]
+     * or [[\yii\base\Module::$actionNamespace]]), falls back to [[\yii\base\Application::$requestedRoute]].
+     *
+     * @throws InvalidConfigException if no controller is active and [[\yii\base\Application::$requestedRoute]] is
+     * empty.
+     *
+     * @return string Route of the currently requested page, without a leading slash.
+     *
+     * @since 22.0
+     */
+    protected static function resolveCurrentRoute(): string
+    {
+        if (Yii::$app->controller !== null) {
+            return Yii::$app->controller->getRoute();
+        }
+
+        $requestedRoute = Yii::$app->requestedRoute;
+
+        if ($requestedRoute !== null && $requestedRoute !== '') {
+            return $requestedRoute;
+        }
+
+        throw new InvalidConfigException(
+            'Unable to determine the current route: no active controller and "Application::$requestedRoute" is empty.',
+        );
     }
 
     /**

--- a/tests/framework/base/StandaloneActionTest.php
+++ b/tests/framework/base/StandaloneActionTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\base;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\base\ActionEvent;
 use yii\base\Controller;
@@ -20,6 +21,7 @@ use yiiunit\framework\base\stub\standalone\BehaviorAction;
 use yiiunit\framework\base\stub\standalone\CancelingAction;
 use yiiunit\framework\base\stub\standalone\GreetAction;
 use yiiunit\framework\base\stub\standalone\InjectingAction;
+use yiiunit\framework\base\stub\standalone\LifecycleRecordingAction;
 use yiiunit\framework\base\stub\standalone\MethodInjectingAction;
 use yiiunit\framework\base\stub\standalone\NoRunAction;
 use yiiunit\framework\base\stub\standalone\StubController;
@@ -29,15 +31,14 @@ use yiiunit\TestCase;
 /**
  * Unit tests for {@see \yii\base\Action} when invoked standalone (without a hosting controller).
  *
- * Covers the nullable `$controller` contract, module-aware {@see \yii\base\Action::getUniqueId()} fallback,
- * DI-based parameter resolution on `run()` via {@see \yii\di\Container::resolveCallableDependencies()}, the
- * `beforeRun()` cancellation hook, and behavior attachment via the action's own event triggers.
+ * Covers the nullable `$controller` contract, module-aware {@see \yii\base\Action::getUniqueId()} fallback, DI-based
+ * parameter resolution on `run()` via {@see \yii\di\Container::resolveCallableDependencies()}, the  `beforeRun()`
+ * cancellation hook, and behavior attachment via the action's own event triggers.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 22.0
- *
- * @group base
  */
+#[Group('base')]
 final class StandaloneActionTest extends TestCase
 {
     protected function setUp(): void
@@ -184,6 +185,24 @@ final class StandaloneActionTest extends TestCase
             'svc-42',
             $result,
             'Method level DI must combine container service and route params.',
+        );
+    }
+
+    public function testAfterRunFiresAfterStandaloneRun(): void
+    {
+        $action = new LifecycleRecordingAction('lifecycle', null);
+
+        $result = $action->runWithParams([]);
+
+        self::assertSame(
+            'done',
+            $result,
+            'Result must propagate from run.',
+        );
+        self::assertSame(
+            ['before', 'run', 'after'],
+            $action->calls,
+            'Order: beforeRun, run, afterRun.',
         );
     }
 

--- a/tests/framework/base/stub/standalone/LifecycleRecordingAction.php
+++ b/tests/framework/base/stub/standalone/LifecycleRecordingAction.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\base\stub\standalone;
+
+use yii\base\Action;
+
+/**
+ * Action recording the `beforeRun()`, `run()`, and `afterRun()` call order for standalone lifecycle tests.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class LifecycleRecordingAction extends Action
+{
+    /** @var list<string> */
+    public array $calls = [];
+
+    public function run(): string
+    {
+        $this->calls[] = 'run';
+
+        return 'done';
+    }
+
+    protected function beforeRun(): bool
+    {
+        $this->calls[] = 'before';
+
+        return true;
+    }
+
+    protected function afterRun(): void
+    {
+        $this->calls[] = 'after';
+    }
+}

--- a/tests/framework/helpers/UrlTest.php
+++ b/tests/framework/helpers/UrlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,8 +10,10 @@
 
 namespace yiiunit\framework\helpers;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\base\Action;
+use yii\base\InvalidConfigException;
 use yii\base\Module;
 use yii\helpers\Url;
 use yii\web\Controller;
@@ -18,9 +22,9 @@ use yiiunit\framework\filters\stubs\UserIdentity;
 use yiiunit\TestCase;
 
 /**
- * UrlTest.
- * @group helpers
+ * Unit tests for {@see \yii\helpers\Url}.
  */
+#[Group('helpers')]
 class UrlTest extends TestCase
 {
     protected function setUp(): void
@@ -294,6 +298,48 @@ class UrlTest extends TestCase
         $this->mockAction('page', 'view', null, ['id' => 10]);
         $this->assertEquals('http://example.com/base/index.php?r=page%2Fview&id=10', Url::canonical());
         $this->removeMockedAction();
+    }
+
+    public function testCurrentFallsBackToRequestedRouteWhenControllerIsNull(): void
+    {
+        $this->removeMockedAction();
+
+        Yii::$app->requestedRoute = 'page/view';
+
+        Yii::$app->request->setQueryParams(['id' => 10]);
+
+        self::assertSame(
+            '/base/index.php?r=page%2Fview&id=10',
+            Url::current(),
+            '`requestedRoute` must supply the route when no controller is active.',
+        );
+    }
+
+    public function testCanonicalFallsBackToRequestedRouteWhenControllerIsNull(): void
+    {
+        $this->removeMockedAction();
+
+        Yii::$app->requestedRoute = 'page/view';
+
+        self::assertSame(
+            'http://example.com/base/index.php?r=page%2Fview',
+            Url::canonical(),
+            '`requestedRoute` must supply the canonical route when no controller is active.',
+        );
+    }
+
+    public function testThrowInvalidConfigExceptionWhenCurrentRouteCannotBeResolved(): void
+    {
+        $this->removeMockedAction();
+
+        Yii::$app->requestedRoute = null;
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage(
+            'Unable to determine the current route: no active controller and "Application::$requestedRoute" is empty.',
+        );
+
+        Url::current();
     }
 
     public function testIsRelative(): void

--- a/tests/framework/web/WebActionTest.php
+++ b/tests/framework/web/WebActionTest.php
@@ -14,8 +14,15 @@ use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\base\Module;
 use yii\web\BadRequestHttpException;
+use yii\web\MethodNotAllowedHttpException;
+use yii\web\ServerErrorHttpException;
+use yiiunit\framework\base\stub\standalone\ActionTestService;
 use yiiunit\framework\web\stub\standalone\CoerceIntAction;
+use yiiunit\framework\web\stub\standalone\GuardedAction;
 use yiiunit\framework\web\stub\standalone\LegacyConstructorWebAction;
+use yiiunit\framework\web\stub\standalone\ModuleServiceAction;
+use yiiunit\framework\web\stub\standalone\NullableServiceAction;
+use yiiunit\framework\web\stub\standalone\RequiredServiceAction;
 use yiiunit\TestCase;
 
 /**
@@ -135,5 +142,123 @@ final class WebActionTest extends TestCase
             $action->getUniqueId(),
             'Unique ID must combine the module ID and the route segment.',
         );
+    }
+
+    public function testWebActionInjectsNullForUnresolvableNullableService(): void
+    {
+        $action = new NullableServiceAction('optional', null);
+
+        $result = $action->runWithParams([]);
+
+        self::assertSame(
+            'null',
+            $result,
+            "Unresolvable nullable service must inject 'null'.",
+        );
+    }
+
+    public function testThrowServerErrorHttpExceptionWhenStandaloneDependencyIsUnresolvable(): void
+    {
+        $action = new RequiredServiceAction('required', null);
+
+        $this->expectException(ServerErrorHttpException::class);
+        $this->expectExceptionMessage(
+            'Could not load required service: dependency',
+        );
+
+        $action->runWithParams([]);
+    }
+
+    public function testWebActionResolvesServiceViaModuleComponent(): void
+    {
+        $module = new Module('mymod', Yii::$app);
+
+        $module->actionMap = ['svc' => ModuleServiceAction::class];
+
+        $module->set('service', ActionTestService::class);
+
+        $result = $module->runAction('svc');
+
+        self::assertSame(
+            'svc',
+            $result,
+            'Module component must satisfy the typed parameter.',
+        );
+        self::assertStringStartsWith(
+            'Component:',
+            Yii::$app->requestedParams['service'],
+            'Resolution path must be tagged Component.',
+        );
+    }
+
+    public function testWebActionResolvesServiceViaModuleDiDefinition(): void
+    {
+        $module = new Module('mymod', Yii::$app);
+
+        $module->actionMap = ['svc' => ModuleServiceAction::class];
+
+        $module->set(ActionTestService::class, ActionTestService::class);
+
+        $result = $module->runAction('svc');
+
+        self::assertSame(
+            'svc',
+            $result,
+            'Module DI definition must satisfy the typed parameter.',
+        );
+        self::assertStringContainsString(
+            'DI:',
+            Yii::$app->requestedParams['service'],
+            'Resolution path must be tagged as module DI.',
+        );
+    }
+
+    public function testStandaloneActionRunsWhenVerbFilterAllowsMethod(): void
+    {
+        $originalMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        try {
+            $module = new Module('mymod', Yii::$app);
+
+            $module->actionMap = ['guarded' => GuardedAction::class];
+
+            self::assertSame(
+                'ok',
+                $module->runAction('guarded'),
+                'Allowed verb must let the standalone action run.',
+            );
+        } finally {
+            $this->restoreRequestMethod($originalMethod);
+        }
+    }
+
+    public function testThrowMethodNotAllowedHttpExceptionWhenVerbFilterRejectsMethod(): void
+    {
+        $originalMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $module = new Module('mymod', Yii::$app);
+
+        $module->actionMap = ['guarded' => GuardedAction::class];
+
+        try {
+            $this->expectException(MethodNotAllowedHttpException::class);
+
+            $module->runAction('guarded');
+        } finally {
+            $this->restoreRequestMethod($originalMethod);
+        }
+    }
+
+    private function restoreRequestMethod(string|null $method): void
+    {
+        if ($method === null) {
+            unset($_SERVER['REQUEST_METHOD']);
+
+            return;
+        }
+
+        $_SERVER['REQUEST_METHOD'] = $method;
     }
 }

--- a/tests/framework/web/stub/standalone/GuardedAction.php
+++ b/tests/framework/web/stub/standalone/GuardedAction.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\web\stub\standalone;
+
+use yii\filters\VerbFilter;
+use yii\web\Action;
+
+/**
+ * Standalone action guarded by a {@see VerbFilter} behavior, used to test real filters through module dispatch.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class GuardedAction extends Action
+{
+    public function behaviors(): array
+    {
+        return [
+            'verbs' => [
+                'class' => VerbFilter::class,
+                'actions' => ['guarded' => ['POST']],
+            ],
+        ];
+    }
+
+    public function run(): string
+    {
+        return 'ok';
+    }
+}

--- a/tests/framework/web/stub/standalone/ModuleServiceAction.php
+++ b/tests/framework/web/stub/standalone/ModuleServiceAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\web\stub\standalone;
+
+use yii\web\Action;
+use yiiunit\framework\base\stub\standalone\ActionTestService;
+
+/**
+ * Action whose `run()` depends on a typed service, used to test module component and module DI resolution paths.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class ModuleServiceAction extends Action
+{
+    public function run(ActionTestService $service): string
+    {
+        return $service->name();
+    }
+}

--- a/tests/framework/web/stub/standalone/NullableServiceAction.php
+++ b/tests/framework/web/stub/standalone/NullableServiceAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\web\stub\standalone;
+
+use yii\web\Action;
+use yiiunit\framework\base\stub\standalone\ActionTestService;
+
+/**
+ * Action used for testing nullable service injection in {@see \yii\web\Action::resolveStandaloneParams()}.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class NullableServiceAction extends Action
+{
+    public function run(?ActionTestService $service): string
+    {
+        return $service === null ? 'null' : $service->name();
+    }
+}

--- a/tests/framework/web/stub/standalone/RequiredServiceAction.php
+++ b/tests/framework/web/stub/standalone/RequiredServiceAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\web\stub\standalone;
+
+use yii\web\Action;
+
+/**
+ * Action whose `run()` requires an unresolvable non-nullable dependency, used to assert HTTP-aware DI failure mapping.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class RequiredServiceAction extends Action
+{
+    public function run(UnregisteredDependency $dependency): string
+    {
+        return $dependency->value();
+    }
+}

--- a/tests/framework/web/stub/standalone/UnregisteredDependency.php
+++ b/tests/framework/web/stub/standalone/UnregisteredDependency.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\web\stub\standalone;
+
+/**
+ * Service never registered in any container, used to force an unresolvable non-nullable dependency.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class UnregisteredDependency
+{
+    public function value(): string
+    {
+        return 'never';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
