### PR TITLE
Restrict MSSQL `dropDefaultValue()` to default constraints and cover catalog-qualified `alterColumn()` constraint replacement.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -96,7 +96,8 @@ Yii Framework 2 Change Log
 - Bug #20942: Fix MSSQL `yii\db\mssql\QueryBuilder::alterColumn()` to drop column default, check, and unique constraints before the `ALTER COLUMN` statement, allowing column redefinition on constrained columns without duplicate constraint name errors (terabytesoftw)
 - Bug #20943: Fix MSSQL `QueryBuilder::renameTable()` to call `sp_rename` with string parameters and one-part new table names (terabytesoftw)
 - Bug #20944: Fix MSSQL `QueryBuilder::renameColumn()` to pass `sp_rename` named arguments and a one-part new column name (terabytesoftw)
-- Bug: Fix MSSQL `QueryBuilder::addDefaultValue()` to generate valid `DEFAULT NULL` and `DEFAULT 0` SQL for `null` and `false` values (terabytesoftw)
+- Bug #20951: Fix MSSQL `QueryBuilder::addDefaultValue()` to generate valid `DEFAULT NULL` and `DEFAULT 0` SQL for `null` and `false` values (terabytesoftw)
+- Bug #20952: Restrict MSSQL `dropDefaultValue()` to default constraints and cover catalog-qualified `alterColumn()` constraint replacement (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -268,11 +268,32 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * {@inheritdoc}
+     *
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-default-constraints-transact-sql
+     * @see https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql
      */
     public function dropDefaultValue($name, $table)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table)
-            . ' DROP CONSTRAINT ' . $this->db->quoteColumnName($name);
+        $tableName = str_replace("'", "''", $this->db->quoteTableName($table));
+        $constraintName = str_replace("'", "''", $name);
+
+        return <<<SQL
+        DECLARE @tableName NVARCHAR(MAX) = N'{$tableName}'
+        DECLARE @constraintName SYSNAME = N'{$constraintName}'
+        DECLARE @dropSql NVARCHAR(MAX)
+
+        SELECT @dropSql = N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name])
+        FROM [sys].[default_constraints] AS [dc]
+        WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName, N'U')
+            AND [dc].[name] = @constraintName
+
+        IF @dropSql IS NULL
+        BEGIN
+            THROW 50000, 'Default constraint not found on table.', 1;
+        END
+
+        EXEC (@dropSql)
+        SQL;
     }
 
     /**

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -12,6 +12,7 @@ namespace yiiunit\framework\db\mssql;
 
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
+use yii\db\Exception;
 use yii\db\IntegrityException;
 use yii\db\mssql\Schema;
 use yii\db\mssql\TableSchema;
@@ -271,6 +272,99 @@ final class CommandTest extends BaseCommand
         }
     }
 
+    public function testDropDefaultValueDoesNotDropNonDefaultConstraints(): void
+    {
+        $db = $this->getConnection(false);
+
+        $tableName = 'test_def_non_default';
+        $defaultName = 'test_def_non_default_constraint';
+        $checkName = 'test_def_non_default_check';
+
+        /** @var Schema $schema */
+        $schema = $db->getSchema();
+
+        if ($schema->getTableSchema($tableName) !== null) {
+            $db->createCommand()->dropTable($tableName)->execute();
+        }
+
+        $db->createCommand()->createTable(
+            $tableName,
+            ['int1' => 'integer'],
+        )->execute();
+        $db->createCommand()->addDefaultValue(
+            $defaultName,
+            $tableName,
+            'int1',
+            41,
+        )->execute();
+        $db->createCommand()->addCheck(
+            $checkName,
+            $tableName,
+            '[[int1]] >= 0',
+        )->execute();
+
+        $db->createCommand()->dropDefaultValue(
+            $defaultName,
+            $tableName,
+        )->execute();
+
+        self::assertEmpty(
+            $schema->getTableDefaultValues($tableName, true),
+            'The default constraint must be removable by its own name.',
+        );
+        self::assertCount(
+            1,
+            $schema->getTableChecks($tableName, true),
+            'The CHECK constraint must remain after dropping only the default constraint.',
+        );
+
+        if ($schema->getTableSchema($tableName, true) !== null) {
+            $db->createCommand()->dropTable($tableName)->execute();
+        }
+    }
+
+    public function testThrowExceptionWhenDropDefaultValueUsesNonDefaultConstraint(): void
+    {
+        $db = $this->getConnection(false);
+
+        $tableName = 'test_def_non_default';
+        $defaultName = 'test_def_non_default_constraint';
+        $checkName = 'test_def_non_default_check';
+
+        /** @var Schema $schema */
+        $schema = $db->getSchema();
+
+        if ($schema->getTableSchema($tableName) !== null) {
+            $db->createCommand()->dropTable($tableName)->execute();
+        }
+
+        $db->createCommand()->createTable(
+            $tableName,
+            ['int1' => 'integer'],
+        )->execute();
+        $db->createCommand()->addDefaultValue(
+            $defaultName,
+            $tableName,
+            'int1',
+            41,
+        )->execute();
+        $db->createCommand()->addCheck(
+            $checkName,
+            $tableName,
+            '[[int1]] >= 0',
+        )->execute();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches(
+            '/Default constraint not found on table\./',
+        );
+
+        $db->createCommand()->dropDefaultValue(
+            $checkName,
+            $tableName,
+        )->execute();
+    }
+
     #[DataProviderExternal(CommandProvider::class, 'addDefaultValue')]
     public function testAddDropDefaultValueWithMssqlLiterals(
         string $tableName,
@@ -369,7 +463,10 @@ final class CommandTest extends BaseCommand
         $db->createCommand()->alterColumn(
             'foo1',
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)->notNull(),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)
+                ->notNull(),
         )->execute();
 
         $tableSchema = $db->getTableSchema('foo1', true);
