### PR TITLE
Fix `yii\db\oci\Schema::insert()` returning only the first primary key value for composite keys, caused by a reused `foreach` reference.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -80,6 +80,7 @@ Yii Framework 2 Change Log
 - Enh #20922: Consolidate SQLite data-type conversion into `ColumnSchema::defaultPhpTypecast()` and fix `DEFAULT NULL` and escaped-quote defaults (terabytesoftw)
 - Enh #20923: Add explicit default values to `ColumnSchema` properties in `yii\db`, `yii\db\mssql`, and `yii\db\pgsql` (terabytesoftw)
 - Chg #20928: Remove legacy MySQL version support code from `yii\db\mysql\Schema` (terabytesoftw)
+- Bug #20929: Fix `yii\db\oci\Schema::insert()` returning only the first primary key value for composite keys, caused by a reused `foreach` reference (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -664,6 +664,8 @@ SQL;
             $command->pdoStatement->bindParam($name, $value['value'], $value['dataType'], $value['size']);
         }
 
+        unset($value);
+
         if (!$command->execute()) {
             return false;
         }

--- a/tests/base/db/BaseSchema.php
+++ b/tests/base/db/BaseSchema.php
@@ -254,6 +254,42 @@ abstract class BaseSchema extends DatabaseTestCase
         $this->assertEquals('item_id', $table->foreignKeys['FK_composite_fk_order_item']['item_id']);
     }
 
+    public function testInsertReturnsProvidedPrimaryKeyValues(): void
+    {
+        $db = $this->getConnection();
+
+        $schema = $db->getSchema();
+
+        if ($schema->getTableSchema('test_pk_insert', true) !== null) {
+            $db->createCommand()->dropTable('test_pk_insert')->execute();
+        }
+
+        $db->createCommand()->createTable(
+            'test_pk_insert',
+            [
+                'id1' => 'int NOT NULL',
+                'id2' => 'int NOT NULL',
+                'description' => 'string',
+                'PRIMARY KEY ([[id1]], [[id2]])',
+            ],
+        )->execute();
+
+        self::assertEquals(
+            ['id1' => 7, 'id2' => 8],
+            $schema->insert(
+                'test_pk_insert',
+                [
+                    'id1' => 7,
+                    'id2' => 8,
+                    'description' => 'provided pk',
+                ],
+            ),
+            'Provided primary key values must be returned.',
+        );
+
+        $db->createCommand()->dropTable('test_pk_insert')->execute();
+    }
+
     public function testGetPDOType(): void
     {
         $values = [

--- a/tests/framework/db/oci/ActiveRecordTest.php
+++ b/tests/framework/db/oci/ActiveRecordTest.php
@@ -130,12 +130,25 @@ class ActiveRecordTest extends BaseActiveRecord
     public function testMultiplePrimaryKeyAfterSave(): void
     {
         $record = new DefaultMultiplePk();
+
         $record->id = 5;
         $record->second_key_column = 'secondKey';
         $record->type = 'type';
+
         $record->save(false);
-        $this->assertEquals(5, $record->id);
-        $this->assertEquals('secondKey', $record->second_key_column);
+
+        self::assertEquals(
+            5,
+            $record->id,
+            'Integer primary key must match the saved value.',
+        );
+        // the column is `char(10)`: Oracle blank-pads stored values, and `RETURNING INTO` surfaces the real stored
+        // value, consistent with what a subsequent `find()` returns.
+        self::assertEquals(
+            'secondKey ',
+            $record->second_key_column,
+            'String primary key must hold the blank-padded value as stored.',
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
