### PR TITLE
Add explicit default values to `ColumnSchema` properties in `yii\db`, `yii\db\mssql`, and `yii\db\pgsql`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -78,6 +78,7 @@ Yii Framework 2 Change Log
 - Enh #20920: Consolidate Oracle data-type conversion into `ColumnSchema::defaultPhpTypecast()` and fix `CURRENT_TIMESTAMP` defaults returned as `null` (terabytesoftw)
 - Enh #20921: Consolidate PostgreSQL data-type conversion into `ColumnSchema::defaultPhpTypecast()` and fix `phpTypecastValue()` for native boolean value (terabytesoftw)
 - Enh #20922: Consolidate SQLite data-type conversion into `ColumnSchema::defaultPhpTypecast()` and fix `DEFAULT NULL` and escaped-quote defaults (terabytesoftw)
+- Enh #20923: Add explicit default values to `ColumnSchema` properties in `yii\db`, `yii\db\mssql`, and `yii\db\pgsql` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/ColumnSchema.php
+++ b/framework/db/ColumnSchema.php
@@ -22,50 +22,50 @@ class ColumnSchema extends BaseObject
     /**
      * @var string name of this column (without quotes).
      */
-    public $name;
+    public $name = '';
     /**
      * @var bool whether this column can be null.
      */
-    public $allowNull;
+    public $allowNull = false;
     /**
      * @var string abstract type of this column. Possible abstract types include:
      * char, string, text, boolean, smallint, integer, bigint, float, decimal, datetime,
      * timestamp, time, date, binary, and money.
      */
-    public $type;
+    public $type = '';
     /**
      * @var string the PHP type of this column. Possible PHP types include:
      * `string`, `boolean`, `integer`, `double`, `array`.
      */
-    public $phpType;
+    public $phpType = '';
     /**
      * @var string the DB type of this column. Possible DB types vary according to the type of DBMS.
      */
-    public $dbType;
+    public $dbType = '';
     /**
      * @var mixed default value of this column
      */
-    public $defaultValue;
+    public $defaultValue = null;
     /**
-     * @var array enumerable values. This is set only if the column is declared to be an enumerable type.
+     * @var array|null enumerable values. This is set only if the column is declared to be an enumerable type.
      */
-    public $enumValues;
+    public $enumValues = null;
     /**
-     * @var int display size of the column.
+     * @var int|null display size of the column.
      */
-    public $size;
+    public $size = null;
     /**
-     * @var int precision of the column data, if it is numeric.
+     * @var int|null precision of the column data, if it is numeric.
      */
-    public $precision;
+    public $precision = null;
     /**
-     * @var int scale of the column data, if it is numeric.
+     * @var int|null scale of the column data, if it is numeric.
      */
-    public $scale;
+    public $scale = null;
     /**
      * @var bool|null whether this column is a primary key
      */
-    public $isPrimaryKey;
+    public $isPrimaryKey = null;
     /**
      * @var bool whether this column is auto-incremental
      */
@@ -74,12 +74,11 @@ class ColumnSchema extends BaseObject
      * @var bool whether this column is unsigned. This is only meaningful
      * when [[type]] is `smallint`, `integer` or `bigint`.
      */
-    public $unsigned;
+    public $unsigned = false;
     /**
-     * @var string comment of this column. Not all DBMS support this.
+     * @var string|null comment of this column. Not all DBMS support this.
      */
-    public $comment;
-
+    public $comment = null;
 
     /**
      * Converts the input value according to [[phpType]] after retrieval from the database.

--- a/framework/db/mssql/ColumnSchema.php
+++ b/framework/db/mssql/ColumnSchema.php
@@ -21,10 +21,6 @@ use function str_replace;
 /**
  * Represents the metadata of a column in a Microsoft SQL Server database table.
  *
- * Extends {@see \yii\db\ColumnSchema} with MSSQL-specific type handling: converts `varbinary` values to explicit
- * `CONVERT()` expressions, normalizes column default values, and builds OUTPUT-clause type declarations for
- * `INSERT ... OUTPUT INTO` temp tables.
- *
  * @since 2.0.23
  */
 class ColumnSchema extends \yii\db\ColumnSchema
@@ -33,7 +29,7 @@ class ColumnSchema extends \yii\db\ColumnSchema
      * @var bool whether this column is a computed column
      * @since 2.0.39
      */
-    public $isComputed;
+    public $isComputed = false;
 
     /**
      * {@inheritdoc}

--- a/framework/db/mysql/ColumnSchema.php
+++ b/framework/db/mysql/ColumnSchema.php
@@ -20,10 +20,6 @@ use function is_string;
 /**
  * Represents the metadata of a column in a MySQL database table.
  *
- * Extends {@see \yii\db\ColumnSchema} with MySQL-specific type handling: converts `json` values to {@see JsonExpression}
- * for binding, normalizes `CURRENT_TIMESTAMP` defaults on temporal columns to {@see Expression} instances, and converts
- * bit defaults (`b'...'`) to their integer representation.
- *
  * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
  * @since 2.0.14.1
  */

--- a/framework/db/oci/ColumnSchema.php
+++ b/framework/db/oci/ColumnSchema.php
@@ -26,10 +26,6 @@ use function uniqid;
 /**
  * Represents the metadata of a column in an Oracle database table.
  *
- * Extends {@see \yii\db\ColumnSchema} with Oracle-specific handling: wraps `string` values for `BLOB` columns in
- * `TO_BLOB(UTL_RAW.CAST_TO_RAW())` expressions, and normalizes `DATA_DEFAULT` metadata (`CURRENT_TIMESTAMP`,
- * server-managed timestamps, quote-wrapped literals) into PHP values.
- *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 22.0
  */

--- a/framework/db/pgsql/ColumnSchema.php
+++ b/framework/db/pgsql/ColumnSchema.php
@@ -28,11 +28,6 @@ use function strtoupper;
 /**
  * Represents the metadata of a column in a PostgreSQL database table.
  *
- * Extends {@see \yii\db\ColumnSchema} with PostgreSQL-specific handling: converts `array` values to {@see ArrayExpression}
- * and `json`/`jsonb` values to {@see JsonExpression} for binding, parses array literals back to PHP on retrieval, and
- * normalizes column default metadata (temporal expressions, bit literals, `boolean`, and cast notation) into PHP
- * values.
- *
  * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
  * @since 2.0
  */
@@ -43,10 +38,10 @@ class ColumnSchema extends \yii\db\ColumnSchema
      */
     public $dimension = 0;
     /**
-     * @var string name of associated sequence if column is auto-incremental
+     * @var string|null name of associated sequence if column is auto-incremental. `null` if no sequence.
      * @since 2.0.29
      */
-    public $sequenceName;
+    public $sequenceName = null;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
