### PR TITLE
Consolidate SQLite data-type conversion into `ColumnSchema::defaultPhpTypecast()` and fix `DEFAULT NULL` and escaped-quote defaults.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -77,6 +77,7 @@ Yii Framework 2 Change Log
 - Enh #20919: Consolidate MySQL data-type conversion into `ColumnSchema::defaultPhpTypecast()` and preserve explicit `CURRENT_TIMESTAMP(0)` default precision (terabytesoftw)
 - Enh #20920: Consolidate Oracle data-type conversion into `ColumnSchema::defaultPhpTypecast()` and fix `CURRENT_TIMESTAMP` defaults returned as `null` (terabytesoftw)
 - Enh #20921: Consolidate PostgreSQL data-type conversion into `ColumnSchema::defaultPhpTypecast()` and fix `phpTypecastValue()` for native boolean value (terabytesoftw)
+- Enh #20922: Consolidate SQLite data-type conversion into `ColumnSchema::defaultPhpTypecast()` and fix `DEFAULT NULL` and escaped-quote defaults (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/sqlite/ColumnSchema.php
+++ b/framework/db/sqlite/ColumnSchema.php
@@ -12,6 +12,7 @@ namespace yii\db\sqlite;
 
 use yii\db\Expression;
 
+use function is_string;
 use function str_replace;
 use function strcasecmp;
 use function strlen;
@@ -32,9 +33,9 @@ class ColumnSchema extends \yii\db\ColumnSchema
      * Handles SQLite-specific default formats reported by `PRAGMA table_info`:
      * - `null`, empty string, or the `NULL` literal (any case) to `null`.
      * - `CURRENT_TIMESTAMP` (any case) on `timestamp` columns to {@see Expression}.
-     * - single/double-quote-wrapped string defaults (`'value'`, `"value"`) to the unwrapped literal, resolving
-     *   doubled quotes (`''` to `'`, `""` to `"`).
-     * - everything else delegates to {@see \yii\db\ColumnSchema::defaultPhpTypecast()}.
+     * - single/double-quote-wrapped string defaults (`'value'`, `"value"`) to the unwrapped literal, resolving doubled
+     *   quotes (`''` to `'`, `""` to `"`).
+     * - non-string values and everything else delegate to {@see \yii\db\ColumnSchema::defaultPhpTypecast()}.
      *
      * @link https://www.sqlite.org/lang_createtable.html#the_default_clause
      *
