### PR TITLE
Exclude configurable system schema names from MSSQL `yii\db\Schema::getSchemaNames()` to match the non-system schema contract.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -89,6 +89,7 @@ Yii Framework 2 Change Log
 - Enh #20934: Replace MSSQL `INFORMATION_SCHEMA.TABLES` in `Schema::findTableNames()` and `Schema::findViewNames()` with catalog-qualified `sys.objects` and `sys.views` catalog views (terabytesoftw)
 - Bug #20935: Fix MSSQL index, foreign key, and constraint metadata lookups for catalog-qualified table names (terabytesoftw)
 - Chg #20936: Remove redundant `resolveTableNames()` from MSSQL, MySQL, PostgreSQL, and Oracle schema classes; `loadTableSchema()` now uses `resolveTableName()` directly (terabytesoftw)
+- Bug #20937: Exclude configurable system schema names from MSSQL `yii\db\Schema::getSchemaNames()` to match the non-system schema contract (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -80,6 +80,12 @@ abstract class Schema extends BaseObject
      */
     public $defaultSchema;
     /**
+     * @var list<string> list of schema names that should be excluded from {@see getSchemaNames()}.
+     *
+     * DBMS-specific implementations may use this list in {@see findSchemaNames()}.
+     */
+    public array $systemSchemaNames = [];
+    /**
      * @var array map of DB errors and corresponding exceptions
      * If left part is found in DB error message exception class from the right part is used.
      */

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types= 1);
+declare(strict_types=1);
 
 /**
  * @link https://www.yiiframework.com/

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types= 1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -23,6 +25,7 @@ use yii\db\Schema as BaseSchema;
 use function count;
 use function implode;
 use function strcasecmp;
+use function str_replace;
 
 /**
  * Schema is the class for retrieving metadata from MS SQL Server databases (version 2019 and above).
@@ -41,11 +44,12 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
     /**
      * {@inheritdoc}
      */
-    public $columnSchemaClass = 'yii\db\mssql\ColumnSchema';
+    public $columnSchemaClass = ColumnSchema::class;
     /**
      * @var string the default schema used for the current session.
      */
     public $defaultSchema = 'dbo';
+    public array $systemSchemaNames = ['guest'];
     /**
      * @var array mapping from physical column types (keys) to abstract column types (values)
      */
@@ -159,19 +163,26 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
 
     /**
      * {@inheritdoc}
-     * @see https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-database-principals-transact-sql
+     *
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-database-principals-transact-sql
      */
     protected function findSchemaNames()
     {
-        static $sql = <<<'SQL'
-SELECT [s].[name]
-FROM [sys].[schemas] AS [s]
-INNER JOIN [sys].[database_principals] AS [p] ON [p].[principal_id] = [s].[principal_id]
-WHERE [p].[is_fixed_role] = 0 AND [p].[sid] IS NOT NULL
-ORDER BY [s].[name] ASC
-SQL;
+        $systemSchemaNames = "'" . implode("', '", str_replace("'", "''", $this->systemSchemaNames)) . "'";
 
-        return $this->db->createCommand($sql)->queryColumn();
+        $sql = <<<SQL
+        SELECT [s].[name]
+        FROM [sys].[schemas] AS [s]
+        INNER JOIN [sys].[database_principals] AS [p] ON [p].[principal_id] = [s].[principal_id]
+        WHERE [p].[is_fixed_role] = 0
+            AND [p].[sid] IS NOT NULL
+            AND [s].[name] NOT IN ({$systemSchemaNames})
+        ORDER BY [s].[name] ASC
+        SQL;
+
+        return $this->db->createCommand(
+            $sql,
+        )->queryColumn();
     }
 
     /**

--- a/tests/framework/db/mssql/SchemaTest.php
+++ b/tests/framework/db/mssql/SchemaTest.php
@@ -22,7 +22,9 @@ use yii\db\mssql\TableSchema;
 use yiiunit\base\db\BaseSchema;
 use yiiunit\framework\db\mssql\providers\SchemaProvider;
 
+use function array_diff;
 use function array_map;
+use function array_values;
 use function chr;
 use function count;
 use function explode;
@@ -49,6 +51,72 @@ final class SchemaTest extends BaseSchema
         'dbo',
     ];
 
+    /**
+     * @param list<string> $systemSchemaNames
+     * @param list<string> $schemaNamesToCreate
+     * @param list<string> $expectedSchemaNames
+     */
+    #[DataProviderExternal(SchemaProvider::class, 'systemSchemaNames')]
+    public function testGetSchemaNamesUsesConfiguredSystemSchemaNames(
+        array $systemSchemaNames,
+        array $schemaNamesToCreate,
+        array $expectedSchemaNames,
+    ): void {
+        $db = $this->getConnection();
+
+        $schema = $db->getSchema();
+
+        self::assertInstanceOf(
+            Schema::class,
+            $schema,
+            'Schema should be an instance of ' . Schema::class . '.',
+        );
+
+        foreach ($schemaNamesToCreate as $schemaName) {
+            $db->createCommand(
+                <<<SQL
+                DROP SCHEMA IF EXISTS {{{$schemaName}}}
+                SQL
+            )->execute();
+            $db->createCommand(
+                <<<SQL
+                CREATE SCHEMA {{{$schemaName}}}
+                SQL
+            )->execute();
+        }
+
+        if ($schemaNamesToCreate !== []) {
+            $schema->systemSchemaNames = [];
+
+            $actualSchemaNames = $schema->getSchemaNames(true);
+
+            $missingSchemaNames = array_values(array_diff($schemaNamesToCreate, $actualSchemaNames));
+
+            self::assertSame(
+                [],
+                $missingSchemaNames,
+                'Created schemas should be present before they are excluded.',
+            );
+        }
+
+        $schema->systemSchemaNames = $systemSchemaNames;
+
+        $actualSchemaNames = $schema->getSchemaNames(true);
+
+        self::assertSame(
+            $expectedSchemaNames,
+            $actualSchemaNames,
+            'Schema names should match the expected list.',
+        );
+
+        foreach ($schemaNamesToCreate as $schemaName) {
+            $db->createCommand(
+                <<<SQL
+                DROP SCHEMA IF EXISTS {{{$schemaName}}}
+                SQL
+            )->execute();
+        }
+    }
 
     public function testGetStringFieldsSize(): void
     {

--- a/tests/framework/db/mssql/providers/SchemaProvider.php
+++ b/tests/framework/db/mssql/providers/SchemaProvider.php
@@ -76,6 +76,30 @@ final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
     }
 
     /**
+     * @return array<string, array{list<string>, list<string>, list<string>}>
+     */
+    public static function systemSchemaNames(): array
+    {
+        return [
+            'custom configured system schemas' => [
+                ['guest', 'yii_custom_system_schema', 'yii custom system schema'],
+                ['yii_custom_system_schema', 'yii custom system schema'],
+                ['dbo'],
+            ],
+            'default system schemas' => [
+                ['guest'],
+                [],
+                ['dbo'],
+            ],
+            'empty configured system schemas' => [
+                [],
+                [],
+                ['dbo', 'guest'],
+            ],
+        ];
+    }
+
+    /**
      * @return array<string, array{string, string|null, string, string, string}>
      */
     public static function resolveTableName(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
