### PR TITLE
Replace MSSQL `INFORMATION_SCHEMA.TABLES` in `Schema::findTableNames()` and `Schema::findViewNames()` with catalog-qualified `sys.objects` and `sys.views` catalog views.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -86,6 +86,7 @@ Yii Framework 2 Change Log
 - Bug #20931: Fix `yii\caching\DbCache` reading PostgreSQL `bytea` cached data as a stream by converting it in `yii\db\pgsql\ColumnSchema::phpTypecast()` (terabytesoftw)
 - Bug #20931: Fix `yii\caching\DbCache` MSSQL reference schema using the invalid `BLOB` type instead of `varbinary(max)` for the `data` column (terabytesoftw)
 - Enh #20933: Replace MSSQL `INFORMATION_SCHEMA.KEY_COLUMN_USAGE` and `TABLE_CONSTRAINTS` in `Schema::findTableConstraints()` with `sys.key_constraints`, and preserve composite key column order with `sys.index_columns.key_ordinal` (terabytesoftw)
+- Enh #20934: Replace MSSQL `INFORMATION_SCHEMA.TABLES` in `Schema::findTableNames()` and `Schema::findViewNames()` with catalog-qualified `sys.objects` and `sys.views` catalog views (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -20,6 +20,7 @@ use yii\db\ViewFinderTrait;
 use yii\helpers\ArrayHelper;
 use yii\db\Schema as BaseSchema;
 
+use function count;
 use function implode;
 use function strcasecmp;
 
@@ -175,20 +176,28 @@ SQL;
 
     /**
      * {@inheritdoc}
+     *
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-objects-transact-sql
      */
     protected function findTableNames($schema = '')
     {
-        if ($schema === '') {
-            $schema = $this->defaultSchema;
-        }
+        [$catalogName, $schemaName] = $this->resolveCatalogSchemaName($schema);
 
-        $sql = <<<'SQL'
-SELECT [t].[table_name]
-FROM [INFORMATION_SCHEMA].[TABLES] AS [t]
-WHERE [t].[table_schema] = :schema AND [t].[table_type] IN ('BASE TABLE', 'VIEW')
-ORDER BY [t].[table_name]
-SQL;
-        return $this->db->createCommand($sql, [':schema' => $schema])->queryColumn();
+        $systemCatalogName = $this->quoteTableNameParts([$catalogName, 'sys']);
+
+        $sql = <<<SQL
+        SELECT [o].[name]
+        FROM {$systemCatalogName}.[objects] AS [o]
+        INNER JOIN {$systemCatalogName}.[schemas] AS [s] ON [s].[schema_id] = [o].[schema_id]
+        WHERE [s].[name] = :schema
+            AND [o].[type] IN ('U', 'V')
+        ORDER BY [o].[name]
+        SQL;
+
+        return $this->db->createCommand(
+            $sql,
+            [':schema' => $schemaName],
+        )->queryColumn();
     }
 
     /**
@@ -569,8 +578,6 @@ SQL;
     {
         $object = $this->quoteTableFullName($table);
 
-        // please refer to the following page for more details:
-        // http://msdn2.microsoft.com/en-us/library/aa175805(SQL.80).aspx
         $sql = <<<'SQL'
 SELECT
 	[fk].[name] AS [fk_name],
@@ -606,21 +613,27 @@ SQL;
 
     /**
      * {@inheritdoc}
+     *
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-views-transact-sql
      */
     protected function findViewNames($schema = '')
     {
-        if ($schema === '') {
-            $schema = $this->defaultSchema;
-        }
+        [$catalogName, $schemaName] = $this->resolveCatalogSchemaName($schema);
 
-        $sql = <<<'SQL'
-SELECT [t].[table_name]
-FROM [INFORMATION_SCHEMA].[TABLES] AS [t]
-WHERE [t].[table_schema] = :schema AND [t].[table_type] = 'VIEW'
-ORDER BY [t].[table_name]
-SQL;
+        $systemCatalogName = $this->quoteTableNameParts([$catalogName, 'sys']);
 
-        return $this->db->createCommand($sql, [':schema' => $schema])->queryColumn();
+        $sql = <<<SQL
+        SELECT [v].[name]
+        FROM {$systemCatalogName}.[views] AS [v]
+        INNER JOIN {$systemCatalogName}.[schemas] AS [s] ON [s].[schema_id] = [v].[schema_id]
+        WHERE [s].[name] = :schema
+        ORDER BY [v].[name]
+        SQL;
+
+        return $this->db->createCommand(
+            $sql,
+            [':schema' => $schemaName],
+        )->queryColumn();
     }
 
     /**
@@ -861,5 +874,29 @@ SQL;
         }
 
         return implode('.', $quotedParts);
+    }
+
+    /**
+     * Resolves a schema argument into optional catalog and schema names.
+     *
+     * @param string $schema The schema argument.
+     *
+     * @return array{string|null, string} The catalog and schema names.
+     */
+    private function resolveCatalogSchemaName($schema)
+    {
+        if ($schema === '') {
+            return [null, $this->defaultSchema];
+        }
+
+        $parts = $this->getTableNameParts($schema);
+
+        $partCount = count($parts);
+
+        if ($partCount > 1) {
+            return [$parts[$partCount - 2], $parts[$partCount - 1]];
+        }
+
+        return [null, $parts[0]];
     }
 }

