### PR TITLE
Fix MSSQL `QueryBuilder::renameTable()` to call `sp_rename` with string parameters and one-part new table names.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -94,6 +94,7 @@ Yii Framework 2 Change Log
 - Enh #20939: Replace `strpos()` with `str_contains()` in `yii\db\Schema` quoting methods and fix `quoteValue()` `@param` to `mixed` (terabytesoftw)
 - Enh #20941: Modernize MSSQL `yii\db\mssql\Schema` internals and remove dead `unsigned` detection (terabytesoftw)
 - Bug #20942: Fix MSSQL `yii\db\mssql\QueryBuilder::alterColumn()` to drop column default, check, and unique constraints before the `ALTER COLUMN` statement, allowing column redefinition on constrained columns without duplicate constraint name errors (terabytesoftw)
+- Bug #20943: Fix MSSQL `QueryBuilder::renameTable()` to call `sp_rename` with string parameters and one-part new table names (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -118,11 +118,19 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     public function renameTable($oldName, $newName)
     {
-        $oldTableName = "N'" . str_replace("'", "''", $this->db->quoteTableName($oldName)) . "'";
-        $newTableName = $this->db->quoteTableName($newName);
+        $schema = $this->db->getSchema();
+
+        $oldTableName = str_replace("'", "''", $this->db->quoteTableName($oldName));
+        $newTableName = $this->db->quoteSql($this->db->quoteTableName($newName));
+
+        if (($pos = strrpos($newTableName, '].[')) !== false) {
+            $newTableName = substr($newTableName, $pos + 2);
+        }
+
+        $newTableName = str_replace("'", "''", $schema->unquoteSimpleTableName($newTableName));
 
         return <<<SQL
-        EXEC sp_rename @objname = {$oldTableName}, @newname = {$newTableName}, @objtype = N'OBJECT'
+        EXEC sp_rename @objname = N'{$oldTableName}', @newname = N'{$newTableName}', @objtype = N'OBJECT'
         SQL;
     }
 

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -12,6 +12,8 @@ namespace yii\db\mssql;
 
 use yii\base\InvalidArgumentException;
 use yii\base\NotSupportedException;
+use yii\db\conditions\InCondition;
+use yii\db\conditions\LikeCondition;
 use yii\db\Expression;
 use yii\db\Query;
 
@@ -62,10 +64,11 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     protected function defaultExpressionBuilders()
     {
-        return array_merge(parent::defaultExpressionBuilders(), [
-            'yii\db\conditions\InCondition' => 'yii\db\mssql\conditions\InConditionBuilder',
-            'yii\db\conditions\LikeCondition' => 'yii\db\mssql\conditions\LikeConditionBuilder',
-        ]);
+        return [
+            ...parent::defaultExpressionBuilders(),
+            InCondition::class => conditions\InConditionBuilder::class,
+            LikeCondition::class => conditions\LikeConditionBuilder::class,
+        ];
     }
 
     /**
@@ -95,6 +98,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         $offset = $this->hasOffset($offset) ? $offset : 0;
+
         $sql .= "{$this->separator}{$orderBy}{$this->separator}OFFSET {$offset} ROWS";
 
         if ($this->hasLimit($limit)) {
@@ -106,13 +110,20 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * Builds a SQL statement for renaming a DB table.
-     * @param string $oldName the table to be renamed. The name will be properly quoted by the method.
-     * @param string $newName the new table name. The name will be properly quoted by the method.
-     * @return string the SQL statement for renaming a DB table.
+     *
+     * @param string $oldName The table to be renamed. The name will be properly quoted by the method.
+     * @param string $newName The new table name. The name will be properly quoted by the method.
+     *
+     * @return string The SQL statement for renaming a DB table.
      */
     public function renameTable($oldName, $newName)
     {
-        return 'sp_rename ' . $this->db->quoteTableName($oldName) . ', ' . $this->db->quoteTableName($newName);
+        $oldTableName = "N'" . str_replace("'", "''", $this->db->quoteTableName($oldName)) . "'";
+        $newTableName = $this->db->quoteTableName($newName);
+
+        return <<<SQL
+        EXEC sp_rename @objname = {$oldTableName}, @newname = {$newTableName}, @objtype = N'OBJECT'
+        SQL;
     }
 
     /**

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -10,15 +10,19 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\db\mssql;
 
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\db\IntegrityException;
 use yii\db\mssql\Schema;
 use yii\db\mssql\TableSchema;
 use yii\db\Query;
 use yiiunit\base\db\BaseCommand;
+use yiiunit\framework\db\mssql\providers\CommandProvider;
 
 /**
  * Unit tests for {@see \yii\db\mssql\Command} functionality for the MSSQL driver.
+ *
+ * {@see CommandProvider} for test case data providers.
  */
 #[Group('db')]
 #[Group('mssql')]
