### PR TITLE
Fix #19747: Load MySQL expression column defaults as `Expression`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -18,6 +18,7 @@ Yii Framework 2 Change Log
 - Bug #20891: Fix `@property` annotation for `Request::$bodyParams` (mspirkov)
 - Bug #20889: Remove unreachable PHP < 7 cookie deserialization fallback in `yii\web\Request::loadCookies()` (terabytesoftw)
 - Enh #20890: Harden `yii\i18n\PhpMessageSource` category path handling to reject `..` segments, absolute paths, and stream-wrapper categories (terabytesoftw)
+- Bug #20927: Load MySQL column expression defaults as `yii\db\Expression` instead of a raw string (WarLikeLaux)
 
 
 2.0.55 May 09, 2026

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -51,6 +51,15 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to follow the instructions
 for both A and B.
 
+Upgrade from Yii 2.0.55
+-----------------------
+
+* `yii\db\mysql\Schema` now reports expression-based column defaults (MySQL 8+, flagged by `DEFAULT_GENERATED` in the
+  `Extra` field, e.g. `date DEFAULT (CURRENT_DATE + INTERVAL 2 YEAR)`) as `yii\db\Expression` objects instead of the raw
+  default string. Code reading `yii\db\ColumnSchema::$defaultValue` for such columns and expecting a string should handle
+  `Expression` (cast with `(string)` when the literal text is needed).
+
+
 Upgrade from Yii 2.0.53
 -----------------------
 

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -57,7 +57,8 @@ Upgrade from Yii 2.0.55
 * `yii\db\mysql\Schema` now reports expression-based column defaults (MySQL 8.0.13+, flagged by `DEFAULT_GENERATED` in the
   `Extra` field, e.g. `date DEFAULT (CURRENT_DATE + INTERVAL 2 YEAR)`) as `yii\db\Expression` objects instead of the raw
   default string. Code reading `yii\db\ColumnSchema::$defaultValue` for such columns and expecting a string should handle
-  `Expression` (cast with `(string)` when the literal text is needed).
+  `Expression` (cast with `(string)` when the literal text is needed). This also covers parenthesized literal defaults
+  such as `text DEFAULT ('abc')`, which MySQL stores as expression defaults.
 
 
 Upgrade from Yii 2.0.53

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -54,7 +54,7 @@ for both A and B.
 Upgrade from Yii 2.0.55
 -----------------------
 
-* `yii\db\mysql\Schema` now reports expression-based column defaults (MySQL 8+, flagged by `DEFAULT_GENERATED` in the
+* `yii\db\mysql\Schema` now reports expression-based column defaults (MySQL 8.0.13+, flagged by `DEFAULT_GENERATED` in the
   `Extra` field, e.g. `date DEFAULT (CURRENT_DATE + INTERVAL 2 YEAR)`) as `yii\db\Expression` objects instead of the raw
   default string. Code reading `yii\db\ColumnSchema::$defaultValue` for such columns and expecting a string should handle
   `Expression` (cast with `(string)` when the literal text is needed).

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -348,6 +348,13 @@ SQL;
                 && preg_match('/^current_timestamp(?:\(([0-9]*)\))?$/i', $info['default'], $matches)
             ) {
                 $column->defaultValue = new Expression('CURRENT_TIMESTAMP' . (!empty($matches[1]) ? '(' . $matches[1] . ')' : ''));
+            } elseif (
+                isset($info['default'], $info['extra'])
+                && stripos($info['extra'], 'DEFAULT_GENERATED') !== false
+            ) {
+                // MySQL 8 flags expression-based column defaults with `DEFAULT_GENERATED` in the `Extra` field.
+                // https://github.com/yiisoft/yii2/issues/19747
+                $column->defaultValue = new Expression($info['default']);
             } elseif (isset($type) && $type === 'bit') {
                 $column->defaultValue = bindec(trim(isset($info['default']) ? $info['default'] : '', 'b\''));
             } else {

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -71,6 +71,35 @@ SQL;
         $this->assertEquals('CURRENT_TIMESTAMP(3)', (string)$ts->defaultValue);
     }
 
