### PR TITLE
Fix #20527: Use `bigint` for `apply_time` in migration table

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -18,7 +18,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
 - Bug #20889: Remove unreachable PHP < 7 cookie deserialization fallback in `yii\web\Request::loadCookies()` (terabytesoftw)
 - Enh #20890: Harden `yii\i18n\PhpMessageSource` category path handling to reject `..` segments, absolute paths, and stream-wrapper categories (terabytesoftw)
-- Bug #20908: Use `bigint` for `apply_time` in the migration history table to avoid the year 2038 overflow (WarLikeLaux)
+- Bug #20527: Use `bigint` for `apply_time` in newly created migration history tables to avoid the year `2038` overflow (WarLikeLaux)
 - Enh #20888: Preserve the modification time of a log file when it is rotated by copy in `yii\log\FileTarget` (WarLikeLaux)
 - Bug #20978: Fix `AssetManager::appendTimestamp` triggering `filemtime()` stat warnings for timestamped asset URLs (terabytesoftw)
 - Bug #20986: Fix `@return` annotation for `yii\base\Component::behaviors()` (mspirkov)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Bug #20908: Use `bigint` for `apply_time` in the migration history table to avoid the year 2038 overflow (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/console/controllers/MigrateController.php
+++ b/framework/console/controllers/MigrateController.php
@@ -37,7 +37,7 @@ use yii\helpers\Inflector;
  * ```
  * CREATE TABLE migration (
  *     version varchar(180) PRIMARY KEY,
- *     apply_time integer
+ *     apply_time bigint
  * )
  * ```
  *
@@ -277,7 +277,7 @@ class MigrateController extends BaseMigrateController
         $this->stdout("Creating migration history table \"$tableName\"...", Console::FG_YELLOW);
         $this->db->createCommand()->createTable($this->migrationTable, [
             'version' => 'varchar(' . static::MAX_NAME_LENGTH . ') NOT NULL PRIMARY KEY',
-            'apply_time' => 'integer',
+            'apply_time' => 'bigint',
         ])->execute();
         $this->db->createCommand()->insert($this->migrationTable, [
             'version' => self::BASE_MIGRATION,

--- a/tests/framework/console/controllers/MigrateControllerTest.php
+++ b/tests/framework/console/controllers/MigrateControllerTest.php
@@ -448,7 +448,33 @@ class MigrateControllerTest extends TestCase
         $this->runMigrateControllerAction('history');
 
         $column = Yii::$app->db->getTableSchema('migration', true)->getColumn('apply_time');
+
         $this->assertSame(Schema::TYPE_BIGINT, $column->type);
+    }
+
+    public function testExistingIntegerMigrationHistoryTableRemainsSupported(): void
+    {
+        Yii::$app->db->createCommand()->createTable(
+            'migration',
+            [
+                'version' => 'varchar(180) NOT NULL PRIMARY KEY',
+                'apply_time' => 'integer',
+            ],
+        )->execute();
+        Yii::$app->db->createCommand()->insert(
+            'migration',
+            [
+                'version' => 'm000000_000000_base',
+                'apply_time' => time(),
+            ],
+        )->execute();
+
+        $this->runMigrateControllerAction('history');
+
+        $column = Yii::$app->db->getTableSchema('migration', true)->getColumn('apply_time');
+
+        $this->assertSame(ExitCode::OK, $this->getExitCode());
+        $this->assertSame(Schema::TYPE_INTEGER, $column->type);
     }
 
     public function testCreateLongNamedMigration(): void

--- a/tests/framework/console/controllers/MigrateControllerTest.php
+++ b/tests/framework/console/controllers/MigrateControllerTest.php
@@ -14,6 +14,7 @@ use yii\console\controllers\MigrateController;
 use yii\console\ExitCode;
 use yii\db\Migration;
 use yii\db\Query;
+use yii\db\Schema;
 use yii\helpers\Inflector;
 use yiiunit\TestCase;
 
@@ -440,6 +441,14 @@ class MigrateControllerTest extends TestCase
 
         $this->assertStringContainsString('1 migration was applied.', $result);
         $this->assertStringContainsString('Migrated up successfully.', $result);
+    }
+
+    public function testMigrationHistoryTableApplyTimeIsBigInt(): void
+    {
+        $this->runMigrateControllerAction('history');
+
+        $column = Yii::$app->db->getTableSchema('migration', true)->getColumn('apply_time');
+        $this->assertSame(Schema::TYPE_BIGINT, $column->type);
     }
 
     public function testCreateLongNamedMigration(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #20527

## What does this PR do?

Creates the `apply_time` column of the migration history table as `bigint` instead of `integer`, so migration timestamps no longer overflow in 2038.

`MigrateController::createMigrationHistoryTable()` defined `apply_time` as `integer`, which stores a Unix timestamp that exceeds the signed 32-bit range on 2038-01-19. `bigint` pushes that limit far out and stays a drop-in numeric column (no `migrate/history` or extension breakage that a switch to `datetime` would cause).

This matches the direction in the issue: @terabytesoftw asked to fix it on master without BC, @bizley objected only to the `datetime` option, and @rob006 called the change from `integer` to `bigint` "a no-brainer".

Existing installations are untouched: their migration table keeps its current column, only freshly created tables use `bigint`. So no upgrade migration and no BC break.