### PR TITLE
Fix MSSQL `QueryBuilder::addDefaultValue()` to generate valid `DEFAULT NULL` and `DEFAULT 0` SQL for `null` and `false` values.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -96,6 +96,7 @@ Yii Framework 2 Change Log
 - Bug #20942: Fix MSSQL `yii\db\mssql\QueryBuilder::alterColumn()` to drop column default, check, and unique constraints before the `ALTER COLUMN` statement, allowing column redefinition on constrained columns without duplicate constraint name errors (terabytesoftw)
 - Bug #20943: Fix MSSQL `QueryBuilder::renameTable()` to call `sp_rename` with string parameters and one-part new table names (terabytesoftw)
 - Bug #20944: Fix MSSQL `QueryBuilder::renameColumn()` to pass `sp_rename` named arguments and a one-part new column name (terabytesoftw)
+- Bug: Fix MSSQL `QueryBuilder::addDefaultValue()` to generate valid `DEFAULT NULL` and `DEFAULT 0` SQL for `null` and `false` values (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -249,9 +249,21 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     public function addDefaultValue($name, $table, $column, $value)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table) . ' ADD CONSTRAINT '
-            . $this->db->quoteColumnName($name) . ' DEFAULT ' . $this->db->quoteValue($value) . ' FOR '
-            . $this->db->quoteColumnName($column);
+        $tableName = $this->db->quoteTableName($table);
+        $constraintName = $this->db->quoteColumnName($name);
+
+        $defaultValue = match ($value) {
+            null => 'NULL',
+            false => '0',
+            true => '1',
+            default => (string) $this->db->quoteValue($value),
+        };
+
+        $columnName = $this->db->quoteColumnName($column);
+
+        return <<<SQL
+        ALTER TABLE {$tableName} ADD CONSTRAINT {$constraintName} DEFAULT {$defaultValue} FOR {$columnName}
+        SQL;
     }
 
     /**

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -216,28 +216,132 @@ final class CommandTest extends BaseCommand
     public function testAddDropDefaultValue(): void
     {
         $db = $this->getConnection(false);
+
         $tableName = 'test_def';
         $name = 'test_def_constraint';
+
         /** @var Schema $schema */
         $schema = $db->getSchema();
 
         if ($schema->getTableSchema($tableName) !== null) {
             $db->createCommand()->dropTable($tableName)->execute();
         }
-        $db->createCommand()->createTable($tableName, [
-            'int1' => 'integer',
-        ])->execute();
+
+        $db->createCommand()->createTable(
+            $tableName,
+            ['int1' => 'integer'],
+        )->execute();
 
         $defaultValues = $schema->getTableDefaultValues($tableName, true);
-        $this->assertEmpty($defaultValues);
 
-        $db->createCommand()->addDefaultValue($name, $tableName, 'int1', 41)->execute();
-        $defaultValues = $schema->getTableDefaultValues($tableName, true);
-        $this->assertMatchesRegularExpression('/^.*41.*$/', $defaultValues[0]->value);
+        self::assertEmpty(
+            $defaultValues,
+            'Default constraints must be empty before adding a default value.',
+        );
 
-        $db->createCommand()->dropDefaultValue($name, $tableName)->execute();
+        $db->createCommand()->addDefaultValue(
+            $name,
+            $tableName,
+            'int1',
+            41,
+        )->execute();
+
         $defaultValues = $schema->getTableDefaultValues($tableName, true);
-        $this->assertEmpty($defaultValues);
+
+        self::assertMatchesRegularExpression(
+            '/^.*41.*$/',
+            $defaultValues[0]->value,
+            'Default constraint definition must contain the integer literal.',
+        );
+
+        $db->createCommand()->dropDefaultValue(
+            $name,
+            $tableName,
+        )->execute();
+
+        $defaultValues = $schema->getTableDefaultValues($tableName, true);
+
+        self::assertEmpty(
+            $defaultValues,
+            'Default constraints must be empty after dropping the default value.',
+        );
+
+        if ($schema->getTableSchema($tableName, true) !== null) {
+            $db->createCommand()->dropTable($tableName)->execute();
+        }
+    }
+
+    #[DataProviderExternal(CommandProvider::class, 'addDefaultValue')]
+    public function testAddDropDefaultValueWithMssqlLiterals(
+        string $tableName,
+        string $name,
+        string $column,
+        string $columnType,
+        mixed $value,
+        string $expectedValuePattern,
+    ): void {
+        $db = $this->getConnection(false);
+
+        /** @var Schema $schema */
+        $schema = $db->getSchema();
+
+        if ($schema->getTableSchema($tableName) !== null) {
+            $db->createCommand()->dropTable($tableName)->execute();
+        }
+
+        $db->createCommand()->createTable(
+            $tableName,
+            [$column => $columnType],
+        )->execute();
+
+        self::assertEmpty(
+            $schema->getTableDefaultValues($tableName, true),
+            'Default constraints must be empty before adding a default value.',
+        );
+
+        $db->createCommand()->addDefaultValue(
+            $name,
+            $tableName,
+            $column,
+            $value,
+        )->execute();
+
+        $defaultValues = $schema->getTableDefaultValues($tableName, true);
+
+        self::assertCount(
+            1,
+            $defaultValues,
+            'Exactly one default constraint must be created.',
+        );
+        self::assertSame(
+            $name,
+            $defaultValues[0]->name,
+            'Default constraint name must match the requested name.',
+        );
+        self::assertSame(
+            [$column],
+            $defaultValues[0]->columnNames,
+            'Default constraint must be bound to the requested column.',
+        );
+        self::assertMatchesRegularExpression(
+            $expectedValuePattern,
+            $defaultValues[0]->value,
+            'Default constraint definition must contain the expected MSSQL literal.',
+        );
+
+        $db->createCommand()->dropDefaultValue(
+            $name,
+            $tableName,
+        )->execute();
+
+        self::assertEmpty(
+            $schema->getTableDefaultValues($tableName, true),
+            'Default constraints must be empty after dropping the default value.',
+        );
+
+        if ($schema->getTableSchema($tableName, true) !== null) {
+            $db->createCommand()->dropTable($tableName)->execute();
+        }
     }
 
     public function testAlterColumn(): void

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -651,6 +651,23 @@ final class QueryBuilderTest extends BaseQueryBuilder
         return $newData;
     }
 
