### PR TITLE
Fix #18113: Return `null` default for nullable `BIT` columns in MySQL

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -18,6 +18,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
 - Bug #20889: Remove unreachable PHP < 7 cookie deserialization fallback in `yii\web\Request::loadCookies()` (terabytesoftw)
 - Enh #20890: Harden `yii\i18n\PhpMessageSource` category path handling to reject `..` segments, absolute paths, and stream-wrapper categories (terabytesoftw)
+- Bug #20924: Fix nullable `BIT` column reporting `defaultValue` as `0` instead of `null` in MySQL schema (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -349,7 +349,9 @@ SQL;
             ) {
                 $column->defaultValue = new Expression('CURRENT_TIMESTAMP' . (!empty($matches[1]) ? '(' . $matches[1] . ')' : ''));
             } elseif (isset($type) && $type === 'bit') {
-                $column->defaultValue = bindec(trim(isset($info['default']) ? $info['default'] : '', 'b\''));
+                $column->defaultValue = isset($info['default'])
+                    ? bindec(trim($info['default'], 'b\''))
+                    : null;
             } else {
                 $column->defaultValue = $column->phpTypecast($info['default']);
             }

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -46,6 +46,25 @@ SQL;
         $this->assertEquals('CURRENT_TIMESTAMP', (string)$dt->defaultValue);
     }
 