@@ -392,7 +489,11 @@ final class CommandTest extends BaseCommand
         $db->createCommand()->alterColumn(
             'foo1',
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)->null()->check('LEN(bar) > 5'),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)
+                ->null()
+                ->check('LEN(bar) > 5'),
         )->execute();
 
         $tableSchema = $db->getTableSchema('foo1', true);
@@ -424,7 +525,10 @@ final class CommandTest extends BaseCommand
         $db->createCommand()->alterColumn(
             'foo1',
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)->check('LEN(bar) > 5'),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)
+                ->check('LEN(bar) > 5'),
         )->execute();
 
         $this->expectException(IntegrityException::class);
@@ -443,7 +547,10 @@ final class CommandTest extends BaseCommand
         $db->createCommand()->alterColumn(
             'foo1',
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)->unique(),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)
+                ->unique(),
         )->execute();
 
         self::assertSame(
@@ -500,10 +607,15 @@ final class CommandTest extends BaseCommand
 
         $table = "{$catalogName}.dbo.foo1";
 
+        $quotedTable = $db->quoteTableName($table);
+
         $db->createCommand()->alterColumn(
             $table,
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)->defaultValue('initial'),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)
+                ->defaultValue('initial'),
         )->execute();
 
         $tableSchema = $db->getTableSchema($table, true);
@@ -527,7 +639,10 @@ final class CommandTest extends BaseCommand
         $db->createCommand()->alterColumn(
             $table,
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_INTEGER)->defaultValue(0),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
+                ->defaultValue(0),
         )->execute();
 
         $tableSchema = $db->getTableSchema($table, true);
@@ -538,18 +653,195 @@ final class CommandTest extends BaseCommand
             'Type change must succeed with a default bound.',
         );
 
+        /** @var Schema $schema */
         $schema = $db->getSchema();
 