@@ -34,6 +38,53 @@ final class CommandTest extends BaseCommand
         $sql = 'SELECT [[id]], [[t.name]] FROM {{customer}} t';
         $command = $db->createCommand($sql);
         $this->assertEquals('SELECT [id], [t].[name] FROM [customer] t', $command->sql);
+    }
+
+    #[DataProviderExternal(CommandProvider::class, 'renameTable')]
+    public function testRenameTableWithQuotedNames(
+        string $fromTableName,
+        string $toTableName,
+        string $fromRawTableName,
+        string $toRawTableName,
+    ): void {
+        $db = $this->getConnection();
+
+        foreach ([$toRawTableName, $fromRawTableName] as $tableName) {
+            if ($db->getSchema()->getTableSchema($tableName, true) !== null) {
+                $db->createCommand()->dropTable($tableName)->execute();
+            }
+        }
+
+        $db->createCommand()->createTable(
+            $fromTableName,
+            ['id' => 'integer'],
+        )->execute();
+
+        self::assertNotNull(
+            $db->getSchema()->getTableSchema($fromRawTableName, true),
+            'Table must be created with the expected raw name.',
+        );
+        self::assertNull(
+            $db->getSchema()->getTableSchema($toRawTableName, true),
+            'Table must not exist with the expected raw name.',
+        );
+
+        $db->createCommand()->renameTable($fromTableName, $toTableName)->execute();
+
+        self::assertNull(
+            $db->getSchema()->getTableSchema($fromRawTableName, true),
+            'Table must not exist with the expected raw name after renaming.',
+        );
+        self::assertNotNull(
+            $db->getSchema()->getTableSchema($toRawTableName, true),
+            'Table must exist with the expected raw name after renaming.',
+        );
+
+        foreach ([$toRawTableName, $fromRawTableName] as $tableName) {
+            if ($db->getSchema()->getTableSchema($tableName, true) !== null) {
+                $db->createCommand()->dropTable($tableName)->execute();
+            }
+        }
     }
 
     public function testBindParamValue(): void

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -787,11 +787,16 @@ final class QueryBuilderTest extends BaseQueryBuilder
         return $data;
     }
 
-    public function testRenameTable(): void
+    #[DataProviderExternal(QueryBuilderProvider::class, 'renameTable')]
+    public function testRenameTable(string $oldName, string $newName, string $expectedSql): void
     {
         $qb = $this->getQueryBuilder();
-        $sql = $qb->renameTable('old_table', 'new_table');
-        $this->assertSame('sp_rename [old_table], [new_table]', $sql);
+
+        self::assertSame(
+            $expectedSql,
+            $qb->renameTable($oldName, $newName),
+            'Generated SQL must match the expected batch.',
+        );
     }
 
     public function testRenameColumn(): void