--- a/tests/framework/db/mssql/SchemaTest.php
+++ b/tests/framework/db/mssql/SchemaTest.php
@@ -13,6 +13,7 @@ namespace yiiunit\framework\db\mssql;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\base\NotSupportedException;
+use yii\db\Connection;
 use yii\db\Constraint;
 use yii\db\ConstraintFinderInterface;
 use yii\db\mssql\ColumnSchemaBuilder;
@@ -21,7 +22,10 @@ use yii\db\mssql\TableSchema;
 use yiiunit\base\db\BaseSchema;
 use yiiunit\framework\db\mssql\providers\SchemaProvider;
 
+use function array_map;
 use function chr;
+use function count;
+use function explode;
 use function hash;
 use function is_resource;
 use function str_starts_with;
@@ -527,6 +531,93 @@ final class SchemaTest extends BaseSchema
         )->execute();
     }
 
+    #[DataProviderExternal(SchemaProvider::class, 'catalogSchemaNames')]
+    public function testGetTableAndViewNamesFromSysCatalogViews(
+        string $schemaName,
+        string $objectSchemaName,
+        string $tableName,
+        string $viewName,
+        string|null $expectedCatalog,
+    ): void {
+        $db = $this->getConnection();
+
+        $schema = $db->getSchema();
+
+        $qualifiedTableName = "{$objectSchemaName}.{$tableName}";
+
+        self::assertInstanceOf(
+            Schema::class,
+            $schema,
+            'Schema should be an instance of ' . Schema::class . '.',
+        );
+
+        $this->dropMssqlViewIfExists($db, $objectSchemaName, $viewName);
+
+        if ($schema->getTableSchema($qualifiedTableName, true) !== null) {
+            $db->createCommand()->dropTable($qualifiedTableName)->execute();
+        }
+
+        $db->createCommand()->createTable(
+            $qualifiedTableName,
+            ['id' => Schema::TYPE_PK],
+        )->execute();
+
+        $this->createMssqlView($db, $objectSchemaName, $viewName, $tableName);
+
+        $tableNames = $schema->getTableNames($schemaName, true);
+
+        self::assertContains(
+            $tableName,
+            $tableNames,
+            "Table '{$tableName}' should be present in the list of table names.",
+        );
+        self::assertContains(
+            $viewName,
+            $tableNames,
+            "View '{$viewName}' should be present in the list of table names.",
+        );
+        self::assertContains(
+            $viewName,
+            $schema->getViewNames($schemaName, true),
+            "View '{$viewName}' should be present in the list of view names.",
+        );
+
+        $tableSchemaNames = array_map(
+            static fn(TableSchema $tableSchema): string => $tableSchema->name,
+            $schema->getTableSchemas($schemaName, true),
+        );
+
+        self::assertContains(
+            $tableName,
+            $tableSchemaNames,
+            "Table '{$tableName}' should be present in the list of table schemas.",
+        );
+        self::assertContains(
+            $viewName,
+            $tableSchemaNames,
+            "View '{$viewName}' should be present in the list of table schemas.",
+        );
+
+        $tableSchema = $schema->getTableSchema($qualifiedTableName, true);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $tableSchema,
+            'Table schema should be returned for existing table.',
+        );
+        self::assertSame(
+            $expectedCatalog,
+            $tableSchema->catalogName,
+            'Table schema catalog name should match the requested table name.',
+        );
+
+        $this->dropMssqlViewIfExists($db, $objectSchemaName, $viewName);
+
+        if ($schema->getTableSchema($qualifiedTableName, true) !== null) {
+            $db->createCommand()->dropTable($qualifiedTableName)->execute();
+        }
+    }
+
     public function testGetViewNamesWithDefaultSchema(): void
     {
         $schema = $this->getConnection()->getSchema();
@@ -554,6 +645,68 @@ final class SchemaTest extends BaseSchema
             $schema->getViewNames('dbo', true),
             "View 'animal_view' should be present when refreshing views with an explicit schema.",
         );