-        self::assertInstanceOf(
-            Schema::class,
-            $schema,
-            'Schema must be available.',
-        );
         self::assertCount(
             1,
             $schema->getTableDefaultValues($table, true),
             'Old default constraint must be replaced, not duplicated.',
         );
+
+        $db->createCommand()->alterColumn(
+            $table,
+            'bar',
+            $db->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 96)
+                ->defaultValue('catalog')
+                ->check('LEN(bar) > 3')
+                ->unique(),
+        )->execute();
+
+        $tableSchema = $db->getTableSchema($table, true);
+
+        self::assertSame(
+            'nvarchar(96)',
+            $tableSchema->getColumn('bar')->dbType,
+            'Column type must reflect the catalog-qualified ALTER COLUMN definition.',
+        );
+        self::assertCount(
+            1,
+            $schema->getTableDefaultValues($table, true),
+            'Exactly one default constraint must be created for the catalog-qualified table.',
+        );
+        self::assertCount(
+            1,
+            $schema->getTableChecks($table, true),
+            'Exactly one check constraint must be created for the catalog-qualified table.',
+        );
+        self::assertCount(
+            1,
+            $schema->getTableUniques($table, true),
+            'Exactly one unique constraint must be created for the catalog-qualified table.',
+        );
+        self::assertSame(
+            1,
+            $db->createCommand(
+                <<<SQL
+                INSERT INTO {$quotedTable} DEFAULT VALUES
+                SQL,
+            )->execute(),
+            'The catalog-qualified default constraint must be usable by INSERT.',
+        );
+        self::assertSame(
+            'catalog',
+            $db->createCommand(
+                <<<SQL
+                SELECT TOP 1 [bar] FROM {$quotedTable} ORDER BY [id] DESC
+                SQL,
+            )->queryScalar(),
+            'The default constraint must populate the column value.',
+        );
+
+        $db->createCommand()->alterColumn(
+            $table,
+            'bar',
+            $db->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)
+                ->defaultValue('changed')
+                ->check('LEN(bar) > 5')
+                ->unique(),
+        )->execute();
+
+        $tableSchema = $db->getTableSchema($table, true);
+
+        self::assertSame(
+            'nvarchar(128)',
+            $tableSchema->getColumn('bar')->dbType,
+            'A second catalog-qualified ALTER COLUMN must change the column type.',
+        );
+        self::assertCount(
+            1,
+            $schema->getTableDefaultValues($table, true),
+            'The old default constraint must be replaced, not duplicated.',
+        );
+        self::assertCount(
+            1,
+            $schema->getTableChecks($table, true),
+            'The old check constraint must be replaced, not duplicated.',
+        );
+        self::assertCount(
+            1,
+            $schema->getTableUniques($table, true),
+            'The old unique constraint must be replaced, not duplicated.',
+        );
+        self::assertSame(
+            1,
+            $db->createCommand(
+                <<<SQL
+                INSERT INTO {$quotedTable} DEFAULT VALUES
+                SQL,
+            )->execute(),
+            'The replacement default constraint must be usable by INSERT.',
+        );
+        self::assertSame(
+            'changed',
+            $db->createCommand(
+                <<<SQL
+                SELECT TOP 1 [bar] FROM {$quotedTable} ORDER BY [id] DESC
+                SQL,
+            )->queryScalar(),
+            'The replacement default constraint must populate the column value.',
+        );
+    }
+
+    public function testThrowIntegrityExceptionWhenInsertViolatesCatalogQualifiedAlterColumnCheckConstraint(): void
+    {
+        $db = $this->getConnection();
+
+        $catalogName = (string) $db->createCommand(
+            <<<SQL
+            SELECT DB_NAME()
+            SQL
+        )->queryScalar();
+
+        $table = "{$catalogName}.dbo.foo1";
+        $quotedTable = $db->quoteTableName($table);
+
+        $db->createCommand()->alterColumn(
+            $table,
+            'bar',
+            $db->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 96)
+                ->defaultValue('catalog')
+                ->check('LEN(bar) > 3')
+                ->unique(),
+        )->execute();
+
+        $this->expectException(IntegrityException::class);
+        $this->expectExceptionMessageMatches(
+            '/CHECK constraint/i',
+        );
+
+        $db->createCommand(
+            <<<SQL
+            INSERT INTO {$quotedTable} ([bar]) VALUES ('abc')
+            SQL,
+        )->execute();
+    }
+
+    public function testThrowIntegrityExceptionWhenInsertViolatesCatalogQualifiedAlterColumnReplacementCheckConstraint(): void
+    {
+        $db = $this->getConnection();
+
+        $catalogName = (string) $db->createCommand(
+            <<<SQL
+            SELECT DB_NAME()
+            SQL
+        )->queryScalar();
+
+        $table = "{$catalogName}.dbo.foo1";
+        $quotedTable = $db->quoteTableName($table);
+
+        $db->createCommand()->alterColumn(
+            $table,
+            'bar',
+            $db->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 96)
+                ->defaultValue('catalog')
+                ->check('LEN(bar) > 3')
+                ->unique(),
+        )->execute();
+        $db->createCommand()->alterColumn(
+            $table,
+            'bar',
+            $db->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)
+                ->defaultValue('changed')
+                ->check('LEN(bar) > 5')
+                ->unique(),
+        )->execute();
+
+        $this->expectException(IntegrityException::class);
+        $this->expectExceptionMessageMatches(
+            '/CHECK constraint/i',
+        );
+
+        $db->createCommand(
+            <<<SQL
+            INSERT INTO {$quotedTable} ([bar]) VALUES ('abcd')
+            SQL,
+        )->execute();
     }
 
     public function testAlterColumnReplacesDefaultValue(): void
