### PR TITLE
[Security] Add allowedClasses property to Cache to restrict unserialize() gadget chains

### DIFF
--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -10,6 +10,7 @@ namespace yii\caching;
 
 use Yii;
 use yii\base\Component;
+use yii\base\InvalidConfigException;
 use yii\helpers\StringHelper;
 
 /**
@@ -115,6 +116,9 @@ abstract class Cache extends Component implements CacheInterface
     {
         parent::init();
         $this->_igbinaryAvailable = \extension_loaded('igbinary');
+        if (!is_array($this->allowedClasses) && !is_bool($this->allowedClasses)) {
+            throw new InvalidConfigException('Cache::$allowedClasses must be a bool or an array of class names.');
+        }
     }
 
     /**
@@ -235,8 +239,8 @@ abstract class Cache extends Component implements CacheInterface
                 } else {
                     $value = $this->serializer === null
                         ? ($this->allowedClasses !== true
-                            ? unserialize($values[$newKey], ['allowed_classes' => $this->allowedClasses])
-                            : unserialize($values[$newKey]))
+                            ? unserialize((string)$values[$newKey], ['allowed_classes' => $this->allowedClasses])
+                            : unserialize((string)$values[$newKey]))
                         : call_user_func($this->serializer[1], $values[$newKey]);
 
                     if (is_array($value) && !($value[1] instanceof Dependency && $value[1]->isChanged($this))) {

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -74,6 +74,28 @@ abstract class Cache extends Component implements CacheInterface
      */
     public $serializer;
     /**
+     * @var array|bool $allowedClasses Passed as the `allowed_classes` option to `unserialize()` when
+     * the default PHP serializer is used (i.e. [[serializer]] is `null`). Set to `false` to disallow
+     * all PHP object deserialization (safest option for caches that only store scalar/array values),
+     * or to an array of fully-qualified class names to restrict which objects may be instantiated.
+     * Defaults to `true` (allow all classes) for backwards compatibility.
+     *
+     * Applications that cache objects should restrict this to the exact set of classes they cache,
+     * including [[Dependency]] subclasses when cache dependencies are used.
+     *
+     * Example:
+     * ```php
+     * 'cache' => [
+     *     'class' => 'yii\caching\FileCache',
+     *     'allowedClasses' => [
+     *         \yii\caching\FileDependency::class,
+     *     ],
+     * ],
+     * ```
+     * @since 2.0.50
+     */
+    public $allowedClasses = true;
+    /**
      * @var int default duration in seconds before a cache entry will expire. Default value is 0, meaning infinity.
      * This value is used by [[set()]] if the duration is not explicitly given.
      * @since 2.0.11
@@ -136,7 +158,9 @@ abstract class Cache extends Component implements CacheInterface
         if ($value === false || $this->serializer === false) {
             return $value;
         } elseif ($this->serializer === null) {
-            $value = unserialize((string)$value);
+            $value = $this->allowedClasses !== true
+                ? unserialize((string)$value, ['allowed_classes' => $this->allowedClasses])
+                : unserialize((string)$value);
         } else {
             $value = call_user_func($this->serializer[1], $value);
         }
@@ -209,7 +233,10 @@ abstract class Cache extends Component implements CacheInterface
                 if ($this->serializer === false) {
                     $results[$key] = $values[$newKey];
                 } else {
-                    $value = $this->serializer === null ? unserialize($values[$newKey])
+                    $value = $this->serializer === null
+                        ? ($this->allowedClasses !== true
+                            ? unserialize($values[$newKey], ['allowed_classes' => $this->allowedClasses])
+                            : unserialize($values[$newKey]))
                         : call_user_func($this->serializer[1], $values[$newKey]);
 
                     if (is_array($value) && !($value[1] instanceof Dependency && $value[1]->isChanged($this))) {


### PR DESCRIPTION
## Summary

`Cache::get()` and `Cache::multiGet()` both call `unserialize()` on data retrieved from the cache backend without restricting the `allowed_classes` option when the default PHP serializer is used (`$serializer === null`). An attacker who can write to the shared cache backend can inject a crafted PHP serialized payload containing a **gadget chain** and achieve **PHP Object Injection → Remote Code Execution**.

## Attack scenario

1. Attacker gains write access to the cache backend (unauthenticated Redis, SSRF, shared multi-tenant cache, or a cache-poisoning vulnerability in the application).
2. Attacker writes a serialized payload that instantiates an exploitable gadget class available in the application (e.g., Monolog, GuzzleHttp, or any library with a dangerous `__destruct`/`__wakeup`).
3. On the next `Cache::get()` call the gadget chain executes.

## Fix

Add a public `$allowedClasses` property (default `true` = allow all, identical to the current behaviour) passed as the `allowed_classes` option to `unserialize()`. Applications can harden their configuration:

```php
'cache' => [
    'class' => 'yii\caching\FileCache',
    // Only allow the exact classes stored in this cache
    'allowedClasses' => [
        \yii\caching\FileDependency::class,
    ],
],
```

Applications that only cache scalar/array values can set `'allowedClasses' => false` to eliminate the attack surface entirely.

## Files changed

- `framework/caching/Cache.php` — add `$allowedClasses` property; honour it in `get()` and `multiGet()`

## Severity

**High** – requires write access to cache backend, but unauthenticated Redis instances are common in the wild.