### PR TITLE
Fix MSSQL `yii\db\mssql\QueryBuilder::alterColumn()` to drop column default, check, and unique constraints before the `ALTER COLUMN` statement, allowing column redefinition on constrained columns without duplicate constraint name errors.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -93,7 +93,7 @@ Yii Framework 2 Change Log
 - Bug #20938: Fix MSSQL `QueryBuilder::dropConstraintsForColumn()` to drop primary key, foreign key, and table-level check constraints, replacing deprecated `sys.sysconstraints` with modern catalog views (terabytesoftw)
 - Enh #20939: Replace `strpos()` with `str_contains()` in `yii\db\Schema` quoting methods and fix `quoteValue()` `@param` to `mixed` (terabytesoftw)
 - Enh #20941: Modernize MSSQL `yii\db\mssql\Schema` internals and remove dead `unsigned` detection (terabytesoftw)
-- Bug #20942: Fix MSSQL `yii\db\mssql\QueryBuilder::alterColumn()` to drop column default constraints before the `ALTER COLUMN` statement, allowing data type changes on columns with a default value (terabytesoftw)
+- Bug #20942: Fix MSSQL `yii\db\mssql\QueryBuilder::alterColumn()` to drop column default, check, and unique constraints before the `ALTER COLUMN` statement, allowing column redefinition on constrained columns without duplicate constraint name errors (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -92,7 +92,8 @@ Yii Framework 2 Change Log
 - Bug #20937: Exclude configurable system schema names from MSSQL `yii\db\Schema::getSchemaNames()` to match the non-system schema contract (terabytesoftw)
 - Bug #20938: Fix MSSQL `QueryBuilder::dropConstraintsForColumn()` to drop primary key, foreign key, and table-level check constraints, replacing deprecated `sys.sysconstraints` with modern catalog views (terabytesoftw)
 - Enh #20939: Replace `strpos()` with `str_contains()` in `yii\db\Schema` quoting methods and fix `quoteValue()` `@param` to `mixed` (terabytesoftw)
-- Enh #20940: Modernize MSSQL `yii\db\mssql\Schema` internals and remove dead `unsigned` detection (terabytesoftw)
+- Enh #20941: Modernize MSSQL `yii\db\mssql\Schema` internals and remove dead `unsigned` detection (terabytesoftw)
+- Bug #20942: Fix MSSQL `yii\db\mssql\QueryBuilder::alterColumn()` to drop column default constraints before the `ALTER COLUMN` statement, allowing data type changes on columns with a default value (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -13,11 +13,13 @@ namespace yii\db\mssql;
 use yii\base\InvalidArgumentException;
 use yii\base\NotSupportedException;
 use yii\db\Expression;
+use yii\db\mssql\ColumnSchemaBuilder;
 use yii\db\Query;
 
 use function count;
+use function implode;
+use function preg_replace;
 use function str_replace;
