### PR TITLE
Fix #19782: Support `min-max` ranges in `Query::andFilterCompare()`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Enh #20905: Support `min-max` numeric ranges in `yii\db\Query::andFilterCompare()` (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -51,6 +51,15 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to follow the instructions
 for both A and B.
 
+Upgrade from Yii 2.0.55
+-----------------------
+
+* `yii\db\Query::andFilterCompare()` now reads a value of the form `min-max`, where both bounds are
+  non-negative numbers (e.g. `2-4` or `1.5-3.5`, spaces around the dash allowed), as a `BETWEEN` condition
+  instead of an exact match. Strings that are not two such numbers, including dashed text like `John-Doe`
+  and dates like `2023-03-03`, keep the previous behavior. If you relied on an exact match for a numeric
+  `min-max` string, switch that call to `andFilterWhere(['=', $column, $value])`.
+
 Upgrade from Yii 2.0.53
 -----------------------
 

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -911,6 +911,9 @@ PATTERN;
      * - `>=`: the column must be greater than or equal to the given value.
      * - `<>`: the column must not be the same as the given value.
      * - `=`: the column must be equal to the given value.
+     * - A range `min-max` where both bounds are non-negative numbers, e.g. `2-4` or `1.5-3.5`: the column
+     *   must be between the two values, added as a `BETWEEN` condition. Spaces around the dash are allowed.
+     *   Available since version 2.0.56.
      * - If none of the above operators is detected, the `$defaultOperator` will be used.
      *
      * @param string $name the column name.
@@ -925,6 +928,9 @@ PATTERN;
         if (preg_match('/^(<>|>=|>|<=|<|=)/', (string)$value, $matches)) {
             $operator = $matches[1];
             $value = substr($value, strlen($operator));
+        } elseif (preg_match('/^(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)$/', (string)$value, $matches)) {
+            // https://github.com/yiisoft/yii2/issues/19782
+            return $this->andFilterWhere(['between', $name, $matches[1], $matches[2]]);
         } else {
             $operator = $defaultOperator;
         }

--- a/tests/framework/db/QueryTest.php
+++ b/tests/framework/db/QueryTest.php
@@ -501,6 +501,33 @@ abstract class QueryTest extends DatabaseTestCase
     }
 
     /**
+     * @dataProvider dataProviderAndFilterCompareRange
+     */
+    public function testAndFilterCompareRange($value, array $expected): void
+    {
+        $query = new Query();
+        $query->andFilterCompare('price', $value);
+        $this->assertSame($expected, $query->where);
+    }
+
+    public static function dataProviderAndFilterCompareRange(): array
+    {
+        return [
+            ['2-4', ['between', 'price', '2', '4']],
+            ['1.5-3.5', ['between', 'price', '1.5', '3.5']],
+            ['1.123 - 1.456', ['between', 'price', '1.123', '1.456']],
+            ['10 - 20', ['between', 'price', '10', '20']],
+            ['John-Doe', ['=', 'price', 'John-Doe']],
+            ['2023-03-03', ['=', 'price', '2023-03-03']],
+            ['5-', ['=', 'price', '5-']],
+            ['-5', ['=', 'price', '-5']],
+            [' 2-4 ', ['=', 'price', ' 2-4 ']],
+            ['<5-10', ['<', 'price', '5-10']],
+            ['5 - a', ['=', 'price', '5 - a']],
+        ];
+    }
+
+    /**
      * @see https://github.com/yiisoft/yii2/issues/8068
      *
      * @depends testCount


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Tests added?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #19782

## What does this PR do?

Teaches `yii\db\Query::andFilterCompare()` to read a `min-max` value of two non-negative numbers (e.g. `2-4` or `1.5-3.5`) as a `BETWEEN` range condition, next to the existing `>`, `<`, `<>` operators.

A value becomes a range only when it is exactly two non-negative numbers (integer or float) split by a dash, with optional spaces around the dash. Everything else keeps the current behavior:

- `John-Doe`, `5 - a` - not two numbers, stay an exact/default match (no BC change for dashed strings)
- `2023-03-03` - three parts, stays an exact match (dates are untouched)
- `<5-10` - the leading operator wins, as before
- `5-`, `-5`, ` 2-4 ` (outer spaces) - not a clean range, stay as-is

The numeric check keeps the change narrow: without it, any dashed string would flip to `BETWEEN` and fail on stricter drivers. This was the concern raised in the issue discussion.
