### PR TITLE
Remove unreachable PHP < 7 cookie deserialization fallback in `yii\web\Request::loadCookies()`.

### DIFF
--- a/docs/guide/caching-data.md
+++ b/docs/guide/caching-data.md
@@ -281,6 +281,11 @@ Below is a summary of the available cache dependencies:
   the dependency associated with the cached data, if there is any, has changed. So a call to
   [[yii\caching\Cache::get()|get()]] may return `false` while [[yii\caching\Cache::exists()|exists()]] returns `true`.
 
+> Warning: Cached values are stored with PHP's native `serialize()` and read back with `unserialize()`, including any
+  attached [[yii\caching\Dependency]] object. Treat the cache backend as trusted storage: never let untrusted parties
+  write to it, since deserializing crafted bytes can instantiate arbitrary objects. See
+  [Avoiding unsafe deserialization](security-best-practices.md#avoiding-unsafe-deserialization).
+
 
 ## Query Caching <span id="query-caching"></span>
 

--- a/docs/guide/security-authorization.md
+++ b/docs/guide/security-authorization.md
@@ -252,6 +252,12 @@ Read more about working with migrations from different namespaces in
 
 The `authManager` can now be accessed via `\Yii::$app->authManager`.
 
+> Warning: Both managers persist rule data with PHP's native `serialize()` and read it back with `unserialize()` —
+  [[yii\rbac\DbManager]] in the `auth_rule.data` (and `auth_item.data`) columns, and [[yii\rbac\PhpManager]] in its
+  rules file. Keep these stores trusted: the database and the `@app/rbac` files must be writable only by the
+  application, since an attacker who can write rule data can stage a deserialization gadget. See
+  [Avoiding unsafe deserialization](security-best-practices.md#avoiding-unsafe-deserialization).
+
 
 ### Building Authorization Data <span id="generating-rbac-data"></span>
 

--- a/docs/guide/security-authorization.md
+++ b/docs/guide/security-authorization.md
@@ -252,10 +252,11 @@ Read more about working with migrations from different namespaces in
 
 The `authManager` can now be accessed via `\Yii::$app->authManager`.
 
-> Warning: Both managers persist rule data with PHP's native `serialize()` and read it back with `unserialize()` —
-  [[yii\rbac\DbManager]] in the `auth_rule.data` (and `auth_item.data`) columns, and [[yii\rbac\PhpManager]] in its
-  rules file. Keep these stores trusted: the database and the `@app/rbac` files must be writable only by the
-  application, since an attacker who can write rule data can stage a deserialization gadget. See
+> Warning: RBAC data is persisted with PHP's native `serialize()` and read back with `unserialize()`.
+  [[yii\rbac\DbManager]] serializes the whole `Rule` object into `auth_rule.data` and the item's `Item::$data` into
+  `auth_item.data`; [[yii\rbac\PhpManager]] serializes only `Rule` objects into its rules file (item data is stored as
+  plain PHP). Keep these stores trusted: the database and the `@app/rbac` files must be writable only by the
+  application, since an attacker who can write this data can stage a deserialization gadget. See
   [Avoiding unsafe deserialization](security-best-practices.md#avoiding-unsafe-deserialization).
 
 

--- a/docs/guide/security-best-practices.md
+++ b/docs/guide/security-best-practices.md
@@ -276,14 +276,16 @@ Never pass untrusted or user-controlled data to PHP's `unserialize()`. Deseriali
 instantiate arbitrary objects and trigger Property-Oriented Programming (POP) gadget chains, potentially leading to
 remote code execution. Parse untrusted input with a safe format such as JSON ([[yii\helpers\Json::decode()]]) instead.
 
-Yii uses native `serialize()`/`unserialize()` internally for data it writes into *trusted* stores: the
-[cache](caching-overview.md) backend (including cache [dependencies](caching-data.md#cache-dependencies)) and RBAC
-storage ([[yii\rbac\DbManager]] `auth_item.data`/`auth_rule.data` columns and [[yii\rbac\PhpManager]] rule files).
-These reads are safe only while those stores stay trusted. Make sure your cache backend (Redis, Memcached, files,
-database) and your RBAC tables and files are writable only by the application; an attacker who can write into them can
-stage a deserialization gadget. Cookies received over HTTP are not trusted: Yii verifies their integrity with an HMAC
-([[yii\web\Request::$cookieValidationKey|cookieValidationKey]]) and deserializes them with `allowed_classes => false`,
-so cookie values can never instantiate objects.
+Yii relies on PHP's native `serialize()`/`unserialize()` for data it writes into *trusted* stores. The
+[cache](caching-overview.md) backend uses native serialization by default, configurable through
+[[yii\caching\Cache::$serializer]] (a custom serializer pair, or `false` to disable it, as in [[yii\caching\ArrayCache]]);
+the same applies to cache [dependencies](caching-data.md#cache-dependencies). RBAC storage always uses native
+`serialize()`/`unserialize()`; [[yii\rbac\DbManager]] in the `auth_item.data`/`auth_rule.data` columns and
+[[yii\rbac\PhpManager]] in its rule files. These reads are safe only while those stores stay trusted. Make sure your
+cache backend (Redis, Memcached, files, database) and your RBAC tables and files are writable only by the application; 
+an attacker who can write into them can stage a deserialization gadget. Cookies received over HTTP are not trusted: Yii
+verifies their integrity with an HMAC ([[yii\web\Request::$cookieValidationKey|cookieValidationKey]]) and deserializes
+them with `allowed_classes => false`, so cookie values can never instantiate objects.
 
 
 Avoiding file exposure

--- a/docs/guide/security-best-practices.md
+++ b/docs/guide/security-best-practices.md
@@ -282,10 +282,12 @@ Yii relies on PHP's native `serialize()`/`unserialize()` for data it writes into
 the same applies to cache [dependencies](caching-data.md#cache-dependencies). RBAC storage always uses native
 `serialize()`/`unserialize()`: [[yii\rbac\DbManager]] persists to the `auth_item.data` and `auth_rule.data` columns,
 while [[yii\rbac\PhpManager]] writes to its rule files. These reads are safe only while those stores stay trusted. Make sure your
-cache backend (Redis, Memcached, files, database) and your RBAC tables and files are writable only by the application; 
+cache backend (Redis, Memcached, files, database) and your RBAC tables and files are writable only by the application;
 an attacker who can write into them can stage a deserialization gadget. Cookies received over HTTP are not trusted: Yii
 verifies their integrity with an HMAC ([[yii\web\Request::$cookieValidationKey|cookieValidationKey]]) and deserializes
-them with `allowed_classes => false`, so cookie values can never instantiate objects.
+them with `allowed_classes => false`, so no application or gadget class is instantiated: any serialized object becomes an
+inert `__PHP_Incomplete_Class` (its `__wakeup()`/`__destruct()` never run), and the cookie is ignored unless it
+deserializes to the expected `[name, value]` array.
 
 
 Avoiding file exposure

--- a/docs/guide/security-best-practices.md
+++ b/docs/guide/security-best-practices.md
@@ -280,8 +280,8 @@ Yii relies on PHP's native `serialize()`/`unserialize()` for data it writes into
 [cache](caching-overview.md) backend uses native serialization by default, configurable through
 [[yii\caching\Cache::$serializer]] (a custom serializer pair, or `false` to disable it, as in [[yii\caching\ArrayCache]]);
 the same applies to cache [dependencies](caching-data.md#cache-dependencies). RBAC storage always uses native
-`serialize()`/`unserialize()`; [[yii\rbac\DbManager]] in the `auth_item.data`/`auth_rule.data` columns and
-[[yii\rbac\PhpManager]] in its rule files. These reads are safe only while those stores stay trusted. Make sure your
+`serialize()`/`unserialize()`: [[yii\rbac\DbManager]] persists to the `auth_item.data` and `auth_rule.data` columns,
+while [[yii\rbac\PhpManager]] writes to its rule files. These reads are safe only while those stores stay trusted. Make sure your
 cache backend (Redis, Memcached, files, database) and your RBAC tables and files are writable only by the application; 
 an attacker who can write into them can stage a deserialization gadget. Cookies received over HTTP are not trusted: Yii
 verifies their integrity with an HMAC ([[yii\web\Request::$cookieValidationKey|cookieValidationKey]]) and deserializes

--- a/docs/guide/security-best-practices.md
+++ b/docs/guide/security-best-practices.md
@@ -269,6 +269,23 @@ Avoiding arbitrary object instantiations
 Yii [configurations](concept-configurations.md) are associative arrays used by the framework to instantiate new objects through `Yii::createObject($config)`. These arrays specify the class name for instantiation, and it is important to ensure that this class name does not originate from untrusted sources. Otherwise, it can lead to Unsafe Reflection, a vulnerability that allows the execution of malicious code by exploiting the loading of specific classes. Additionally, when you need to dynamically add keys to an object derived from a framework class, such as the base `Component` class, it's essential to validate these dynamic properties using a whitelist approach. This precaution is necessary because the framework might employ `Yii::createObject($config)` within the `__set()` magic method.
 
 
+Avoiding unsafe deserialization
+-------------------------------
+
+Never pass untrusted or user-controlled data to PHP's `unserialize()`. Deserializing attacker-controlled bytes can
+instantiate arbitrary objects and trigger Property-Oriented Programming (POP) gadget chains, potentially leading to
+remote code execution. Parse untrusted input with a safe format such as JSON ([[yii\helpers\Json::decode()]]) instead.
+
+Yii uses native `serialize()`/`unserialize()` internally for data it writes into *trusted* stores: the
+[cache](caching-overview.md) backend (including cache [dependencies](caching-data.md#cache-dependencies)) and RBAC
+storage ([[yii\rbac\DbManager]] `auth_item.data`/`auth_rule.data` columns and [[yii\rbac\PhpManager]] rule files).
+These reads are safe only while those stores stay trusted. Make sure your cache backend (Redis, Memcached, files,
+database) and your RBAC tables and files are writable only by the application; an attacker who can write into them can
+stage a deserialization gadget. Cookies received over HTTP are not trusted: Yii verifies their integrity with an HMAC
+([[yii\web\Request::$cookieValidationKey|cookieValidationKey]]) and deserializes them with `allowed_classes => false`,
+so cookie values can never instantiate objects.
+
+
 Avoiding file exposure
 ----------------------
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@return` annotation for `RequestParserInterface::parse()`, `JsonParser::parse()`, `Request::getBodyParams()`, and `Request::post()` (mspirkov)
 - Bug #20891: Fix `@param` annotation for `$values` in `Request::setBodyParams()` (mspirkov)
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
+- Bug #20889: Remove unreachable PHP < 7 cookie deserialization fallback in `yii\web\Request::loadCookies()` (terabytesoftw)
 
 
 2.0.55 May 09, 2026

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -1765,11 +1765,7 @@ class Request extends \yii\base\Request
                 if ($data === false) {
                     continue;
                 }
-                if (defined('PHP_VERSION_ID') && PHP_VERSION_ID >= 70000) {
-                    $data = @unserialize($data, ['allowed_classes' => false]);
-                } else {
-                    $data = @unserialize($data);
-                }
+                $data = @unserialize($data, ['allowed_classes' => false]);
                 if (is_array($data) && isset($data[0], $data[1]) && $data[0] === $name) {
                     $cookies[$name] = Yii::createObject([
                         'class' => 'yii\web\Cookie',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20889