-use function strpos;
 
 /**
  * QueryBuilder is the query builder for MS SQL Server databases (version 2019 and above).
@@ -129,52 +131,81 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * Builds a SQL statement for changing the definition of a column.
-     * @param string $table the table whose column is to be changed. The table name will be properly quoted by the method.
-     * @param string $column the name of the column to be changed. The name will be properly quoted by the method.
-     * @param string $type the new column type. The [[getColumnType]] method will be invoked to convert abstract column type (if any)
-     * into the physical one. Anything that is not recognized as abstract type will be kept in the generated SQL.
-     * For example, 'string' will be turned into 'varchar(255)', while 'string not null' will become 'varchar(255) not null'.
-     * @return string the SQL statement for changing the definition of a column.
+     *
+     * Drops the default constraints attached to the column before the `ALTER COLUMN` statement, because SQL Server
+     * rejects a data type change while a `DEFAULT` definition is bound to the column. Default, check, and unique
+     * constraints defined by a {@see ColumnSchemaBuilder} type are re-created after the column is altered.
+     *
+     * @param string $table The table whose column is to be changed. The table name will be properly quoted by the
+     * method.
+     * @param string $column The name of the column to be changed. The name will be properly quoted by the method.
+     * @param string $type The new column type. The {@see getColumnType} method will be invoked to convert abstract
+     * column type (if any) into the physical one. Anything that is not recognized as abstract type will be kept in the
+     * generated SQL. For example, 'string' will be turned into 'varchar(255)', while 'string not null' will become
+     * 'varchar(255) not null'.
+     *
      * @throws NotSupportedException if this is not supported by the underlying DBMS.
+     *
+     * @return string The SQL statement for changing the definition of a column.
      */
     public function alterColumn($table, $column, $type)
     {
-        $sqlAfter = [$this->dropConstraintsForColumn($table, $column, 'D')];
-
-        $columnName = $this->db->quoteColumnName($column);
         $tableName = $this->db->quoteTableName($table);
-        $constraintBase = preg_replace('/[^a-z0-9_]/i', '', $table . '_' . $column);
+        $columnName = $this->db->quoteColumnName($column);
 
-        if ($type instanceof \yii\db\mssql\ColumnSchemaBuilder) {
+        $dropDefaultsSql = $this->dropConstraintsForColumn($tableName, $column, 'D');
+
+        $sqlAfter = [];
+
+        $constraintBase = preg_replace('/[^a-z0-9_]/i', '', "{$table}_{$column}");
+
+        if ($type instanceof ColumnSchemaBuilder) {
             $type->setAlterColumnFormat();
 
-
             $defaultValue = $type->getDefaultValue();
+
             if ($defaultValue !== null) {
                 $sqlAfter[] = $this->addDefaultValue(
                     "DF_{$constraintBase}",
                     $table,
                     $column,
-                    $defaultValue instanceof Expression ? $defaultValue : new Expression($defaultValue)
+                    $defaultValue instanceof Expression ? $defaultValue : new Expression($defaultValue),
                 );
             }
 
             $checkValue = $type->getCheckValue();
+
             if ($checkValue !== null) {
-                $sqlAfter[] = "ALTER TABLE {$tableName} ADD CONSTRAINT " .
-                    $this->db->quoteColumnName("CK_{$constraintBase}") .
-                    ' CHECK (' . ($defaultValue instanceof Expression ?  $checkValue : new Expression($checkValue)) . ')';
+                $columnCheckConstraint = $this->db->quoteColumnName("CK_{$constraintBase}");
+
+                $checkSQL = $checkValue instanceof Expression ?  $checkValue : new Expression($checkValue);
+
+                $sqlAfter[] = <<<SQL
+                ALTER TABLE {$tableName} ADD CONSTRAINT {$columnCheckConstraint} CHECK ({$checkSQL})
+                SQL;
             }
 
             if ($type->isUnique()) {
-                $sqlAfter[] = "ALTER TABLE {$tableName} ADD CONSTRAINT " . $this->db->quoteColumnName("UQ_{$constraintBase}") . " UNIQUE ({$columnName})";
+                $columnUniqueConstraint = $this->db->quoteColumnName("UQ_{$constraintBase}");
+
+                $sqlAfter[] = <<<SQL
+                ALTER TABLE {$tableName} ADD CONSTRAINT {$columnUniqueConstraint} UNIQUE ({$columnName})
+                SQL;
             }
         }
 
-        return 'ALTER TABLE ' . $tableName . ' ALTER COLUMN '
-            . $columnName . ' '
-            . $this->getColumnType($type) . "\n"
-            . implode("\n", $sqlAfter);
+        $columnType = $this->getColumnType($type);
+
+        return implode(
+            "\n",
+            [
+                $dropDefaultsSql,
+                <<<SQL
+                ALTER TABLE {$tableName} ALTER COLUMN {$columnName} {$columnType}
+                SQL,
+                ...$sqlAfter,
+            ],
+        );
     }
 
     /**
@@ -536,6 +567,24 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
+     * Drop all constraints before column delete.
+     *
+     * {@inheritdoc}
+     */
+    public function dropColumn($table, $column)
+    {
+        $tableName = $this->db->quoteTableName($table);
+        $columnName = $this->db->quoteColumnName($column);
+
+        $dropConstraintsSql = $this->dropConstraintsForColumn($tableName, $column);
+
+        return <<<SQL
+        {$dropConstraintsSql}
+        ALTER TABLE {$tableName} DROP COLUMN {$columnName}
+        SQL;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function extractAlias($table)
@@ -554,9 +603,10 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * dynamic batch. Foreign key constraints are dropped first because a primary key or unique constraint cannot be
      * dropped while a foreign key references it.
      *
-     * @param string $table The table whose constraints are to be dropped. The name is properly quoted by the method.
-     * @param string $column The column whose constraints are to be dropped. The name is matched verbatim against the
-     * system catalog.
+     * @param string $table The table whose constraints are to be dropped. The name must already be quoted by the
+     * caller.
+     * @param string $column The column whose constraints are to be dropped. The raw, unquoted name is matched verbatim
+     * against the system catalog; single quotes are escaped by the method.
      * @param string $type The constraint type: `'D'` - default, `'C'` - check, `'PK'` - primary key, `'UQ'` - unique,
      * `'F'` - foreign key. Leave empty to drop the constraints of all these types.
      *
@@ -571,7 +621,6 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     private function dropConstraintsForColumn($table, $column, $type = '')
     {
-        $tableName = strpos($table, '{{') === false ? "{{{$table}}}" : $table;
         $columnName = str_replace("'", "''", $column);
 
         $subqueries = [
@@ -624,7 +673,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         $unionSql = implode("\n    UNION\n", $type === '' ? $subqueries : [$subqueries[$type]]);
 
         return <<<SQL
-        DECLARE @tableName NVARCHAR(MAX) = N'{$tableName}'
+        DECLARE @tableName NVARCHAR(MAX) = N'{$table}'
         DECLARE @columnName NVARCHAR(MAX) = N'{$columnName}'
         DECLARE @dropCommands NVARCHAR(MAX)
 
@@ -655,15 +704,5 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         return parent::buildWithQueries($withs, $params);
-    }
-
-    /**
-     * Drop all constraints before column delete
-     * {@inheritdoc}
-     */
-    public function dropColumn($table, $column)
-    {
-        return $this->dropConstraintsForColumn($table, $column) . "\nALTER TABLE " . $this->db->quoteTableName($table)
-            . ' DROP COLUMN ' . $this->db->quoteColumnName($column);
     }
 }

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -13,9 +13,10 @@ namespace yii\db\mssql;
 use yii\base\InvalidArgumentException;
 use yii\base\NotSupportedException;
 use yii\db\Expression;
-use yii\db\mssql\ColumnSchemaBuilder;
 use yii\db\Query;
 
+use function array_flip;
+use function array_intersect_key;
 use function count;
 use function implode;
 use function preg_replace;
@@ -132,8 +133,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
     /**
      * Builds a SQL statement for changing the definition of a column.
      *
-     * Drops the default constraints attached to the column before the `ALTER COLUMN` statement, because SQL Server
-     * rejects a data type change while a `DEFAULT` definition is bound to the column. Default, check, and unique
+     * Drops the default, check, and unique constraints attached to the column before the `ALTER COLUMN` statement,
+     * because SQL Server rejects altering a column while such constraints are bound to it. Default, check, and unique
      * constraints defined by a {@see ColumnSchemaBuilder} type are re-created after the column is altered.
      *
      * @param string $table The table whose column is to be changed. The table name will be properly quoted by the
@@ -153,7 +154,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         $tableName = $this->db->quoteTableName($table);
         $columnName = $this->db->quoteColumnName($column);
 
-        $dropDefaultsSql = $this->dropConstraintsForColumn($tableName, $column, 'D');
+        $dropConstraintsSql = $this->dropConstraintsForColumn($tableName, $column, ['D', 'C', 'UQ']);
 
         $sqlAfter = [];
 
@@ -199,7 +200,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         return implode(
             "\n",
             [
-                $dropDefaultsSql,
+                $dropConstraintsSql,
                 <<<SQL
                 ALTER TABLE {$tableName} ALTER COLUMN {$columnName} {$columnType}
                 SQL,
@@ -607,8 +608,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * caller.
      * @param string $column The column whose constraints are to be dropped. The raw, unquoted name is matched verbatim
      * against the system catalog; single quotes are escaped by the method.
-     * @param string $type The constraint type: `'D'` - default, `'C'` - check, `'PK'` - primary key, `'UQ'` - unique,
-     * `'F'` - foreign key. Leave empty to drop the constraints of all these types.
+     * @param string[] $types The constraint types: `'D'` - default, `'C'` - check, `'PK'` - primary key,
+     * `'UQ'` - unique, `'F'` - foreign key. Leave empty to drop the constraints of all these types.
      *
      * @return string The DROP CONSTRAINTS SQL batch.
      *
@@ -619,7 +620,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-index-columns-transact-sql
      * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-foreign-key-columns-transact-sql
      */
-    private function dropConstraintsForColumn($table, $column, $type = '')
+    private function dropConstraintsForColumn($table, $column, $types = [])
     {
         $columnName = str_replace("'", "''", $column);
 
@@ -670,7 +671,9 @@ class QueryBuilder extends \yii\db\QueryBuilder
             SQL;
         }
 
-        $unionSql = implode("\n    UNION\n", $type === '' ? $subqueries : [$subqueries[$type]]);
+        $selectedSubqueries = $types === [] ? $subqueries : array_intersect_key($subqueries, array_flip($types));
+
+        $unionSql = implode("\n    UNION\n", $selectedSubqueries);
 
         return <<<SQL
         DECLARE @tableName NVARCHAR(MAX) = N'{$table}'

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -53,12 +53,12 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     public $columnSchemaClass = ColumnSchema::class;
     /**
-     * @var string the default schema used for the current session.
+     * @var string The default schema used for the current session.
      */
     public $defaultSchema = 'dbo';
     public array $systemSchemaNames = ['guest'];
     /**
-     * @var array mapping from physical column types (keys) to abstract column types (values)
+     * @var array Mapping from physical column types (keys) to abstract column types (values).
      */
     public $typeMap = [
         // exact numbers
@@ -362,7 +362,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     public function releaseSavepoint($name)
     {
-        // does nothing as MSSQL does not support this
+        // Does nothing as MSSQL does not support this.
     }
 
     /**
@@ -375,7 +375,8 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
 
     /**
      * Creates a query builder for the MSSQL database.
-     * @return QueryBuilder query builder interface.
+     *
+     * @return QueryBuilder Query builder interface.
      */
     public function createQueryBuilder()
     {
@@ -383,9 +384,11 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
     }
 
     /**
-     * Loads the column information into a [[ColumnSchema]] object.
-     * @param array $info column information
-     * @return T the column schema object
+     * Loads the column information into a {@see ColumnSchema} object.
+     *
+     * @param array $info Column information.
+     *
+     * @return T The column schema object.
      */
     protected function loadColumnSchema($info)
     {
@@ -394,8 +397,8 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
         $column->name = $info['column_name'];
         $column->allowNull = $info['is_nullable'] === 'YES';
         $column->dbType = $info['data_type'];
-        $column->enumValues = []; // mssql has only vague equivalents to enum
-        $column->isPrimaryKey = null; // primary key will be determined in findColumns() method
+        $column->enumValues = []; // MSSQL has only vague equivalents to enum.
+        $column->isPrimaryKey = null; // Primary key will be determined in `findColumns()` method.
         $column->autoIncrement = (bool) $info['is_identity'];
         $column->isComputed = (bool) $info['is_computed'];
         $column->comment = $info['comment'] === null ? '' : $info['comment'];
@@ -424,7 +427,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
 
         $column->phpType = $this->getColumnPhpType($column);
 
-        // store raw default for deferred resolution in `findColumns()`, where isPrimaryKey is known.
+        // Store raw default for deferred resolution in `findColumns()`, where isPrimaryKey is known.
         $column->defaultValue = $info['column_default'];
 
         return $column;
@@ -554,7 +557,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
     /**
      * Collects the primary key column details for the given table.
      *
-     * @param TableSchema $table the table metadata
+     * @param TableSchema $table The table metadata
      */
     protected function findPrimaryKeys($table)
     {

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace yiiunit\framework\db\mssql;
 
 use PHPUnit\Framework\Attributes\Group;
-use yii\db\Connection;
 use yii\db\IntegrityException;
 use yii\db\mssql\Schema;
 use yii\db\mssql\TableSchema;
@@ -323,9 +322,9 @@ final class CommandTest extends BaseCommand
             $tableSchema->getColumn('bar')->dbType,
             'Type change must succeed with a default bound.',
         );
-        self::assertSame(
+        self::assertCount(
             1,
-            $this->countDefaultConstraints($db),
+            $db->getSchema()->getTableDefaultValues($table, true),
             'Old default constraint must be replaced, not duplicated.',
         );
     }
@@ -352,10 +351,66 @@ final class CommandTest extends BaseCommand
             $tableSchema->getColumn('bar')->dbType,
             'Type change must succeed with a default bound.',
         );
+        self::assertCount(
+            1,
+            $db->getSchema()->getTableDefaultValues('foo1', true),
+            'Old default constraint must be replaced, not duplicated.',
+        );
+    }
+
+    public function testAlterColumnReplacesCheckConstraint(): void
+    {
+        $db = $this->getConnection();
+
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)->check('LEN(bar) > 5'),
+        )->execute();
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)->check('LEN(bar) > 3'),
+        )->execute();
+
+        self::assertCount(
+            1,
+            $db->getSchema()->getTableChecks('foo1', true),
+            'Old check constraint must be replaced, not duplicated.',
+        );
         self::assertSame(
             1,
-            $this->countDefaultConstraints($db),
-            'Old default constraint must be replaced, not duplicated.',
+            $db->createCommand("INSERT INTO [foo1]([bar]) VALUES('abcd')")->execute(),
+            'New check must be in effect instead of the old one.',
+        );
+    }
+
+    public function testAlterColumnReplacesUniqueConstraint(): void
+    {
+        $db = $this->getConnection();
+
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)->unique(),
+        )->execute();
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 32)->unique(),
+        )->execute();
+
+        $tableSchema = $db->getTableSchema('foo1', true);
+
+        self::assertSame(
+            'nvarchar(32)',
+            $tableSchema->getColumn('bar')->dbType,
+            'Column type must reflect the new definition.',
+        );
+        self::assertCount(
+            1,
+            $db->getSchema()->getTableUniques('foo1', true),
+            'Old unique constraint must be replaced, not duplicated.',
         );
     }
 