@@ -559,12 +851,18 @@ final class CommandTest extends BaseCommand
         $db->createCommand()->alterColumn(
             'foo1',
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)->defaultValue('initial'),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)
+                ->defaultValue('initial'),
         )->execute();
         $db->createCommand()->alterColumn(
             'foo1',
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_INTEGER)->defaultValue(0),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
+                ->defaultValue(0),
         )->execute();
 
         $tableSchema = $db->getTableSchema('foo1', true);
@@ -596,12 +894,18 @@ final class CommandTest extends BaseCommand
         $db->createCommand()->alterColumn(
             'foo1',
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)->check('LEN(bar) > 5'),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)
+                ->check('LEN(bar) > 5'),
         )->execute();
         $db->createCommand()->alterColumn(
             'foo1',
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)->check('LEN(bar) > 3'),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)
+                ->check('LEN(bar) > 3'),
         )->execute();
 
         $schema = $db->getSchema();
@@ -634,12 +938,18 @@ final class CommandTest extends BaseCommand
         $db->createCommand()->alterColumn(
             'foo1',
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)->unique(),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)
+                ->unique(),
         )->execute();
         $db->createCommand()->alterColumn(
             'foo1',
             'bar',
-            $db->getSchema()->createColumnSchemaBuilder(Schema::TYPE_STRING, 32)->unique(),
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 32)
+                ->unique(),
         )->execute();
 
         $tableSchema = $db->getTableSchema('foo1', true);

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -668,6 +668,12 @@ final class QueryBuilderTest extends BaseQueryBuilder
         );
     }
 
