### PR TITLE
Fix release changelog version detection

### DIFF
--- a/build/controllers/ReleaseController.php
+++ b/build/controllers/ReleaseController.php
@@ -854,10 +854,27 @@ class ReleaseController extends Controller
     protected function resortChangelogs($what, $version)
     {
         foreach ($this->getChangelogs($what) as $file) {
+            $this->updateChangelogDevelopmentVersion($file, $version);
             // split the file into relevant parts
             list($start, $changelog, $end) = $this->splitChangelog($file, $version);
             $changelog = $this->resortChangelog($changelog);
             file_put_contents($file, implode("\n", array_merge($start, $changelog, $end)));
+        }
+    }
+
+    protected function updateChangelogDevelopmentVersion($file, $version)
+    {
+        $contents = file_get_contents($file);
+        $headline = $version . ' under development';
+        $updatedContents = preg_replace(
+            '/^([^\s]+) under development\R-+\R/m',
+            $headline . "\n" . str_repeat('-', \strlen($headline)) . "\n",
+            $contents,
+            1
+        );
+
+        if ($updatedContents !== $contents) {
+            file_put_contents($file, $updatedContents);
         }
     }
 
@@ -877,13 +894,15 @@ class ReleaseController extends Controller
         $end = [];
 
         $state = 'start';
+        $found = false;
         foreach ($lines as $l => $line) {
             // starting from the changelogs headline
             if (
-                isset($lines[$l - 2]) && strpos($lines[$l - 2], $version) !== false &&
+                isset($lines[$l - 2]) && $this->matchesChangelogVersion($lines[$l - 2], $version) &&
                 isset($lines[$l - 1]) && strncmp($lines[$l - 1], '---', 3) === 0
             ) {
                 $state = 'changelog';
+                $found = true;
             }
             if ($state === 'changelog' && isset($lines[$l + 1]) && strncmp($lines[$l + 1], '---', 3) === 0) {
                 $state = 'end';
@@ -900,7 +919,17 @@ class ReleaseController extends Controller
             }
         }
 
+        if (!$found) {
+            throw new Exception("Changelog section for version $version was not found in $file.");
+        }
+
         return [$start, $changelog, $end];
+    }
+
+    protected function matchesChangelogVersion($line, $version)
+    {
+        $v = str_replace('\\-', '[\\- ]', preg_quote($version, '/'));
+        return preg_match('/^' . $v . '(?:\s|$)/', $line) === 1;
     }
 
     /**

--- a/tests/framework/ReleaseControllerTest.php
+++ b/tests/framework/ReleaseControllerTest.php
@@ -11,10 +11,11 @@ declare(strict_types=1);
 namespace yiiunit\framework;
 
 use ReflectionClass;
+use ReflectionMethod;
+use yii\base\Exception;
 use yii\build\controllers\ReleaseController;
+use yii\helpers\FileHelper;
 use yiiunit\TestCase;
-
-require_once __DIR__ . '/../../build/controllers/ReleaseController.php';
 
 /**
  * ReleaseControllerTest.
@@ -22,10 +23,21 @@ require_once __DIR__ . '/../../build/controllers/ReleaseController.php';
  */
 class ReleaseControllerTest extends TestCase
 {
+    private array $tempPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempPaths as $path) {
+            FileHelper::removeDirectory($path);
+        }
+        $this->tempPaths = [];
+        parent::tearDown();
+    }
+
     public function testResortChangelogConvertsFixEntriesToBugsAndSortsThem(): void
     {
-        $controller = (new ReflectionClass(ReleaseController::class))->newInstanceWithoutConstructor();
-        $method = new \ReflectionMethod($controller, 'resortChangelog');
+        $controller = $this->createController();
+        $method = new ReflectionMethod($controller, 'resortChangelog');
         $method->setAccessible(true);
 
         $this->assertSame(
@@ -53,5 +65,96 @@ class ReleaseControllerTest extends TestCase
                 '- Bug #283: Fix first sentence extraction (samdark)',
             ])
         );