+    #[DataProviderExternal(QueryBuilderProvider::class, 'addDefaultValue')]
+    public function testAddDefaultValue(
+        string $name,
+        string $table,
+        string $column,
+        mixed $value,
+        string $expected,
+    ): void {
+        $qb = $this->getQueryBuilder(false);
+
+        self::assertSame(
+            $expected,
+            $qb->addDefaultValue($name, $table, $column, $value),
+            'Generated SQL must match the expected DEFAULT constraint statement.',
+        );
+    }
+
     #[DataProviderExternal(QueryBuilderProvider::class, 'alterColumn')]
     public function testAlterColumn(string|Closure $type, string $expected): void
     {

--- a/tests/framework/db/mssql/providers/CommandProvider.php
+++ b/tests/framework/db/mssql/providers/CommandProvider.php
@@ -19,6 +19,39 @@ namespace yiiunit\framework\db\mssql\providers;
 final class CommandProvider
 {
     /**
+     * @return array<string, array{string, string, string, string, mixed, string}>
+     */
+    public static function addDefaultValue(): array
+    {
+        return [
+            'false bit default' => [
+                'test_def_bit',
+                'test_def_bit_constraint',
+                'bit1',
+                'bit',
+                false,
+                '/^.*0.*$/',
+            ],
+            'integer default' => [
+                'test_def_int',
+                'test_def_int_constraint',
+                'int1',
+                'integer',
+                41,
+                '/^.*41.*$/',
+            ],
+            'null default' => [
+                'test_def_null',
+                'test_def_null_constraint',
+                'int1',
+                'integer',
+                null,
+                '/^.*NULL.*$/i',
+            ],
+        ];
+    }
+
+    /**
      * @return array<string, array{string, string, string, string}>
      */
     public static function renameTable(): array

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -170,6 +170,51 @@ final class QueryBuilderProvider
     }
 
     /**
+     * @return array<string, array{string, string, string, mixed, string}>
+     */
+    public static function addDefaultValue(): array
+    {
+        return [
+            'expression default' => [
+                'CN_default',
+                'T_constraints_1',
+                'C_timestamp',
+                new Expression('CURRENT_TIMESTAMP'),
+                <<<SQL
+                ALTER TABLE [T_constraints_1] ADD CONSTRAINT [CN_default] DEFAULT CURRENT_TIMESTAMP FOR [C_timestamp]
+                SQL,
+            ],
+            'false default' => [
+                'CN_default',
+                'T_constraints_1',
+                'C_bit',
+                false,
+                <<<SQL
+                ALTER TABLE [T_constraints_1] ADD CONSTRAINT [CN_default] DEFAULT 0 FOR [C_bit]
+                SQL,
+            ],
+            'integer default' => [
+                'CN_default',
+                'T_constraints_1',
+                'C_default',
+                1,
+                <<<SQL
+                ALTER TABLE [T_constraints_1] ADD CONSTRAINT [CN_default] DEFAULT 1 FOR [C_default]
+                SQL,
+            ],
+            'null default' => [
+                'CN_default',
+                'T_constraints_1',
+                'C_default',
+                null,
+                <<<SQL
+                ALTER TABLE [T_constraints_1] ADD CONSTRAINT [CN_default] DEFAULT NULL FOR [C_default]
+                SQL,
+            ],
+        ];
+    }
+
+    /**
      * @return array<string, array{Closure|string, string}>
      */
     public static function alterColumn(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
