### PR TITLE
Replace `strpos()` with `str_contains()` in `yii\db\Schema` quoting methods and fix `quoteValue()` `@param` to `mixed`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -91,6 +91,7 @@ Yii Framework 2 Change Log
 - Chg #20936: Remove redundant `resolveTableNames()` from MSSQL, MySQL, PostgreSQL, and Oracle schema classes; `loadTableSchema()` now uses `resolveTableName()` directly (terabytesoftw)
 - Bug #20937: Exclude configurable system schema names from MSSQL `yii\db\Schema::getSchemaNames()` to match the non-system schema contract (terabytesoftw)
 - Bug #20938: Fix MSSQL `QueryBuilder::dropConstraintsForColumn()` to drop primary key, foreign key, and table-level check constraints, replacing deprecated `sys.sysconstraints` with modern catalog views (terabytesoftw)
+- Enh #20939: Replace `strpos()` with `str_contains()` in `yii\db\Schema` quoting methods and fix `quoteValue()` `@param` to `mixed` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -16,6 +18,19 @@ use yii\base\NotSupportedException;
 use yii\caching\Cache;
 use yii\caching\CacheInterface;
 use yii\caching\TagDependency;
+
+use function addcslashes;
+use function array_map;
+use function explode;
+use function implode;
+use function is_string;
+use function mb_stripos;
+use function str_contains;
+use function str_replace;
+use function strlen;
+use function strpos;
+use function strrpos;
+use function substr;
 
 /**
  * Schema is the base class for concrete DBMS-specific schema classes.
@@ -455,9 +470,13 @@ abstract class Schema extends BaseObject
 
     /**
      * Quotes a string value for use in a query.
+     *
      * Note that if the parameter is not a string, it will be returned without change.
-     * @param string $str string to be quoted
-     * @return string the properly quoted string
+     *
+     * @param mixed $str String to be quoted. If the parameter is not a string, it will be returned without change.
+     *
+     * @return mixed The properly quoted string, or the original data if it is not a string.
+     *
      * @see https://www.php.net/manual/en/function.PDO-quote.php
      */
     public function quoteValue($str)
@@ -466,46 +485,52 @@ abstract class Schema extends BaseObject
             return $str;
         }
 
