### PR TITLE
Fix MSSQL `QueryBuilder::dropConstraintsForColumn()` to drop primary key, foreign key, and table-level check constraints, replacing deprecated `sys.sysconstraints` with modern catalog views.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -90,7 +90,7 @@ Yii Framework 2 Change Log
 - Bug #20935: Fix MSSQL index, foreign key, and constraint metadata lookups for catalog-qualified table names (terabytesoftw)
 - Chg #20936: Remove redundant `resolveTableNames()` from MSSQL, MySQL, PostgreSQL, and Oracle schema classes; `loadTableSchema()` now uses `resolveTableName()` directly (terabytesoftw)
 - Bug #20937: Exclude configurable system schema names from MSSQL `yii\db\Schema::getSchemaNames()` to match the non-system schema contract (terabytesoftw)
-- Enh: Replace deprecated MSSQL `sys.sysconstraints` in `QueryBuilder::dropConstraintsForColumn()` with `sys.default_constraints` and `sys.check_constraints` catalog views (terabytesoftw)
+- Bug #20938: Fix MSSQL `QueryBuilder::dropConstraintsForColumn()` to drop primary key, foreign key, and table-level check constraints, replacing deprecated `sys.sysconstraints` with modern catalog views (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -90,6 +90,7 @@ Yii Framework 2 Change Log
 - Bug #20935: Fix MSSQL index, foreign key, and constraint metadata lookups for catalog-qualified table names (terabytesoftw)
 - Chg #20936: Remove redundant `resolveTableNames()` from MSSQL, MySQL, PostgreSQL, and Oracle schema classes; `loadTableSchema()` now uses `resolveTableName()` directly (terabytesoftw)
 - Bug #20937: Exclude configurable system schema names from MSSQL `yii\db\Schema::getSchemaNames()` to match the non-system schema contract (terabytesoftw)