@@ -388,24 +443,5 @@ final class CommandTest extends BaseCommand
         $resultData = $query->createCommand($db)->queryOne();
 
         $this->assertSame($testData, $resultData['blob_col']);
-    }
-
-    private function countDefaultConstraints(
-        Connection $db,
-        string $table = 'dbo.foo1',
-        string $column = 'bar',
-    ): int {
-        return (int) $db->createCommand(
-            <<<SQL
-            SELECT COUNT(*)
-            FROM [sys].[default_constraints] AS [dc]
-            JOIN [sys].[columns] AS [c] ON [c].[object_id] = [dc].[parent_object_id] AND [c].[column_id] = [dc].[parent_column_id]
-            WHERE [dc].[parent_object_id] = OBJECT_ID(:tableName) AND [c].[name] = :columnName
-            SQL,
-            [
-                ':tableName' => $table,
-                ':columnName' => $column,
-            ],
-        )->queryScalar();
     }
 }

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,15 +10,21 @@
 
 namespace yiiunit\framework\db\mssql;
 
-use yii\db\pgsql\Schema;
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\Connection;
+use yii\db\IntegrityException;
+use yii\db\mssql\Schema;
+use yii\db\mssql\TableSchema;
 use yii\db\Query;
 use yiiunit\base\db\BaseCommand;
 
 /**
- * @group db
- * @group mssql
+ * Unit tests for {@see \yii\db\mssql\Command} functionality for the MSSQL driver.
  */