-        if (mb_stripos((string)$this->db->dsn, 'odbc:') === false && ($value = $this->db->getSlavePdo(true)->quote($str)) !== false) {
+        if (
+            mb_stripos((string)$this->db->dsn, 'odbc:') === false &&
+            ($value = $this->db->getSlavePdo(true)->quote($str)
+        ) !== false) {
             return $value;
         }
 
-        // the driver doesn't support quote (e.g. oci)
+        // The driver doesn't support quote (for example, oci).
         return "'" . addcslashes(str_replace("'", "''", $str), "\000\n\r\\\032") . "'";
     }
 
     /**
      * Quotes a table name for use in a query.
+     *
      * If the table name contains schema prefix, the prefix will also be properly quoted.
-     * If the table name is already quoted or contains '(' or '{{',
-     * then this method will do nothing.
-     * @param string $name table name
-     * @return string the properly quoted table name
+     * If the table name is already quoted or contains '(' or '{{', then this method will do nothing.
+     *
+     * @param string $name Table name.
+     * @return string The properly quoted table name.
+     *
      * @see quoteSimpleTableName()
      */
     public function quoteTableName($name)
     {
+        if (str_starts_with($name, '(') && strpos($name, ')') === strlen($name) - 1) {
+            return $name;
+        }
 
-        if (strncmp($name, '(', 1) === 0 && strpos($name, ')') === strlen($name) - 1) {
+        if (str_contains($name, '{{')) {
             return $name;
         }
-        if (strpos($name, '{{') !== false) {
-            return $name;
-        }
-        if (strpos($name, '.') === false) {
+
+        if (!str_contains($name, '.')) {
             return $this->quoteSimpleTableName($name);
         }
-        $parts = $this->getTableNameParts($name);
-        foreach ($parts as $i => $part) {
-            $parts[$i] = $this->quoteSimpleTableName($part);
-        }
-        return implode('.', $parts);
+
+        return implode('.', array_map([$this, 'quoteSimpleTableName'], $this->getTableNameParts($name)));
     }
 
     /**
-     * Splits full table name into parts
-     * @param string $name
-     * @return array
+     * Splits full table name into parts.
+     *
+     * @param string $name Full table name.
+     *
+     * @return array Table name parts.
+     *
      * @since 2.0.22
      */
     protected function getTableNameParts($name)
@@ -515,29 +540,35 @@ abstract class Schema extends BaseObject
 
     /**
      * Quotes a column name for use in a query.
+     *
      * If the column name contains prefix, the prefix will also be properly quoted.
-     * If the column name is already quoted or contains '(', '[[' or '{{',
-     * then this method will do nothing.
-     * @param string $name column name
-     * @return string the properly quoted column name
+     * If the column name is already quoted or contains '(', '[[' or '{{', then this method will do nothing.
+     *
+     * @param string $name Column name.
+     *
+     * @return string The properly quoted column name.
+     *
      * @see quoteSimpleColumnName()
      */
     public function quoteColumnName($name)
     {
-        if ($name === null) {
+        if ($name === '') {
             return '';
         }
 
-        if (strpos($name, '(') !== false || strpos($name, '[[') !== false) {
+        if (str_contains($name, '(') || str_contains($name, '[[')) {
             return $name;
         }
+
         if (($pos = strrpos($name, '.')) !== false) {
             $prefix = $this->quoteTableName(substr($name, 0, $pos)) . '.';
+
             $name = substr($name, $pos + 1);
         } else {
             $prefix = '';
         }
-        if (strpos($name, '{{') !== false) {
+
+        if (str_contains($name, '{{')) {
             return $name;
         }
 
@@ -546,44 +577,60 @@ abstract class Schema extends BaseObject
 
     /**
      * Quotes a simple table name for use in a query.
+     *
      * A simple table name should contain the table name only without any schema prefix.
      * If the table name is already quoted, this method will do nothing.
-     * @param string $name table name
-     * @return string the properly quoted table name
+     *
+     * @param string $name Table name.
+     *
+     * @return string The properly quoted table name.
      */
     public function quoteSimpleTableName($name)
     {
         if (is_string($this->tableQuoteCharacter)) {
             $startingCharacter = $endingCharacter = $this->tableQuoteCharacter;
         } else {
-            list($startingCharacter, $endingCharacter) = $this->tableQuoteCharacter;
+            [$startingCharacter, $endingCharacter] = $this->tableQuoteCharacter;
         }
-        return strpos($name, $startingCharacter) !== false ? $name : $startingCharacter . $name . $endingCharacter;
+
+        return str_contains($name, $startingCharacter)
+            ? $name
+            : "{$startingCharacter}{$name}{$endingCharacter}";
     }
 
     /**
      * Quotes a simple column name for use in a query.
+     *
      * A simple column name should contain the column name only without any prefix.
      * If the column name is already quoted or is the asterisk character '*', this method will do nothing.
-     * @param string $name column name
-     * @return string the properly quoted column name
+     *
+     * @param string $name Column name.
+     *
+     * @return string The properly quoted column name.
      */
     public function quoteSimpleColumnName($name)
     {
         if (is_string($this->columnQuoteCharacter)) {
             $startingCharacter = $endingCharacter = $this->columnQuoteCharacter;
         } else {
-            list($startingCharacter, $endingCharacter) = $this->columnQuoteCharacter;
+            [$startingCharacter, $endingCharacter] = $this->columnQuoteCharacter;
         }
-        return $name === '*' || strpos($name, $startingCharacter) !== false ? $name : $startingCharacter . $name . $endingCharacter;
+
+        return $name === '*' || str_contains($name, $startingCharacter)
+            ? $name
+            : "{$startingCharacter}{$name}{$endingCharacter}";
     }
 
     /**
      * Unquotes a simple table name.
+     *
      * A simple table name should contain the table name only without any schema prefix.
      * If the table name is not quoted, this method will do nothing.
-     * @param string $name table name.
-     * @return string unquoted table name.
+     *
+     * @param string $name Table name.
+     *
+     * @return string Unquoted table name.
+     *
      * @since 2.0.14
      */
     public function unquoteSimpleTableName($name)
@@ -593,15 +640,22 @@ abstract class Schema extends BaseObject
         } else {
             $startingCharacter = $this->tableQuoteCharacter[0];
         }
-        return strpos($name, $startingCharacter) === false ? $name : substr($name, 1, -1);
+
+        return !str_contains($name, $startingCharacter)
+            ? $name
+            : substr($name, 1, -1);
     }
 
     /**
      * Unquotes a simple column name.
+     *
      * A simple column name should contain the column name only without any prefix.
      * If the column name is not quoted or is the asterisk character '*', this method will do nothing.
-     * @param string $name column name.
-     * @return string unquoted column name.
+     *
+     * @param string $name Column name.
+     *
+     * @return string Unquoted column name.
+     *
      * @since 2.0.14
      */
     public function unquoteSimpleColumnName($name)
@@ -611,7 +665,10 @@ abstract class Schema extends BaseObject
         } else {
             $startingCharacter = $this->columnQuoteCharacter[0];
         }
-        return strpos($name, $startingCharacter) === false ? $name : substr($name, 1, -1);
+
+        return !str_contains($name, $startingCharacter)
+            ? $name
+            : substr($name, 1, -1);
     }
 
     /**

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -27,6 +27,7 @@ use function is_string;
 use function mb_stripos;
 use function str_contains;
 use function str_replace;
+use function str_starts_with;
 use function strlen;
 use function strpos;
 use function strrpos;

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -488,7 +488,8 @@ abstract class Schema extends BaseObject
         if (
             mb_stripos((string)$this->db->dsn, 'odbc:') === false &&
             ($value = $this->db->getSlavePdo(true)->quote($str)
-        ) !== false) {
+            ) !== false
+        ) {
             return $value;
         }
 

--- a/tests/base/db/BaseSchemaQuote.php
+++ b/tests/base/db/BaseSchemaQuote.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\base\db;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use yiiunit\base\db\providers\SchemaProvider;
+use yiiunit\framework\db\DatabaseTestCase;
+
+/**
+ * Base unit tests for {@see \yii\db\Schema} identifier and value quoting across all database drivers.
+ *
+ * {@see SchemaProvider} for test case data providers.
+ */
+abstract class BaseSchemaQuote extends DatabaseTestCase
+{
+    #[DataProviderExternal(SchemaProvider::class, 'quoteColumnName')]
+    public function testQuoteColumnName(string $name, string $expectedName): void
+    {
+        $schema = $this->getConnection(false, false)->getSchema();
+
+        self::assertSame(
+            static::replaceQuotes($expectedName),
+            $schema->quoteColumnName(static::replaceQuotes($name)),
+            'Quoted column name must match the expected quoting.',
+        );
+    }
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteSimpleColumnName')]
+    public function testQuoteSimpleColumnName(string $name, string $expectedName): void
+    {
+        $schema = $this->getConnection(false, false)->getSchema();
+
+        self::assertSame(
+            static::replaceQuotes($expectedName),
+            $schema->quoteSimpleColumnName(static::replaceQuotes($name)),
+            'Quoted simple column name must match the expected quoting.',
+        );
+    }
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteSimpleTableName')]
+    public function testQuoteSimpleTableName(string $name, string $expectedName): void
+    {
+        $schema = $this->getConnection(false, false)->getSchema();
+
+        self::assertSame(
+            static::replaceQuotes($expectedName),
+            $schema->quoteSimpleTableName(static::replaceQuotes($name)),
+            'Quoted simple table name must match the expected quoting.',
+        );
+    }
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteTableName')]
+    public function testQuoteTableName(string $name, string $expectedName): void
+    {
+        $schema = $this->getConnection(false, false)->getSchema();
+
+        self::assertSame(
+            static::replaceQuotes($expectedName),
+            $schema->quoteTableName(static::replaceQuotes($name)),
+            'Quoted table name must match the expected quoting.',
+        );
+    }
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteValue')]
+    public function testQuoteValueQuotesString(string $value, string $expectedValue): void
+    {
+        $schema = $this->getConnection(false)->getSchema();
+
+        self::assertSame(
+            $expectedValue,
+            $schema->quoteValue($value),
+            'String value must be quoted and escaped for the driver.',
+        );
+    }
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteValueNotString')]
+    public function testQuoteValueReturnsNonStringValueUnchanged(mixed $value): void
+    {
+        $schema = $this->getConnection(false, false)->getSchema();
+
+        self::assertSame(
+            $value,
+            $schema->quoteValue($value),
+            'Non-string value must be returned unchanged.',
+        );
+    }
+
+    #[DataProviderExternal(SchemaProvider::class, 'unquoteSimpleColumnName')]
+    public function testUnquoteSimpleColumnName(string $name, string $expectedName): void
+    {
+        $schema = $this->getConnection(false, false)->getSchema();
+
+        self::assertSame(
+            static::replaceQuotes($expectedName),
+            $schema->unquoteSimpleColumnName(static::replaceQuotes($name)),
+            'Unquoted simple column name must match the expected name.',
+        );
+    }
+
+    #[DataProviderExternal(SchemaProvider::class, 'unquoteSimpleTableName')]
+    public function testUnquoteSimpleTableName(string $name, string $expectedName): void
+    {
+        $schema = $this->getConnection(false, false)->getSchema();
+
+        self::assertSame(
+            static::replaceQuotes($expectedName),
+            $schema->unquoteSimpleTableName(static::replaceQuotes($name)),
+            'Unquoted simple table name must match the expected name.',
+        );
+    }
+}

--- a/tests/base/db/providers/SchemaProvider.php
+++ b/tests/base/db/providers/SchemaProvider.php
@@ -13,7 +13,7 @@ namespace yiiunit\base\db\providers;
 use PDO;
 
 /**
- * Data provider for {@see \yiiunit\base\db\BaseSchema} test cases.
+ * Data provider for {@see \yiiunit\base\db\BaseSchema} and {@see \yiiunit\base\db\BaseSchemaQuote} test cases.
  */
 class SchemaProvider
 {
@@ -36,6 +36,124 @@ class SchemaProvider
         return [
             [[PDO::ATTR_EMULATE_PREPARES => true]],
             [[PDO::ATTR_EMULATE_PREPARES => false]],
+        ];
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    public static function quoteTableName(): array
+    {
+        return [
+            ['{{table}}', '{{table}}'],
+            ['(table)', '(table)'],
+            ['[[test]]', '[[test]]'],
+            ['[[test]].[[test]]', '[[test]].[[test]]'],
+            ['test', '[[test]]'],
+            ['test.[[test]].test', '[[test]].[[test]].[[test]]'],
+            ['test.test', '[[test]].[[test]]'],
+            ['test.test.test', '[[test]].[[test]].[[test]]'],
+        ];
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    public static function quoteColumnName(): array
+    {
+        return [
+            ['', ''],
+            ['*', '*'],
+            ['(*)', '(*)'],
+            ['(column)', '(column)'],
+            ['{{column}}', '{{column}}'],
+            ['[[*]]', '[[*]]'],
+            ['[[column]]', '[[column]]'],
+            ['column', '[[column]]'],
+            ['table.*', '[[table]].*'],
+            ['[[table]].*', '[[table]].*'],
+            ['table.column', '[[table]].[[column]]'],
+            ['table.[[column]]', '[[table]].[[column]]'],
+            ['[[table]].column', '[[table]].[[column]]'],
+            ['[[table]].[[column]]', '[[table]].[[column]]'],
+            ['schema.table.column', '[[schema]].[[table]].[[column]]'],
+            ['{{table}}.column', '{{table}}.[[column]]'],
+        ];
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    public static function quoteSimpleTableName(): array
+    {
+        return [
+            ['[[test]]', '[[test]]'],
+            ['test', '[[test]]'],
+            ['test.test', '[[test.test]]'],
+            ['(test)', '[[(test)]]'],
+            ['current-table-name', '[[current-table-name]]'],
+            ["te'st", "[[te'st]]"],
+        ];
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    public static function quoteSimpleColumnName(): array
+    {
+        return [
+            ['*', '*'],
+            ['[[column]]', '[[column]]'],
+            ['column', '[[column]]'],
+        ];
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    public static function unquoteSimpleTableName(): array
+    {
+        return [
+            ['[[test]]', 'test'],
+            ['test', 'test'],
+        ];
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    public static function unquoteSimpleColumnName(): array
+    {
+        return [
+            ['*', '*'],
+            ['[[column]]', 'column'],
+            ['column', 'column'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function quoteValueNotString(): array
+    {
+        return [
+            'false' => [false],
+            'float' => [1.5],
+            'int' => [123],
+            'negative int' => [-5],
+            'null' => [null],
+            'true' => [true],
+        ];
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    public static function quoteValue(): array
+    {
+        return [
+            ["It's interesting", "'It''s interesting'"],
+            ['string', "'string'"],
         ];
     }
 }

--- a/tests/framework/db/mssql/SchemaQuoteTest.php
+++ b/tests/framework/db/mssql/SchemaQuoteTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mssql;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use yiiunit\base\db\BaseSchemaQuote;
+use yiiunit\framework\db\mssql\providers\SchemaProvider;
+
+/**
+ * Unit tests for {@see \yii\db\mssql\Schema::quoteTableName()} and {@see \yii\db\mssql\Schema::quoteColumnName()}
+ * identifier quoting for the MSSQL driver.
+ *
+ * {@see SchemaProvider} for test case data providers.
+ */
+#[Group('db')]
+#[Group('mssql')]
+#[Group('schema')]
+#[Group('quote')]
+final class SchemaQuoteTest extends BaseSchemaQuote
+{
+    protected $driverName = 'sqlsrv';
+    protected static string $driverNameStatic = 'sqlsrv';
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteColumnName')]
+    public function testQuoteColumnName(string $name, string $expectedName): void
+    {
+        parent::testQuoteColumnName($name, $expectedName);
+    }
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteSimpleTableName')]
+    public function testQuoteSimpleTableName(string $name, string $expectedName): void
+    {
+        parent::testQuoteSimpleTableName($name, $expectedName);
+    }
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteTableName')]
+    public function testQuoteTableName(string $name, string $expectedName): void
+    {
+        parent::testQuoteTableName($name, $expectedName);
+    }
+}

--- a/tests/framework/db/mssql/SchemaTest.php
+++ b/tests/framework/db/mssql/SchemaTest.php
@@ -176,21 +176,6 @@ final class SchemaTest extends BaseSchema
     }
 
     /**
-     * @throws NotSupportedException
-     */
-    #[DataProviderExternal(SchemaProvider::class, 'quoteTableName')]
-    public function testQuoteTableName(string $name, string $expectedName): void
-    {
-        $schema = $this->getConnection()->getSchema();
-
-        self::assertSame(
-            $expectedName,
-            $schema->quoteTableName($name),
-            "Quoted table name for '{$name}' should be '{$expectedName}'.",
-        );
-    }
-
-    /**
      * @throws NotSupportedException if the table does not exist or schema retrieval is not supported.
      */
     #[DataProviderExternal(SchemaProvider::class, 'getTableSchema')]
@@ -308,17 +293,6 @@ final class SchemaTest extends BaseSchema
             'dbo',
             $schema->defaultSchema,
             "Default schema should be 'dbo'.",
-        );
-    }
-
-    public function testQuoteColumnNameWithBrackets(): void
-    {
-        $schema = $this->getConnection()->getSchema();
-
-        self::assertSame(
-            '[already_quoted]',
-            $schema->quoteColumnName('[already_quoted]'),
-            "Column name '[already_quoted]' should not be double-quoted.",
         );
     }
 

--- a/tests/framework/db/mssql/providers/SchemaProvider.php
+++ b/tests/framework/db/mssql/providers/SchemaProvider.php
@@ -11,7 +11,8 @@ declare(strict_types=1);
 namespace yiiunit\framework\db\mssql\providers;
 
 /**
- * Data provider for {@see \yiiunit\framework\db\mssql\SchemaTest} test cases.
+ * Data provider for {@see \yiiunit\framework\db\mssql\SchemaTest} and {@see \yiiunit\framework\db\mssql\SchemaQuoteTest}
+ * test cases.
  */
 final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
 {
@@ -21,14 +22,33 @@ final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
     public static function quoteTableName(): array
     {
         return [
-            ['[test]', '[test]'],
-            ['[test].[test.test]', '[test].[test.test]'],
-            ['[test].[test]', '[test].[test]'],
-            ['test', '[test]'],
-            ['test.[test.test]', '[test].[test.test]'],
-            ['test.test', '[test].[test]'],
-            ['test.test.[test.test]', '[test].[test].[test.test]'],
-            ['test.test.test', '[test].[test].[test]'],
+            ...parent::quoteTableName(),
+            ['[[test]].[[test.test]]', '[[test]].[[test.test]]'],
+            ['test.[[test.test]]', '[[test]].[[test.test]]'],
+            ['test.test.[[test.test]]', '[[test]].[[test]].[[test.test]]'],
+        ];
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    public static function quoteColumnName(): array
+    {
+        return [
+            ...parent::quoteColumnName(),
+            ['[[already_quoted]]', '[[already_quoted]]'],
+            ['[[a.b]]', '[[a.b]]'],
+        ];
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    public static function quoteSimpleTableName(): array
+    {
+        return [
+            ...parent::quoteSimpleTableName(),
+            ['a[b', 'a[b'],
         ];
     }
 

--- a/tests/framework/db/mysql/SchemaQuoteTest.php
+++ b/tests/framework/db/mysql/SchemaQuoteTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mysql;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use yiiunit\base\db\BaseSchemaQuote;
+use yiiunit\framework\db\mysql\providers\SchemaProvider;
+
+/**
+ * Unit tests for {@see \yii\db\mysql\Schema} identifier and value quoting for the MySQL driver.
+ *
+ * {@see SchemaProvider} for test case data providers.
+ */
+#[Group('db')]
+#[Group('mysql')]
+#[Group('schema')]
+#[Group('quote')]
+final class SchemaQuoteTest extends BaseSchemaQuote
+{
+    protected $driverName = 'mysql';
+    protected static string $driverNameStatic = 'mysql';
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteSimpleTableName')]
+    public function testQuoteSimpleTableName(string $name, string $expectedName): void
+    {
+        parent::testQuoteSimpleTableName($name, $expectedName);
+    }
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteValue')]
+    public function testQuoteValueQuotesString(string $value, string $expectedValue): void
+    {
+        parent::testQuoteValueQuotesString($value, $expectedValue);
+    }
+}

--- a/tests/framework/db/mysql/providers/SchemaProvider.php
+++ b/tests/framework/db/mysql/providers/SchemaProvider.php
@@ -8,13 +8,24 @@ declare(strict_types=1);
  * @license https://www.yiiframework.com/license/
  */
 
-namespace yiiunit\framework\db\sqlite\providers;
+namespace yiiunit\framework\db\mysql\providers;
 
 /**
- * Data provider for {@see \yiiunit\framework\db\sqlite\SchemaQuoteTest} test cases.
+ * Data provider for {@see \yiiunit\framework\db\mysql\SchemaQuoteTest} test cases.
  */
 final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
 {
+    /**
+     * @return list<array{string, string}>
+     */
+    public static function quoteValue(): array
+    {
+        return [
+            ['string', "'string'"],
+            ["It's interesting", "'It\\'s interesting'"],
+        ];
+    }
+
     /**
      * @return list<array{string, string}>
      */

--- a/tests/framework/db/oci/SchemaQuoteTest.php
+++ b/tests/framework/db/oci/SchemaQuoteTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\oci;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use yiiunit\base\db\BaseSchemaQuote;
+use yiiunit\framework\db\oci\providers\SchemaProvider;
+
+/**
+ * Unit tests for {@see \yii\db\oci\Schema} identifier quoting for the Oracle driver.
+ *
+ * {@see SchemaProvider} for test case data providers.
+ */
+#[Group('db')]
+#[Group('oci')]
+#[Group('schema')]
+#[Group('quote')]
+final class SchemaQuoteTest extends BaseSchemaQuote
+{
+    protected $driverName = 'oci';
+    protected static string $driverNameStatic = 'oci';
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteSimpleTableName')]
+    public function testQuoteSimpleTableName(string $name, string $expectedName): void
+    {
+        parent::testQuoteSimpleTableName($name, $expectedName);
+    }
+}

--- a/tests/framework/db/oci/providers/SchemaProvider.php
+++ b/tests/framework/db/oci/providers/SchemaProvider.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * @license https://www.yiiframework.com/license/
  */
 
-namespace yiiunit\framework\db\sqlite\providers;
+namespace yiiunit\framework\db\oci\providers;
 
 /**
- * Data provider for {@see \yiiunit\framework\db\sqlite\SchemaQuoteTest} test cases.
+ * Data provider for {@see \yiiunit\framework\db\oci\SchemaQuoteTest} test cases.
  */
 final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
 {
@@ -22,7 +22,7 @@ final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
     {
         return [
             ...parent::quoteSimpleTableName(),
-            ['a`b', 'a`b'],
+            ['a"b', 'a"b'],
         ];
     }
 }

--- a/tests/framework/db/pgsql/SchemaQuoteTest.php
+++ b/tests/framework/db/pgsql/SchemaQuoteTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\pgsql;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use yiiunit\base\db\BaseSchemaQuote;
+use yiiunit\framework\db\pgsql\providers\SchemaProvider;
+
+/**
+ * Unit tests for {@see \yii\db\pgsql\Schema} identifier quoting for the PostgreSQL driver.
+ *
+ * {@see SchemaProvider} for test case data providers.
+ */
+#[Group('db')]
+#[Group('pgsql')]
+#[Group('schema')]
+#[Group('quote')]
+final class SchemaQuoteTest extends BaseSchemaQuote
+{
+    protected $driverName = 'pgsql';
+    protected static string $driverNameStatic = 'pgsql';
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteSimpleTableName')]
+    public function testQuoteSimpleTableName(string $name, string $expectedName): void
+    {
+        parent::testQuoteSimpleTableName($name, $expectedName);
+    }
+}

--- a/tests/framework/db/pgsql/providers/SchemaProvider.php
+++ b/tests/framework/db/pgsql/providers/SchemaProvider.php
@@ -11,7 +11,8 @@ declare(strict_types=1);
 namespace yiiunit\framework\db\pgsql\providers;
 
 /**
- * Data provider for {@see \yiiunit\framework\db\pgsql\SchemaTest} test cases.
+ * Data provider for {@see \yiiunit\framework\db\pgsql\SchemaTest} and {@see \yiiunit\framework\db\pgsql\SchemaQuoteTest}
+ * test cases.
  */
 final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
 {
@@ -28,6 +29,20 @@ final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
             [922_337_203_685_477_580],
             [9_223_372_036_854_775_807],
             [-9_223_372_036_854_775_808.0],
+        ];
+    }
+
+    /**
+     * Extends the shared cases with a name embedding a double quote (the driver's own quote character), passed through
+     * unchanged.
+     *
+     * @return list<array{string, string}>
+     */
+    public static function quoteSimpleTableName(): array
+    {
+        return [
+            ...parent::quoteSimpleTableName(),
+            ['a"b', 'a"b'],
         ];
     }
 }

--- a/tests/framework/db/sqlite/SchemaQuoteTest.php
+++ b/tests/framework/db/sqlite/SchemaQuoteTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\sqlite;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use yiiunit\base\db\BaseSchemaQuote;
+use yiiunit\framework\db\sqlite\providers\SchemaProvider;
+
+/**
+ * Unit tests for {@see \yii\db\sqlite\Schema} identifier quoting for the SQLite driver.
+ *
+ * {@see SchemaProvider} for test case data providers.
+ */
+#[Group('db')]
+#[Group('sqlite')]
+#[Group('schema')]
+#[Group('quote')]
+final class SchemaQuoteTest extends BaseSchemaQuote
+{
+    protected $driverName = 'sqlite';
+    protected static string $driverNameStatic = 'sqlite';
+
+    #[DataProviderExternal(SchemaProvider::class, 'quoteSimpleTableName')]
+    public function testQuoteSimpleTableName(string $name, string $expectedName): void
+    {
+        parent::testQuoteSimpleTableName($name, $expectedName);
+    }
+}

--- a/tests/framework/db/sqlite/SchemaTest.php
+++ b/tests/framework/db/sqlite/SchemaTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\db\sqlite;
 
-use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\base\NotSupportedException;
 use yii\db\ConstraintFinderInterface;
@@ -18,7 +17,6 @@ use yii\db\Expression;
 use yii\db\Transaction;
 use yii\db\sqlite\Schema;
 use yiiunit\base\db\BaseSchema;
-use yiiunit\framework\db\sqlite\providers\SchemaProvider;
 
 /**
  * Unit tests for {@see \yii\db\sqlite\Schema} schema reflection and metadata retrieval for the SQLite driver.
@@ -300,16 +298,5 @@ final class SchemaTest extends BaseSchema
         );
 
         $this->getConnection()->getSchema()->setTransactionIsolationLevel(Transaction::READ_COMMITTED);
-    }
-
-    /**
-     * @throws NotSupportedException
-     */
-    #[DataProviderExternal(SchemaProvider::class, 'quoteTableName')]
-    public function testQuoteTableName(string $name, string $expectedName): void
-    {
-        $schema = $this->getConnection()->getSchema();
-        $quotedName = $schema->quoteTableName($name);
-        $this->assertEquals($expectedName, $quotedName);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