+- Enh: Replace deprecated MSSQL `sys.sysconstraints` in `QueryBuilder::dropConstraintsForColumn()` with `sys.default_constraints` and `sys.check_constraints` catalog views (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -16,6 +16,7 @@ use yii\db\Expression;
 use yii\db\Query;
 
 use function count;
+use function str_replace;
 use function strpos;
 
 /**
@@ -571,6 +572,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
     private function dropConstraintsForColumn($table, $column, $type = '')
     {
         $tableName = strpos($table, '{{') === false ? "{{{$table}}}" : $table;
+        $columnName = str_replace("'", "''", $column);
 
         $subqueries = [
             'F' => <<<SQL
@@ -623,7 +625,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
         return <<<SQL
         DECLARE @tableName NVARCHAR(MAX) = N'{$tableName}'
-        DECLARE @columnName NVARCHAR(MAX) = N'{$column}'
+        DECLARE @columnName NVARCHAR(MAX) = N'{$columnName}'
         DECLARE @dropCommands NVARCHAR(MAX)
 
         SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -16,6 +16,7 @@ use yii\db\Expression;
 use yii\db\Query;
 
 use function count;
+use function strpos;
 
 /**
  * QueryBuilder is the query builder for MS SQL Server databases (version 2019 and above).
@@ -551,33 +552,44 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * @param string $table the table whose constraint is to be dropped. The name will be properly quoted by the method.
      * @param string $column the column whose constraint is to be dropped. The name will be properly quoted by the method.
      * @param string $type type of constraint, leave empty for all type of constraints(for example: D - default, 'UQ' - unique, 'C' - check)
-     * @see https://docs.microsoft.com/sql/relational-databases/system-catalog-views/sys-objects-transact-sql
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-default-constraints-transact-sql
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-check-constraints-transact-sql
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-indexes-transact-sql
      * @return string the DROP CONSTRAINTS SQL
      */
     private function dropConstraintsForColumn($table, $column, $type = '')
     {
-        return "DECLARE @tableName VARCHAR(MAX) = '" . $this->db->quoteTableName($table) . "'
-DECLARE @columnName VARCHAR(MAX) = '{$column}'
+        $tableName = strpos($table, '{{') === false ? "{{{$table}}}" : $table;
 
-WHILE 1=1 BEGIN
-    DECLARE @constraintName NVARCHAR(128)
-    SET @constraintName = (SELECT TOP 1 OBJECT_NAME(cons.[object_id])
+        $typeFilter = $type !== '' ? "\nWHERE [cons].[type] = N'{$type}'" : '';
+
+        return <<<SQL
+        DECLARE @tableName VARCHAR(MAX) = '{$tableName}'
+        DECLARE @columnName VARCHAR(MAX) = '{$column}'
+        DECLARE @constraintNames NVARCHAR(MAX)
+
+        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
         FROM (
-            SELECT sc.[constid] object_id
-            FROM [sys].[sysconstraints] sc
-            JOIN [sys].[columns] c ON c.[object_id]=sc.[id] AND c.[column_id]=sc.[colid] AND c.[name]=@columnName
-            WHERE sc.[id] = OBJECT_ID(@tableName)
+            SELECT [dc].[name], N'D' AS [type]
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
             UNION
-            SELECT object_id(i.[name]) FROM [sys].[indexes] i
-            JOIN [sys].[columns] c ON c.[object_id]=i.[object_id] AND c.[name]=@columnName
-            JOIN [sys].[index_columns] ic ON ic.[object_id]=i.[object_id] AND i.[index_id]=ic.[index_id] AND c.[column_id]=ic.[column_id]
-            WHERE i.[is_unique_constraint]=1 and i.[object_id]=OBJECT_ID(@tableName)
-        ) cons
-        JOIN [sys].[objects] so ON so.[object_id]=cons.[object_id]
-        " . (!empty($type) ? " WHERE so.[type]='{$type}'" : '') . ")
-    IF @constraintName IS NULL BREAK
-    EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
-END";
+            SELECT [cc].[name], N'C' AS [type]
+            FROM [sys].[check_constraints] AS [cc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+            UNION
+            SELECT [i].[name], N'UQ' AS [type]
+            FROM [sys].[indexes] AS [i]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
+            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
+            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
+        ) AS [cons]{$typeFilter}
+
+        IF @constraintNames IS NOT NULL
+            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        SQL;
     }
 
     /**

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -547,48 +547,92 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
-     * Builds a SQL statement for dropping constraints for column of table.
+     * Builds a SQL batch that drops the constraints attached to a column.
      *
-     * @param string $table the table whose constraint is to be dropped. The name will be properly quoted by the method.
-     * @param string $column the column whose constraint is to be dropped. The name will be properly quoted by the method.
-     * @param string $type type of constraint, leave empty for all type of constraints(for example: D - default, 'UQ' - unique, 'C' - check)
+     * Generates one `ALTER TABLE ... DROP CONSTRAINT` command per matching constraint and executes them in a single
+     * dynamic batch. Foreign key constraints are dropped first because a primary key or unique constraint cannot be
+     * dropped while a foreign key references it.
+     *
+     * @param string $table The table whose constraints are to be dropped. The name is properly quoted by the method.
+     * @param string $column The column whose constraints are to be dropped. The name is matched verbatim against the
+     * system catalog.
+     * @param string $type The constraint type: `'D'` - default, `'C'` - check, `'PK'` - primary key, `'UQ'` - unique,
+     * `'F'` - foreign key. Leave empty to drop the constraints of all these types.
+     *
+     * @return string The DROP CONSTRAINTS SQL batch.
+     *
      * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-default-constraints-transact-sql
      * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-check-constraints-transact-sql
-     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-indexes-transact-sql
-     * @return string the DROP CONSTRAINTS SQL
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-sql-expression-dependencies-transact-sql
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-key-constraints-transact-sql
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-index-columns-transact-sql
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-foreign-key-columns-transact-sql
      */
     private function dropConstraintsForColumn($table, $column, $type = '')
     {
         $tableName = strpos($table, '{{') === false ? "{{{$table}}}" : $table;
 
-        $typeFilter = $type !== '' ? "\nWHERE [cons].[type] = N'{$type}'" : '';
+        $subqueries = [
+            'F' => <<<SQL
+                SELECT DISTINCT N'ALTER TABLE '
+                    + QUOTENAME(OBJECT_SCHEMA_NAME([fk].[parent_object_id])) + N'.'
+                    + QUOTENAME(OBJECT_NAME([fk].[parent_object_id]))
+                    + N' DROP CONSTRAINT ' + QUOTENAME([fk].[name]) AS [sql], 0 AS [ord]
+                FROM [sys].[foreign_keys] AS [fk]
+                JOIN [sys].[foreign_key_columns] AS [fkc] ON [fkc].[constraint_object_id]=[fk].[object_id]
+                JOIN [sys].[columns] AS [pc] ON [pc].[object_id]=[fkc].[parent_object_id] AND [pc].[column_id]=[fkc].[parent_column_id]
+                JOIN [sys].[columns] AS [rc] ON [rc].[object_id]=[fkc].[referenced_object_id] AND [rc].[column_id]=[fkc].[referenced_column_id]
+                WHERE ([fkc].[parent_object_id]=OBJECT_ID(@tableName) AND [pc].[name]=@columnName)
+                    OR ([fkc].[referenced_object_id]=OBJECT_ID(@tableName) AND [rc].[name]=@columnName)
+            SQL,
+            'D' => <<<SQL
+                SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                FROM [sys].[default_constraints] AS [dc]
+                JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+            SQL,
+            'C' => <<<SQL
+                SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                FROM [sys].[check_constraints] AS [cc]
+                JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                    AND (
+                        [cc].[parent_column_id]=[c].[column_id]
+                        OR EXISTS (
+                            SELECT 1
+                            FROM [sys].[sql_expression_dependencies] AS [sed]
+                            WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                AND [sed].[referenced_minor_id]=[c].[column_id]
+                        )
+                    )
+            SQL,
+        ];
+
+        foreach (['PK', 'UQ'] as $keyType) {
+            $subqueries[$keyType] = <<<SQL
+                SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                FROM [sys].[key_constraints] AS [kc]
+                JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'{$keyType}'
+            SQL;
+        }
+
+        $unionSql = implode("\n    UNION\n", $type === '' ? $subqueries : [$subqueries[$type]]);
 
         return <<<SQL
-        DECLARE @tableName VARCHAR(MAX) = '{$tableName}'
-        DECLARE @columnName VARCHAR(MAX) = '{$column}'
-        DECLARE @constraintNames NVARCHAR(MAX)
+        DECLARE @tableName NVARCHAR(MAX) = N'{$tableName}'
+        DECLARE @columnName NVARCHAR(MAX) = N'{$column}'
+        DECLARE @dropCommands NVARCHAR(MAX)
 
-        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
+        SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
         FROM (
-            SELECT [dc].[name], N'D' AS [type]
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [cc].[name], N'C' AS [type]
-            FROM [sys].[check_constraints] AS [cc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [i].[name], N'UQ' AS [type]
-            FROM [sys].[indexes] AS [i]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
-            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
-            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
-        ) AS [cons]{$typeFilter}
+        {$unionSql}
+        ) AS [cons]
 
-        IF @constraintNames IS NOT NULL
-            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        IF @dropCommands IS NOT NULL
+            EXEC (@dropCommands)
         SQL;
     }
 

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -649,190 +649,232 @@ final class QueryBuilderTest extends BaseQueryBuilder
     {
         $qb = $this->getQueryBuilder();
 
-        $expected = "ALTER TABLE [foo1] ALTER COLUMN [bar] varchar(255)
-DECLARE @tableName VARCHAR(MAX) = '[foo1]'
-DECLARE @columnName VARCHAR(MAX) = 'bar'
+        $expected = <<<SQL
+        ALTER TABLE [foo1] ALTER COLUMN [bar] varchar(255)
+        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
+        DECLARE @columnName VARCHAR(MAX) = 'bar'
+        DECLARE @constraintNames NVARCHAR(MAX)
 
-WHILE 1=1 BEGIN
-    DECLARE @constraintName NVARCHAR(128)
-    SET @constraintName = (SELECT TOP 1 OBJECT_NAME(cons.[object_id])
+        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
         FROM (
-            SELECT sc.[constid] object_id
-            FROM [sys].[sysconstraints] sc
-            JOIN [sys].[columns] c ON c.[object_id]=sc.[id] AND c.[column_id]=sc.[colid] AND c.[name]=@columnName
-            WHERE sc.[id] = OBJECT_ID(@tableName)
+            SELECT [dc].[name], N'D' AS [type]
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
             UNION
-            SELECT object_id(i.[name]) FROM [sys].[indexes] i
-            JOIN [sys].[columns] c ON c.[object_id]=i.[object_id] AND c.[name]=@columnName
-            JOIN [sys].[index_columns] ic ON ic.[object_id]=i.[object_id] AND i.[index_id]=ic.[index_id] AND c.[column_id]=ic.[column_id]
-            WHERE i.[is_unique_constraint]=1 and i.[object_id]=OBJECT_ID(@tableName)
-        ) cons
-        JOIN [sys].[objects] so ON so.[object_id]=cons.[object_id]
-         WHERE so.[type]='D')
-    IF @constraintName IS NULL BREAK
-    EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
-END";
+            SELECT [cc].[name], N'C' AS [type]
+            FROM [sys].[check_constraints] AS [cc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+            UNION
+            SELECT [i].[name], N'UQ' AS [type]
+            FROM [sys].[indexes] AS [i]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
+            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
+            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
+        ) AS [cons]
+        WHERE [cons].[type] = N'D'
+
+        IF @constraintNames IS NOT NULL
+            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        SQL;
         $sql = $qb->alterColumn('foo1', 'bar', 'varchar(255)');
         $this->assertEquals($expected, $sql);
 
-        $expected = "ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255) NOT NULL
-DECLARE @tableName VARCHAR(MAX) = '[foo1]'
-DECLARE @columnName VARCHAR(MAX) = 'bar'
+        $expected = <<<SQL
+        ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255) NOT NULL
+        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
+        DECLARE @columnName VARCHAR(MAX) = 'bar'
+        DECLARE @constraintNames NVARCHAR(MAX)
 
-WHILE 1=1 BEGIN
-    DECLARE @constraintName NVARCHAR(128)
-    SET @constraintName = (SELECT TOP 1 OBJECT_NAME(cons.[object_id])
+        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
         FROM (
-            SELECT sc.[constid] object_id
-            FROM [sys].[sysconstraints] sc
-            JOIN [sys].[columns] c ON c.[object_id]=sc.[id] AND c.[column_id]=sc.[colid] AND c.[name]=@columnName
-            WHERE sc.[id] = OBJECT_ID(@tableName)
+            SELECT [dc].[name], N'D' AS [type]
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
             UNION
-            SELECT object_id(i.[name]) FROM [sys].[indexes] i
-            JOIN [sys].[columns] c ON c.[object_id]=i.[object_id] AND c.[name]=@columnName
-            JOIN [sys].[index_columns] ic ON ic.[object_id]=i.[object_id] AND i.[index_id]=ic.[index_id] AND c.[column_id]=ic.[column_id]
-            WHERE i.[is_unique_constraint]=1 and i.[object_id]=OBJECT_ID(@tableName)
-        ) cons
-        JOIN [sys].[objects] so ON so.[object_id]=cons.[object_id]
-         WHERE so.[type]='D')
-    IF @constraintName IS NULL BREAK
-    EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
-END";
+            SELECT [cc].[name], N'C' AS [type]
+            FROM [sys].[check_constraints] AS [cc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+            UNION
+            SELECT [i].[name], N'UQ' AS [type]
+            FROM [sys].[indexes] AS [i]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
+            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
+            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
+        ) AS [cons]
+        WHERE [cons].[type] = N'D'
+
+        IF @constraintNames IS NOT NULL
+            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        SQL;
         $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->notNull());
         $this->assertEquals($expected, $sql);
 
