### PR TITLE
Consolidate MSSQL data-type conversion into `ColumnSchema`: harden `defaultPhpTypecast()` for unicode (`N'...'`), escaped quotes, and expression defaults; add `getOutputColumnDeclaration()` used by `QueryBuilder::insert()`.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -248,16 +248,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.11",
+            "version": "1.5.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "68ff39175e8e94a4bb1d259407ce51a6a60f09e6"
+                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/68ff39175e8e94a4bb1d259407ce51a6a60f09e6",
-                "reference": "68ff39175e8e94a4bb1d259407ce51a6a60f09e6",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
+                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
                 "shasum": ""
             },
             "require": {
@@ -304,7 +304,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.11"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.12"
             },
             "funding": [
                 {
@@ -316,7 +316,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-30T09:16:10+00:00"
+            "time": "2026-05-19T11:26:22+00:00"
         },
         {
             "name": "composer/class-map-generator",
@@ -389,16 +389,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.9.8",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "39ee8baff8e97a1b657bbfcd6a236ff93a5efbb2"
+                "reference": "c13824d95608b15913a7c0def0a3dea4474b71fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/39ee8baff8e97a1b657bbfcd6a236ff93a5efbb2",
-                "reference": "39ee8baff8e97a1b657bbfcd6a236ff93a5efbb2",
+                "url": "https://api.github.com/repos/composer/composer/zipball/c13824d95608b15913a7c0def0a3dea4474b71fc",
+                "reference": "c13824d95608b15913a7c0def0a3dea4474b71fc",
                 "shasum": ""
             },
             "require": {
@@ -451,7 +451,7 @@
                     ]
                 },
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.10-dev"
                 }
             },
             "autoload": {
@@ -486,7 +486,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.9.8"
+                "source": "https://github.com/composer/composer/tree/2.10.0"
             },
             "funding": [
                 {
@@ -498,7 +498,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-13T07:28:38+00:00"
+            "time": "2026-05-28T09:22:08+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -1426,11 +1426,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.55",
+            "version": "2.2.1",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9eaac3826ed5e9b8427350a43cac825eeca3f566",
-                "reference": "9eaac3826ed5e9b8427350a43cac825eeca3f566",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dea9c8f2d25cc849391042b71e429c1a4bf82660",
+                "reference": "dea9c8f2d25cc849391042b71e429c1a4bf82660",
                 "shasum": ""
             },
             "require": {
@@ -1452,6 +1452,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -1475,7 +1486,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-18T11:57:34+00:00"
+            "time": "2026-05-28T14:44:12+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -3458,16 +3469,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.11",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075"
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ed0107e43ab452aa77ae99e005b95e56b556e075",
-                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
                 "shasum": ""
             },
             "require": {
@@ -3532,7 +3543,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.11"
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -3552,7 +3563,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:04:42+00:00"
+            "time": "2026-05-24T08:56:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3627,20 +3638,21 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v8.0.11",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "224db910898ce1317b892a9a1338f1f8f17eb7c7"
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/224db910898ce1317b892a9a1338f1f8f17eb7c7",
-                "reference": "224db910898ce1317b892a9a1338f1f8f17eb7c7",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -3673,7 +3685,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.0.11"
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3693,24 +3705,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-11T16:39:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v8.0.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8da41214757b87d97f181e3d14a4179286151007"
+                "reference": "58d2e767a66052c1487356f953445634a8194c64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8da41214757b87d97f181e3d14a4179286151007",
-                "reference": "8da41214757b87d97f181e3d14a4179286151007",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/58d2e767a66052c1487356f953445634a8194c64",
+                "reference": "58d2e767a66052c1487356f953445634a8194c64",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": ">=8.4.1"
             },
             "require-dev": {
                 "symfony/filesystem": "^7.4|^8.0"
@@ -3741,7 +3753,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v8.0.8"
+                "source": "https://github.com/symfony/finder/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3761,7 +3773,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3848,16 +3860,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -3906,7 +3918,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -3926,20 +3938,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:13:48+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -3991,7 +4003,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -4011,20 +4023,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -4076,7 +4088,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4096,7 +4108,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -4264,16 +4276,16 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
                 "shasum": ""
             },
             "require": {
@@ -4320,7 +4332,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4340,20 +4352,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -4400,7 +4412,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4420,24 +4432,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T18:47:49+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v8.0.11",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0"
+                "reference": "c4a9e58f235a6bf7f97ffbfedae2687353ac79e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/26d89e459f037d2873300605d0a07e7a8ef84db0",
-                "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c4a9e58f235a6bf7f97ffbfedae2687353ac79e5",
+                "reference": "c4a9e58f235a6bf7f97ffbfedae2687353ac79e5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": ">=8.4.1"
             },
             "type": "library",
             "autoload": {
@@ -4465,7 +4477,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.0.11"
+                "source": "https://github.com/symfony/process/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4485,7 +4497,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-11T16:56:32+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4576,20 +4588,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.11",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/39be2ad058a3c0bd558edca23e65f009865d75ff",
-                "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-intl-grapheme": "^1.33",
                 "symfony/polyfill-intl-normalizer": "^1.0",
@@ -4642,7 +4654,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.11"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4662,7 +4674,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:07:53+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -73,6 +73,7 @@ Yii Framework 2 Change Log
 - Chg: Drop dead SQL Server `< 2005` branches from MSSQL `Schema::insert()` (terabytesoftw)
 - Bug: Fix `Sort::createUrl()` and `Pagination::createUrl()` to fall back when no controller is active, supporting standalone actions discovered through `Module::$actionNamespace` (terabytesoftw)
 - Bug: Fix `yii\helpers\Url::current()` and `yii\helpers\Url::canonical()` to fall back to `Application::$requestedRoute` when no controller is active, supporting standalone actions (terabytesoftw)
+- Enh: Consolidate MSSQL data-type conversion into `ColumnSchema`: harden `defaultPhpTypecast()` for unicode (`N'...'`), escaped quotes, and expression defaults; add `getOutputColumnDeclaration()` used by `QueryBuilder::insert()` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/ColumnSchema.php
+++ b/framework/db/mssql/ColumnSchema.php
@@ -13,10 +13,17 @@ namespace yii\db\mssql;
 use yii\db\Expression;
 
 use function bin2hex;
+use function in_array;
 use function is_string;
+use function preg_match;
+use function str_replace;
 
 /**
- * Class ColumnSchema for MSSQL database
+ * Represents the metadata of a column in a Microsoft SQL Server database table.
+ *
+ * Extends {@see \yii\db\ColumnSchema} with MSSQL-specific type handling: converts `varbinary` values to explicit
+ * `CONVERT()` expressions, normalizes column default values, and builds OUTPUT-clause type declarations for
+ * `INSERT ... OUTPUT INTO` temp tables.
  *
  * @since 2.0.23
  */
@@ -53,18 +60,69 @@ class ColumnSchema extends \yii\db\ColumnSchema
     }
 
     /**
-     * Prepares default value and converts it according to [[phpType]]
-     * @param mixed $value default value
-     * @return mixed converted value
+     * Converts a MSSQL column default value to its PHP representation.
+     *
+     * Handles MSSQL-specific default formats:
+     * - `null` or `(NULL)` to `null`.
+     * - `CURRENT_TIMESTAMP` on `timestamp` columns to `null` (server-managed value).
+     * - `('value')` / `(N'value')` string wrappers to the unwrapped literal with escaped quotes resolved.
+     * - `((number))` numeric wrapper to the unwrapped numeric string.
+     * - expression defaults such as `(getdate())` or `(newid())` to `null` (server-computed, not a literal).
+     *
+     * @param mixed $value Default value in MSSQL `column_default` format.
+     *
+     * @return mixed Converted value.
+     *
      * @since 2.0.24
      */
     public function defaultPhpTypecast($value)
     {
-        if ($value !== null) {
-            // convert from MSSQL column_default format, e.g. ('1') -> 1, ('string') -> string
-            $value = substr(substr($value, 2), 0, -2);
+        if ($value === null || $value === '(NULL)') {
+            return null;
+        }
+
+        if ($this->type === Schema::TYPE_TIMESTAMP && $value === 'CURRENT_TIMESTAMP') {
+            return null;
+        }
+
+        if (is_string($value)) {
+            // string defaults: ('value') or unicode (N'value') — unwrap and resolve escaped single quotes.
+            if (preg_match("/^\(N?'(.*)'\)$/s", $value, $matches) === 1) {
+                $value = str_replace("''", "'", $matches[1]);
+            } elseif (preg_match('/^\(\((.+)\)\)$/s', $value, $matches) === 1) {
+                // numeric defaults: ((0)), ((42)), ((3.14)).
+                $value = $matches[1];
+            } else {
+                // expression defaults: (getdate()), (newid()) — not representable as a PHP literal.
+                return null;
+            }
         }
 
         return parent::phpTypecast($value);
+    }
+
+    /**
+     * Returns the SQL type declaration for this column inside an OUTPUT clause temp table.
+     *
+     * Appends `(MAX)` to variable-length types (`varchar`, `nvarchar`, `varbinary`), preserves the declared size for
+     * fixed-length types (`char`, `nchar`, `binary`), and maps `timestamp` to `varbinary(8)` or `binary(8)`.
+     *
+     * @return string SQL type declaration.
+     */
+    public function getOutputColumnDeclaration(): string
+    {
+        if ($this->dbType === Schema::TYPE_TIMESTAMP) {
+            return $this->allowNull ? 'varbinary(8)' : 'binary(8)';
+        }
+
+        $dbType = $this->dbType;
+
+        if (in_array($dbType, ['varchar', 'nvarchar', 'varbinary'], true)) {
+            $dbType .= '(MAX)';
+        } elseif (in_array($dbType, ['char', 'nchar', 'binary'], true)) {
+            $dbType .= "($this->size)";
+        }
+
+        return $dbType;
     }
 }

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -16,7 +16,6 @@ use yii\db\Expression;
 use yii\db\Query;
 
 use function count;
-use function in_array;
 
 /**
  * QueryBuilder is the query builder for MS SQL Server databases (version 2019 and above).
@@ -431,23 +430,13 @@ class QueryBuilder extends \yii\db\QueryBuilder
         $outputColumns = [];
 
         foreach ($schema->columns as $column) {
-            if ($column->isComputed) {
+            if (!$column instanceof ColumnSchema || $column->isComputed) {
                 continue;
-            }
-
-            $dbType = $column->dbType;
-
-            if (in_array($dbType, ['varchar', 'nvarchar', 'binary', 'varbinary'], true)) {
-                $dbType .= '(MAX)';
-            }
-
-            if ($column->dbType === Schema::TYPE_TIMESTAMP) {
-                $dbType = $column->allowNull ? 'varbinary(8)' : 'binary(8)';
             }
 
             $quoteColumnName = $this->db->quoteColumnName($column->name);
 
-            $cols[] = "{$quoteColumnName} {$dbType} " . ($column->allowNull ? 'NULL' : '');
+            $cols[] = "{$quoteColumnName} {$column->getOutputColumnDeclaration()} " . ($column->allowNull ? 'NULL' : '');
             $outputColumns[] = "INSERTED.{$quoteColumnName}";
         }
 

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -416,12 +416,8 @@ SQL;
 
         $column->phpType = $this->getColumnPhpType($column);
 
-        if ($info['column_default'] === '(NULL)') {
-            $info['column_default'] = null;
-        }
-        if (!$column->isPrimaryKey && ($column->type !== 'timestamp' || $info['column_default'] !== 'CURRENT_TIMESTAMP')) {
-            $column->defaultValue = $column->defaultPhpTypecast($info['column_default']);
-        }
+        // store raw default for deferred resolution in `findColumns()`, where isPrimaryKey is known.
+        $column->defaultValue = $info['column_default'];
 
         return $column;
     }
@@ -493,6 +489,9 @@ SQL;
             if ($column->isPrimaryKey && $column->autoIncrement) {
                 $table->sequenceName = '';
             }
+            $column->defaultValue = $column->isPrimaryKey
+                ? null
+                : $column->defaultPhpTypecast($column->defaultValue);
             $table->columns[$column->name] = $column;
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -373,12 +373,6 @@ parameters:
 			path: framework/db/conditions/SimpleConditionBuilder.php
 
 		-
-			message: '#^Access to an undefined property yii\\db\\ColumnSchema\:\:\$isComputed\.$#'
-			identifier: property.notFound
-			count: 1
-			path: framework/db/mssql/QueryBuilder.php
-
-		-
 			message: '#^Call to an undefined method yii\\db\\ExpressionInterface\:\:getValue\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/tests/framework/db/mssql/ColumnSchemaTest.php
+++ b/tests/framework/db/mssql/ColumnSchemaTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mssql;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\Expression;
+use yii\db\mssql\ColumnSchema;
+use yiiunit\framework\db\DatabaseTestCase;
+use yiiunit\framework\db\mssql\providers\ColumnSchemaProvider;
+
+/**
+ * Unit tests for {@see \yii\db\mssql\ColumnSchema} type-casting and OUTPUT column declarations for the MSSQL driver.
+ *
+ * {@see ColumnSchemaProvider} for test case data providers.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('db')]
+#[Group('mssql')]
+#[Group('column')]
+final class ColumnSchemaTest extends DatabaseTestCase
+{
+    protected $driverName = 'sqlsrv';
+
+    #[DataProviderExternal(ColumnSchemaProvider::class, 'dbTypecast')]
+    public function testDbTypecast(
+        string $type,
+        string $dbType,
+        bool $allowNull,
+        mixed $value,
+        mixed $expected,
+    ): void {
+        $column = new ColumnSchema();
+
+        $column->type = $type;
+        $column->dbType = $dbType;
+        $column->allowNull = $allowNull;
+
+        $result = $column->dbTypecast($value);
+
+        if (!$expected instanceof Expression) {
+            self::assertSame(
+                $expected,
+                $result,
+                'Converted value must match.',
+            );
+
+            return;
+        }
+
+        self::assertInstanceOf(
+            Expression::class,
+            $result,
+            'Value must yield an Expression.',
+        );
+        self::assertSame(
+            $expected->expression,
+            $result->expression,
+            'Expression SQL must match.',
+        );
+    }
+
+    #[DataProviderExternal(ColumnSchemaProvider::class, 'defaultPhpTypecast')]
+    public function testDefaultPhpTypecast(string $type, mixed $value, mixed $expected): void
+    {
+        $column = new ColumnSchema();
+
+        $column->type = $type;
+        $column->phpType = match ($type) {
+            'integer' => 'integer',
+            default => 'string',
+        };
+
+        self::assertSame(
+            $expected,
+            $column->defaultPhpTypecast($value),
+            'Converted default must match.',
+        );
+    }
+
+    #[DataProviderExternal(ColumnSchemaProvider::class, 'getOutputColumnDeclaration')]
+    public function testGetOutputColumnDeclaration(
+        string $dbType,
+        bool $allowNull,
+        int|null $size,
+        string $expected,
+    ): void {
+        $column = new ColumnSchema();
+
+        $column->dbType = $dbType;
+        $column->allowNull = $allowNull;
+        $column->size = $size;
+
+        self::assertSame(
+            $expected,
+            $column->getOutputColumnDeclaration(),
+            'Type declaration must match.',
+        );
+    }
+}

--- a/tests/framework/db/mssql/SchemaTest.php
+++ b/tests/framework/db/mssql/SchemaTest.php
@@ -342,6 +342,60 @@ class SchemaTest extends BaseSchema
         $this->assertNull($table->getColumn('stringcol')->defaultValue);
     }
 
+    public function testExpressionAndLiteralColumnDefaultValues(): void
+    {
+        $db = $this->getConnection();
+
+        if ($db->getSchema()->getTableSchema('column_default') !== null) {
+            $db->createCommand()->dropTable('column_default')->execute();
+        }
+
+        $db->createCommand()->createTable(
+            'column_default',
+            [
+                'id' => 'int',
+                'created_getdate' => 'datetime DEFAULT GETDATE()',
+                'created_cts' => 'datetime DEFAULT CURRENT_TIMESTAMP',
+                'uuid' => 'uniqueidentifier DEFAULT NEWID()',
+                'status' => 'int DEFAULT 5',
+                'label' => "varchar(32) DEFAULT 'pending'",
+                'note' => "nvarchar(32) DEFAULT N'it''s'",
+            ],
+        )->execute();
+
+        $table = $db->getSchema()->getTableSchema('column_default', true);
+
+        self::assertNull(
+            $table->getColumn('created_getdate')->defaultValue,
+            "Default must resolve to 'null'.",
+        );
+        self::assertNull(
+            $table->getColumn('created_cts')->defaultValue,
+            "Default must resolve to 'null'.",
+        );
+        self::assertNull(
+            $table->getColumn('uuid')->defaultValue,
+            "Default must resolve to 'null'.",
+        );
+        self::assertSame(
+            5,
+            $table->getColumn('status')->defaultValue,
+            "Numeric default must unwrap to 'int'.",
+        );
+        self::assertSame(
+            'pending',
+            $table->getColumn('label')->defaultValue,
+            'String default must unwrap.',
+        );
+        self::assertSame(
+            "it's",
+            $table->getColumn('note')->defaultValue,
+            'Escaped unicode default must unwrap.',
+        );
+
+        $db->createCommand()->dropTable('column_default')->execute();
+    }
+
     public function testInsertWithCompositePrimaryKey(): void
     {
         $db = $this->getConnection(true, true);

--- a/tests/framework/db/mssql/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/mssql/providers/ColumnSchemaProvider.php
@@ -93,6 +93,11 @@ final class ColumnSchemaProvider
                 '(newid())',
                 null,
             ],
+            'expression default sysdatetime returns null' => [
+                Schema::TYPE_STRING,
+                '(sysdatetime())',
+                null,
+            ],
             'integer default value unwrapped' => [
                 Schema::TYPE_INTEGER,
                 '((0))',

--- a/tests/framework/db/mssql/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/mssql/providers/ColumnSchemaProvider.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mssql\providers;
+
+use yii\db\Expression;
+use yii\db\mssql\Schema;
+
+use function bin2hex;
+
+/**
+ * Data provider for {@see \yiiunit\framework\db\mssql\ColumnSchemaTest} test cases.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class ColumnSchemaProvider
+{
+    /**
+     * @return array<string, array{string, string, bool, mixed, mixed}>
+     */
+    public static function dbTypecast(): array
+    {
+        return [
+            'non-varbinary string falls through to parent' => [
+                Schema::TYPE_STRING,
+                'varchar',
+                true,
+                'test',
+                'test',
+            ],
+            'varbinary integer value falls through to parent' => [
+                Schema::TYPE_BINARY,
+                'varbinary',
+                true,
+                123,
+                123,
+            ],
+            'varbinary null when not nullable' => [
+                Schema::TYPE_BINARY,
+                'varbinary',
+                false,
+                null,
+                null,
+            ],
+            'varbinary null when nullable' => [
+                Schema::TYPE_BINARY,
+                'varbinary',
+                true,
+                null,
+                new Expression('CAST(NULL AS VARBINARY(MAX))'),
+            ],
+            'varbinary string value' => [
+                Schema::TYPE_BINARY,
+                'varbinary',
+                true,
+                'binary data',
+                new Expression('CONVERT(VARBINARY(MAX), 0x' . bin2hex('binary data') . ')'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, mixed, mixed}>
+     */
+    public static function defaultPhpTypecast(): array
+    {
+        return [
+            'CURRENT_TIMESTAMP on timestamp column returns null' => [
+                Schema::TYPE_TIMESTAMP,
+                'CURRENT_TIMESTAMP',
+                null,
+            ],
+            'decimal default value unwrapped' => [
+                Schema::TYPE_DECIMAL,
+                '((3.14))',
+                '3.14',
+            ],
+            'expression default getdate returns null' => [
+                Schema::TYPE_STRING,
+                '(getdate())',
+                null,
+            ],
+            'expression default newid returns null' => [
+                Schema::TYPE_STRING,
+                '(newid())',
+                null,
+            ],
+            'integer default value unwrapped' => [
+                Schema::TYPE_INTEGER,
+                '((0))',
+                0,
+            ],
+            'null string returns null' => [
+                Schema::TYPE_STRING,
+                '(NULL)',
+                null,
+            ],
+            'null value returns null' => [
+                Schema::TYPE_STRING,
+                null,
+                null,
+            ],
+            'string default value unwrapped' => [
+                Schema::TYPE_STRING,
+                "('hello')",
+                'hello',
+            ],
+            'string with escaped single quotes' => [
+                Schema::TYPE_STRING,
+                "('it''s')",
+                "it's",
+            ],
+            'unicode string default value unwrapped' => [
+                Schema::TYPE_STRING,
+                "(N'unicode')",
+                'unicode',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, bool, int|null, string}>
+     */
+    public static function getOutputColumnDeclaration(): array
+    {
+        return [
+            'bigint returns as-is' => [
+                'bigint',
+                false,
+                null,
+                'bigint',
+            ],
+            'binary appends size' => [
+                'binary',
+                false,
+                16,
+                'binary(16)',
+            ],
+            'char appends size' => [
+                'char',
+                false,
+                10,
+                'char(10)',
+            ],
+            'int returns as-is' => [
+                'int',
+                false,
+                null,
+                'int',
+            ],
+            'nchar appends size' => [
+                'nchar',
+                false,
+                20,
+                'nchar(20)',
+            ],
+            'nvarchar appends MAX' => [
+                'nvarchar',
+                false,
+                null,
+                'nvarchar(MAX)',
+            ],
+            'timestamp not nullable' => [
+                Schema::TYPE_TIMESTAMP,
+                false,
+                null,
+                'binary(8)',
+            ],
+            'timestamp nullable' => [
+                Schema::TYPE_TIMESTAMP,
+                true,
+                null,
+                'varbinary(8)',
+            ],
+            'varbinary appends MAX' => [
+                'varbinary',
+                false,
+                null,
+                'varbinary(MAX)',
+            ],
+            'varchar appends MAX' => [
+                'varchar',
+                false,
+                null,
+                'varchar(MAX)',
+            ],
+        ];
+    }
+}

--- a/tests/framework/db/mssql/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/mssql/providers/ColumnSchemaProvider.php
@@ -123,6 +123,11 @@ final class ColumnSchemaProvider
                 "(N'unicode')",
                 'unicode',
             ],
+            'unicode string with escaped single quotes' => [
+                Schema::TYPE_STRING,
+                "(N'it''s')",
+                "it's",
+            ],
         ];
     }
 
@@ -144,8 +149,20 @@ final class ColumnSchemaProvider
                 16,
                 'binary(16)',
             ],
+            'binary with embedded size stays as-is' => [
+                'binary(16)',
+                false,
+                16,
+                'binary(16)',
+            ],
             'char appends size' => [
                 'char',
+                false,
+                10,
+                'char(10)',
+            ],
+            'char with embedded size stays as-is' => [
+                'char(10)',
                 false,
                 10,
                 'char(10)',
@@ -162,11 +179,23 @@ final class ColumnSchemaProvider
                 20,
                 'nchar(20)',
             ],
+            'nchar with embedded size stays as-is' => [
+                'nchar(20)',
+                false,
+                20,
+                'nchar(20)',
+            ],
             'nvarchar appends MAX' => [
                 'nvarchar',
                 false,
                 null,
                 'nvarchar(MAX)',
+            ],
+            'nvarchar with embedded size stays as-is' => [
+                'nvarchar(100)',
+                false,
+                100,
+                'nvarchar(100)',
             ],
             'timestamp not nullable' => [
                 Schema::TYPE_TIMESTAMP,
@@ -186,11 +215,23 @@ final class ColumnSchemaProvider
                 null,
                 'varbinary(MAX)',
             ],
+            'varbinary with embedded size stays as-is' => [
+                'varbinary(50)',
+                false,
+                50,
+                'varbinary(50)',
+            ],
             'varchar appends MAX' => [
                 'varchar',
                 false,
                 null,
                 'varchar(MAX)',
+            ],
+            'varchar with embedded size stays as-is' => [
+                'varchar(128)',
+                false,
+                128,
+                'varchar(128)',
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