--- a/tests/framework/db/mssql/providers/CommandProvider.php
+++ b/tests/framework/db/mssql/providers/CommandProvider.php
@@ -24,17 +24,11 @@ final class CommandProvider
     public static function renameTable(): array
     {
         return [
-            'simple table names' => [
-                'yii2_mssql_rename_from',
-                'yii2_mssql_rename_to',
-                'yii2_mssql_rename_from',
-                'yii2_mssql_rename_to',
-            ],
-            'schema qualified old table name' => [
-                'dbo.yii2_mssql_rename_schema_from',
-                'yii2_mssql_rename_schema_to',
-                'yii2_mssql_rename_schema_from',
-                'yii2_mssql_rename_schema_to',
+            'already quoted table names' => [
+                '[dbo].[yii2_mssql_rename_quoted_from]',
+                '[yii2_mssql_rename_quoted_to]',
+                'yii2_mssql_rename_quoted_from',
+                'yii2_mssql_rename_quoted_to',
             ],
             'curly brace table placeholders' => [
                 '{{yii2_mssql_rename_curly_from}}',
@@ -42,17 +36,35 @@ final class CommandProvider
                 'yii2_mssql_rename_curly_from',
                 'yii2_mssql_rename_curly_to',
             ],
+            'new table name with single quote' => [
+                'yii2_mssql_rename_quote_from',
+                "yii2_mssql_rename_quote_to'",
+                'yii2_mssql_rename_quote_from',
+                "yii2_mssql_rename_quote_to'",
+            ],
+            'schema qualified new table name' => [
+                'yii2_mssql_rename_new_schema_from',
+                'dbo.yii2_mssql_rename_new_schema_to',
+                'yii2_mssql_rename_new_schema_from',
+                'yii2_mssql_rename_new_schema_to',
+            ],
+            'schema qualified old table name' => [
+                'dbo.yii2_mssql_rename_schema_from',
+                'yii2_mssql_rename_schema_to',
+                'yii2_mssql_rename_schema_from',
+                'yii2_mssql_rename_schema_to',
+            ],
+            'simple table names' => [
+                'yii2_mssql_rename_from',
+                'yii2_mssql_rename_to',
+                'yii2_mssql_rename_from',
+                'yii2_mssql_rename_to',
+            ],
             'square bracket placeholders' => [
                 '[[yii2_mssql_rename_square_from]]',
                 '[[yii2_mssql_rename_square_to]]',
                 'yii2_mssql_rename_square_from',
                 'yii2_mssql_rename_square_to',
-            ],
-            'already quoted table names' => [
-                '[dbo].[yii2_mssql_rename_quoted_from]',
-                '[yii2_mssql_rename_quoted_to]',
-                'yii2_mssql_rename_quoted_from',
-                'yii2_mssql_rename_quoted_to',
             ],
             'table names with spaces' => [
                 'yii2 mssql rename from',
@@ -60,11 +72,11 @@ final class CommandProvider
                 'yii2 mssql rename from',
                 'yii2 mssql rename to',
             ],
-            'new table name with single quote' => [
-                'yii2_mssql_rename_quote_from',
-                "yii2_mssql_rename_quote_to'",
-                'yii2_mssql_rename_quote_from',
-                "yii2_mssql_rename_quote_to'",
+            'table names with unicode characters' => [
+                'yii2_mssql_rename_unicode_from',
+                'yii2_mssql_rename_unicode_ñ_表',
+                'yii2_mssql_rename_unicode_from',
+                'yii2_mssql_rename_unicode_ñ_表',
             ],
         ];
     }

--- a/tests/framework/db/mssql/providers/CommandProvider.php
+++ b/tests/framework/db/mssql/providers/CommandProvider.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mssql\providers;
+
+/**
+ * Data provider for {@see \yiiunit\framework\db\mssql\CommandTest} test cases.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+final class CommandProvider
+{
+    /**
+     * @return array<string, array{string, string, string, string}>
+     */
+    public static function renameTable(): array
+    {
+        return [
+            'simple table names' => [
+                'yii2_mssql_rename_from',
+                'yii2_mssql_rename_to',
+                'yii2_mssql_rename_from',
+                'yii2_mssql_rename_to',
+            ],
+            'schema qualified old table name' => [
+                'dbo.yii2_mssql_rename_schema_from',
+                'yii2_mssql_rename_schema_to',
+                'yii2_mssql_rename_schema_from',
+                'yii2_mssql_rename_schema_to',
+            ],
+            'curly brace table placeholders' => [
+                '{{yii2_mssql_rename_curly_from}}',
+                '{{yii2_mssql_rename_curly_to}}',
+                'yii2_mssql_rename_curly_from',
+                'yii2_mssql_rename_curly_to',
+            ],
+            'square bracket placeholders' => [
+                '[[yii2_mssql_rename_square_from]]',
+                '[[yii2_mssql_rename_square_to]]',
+                'yii2_mssql_rename_square_from',
+                'yii2_mssql_rename_square_to',
+            ],
+            'already quoted table names' => [
+                '[dbo].[yii2_mssql_rename_quoted_from]',
+                '[yii2_mssql_rename_quoted_to]',
+                'yii2_mssql_rename_quoted_from',
+                'yii2_mssql_rename_quoted_to',
+            ],
+            'table names with spaces' => [
+                'yii2 mssql rename from',
+                'yii2 mssql rename to',
+                'yii2 mssql rename from',
+                'yii2 mssql rename to',
+            ],
+            'new table name with single quote' => [
+                'yii2_mssql_rename_quote_from',
+                "yii2_mssql_rename_quote_to'",
+                'yii2_mssql_rename_quote_from',
+                "yii2_mssql_rename_quote_to'",
+            ],
+        ];
+    }
+}

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -34,49 +34,63 @@ final class QueryBuilderProvider
                 '[dbo].[old_table]',
                 '[new_table]',
                 <<<SQL
-                EXEC sp_rename @objname = N'[dbo].[old_table]', @newname = [new_table], @objtype = N'OBJECT'
+                EXEC sp_rename @objname = N'[dbo].[old_table]', @newname = N'new_table', @objtype = N'OBJECT'
                 SQL,
             ],
             'curly brace table placeholders' => [
                 '{{old_table}}',
                 '{{new_table}}',
                 <<<SQL
-                EXEC sp_rename @objname = N'{{old_table}}', @newname = {{new_table}}, @objtype = N'OBJECT'
+                EXEC sp_rename @objname = N'{{old_table}}', @newname = N'new_table', @objtype = N'OBJECT'
+                SQL,
+            ],
+            'schema qualified new table name' => [
+                'old_table',
+                'dbo.new_table',
+                <<<SQL
+                EXEC sp_rename @objname = N'[old_table]', @newname = N'new_table', @objtype = N'OBJECT'
                 SQL,
             ],
             'schema qualified old table name' => [
                 'dbo.old_table',
                 'new_table',
                 <<<SQL
-                EXEC sp_rename @objname = N'[dbo].[old_table]', @newname = [new_table], @objtype = N'OBJECT'
+                EXEC sp_rename @objname = N'[dbo].[old_table]', @newname = N'new_table', @objtype = N'OBJECT'
                 SQL,
             ],
             'simple table names' => [
                 'old_table',
                 'new_table',
                 <<<SQL
-                EXEC sp_rename @objname = N'[old_table]', @newname = [new_table], @objtype = N'OBJECT'
+                EXEC sp_rename @objname = N'[old_table]', @newname = N'new_table', @objtype = N'OBJECT'
                 SQL,
             ],
             'square bracket placeholders' => [
                 '[[old_table]]',
                 '[[new_table]]',
                 <<<SQL
-                EXEC sp_rename @objname = N'[[old_table]]', @newname = [[new_table]], @objtype = N'OBJECT'
+                EXEC sp_rename @objname = N'[[old_table]]', @newname = N'new_table', @objtype = N'OBJECT'
                 SQL,
             ],
             'table names with single quotes' => [
                 "old'table",
                 "new'table",
                 <<<SQL
-                EXEC sp_rename @objname = N'[old''table]', @newname = [new'table], @objtype = N'OBJECT'
+                EXEC sp_rename @objname = N'[old''table]', @newname = N'new''table', @objtype = N'OBJECT'
                 SQL,
             ],
             'table names with spaces' => [
                 'old table',
                 'new table',
                 <<<SQL
-                EXEC sp_rename @objname = N'[old table]', @newname = [new table], @objtype = N'OBJECT'
+                EXEC sp_rename @objname = N'[old table]', @newname = N'new table', @objtype = N'OBJECT'
+                SQL,
+            ],
+            'table names with unicode characters' => [
+                'old_table',
+                'new_ñ_表',
+                <<<SQL
+                EXEC sp_rename @objname = N'[old_table]', @newname = N'new_ñ_表', @objtype = N'OBJECT'
                 SQL,
             ],
         ];

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -18,9 +18,70 @@ use yii\db\Schema;
 
 /**
  * Data provider for {@see \yiiunit\framework\db\mssql\QueryBuilderTest} test cases.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
  */
 final class QueryBuilderProvider
 {
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function renameTable(): array
+    {
+        return [
+            'already quoted table names' => [
+                '[dbo].[old_table]',
+                '[new_table]',
+                <<<SQL
+                EXEC sp_rename @objname = N'[dbo].[old_table]', @newname = [new_table], @objtype = N'OBJECT'
+                SQL,
+            ],
+            'curly brace table placeholders' => [
+                '{{old_table}}',
+                '{{new_table}}',
+                <<<SQL
+                EXEC sp_rename @objname = N'{{old_table}}', @newname = {{new_table}}, @objtype = N'OBJECT'
+                SQL,
+            ],
+            'schema qualified old table name' => [
+                'dbo.old_table',
+                'new_table',
+                <<<SQL
+                EXEC sp_rename @objname = N'[dbo].[old_table]', @newname = [new_table], @objtype = N'OBJECT'
+                SQL,
+            ],
+            'simple table names' => [
+                'old_table',
+                'new_table',
+                <<<SQL
+                EXEC sp_rename @objname = N'[old_table]', @newname = [new_table], @objtype = N'OBJECT'
+                SQL,
+            ],
+            'square bracket placeholders' => [
+                '[[old_table]]',
+                '[[new_table]]',
+                <<<SQL
+                EXEC sp_rename @objname = N'[[old_table]]', @newname = [[new_table]], @objtype = N'OBJECT'
+                SQL,
+            ],
+            'table names with single quotes' => [
+                "old'table",
+                "new'table",
+                <<<SQL
+                EXEC sp_rename @objname = N'[old''table]', @newname = [new'table], @objtype = N'OBJECT'
+                SQL,
+            ],
+            'table names with spaces' => [
+                'old table',
+                'new table',
+                <<<SQL
+                EXEC sp_rename @objname = N'[old table]', @newname = [new table], @objtype = N'OBJECT'
+                SQL,
+            ],
+        ];
+    }
+
     /**
      * @return array<string, array{Closure|string, string}>
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