-        $expected = "ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-DECLARE @tableName VARCHAR(MAX) = '[foo1]'
-DECLARE @columnName VARCHAR(MAX) = 'bar'
+        $expected = <<<SQL
+        ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
+        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
+        DECLARE @columnName VARCHAR(MAX) = 'bar'
+        DECLARE @constraintNames NVARCHAR(MAX)
 
-WHILE 1=1 BEGIN
-    DECLARE @constraintName NVARCHAR(128)
-    SET @constraintName = (SELECT TOP 1 OBJECT_NAME(cons.[object_id])
+        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
         FROM (
-            SELECT sc.[constid] object_id
-            FROM [sys].[sysconstraints] sc
-            JOIN [sys].[columns] c ON c.[object_id]=sc.[id] AND c.[column_id]=sc.[colid] AND c.[name]=@columnName
-            WHERE sc.[id] = OBJECT_ID(@tableName)
+            SELECT [dc].[name], N'D' AS [type]
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
             UNION
-            SELECT object_id(i.[name]) FROM [sys].[indexes] i
-            JOIN [sys].[columns] c ON c.[object_id]=i.[object_id] AND c.[name]=@columnName
-            JOIN [sys].[index_columns] ic ON ic.[object_id]=i.[object_id] AND i.[index_id]=ic.[index_id] AND c.[column_id]=ic.[column_id]
-            WHERE i.[is_unique_constraint]=1 and i.[object_id]=OBJECT_ID(@tableName)
-        ) cons
-        JOIN [sys].[objects] so ON so.[object_id]=cons.[object_id]
-         WHERE so.[type]='D')
-    IF @constraintName IS NULL BREAK
-    EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
-END
-ALTER TABLE [foo1] ADD CONSTRAINT [CK_foo1_bar] CHECK (LEN(bar) > 5)";
+            SELECT [cc].[name], N'C' AS [type]
+            FROM [sys].[check_constraints] AS [cc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+            UNION
+            SELECT [i].[name], N'UQ' AS [type]
+            FROM [sys].[indexes] AS [i]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
+            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
+            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
+        ) AS [cons]
+        WHERE [cons].[type] = N'D'
+
+        IF @constraintNames IS NOT NULL
+            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        ALTER TABLE [foo1] ADD CONSTRAINT [CK_foo1_bar] CHECK (LEN(bar) > 5)
+        SQL;
         $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->check('LEN(bar) > 5'));
         $this->assertEquals($expected, $sql);
 
-        $expected = "ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-DECLARE @tableName VARCHAR(MAX) = '[foo1]'
-DECLARE @columnName VARCHAR(MAX) = 'bar'
+        $expected = <<<SQL
+        ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
+        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
+        DECLARE @columnName VARCHAR(MAX) = 'bar'
+        DECLARE @constraintNames NVARCHAR(MAX)
 
-WHILE 1=1 BEGIN
-    DECLARE @constraintName NVARCHAR(128)
-    SET @constraintName = (SELECT TOP 1 OBJECT_NAME(cons.[object_id])
+        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
         FROM (
-            SELECT sc.[constid] object_id
-            FROM [sys].[sysconstraints] sc
-            JOIN [sys].[columns] c ON c.[object_id]=sc.[id] AND c.[column_id]=sc.[colid] AND c.[name]=@columnName
-            WHERE sc.[id] = OBJECT_ID(@tableName)
+            SELECT [dc].[name], N'D' AS [type]
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
             UNION
-            SELECT object_id(i.[name]) FROM [sys].[indexes] i
-            JOIN [sys].[columns] c ON c.[object_id]=i.[object_id] AND c.[name]=@columnName
-            JOIN [sys].[index_columns] ic ON ic.[object_id]=i.[object_id] AND i.[index_id]=ic.[index_id] AND c.[column_id]=ic.[column_id]
-            WHERE i.[is_unique_constraint]=1 and i.[object_id]=OBJECT_ID(@tableName)
-        ) cons
-        JOIN [sys].[objects] so ON so.[object_id]=cons.[object_id]
-         WHERE so.[type]='D')
-    IF @constraintName IS NULL BREAK
-    EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
-END
-ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT '' FOR [bar]";
+            SELECT [cc].[name], N'C' AS [type]
+            FROM [sys].[check_constraints] AS [cc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+            UNION
+            SELECT [i].[name], N'UQ' AS [type]
+            FROM [sys].[indexes] AS [i]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
+            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
+            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
+        ) AS [cons]
+        WHERE [cons].[type] = N'D'
+
+        IF @constraintNames IS NOT NULL
+            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT '' FOR [bar]
+        SQL;
         $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->defaultValue(''));
         $this->assertEquals($expected, $sql);
 
-        $expected = "ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-DECLARE @tableName VARCHAR(MAX) = '[foo1]'
-DECLARE @columnName VARCHAR(MAX) = 'bar'
+        $expected = <<<SQL
+        ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
+        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
+        DECLARE @columnName VARCHAR(MAX) = 'bar'
+        DECLARE @constraintNames NVARCHAR(MAX)
 
-WHILE 1=1 BEGIN
-    DECLARE @constraintName NVARCHAR(128)
-    SET @constraintName = (SELECT TOP 1 OBJECT_NAME(cons.[object_id])
+        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
         FROM (
-            SELECT sc.[constid] object_id
-            FROM [sys].[sysconstraints] sc
-            JOIN [sys].[columns] c ON c.[object_id]=sc.[id] AND c.[column_id]=sc.[colid] AND c.[name]=@columnName
-            WHERE sc.[id] = OBJECT_ID(@tableName)
+            SELECT [dc].[name], N'D' AS [type]
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
             UNION
-            SELECT object_id(i.[name]) FROM [sys].[indexes] i
-            JOIN [sys].[columns] c ON c.[object_id]=i.[object_id] AND c.[name]=@columnName
-            JOIN [sys].[index_columns] ic ON ic.[object_id]=i.[object_id] AND i.[index_id]=ic.[index_id] AND c.[column_id]=ic.[column_id]
-            WHERE i.[is_unique_constraint]=1 and i.[object_id]=OBJECT_ID(@tableName)
-        ) cons
-        JOIN [sys].[objects] so ON so.[object_id]=cons.[object_id]
-         WHERE so.[type]='D')
-    IF @constraintName IS NULL BREAK
-    EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
-END
-ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT 'AbCdE' FOR [bar]";
+            SELECT [cc].[name], N'C' AS [type]
+            FROM [sys].[check_constraints] AS [cc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+            UNION
+            SELECT [i].[name], N'UQ' AS [type]
+            FROM [sys].[indexes] AS [i]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
+            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
+            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
+        ) AS [cons]
+        WHERE [cons].[type] = N'D'
+
+        IF @constraintNames IS NOT NULL
+            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT 'AbCdE' FOR [bar]
+        SQL;
         $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->defaultValue('AbCdE'));
         $this->assertEquals($expected, $sql);
 
