### PR TITLE
Replace MSSQL `INFORMATION_SCHEMA.KEY_COLUMN_USAGE` and `TABLE_CONSTRAINTS` in `Schema::findTableConstraints()` with `sys.key_constraints`, and preserve composite key column order with `sys.index_columns.key_ordinal`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -85,6 +85,7 @@ Yii Framework 2 Change Log
 - Chg #19595: Store `yii\web\DbSession` `data` as `varbinary(max)` on MSSQL and cast it through `yii\db\mssql\ColumnSchema`, fixing binary session payloads; existing MSSQL session tables must alter the column (terabytesoftw)
 - Bug #20931: Fix `yii\caching\DbCache` reading PostgreSQL `bytea` cached data as a stream by converting it in `yii\db\pgsql\ColumnSchema::phpTypecast()` (terabytesoftw)
 - Bug #20931: Fix `yii\caching\DbCache` MSSQL reference schema using the invalid `BLOB` type instead of `varbinary(max)` for the `data` column (terabytesoftw)
+- Enh #20933: Replace MSSQL `INFORMATION_SCHEMA.KEY_COLUMN_USAGE` and `TABLE_CONSTRAINTS` in `Schema::findTableConstraints()` with `sys.key_constraints`, and preserve composite key column order with `sys.index_columns.key_ordinal` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -20,6 +20,7 @@ use yii\db\ViewFinderTrait;
 use yii\helpers\ArrayHelper;
 use yii\db\Schema as BaseSchema;
 
