### PR TITLE
Fix MSSQL `QueryBuilder::renameColumn()` to pass `sp_rename` named arguments and a one-part new column name.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -95,6 +95,7 @@ Yii Framework 2 Change Log
 - Enh #20941: Modernize MSSQL `yii\db\mssql\Schema` internals and remove dead `unsigned` detection (terabytesoftw)
 - Bug #20942: Fix MSSQL `yii\db\mssql\QueryBuilder::alterColumn()` to drop column default, check, and unique constraints before the `ALTER COLUMN` statement, allowing column redefinition on constrained columns without duplicate constraint name errors (terabytesoftw)
 - Bug #20943: Fix MSSQL `QueryBuilder::renameTable()` to call `sp_rename` with string parameters and one-part new table names (terabytesoftw)
+- Bug #20944: Fix MSSQL `QueryBuilder::renameColumn()` to pass `sp_rename` named arguments and a one-part new column name (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -23,6 +23,8 @@ use function count;
 use function implode;
 use function preg_replace;
 use function str_replace;
+use function strrpos;
+use function substr;
 
 /**
  * QueryBuilder is the query builder for MS SQL Server databases (version 2019 and above).
@@ -136,17 +138,31 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * Builds a SQL statement for renaming a column.
-     * @param string $table the table whose column is to be renamed. The name will be properly quoted by the method.
-     * @param string $oldName the old name of the column. The name will be properly quoted by the method.
-     * @param string $newName the new name of the column. The name will be properly quoted by the method.
-     * @return string the SQL statement for renaming a DB column.
+     *
+     * @param string $table The table whose column is to be renamed. The name will be properly quoted by the method.
+     * @param string $oldName The old name of the column. The name will be properly quoted by the method.
+     * @param string $newName The new name of the column. The name will be properly quoted by the method.
+     *
+     * @return string The SQL statement for renaming a DB column.
      */
     public function renameColumn($table, $oldName, $newName)
     {
-        $table = $this->db->quoteTableName($table);
-        $oldName = $this->db->quoteColumnName($oldName);
-        $newName = $this->db->quoteColumnName($newName);
-        return "sp_rename '{$table}.{$oldName}', {$newName}, 'COLUMN'";
+        $schema = $this->db->getSchema();
+
+        $table = str_replace("'", "''", $this->db->quoteTableName($table));
+        $oldName = str_replace("'", "''", $this->db->quoteColumnName($oldName));
+
+        $newName = $this->db->quoteSql($this->db->quoteColumnName($newName));
+
+        if (($pos = strrpos($newName, '].[')) !== false) {
+            $newName = substr($newName, $pos + 2);
+        }
+
+        $newName = str_replace("'", "''", $schema->unquoteSimpleColumnName($newName));
+
+        return <<<SQL
+        EXEC sp_rename @objname = N'{$table}.{$oldName}', @newname = N'{$newName}', @objtype = N'COLUMN'
+        SQL;
     }
 
     /**

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -87,6 +87,66 @@ final class CommandTest extends BaseCommand
         }
     }
 
+    #[DataProviderExternal(CommandProvider::class, 'renameColumn')]
+    public function testRenameColumnWithQuotedNames(
+        string $tableName,
+        string $oldColumnName,
+        string $newColumnName,
+        string $rawTableName,
+        string $oldRawColumnName,
+        string $newRawColumnName,
+    ): void {
+        $db = $this->getConnection();
+        $schema = $db->getSchema();
+
+        if ($schema->getTableSchema($rawTableName, true) !== null) {
+            $db->createCommand()->dropTable($rawTableName)->execute();
+        }
+
+        $db->createCommand()->createTable(
+            $tableName,
+            [$oldColumnName => 'integer'],
+        )->execute();
+
+        $tableSchema = $schema->getTableSchema($rawTableName, true);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $tableSchema,
+            'Table must be created with the expected raw name.',
+        );
+        self::assertNotNull(
+            $tableSchema->getColumn($oldRawColumnName),
+            'Old column must exist before renaming.',
+        );
+        self::assertNull(
+            $tableSchema->getColumn($newRawColumnName),
+            'New column must not exist before renaming.',
+        );
+
+        $db->createCommand()->renameColumn($tableName, $oldColumnName, $newColumnName)->execute();
+
+        $tableSchema = $schema->getTableSchema($rawTableName, true);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $tableSchema,
+            'Table must exist with the expected raw name after renaming.',
+        );
+        self::assertNull(
+            $tableSchema->getColumn($oldRawColumnName),
+            'Old column must not exist after renaming.',
+        );
+        self::assertNotNull(
+            $tableSchema->getColumn($newRawColumnName),
+            'New column must exist after renaming.',
+        );
+
+        if ($schema->getTableSchema($rawTableName, true) !== null) {
+            $db->createCommand()->dropTable($rawTableName)->execute();
+        }
+    }
+
     public function testBindParamValue(): void
     {
         $db = $this->getConnection();

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -799,11 +799,16 @@ final class QueryBuilderTest extends BaseQueryBuilder
         );
     }
 
-    public function testRenameColumn(): void
+    #[DataProviderExternal(QueryBuilderProvider::class, 'renameColumn')]
+    public function testRenameColumn(string $table, string $oldName, string $newName, string $expectedSql): void
     {
         $qb = $this->getQueryBuilder();
-        $sql = $qb->renameColumn('test_table', 'old_col', 'new_col');
-        $this->assertSame("sp_rename '[test_table].[old_col]', [new_col], 'COLUMN'", $sql);
+
+        self::assertSame(
+            $expectedSql,
+            $qb->renameColumn($table, $oldName, $newName),
+            'Generated SQL must match the expected batch.',
+        );
     }
 
     public function testSelectExists(): void

--- a/tests/framework/db/mssql/providers/CommandProvider.php
+++ b/tests/framework/db/mssql/providers/CommandProvider.php
@@ -80,4 +80,77 @@ final class CommandProvider
             ],
         ];
     }
+
+    /**
+     * @return array<string, array{string, string, string, string, string, string}>
+     */
+    public static function renameColumn(): array
+    {
+        return [
+            'already quoted names' => [
+                '[dbo].[yii2_mssql_rename_column_quoted]',
+                '[old_col]',
+                '[new_col]',
+                'yii2_mssql_rename_column_quoted',
+                'old_col',
+                'new_col',
+            ],
+            'curly brace table and square bracket column placeholders' => [
+                '{{yii2_mssql_rename_column_curly}}',
+                '[[old_col]]',
+                '[[new_col]]',
+                'yii2_mssql_rename_column_curly',
+                'old_col',
+                'new_col',
+            ],
+            'names with single quotes' => [
+                "yii2_mssql_rename_column_quote'from",
+                "old'col",
+                "new'col",
+                "yii2_mssql_rename_column_quote'from",
+                "old'col",
+                "new'col",
+            ],
+            'names with spaces' => [
+                'yii2 mssql rename column',
+                'old col',
+                'new col',
+                'yii2 mssql rename column',
+                'old col',
+                'new col',
+            ],
+            'names with unicode characters' => [
+                'yii2_mssql_rename_column_unicode',
+                'old_ñ_表',
+                'new_ñ_表',
+                'yii2_mssql_rename_column_unicode',
+                'old_ñ_表',
+                'new_ñ_表',
+            ],
+            'schema qualified new column name' => [
+                'yii2_mssql_rename_column_new_schema',
+                'old_col',
+                'dbo.new_col',
+                'yii2_mssql_rename_column_new_schema',
+                'old_col',
+                'new_col',
+            ],
+            'schema qualified table name' => [
+                'dbo.yii2_mssql_rename_column_schema',
+                'old_col',
+                'new_col',
+                'yii2_mssql_rename_column_schema',
+                'old_col',
+                'new_col',
+            ],
+            'simple names' => [
+                'yii2_mssql_rename_column',
+                'old_col',
+                'new_col',
+                'yii2_mssql_rename_column',
+                'old_col',
+                'new_col',
+            ],
+        ];
+    }
 }

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -97,6 +97,79 @@ final class QueryBuilderProvider
     }
 
     /**
+     * @return array<string, array{string, string, string, string}>
+     */
+    public static function renameColumn(): array
+    {
+        return [
+            'already quoted names' => [
+                '[dbo].[test_table]',
+                '[old_col]',
+                '[new_col]',
+                <<<SQL
+                EXEC sp_rename @objname = N'[dbo].[test_table].[old_col]', @newname = N'new_col', @objtype = N'COLUMN'
+                SQL,
+            ],
+            'curly brace table and square bracket column placeholders' => [
+                '{{test_table}}',
+                '[[old_col]]',
+                '[[new_col]]',
+                <<<SQL
+                EXEC sp_rename @objname = N'{{test_table}}.[[old_col]]', @newname = N'new_col', @objtype = N'COLUMN'
+                SQL,
+            ],
+            'names with single quotes' => [
+                "test'table",
+                "old'col",
+                "new'col",
+                <<<SQL
+                EXEC sp_rename @objname = N'[test''table].[old''col]', @newname = N'new''col', @objtype = N'COLUMN'
+                SQL,
+            ],
+            'names with spaces' => [
+                'test table',
+                'old col',
+                'new col',
+                <<<SQL
+                EXEC sp_rename @objname = N'[test table].[old col]', @newname = N'new col', @objtype = N'COLUMN'
+                SQL,
+            ],
+            'names with unicode characters' => [
+                'test_table',
+                'old_ñ_表',
+                'new_ñ_表',
+                <<<SQL
+                EXEC sp_rename @objname = N'[test_table].[old_ñ_表]', @newname = N'new_ñ_表', @objtype = N'COLUMN'
+                SQL,
+            ],
+            'schema qualified new column name' => [
+                'test_table',
+                'old_col',
+                'dbo.new_col',
+                <<<SQL
+                EXEC sp_rename @objname = N'[test_table].[old_col]', @newname = N'new_col', @objtype = N'COLUMN'
+                SQL,
+            ],
+            'schema qualified table name' => [
+                'dbo.test_table',
+                'old_col',
+                'new_col',
+                <<<SQL
+                EXEC sp_rename @objname = N'[dbo].[test_table].[old_col]', @newname = N'new_col', @objtype = N'COLUMN'
+                SQL,
+            ],
+            'simple names' => [
+                'test_table',
+                'old_col',
+                'new_col',
+                <<<SQL
+                EXEC sp_rename @objname = N'[test_table].[old_col]', @newname = N'new_col', @objtype = N'COLUMN'
+                SQL,
+            ],
+        ];
+    }
+
+    /**
      * @return array<string, array{Closure|string, string}>
      */
     public static function alterColumn(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