-        $expected = "ALTER TABLE [foo1] ALTER COLUMN [bar] datetime
-DECLARE @tableName VARCHAR(MAX) = '[foo1]'
-DECLARE @columnName VARCHAR(MAX) = 'bar'
+        $expected = <<<SQL
+        ALTER TABLE [foo1] ALTER COLUMN [bar] datetime
+        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
+        DECLARE @columnName VARCHAR(MAX) = 'bar'
+        DECLARE @constraintNames NVARCHAR(MAX)
 
-WHILE 1=1 BEGIN
-    DECLARE @constraintName NVARCHAR(128)
-    SET @constraintName = (SELECT TOP 1 OBJECT_NAME(cons.[object_id])
+        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
         FROM (
-            SELECT sc.[constid] object_id
-            FROM [sys].[sysconstraints] sc
-            JOIN [sys].[columns] c ON c.[object_id]=sc.[id] AND c.[column_id]=sc.[colid] AND c.[name]=@columnName
-            WHERE sc.[id] = OBJECT_ID(@tableName)
+            SELECT [dc].[name], N'D' AS [type]
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
             UNION
-            SELECT object_id(i.[name]) FROM [sys].[indexes] i
-            JOIN [sys].[columns] c ON c.[object_id]=i.[object_id] AND c.[name]=@columnName
-            JOIN [sys].[index_columns] ic ON ic.[object_id]=i.[object_id] AND i.[index_id]=ic.[index_id] AND c.[column_id]=ic.[column_id]
-            WHERE i.[is_unique_constraint]=1 and i.[object_id]=OBJECT_ID(@tableName)
-        ) cons
-        JOIN [sys].[objects] so ON so.[object_id]=cons.[object_id]
-         WHERE so.[type]='D')
-    IF @constraintName IS NULL BREAK
-    EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
-END
-ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CURRENT_TIMESTAMP FOR [bar]";
+            SELECT [cc].[name], N'C' AS [type]
+            FROM [sys].[check_constraints] AS [cc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+            UNION
+            SELECT [i].[name], N'UQ' AS [type]
+            FROM [sys].[indexes] AS [i]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
+            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
+            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
+        ) AS [cons]
+        WHERE [cons].[type] = N'D'
+
+        IF @constraintNames IS NOT NULL
+            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CURRENT_TIMESTAMP FOR [bar]
+        SQL;
         $sql = $qb->alterColumn('foo1', 'bar', $this->timestamp()->defaultExpression('CURRENT_TIMESTAMP'));
         $this->assertEquals($expected, $sql);
 
-        $expected = "ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(30)
-DECLARE @tableName VARCHAR(MAX) = '[foo1]'
-DECLARE @columnName VARCHAR(MAX) = 'bar'
+        $expected = <<<SQL
+        ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(30)
+        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
+        DECLARE @columnName VARCHAR(MAX) = 'bar'
+        DECLARE @constraintNames NVARCHAR(MAX)
 
-WHILE 1=1 BEGIN
-    DECLARE @constraintName NVARCHAR(128)
-    SET @constraintName = (SELECT TOP 1 OBJECT_NAME(cons.[object_id])
+        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
         FROM (
-            SELECT sc.[constid] object_id
-            FROM [sys].[sysconstraints] sc
-            JOIN [sys].[columns] c ON c.[object_id]=sc.[id] AND c.[column_id]=sc.[colid] AND c.[name]=@columnName
-            WHERE sc.[id] = OBJECT_ID(@tableName)
+            SELECT [dc].[name], N'D' AS [type]
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
             UNION
-            SELECT object_id(i.[name]) FROM [sys].[indexes] i
-            JOIN [sys].[columns] c ON c.[object_id]=i.[object_id] AND c.[name]=@columnName
-            JOIN [sys].[index_columns] ic ON ic.[object_id]=i.[object_id] AND i.[index_id]=ic.[index_id] AND c.[column_id]=ic.[column_id]
-            WHERE i.[is_unique_constraint]=1 and i.[object_id]=OBJECT_ID(@tableName)
-        ) cons
-        JOIN [sys].[objects] so ON so.[object_id]=cons.[object_id]
-         WHERE so.[type]='D')
-    IF @constraintName IS NULL BREAK
-    EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
-END
-ALTER TABLE [foo1] ADD CONSTRAINT [UQ_foo1_bar] UNIQUE ([bar])";
+            SELECT [cc].[name], N'C' AS [type]
+            FROM [sys].[check_constraints] AS [cc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+            UNION
+            SELECT [i].[name], N'UQ' AS [type]
+            FROM [sys].[indexes] AS [i]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
+            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
+            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
+        ) AS [cons]
+        WHERE [cons].[type] = N'D'
+
+        IF @constraintNames IS NOT NULL
+            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        ALTER TABLE [foo1] ADD CONSTRAINT [UQ_foo1_bar] UNIQUE ([bar])
+        SQL;
         $sql = $qb->alterColumn('foo1', 'bar', $this->string(30)->unique());
         $this->assertEquals($expected, $sql);
     }
@@ -859,30 +901,36 @@ ALTER TABLE [foo1] ADD CONSTRAINT [UQ_foo1_bar] UNIQUE ([bar])";
     {
         $qb = $this->getQueryBuilder();
 
-        $expected = "ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
-DECLARE @tableName VARCHAR(MAX) = '[foo1]'
-DECLARE @columnName VARCHAR(MAX) = 'bar'
+        $expected = <<<SQL
+        ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
+        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
+        DECLARE @columnName VARCHAR(MAX) = 'bar'
+        DECLARE @constraintNames NVARCHAR(MAX)
 
-WHILE 1=1 BEGIN
-    DECLARE @constraintName NVARCHAR(128)
-    SET @constraintName = (SELECT TOP 1 OBJECT_NAME(cons.[object_id])
+        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
         FROM (
-            SELECT sc.[constid] object_id
-            FROM [sys].[sysconstraints] sc
-            JOIN [sys].[columns] c ON c.[object_id]=sc.[id] AND c.[column_id]=sc.[colid] AND c.[name]=@columnName
-            WHERE sc.[id] = OBJECT_ID(@tableName)
+            SELECT [dc].[name], N'D' AS [type]
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
             UNION
-            SELECT object_id(i.[name]) FROM [sys].[indexes] i
-            JOIN [sys].[columns] c ON c.[object_id]=i.[object_id] AND c.[name]=@columnName
-            JOIN [sys].[index_columns] ic ON ic.[object_id]=i.[object_id] AND i.[index_id]=ic.[index_id] AND c.[column_id]=ic.[column_id]
-            WHERE i.[is_unique_constraint]=1 and i.[object_id]=OBJECT_ID(@tableName)
-        ) cons
-        JOIN [sys].[objects] so ON so.[object_id]=cons.[object_id]
-         WHERE so.[type]='D')
-    IF @constraintName IS NULL BREAK
-    EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
-END
-ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT NULL FOR [bar]";
+            SELECT [cc].[name], N'C' AS [type]
+            FROM [sys].[check_constraints] AS [cc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+            UNION
+            SELECT [i].[name], N'UQ' AS [type]
+            FROM [sys].[indexes] AS [i]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
+            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
+            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
+        ) AS [cons]
+        WHERE [cons].[type] = N'D'
+
+        IF @constraintNames IS NOT NULL
+            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT NULL FOR [bar]
+        SQL;
         $sql = $qb->alterColumn('foo1', 'bar', $this->integer()->null()->defaultValue(null));
         $this->assertEquals($expected, $sql);
     }