+    }
+
+    private function createMssqlView(
+        Connection $db,
+        string $objectSchemaName,
+        string $viewName,
+        string $tableName,
+    ): void {
+        [$catalogName, $schemaName] = $this->resolveMssqlCatalogSchemaName($objectSchemaName);
+
+        $quotedTableName = $db->quoteTableName("{$schemaName}.{$tableName}");
+        $quotedViewName = $db->quoteTableName("{$schemaName}.{$viewName}");
+
+        $sql = <<<SQL
+        CREATE VIEW {$quotedViewName}
+        AS SELECT [id] FROM {$quotedTableName}
+        SQL;
+
+        $this->executeMssqlCatalogCommand($db, $catalogName, $sql);
+    }
+
+    private function dropMssqlViewIfExists(Connection $db, string $objectSchemaName, string $viewName): void
+    {
+        [$catalogName, $schemaName] = $this->resolveMssqlCatalogSchemaName($objectSchemaName);
+
+        $quotedObjectName = $db->quoteValue("{$schemaName}.{$viewName}");
+        $quotedViewName = $db->quoteTableName("{$schemaName}.{$viewName}");
+
+        $sql = <<<SQL
+        IF OBJECT_ID(N{$quotedObjectName}, N'V') IS NOT NULL
+            DROP VIEW {$quotedViewName}
+        SQL;
+
+        $this->executeMssqlCatalogCommand($db, $catalogName, $sql);
+    }
+
+    private function executeMssqlCatalogCommand(Connection $db, string|null $catalogName, string $sql): void
+    {
+        if ($catalogName === null) {
+            $db->createCommand($sql)->execute();
+
+            return;
+        }
+
+        $db->createCommand(
+            'EXEC ' . $db->quoteTableName("{$catalogName}.sys.sp_executesql") . ' N' . $db->quoteValue($sql),
+        )->execute();
+    }
+
+    /**
+     * @return array{string|null, string}
+     */
+    private function resolveMssqlCatalogSchemaName(string $schemaName): array
+    {
+        $parts = explode('.', $schemaName);
+        $partCount = count($parts);
+
+        if ($partCount > 1) {
+            return [$parts[$partCount - 2], $parts[$partCount - 1]];
+        }
+
+        return [null, $schemaName];
     }
 
 

--- a/tests/framework/db/mssql/providers/SchemaProvider.php
+++ b/tests/framework/db/mssql/providers/SchemaProvider.php
@@ -46,6 +46,36 @@ final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
     }
 
     /**
+     * @return array<string, array{string, string, string, string, string|null}>
+     */
+    public static function catalogSchemaNames(): array
+    {
+        return [
+            'across database' => [
+                'tempdb.dbo',
+                'tempdb.dbo',
+                'test_sys_catalog_table_cross_db',
+                'test_sys_catalog_view_cross_db',
+                'tempdb',
+            ],
+            'current database' => [
+                'dbo',
+                'dbo',
+                'test_sys_catalog_table_current',
+                'test_sys_catalog_view_current',
+                null,
+            ],
+            'default schema' => [
+                '',
+                'dbo',
+                'test_sys_catalog_table_default',
+                'test_sys_catalog_view_default',
+                null,
+            ],
+        ];
+    }
+
+    /**
      * @return array<string, array{string, string|null, string, string, string}>
      */
     public static function resolveTableName(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