-class CommandTest extends BaseCommand
+#[Group('db')]
+#[Group('mssql')]
+#[Group('command')]
+final class CommandTest extends BaseCommand
 {
     protected $driverName = 'sqlsrv';
 
@@ -122,6 +130,235 @@ class CommandTest extends BaseCommand
         $this->assertEmpty($defaultValues);
     }
 
+    public function testAlterColumn(): void
+    {
+        $db = $this->getConnection();
+
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            'varchar(255)',
+        )->execute();
+
+        $tableSchema = $db->getTableSchema('foo1', true);
+
+        self::assertSame(
+            'varchar(255)',
+            $tableSchema->getColumn('bar')->dbType,
+            'Column type must reflect the new definition.',
+        );
+        self::assertTrue(
+            $tableSchema->getColumn('bar')->allowNull,
+            'Column must stay nullable.',
+        );
+
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)->notNull(),
+        )->execute();
+
+        $tableSchema = $db->getTableSchema('foo1', true);
+
+        self::assertSame(
+            'nvarchar(128)',
+            $tableSchema->getColumn('bar')->dbType,
+            'Column type must reflect the new definition.',
+        );
+        self::assertFalse(
+            $tableSchema->getColumn('bar')->allowNull,
+            'Column must be NOT NULL after the change.',
+        );
+    }
+
+    public function testAlterColumnWithCheckConstraint(): void
+    {
+        $db = $this->getConnection();
+
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)->null()->check('LEN(bar) > 5'),
+        )->execute();
+
+        $tableSchema = $db->getTableSchema('foo1', true);
+
+        self::assertSame(
+            'nvarchar(128)',
+            $tableSchema->getColumn('bar')->dbType,
+            'Column type must reflect the new definition.',
+        );
+        self::assertTrue(
+            $tableSchema->getColumn('bar')->allowNull,
+            'Column must stay nullable.',
+        );
+        self::assertSame(
+            1,
+            $db->createCommand(
+                <<<SQL
+                INSERT INTO [foo1]([bar]) VALUES('abcdef')
+                SQL
+            )->execute(),
+            'Value satisfying the check must be accepted.',
+        );
+    }
+
+    public function testThrowIntegrityExceptionWhenInsertViolatesAlterColumnCheckConstraint(): void
+    {
+        $db = $this->getConnection();
+
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)->check('LEN(bar) > 5'),
+        )->execute();
+
+        $this->expectException(IntegrityException::class);
+
+        $db->createCommand(
+            <<<SQL
+            INSERT INTO [foo1]([bar]) VALUES('abcde')
+            SQL,
+        )->execute();
+    }
+
+    public function testThrowIntegrityExceptionWhenInsertViolatesAlterColumnUniqueConstraint(): void
+    {
+        $db = $this->getConnection();
+
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)->unique(),
+        )->execute();
+
+        self::assertSame(
+            1,
+            $db->createCommand(
+                <<<SQL
+                INSERT INTO [foo1]([bar]) VALUES('abcdef')
+                SQL
+            )->execute(),
+            'First value must be accepted.',
+        );
+
+        $this->expectException(IntegrityException::class);
+
+        $db->createCommand(
+            <<<SQL
+            INSERT INTO [foo1]([bar]) VALUES('abcdef')
+            SQL
+        )->execute();
+    }
+
+    public function testAlterColumnWithSchemaQualifiedTable(): void
+    {
+        $db = $this->getConnection();
+
+        $db->createCommand()->alterColumn(
+            'dbo.foo1',
+            'bar',
+            'varchar(255)',
+        )->execute();
+
+        $tableSchema = $db->getTableSchema('dbo.foo1', true);
+
+        self::assertSame(
+            'varchar(255)',
+            $tableSchema->getColumn('bar')->dbType,
+            'Column type must reflect the new definition.',
+        );
+        self::assertTrue(
+            $tableSchema->getColumn('bar')->allowNull,
+            'Column must stay nullable.',
+        );
+    }
+
+    public function testAlterColumnWithCatalogQualifiedTable(): void
+    {
+        $db = $this->getConnection();
+
+        $catalogName = (string) $db->createCommand(
+            <<<SQL
+            SELECT DB_NAME()
+            SQL
+        )->queryScalar();
+
+        $table = "{$catalogName}.dbo.foo1";
+
+        $db->createCommand()->alterColumn(
+            $table,
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)->defaultValue('initial'),
+        )->execute();
+
+        $tableSchema = $db->getTableSchema($table, true);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $tableSchema,
+            'Schema must load for the catalog-qualified name.',
+        );
+        self::assertSame(
+            $catalogName,
+            $tableSchema->catalogName,
+            'Catalog name must be preserved.',
+        );
+        self::assertSame(
+            'nvarchar(128)',
+            $tableSchema->getColumn('bar')->dbType,
+            'Column type must reflect the new definition.',
+        );
+
+        $db->createCommand()->alterColumn(
+            $table,
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_INTEGER)->defaultValue(0),
+        )->execute();
+
+        $tableSchema = $db->getTableSchema($table, true);
+
+        self::assertSame(
+            'int',
+            $tableSchema->getColumn('bar')->dbType,
+            'Type change must succeed with a default bound.',
+        );
+        self::assertSame(
+            1,
+            $this->countDefaultConstraints($db),
+            'Old default constraint must be replaced, not duplicated.',
+        );
+    }
+
+    public function testAlterColumnReplacesDefaultValue(): void
+    {
+        $db = $this->getConnection();
+
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)->defaultValue('initial'),
+        )->execute();
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_INTEGER)->defaultValue(0),
+        )->execute();
+
+        $tableSchema = $db->getTableSchema('foo1', true);
+
+        self::assertSame(
+            'int',
+            $tableSchema->getColumn('bar')->dbType,
+            'Type change must succeed with a default bound.',
+        );
+        self::assertSame(
+            1,
+            $this->countDefaultConstraints($db),
+            'Old default constraint must be replaced, not duplicated.',
+        );
+    }
+
     public static function batchInsertSqlProvider(): array
     {
         $data = parent::batchInsertSqlProvider();
@@ -151,5 +388,24 @@ class CommandTest extends BaseCommand
         $resultData = $query->createCommand($db)->queryOne();
 
         $this->assertSame($testData, $resultData['blob_col']);
+    }
+
+    private function countDefaultConstraints(
+        Connection $db,
+        string $table = 'dbo.foo1',
+        string $column = 'bar',
+    ): int {
+        return (int) $db->createCommand(
+            <<<SQL
+            SELECT COUNT(*)
+            FROM [sys].[default_constraints] AS [dc]
+            JOIN [sys].[columns] AS [c] ON [c].[object_id] = [dc].[parent_object_id] AND [c].[column_id] = [dc].[parent_column_id]
+            WHERE [dc].[parent_object_id] = OBJECT_ID(:tableName) AND [c].[name] = :columnName
+            SQL,
+            [
+                ':tableName' => $table,
+                ':columnName' => $column,
+            ],
+        )->queryScalar();
     }
 }

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -322,9 +322,17 @@ final class CommandTest extends BaseCommand
             $tableSchema->getColumn('bar')->dbType,
             'Type change must succeed with a default bound.',
         );
