### PR TITLE
Consolidate MySQL data-type conversion into `ColumnSchema::defaultPhpTypecast()` and preserve explicit `CURRENT_TIMESTAMP(0)` default precision.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -74,6 +74,7 @@ Yii Framework 2 Change Log
 - Bug: Fix `Sort::createUrl()` and `Pagination::createUrl()` to fall back when no controller is active, supporting standalone actions discovered through `Module::$actionNamespace` (terabytesoftw)
 - Bug: Fix `yii\helpers\Url::current()` and `yii\helpers\Url::canonical()` to fall back to `Application::$requestedRoute` when no controller is active, supporting standalone actions (terabytesoftw)
 - Enh: Consolidate MSSQL data-type conversion into `ColumnSchema`: harden `defaultPhpTypecast()` for unicode (`N'...'`), escaped quotes, and expression defaults; add `getOutputColumnDeclaration()` used by `QueryBuilder::insert()` (terabytesoftw)
+- Enh: Consolidate MySQL data-type conversion into `ColumnSchema::defaultPhpTypecast()` and preserve explicit `CURRENT_TIMESTAMP(0)` default precision (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mysql/ColumnSchema.php
+++ b/framework/db/mysql/ColumnSchema.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,11 +10,19 @@
 
 namespace yii\db\mysql;
 
+use yii\db\Expression;
 use yii\db\ExpressionInterface;
 use yii\db\JsonExpression;
 
+use function in_array;
+use function is_string;
+
 /**
- * Class ColumnSchema for MySQL database
+ * Represents the metadata of a column in a MySQL database table.
+ *
+ * Extends {@see \yii\db\ColumnSchema} with MySQL-specific type handling: converts `json` values to {@see JsonExpression}
+ * for binding, normalizes `CURRENT_TIMESTAMP` defaults on temporal columns to {@see Expression} instances, and converts
+ * bit defaults (`b'...'`) to their integer representation.
  *
  * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
  * @since 2.0.14.1
@@ -53,5 +63,44 @@ class ColumnSchema extends \yii\db\ColumnSchema
         }
 
         return parent::phpTypecast($value);
+    }
+
+    /**
+     * Converts a MySQL column default value to its PHP representation.
+     *
+     * Handles MySQL-specific default value formats:
+     * - `null` to `null`.
+     * - `CURRENT_TIMESTAMP` / `current_timestamp()` on temporal columns (`timestamp`, `datetime`, `date`, `time`) to an
+     *   {@see Expression}, preserving any declared fractional-seconds precision such as `CURRENT_TIMESTAMP(3)`.
+     * - bit defaults (`b'...'`) when `$dbType` starts with `bit` to their integer value via `bindec()`.
+     * - everything else delegates to {@see phpTypecast()}.
+     *
+     * @param mixed $value default value in the format reported by `SHOW FULL COLUMNS`.
+     *
+     * @return mixed converted value.
+     *
+     * @since 22.0
+     */
+    public function defaultPhpTypecast($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (
+            is_string($value)
+            && in_array($this->type, ['timestamp', 'datetime', 'date', 'time'], true)
+            && preg_match('/^current_timestamp(?:\(([0-9]*)\))?$/i', $value, $matches)
+        ) {
+            $precision = $matches[1] ?? '';
+
+            return new Expression('CURRENT_TIMESTAMP' . ($precision !== '' ? "({$precision})" : ''));
+        }
+
+        if (is_string($value) && strncasecmp($this->dbType, 'bit', 3) === 0) {
+            return bindec(trim($value, "b'"));
+        }
+
+        return $this->phpTypecast($value);
     }
 }

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -16,7 +16,6 @@ use yii\db\CheckConstraint;
 use yii\db\Constraint;
 use yii\db\ConstraintFinderInterface;
 use yii\db\ConstraintFinderTrait;
-use yii\db\Expression;
 use yii\db\ForeignKeyConstraint;
 use yii\db\IndexConstraint;
 use yii\db\TableSchema;
@@ -330,25 +329,8 @@ SQL;
 
         $column->phpType = $this->getColumnPhpType($column);
 
-        if (!$column->isPrimaryKey) {
-            /**
-             * When displayed in the INFORMATION_SCHEMA.COLUMNS table, a default CURRENT TIMESTAMP is displayed
-             * as CURRENT_TIMESTAMP up until MariaDB 10.2.2, and as current_timestamp() from MariaDB 10.2.3.
-             *
-             * See details here: https://mariadb.com/kb/en/library/now/#description
-             */
-            if (
-                in_array($column->type, ['timestamp', 'datetime', 'date', 'time'])
-                && isset($info['default'])
-                && preg_match('/^current_timestamp(?:\(([0-9]*)\))?$/i', $info['default'], $matches)
-            ) {
-                $column->defaultValue = new Expression('CURRENT_TIMESTAMP' . (!empty($matches[1]) ? '(' . $matches[1] . ')' : ''));
-            } elseif (isset($type) && $type === 'bit') {
-                $column->defaultValue = bindec(trim(isset($info['default']) ? $info['default'] : '', 'b\''));
-            } else {
-                $column->defaultValue = $column->phpTypecast($info['default']);
-            }
-        }
+        // store the raw default for deferred resolution in `findColumns()`, where `isPrimaryKey` is known.
+        $column->defaultValue = $info['default'] ?? null;
 
         return $column;
     }