+    public function testNullableBitColumnHasNullDefaultValue(): void
+    {
+        $db = $this->getConnection();
+        if ($db->getTableSchema('bit_default_test') !== null) {
+            $db->createCommand()->dropTable('bit_default_test')->execute();
+        }
+
+        $sql = <<<SQL
+CREATE TABLE `bit_default_test` (
+  `nullable_bit` BIT(1) NULL DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+SQL;
+        $db->createCommand($sql)->execute();
+
+        $table = $db->getTableSchema('bit_default_test', true);
+
+        $this->assertNull($table->getColumn('nullable_bit')->defaultValue);
+    }
+
     public function testDefaultDatetimeColumnWithMicrosecs(): void
     {
         if (!version_compare($this->getConnection()->pdo->getAttribute(PDO::ATTR_SERVER_VERSION), '5.6.4', '>=')) {

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -55,14 +55,37 @@ SQL;
 
         $sql = <<<SQL
 CREATE TABLE `bit_default_test` (
-  `nullable_bit` BIT(1) NULL DEFAULT NULL
+  `nullable_bit_explicit` BIT(1) NULL DEFAULT NULL,
+  `nullable_bit_implicit` BIT(1) NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8
 SQL;
         $db->createCommand($sql)->execute();
 
         $table = $db->getTableSchema('bit_default_test', true);
 
-        $this->assertNull($table->getColumn('nullable_bit')->defaultValue);
+        $this->assertNull($table->getColumn('nullable_bit_explicit')->defaultValue);
+        $this->assertNull($table->getColumn('nullable_bit_implicit')->defaultValue);
+    }
+
+    public function testBitColumnDefaultValueIsDecoded(): void
+    {
+        $db = $this->getConnection();
+        if ($db->getTableSchema('bit_default_decode_test') !== null) {
+            $db->createCommand()->dropTable('bit_default_decode_test')->execute();
+        }
+
+        $sql = <<<SQL
+CREATE TABLE `bit_default_decode_test` (
+  `zero_bit` BIT(1) NOT NULL DEFAULT b'0',
+  `multi_bit` BIT(8) NOT NULL DEFAULT b'10000010'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+SQL;
+        $db->createCommand($sql)->execute();
+
+        $table = $db->getTableSchema('bit_default_decode_test', true);
+
+        $this->assertSame(0, $table->getColumn('zero_bit')->defaultValue);
+        $this->assertSame(130, $table->getColumn('multi_bit')->defaultValue);
     }
 
     public function testDefaultDatetimeColumnWithMicrosecs(): void

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -350,13 +350,34 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         }
 
         $db->createCommand()->createTable('bit_default_test', [
-            'nullable_bit' => 'bit(1) DEFAULT NULL',
+            'nullable_bit_explicit' => 'bit(1) DEFAULT NULL',
+            'nullable_bit_implicit' => 'bit(1)',
         ])->execute();
 
         $db->schema->refreshTableSchema('bit_default_test');
         $table = $db->schema->getTableSchema('bit_default_test');
 
-        $this->assertNull($table->getColumn('nullable_bit')->defaultValue);
+        $this->assertNull($table->getColumn('nullable_bit_explicit')->defaultValue);
+        $this->assertNull($table->getColumn('nullable_bit_implicit')->defaultValue);
+    }
+
+    public function testBitColumnDefaultValueIsDecoded(): void
+    {
+        $db = $this->getConnection(false);
+        if ($db->schema->getTableSchema('bit_default_decode_test') !== null) {
+            $db->createCommand()->dropTable('bit_default_decode_test')->execute();
+        }
+
+        $db->createCommand()->createTable('bit_default_decode_test', [
+            'zero_bit' => "bit(1) NOT NULL DEFAULT B'0'",
+            'multi_bit' => "bit(8) NOT NULL DEFAULT B'10000010'",
+        ])->execute();
+
+        $db->schema->refreshTableSchema('bit_default_decode_test');
+        $table = $db->schema->getTableSchema('bit_default_decode_test');
+
+        $this->assertSame(0, $table->getColumn('zero_bit')->defaultValue);
+        $this->assertSame(130, $table->getColumn('multi_bit')->defaultValue);
     }
 
     /**

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -342,6 +342,23 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         $this->assertNull($tableSchema->getColumn('timestamp')->defaultValue);
     }
 
+    public function testNullableBitColumnHasNullDefaultValue(): void
+    {
+        $db = $this->getConnection(false);
+        if ($db->schema->getTableSchema('bit_default_test') !== null) {
+            $db->createCommand()->dropTable('bit_default_test')->execute();
+        }
+
+        $db->createCommand()->createTable('bit_default_test', [
+            'nullable_bit' => 'bit(1) DEFAULT NULL',
+        ])->execute();
+
+        $db->schema->refreshTableSchema('bit_default_test');
+        $table = $db->schema->getTableSchema('bit_default_test');
+
+        $this->assertNull($table->getColumn('nullable_bit')->defaultValue);
+    }
+
     /**
      * @see https://github.com/yiisoft/yii2/issues/20329
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #18113

## What does this PR do?

Fixes nullable MySQL `BIT` columns reporting a `defaultValue` of `0` instead of `null` during schema introspection.

`yii\db\mysql\Schema::loadColumnSchema()` ran `bindec(trim($info['default'], 'b\''))` even when the column had no default, and `bindec('')` returns `0`. A missing default now resolves to `null`; a real default (e.g. `b'10000010'`) still resolves to its integer value (`130`).

PostgreSQL already returns `null` here - its bit-default parsing sits behind a truthy-default check - so its code is unchanged. CUBRID has the same `hexdec(trim($info['Default'], ...))` shape in `yii\db\cubrid\Schema` and is likely affected too, but it isn't run in CI and couldn't be verified; it's left out of this PR and tracked as a follow-up.

### Coverage

The fix is MySQL-only; the MySQL tests cover the changed branch. The PostgreSQL tests document the already-correct behavior for parity (its code is unchanged).

| Driver | Tests |
|---|---|
| mysql | `testNullableBitColumnHasNullDefaultValue`, `testBitColumnDefaultValueIsDecoded` |
| pgsql | `testNullableBitColumnHasNullDefaultValue`, `testBitColumnDefaultValueIsDecoded` |

`testNullableBitColumnHasNullDefaultValue` asserts `defaultValue` is `null` for both an explicit `DEFAULT NULL` and an implicit-nullable `BIT` column (`assertNull`, so `0` would fail). `testBitColumnDefaultValueIsDecoded` locks the happy path: a `b'0'` default stays `0` and `b'10000010'` decodes to `130`, so the fix doesn't regress real defaults. Locally only SQLite is available, so the MySQL/PgSQL drivers run in CI.