+
+        $schema = $db->getSchema();
+
+        self::assertInstanceOf(
+            Schema::class,
+            $schema,
+            'Schema must be available.',
+        );
         self::assertCount(
             1,
-            $db->getSchema()->getTableDefaultValues($table, true),
+            $schema->getTableDefaultValues($table, true),
             'Old default constraint must be replaced, not duplicated.',
         );
     }
@@ -351,9 +359,17 @@ final class CommandTest extends BaseCommand
             $tableSchema->getColumn('bar')->dbType,
             'Type change must succeed with a default bound.',
         );
+
+        $schema = $db->getSchema();
+
+        self::assertInstanceOf(
+            Schema::class,
+            $schema,
+            'Schema must be available.',
+        );
         self::assertCount(
             1,
-            $db->getSchema()->getTableDefaultValues('foo1', true),
+            $schema->getTableDefaultValues('foo1', true),
             'Old default constraint must be replaced, not duplicated.',
         );
     }
@@ -373,14 +389,25 @@ final class CommandTest extends BaseCommand
             $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)->check('LEN(bar) > 3'),
         )->execute();
 
+        $schema = $db->getSchema();
+
+        self::assertInstanceOf(
+            Schema::class,
+            $schema,
+            'Schema must be available.',
+        );
         self::assertCount(
             1,
-            $db->getSchema()->getTableChecks('foo1', true),
+            $schema->getTableChecks('foo1', true),
             'Old check constraint must be replaced, not duplicated.',
         );
         self::assertSame(
             1,
-            $db->createCommand("INSERT INTO [foo1]([bar]) VALUES('abcd')")->execute(),
+            $db->createCommand(
+                <<<SQL
+                INSERT INTO [foo1]([bar]) VALUES('abcd')
+                SQL
+            )->execute(),
             'New check must be in effect instead of the old one.',
         );
     }