@@ -387,13 +369,16 @@ SQL;
             }
 
             $column = $this->loadColumnSchema($info);
-            $table->columns[$column->name] = $column;
             if ($column->isPrimaryKey) {
                 $table->primaryKey[] = $column->name;
                 if ($column->autoIncrement) {
                     $table->sequenceName = '';
                 }
             }
+            $column->defaultValue = $column->isPrimaryKey
+                ? null
+                : $column->defaultPhpTypecast($column->defaultValue);
+            $table->columns[$column->name] = $column;
         }
 
         return true;

--- a/tests/framework/db/mysql/ColumnSchemaTest.php
+++ b/tests/framework/db/mysql/ColumnSchemaTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mysql;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\Expression;
+use yii\db\mysql\ColumnSchema;
+use yiiunit\framework\db\DatabaseTestCase;
+use yiiunit\framework\db\mysql\providers\ColumnSchemaProvider;
+
+/**
+ * Unit tests for {@see \yii\db\mysql\ColumnSchema} default value type-casting for the MySQL driver.
+ *
+ * {@see ColumnSchemaProvider} for test case data providers.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('db')]
+#[Group('mysql')]
+#[Group('column')]
+final class ColumnSchemaTest extends DatabaseTestCase
+{
+    protected $driverName = 'mysql';
+
+    #[DataProviderExternal(ColumnSchemaProvider::class, 'defaultPhpTypecast')]
+    public function testDefaultPhpTypecast(
+        string $type,
+        string $dbType,
+        string $phpType,
+        mixed $value,
+        mixed $expected,
+    ): void {
+        $column = new ColumnSchema();
+
+        $column->type = $type;
+        $column->dbType = $dbType;
+        $column->phpType = $phpType;
+
+        $result = $column->defaultPhpTypecast($value);
+
+        if (!$expected instanceof Expression) {
+            self::assertSame(
+                $expected,
+                $result,
+                'Converted default must match.',
+            );
+
+            return;
+        }
+
+        self::assertInstanceOf(
+            Expression::class,
+            $result,
+            'Default must yield an Expression.',
+        );
+        self::assertSame(
+            $expected->expression,
+            $result->expression,
+            'Expression SQL must match.',
+        );
+    }
+}

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -14,6 +14,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\Group;
 use yii\db\Expression;
 use yii\db\mysql\ColumnSchema;
+use yii\db\mysql\QueryBuilder;
 use yii\db\mysql\Schema;
 use yiiunit\framework\db\AnyCaseValue;
 use yiiunit\base\db\BaseSchema;
@@ -71,6 +72,37 @@ SQL;
         $ts = $schema->columns['ts'];
         $this->assertInstanceOf(Expression::class, $ts->defaultValue);
         $this->assertEquals('CURRENT_TIMESTAMP(3)', (string)$ts->defaultValue);
+    }
+
+    public function testLoadBitDefaultColumn(): void
+    {
+        $sql = <<<SQL
+        CREATE TABLE IF NOT EXISTS `bit_default_test` (
+            `bit1` bit(1) NOT NULL DEFAULT b'1',
+            `bit5` bit(5) NOT NULL DEFAULT b'10101',
+            `bit8` bit(8) NOT NULL DEFAULT b'10000010'
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8
+        SQL;
+
+        $this->getConnection()->createCommand($sql)->execute();
+
+        $schema = $this->getConnection()->getTableSchema('bit_default_test');
+
+        self::assertSame(
+            1,
+            $schema->columns['bit1']->defaultValue,
+            "bit(1) `b\'1\'` must decode to '1'.",
+        );
+        self::assertSame(
+            21,
+            $schema->columns['bit5']->defaultValue,
+            "bit(5) `b\'10101\'` must decode to '21'.",
+        );
+        self::assertSame(
+            130,
+            $schema->columns['bit8']->defaultValue,
+            "bit(8) `b\'10000010\'` must decode to '130'.",
+        );
     }
 
     public function testGetSchemaNames(): void
@@ -214,21 +246,42 @@ SQL;
          * returns in response to the query `SHOW FULL COLUMNS FROM ...`
          */
         $schema = new Schema();