@@ -891,30 +939,36 @@ ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT NULL FOR [bar]";
     {
         $qb = $this->getQueryBuilder();
 
-        $expected = "ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
-DECLARE @tableName VARCHAR(MAX) = '[foo1]'
-DECLARE @columnName VARCHAR(MAX) = 'bar'
+        $expected = <<<SQL
+        ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
+        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
+        DECLARE @columnName VARCHAR(MAX) = 'bar'
+        DECLARE @constraintNames NVARCHAR(MAX)
 
-WHILE 1=1 BEGIN
-    DECLARE @constraintName NVARCHAR(128)
-    SET @constraintName = (SELECT TOP 1 OBJECT_NAME(cons.[object_id])
+        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
         FROM (
-            SELECT sc.[constid] object_id
-            FROM [sys].[sysconstraints] sc
-            JOIN [sys].[columns] c ON c.[object_id]=sc.[id] AND c.[column_id]=sc.[colid] AND c.[name]=@columnName
-            WHERE sc.[id] = OBJECT_ID(@tableName)
+            SELECT [dc].[name], N'D' AS [type]
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
             UNION
-            SELECT object_id(i.[name]) FROM [sys].[indexes] i
-            JOIN [sys].[columns] c ON c.[object_id]=i.[object_id] AND c.[name]=@columnName
-            JOIN [sys].[index_columns] ic ON ic.[object_id]=i.[object_id] AND i.[index_id]=ic.[index_id] AND c.[column_id]=ic.[column_id]
-            WHERE i.[is_unique_constraint]=1 and i.[object_id]=OBJECT_ID(@tableName)
-        ) cons
-        JOIN [sys].[objects] so ON so.[object_id]=cons.[object_id]
-         WHERE so.[type]='D')
-    IF @constraintName IS NULL BREAK
-    EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
-END
-ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CAST(GETDATE() AS INT) FOR [bar]";
+            SELECT [cc].[name], N'C' AS [type]
+            FROM [sys].[check_constraints] AS [cc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+            UNION
+            SELECT [i].[name], N'UQ' AS [type]
+            FROM [sys].[indexes] AS [i]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
+            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
+            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
+        ) AS [cons]
+        WHERE [cons].[type] = N'D'
+
+        IF @constraintNames IS NOT NULL
+            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CAST(GETDATE() AS INT) FOR [bar]
+        SQL;
         $sql = $qb->alterColumn('foo1', 'bar', $this->integer()->null()->defaultValue(new Expression('CAST(GETDATE() AS INT)')));
         $this->assertEquals($expected, $sql);
     }
@@ -963,29 +1017,34 @@ ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CAST(GETDATE() AS INT) F
     {
         $qb = $this->getQueryBuilder();
 
-        $expected = "DECLARE @tableName VARCHAR(MAX) = '[foo1]'
-DECLARE @columnName VARCHAR(MAX) = 'bar'
+        $expected = <<<SQL
+        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
+        DECLARE @columnName VARCHAR(MAX) = 'bar'
+        DECLARE @constraintNames NVARCHAR(MAX)
 
-WHILE 1=1 BEGIN
-    DECLARE @constraintName NVARCHAR(128)
-    SET @constraintName = (SELECT TOP 1 OBJECT_NAME(cons.[object_id])
+        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
         FROM (
-            SELECT sc.[constid] object_id
-            FROM [sys].[sysconstraints] sc
-            JOIN [sys].[columns] c ON c.[object_id]=sc.[id] AND c.[column_id]=sc.[colid] AND c.[name]=@columnName
-            WHERE sc.[id] = OBJECT_ID(@tableName)
+            SELECT [dc].[name], N'D' AS [type]
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
             UNION
-            SELECT object_id(i.[name]) FROM [sys].[indexes] i
-            JOIN [sys].[columns] c ON c.[object_id]=i.[object_id] AND c.[name]=@columnName
-            JOIN [sys].[index_columns] ic ON ic.[object_id]=i.[object_id] AND i.[index_id]=ic.[index_id] AND c.[column_id]=ic.[column_id]
-            WHERE i.[is_unique_constraint]=1 and i.[object_id]=OBJECT_ID(@tableName)
-        ) cons
-        JOIN [sys].[objects] so ON so.[object_id]=cons.[object_id]
-        )
-    IF @constraintName IS NULL BREAK
-    EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
-END
-ALTER TABLE [foo1] DROP COLUMN [bar]";
+            SELECT [cc].[name], N'C' AS [type]
+            FROM [sys].[check_constraints] AS [cc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
+            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+            UNION
+            SELECT [i].[name], N'UQ' AS [type]
+            FROM [sys].[indexes] AS [i]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
+            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
+            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
+        ) AS [cons]
+
+        IF @constraintNames IS NOT NULL
+            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
+        ALTER TABLE [foo1] DROP COLUMN [bar]
+        SQL;
         $sql = $qb->dropColumn('foo1', 'bar');
         $this->assertEquals($expected, $sql);
     }

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -10,14 +10,20 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\db\mssql;
 
+use Closure;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\base\InvalidArgumentException;
+use yii\db\Connection;
 use yii\db\Expression;
 use yii\db\Query;
 use yiiunit\base\db\BaseQueryBuilder;
+use yiiunit\framework\db\mssql\providers\QueryBuilderProvider;
 
 /**
  * Unit test for {@see \yii\db\QueryBuilder} with MSSQL driver.
+ *
+ * {@see QueryBuilderProvider} for test case data providers.
  */
 #[Group('db')]
 #[Group('mssql')]
@@ -645,238 +651,20 @@ final class QueryBuilderTest extends BaseQueryBuilder
         return $newData;
     }
 