@@ -407,9 +434,17 @@ final class CommandTest extends BaseCommand
             $tableSchema->getColumn('bar')->dbType,
             'Column type must reflect the new definition.',
         );
+
+        $schema = $db->getSchema();
+
+        self::assertInstanceOf(
+            Schema::class,
+            $schema,
+            'Schema must be available.',
+        );
         self::assertCount(
             1,
-            $db->getSchema()->getTableUniques('foo1', true),
+            $schema->getTableUniques('foo1', true),
             'Old unique constraint must be replaced, not duplicated.',
         );
     }

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -27,7 +27,7 @@ use yiiunit\framework\db\mssql\providers\QueryBuilderProvider;
  */
 #[Group('db')]
 #[Group('mssql')]
-#[Group('queryBuilder')]
+#[Group('query-builder')]
 final class QueryBuilderTest extends BaseQueryBuilder
 {
     public $driverName = 'sqlsrv';
@@ -667,62 +667,20 @@ final class QueryBuilderTest extends BaseQueryBuilder
         );
     }
 
-    public function testAlterColumnOnDb(): void
+    #[DataProviderExternal(QueryBuilderProvider::class, 'alterColumnQualifiedTableNames')]
+    public function testAlterColumnWithQualifiedTableName(string $table, string|Closure $type, string $expected): void
     {
-        $connection = $this->getConnection();
+        $qb = $this->getQueryBuilder(false);
 
-        $sql = $connection->getQueryBuilder()->alterColumn('foo1', 'bar', 'varchar(255)');
-        $connection->createCommand($sql)->execute();
-        $schema = $connection->getTableSchema('[foo1]', true);
+        if ($type instanceof Closure) {
+            $type = $type($this->getDb());
+        }
 
-        $this->assertEquals('varchar(255)', $schema->getColumn('bar')->dbType);
-        $this->assertEquals(true, $schema->getColumn('bar')->allowNull);
-
-        $sql = $connection->getQueryBuilder()->alterColumn('foo1', 'bar', $this->string(128)->notNull());
-        $connection->createCommand($sql)->execute();
-        $schema = $connection->getTableSchema('[foo1]', true);
-        $this->assertEquals('nvarchar(128)', $schema->getColumn('bar')->dbType);
-        $this->assertEquals(false, $schema->getColumn('bar')->allowNull);
-    }
-
-    public function testAlterColumnWithCheckConstraintOnDb(): void
-    {
-        $connection = $this->getConnection();
-
-        $sql = $connection->getQueryBuilder()->alterColumn('foo1', 'bar', $this->string(128)->null()->check('LEN(bar) > 5'));
-        $connection->createCommand($sql)->execute();
-        $schema = $connection->getTableSchema('[foo1]', true);
-        $this->assertEquals('nvarchar(128)', $schema->getColumn('bar')->dbType);
-        $this->assertEquals(true, $schema->getColumn('bar')->allowNull);
-
-        $sql = "INSERT INTO [foo1]([bar]) values('abcdef')";
-        $this->assertEquals(1, $connection->createCommand($sql)->execute());
-    }
-
-    public function testAlterColumnWithCheckConstraintOnDbWithException(): void
-    {
-        $connection = $this->getConnection();
-
-        $sql = $connection->getQueryBuilder()->alterColumn('foo1', 'bar', $this->string(64)->check('LEN(bar) > 5'));
-        $connection->createCommand($sql)->execute();
-
-        $sql = "INSERT INTO [foo1]([bar]) values('abcde')";
-        $this->expectException('yii\db\IntegrityException');
-        $this->assertEquals(1, $connection->createCommand($sql)->execute());
-    }
-
-    public function testAlterColumnWithUniqueConstraintOnDbWithException(): void
-    {
-        $connection = $this->getConnection();
-
-        $sql = $connection->getQueryBuilder()->alterColumn('foo1', 'bar', $this->string(64)->unique());
-        $connection->createCommand($sql)->execute();
-
-        $sql = "INSERT INTO [foo1]([bar]) values('abcdef')";
-        $this->assertEquals(1, $connection->createCommand($sql)->execute());
-
-        $this->expectException('yii\db\IntegrityException');
-        $this->assertEquals(1, $connection->createCommand($sql)->execute());
+        self::assertSame(
+            $expected,
+            $qb->alterColumn($table, 'bar', $type),
+            'Generated SQL must match the expected batch.',
+        );
     }
 
     #[DataProviderExternal(QueryBuilderProvider::class, 'dropColumn')]