+use function implode;
 use function strcasecmp;
 
 /**
@@ -432,19 +433,7 @@ SQL;
      */
     protected function findColumns($table)
     {
-        $fullName = $this->quoteSimpleTableName($table->name);
-
-        if ($table->schemaName !== null) {
-            $fullName = $this->quoteSimpleTableName($table->schemaName) . '.' . $fullName;
-        }
-
-        if ($table->catalogName !== null) {
-            $fullName = $this->quoteSimpleTableName($table->catalogName) . '.' . $fullName;
-        }
-
-        $systemCatalogName = $table->catalogName === null
-            ? $this->quoteSimpleTableName('sys')
-            : $this->quoteSimpleTableName($table->catalogName) . '.' . $this->quoteSimpleTableName('sys');
+        $systemCatalogName = $this->quoteSystemCatalogName($table);
 
         $sql = <<<SQL
         SELECT
@@ -485,7 +474,7 @@ SQL;
 
         $columns = $this->db->createCommand(
             $sql,
-            [':fullName' => $fullName],
+            [':fullName' => $this->quoteTableFullName($table)],
         )->queryAll();
 
         if (empty($columns)) {
@@ -518,56 +507,57 @@ SQL;
 
     /**
      * Collects the constraint details for the given table and constraint type.
-     * @param TableSchema $table
-     * @param string $type either PRIMARY KEY or UNIQUE
-     * @return array each entry contains index_name and field_name
+     *
+     * @param TableSchema $table The table metadata.
+     * @param string $type Either `PK` or `UQ`.
+     *
+     * @return array Each entry contains index_name and field_name.
      * @since 2.0.4
+     *
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-key-constraints-transact-sql
      */
     protected function findTableConstraints($table, $type)
     {
-        $keyColumnUsageTableName = 'INFORMATION_SCHEMA.KEY_COLUMN_USAGE';
-        $tableConstraintsTableName = 'INFORMATION_SCHEMA.TABLE_CONSTRAINTS';
-        if ($table->catalogName !== null) {
-            $keyColumnUsageTableName = $table->catalogName . '.' . $keyColumnUsageTableName;
-            $tableConstraintsTableName = $table->catalogName . '.' . $tableConstraintsTableName;
-        }
-        $keyColumnUsageTableName = $this->quoteTableName($keyColumnUsageTableName);
-        $tableConstraintsTableName = $this->quoteTableName($tableConstraintsTableName);
+        $systemCatalogName = $this->quoteSystemCatalogName($table);
 
         $sql = <<<SQL
-SELECT
-    [kcu].[constraint_name] AS [index_name],
-    [kcu].[column_name] AS [field_name]
-FROM {$keyColumnUsageTableName} AS [kcu]
-LEFT JOIN {$tableConstraintsTableName} AS [tc] ON
-    [kcu].[table_schema] = [tc].[table_schema] AND
-    [kcu].[table_name] = [tc].[table_name] AND
-    [kcu].[constraint_name] = [tc].[constraint_name]
-WHERE
-    [tc].[constraint_type] = :type AND
-    [kcu].[table_name] = :tableName AND
-    [kcu].[table_schema] = :schemaName
-SQL;
+        SELECT
+            [kc].[name] AS [index_name],
+            [col].[name] AS [field_name]
+        FROM {$systemCatalogName}.[key_constraints] AS [kc]
+        INNER JOIN {$systemCatalogName}.[index_columns] AS [ic]
+            ON [ic].[object_id] = [kc].[parent_object_id]
+            AND [ic].[index_id] = [kc].[unique_index_id]
+        INNER JOIN {$systemCatalogName}.[columns] AS [col]
+            ON [col].[object_id] = [ic].[object_id]
+            AND [col].[column_id] = [ic].[column_id]
+        WHERE [kc].[parent_object_id] = OBJECT_ID(:fullName)
+            AND [kc].[type] = :type
+        ORDER BY [ic].[key_ordinal] ASC
+        SQL;
 
-        return $this->db
-            ->createCommand($sql, [
-                ':tableName' => $table->name,
-                ':schemaName' => $table->schemaName,
+        return $this->db->createCommand(
+            $sql,
+            [
+                ':fullName' => $this->quoteTableFullName($table),
                 ':type' => $type,
-            ])
-            ->queryAll();
+            ],
+        )->queryAll();
     }
 
     /**
      * Collects the primary key column details for the given table.
+     *
      * @param TableSchema $table the table metadata
      */
     protected function findPrimaryKeys($table)
     {
         $result = [];
-        foreach ($this->findTableConstraints($table, 'PRIMARY KEY') as $row) {
+
+        foreach ($this->findTableConstraints($table, 'PK') as $row) {
             $result[] = $row['field_name'];
         }
+
         $table->primaryKey = $result;
     }
 
@@ -577,13 +567,7 @@ SQL;
      */
     protected function findForeignKeys($table)
     {
-        $object = $this->quoteSimpleTableName($table->name);
-        if ($table->schemaName !== null) {
-            $object = $this->quoteSimpleTableName($table->schemaName) . '.' . $object;
-        }
-        if ($table->catalogName !== null) {
-            $object = $this->quoteSimpleTableName($table->catalogName) . '.' . $object;
-        }
+        $object = $this->quoteTableFullName($table);
 
         // please refer to the following page for more details:
         // http://msdn2.microsoft.com/en-us/library/aa175805(SQL.80).aspx
@@ -651,14 +635,16 @@ SQL;
      * ]
      * ```
      *
-     * @param TableSchema $table the table metadata
-     * @return array all unique indexes for the given table.
+     * @param TableSchema $table The table metadata.
+     *
+     * @return array All unique indexes for the given table.
      * @since 2.0.4
      */
     public function findUniqueIndexes($table)
     {
         $result = [];
-        foreach ($this->findTableConstraints($table, 'UNIQUE') as $row) {
+
+        foreach ($this->findTableConstraints($table, 'UQ') as $row) {
             $result[$row['index_name']][] = $row['field_name'];
         }
 
@@ -831,5 +817,49 @@ SQL;
     public function createColumnSchemaBuilder($type, $length = null)
     {
         return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length, $this->db]);
+    }
+
+    /**
+     * Quotes the fully qualified table name from resolved raw table metadata.
+     *
+     * @param TableSchema $table The table metadata.
+     *
+     * @return string The quoted fully qualified table name.
+     */
+    private function quoteTableFullName($table)
+    {
+        return $this->quoteTableNameParts([$table->catalogName, $table->schemaName, $table->name]);
+    }
+
+    /**
+     * Quotes the SQL Server system catalog name for the table catalog context.
+     *
+     * @param TableSchema $table The table metadata.
+     *
+     * @return string The quoted system catalog name.
+     */
+    private function quoteSystemCatalogName($table)
+    {
+        return $this->quoteTableNameParts([$table->catalogName, 'sys']);
+    }
+
+    /**
+     * Quotes qualified table name parts without reparsing raw parts that may contain dots.
+     *
+     * @param array<int, string|null> $parts The raw table name parts.
+     *
+     * @return string The quoted qualified name.
+     */
+    private function quoteTableNameParts($parts)
+    {
+        $quotedParts = [];
+
+        foreach ($parts as $part) {
+            if ($part !== null) {
+                $quotedParts[] = $this->quoteSimpleTableName($part);
+            }
+        }
+
+        return implode('.', $quotedParts);
     }
 }

--- a/tests/framework/db/mssql/SchemaConstraintsTest.php
+++ b/tests/framework/db/mssql/SchemaConstraintsTest.php
@@ -13,6 +13,8 @@ namespace yiiunit\framework\db\mssql;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\db\Constraint;
+use yii\db\mssql\Schema;
+use yii\db\mssql\TableSchema;
 use yiiunit\base\db\BaseSchemaConstraints;
 use yiiunit\framework\db\mssql\providers\ConstraintsProvider;
 
@@ -52,6 +54,116 @@ final class SchemaConstraintsTest extends BaseSchemaConstraints
             array_values($indexes),
             "Composite unique constraint on 'email, recovery_email' is missing.",
         );
+    }
+
+    #[DataProviderExternal(ConstraintsProvider::class, 'compositePrimaryKeyColumnOrder')]
+    public function testCompositePrimaryKeyColumnOrder(
+        string $tableName,
+        string $constraintName,
+        string|null $expectedCatalog,
+    ): void {
+        $db = $this->getConnection();
+
+        $schema = $db->getSchema();
+
+        if ($schema->getTableSchema($tableName, true) !== null) {
+            $db->createCommand()->dropTable($tableName)->execute();
+        }
+
+        $db->createCommand()->createTable(
+            $tableName,
+            [
+                'col_b' => Schema::TYPE_INTEGER . ' NOT NULL',
+                'col_a' => Schema::TYPE_INTEGER . ' NOT NULL',
+                'col_c' => Schema::TYPE_INTEGER . ' NOT NULL',
+                'data' => Schema::TYPE_STRING,
+            ],
+        )->execute();
+        $db->createCommand()->addPrimaryKey(
+            $constraintName,
+            $tableName,
+            ['col_b', 'col_a', 'col_c'],
+        )->execute();
+
+        $schema->refreshTableSchema($tableName);
+
+        $tableSchema = $schema->getTableSchema($tableName);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $tableSchema,
+            'Table schema should be returned for existing table.',
+        );
+        self::assertSame(
+            $expectedCatalog,
+            $tableSchema->catalogName,
+            'Table schema catalog name should match the requested table name.',
+        );
+        self::assertSame(
+            ['col_b', 'col_a', 'col_c'],
+            $tableSchema->primaryKey,
+            "Composite PK columns should follow 'key_ordinal' order, not alphabetical.",
+        );
+
+        $db->createCommand()->dropTable($tableName)->execute();
+    }
+
+    #[DataProviderExternal(ConstraintsProvider::class, 'compositeUniqueConstraintColumnOrder')]
+    public function testCompositeUniqueConstraintColumnOrder(
+        string $tableName,
+        string $constraintName,
+        string|null $expectedCatalog,
+    ): void {
+        $db = $this->getConnection();
+
+        $schema = $db->getSchema();
+
+        if ($schema->getTableSchema($tableName, true) !== null) {
+            $db->createCommand()->dropTable($tableName)->execute();
+        }
+
+        $db->createCommand()->createTable(
+            $tableName,
+            [
+                'id' => Schema::TYPE_PK,
+                'col_z' => Schema::TYPE_INTEGER . ' NOT NULL',
+                'col_y' => Schema::TYPE_INTEGER . ' NOT NULL',
+                'col_x' => Schema::TYPE_INTEGER . ' NOT NULL',
+            ],
+        )->execute();
+        $db->createCommand()->addUnique(
+            $constraintName,
+            $tableName,
+            ['col_z', 'col_y', 'col_x'],
+        )->execute();
+
+        $schema->refreshTableSchema($tableName);
+
+        $tableSchema = $schema->getTableSchema($tableName);
+        $uniqueIndexes = $schema->findUniqueIndexes($tableSchema);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $tableSchema,
+            'Table schema should be returned for existing table.',
+        );
+        self::assertSame(
+            $expectedCatalog,
+            $tableSchema->catalogName,
+            'Table schema catalog name should match the requested table name.',
+        );
+        self::assertArrayHasKey(
+            $constraintName,
+            $uniqueIndexes,
+            'Unique constraint should be found by name.',
+        );
+        self::assertSame(
+            ['col_z', 'col_y', 'col_x'],
+            $uniqueIndexes[$constraintName],
+            "Composite UQ columns should follow 'key_ordinal' order, not alphabetical.",
+        );
+
+        $db->createCommand()->dropTable($tableName)->execute();
     }
 
     /**

--- a/tests/framework/db/mssql/SchemaTest.php
+++ b/tests/framework/db/mssql/SchemaTest.php
@@ -595,35 +595,49 @@ final class SchemaTest extends BaseSchema
             $payload .= chr($i % 256);
         }
 
-        try {
-            $db->createCommand()->insert('test_varbinary_max', ['id' => 1, 'data' => $payload])->execute();
+        $db->createCommand()->insert(
+            'test_varbinary_max',
+            [
+                'id' => 1,
+                'data' => $payload,
+            ],
+        )->execute();
 
-            $length = (int) $db->createCommand(
-                <<<SQL
-                SELECT DATALENGTH(data) FROM test_varbinary_max WHERE id = 1
-                SQL,
-            )->queryScalar();
+        $length = (int) $db->createCommand(
+            <<<SQL
+            SELECT DATALENGTH(data) FROM test_varbinary_max WHERE id = 1
+            SQL,
+        )->queryScalar();
+        $stored = $db->createCommand(
+            <<<SQL
+            SELECT data FROM test_varbinary_max WHERE id = 1
+            SQL,
+        )->queryScalar();
+        $stored = is_resource($stored) ? stream_get_contents($stored) : (string) $stored;
 
-            $stored = $db->createCommand(
-                <<<SQL
-                SELECT data FROM test_varbinary_max WHERE id = 1
-                SQL,
-            )->queryScalar();
-            $stored = is_resource($stored) ? stream_get_contents($stored) : (string) $stored;
+        $column = $db->getTableSchema('test_varbinary_max', true)->columns['data'];
 
-            $column = $db->getTableSchema('test_varbinary_max', true)->columns['data'];
+        self::assertSame(
+            strlen($payload),
+            $length,
+            'Stored length must match the payload (no truncation).',
+        );
+        self::assertSame(
+            hash('sha256', $payload),
+            hash('sha256', $stored),
+            'Binary payload must round-trip byte-for-byte.',
+        );
+        self::assertSame(
+            'varbinary(max)',
+            $column->dbType,
+            "'max' declaration must be preserved.",
+        );
+        self::assertNull(
+            $column->size,
+            "'max' length must not be parsed as a fixed size.",
+        );
 
-            self::assertSame(strlen($payload), $length, 'Stored length must match the payload (no truncation).');
-            self::assertSame(
-                hash('sha256', $payload),
-                hash('sha256', $stored),
-                'Binary payload must round-trip byte-for-byte.',
-            );
-            self::assertSame('varbinary(max)', $column->dbType, '`max` declaration must be preserved.');
-            self::assertNull($column->size, '`max` length must not be parsed as a fixed size.');
-        } finally {
-            $db->createCommand()->dropTable('test_varbinary_max')->execute();
-        }
+        $db->createCommand()->dropTable('test_varbinary_max')->execute();
     }
 
     /**
@@ -632,64 +646,53 @@ final class SchemaTest extends BaseSchema
     public function testGetTableSchemaDetectsIdentityColumnAcrossDatabases(): void
     {
         $db = $this->getConnection();
-        $database = 'yii2_cross_db_test';
 
-        $drop = <<<SQL
-        IF DB_ID('{$database}') IS NOT NULL
-        BEGIN
-            ALTER DATABASE [{$database}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
-            DROP DATABASE [{$database}];
-        END
-        SQL;
+        $database = 'tempdb';
+        $tableName = "{$database}.dbo.cross_identity";
 
-        $db->createCommand($drop)->execute();
-
-        try {
-            $db->createCommand(
-                <<<SQL
-                CREATE DATABASE [{$database}]
-                SQL,
-            )->execute();
-            $db->createCommand()->createTable(
-                "{$database}.dbo.cross_identity",
-                [
-                    'id' => Schema::TYPE_PK,
-                    'name' => 'nvarchar(50)',
-                ],
-            )->execute();
-
-            $table = $db->getTableSchema("{$database}.dbo.cross_identity", true);
-
-            self::assertInstanceOf(
-                TableSchema::class,
-                $table,
-                'Cross-database table metadata must be retrievable.',
-            );
-            self::assertSame(
-                $database,
-                $table->catalogName,
-                'Catalog name must be parsed from the three-part name.',
-            );
-            self::assertTrue(
-                $table->columns['id']->autoIncrement,
-                'Identity must be detected across databases.',
-            );
-            self::assertTrue(
-                $table->columns['id']->isPrimaryKey,
-                'Primary key membership must be applied.',
-            );
-            self::assertSame(
-                ['id'],
-                $table->primaryKey,
-                'Primary key column must be discovered.',
-            );
-            self::assertSame(
-                '',
-                $table->sequenceName,
-                'Identity primary key must set the sequence marker.',
-            );
-        } finally {
-            $db->createCommand($drop)->execute();
+        if ($db->getSchema()->getTableSchema($tableName, true) !== null) {
+            $db->createCommand()->dropTable($tableName)->execute();
         }
+
+        $db->createCommand()->createTable(
+            $tableName,
+            [
+                'id' => Schema::TYPE_PK,
+                'name' => 'nvarchar(50)',
+            ],
+        )->execute();
+
+        $table = $db->getTableSchema($tableName, true);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $table,
+            'Cross-database table metadata must be retrievable.',
+        );
+        self::assertSame(
+            $database,
+            $table->catalogName,
+            'Catalog name must be parsed from the three-part name.',
+        );
+        self::assertTrue(
+            $table->columns['id']->autoIncrement,
+            'Identity must be detected across databases.',
+        );
+        self::assertTrue(
+            $table->columns['id']->isPrimaryKey,
+            'Primary key membership must be applied.',
+        );
+        self::assertSame(
+            ['id'],
+            $table->primaryKey,
+            'Primary key column must be discovered.',
+        );
+        self::assertSame(
+            '',
+            $table->sequenceName,
+            'Identity primary key must set the sequence marker.',
+        );
+
+        $db->createCommand()->dropTable($tableName)->execute();
     }
 }

--- a/tests/framework/db/mssql/providers/ConstraintsProvider.php
+++ b/tests/framework/db/mssql/providers/ConstraintsProvider.php
@@ -16,9 +16,50 @@ use yiiunit\framework\db\AnyValue;
 
 /**
  * Data provider for {@see \yiiunit\framework\db\mssql\SchemaConstraintsTest} test cases.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
  */
 final class ConstraintsProvider extends \yiiunit\base\db\providers\ConstraintsProvider
 {
+    /**
+     * @return array<string, array{string, string, string|null}>
+     */
+    public static function compositePrimaryKeyColumnOrder(): array
+    {
+        return [
+            'across database' => [
+                'tempdb.dbo.test_composite_pk_cross_db',
+                'PK_test_composite_cross_db',
+                'tempdb',
+            ],
+            'current database' => [
+                'test_composite_pk',
+                'PK_test_composite',
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string, string|null}>
+     */
+    public static function compositeUniqueConstraintColumnOrder(): array
+    {
+        return [
+            'across database' => [
+                'tempdb.dbo.test_composite_uq_cross_db',
+                'UQ_test_composite_cross_db',
+                'tempdb',
+            ],
+            'current database' => [
+                'test_composite_uq',
+                'UQ_test_composite',
+                null,
+            ],
+        ];
+    }
+
     /**
      * @return array<string, array{string, string, Constraint|bool|array<array-key, mixed>|null}>
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