+    #[DataProviderExternal(QueryBuilderProvider::class, 'defaultValuesProvider')]
+    public function testAddDropDefaultValue(string $sql, Closure $builder): void
+    {
+        parent::testAddDropDefaultValue($sql, $builder);
+    }
+
     #[DataProviderExternal(QueryBuilderProvider::class, 'alterColumn')]
     public function testAlterColumn(string|Closure $type, string $expected): void
     {

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -14,6 +14,7 @@ use Closure;
 use yii\db\ColumnSchemaBuilder;
 use yii\db\Connection;
 use yii\db\Expression;
+use yii\db\QueryBuilder;
 use yii\db\Schema;
 
 /**
@@ -24,6 +25,72 @@ use yii\db\Schema;
  */
 final class QueryBuilderProvider
 {
+    /**
+     * @return array<string, array{string, Closure}>
+     */
+    public static function defaultValuesProvider(): array
+    {
+        return [
+            'add' => [
+                <<<SQL
+                ALTER TABLE [T_constraints_1] ADD CONSTRAINT [CN_default] DEFAULT 0 FOR [C_default]
+                SQL,
+                fn (QueryBuilder $qb): string => $qb->addDefaultValue(
+                    'CN_default',
+                    'T_constraints_1',
+                    'C_default',
+                    0,
+                ),
+            ],
+            'drop' => [
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[T_constraints_1]'
+                DECLARE @constraintName SYSNAME = N'CN_default'
+                DECLARE @dropSql NVARCHAR(MAX)
+
+                SELECT @dropSql = N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name])
+                FROM [sys].[default_constraints] AS [dc]
+                WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName, N'U')
+                    AND [dc].[name] = @constraintName
+
+                IF @dropSql IS NULL
+                BEGIN
+                    THROW 50000, 'Default constraint not found on table.', 1;
+                END
+
+                EXEC (@dropSql)
+                SQL,
+                fn (QueryBuilder $qb): string => $qb->dropDefaultValue(
+                    'CN_default',
+                    'T_constraints_1',
+                ),
+            ],
+            'drop catalog-qualified' => [
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[yiitest].[dbo].[T_constraints_1]'
+                DECLARE @constraintName SYSNAME = N'CN_default'
+                DECLARE @dropSql NVARCHAR(MAX)
+
+                SELECT @dropSql = N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name])
+                FROM [sys].[default_constraints] AS [dc]
+                WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName, N'U')
+                    AND [dc].[name] = @constraintName
+
+                IF @dropSql IS NULL
+                BEGIN
+                    THROW 50000, 'Default constraint not found on table.', 1;
+                END
+
+                EXEC (@dropSql)
+                SQL,
+                fn (QueryBuilder $qb): string => $qb->dropDefaultValue(
+                    'CN_default',
+                    'yiitest.dbo.T_constraints_1',
+                ),
+            ],
+        ];
+    }
+
     /**
      * @return array<string, array{string, string, string}>
      */
@@ -708,6 +775,55 @@ final class QueryBuilderProvider
                     EXEC (@dropCommands)
                 ALTER TABLE [yiitest].[dbo].[foo1] ALTER COLUMN [bar] nvarchar(255)
                 ALTER TABLE [yiitest].[dbo].[foo1] ADD CONSTRAINT [DF_yiitestdbofoo1_bar] DEFAULT 'AbCdE' FOR [bar]
+                SQL,
+            ],
+            'catalog-qualified string with default check and unique constraints' => [
+                'yiitest.dbo.foo1',
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)
+                    ->defaultValue('AbCdE')
+                    ->check('LEN(bar) > 3')
+                    ->unique(),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[yiitest].[dbo].[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [yiitest].[dbo].[foo1] ALTER COLUMN [bar] nvarchar(64)
+                ALTER TABLE [yiitest].[dbo].[foo1] ADD CONSTRAINT [DF_yiitestdbofoo1_bar] DEFAULT 'AbCdE' FOR [bar]
+                ALTER TABLE [yiitest].[dbo].[foo1] ADD CONSTRAINT [CK_yiitestdbofoo1_bar] CHECK (LEN(bar) > 3)
+                ALTER TABLE [yiitest].[dbo].[foo1] ADD CONSTRAINT [UQ_yiitestdbofoo1_bar] UNIQUE ([bar])
                 SQL,
             ],
             'schema-qualified plain string type' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