--- a/tests/framework/db/mssql/QueryBuilderUnionTest.php
+++ b/tests/framework/db/mssql/QueryBuilderUnionTest.php
@@ -22,7 +22,7 @@ use yiiunit\base\db\BaseQueryBuilderUnion;
  */
 #[Group('db')]
 #[Group('mssql')]
-#[Group('querybuilder')]
+#[Group('query-builder')]
 class QueryBuilderUnionTest extends BaseQueryBuilderUnion
 {
     protected $driverName = 'sqlsrv';

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -43,6 +43,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -67,6 +88,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -88,6 +130,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -110,6 +173,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -132,6 +216,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -155,6 +260,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -178,6 +304,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -201,6 +348,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -224,6 +392,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -255,6 +444,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -278,6 +488,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -300,6 +531,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL
@@ -323,6 +575,27 @@ final class QueryBuilderProvider
                     FROM [sys].[default_constraints] AS [dc]
                     JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
                     WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
                 ) AS [cons]
 
                 IF @dropCommands IS NOT NULL

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -33,8 +33,7 @@ final class QueryBuilderProvider
                     ->null()
                     ->defaultValue(new Expression('CAST(GETDATE() AS INT)')),
                 <<<SQL
-                ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
-                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
                 DECLARE @dropCommands NVARCHAR(MAX)
 
@@ -48,6 +47,7 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
                 ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CAST(GETDATE() AS INT) FOR [bar]
                 SQL,
             ],
