### PR TITLE
Remove redundant `resolveTableNames()` from MSSQL, MySQL, PostgreSQL, and Oracle schema classes; `loadTableSchema()` now uses `resolveTableName()`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -88,6 +88,7 @@ Yii Framework 2 Change Log
 - Enh #20933: Replace MSSQL `INFORMATION_SCHEMA.KEY_COLUMN_USAGE` and `TABLE_CONSTRAINTS` in `Schema::findTableConstraints()` with `sys.key_constraints`, and preserve composite key column order with `sys.index_columns.key_ordinal` (terabytesoftw)
 - Enh #20934: Replace MSSQL `INFORMATION_SCHEMA.TABLES` in `Schema::findTableNames()` and `Schema::findViewNames()` with catalog-qualified `sys.objects` and `sys.views` catalog views (terabytesoftw)
 - Bug #20935: Fix MSSQL index, foreign key, and constraint metadata lookups for catalog-qualified table names (terabytesoftw)
+- Chg #20936: Remove redundant `resolveTableNames()` from MSSQL, MySQL, PostgreSQL, and Oracle schema classes; `loadTableSchema()` now uses `resolveTableName()` directly (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -77,6 +77,27 @@ Example:
 
 If your tests assert exact SQL strings for composite `IN` / `NOT IN`, update expected SQL.
 
+#### `resolveTableNames()` removed from MSSQL, MySQL, PostgreSQL, and Oracle drivers
+
+The `protected` method `resolveTableNames($table, $name)` has been removed from MSSQL, MySQL, PostgreSQL, and Oracle
+Schema classes. This method was never defined in the parent `\yii\db\Schema` class; it was a per-driver internal method
+that duplicated table-name resolution logic.
+
+`loadTableSchema()` now uses `resolveTableName()` directly:
+
+```php
+// before
+$table = new TableSchema();
+$this->resolveTableNames($table, $name);
+
+// after
+$table = $this->resolveTableName($name);
+```
+
+If your application extends any affected database Schema class and overrides `resolveTableNames()`, migrate your logic
+to `resolveTableName($name)` instead. The method signature differs: `resolveTableName($name)` returns a new `TableSchema`
+with the resolved parts, rather than mutating an existing one.
+
 #### MariaDB
 
 ##### Pagination now uses `OFFSET ... FETCH` (`10.6+`)
@@ -103,7 +124,7 @@ pagination.
 > through June 4, `2028`). MariaDB `10.5` LTS reached community support EOL on June 24, `2025` and is no longer covered
 > by Yii. The `10.6+` floor matches the earliest MariaDB release with the standard `OFFSET ... FETCH` syntax.
 
-#### MSSQL 
+#### MSSQL
 
 ##### Pagination now uses `OFFSET ... FETCH` (`2019+`)
 