+    }
+
+    public function testResortChangelogsUpdatesDevelopmentHeaderToRequestedVersion(): void
+    {
+        $basePath = sys_get_temp_dir() . '/yii-release-controller-test-' . str_replace('.', '', uniqid('', true));
+        $this->tempPaths[] = $basePath;
+        mkdir($basePath . '/extensions/apidoc', 0777, true);
+        $file = $basePath . '/extensions/apidoc/CHANGELOG.md';
+        file_put_contents(
+            $file,
+            "Yii Framework 2 apidoc extension Change Log\n"
+            . "===========================================\n\n"
+            . "4.0.0 under development\n"
+            . "-----------------------\n\n"
+            . "- Enh #2: Test enhancement (samdark)\n"
+            . "- Fix #1: Test fix (samdark)\n"
+        );
+
+        $controller = $this->createController();
+        $controller->basePath = $basePath;
+        $method = new ReflectionMethod($controller, 'resortChangelogs');
+        $method->setAccessible(true);
+        $method->invoke($controller, ['apidoc'], '3.0.9');
+
+        $this->assertSame(
+            "Yii Framework 2 apidoc extension Change Log\n"
+            . "===========================================\n\n"
+            . "3.0.9 under development\n"
+            . "-----------------------\n\n"
+            . "- Bug #1: Test fix (samdark)\n"
+            . "- Enh #2: Test enhancement (samdark)\n\n",
+            file_get_contents($file)
+        );
+    }
+
+    public function testResortChangelogsFailsWhenVersionSectionIsMissing(): void
+    {
+        $basePath = sys_get_temp_dir() . '/yii-release-controller-test-' . str_replace('.', '', uniqid('', true));
+        $this->tempPaths[] = $basePath;
+        mkdir($basePath . '/extensions/apidoc', 0777, true);
+        $file = $basePath . '/extensions/apidoc/CHANGELOG.md';
+        $contents = "Yii Framework 2 apidoc extension Change Log\n"
+            . "===========================================\n\n"
+            . "3.0.8 November 24, 2025\n"
+            . "-----------------------\n\n"
+            . "- Bug #1: Test change (samdark)\n";
+        file_put_contents($file, $contents);
+
+        $controller = $this->createController();
+        $controller->basePath = $basePath;
+        $method = new ReflectionMethod($controller, 'resortChangelogs');
+        $method->setAccessible(true);
+
+        try {
+            $method->invoke($controller, ['apidoc'], '3.0.9');
+            $this->fail('Expected missing changelog version exception.');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('3.0.9', $e->getMessage());
+        }
+
+        $this->assertSame($contents, file_get_contents($file));
+    }
+
+    public function testSplitChangelogUsesExactVersionBoundary(): void
+    {
+        $basePath = sys_get_temp_dir() . '/yii-release-controller-test-' . str_replace('.', '', uniqid('', true));
+        $this->tempPaths[] = $basePath;
+        mkdir($basePath, 0777, true);
+        $file = $basePath . '/CHANGELOG.md';
+        file_put_contents(
+            $file,
+            "Yii Framework 2 Change Log\n"
+            . "==========================\n\n"
+            . "2.0.50 May 09, 2026\n"
+            . "-------------------\n\n"
+            . "- Bug #1: Test change (samdark)\n"
+        );
+
+        $controller = $this->createController();
+        $method = new ReflectionMethod($controller, 'splitChangelog');
+        $method->setAccessible(true);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('2.0.5');
+
+        $method->invoke($controller, $file, '2.0.5');
+    }
+
+    private function createController(): ReleaseController
+    {
+        return (new ReflectionClass(ReleaseController::class))->newInstanceWithoutConstructor();
     }
 }


### PR DESCRIPTION
## Summary
- keep the release command's selected version authoritative
- update the active CHANGELOG `under development` section to the selected version before sorting
- normalize invalid `Fix #...` changelog entries to canonical `Bug #...` before sorting
- fail loudly when no matching changelog section exists after the header adjustment attempt

## Tests
- `vendor/bin/phpunit --filter ReleaseControllerTest tests/framework/ReleaseControllerTest.php`