-        $column = $this->invokeMethod($schema, 'loadColumnSchema', [[
-            'field' => 'emulated_MariaDB_field',
-            'type' => 'timestamp',
-            'collation' => null,
-            'null' => 'NO',
-            'key' => '',
-            'default' => 'current_timestamp()',
-            'extra' => '',
-            'privileges' => 'select,insert,update,references',
-            'comment' => '',
-        ]]);
 
-        $this->assertInstanceOf(ColumnSchema::class, $column);
-        $this->assertInstanceOf(Expression::class, $column->defaultValue);
-        $this->assertEquals('CURRENT_TIMESTAMP', $column->defaultValue);
+        $column = $this->invokeMethod(
+            $schema,
+            'loadColumnSchema',
+            [
+                [
+                    'field' => 'emulated_MariaDB_field',
+                    'type' => 'timestamp',
+                    'collation' => null,
+                    'null' => 'NO',
+                    'key' => '',
+                    'default' => 'current_timestamp()',
+                    'extra' => '',
+                    'privileges' => 'select,insert,update,references',
+                    'comment' => '',
+                ],
+            ],
+        );
+
+        $column->defaultValue = $column->defaultPhpTypecast($column->defaultValue);
+
+        self::assertInstanceOf(
+            ColumnSchema::class,
+            $column,
+            'Loaded column must be a MariaDB/MySQL ColumnSchema.',
+        );
+        self::assertInstanceOf(
+            Expression::class,
+            $column->defaultValue,
+            'MariaDB `current_timestamp()` must yield an Expression.',
+        );
+        self::assertSame(
+            'CURRENT_TIMESTAMP',
+            (string) $column->defaultValue,
+            'Expression must normalize to CURRENT_TIMESTAMP.',
+        );
     }
 
     /**
@@ -240,20 +293,75 @@ SQL;
     public function testAlternativeDisplayOfDefaultCurrentTimestampAsNullInMariaDB(): void
     {
         $schema = new Schema();
-        $column = $this->invokeMethod($schema, 'loadColumnSchema', [[
-            'field' => 'emulated_MariaDB_field',
-            'type' => 'timestamp',
-            'collation' => null,
-            'null' => 'NO',
-            'key' => '',
-            'default' => null,
-            'extra' => '',
-            'privileges' => 'select,insert,update,references',
-            'comment' => '',
-        ]]);
 
-        $this->assertInstanceOf(ColumnSchema::class, $column);
-        $this->assertEquals(null, $column->defaultValue);
+        $column = $this->invokeMethod(
+            $schema,
+            'loadColumnSchema',
+            [
+                [
+                    'field' => 'emulated_MariaDB_field',
+                    'type' => 'timestamp',
+                    'collation' => null,
+                    'null' => 'NO',
+                    'key' => '',
+                    'default' => null,
+                    'extra' => '',
+                    'privileges' => 'select,insert,update,references',
+                    'comment' => '',
+                ],
+            ],
+        );
+
+        $column->defaultValue = $column->defaultPhpTypecast($column->defaultValue);
+
+        self::assertInstanceOf(
+            ColumnSchema::class,
+            $column,
+            'Loaded column must be a MariaDB/MySQL ColumnSchema.',
+        );
+        self::assertSame(
+            null,
+            $column->defaultValue,
+            "Default must remain 'null'.",
+        );
+    }
+
+    /**
+     * Real counterpart to {@see testAlternativeDisplayOfDefaultCurrentTimestampInMariaDB}: on MariaDB >= 10.2.3,
+     * `SHOW FULL COLUMNS` reports a `CURRENT_TIMESTAMP` default as the lowercase `current_timestamp()` form, which must
+     * still normalize to an {@see Expression}. Skipped on MySQL, which never emits that form.
+     *
+     * @see https://mariadb.com/kb/en/now/#description
+     */
+    public function testLoadDefaultCurrentTimestampOnMariaDB(): void
+    {
+        /** @var QueryBuilder $qb */
+        $qb = $this->getConnection(false)->getQueryBuilder();
+
+        if ($qb->isMariaDb() === false) {
+            $this->markTestSkipped('Test requires MariaDB.');
+        }
+
+        $sql = <<<SQL
+        CREATE TABLE IF NOT EXISTS `mariadb_current_timestamp_test` (
+            `dt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8
+        SQL;
+
+        $this->getConnection()->createCommand($sql)->execute();
+
+        $column = $this->getConnection()->getTableSchema('mariadb_current_timestamp_test')->columns['dt'];
+
+        self::assertInstanceOf(
+            Expression::class,
+            $column->defaultValue,
+            'Lowercase form must yield an Expression.',
+        );
+        self::assertSame(
+            'CURRENT_TIMESTAMP',
+            (string) $column->defaultValue,
+            'Expression must normalize to CURRENT_TIMESTAMP.',
+        );
     }
 
     public function getExpectedColumns()

--- a/tests/framework/db/mysql/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/mysql/providers/ColumnSchemaProvider.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mysql\providers;
+
+use yii\db\Expression;
+
+/**
+ * Data provider for {@see \yiiunit\framework\db\mysql\ColumnSchemaTest} test cases.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class ColumnSchemaProvider
+{
+    /**
+     * @return array<string, array{string, string, string, mixed, mixed}>
+     */
+    public static function defaultPhpTypecast(): array
+    {
+        return [
+            'bit default b\'0\' on bit(1)' => [
+                'boolean',
+                'bit(1)',
+                'boolean',
+                "b'0'",
+                0,
+            ],
+            'bit default b\'1\' on bit(1)' => [
+                'boolean',
+                'bit(1)',
+                'boolean',
+                "b'1'",
+                1,
+            ],
+            'bit default b\'10000010\' on bit(8) matches fixture' => [
+                'integer',
+                'bit(8)',
+                'integer',
+                "b'10000010'",
+                130,
+            ],
+            'bit default b\'10101\' on bit(5)' => [
+                'integer',
+                'bit(5)',
+                'integer',
+                "b'10101'",
+                21,
+            ],
+            'bit default with uppercase BIT dbType' => [
+                'integer',
+                'BIT(8)',
+                'integer',
+                "b'10000010'",
+                130,
+            ],
+            'current_timestamp() lowercase on timestamp column (MariaDB >= 10.2.3)' => [
+                'timestamp',
+                'timestamp',
+                'string',
+                'current_timestamp()',
+                new Expression('CURRENT_TIMESTAMP'),
+            ],
+            'current_timestamp(3) lowercase preserves precision' => [
+                'datetime',
+                'datetime',
+                'string',
+                'current_timestamp(3)',
+                new Expression('CURRENT_TIMESTAMP(3)'),
+            ],
+            'CURRENT_TIMESTAMP on date column' => [
+                'date',
+                'date',
+                'string',
+                'CURRENT_TIMESTAMP',
+                new Expression('CURRENT_TIMESTAMP'),
+            ],
+            'CURRENT_TIMESTAMP on datetime column' => [
+                'datetime',
+                'datetime',
+                'string',
+                'CURRENT_TIMESTAMP',
+                new Expression('CURRENT_TIMESTAMP'),
+            ],
+            'CURRENT_TIMESTAMP on non-temporal column stays a literal' => [
+                'string',
+                'varchar(255)',
+                'string',
+                'CURRENT_TIMESTAMP',
+                'CURRENT_TIMESTAMP',
+            ],
+            'CURRENT_TIMESTAMP on time column' => [
+                'time',
+                'time',
+                'string',
+                'CURRENT_TIMESTAMP',
+                new Expression('CURRENT_TIMESTAMP'),
+            ],
+            'CURRENT_TIMESTAMP on timestamp column' => [
+                'timestamp',
+                'timestamp',
+                'string',
+                'CURRENT_TIMESTAMP',
+                new Expression('CURRENT_TIMESTAMP'),
+            ],
+            'CURRENT_TIMESTAMP(0) preserves zero precision' => [
+                'timestamp',
+                'timestamp',
+                'string',
+                'CURRENT_TIMESTAMP(0)',
+                new Expression('CURRENT_TIMESTAMP(0)'),
+            ],
+            'CURRENT_TIMESTAMP(3) preserves precision' => [
+                'datetime',
+                'datetime',
+                'string',
+                'CURRENT_TIMESTAMP(3)',
+                new Expression('CURRENT_TIMESTAMP(3)'),
+            ],
+            'CURRENT_TIMESTAMP(6) preserves precision' => [
+                'timestamp',
+                'timestamp',
+                'string',
+                'CURRENT_TIMESTAMP(6)',
+                new Expression('CURRENT_TIMESTAMP(6)'),
+            ],
+            'decimal default kept as string' => [
+                'decimal',
+                'decimal(5,2)',
+                'string',
+                '33.22',
+                '33.22',
+            ],
+            'double default cast to float' => [
+                'double',
+                'double',
+                'double',
+                '1.23',
+                1.23,
+            ],
+            'JSON array default decodes to list' => [
+                'json',
+                'json',
+                'array',
+                '[1, 2, 3]',
+                [1, 2, 3],
+            ],
+            'JSON object default decodes to array' => [
+                'json',
+                'json',
+                'array',
+                '{"key":"value"}',
+                ['key' => 'value'],
+            ],
+            'null value returns null' => [
+                'timestamp',
+                'timestamp',
+                'string',
+                null,
+                null,
+            ],
+            'regular integer default cast to int' => [
+                'integer',
+                'int',
+                'integer',
+                '42',
+                42,
+            ],
+            'regular string default kept verbatim' => [
+                'string',
+                'varchar(255)',
+                'string',
+                'hello',
+                'hello',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