+    public function testLoadDefaultExpressionColumn(): void
+    {
+        $version = $this->getConnection()->getServerVersion();
+        if (stripos($version, 'mariadb') !== false) {
+            $this->markTestSkipped('MariaDB does not expose DEFAULT_GENERATED; detection is tracked separately in #19747.');
+        }
+        if (version_compare($version, '8.0.13', '<')) {
+            $this->markTestSkipped('Expression-based column defaults are supported since MySQL 8.0.13.');
+        }
+
+        $db = $this->getConnection();
+        if ($db->getTableSchema('default_expression_test') !== null) {
+            $db->createCommand()->dropTable('default_expression_test')->execute();
+        }
+
+        $sql = <<<SQL
+CREATE TABLE `default_expression_test` (
+  `expr_col` date DEFAULT (CURRENT_DATE + INTERVAL 2 YEAR),
+  `literal_col` date DEFAULT '2011-11-11'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+SQL;
+        $db->createCommand($sql)->execute();
+
+        $table = $db->getTableSchema('default_expression_test', true);
+
+        $this->assertInstanceOf(Expression::class, $table->getColumn('expr_col')->defaultValue);
+        $this->assertSame('2011-11-11', $table->getColumn('literal_col')->defaultValue);
+    }
+
     public function testGetSchemaNames(): void
     {
         $this->markTestSkipped('Schemas are not supported in MySQL.');

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -74,7 +74,7 @@ SQL;
     public function testLoadDefaultExpressionColumn(): void
     {
         $version = $this->getConnection()->getServerVersion();
-        if (stripos($version, 'mariadb') !== false) {
+        if (\stripos($version, 'mariadb') !== false) {
             $this->markTestSkipped('MariaDB does not expose DEFAULT_GENERATED; detection is tracked separately in #19747.');
         }
         if (version_compare($version, '8.0.13', '<')) {
@@ -89,6 +89,7 @@ SQL;
         $sql = <<<SQL
 CREATE TABLE `default_expression_test` (
   `expr_col` date DEFAULT (CURRENT_DATE + INTERVAL 2 YEAR),
+  `paren_literal_col` text DEFAULT ('abc'),
   `literal_col` date DEFAULT '2011-11-11'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8
 SQL;
@@ -99,10 +100,13 @@ SQL;
 
             $exprDefault = $table->getColumn('expr_col')->defaultValue;
             $this->assertInstanceOf(Expression::class, $exprDefault);
-            $this->assertStringContainsString('INTERVAL', strtoupper((string) $exprDefault));
+            $this->assertStringContainsString('INTERVAL 2 YEAR', strtoupper((string) $exprDefault));
+
+            $this->assertInstanceOf(Expression::class, $table->getColumn('paren_literal_col')->defaultValue);
+
             $this->assertSame('2011-11-11', $table->getColumn('literal_col')->defaultValue);
         } finally {
-            $db->createCommand()->dropTable('default_expression_test')->execute();
+            $db->createCommand('DROP TABLE IF EXISTS `default_expression_test`')->execute();
         }
     }
 

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -92,12 +92,39 @@ CREATE TABLE `default_expression_test` (
   `literal_col` date DEFAULT '2011-11-11'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8
 SQL;
-        $db->createCommand($sql)->execute();
+        try {
+            $db->createCommand($sql)->execute();
 
-        $table = $db->getTableSchema('default_expression_test', true);
+            $table = $db->getTableSchema('default_expression_test', true);
 
-        $this->assertInstanceOf(Expression::class, $table->getColumn('expr_col')->defaultValue);
-        $this->assertSame('2011-11-11', $table->getColumn('literal_col')->defaultValue);
+            $exprDefault = $table->getColumn('expr_col')->defaultValue;
+            $this->assertInstanceOf(Expression::class, $exprDefault);
+            $this->assertStringContainsString('INTERVAL', strtoupper((string) $exprDefault));
+            $this->assertSame('2011-11-11', $table->getColumn('literal_col')->defaultValue);
+        } finally {
+            $db->createCommand()->dropTable('default_expression_test')->execute();
+        }
+    }
+
+    public function testLoadDefaultGeneratedColumnSchema(): void
+    {
+        $schema = new Schema();
+
+        $column = $this->invokeMethod($schema, 'loadColumnSchema', [[
+            'field' => 'expr_col',
+            'type' => 'date',
+            'collation' => null,
+            'null' => 'YES',
+            'key' => '',
+            'default' => '(CURRENT_DATE + INTERVAL 2 YEAR)',
+            'extra' => 'DEFAULT_GENERATED',
+            'privileges' => 'select,insert,update,references',
+            'comment' => '',
+        ]]);
+
+        $this->assertInstanceOf(ColumnSchema::class, $column);
+        $this->assertInstanceOf(Expression::class, $column->defaultValue);
+        $this->assertSame('(CURRENT_DATE + INTERVAL 2 YEAR)', (string) $column->defaultValue);
     }
 
     public function testGetSchemaNames(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #19747

## What does this PR do?

Loads expression-based column defaults on MySQL as `yii\db\Expression` instead of the raw default string.

When a MySQL column has an expression default (e.g. `date DEFAULT (CURRENT_DATE + INTERVAL 2 YEAR)`), `yii\db\mysql\Schema::loadColumnSchema()` returned `defaultValue` as the plain string `'(CURRENT_DATE + INTERVAL 2 YEAR)'`, indistinguishable from a literal default. MySQL 8 flags such defaults with `DEFAULT_GENERATED` in the `Extra` field, so the column now wraps them in `Expression`. Literal defaults and the existing `CURRENT_TIMESTAMP` handling are unchanged.

Scope is MySQL only - it reuses the `Extra` field already read for `auto_increment`, with no extra queries. MariaDB (no `DEFAULT_GENERATED`) and PostgreSQL (`::type` suffix) are left as follow-ups.

The MySQL approach is taken from #19758 by @SOHELAHMED7 (which @cebe had approved in principle); this redo keeps that detection but drops the MariaDB per-column heuristic/extra-query path, so it stays small and queryless.

Behavior change is documented in `UPGRADE.md` (Upgrade from Yii 2.0.55).