-    public function testAlterColumn(): void
+    #[DataProviderExternal(QueryBuilderProvider::class, 'alterColumn')]
+    public function testAlterColumn(string|Closure $type, string $expected): void
     {
-        $qb = $this->getQueryBuilder();
+        $qb = $this->getQueryBuilder(false);
 
-        $expected = <<<SQL
-        ALTER TABLE [foo1] ALTER COLUMN [bar] varchar(255)
-        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
-        DECLARE @columnName VARCHAR(MAX) = 'bar'
-        DECLARE @constraintNames NVARCHAR(MAX)
+        if ($type instanceof Closure) {
+            $type = $type($this->getDb());
+        }
 
-        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
-        FROM (
-            SELECT [dc].[name], N'D' AS [type]
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [cc].[name], N'C' AS [type]
-            FROM [sys].[check_constraints] AS [cc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [i].[name], N'UQ' AS [type]
-            FROM [sys].[indexes] AS [i]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
-            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
-            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
-        ) AS [cons]
-        WHERE [cons].[type] = N'D'
-
-        IF @constraintNames IS NOT NULL
-            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
-        SQL;
-        $sql = $qb->alterColumn('foo1', 'bar', 'varchar(255)');
-        $this->assertEquals($expected, $sql);
-
-        $expected = <<<SQL
-        ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255) NOT NULL
-        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
-        DECLARE @columnName VARCHAR(MAX) = 'bar'
-        DECLARE @constraintNames NVARCHAR(MAX)
-
-        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
-        FROM (
-            SELECT [dc].[name], N'D' AS [type]
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [cc].[name], N'C' AS [type]
-            FROM [sys].[check_constraints] AS [cc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [i].[name], N'UQ' AS [type]
-            FROM [sys].[indexes] AS [i]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
-            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
-            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
-        ) AS [cons]
-        WHERE [cons].[type] = N'D'
-
-        IF @constraintNames IS NOT NULL
-            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
-        SQL;
-        $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->notNull());
-        $this->assertEquals($expected, $sql);
-
-        $expected = <<<SQL
-        ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
-        DECLARE @columnName VARCHAR(MAX) = 'bar'
-        DECLARE @constraintNames NVARCHAR(MAX)
-
-        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
-        FROM (
-            SELECT [dc].[name], N'D' AS [type]
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [cc].[name], N'C' AS [type]
-            FROM [sys].[check_constraints] AS [cc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [i].[name], N'UQ' AS [type]
-            FROM [sys].[indexes] AS [i]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
-            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
-            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
-        ) AS [cons]
-        WHERE [cons].[type] = N'D'
-
-        IF @constraintNames IS NOT NULL
-            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
-        ALTER TABLE [foo1] ADD CONSTRAINT [CK_foo1_bar] CHECK (LEN(bar) > 5)
-        SQL;
-        $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->check('LEN(bar) > 5'));
-        $this->assertEquals($expected, $sql);
-
-        $expected = <<<SQL
-        ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
-        DECLARE @columnName VARCHAR(MAX) = 'bar'
-        DECLARE @constraintNames NVARCHAR(MAX)
-
-        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
-        FROM (
-            SELECT [dc].[name], N'D' AS [type]
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [cc].[name], N'C' AS [type]
-            FROM [sys].[check_constraints] AS [cc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [i].[name], N'UQ' AS [type]
-            FROM [sys].[indexes] AS [i]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
-            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
-            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
-        ) AS [cons]
-        WHERE [cons].[type] = N'D'
-
-        IF @constraintNames IS NOT NULL
-            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
-        ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT '' FOR [bar]
-        SQL;
-        $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->defaultValue(''));
-        $this->assertEquals($expected, $sql);
-
-        $expected = <<<SQL
-        ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
-        DECLARE @columnName VARCHAR(MAX) = 'bar'
-        DECLARE @constraintNames NVARCHAR(MAX)
-
-        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
-        FROM (
-            SELECT [dc].[name], N'D' AS [type]
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [cc].[name], N'C' AS [type]
-            FROM [sys].[check_constraints] AS [cc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [i].[name], N'UQ' AS [type]
-            FROM [sys].[indexes] AS [i]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
-            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
-            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
-        ) AS [cons]
-        WHERE [cons].[type] = N'D'
-
-        IF @constraintNames IS NOT NULL
-            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
-        ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT 'AbCdE' FOR [bar]
-        SQL;
-        $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->defaultValue('AbCdE'));
-        $this->assertEquals($expected, $sql);
-
-        $expected = <<<SQL
-        ALTER TABLE [foo1] ALTER COLUMN [bar] datetime
-        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
-        DECLARE @columnName VARCHAR(MAX) = 'bar'
-        DECLARE @constraintNames NVARCHAR(MAX)
-
-        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
-        FROM (
-            SELECT [dc].[name], N'D' AS [type]
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [cc].[name], N'C' AS [type]
-            FROM [sys].[check_constraints] AS [cc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [i].[name], N'UQ' AS [type]
-            FROM [sys].[indexes] AS [i]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
-            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
-            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
-        ) AS [cons]
-        WHERE [cons].[type] = N'D'
-
-        IF @constraintNames IS NOT NULL
-            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
-        ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CURRENT_TIMESTAMP FOR [bar]
-        SQL;
-        $sql = $qb->alterColumn('foo1', 'bar', $this->timestamp()->defaultExpression('CURRENT_TIMESTAMP'));
-        $this->assertEquals($expected, $sql);
-
-        $expected = <<<SQL
-        ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(30)
-        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
-        DECLARE @columnName VARCHAR(MAX) = 'bar'
-        DECLARE @constraintNames NVARCHAR(MAX)
-
-        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
-        FROM (
-            SELECT [dc].[name], N'D' AS [type]
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [cc].[name], N'C' AS [type]
-            FROM [sys].[check_constraints] AS [cc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [i].[name], N'UQ' AS [type]
-            FROM [sys].[indexes] AS [i]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
-            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
-            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
-        ) AS [cons]
-        WHERE [cons].[type] = N'D'
-
-        IF @constraintNames IS NOT NULL
-            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
-        ALTER TABLE [foo1] ADD CONSTRAINT [UQ_foo1_bar] UNIQUE ([bar])
-        SQL;
-        $sql = $qb->alterColumn('foo1', 'bar', $this->string(30)->unique());
-        $this->assertEquals($expected, $sql);
+        self::assertSame(
+            $expected,
+            $qb->alterColumn('foo1', 'bar', $type),
+            'Generated SQL must match the expected batch.',
+        );
     }
 
     public function testAlterColumnOnDb(): void
@@ -895,82 +683,6 @@ final class QueryBuilderTest extends BaseQueryBuilder
         $schema = $connection->getTableSchema('[foo1]', true);
         $this->assertEquals('nvarchar(128)', $schema->getColumn('bar')->dbType);
         $this->assertEquals(false, $schema->getColumn('bar')->allowNull);
-    }
-
-    public function testAlterColumnWithNull(): void
-    {
-        $qb = $this->getQueryBuilder();
-
-        $expected = <<<SQL
-        ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
-        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
-        DECLARE @columnName VARCHAR(MAX) = 'bar'
-        DECLARE @constraintNames NVARCHAR(MAX)
-
-        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
-        FROM (
-            SELECT [dc].[name], N'D' AS [type]
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [cc].[name], N'C' AS [type]
-            FROM [sys].[check_constraints] AS [cc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [i].[name], N'UQ' AS [type]
-            FROM [sys].[indexes] AS [i]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
-            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
-            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
-        ) AS [cons]
-        WHERE [cons].[type] = N'D'
-
-        IF @constraintNames IS NOT NULL
-            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
-        ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT NULL FOR [bar]
-        SQL;
-        $sql = $qb->alterColumn('foo1', 'bar', $this->integer()->null()->defaultValue(null));
-        $this->assertEquals($expected, $sql);
-    }
-
-    public function testAlterColumnWithExpression(): void
-    {
-        $qb = $this->getQueryBuilder();
-
-        $expected = <<<SQL
-        ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
-        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
-        DECLARE @columnName VARCHAR(MAX) = 'bar'
-        DECLARE @constraintNames NVARCHAR(MAX)
-
-        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
-        FROM (
-            SELECT [dc].[name], N'D' AS [type]
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [cc].[name], N'C' AS [type]
-            FROM [sys].[check_constraints] AS [cc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [i].[name], N'UQ' AS [type]
-            FROM [sys].[indexes] AS [i]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
-            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
-            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
-        ) AS [cons]
-        WHERE [cons].[type] = N'D'
-
-        IF @constraintNames IS NOT NULL
-            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
-        ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CAST(GETDATE() AS INT) FOR [bar]
-        SQL;
-        $sql = $qb->alterColumn('foo1', 'bar', $this->integer()->null()->defaultValue(new Expression('CAST(GETDATE() AS INT)')));
-        $this->assertEquals($expected, $sql);
     }
 
     public function testAlterColumnWithCheckConstraintOnDb(): void
@@ -1013,40 +725,16 @@ final class QueryBuilderTest extends BaseQueryBuilder
         $this->assertEquals(1, $connection->createCommand($sql)->execute());
     }
 
-    public function testDropColumn(): void
+    #[DataProviderExternal(QueryBuilderProvider::class, 'dropColumn')]
+    public function testDropColumn(string $table, string $column, string $expected): void
     {
-        $qb = $this->getQueryBuilder();
+        $qb = $this->getQueryBuilder(false);
 
-        $expected = <<<SQL
-        DECLARE @tableName VARCHAR(MAX) = '{{foo1}}'
-        DECLARE @columnName VARCHAR(MAX) = 'bar'
-        DECLARE @constraintNames NVARCHAR(MAX)
-
-        SELECT @constraintNames = STRING_AGG(CONVERT(NVARCHAR(MAX), QUOTENAME([cons].[name])), N', ')
-        FROM (
-            SELECT [dc].[name], N'D' AS [type]
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [cc].[name], N'C' AS [type]
-            FROM [sys].[check_constraints] AS [cc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[column_id]=[cc].[parent_column_id] AND [c].[name]=@columnName
-            WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-            UNION
-            SELECT [i].[name], N'UQ' AS [type]
-            FROM [sys].[indexes] AS [i]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id]=[i].[object_id] AND [c].[name]=@columnName
-            JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[i].[object_id] AND [i].[index_id]=[ic].[index_id] AND [c].[column_id]=[ic].[column_id]
-            WHERE [i].[is_unique_constraint]=1 and [i].[object_id]=OBJECT_ID(@tableName)
-        ) AS [cons]
-
-        IF @constraintNames IS NOT NULL
-            EXEC (N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + @constraintNames)
-        ALTER TABLE [foo1] DROP COLUMN [bar]
-        SQL;
-        $sql = $qb->dropColumn('foo1', 'bar');
-        $this->assertEquals($expected, $sql);
+        self::assertSame(
+            $expected,
+            $qb->dropColumn($table, $column),
+            'Generated SQL must match the expected batch.',
+        );
     }
 
     public function testDropColumnOnDb(): void
@@ -1061,6 +749,59 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
         $schema = $connection->getTableSchema('[foo1]', true);
         $this->assertEquals(null, $schema->getColumn('bar'));
+    }
+
+    #[DataProviderExternal(QueryBuilderProvider::class, 'dropColumnConstraintsOnDb')]
+    public function testDropColumnDropsConstraintOnDb(
+        array $tableNames,
+        array $createTablesSql,
+        string $table,
+        string $column,
+    ): void {
+        $db = $this->getConnection(false);
+
+        $this->dropTablesIfExist($db, $tableNames);
+
+        foreach ($createTablesSql as $sql) {
+            $db->createCommand($sql)->execute();
+        }
+
+        $this->assertDropColumnOnDb($db, $table, $column);
+
+        $this->dropTablesIfExist($db, $tableNames);
+    }
+
+    private function assertDropColumnOnDb(Connection $db, string $table, string $column): void
+    {
+        $qb = $db->getQueryBuilder();
+
+        $sql = $qb->dropColumn($table, $column);
+
+        self::assertSame(
+            0,
+            $db->createCommand($sql)->execute(),
+            'Batch must affect zero rows.',
+        );
+
+        $schema = $db->getTableSchema($db->quoteTableName($table), true);
+
+        self::assertNull(
+            $schema->getColumn($column),
+            'Column must be removed from the table schema.',
+        );
+    }
+
+    private function dropTablesIfExist(Connection $connection, array $tables): void
+    {
+        foreach ($tables as $table) {
+            $quotedTable = $connection->quoteTableName($table);
+
+            $connection->createCommand(
+                <<<SQL
+                IF OBJECT_ID(N'{$quotedTable}', N'U') IS NOT NULL DROP TABLE {$quotedTable}
+                SQL,
+            )->execute();
+        }
     }
 
     public function testThrowInvalidArgumentExceptionWhenInsertTargetsMissingTableSchema(): void

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -1,0 +1,423 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mssql\providers;
+
+use Closure;
+use yii\db\ColumnSchemaBuilder;
+use yii\db\Connection;
+use yii\db\Expression;
+use yii\db\Schema;
+
+/**
+ * Data provider for {@see \yiiunit\framework\db\mssql\QueryBuilderTest} test cases.
+ */
+final class QueryBuilderProvider
+{
+    /**
+     * @return array<string, array{Closure|string, string}>
+     */
+    public static function alterColumn(): array
+    {
+        return [
+            'integer null with default expression' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
+                    ->null()
+                    ->defaultValue(new Expression('CAST(GETDATE() AS INT)')),
+                <<<SQL
+                ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
+                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CAST(GETDATE() AS INT) FOR [bar]
+                SQL,
+            ],
+            'integer null with null default value' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
+                    ->null()
+                    ->defaultValue(null),
+                <<<SQL
+                ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
+                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT NULL FOR [bar]
+                SQL,
+            ],
+            'plain string type' => [
+                'varchar(255)',
+                <<<SQL
+                ALTER TABLE [foo1] ALTER COLUMN [bar] varchar(255)
+                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                SQL,
+            ],
+            'string not null' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->notNull(),
+                <<<SQL
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255) NOT NULL
+                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                SQL,
+            ],
+            'string unique' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 30)
+                    ->unique(),
+                <<<SQL
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(30)
+                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ADD CONSTRAINT [UQ_foo1_bar] UNIQUE ([bar])
+                SQL,
+            ],
+            'string with check constraint' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->check('LEN(bar) > 5'),
+                <<<SQL
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
+                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ADD CONSTRAINT [CK_foo1_bar] CHECK (LEN(bar) > 5)
+                SQL,
+            ],
+            'string with default value' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue('AbCdE'),
+                <<<SQL
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
+                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT 'AbCdE' FOR [bar]
+                SQL,
+            ],
+            'string with empty default value' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue(''),
+                <<<SQL
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
+                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT '' FOR [bar]
+                SQL,
+            ],
+            'timestamp with default expression' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_TIMESTAMP)
+                    ->defaultExpression('CURRENT_TIMESTAMP'),
+                <<<SQL
+                ALTER TABLE [foo1] ALTER COLUMN [bar] datetime
+                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CURRENT_TIMESTAMP FOR [bar]
+                SQL,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function dropColumn(): array
+    {
+        return [
+            'drops all constraint types for column' => [
+                'foo1',
+                'bar',
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT DISTINCT N'ALTER TABLE '
+                        + QUOTENAME(OBJECT_SCHEMA_NAME([fk].[parent_object_id])) + N'.'
+                        + QUOTENAME(OBJECT_NAME([fk].[parent_object_id]))
+                        + N' DROP CONSTRAINT ' + QUOTENAME([fk].[name]) AS [sql], 0 AS [ord]
+                    FROM [sys].[foreign_keys] AS [fk]
+                    JOIN [sys].[foreign_key_columns] AS [fkc] ON [fkc].[constraint_object_id]=[fk].[object_id]
+                    JOIN [sys].[columns] AS [pc] ON [pc].[object_id]=[fkc].[parent_object_id] AND [pc].[column_id]=[fkc].[parent_column_id]
+                    JOIN [sys].[columns] AS [rc] ON [rc].[object_id]=[fkc].[referenced_object_id] AND [rc].[column_id]=[fkc].[referenced_column_id]
+                    WHERE ([fkc].[parent_object_id]=OBJECT_ID(@tableName) AND [pc].[name]=@columnName)
+                        OR ([fkc].[referenced_object_id]=OBJECT_ID(@tableName) AND [rc].[name]=@columnName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'PK'
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] DROP COLUMN [bar]
+                SQL,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{list<string>, list<string>, string, string}>
+     */
+    public static function dropColumnConstraintsOnDb(): array
+    {
+        return [
+            'column check constraint' => [
+                ['yii2_mssql_drop_column_check'],
+                [
+                    <<<SQL
+                    CREATE TABLE [yii2_mssql_drop_column_check] (
+                        [id] [int] NOT NULL,
+                        [bar] [int] NULL CONSTRAINT [CK_yii2_mssql_drop_column_check_bar] CHECK ([bar] > 0)
+                    )
+                    SQL,
+                ],
+                'yii2_mssql_drop_column_check',
+                'bar',
+            ],
+            'default constraint' => [
+                ['yii2_mssql_drop_default'],
+                [
+                    <<<SQL
+                    CREATE TABLE [yii2_mssql_drop_default] (
+                        [id] [int] NOT NULL,
+                        [bar] [int] NULL CONSTRAINT [DF_yii2_mssql_drop_default_bar] DEFAULT 1
+                    )
+                    SQL,
+                ],
+                'yii2_mssql_drop_default',
+                'bar',
+            ],
+            'foreign key constraint' => [
+                ['yii2_mssql_drop_fk_child', 'yii2_mssql_drop_fk_parent'],
+                [
+                    <<<SQL
+                    CREATE TABLE [yii2_mssql_drop_fk_parent] (
+                        [id] [int] NOT NULL,
+                        CONSTRAINT [PK_yii2_mssql_drop_fk_parent_id] PRIMARY KEY ([id])
+                    )
+                    SQL,
+                    <<<SQL
+                    CREATE TABLE [yii2_mssql_drop_fk_child] (
+                        [id] [int] NOT NULL,
+                        [parent_id] [int] NULL,
+                        CONSTRAINT [FK_yii2_mssql_drop_fk_child_parent_id] FOREIGN KEY ([parent_id]) REFERENCES [yii2_mssql_drop_fk_parent] ([id])
+                    )
+                    SQL,
+                ],
+                'yii2_mssql_drop_fk_child',
+                'parent_id',
+            ],
+            'multi column check constraint' => [
+                ['yii2_mssql_drop_multi_check'],
+                [
+                    <<<SQL
+                    CREATE TABLE [yii2_mssql_drop_multi_check] (
+                        [id] [int] NOT NULL,
+                        [bar] [int] NULL,
+                        CONSTRAINT [CK_yii2_mssql_drop_multi_check_bar] CHECK ([bar] > [id])
+                    )
+                    SQL,
+                ],
+                'yii2_mssql_drop_multi_check',
+                'bar',
+            ],
+            'primary key constraint' => [
+                ['yii2_mssql_drop_pk'],
+                [
+                    <<<SQL
+                    CREATE TABLE [yii2_mssql_drop_pk] (
+                        [id] [int] NULL,
+                        [bar] [int] NOT NULL,
+                        CONSTRAINT [PK_yii2_mssql_drop_pk_bar] PRIMARY KEY ([bar])
+                    )
+                    SQL,
+                ],
+                'yii2_mssql_drop_pk',
+                'bar',
+            ],
+            'referencing foreign key constraint' => [
+                ['yii2_mssql_drop_ref_fk_child', 'yii2_mssql_drop_ref_fk_parent'],
+                [
+                    <<<SQL
+                    CREATE TABLE [yii2_mssql_drop_ref_fk_parent] (
+                        [id] [int] NOT NULL,
+                        [name] [varchar](32) NULL,
+                        CONSTRAINT [PK_yii2_mssql_drop_ref_fk_parent_id] PRIMARY KEY ([id])
+                    )
+                    SQL,
+                    <<<SQL
+                    CREATE TABLE [yii2_mssql_drop_ref_fk_child] (
+                        [id] [int] NOT NULL,
+                        [parent_id] [int] NULL,
+                        CONSTRAINT [FK_yii2_mssql_drop_ref_fk_child_parent_id] FOREIGN KEY ([parent_id]) REFERENCES [yii2_mssql_drop_ref_fk_parent] ([id])
+                    )
+                    SQL,
+                ],
+                'yii2_mssql_drop_ref_fk_parent',
+                'id',
+            ],
+            'unique constraint' => [
+                ['yii2_mssql_drop_unique'],
+                [
+                    <<<SQL
+                    CREATE TABLE [yii2_mssql_drop_unique] (
+                        [id] [int] NOT NULL,
+                        [bar] [int] NULL,
+                        CONSTRAINT [UQ_yii2_mssql_drop_unique_bar] UNIQUE ([bar])
+                    )
+                    SQL,
+                ],
+                'yii2_mssql_drop_unique',
+                'bar',
+            ],
+        ];
+    }
+}

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -241,6 +241,65 @@ final class QueryBuilderProvider
     public static function dropColumn(): array
     {
         return [
+            'column name with single quote' => [
+                'foo1',
+                "my'col",
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @columnName NVARCHAR(MAX) = N'my''col'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT DISTINCT N'ALTER TABLE '
+                        + QUOTENAME(OBJECT_SCHEMA_NAME([fk].[parent_object_id])) + N'.'
+                        + QUOTENAME(OBJECT_NAME([fk].[parent_object_id]))
+                        + N' DROP CONSTRAINT ' + QUOTENAME([fk].[name]) AS [sql], 0 AS [ord]
+                    FROM [sys].[foreign_keys] AS [fk]
+                    JOIN [sys].[foreign_key_columns] AS [fkc] ON [fkc].[constraint_object_id]=[fk].[object_id]
+                    JOIN [sys].[columns] AS [pc] ON [pc].[object_id]=[fkc].[parent_object_id] AND [pc].[column_id]=[fkc].[parent_column_id]
+                    JOIN [sys].[columns] AS [rc] ON [rc].[object_id]=[fkc].[referenced_object_id] AND [rc].[column_id]=[fkc].[referenced_column_id]
+                    WHERE ([fkc].[parent_object_id]=OBJECT_ID(@tableName) AND [pc].[name]=@columnName)
+                        OR ([fkc].[referenced_object_id]=OBJECT_ID(@tableName) AND [rc].[name]=@columnName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'PK'
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] DROP COLUMN [my'col]
+                SQL,
+            ],
             'drops all constraint types for column' => [
                 'foo1',
                 'bar',
@@ -334,6 +393,19 @@ final class QueryBuilderProvider
                 ],
                 'yii2_mssql_drop_default',
                 'bar',
+            ],
+            'default constraint on column with single quote' => [
+                ['yii2_mssql_drop_quote'],
+                [
+                    <<<SQL
+                    CREATE TABLE [yii2_mssql_drop_quote] (
+                        [id] [int] NOT NULL,
+                        [my'col] [int] NULL CONSTRAINT [DF_yii2_mssql_drop_quote_col] DEFAULT 1
+                    )
+                    SQL,
+                ],
+                'yii2_mssql_drop_quote',
+                "my'col",
             ],
             'foreign key constraint' => [
                 ['yii2_mssql_drop_fk_child', 'yii2_mssql_drop_fk_parent'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