@@ -147,7 +168,7 @@ Existing MSSQL installations must convert the column manually before upgrading (
 ALTER TABLE [session] ALTER COLUMN [data] VARBINARY(MAX) NULL;
 ```
 
-#### MySQL 
+#### MySQL
 
 ##### Dead code removal and integer display width cleanup
 
@@ -473,7 +494,7 @@ ALTER TABLE auth_item_child WITH CHECK CHECK CONSTRAINT FK__auth_item__child;
 The `auth_item_child.child` FK is intentionally left without actions; do not add `ON DELETE CASCADE` or
 `ON UPDATE CASCADE` to it (MSSQL will reject the constraint with error 1785).
 
-The orphan row in your `migration` table for `m200409_110543_rbac_update_mssql_trigger` is harmless for `migrate/up`, 
+The orphan row in your `migration` table for `m200409_110543_rbac_update_mssql_trigger` is harmless for `migrate/up`,
 but `migrate/down --all` will fail trying to load the missing class. If you need full rollback, remove the row:
 
 ```sql

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -1328,7 +1328,7 @@ class QueryBuilder extends \yii\base\BaseObject
         foreach ($tables as $i => $table) {
             if ($table instanceof Query) {
                 list($sql, $params) = $this->build($table, $params);
-                $tables[$i] = "($sql) " . $this->db->quoteTableName($i);
+                $tables[$i] = "($sql) " . $this->db->quoteTableName((string) $i);
             } elseif (is_string($i)) {
                 if (strpos($table, '(') === false) {
                     $table = $this->db->quoteTableName($table);

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -104,36 +104,36 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
 
     /**
      * Resolves the table name and schema name (if any).
-     * @param string $name the table name
-     * @return TableSchema resolved table, schema, etc. names.
+     *
+     * @param string $name The table name
+     *
+     * @return TableSchema Resolved table, schema, etc. names.
      */
     protected function resolveTableName($name)
     {
-        $resolvedName = new TableSchema();
         $parts = $this->getTableNameParts($name);
+
         $partCount = count($parts);
-        if ($partCount === 4) {
-            // server name, catalog name, schema name and table name passed
-            $resolvedName->catalogName = $parts[1];
-            $resolvedName->schemaName = $parts[2];
-            $resolvedName->name = $parts[3];
-            $resolvedName->fullName = $resolvedName->catalogName . '.' . $resolvedName->schemaName . '.' . $resolvedName->name;
-        } elseif ($partCount === 3) {
-            // catalog name, schema name and table name passed
-            $resolvedName->catalogName = $parts[0];
-            $resolvedName->schemaName = $parts[1];
-            $resolvedName->name = $parts[2];
-            $resolvedName->fullName = $resolvedName->catalogName . '.' . $resolvedName->schemaName . '.' . $resolvedName->name;
-        } elseif ($partCount === 2) {
-            // only schema name and table name passed
-            $resolvedName->schemaName = $parts[0];
-            $resolvedName->name = $parts[1];
-            $resolvedName->fullName = ($resolvedName->schemaName !== $this->defaultSchema ? $resolvedName->schemaName . '.' : '') . $resolvedName->name;
-        } else {
-            // only table name passed
-            $resolvedName->schemaName = $this->defaultSchema;
-            $resolvedName->fullName = $resolvedName->name = $parts[0];
-        }
+
+        $last = $partCount - 1;
+        $penultimate = $partCount - 2;
+        $catalogIndex = $partCount === 4 ? 1 : 0;
+        $tableName = $parts[$last];
+        $schemaName = $partCount >= 2 ? $parts[$penultimate] : $this->defaultSchema;
+        $catalogName = $partCount >= 3 ? $parts[$catalogIndex] : null;
+
+        $fullName = match (true) {
+            $catalogName !== null => "{$catalogName}.{$schemaName}.{$tableName}",
+            $schemaName !== $this->defaultSchema => "{$schemaName}.{$tableName}",
+            default => $tableName,
+        };
+
+        $resolvedName = new TableSchema();
+
+        $resolvedName->name = $tableName;
+        $resolvedName->schemaName = $schemaName;
+        $resolvedName->catalogName = $catalogName;
+        $resolvedName->fullName = $fullName;
 
         return $resolvedName;
     }
@@ -205,8 +205,7 @@ SQL;
      */
     protected function loadTableSchema($name)
     {
-        $table = new TableSchema();
-        $this->resolveTableNames($table, $name);
+        $table = $this->resolveTableName($name);
         $this->findPrimaryKeys($table);
         if ($this->findColumns($table)) {
             $this->findForeignKeys($table);
@@ -359,39 +358,6 @@ SQL;
     public function createQueryBuilder()
     {
         return Yii::createObject(QueryBuilder::class, [$this->db]);
-    }
-
-    /**
-     * Resolves the table name and schema name (if any).
-     * @param TableSchema $table the table metadata object
-     * @param string $name the table name
-     */
-    protected function resolveTableNames($table, $name)
-    {
-        $parts = $this->getTableNameParts($name);
-        $partCount = count($parts);
-        if ($partCount === 4) {
-            // server name, catalog name, schema name and table name passed
-            $table->catalogName = $parts[1];
-            $table->schemaName = $parts[2];
-            $table->name = $parts[3];
-            $table->fullName = $table->catalogName . '.' . $table->schemaName . '.' . $table->name;
-        } elseif ($partCount === 3) {
-            // catalog name, schema name and table name passed
-            $table->catalogName = $parts[0];
-            $table->schemaName = $parts[1];
-            $table->name = $parts[2];
-            $table->fullName = $table->catalogName . '.' . $table->schemaName . '.' . $table->name;
-        } elseif ($partCount === 2) {
-            // only schema name and table name passed
-            $table->schemaName = $parts[0];
-            $table->name = $parts[1];
-            $table->fullName = $table->schemaName !== $this->defaultSchema ? $table->schemaName . '.' . $table->name : $table->name;
-        } else {
-            // only table name passed
-            $table->schemaName = $this->defaultSchema;
-            $table->fullName = $table->name = $parts[0];
-        }
     }
 
     /**

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -22,6 +22,9 @@ use yii\db\TableSchema;
 use yii\helpers\ArrayHelper;
 use yii\db\Schema as BaseSchema;
 
+use function explode;
+use function str_replace;
+
 /**
  * Schema is the class for retrieving metadata from a MySQL database (version 8.0 and later).
  *
@@ -96,16 +99,20 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function resolveTableName($name)
     {
-        $resolvedName = new TableSchema();
         $parts = explode('.', str_replace('`', '', $name));
-        if (isset($parts[1])) {
-            $resolvedName->schemaName = $parts[0];
-            $resolvedName->name = $parts[1];
-        } else {
-            $resolvedName->schemaName = $this->defaultSchema;
-            $resolvedName->name = $name;
-        }
-        $resolvedName->fullName = ($resolvedName->schemaName !== $this->defaultSchema ? $resolvedName->schemaName . '.' : '') . $resolvedName->name;
+
+        $hasSchemaName = isset($parts[1]);
+
+        $tableName = $hasSchemaName ? $parts[1] : $parts[0];
+        $schemaName = $hasSchemaName ? $parts[0] : null;
+        $fullName = $hasSchemaName ? "{$schemaName}.{$tableName}" : $tableName;
+
+        $resolvedName = new TableSchema();
+
+        $resolvedName->name = $tableName;
+        $resolvedName->schemaName = $schemaName;
+        $resolvedName->fullName = $fullName;
+
         return $resolvedName;
     }
 
@@ -127,8 +134,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function loadTableSchema($name)
     {
-        $table = new TableSchema();
-        $this->resolveTableNames($table, $name);
+        $table = $this->resolveTableName($name);
 
         if ($this->findColumns($table)) {
             $this->findConstraints($table);
@@ -251,23 +257,6 @@ SQL;
     public function createQueryBuilder()
     {
         return Yii::createObject(QueryBuilder::class, [$this->db]);
-    }
-
-    /**
-     * Resolves the table name and schema name (if any).
-     * @param TableSchema $table the table metadata object
-     * @param string $name the table name
-     */
-    protected function resolveTableNames($table, $name)
-    {
-        $parts = explode('.', str_replace('`', '', $name));
-        if (isset($parts[1])) {
-            $table->schemaName = $parts[0];
-            $table->name = $parts[1];
-            $table->fullName = $table->schemaName . '.' . $table->name;
-        } else {
-            $table->fullName = $table->name = $parts[0];
-        }
     }
 
     /**

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -83,7 +83,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
     {
         $parts = explode('.', str_replace('"', '', $name));
 
-        $tableName = $parts[1] ?? $name;
+        $tableName = $parts[1] ?? $parts[0];
         $schemaName = isset($parts[1]) ? $parts[0] : $this->defaultSchema;
         $fullName = $schemaName !== $this->defaultSchema ? "{$schemaName}.{$tableName}" : $tableName;
 

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -25,6 +25,9 @@ use yii\db\TableSchema;
 use yii\helpers\ArrayHelper;
 use yii\db\Schema as BaseSchema;
 
+use function explode;
+use function str_replace;
+
 /**
  * Schema is the class for retrieving metadata from an Oracle database.
  *
@@ -78,16 +81,18 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function resolveTableName($name)
     {
-        $resolvedName = new TableSchema();
         $parts = explode('.', str_replace('"', '', $name));
-        if (isset($parts[1])) {
-            $resolvedName->schemaName = $parts[0];
-            $resolvedName->name = $parts[1];
-        } else {
-            $resolvedName->schemaName = $this->defaultSchema;
-            $resolvedName->name = $name;
-        }
-        $resolvedName->fullName = ($resolvedName->schemaName !== $this->defaultSchema ? $resolvedName->schemaName . '.' : '') . $resolvedName->name;
+
+        $tableName = $parts[1] ?? $name;
+        $schemaName = isset($parts[1]) ? $parts[0] : $this->defaultSchema;
+        $fullName = $schemaName !== $this->defaultSchema ? "{$schemaName}.{$tableName}" : $tableName;
+
+        $resolvedName = new TableSchema();
+
+        $resolvedName->name = $tableName;
+        $resolvedName->schemaName = $schemaName;
+        $resolvedName->fullName = $fullName;
+
         return $resolvedName;
     }
 
@@ -158,8 +163,7 @@ SQL;
      */
     protected function loadTableSchema($name)
     {
-        $table = new TableSchema();
-        $this->resolveTableNames($table, $name);
+        $table = $this->resolveTableName($name);
         if ($this->findColumns($table)) {
             $this->findConstraints($table);
 
@@ -288,26 +292,6 @@ SQL;
     public function createColumnSchemaBuilder($type, $length = null)
     {
         return Yii::createObject(ColumnSchemaBuilder::class, [$type, $length]);
-    }
-
-    /**
-     * Resolves the table name and schema name (if any).
-     *
-     * @param TableSchema $table the table metadata object
-     * @param string $name the table name
-     */
-    protected function resolveTableNames($table, $name)
-    {
-        $parts = explode('.', str_replace('"', '', $name));
-        if (isset($parts[1])) {
-            $table->schemaName = $parts[0];
-            $table->name = $parts[1];
-        } else {
-            $table->schemaName = $this->defaultSchema;
-            $table->name = $name;
-        }
-
-        $table->fullName = $table->schemaName !== $this->defaultSchema ? $table->schemaName . '.' . $table->name : $table->name;
     }
 
     /**

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -23,6 +23,9 @@ use yii\db\ViewFinderTrait;
 use yii\helpers\ArrayHelper;
 use yii\db\Schema as BaseSchema;
 
+use function explode;
+use function str_replace;
+
 /**
  * Schema is the class for retrieving metadata from a PostgreSQL database
  * (version 13.0 and above).
@@ -141,16 +144,18 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function resolveTableName($name)
     {
-        $resolvedName = new TableSchema();
         $parts = explode('.', str_replace('"', '', $name));
-        if (isset($parts[1])) {
-            $resolvedName->schemaName = $parts[0];
-            $resolvedName->name = $parts[1];
-        } else {
-            $resolvedName->schemaName = $this->defaultSchema;
-            $resolvedName->name = $name;
-        }
-        $resolvedName->fullName = ($resolvedName->schemaName !== $this->defaultSchema ? $resolvedName->schemaName . '.' : '') . $resolvedName->name;
+
+        $tableName = $parts[1] ?? $parts[0];
+        $schemaName = isset($parts[1]) ? $parts[0] : $this->defaultSchema;
+        $fullName = $schemaName !== $this->defaultSchema ? "{$schemaName}.{$tableName}" : $tableName;
+
+        $resolvedName = new TableSchema();
+
+        $resolvedName->name = $tableName;
+        $resolvedName->schemaName = $schemaName;
+        $resolvedName->fullName = $fullName;
+
         return $resolvedName;
     }
 
@@ -192,8 +197,7 @@ SQL;
      */
     protected function loadTableSchema($name)
     {
-        $table = new TableSchema();
-        $this->resolveTableNames($table, $name);
+        $table = $this->resolveTableName($name);
         if ($this->findColumns($table)) {
             $this->findConstraints($table);
             return $table;
@@ -294,26 +298,6 @@ SQL;
     public function createQueryBuilder()
     {
         return Yii::createObject(QueryBuilder::class, [$this->db]);
-    }
-
-    /**
-     * Resolves the table name and schema name (if any).
-     * @param TableSchema $table the table metadata object
-     * @param string $name the table name
-     */
-    protected function resolveTableNames($table, $name)
-    {
-        $parts = explode('.', str_replace('"', '', $name));
-
-        if (isset($parts[1])) {
-            $table->schemaName = $parts[0];
-            $table->name = $parts[1];
-        } else {
-            $table->schemaName = $this->defaultSchema;
-            $table->name = $parts[0];
-        }
-
-        $table->fullName = $table->schemaName !== $this->defaultSchema ? $table->schemaName . '.' . $table->name : $table->name;
     }
 
     /**

--- a/tests/framework/db/mssql/SchemaTest.php
+++ b/tests/framework/db/mssql/SchemaTest.php
@@ -364,48 +364,6 @@ final class SchemaTest extends BaseSchema
         $db->transaction->rollBack();
     }
 
-    #[DataProviderExternal(SchemaProvider::class, 'resolveTableName')]
-    public function testResolveTableNames(
-        string $name,
-        string|null $expectedCatalog,
-        string $expectedSchema,
-        string $expectedTable,
-        string $expectedFullName
-    ): void {
-        $schema = $this->getConnection()->getSchema();
-        $table = new TableSchema();
-
-        $this->invokeMethod(
-            $schema,
-            'resolveTableNames',
-            [
-                $table,
-                $name,
-            ],
-        );
-
-        self::assertSame(
-            $expectedCatalog,
-            $table->catalogName,
-            'Resolved catalog name should match expected value.',
-        );
-        self::assertSame(
-            $expectedSchema,
-            $table->schemaName,
-            'Resolved schema name should match expected value.',
-        );
-        self::assertSame(
-            $expectedTable,
-            $table->name,
-            'Resolved table name should match expected value.',
-        );
-        self::assertSame(
-            $expectedFullName,
-            $table->fullName,
-            'Resolved full name should match expected value.',
-        );
-    }
-
     public function testGetSchemaPrimaryKeysWithExplicitSchema(): void
     {
         $schema = $this->getConnection(true, true)->getSchema();

--- a/tests/framework/db/oci/SchemaTest.php
+++ b/tests/framework/db/oci/SchemaTest.php
@@ -112,6 +112,24 @@ final class SchemaTest extends BaseSchema
         );
     }
 
+    public function testGetTableSchemaWithQuotedTableName(): void
+    {
+        $schema = $this->getConnection()->getSchema();
+
+        $tableSchema = $schema->getTableSchema('"profile"', true);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $tableSchema,
+            'Table schema should be loadable with a quoted table name.',
+        );
+        self::assertSame(
+            'profile',
+            $tableSchema->name,
+            'Loaded table name should not keep quote characters.',
+        );
+    }
+
     public function testIntegerDataTypeColumn(): void
     {
         $table = $this->getConnection()->getSchema()->getTableSchema('employee');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