@@ -46,25 +47,23 @@ class ColumnSchema extends \yii\db\ColumnSchema
      */
     public function defaultPhpTypecast($value)
     {
-        if ($value === null) {
-            return null;
-        }
+        if (is_string($value)) {
+            $value = trim($value);
 
-        $value = trim((string) $value);
+            if ($value === '' || strcasecmp($value, 'NULL') === 0) {
+                return null;
+            }
 
-        if ($value === '' || strcasecmp($value, 'NULL') === 0) {
-            return null;
-        }
+            // `CURRENT_TIMESTAMP` is a case-independent keyword (consistency with all driver).
+            if ($this->type === Schema::TYPE_TIMESTAMP && strcasecmp($value, 'CURRENT_TIMESTAMP') === 0) {
+                return new Expression('CURRENT_TIMESTAMP');
+            }
 
-        // `CURRENT_TIMESTAMP` is a case-independent keyword (consistency with MySQL driver).
-        if ($this->type === Schema::TYPE_TIMESTAMP && strcasecmp($value, 'CURRENT_TIMESTAMP') === 0) {
-            return new Expression('CURRENT_TIMESTAMP');
-        }
-
-        // quote-wrapped string defaults: 'value' / "value" -> unwrapped, resolving doubled quotes ('' -> ', "" -> ").
-        if (strlen($value) > 1 && ($value[0] === "'" || $value[0] === '"') && $value[-1] === $value[0]) {
-            $quote = $value[0];
-            $value = str_replace($quote . $quote, $quote, substr($value, 1, -1));
+            // quote-wrapped defaults: 'value' / "value" -> unwrapped, resolving doubled quotes ('' -> ', "" -> ").
+            if (strlen($value) > 1 && ($value[0] === "'" || $value[0] === '"') && $value[-1] === $value[0]) {
+                $quote = $value[0];
+                $value = str_replace($quote . $quote, $quote, substr($value, 1, -1));
+            }
         }
 
         return parent::defaultPhpTypecast($value);

--- a/framework/db/sqlite/ColumnSchema.php
+++ b/framework/db/sqlite/ColumnSchema.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yii\db\sqlite;
+
+use yii\db\Expression;
+
+use function str_replace;
+use function strcasecmp;
+use function strlen;
+use function substr;
+use function trim;
+
+/**
+ * Represents the metadata of a column in a SQLite database table.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+class ColumnSchema extends \yii\db\ColumnSchema
+{
+    /**
+     * Converts a SQLite column default value to its PHP representation.
+     *
+     * Handles SQLite-specific default formats reported by `PRAGMA table_info`:
+     * - `null`, empty string, or the `NULL` literal (any case) to `null`.
+     * - `CURRENT_TIMESTAMP` (any case) on `timestamp` columns to {@see Expression}.
+     * - single/double-quote-wrapped string defaults (`'value'`, `"value"`) to the unwrapped literal, resolving
+     *   doubled quotes (`''` to `'`, `""` to `"`).
+     * - everything else delegates to {@see \yii\db\ColumnSchema::defaultPhpTypecast()}.
+     *
+     * @link https://www.sqlite.org/lang_createtable.html#the_default_clause
+     *
+     * @param mixed $value Default value in SQLite `dflt_value` format.
+     *
+     * @return mixed Converted value.
+     *
+     * @since 22.0
+     */
+    public function defaultPhpTypecast($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        if ($value === '' || strcasecmp($value, 'NULL') === 0) {
+            return null;
+        }
+
+        // `CURRENT_TIMESTAMP` is a case-independent keyword (consistency with MySQL driver).
+        if ($this->type === Schema::TYPE_TIMESTAMP && strcasecmp($value, 'CURRENT_TIMESTAMP') === 0) {
+            return new Expression('CURRENT_TIMESTAMP');
+        }
+
+        // quote-wrapped string defaults: 'value' / "value" -> unwrapped, resolving doubled quotes ('' -> ', "" -> ").
+        if (strlen($value) > 1 && ($value[0] === "'" || $value[0] === '"') && $value[-1] === $value[0]) {
+            $quote = $value[0];
+            $value = str_replace($quote . $quote, $quote, substr($value, 1, -1));
+        }
+
+        return parent::defaultPhpTypecast($value);
+    }
+}

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -11,11 +11,9 @@ namespace yii\db\sqlite;
 use Yii;
 use yii\base\NotSupportedException;
 use yii\db\CheckConstraint;
-use yii\db\ColumnSchema;
 use yii\db\Constraint;
 use yii\db\ConstraintFinderInterface;
 use yii\db\ConstraintFinderTrait;
-use yii\db\Expression;
 use yii\db\ForeignKeyConstraint;
 use yii\db\IndexConstraint;
 use yii\db\SqlToken;
@@ -39,6 +37,11 @@ use yii\db\Schema as BaseSchema;
 class Schema extends BaseSchema implements ConstraintFinderInterface
 {
     use ConstraintFinderTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public $columnSchemaClass = ColumnSchema::class;
 
     /**
      * @var array mapping from physical column types (keys) to abstract column types (values)
@@ -348,16 +351,9 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
         }
         $column->phpType = $this->getColumnPhpType($column);
 
-        if (!$column->isPrimaryKey) {
-            if ($info['dflt_value'] === 'null' || $info['dflt_value'] === '' || $info['dflt_value'] === null) {
-                $column->defaultValue = null;
-            } elseif ($column->type === 'timestamp' && $info['dflt_value'] === 'CURRENT_TIMESTAMP') {
-                $column->defaultValue = new Expression('CURRENT_TIMESTAMP');
-            } else {
-                $value = trim($info['dflt_value'], "'\"");
-                $column->defaultValue = $column->phpTypecast($value);
-            }
-        }
+        $column->defaultValue = $column->isPrimaryKey
+            ? null
+            : $column->defaultPhpTypecast($info['dflt_value']);
 
         return $column;
     }

--- a/tests/framework/db/sqlite/ColumnSchemaTest.php
+++ b/tests/framework/db/sqlite/ColumnSchemaTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\sqlite;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\Expression;
+use yii\db\sqlite\ColumnSchema;
+use yiiunit\framework\db\DatabaseTestCase;
+use yiiunit\framework\db\sqlite\providers\ColumnSchemaProvider;
+
+/**
+ * Unit tests for {@see \yii\db\sqlite\ColumnSchema} default value type-casting for the SQLite driver.
+ *
+ * {@see ColumnSchemaProvider} for test case data providers.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('db')]
+#[Group('sqlite')]
+#[Group('column-schema')]
+final class ColumnSchemaTest extends DatabaseTestCase
+{
+    protected $driverName = 'sqlite';
+
+    #[DataProviderExternal(ColumnSchemaProvider::class, 'defaultPhpTypecast')]
+    public function testDefaultPhpTypecast(
+        string $type,
+        string $dbType,
+        string $phpType,
+        mixed $value,
+        mixed $expected,
+    ): void {
+        $column = new ColumnSchema();
+
+        $column->type = $type;
+        $column->dbType = $dbType;
+        $column->phpType = $phpType;
+
+        $result = $column->defaultPhpTypecast($value);
+
+        if (!$expected instanceof Expression) {
+            self::assertSame(
+                $expected,
+                $result,
+                'Converted default must match.',
+            );
+
+            return;
+        }
+
+        self::assertInstanceOf(
+            Expression::class,
+            $result,
+            'Default must yield an Expression.',
+        );
+        self::assertSame(
+            $expected->expression,
+            $result->expression,
+            'Expression SQL must match.',
+        );
+    }
+}

--- a/tests/framework/db/sqlite/SchemaTest.php
+++ b/tests/framework/db/sqlite/SchemaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,16 +10,20 @@
 
 namespace yiiunit\framework\db\sqlite;
 
+use PHPUnit\Framework\Attributes\Group;
 use yii\base\NotSupportedException;
 use yii\db\Constraint;
+use yii\db\Expression;
 use yiiunit\framework\db\AnyValue;
 use yiiunit\base\db\BaseSchema;
 
 /**
- * @group db
- * @group sqlite
+ * Unit tests for {@see \yii\db\sqlite\Schema} schema reflection and metadata retrieval for the SQLite driver.
  */
-class SchemaTest extends BaseSchema
+#[Group('db')]
+#[Group('sqlite')]
+#[Group('schema')]
+final class SchemaTest extends BaseSchema
 {
     protected $driverName = 'sqlite';
 
@@ -57,6 +63,205 @@ class SchemaTest extends BaseSchema
         $this->assertEquals('order_item', $table->foreignKeys[0][0]);
         $this->assertEquals('order_id', $table->foreignKeys[0]['order_id']);
         $this->assertEquals('item_id', $table->foreignKeys[0]['item_id']);
+    }
+
+    public function testCurrentTimestampLowercaseDefaultValue(): void
+    {
+        $db = $this->getConnection(false);
+
+        if ($db->schema->getTableSchema('test_default_current_ts') !== null) {
+            $db->createCommand()->dropTable('test_default_current_ts')->execute();
+        }
+
+        $db->createCommand()->createTable(
+            'test_default_current_ts',
+            [
+                'id' => 'pk',
+                'ts_col' => 'timestamp NOT NULL DEFAULT current_timestamp',
+            ],
+        )->execute();
+
+        $db->schema->refreshTableSchema('test_default_current_ts');
+
+        $tableSchema = $db->schema->getTableSchema('test_default_current_ts');
+
+        self::assertEquals(
+            new Expression('CURRENT_TIMESTAMP'),
+            $tableSchema->getColumn('ts_col')->defaultValue,
+            "Default must be a 'CURRENT_TIMESTAMP' expression.",
+        );
+    }
+
+    public function testUppercaseNullDefaultValue(): void
+    {
+        $db = $this->getConnection();
+
+        $table = $db->schema->getTableSchema('null_values');
+
+        self::assertNull(
+            $table->getColumn('var3')->defaultValue,
+            "Integer default must be 'null', not '0'.",
+        );
+        self::assertNull(
+            $table->getColumn('stringcol')->defaultValue,
+            "String default must be 'null', not the literal 'NULL'.",
+        );
+    }
+
+    public function testEscapedSingleQuoteDefaultValue(): void
+    {
+        $db = $this->getConnection(false);
+
+        if ($db->schema->getTableSchema('test_default_escaped_quote') !== null) {
+            $db->createCommand()->dropTable('test_default_escaped_quote')->execute();
+        }
+
+        $db->createCommand()->createTable(
+            'test_default_escaped_quote',
+            [
+                'id' => 'pk',
+                'str_col' => "varchar(32) NOT NULL DEFAULT 'it''s'",
+            ],
+        )->execute();
+
+        $db->schema->refreshTableSchema('test_default_escaped_quote');
+
+        $tableSchema = $db->schema->getTableSchema('test_default_escaped_quote');
+
+        self::assertSame(
+            "it's",
+            $tableSchema->getColumn('str_col')->defaultValue,
+            'Doubled single quote must resolve to one quote.',
+        );
+    }
+
+    public function testDoubleQuotedDefaultValue(): void
+    {
+        $db = $this->getConnection(false);
+
+        if ($db->schema->getTableSchema('test_default_double_quoted') !== null) {
+            $db->createCommand()->dropTable('test_default_double_quoted')->execute();
+        }
+
+        $db->createCommand()->createTable(
+            'test_default_double_quoted',
+            [
+                'id' => 'pk',
+                'str_col' => 'varchar(32) NOT NULL DEFAULT "do""uble"',
+            ],
+        )->execute();
+
+        $db->schema->refreshTableSchema('test_default_double_quoted');
+
+        $tableSchema = $db->schema->getTableSchema('test_default_double_quoted');
+
+        self::assertSame(
+            'do"uble',
+            $tableSchema->getColumn('str_col')->defaultValue,
+            'Doubled double quote must resolve to one quote.',
+        );
+    }
+
+    public function testEmptyStringDefaultValue(): void
+    {
+        $db = $this->getConnection(false);
+
+        if ($db->schema->getTableSchema('test_default_empty_string') !== null) {
+            $db->createCommand()->dropTable('test_default_empty_string')->execute();
+        }
+
+        $db->createCommand()->createTable(
+            'test_default_empty_string',
+            [
+                'id' => 'pk',
+                'str_col' => "varchar(32) NOT NULL DEFAULT ''",
+            ],
+        )->execute();
+
+        $db->schema->refreshTableSchema('test_default_empty_string');
+
+        $tableSchema = $db->schema->getTableSchema('test_default_empty_string');
+
+        self::assertSame(
+            '',
+            $tableSchema->getColumn('str_col')->defaultValue,
+            "Empty string literal must stay an empty 'string', not 'null'.",
+        );
+    }
+
+    public function testBooleanKeywordDefaultValues(): void
+    {
+        $db = $this->getConnection(false);
+
+        if ($db->schema->getTableSchema('test_default_boolean_keyword') !== null) {
+            $db->createCommand()->dropTable('test_default_boolean_keyword')->execute();
+        }
+
+        $db->createCommand()->createTable(
+            'test_default_boolean_keyword',
+            [
+                'id' => 'pk',
+                'bool_true' => 'boolean NOT NULL DEFAULT true',
+                'bool_false' => 'boolean NOT NULL DEFAULT FALSE',
+            ],
+        )->execute();
+
+        $db->schema->refreshTableSchema('test_default_boolean_keyword');
+
+        $tableSchema = $db->schema->getTableSchema('test_default_boolean_keyword');
+
+        self::assertTrue(
+            $tableSchema->getColumn('bool_true')->defaultValue,
+            "Keyword `true` must cast to 'true'.",
+        );
+        self::assertFalse(
+            $tableSchema->getColumn('bool_false')->defaultValue,
+            "Keyword 'FALSE' must cast to 'false'.",
+        );
+    }
+
+    public function testExpressionDefaultValueIsPreservedAsString(): void
+    {
+        $db = $this->getConnection(false);
+
+        if ($db->schema->getTableSchema('test_default_expression') !== null) {
+            $db->createCommand()->dropTable('test_default_expression')->execute();
+        }
+
+        $db->createCommand()->createTable(
+            'test_default_expression',
+            [
+                'id' => 'pk',
+                'expr_col' => "text DEFAULT (datetime('now'))",
+            ],
+        )->execute();
+
+        $db->schema->refreshTableSchema('test_default_expression');
+
+        $tableSchema = $db->schema->getTableSchema('test_default_expression');
+
+        self::assertSame(
+            "datetime('now')",
+            $tableSchema->getColumn('expr_col')->defaultValue,
+            'Expression default must be preserved verbatim.',
+        );
+    }
+
+    public function testPrimaryKeyDefaultValueIsNull(): void
+    {
+        $db = $this->getConnection();
+
+        $table = $db->schema->getTableSchema('default_pk');
+        $column = $table->getColumn('id');
+
+        self::assertTrue(
+            $column->isPrimaryKey,
+            'Column must be flagged as primary key.',
+        );
+        self::assertNull(
+            $column->defaultValue,
+            "Primary key default must stay 'null'.",
+        );
     }
 
     public static function constraintsProvider(): array

--- a/tests/framework/db/sqlite/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/sqlite/providers/ColumnSchemaProvider.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\sqlite\providers;
+
+use yii\db\Expression;
+
+/**
+ * Data provider for {@see \yiiunit\framework\db\sqlite\ColumnSchemaTest} test cases.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class ColumnSchemaProvider
+{
+    /**
+     * @return array<string, array{string, string, string, mixed, mixed}>
+     */
+    public static function defaultPhpTypecast(): array
+    {
+        return [
+            'blob literal passes through raw' => [
+                'binary',
+                'blob',
+                'resource',
+                "x'414243'",
+                "x'414243'",
+            ],
+            'boolean keyword FALSE returns false' => [
+                'boolean',
+                'boolean',
+                'boolean',
+                'FALSE',
+                false,
+            ],
+            'boolean keyword true returns true' => [
+                'boolean',
+                'boolean',
+                'boolean',
+                'true',
+                true,
+            ],
+            'boolean tinyint(1) one returns true' => [
+                'boolean',
+                'tinyint(1)',
+                'boolean',
+                '1',
+                true,
+            ],
+            'boolean tinyint(1) zero returns false' => [
+                'boolean',
+                'tinyint(1)',
+                'boolean',
+                '0',
+                false,
+            ],
+            'CURRENT_DATE on date column passes through as string' => [
+                'date',
+                'date',
+                'string',
+                'CURRENT_DATE',
+                'CURRENT_DATE',
+            ],
+            'CURRENT_TIME on time column passes through as string' => [
+                'time',
+                'time',
+                'string',
+                'CURRENT_TIME',
+                'CURRENT_TIME',
+            ],
+            'CURRENT_TIMESTAMP lowercase on timestamp column returns Expression' => [
+                'timestamp',
+                'timestamp',
+                'string',
+                'current_timestamp',
+                new Expression('CURRENT_TIMESTAMP'),
+            ],
+            'CURRENT_TIMESTAMP mixed case on timestamp column returns Expression' => [
+                'timestamp',
+                'timestamp',
+                'string',
+                'Current_Timestamp',
+                new Expression('CURRENT_TIMESTAMP'),
+            ],
+            'CURRENT_TIMESTAMP on datetime column passes through as string' => [
+                'datetime',
+                'datetime',
+                'string',
+                'CURRENT_TIMESTAMP',
+                'CURRENT_TIMESTAMP',
+            ],
+            'CURRENT_TIMESTAMP on string column passes through as string' => [
+                'string',
+                'varchar',
+                'string',
+                'CURRENT_TIMESTAMP',
+                'CURRENT_TIMESTAMP',
+            ],
+            'CURRENT_TIMESTAMP on timestamp column returns Expression' => [
+                'timestamp',
+                'timestamp',
+                'string',
+                'CURRENT_TIMESTAMP',
+                new Expression('CURRENT_TIMESTAMP'),
+            ],
+            'decimal default keeps numeric string' => [
+                'decimal',
+                'decimal(5,2)',
+                'string',
+                '3.14',
+                '3.14',
+            ],
+            'double default' => [
+                'double',
+                'double',
+                'double',
+                '1.5',
+                1.5,
+            ],
+            'double-quoted string default is unwrapped' => [
+                'string',
+                'varchar(32)',
+                'string',
+                '"hello"',
+                'hello',
+            ],
+            'double-quoted string resolves doubled quotes' => [
+                'string',
+                'varchar(32)',
+                'string',
+                '"do""uble"',
+                'do"uble',
+            ],
+            'empty string literal is unwrapped to empty string' => [
+                'string',
+                'varchar(32)',
+                'string',
+                "''",
+                '',
+            ],
+            'empty string returns null' => [
+                'string',
+                'varchar(32)',
+                'string',
+                '',
+                null,
+            ],
+            'expression default passes through as string' => [
+                'text',
+                'text',
+                'string',
+                "datetime('now')",
+                "datetime('now')",
+            ],
+            'integer default' => [
+                'integer',
+                'integer',
+                'integer',
+                '42',
+                42,
+            ],
+            'negative double default' => [
+                'double',
+                'double',
+                'double',
+                '-12345.6789',
+                -12345.6789,
+            ],
+            'negative integer default' => [
+                'integer',
+                'integer',
+                'integer',
+                '-42',
+                -42,
+            ],
+            'null literal lowercase returns null' => [
+                'string',
+                'varchar(32)',
+                'string',
+                'null',
+                null,
+            ],
+            'NULL literal mixed case returns null' => [
+                'integer',
+                'integer',
+                'integer',
+                'Null',
+                null,
+            ],
+            'NULL literal uppercase returns null' => [
+                'string',
+                'varchar(32)',
+                'string',
+                'NULL',
+                null,
+            ],
+            'null value returns null' => [
+                'timestamp',
+                'timestamp',
+                'string',
+                null,
+                null,
+            ],
+            'plus-signed integer default' => [
+                'integer',
+                'integer',
+                'integer',
+                '+5',
+                5,
+            ],
+            'quote-only literal resolves to single quote' => [
+                'string',
+                'varchar(32)',
+                'string',
+                "''''",
+                "'",
+            ],
+            'quoted integer default is unwrapped and cast' => [
+                'integer',
+                'integer',
+                'integer',
+                "'1'",
+                1,
+            ],
+            'quoted negative integer default is unwrapped and cast' => [
+                'integer',
+                'integer',
+                'integer',
+                "'-123'",
+                -123,
+            ],
+            'single-quoted string default is unwrapped' => [
+                'string',
+                'varchar(32)',
+                'string',
+                "'hello'",
+                'hello',
+            ],
+            'single-quoted string resolves doubled quotes' => [
+                'string',
+                'varchar(32)',
+                'string',
+                "'it''s'",
+                "it's",
+            ],
+            'timestamp literal default is unwrapped' => [
+                'timestamp',
+                'timestamp',
+                'string',
+                "'2002-01-01 00:00:00'",
+                '2002-01-01 00:00:00',
+            ],
+            'whitespace-padded integer default is trimmed' => [
+                'integer',
+                'integer',
+                'integer',
+                ' 42 ',
+                42,
+            ],
+        ];
+    }
+}

--- a/tests/framework/db/sqlite/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/sqlite/providers/ColumnSchemaProvider.php
@@ -26,6 +26,27 @@ final class ColumnSchemaProvider
     public static function defaultPhpTypecast(): array
     {
         return [
+            'already typed boolean passes through' => [
+                'boolean',
+                'tinyint(1)',
+                'boolean',
+                true,
+                true,
+            ],
+            'already typed double passes through' => [
+                'double',
+                'double',
+                'double',
+                1.5,
+                1.5,
+            ],
+            'already typed integer passes through' => [
+                'integer',
+                'integer',
+                'integer',
+                42,
+                42,
+            ],
             'blob literal passes through raw' => [
                 'binary',
                 'blob',
@@ -151,6 +172,13 @@ final class ColumnSchemaProvider
                 'string',
                 '',
                 null,
+            ],
+            'Expression object passes through without string coercion' => [
+                'integer',
+                'integer',
+                'integer',
+                new Expression('1 + 2'),
+                new Expression('1 + 2'),
             ],
             'expression default passes through as string' => [
                 'text',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