@@ -57,8 +57,7 @@ final class QueryBuilderProvider
                     ->null()
                     ->defaultValue(null),
                 <<<SQL
-                ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
-                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
                 DECLARE @dropCommands NVARCHAR(MAX)
 
@@ -72,14 +71,14 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
                 ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT NULL FOR [bar]
                 SQL,
             ],
             'plain string type' => [
                 'varchar(255)',
                 <<<SQL
-                ALTER TABLE [foo1] ALTER COLUMN [bar] varchar(255)
-                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
                 DECLARE @dropCommands NVARCHAR(MAX)
 
@@ -93,6 +92,7 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] varchar(255)
                 SQL,
             ],
             'string not null' => [
@@ -100,8 +100,7 @@ final class QueryBuilderProvider
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
                     ->notNull(),
                 <<<SQL
-                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255) NOT NULL
-                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
                 DECLARE @dropCommands NVARCHAR(MAX)
 
@@ -115,6 +114,7 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255) NOT NULL
                 SQL,
             ],
             'string unique' => [
@@ -122,8 +122,7 @@ final class QueryBuilderProvider
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 30)
                     ->unique(),
                 <<<SQL
-                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(30)
-                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
                 DECLARE @dropCommands NVARCHAR(MAX)
 
@@ -137,6 +136,7 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(30)
                 ALTER TABLE [foo1] ADD CONSTRAINT [UQ_foo1_bar] UNIQUE ([bar])
                 SQL,
             ],
@@ -145,8 +145,7 @@ final class QueryBuilderProvider
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
                     ->check('LEN(bar) > 5'),
                 <<<SQL
-                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
                 DECLARE @dropCommands NVARCHAR(MAX)
 
@@ -160,6 +159,7 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
                 ALTER TABLE [foo1] ADD CONSTRAINT [CK_foo1_bar] CHECK (LEN(bar) > 5)
                 SQL,
             ],
@@ -168,8 +168,7 @@ final class QueryBuilderProvider
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
                     ->defaultValue('AbCdE'),
                 <<<SQL
-                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
                 DECLARE @dropCommands NVARCHAR(MAX)
 
@@ -183,6 +182,7 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
                 ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT 'AbCdE' FOR [bar]
                 SQL,
             ],
@@ -191,8 +191,7 @@ final class QueryBuilderProvider
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
                     ->defaultValue(''),
                 <<<SQL
-                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
                 DECLARE @dropCommands NVARCHAR(MAX)
 
@@ -206,6 +205,7 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
                 ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT '' FOR [bar]
                 SQL,
             ],
@@ -214,8 +214,7 @@ final class QueryBuilderProvider
                     ->createColumnSchemaBuilder(Schema::TYPE_TIMESTAMP)
                     ->defaultExpression('CURRENT_TIMESTAMP'),
                 <<<SQL
-                ALTER TABLE [foo1] ALTER COLUMN [bar] datetime
-                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
                 DECLARE @dropCommands NVARCHAR(MAX)
 
@@ -229,7 +228,107 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] datetime
                 ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CURRENT_TIMESTAMP FOR [bar]
+                SQL,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, Closure|string, string}>
+     */
+    public static function alterColumnQualifiedTableNames(): array
+    {
+        return [
+            'catalog-qualified plain string type' => [
+                'yiitest.dbo.foo1',
+                'varchar(255)',
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[yiitest].[dbo].[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [yiitest].[dbo].[foo1] ALTER COLUMN [bar] varchar(255)
+                SQL,
+            ],
+            'catalog-qualified string with default value' => [
+                'yiitest.dbo.foo1',
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue('AbCdE'),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[yiitest].[dbo].[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [yiitest].[dbo].[foo1] ALTER COLUMN [bar] nvarchar(255)
+                ALTER TABLE [yiitest].[dbo].[foo1] ADD CONSTRAINT [DF_yiitestdbofoo1_bar] DEFAULT 'AbCdE' FOR [bar]
+                SQL,
+            ],
+            'schema-qualified plain string type' => [
+                'dbo.foo1',
+                'varchar(255)',
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[dbo].[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [dbo].[foo1] ALTER COLUMN [bar] varchar(255)
+                SQL,
+            ],
+            'schema-qualified string with default value' => [
+                'dbo.foo1',
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue('AbCdE'),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[dbo].[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [dbo].[foo1] ALTER COLUMN [bar] nvarchar(255)
+                ALTER TABLE [dbo].[foo1] ADD CONSTRAINT [DF_dbofoo1_bar] DEFAULT 'AbCdE' FOR [bar]
                 SQL,
             ],
         ];
@@ -245,7 +344,7 @@ final class QueryBuilderProvider
                 'foo1',
                 "my'col",
                 <<<SQL
-                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'my''col'
                 DECLARE @dropCommands NVARCHAR(MAX)
 
@@ -304,7 +403,7 @@ final class QueryBuilderProvider
                 'foo1',
                 'bar',
                 <<<SQL
-                DECLARE @tableName NVARCHAR(MAX) = N'{{foo1}}'
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
                 DECLARE @dropCommands NVARCHAR(MAX)
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
