### PR TITLE
Fix MSSQL `QueryBuilder::resetSequence()` to reseed `DBCC CHECKIDENT` for the requested next identity value.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -98,6 +98,7 @@ Yii Framework 2 Change Log
 - Bug #20944: Fix MSSQL `QueryBuilder::renameColumn()` to pass `sp_rename` named arguments and a one-part new column name (terabytesoftw)
 - Bug #20951: Fix MSSQL `QueryBuilder::addDefaultValue()` to generate valid `DEFAULT NULL` and `DEFAULT 0` SQL for `null` and `false` values (terabytesoftw)
 - Bug #20952: Restrict MSSQL `dropDefaultValue()` to default constraints and cover catalog-qualified `alterColumn()` constraint replacement (terabytesoftw)
+- Bug #20953: Fix MSSQL `QueryBuilder::resetSequence()` to reseed `DBCC CHECKIDENT` for the requested next identity value (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -958,13 +958,17 @@ class Command extends Component
 
     /**
      * Creates a SQL command for resetting the sequence value of a table's primary key.
-     * The sequence will be reset such that the primary key of the next new row inserted
-     * will have the specified value or the maximum existing value +1.
-     * @param string $table the name of the table whose primary key sequence will be reset
-     * @param mixed $value the value for the primary key of the next new row inserted. If this is not set,
-     * the next new row's primary key will have the maximum existing value +1.
-     * @return $this the command object itself
-     * @throws NotSupportedException if this is not supported by the underlying DBMS
+     *
+     * The sequence will be reset such that the primary key of the next new row inserted will have the specified value
+     * or the maximum existing value `+1`.
+     *
+     * @param string $table The name of the table whose primary key sequence will be reset.
+     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
+     * inserted. If this is not set, the next new row's primary key will have the maximum existing value `+1`.
+     *
+     * @throws NotSupportedException if this is not supported by the underlying DBMS.
+     *
+     * @return $this The command object itself.
      */
     public function resetSequence($table, $value = null)
     {
@@ -975,13 +979,18 @@ class Command extends Component
 
     /**
      * Executes a db command resetting the sequence value of a table's primary key.
+     *
      * Reason for execute is that some databases (Oracle) need several queries to do so.
-     * The sequence is reset such that the primary key of the next new row inserted
-     * will have the specified value or the maximum existing value +1.
-     * @param string $table the name of the table whose primary key sequence is reset
-     * @param mixed $value the value for the primary key of the next new row inserted. If this is not set,
-     * the next new row's primary key will have the maximum existing value +1.
-     * @throws NotSupportedException if this is not supported by the underlying DBMS
+     *
+     * The sequence is reset such that the primary key of the next new row inserted will have the specified value or the
+     * maximum existing value `+1`.
+     *
+     * @param string $table The name of the table whose primary key sequence is reset.
+     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
+     * inserted. If this is not set, the next new row's primary key will have the maximum existing value `+1`.
+     *
+     * @throws NotSupportedException if this is not supported by the underlying DBMS.
+     *
      * @since 2.0.16
      */
     public function executeResetSequence($table, $value = null)

--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -963,8 +963,8 @@ class Command extends Component
      * or the maximum existing value `+1`.
      *
      * @param string $table The name of the table whose primary key sequence will be reset.
-     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
-     * inserted. If this is not set, the next new row's primary key will have the maximum existing value `+1`.
+     * @param int|null $value The integer value for the primary key of the next new row inserted. If this is not set,
+     * the next new row's primary key will have the maximum existing value `+1`.
      *
      * @throws NotSupportedException if this is not supported by the underlying DBMS.
      *
@@ -986,8 +986,8 @@ class Command extends Component
      * maximum existing value `+1`.
      *
      * @param string $table The name of the table whose primary key sequence is reset.
-     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
-     * inserted. If this is not set, the next new row's primary key will have the maximum existing value `+1`.
+     * @param int|null $value The integer value for the primary key of the next new row inserted. If this is not set,
+     * the next new row's primary key will have the maximum existing value `+1`.
      *
      * @throws NotSupportedException if this is not supported by the underlying DBMS.
      *

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -1036,8 +1036,8 @@ class QueryBuilder extends \yii\base\BaseObject
      * or the maximum existing value `+1`.
      *
      * @param string $tableName The name of the table whose primary key sequence will be reset.
-     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
-     * inserted. If this is not set, the next new row's primary key will have the maximum existing value `+1`.
+     * @param int|null $value The integer value for the primary key of the next new row inserted. If this is not set,
+     * the next new row's primary key will have the maximum existing value `+1`.
      *
      * @throws NotSupportedException if this is not supported by the underlying DBMS.
      *
@@ -1057,8 +1057,8 @@ class QueryBuilder extends \yii\base\BaseObject
      * maximum existing value `+1`.
      *
      * @param string $table The name of the table whose primary key sequence is reset.
-     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
-     * inserted. If this is not set, the next new row's primary key will have the maximum existing value `+1`.
+     * @param int|null $value The integer value for the primary key of the next new row inserted. If this is not set,
+     * the next new row's primary key will have the maximum existing value `+1`.
      *
      * @throws NotSupportedException if this is not supported by the underlying DBMS
      *

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -1031,13 +1031,17 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Creates a SQL statement for resetting the sequence value of a table's primary key.
-     * The sequence will be reset such that the primary key of the next new row inserted
-     * will have the specified value or the maximum existing value +1.
-     * @param string $tableName the name of the table whose primary key sequence will be reset
-     * @param array|string|null $value the value for the primary key of the next new row inserted. If this is not set,
-     * the next new row's primary key will have the maximum existing value +1.
-     * @return string the SQL statement for resetting sequence
-     * @throws NotSupportedException if this is not supported by the underlying DBMS
+     *
+     * The sequence will be reset such that the primary key of the next new row inserted will have the specified value
+     * or the maximum existing value `+1`.
+     *
+     * @param string $tableName The name of the table whose primary key sequence will be reset.
+     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
+     * inserted. If this is not set, the next new row's primary key will have the maximum existing value `+1`.
+     *
+     * @throws NotSupportedException if this is not supported by the underlying DBMS.
+     *
+     * @return string The SQL statement for resetting sequence.
      */
     public function resetSequence($tableName, $value = null)
     {
@@ -1046,13 +1050,18 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Execute a SQL statement for resetting the sequence value of a table's primary key.
+     *
      * Reason for execute is that some databases (Oracle) need several queries to do so.
-     * The sequence is reset such that the primary key of the next new row inserted
-     * will have the specified value or the maximum existing value +1.
-     * @param string $table the name of the table whose primary key sequence is reset
-     * @param array|string|null $value the value for the primary key of the next new row inserted. If this is not set,
-     * the next new row's primary key will have the maximum existing value +1.
+     *
+     * The sequence is reset such that the primary key of the next new row inserted will have the specified value or the
+     * maximum existing value `+1`.
+     *
+     * @param string $table The name of the table whose primary key sequence is reset.
+     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
+     * inserted. If this is not set, the next new row's primary key will have the maximum existing value `+1`.
+     *
      * @throws NotSupportedException if this is not supported by the underlying DBMS
+     *
      * @since 2.0.16
      */
     public function executeResetSequence($table, $value = null)

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -302,7 +302,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * or the next value after the current maximum identity value.
      *
      * @param string $tableName The name of the table whose primary key sequence will be reset.
-     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row inserted.
+     * @param int|null $value The integer value for the primary key of the next new row inserted.
      * If this is not set, the next new row's primary key will have the next value after the current maximum identity
      * value.
      *

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -15,7 +15,6 @@ use yii\base\NotSupportedException;
 use yii\db\conditions\InCondition;
 use yii\db\conditions\LikeCondition;
 use yii\db\Expression;
-use yii\db\Query;
 
 use function array_flip;
 use function array_intersect_key;
@@ -298,36 +297,95 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * Creates a SQL statement for resetting the sequence value of a table's primary key.
-     * The sequence will be reset such that the primary key of the next new row inserted
-     * will have the specified value or 1.
-     * @param string $tableName the name of the table whose primary key sequence will be reset
-     * @param mixed $value the value for the primary key of the next new row inserted. If this is not set,
-     * the next new row's primary key will have a value 1.
-     * @return string the SQL statement for resetting sequence
+     *
+     * The sequence will be reset such that the primary key of the next new row inserted will have the specified value
+     * or the next value after the current maximum identity value.
+     *
+     * @param string $tableName The name of the table whose primary key sequence will be reset.
+     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row inserted.
+     * If this is not set, the next new row's primary key will have the next value after the current maximum identity
+     * value.
+     *
      * @throws InvalidArgumentException if the table does not exist or there is no sequence associated with the table.
+     *
+     * @return string The SQL statement for resetting sequence.
+     *
+     * @see https://learn.microsoft.com/en-us/sql/t-sql/database-console-commands/dbcc-checkident-transact-sql
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-identity-columns-transact-sql
+     * @see https://learn.microsoft.com/en-us/sql/t-sql/functions/ident-seed-transact-sql
+     * @see https://learn.microsoft.com/en-us/sql/t-sql/functions/ident-incr-transact-sql
      */
     public function resetSequence($tableName, $value = null)
     {
         $table = $this->db->getTableSchema($tableName);
-        if ($table !== null && $table->sequenceName !== null) {
-            $tableName = $this->db->quoteTableName($tableName);
 
-            if ($value === null || $value === 1) {
-                $key = $this->db->quoteColumnName(reset($table->primaryKey));
-                $subSql = (new Query())
-                    ->select('last_value')
-                    ->from('sys.identity_columns')
-                    ->where(['object_id' => new Expression("OBJECT_ID('{$tableName}')")])
-                    ->andWhere(['IS NOT', 'last_value', null])
-                    ->createCommand($this->db)
-                    ->getRawSql();
-                $sql = "SELECT COALESCE(MAX({$key}), CASE WHEN EXISTS({$subSql}) THEN 0 ELSE 1 END) FROM {$tableName}";
-                $value = $this->db->createCommand($sql)->queryScalar();
-            } else {
-                $value = (int) $value;
+        if ($table !== null && $table->sequenceName !== null) {
+            $quotedTableName = $this->db->quoteTableName($tableName);
+
+            $tableNameLiteral = str_replace("'", "''", $quotedTableName);
+
+            $requestedNextValue = $value === null ? 'NULL' : (string) (int) $value;
+            $systemCatalogName = '[sys]';
+
+            if ($table instanceof TableSchema && $table->catalogName !== null) {
+                $systemCatalogName = $this->db->getSchema()->quoteSimpleTableName($table->catalogName) . '.[sys]';
             }
 
-            return "DBCC CHECKIDENT ('{$tableName}', RESEED, {$value})";
+            return <<<SQL
+            DECLARE @tableName NVARCHAR(MAX) = N'{$tableNameLiteral}'
+            DECLARE @requestedNextValue DECIMAL(38, 0) = {$requestedNextValue}
+            DECLARE @identityColumn SYSNAME
+            DECLARE @seedValue DECIMAL(38, 0)
+            DECLARE @incrementValue DECIMAL(38, 0)
+            DECLARE @lastValue DECIMAL(38, 0)
+            DECLARE @maxValue DECIMAL(38, 0)
+            DECLARE @reseedValue DECIMAL(38, 0)
+            DECLARE @maxSql NVARCHAR(MAX)
+            DECLARE @checkIdentSql NVARCHAR(MAX)
+
+            SELECT
+                @identityColumn = [name],
+                @seedValue = CONVERT(DECIMAL(38, 0), [seed_value]),
+                @incrementValue = CONVERT(DECIMAL(38, 0), [increment_value]),
+                @lastValue = CONVERT(DECIMAL(38, 0), [last_value])
+            FROM {$systemCatalogName}.[identity_columns]
+            WHERE [object_id] = OBJECT_ID(@tableName, N'U')
+
+            IF @identityColumn IS NULL
+            BEGIN
+                THROW 50000, 'Identity column not found on table.', 1;
+            END
+
+            SET @maxSql = N'SELECT @maxValue = CONVERT(DECIMAL(38, 0), MAX('
+                + QUOTENAME(@identityColumn)
+                + N')) FROM '
+                + @tableName
+
+            EXEC sp_executesql
+                @maxSql,
+                N'@maxValue DECIMAL(38, 0) OUTPUT',
+                @maxValue OUTPUT
+
+            SET @reseedValue = CASE
+                WHEN @requestedNextValue IS NOT NULL AND (@maxValue IS NOT NULL OR @lastValue IS NOT NULL)
+                    THEN @requestedNextValue - @incrementValue
+                WHEN @requestedNextValue IS NOT NULL
+                    THEN @requestedNextValue
+                WHEN @maxValue IS NOT NULL
+                    THEN @maxValue
+                WHEN @lastValue IS NOT NULL
+                    THEN @seedValue - @incrementValue
+                ELSE @seedValue
+            END
+
+            SET @checkIdentSql = N'DBCC CHECKIDENT (N'''
+                + REPLACE(@tableName, '''', '''''')
+                + N''', RESEED, '
+                + CONVERT(NVARCHAR(50), @reseedValue)
+                + N')'
+
+            EXEC (@checkIdentSql)
+            SQL;
         } elseif ($table === null) {
             throw new InvalidArgumentException("Table not found: $tableName");
         }

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -161,8 +161,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * The sequence will be reset such that the primary key of the next new row inserted will have the specified value
      * or `1`.
      * @param string $tableName The name of the table whose primary key sequence will be reset.
-     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
-     * inserted. If this is not set, the next new row's primary key will have a value `1`.
+     * @param int|null $value The integer value for the primary key of the next new row inserted. If this is not set,
+     * the next new row's primary key will have a value `1`.
      *
      * @throws InvalidArgumentException if the table does not exist or there is no sequence associated with the table.
      *

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -157,13 +157,16 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * Creates a SQL statement for resetting the sequence value of a table's primary key.
-     * The sequence will be reset such that the primary key of the next new row inserted
-     * will have the specified value or 1.
-     * @param string $tableName the name of the table whose primary key sequence will be reset
-     * @param mixed $value the value for the primary key of the next new row inserted. If this is not set,
-     * the next new row's primary key will have a value 1.
-     * @return string the SQL statement for resetting sequence
+     *
+     * The sequence will be reset such that the primary key of the next new row inserted will have the specified value
+     * or `1`.
+     * @param string $tableName The name of the table whose primary key sequence will be reset.
+     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
+     * inserted. If this is not set, the next new row's primary key will have a value `1`.
+     *
      * @throws InvalidArgumentException if the table does not exist or there is no sequence associated with the table.
+     *
+     * @return string the SQL statement for resetting sequence.
      */
     public function resetSequence($tableName, $value = null)
     {

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -217,13 +217,17 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * Creates a SQL statement for resetting the sequence value of a table's primary key.
-     * The sequence will be reset such that the primary key of the next new row inserted
-     * will have the specified value or 1.
-     * @param string $tableName the name of the table whose primary key sequence will be reset
-     * @param mixed $value the value for the primary key of the next new row inserted. If this is not set,
-     * the next new row's primary key will have a value 1.
-     * @return string the SQL statement for resetting sequence
+     *
+     * The sequence will be reset such that the primary key of the next new row inserted will have the specified value
+     * or `1`.
+     *
+     * @param string $tableName The name of the table whose primary key sequence will be reset.
+     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
+     * inserted. If this is not set, the next new row's primary key will have a value `1`.
+     *
      * @throws InvalidArgumentException if the table does not exist or there is no sequence associated with the table.
+     *
+     * @return string the SQL statement for resetting sequence.
      */
     public function resetSequence($tableName, $value = null)
     {

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -222,8 +222,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * or `1`.
      *
      * @param string $tableName The name of the table whose primary key sequence will be reset.
-     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
-     * inserted. If this is not set, the next new row's primary key will have a value `1`.
+     * @param int|null $value The integer value for the primary key of the next new row inserted. If this is not set,
+     * the next new row's primary key will have a value `1`.
      *
      * @throws InvalidArgumentException if the table does not exist or there is no sequence associated with the table.
      *

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -115,13 +115,17 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * Creates a SQL statement for resetting the sequence value of a table's primary key.
-     * The sequence will be reset such that the primary key of the next new row inserted
-     * will have the specified value or 1.
-     * @param string $tableName the name of the table whose primary key sequence will be reset
-     * @param mixed $value the value for the primary key of the next new row inserted. If this is not set,
-     * the next new row's primary key will have a value 1.
-     * @return string the SQL statement for resetting sequence
+     *
+     * The sequence will be reset such that the primary key of the next new row inserted will have the specified value
+     * or `1`.
+     *
+     * @param string $tableName The name of the table whose primary key sequence will be reset.
+     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
+     * inserted. If this is not set, the next new row's primary key will have a value `1`.
+     *
      * @throws InvalidArgumentException if the table does not exist or there is no sequence associated with the table.
+     *
+     * @return string The SQL statement for resetting sequence.
      */
     public function resetSequence($tableName, $value = null)
     {

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -120,8 +120,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * or `1`.
      *
      * @param string $tableName The name of the table whose primary key sequence will be reset.
-     * @param int|string|null $value The integer or numeric string value for the primary key of the next new row
-     * inserted. If this is not set, the next new row's primary key will have a value `1`.
+     * @param int|null $value The integer value for the primary key of the next new row inserted. If this is not set,
+     * the next new row's primary key will have a value `1`.
      *
      * @throws InvalidArgumentException if the table does not exist or there is no sequence associated with the table.
      *

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -444,7 +444,7 @@ final class CommandTest extends BaseCommand
         string $rawTableName,
         int $rowsBeforeReset,
         bool $deleteBeforeReset,
-        int|string|null $value,
+        int|null $value,
         int $expectedId,
     ): void {
         $db = $this->getConnection(false);

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -438,6 +438,72 @@ final class CommandTest extends BaseCommand
         }
     }
 
+    #[DataProviderExternal(CommandProvider::class, 'resetSequence')]
+    public function testResetSequence(
+        string $tableName,
+        string $rawTableName,
+        int $rowsBeforeReset,
+        bool $deleteBeforeReset,
+        int|string|null $value,
+        int $expectedId,
+    ): void {
+        $db = $this->getConnection(false);
+        $schema = $db->getSchema();
+
+        if ($schema->getTableSchema($rawTableName, true) !== null) {
+            $db->createCommand()->dropTable($rawTableName)->execute();
+        }
+
+        $db->createCommand()->createTable(
+            $tableName,
+            [
+                'id' => Schema::TYPE_PK,
+                'description' => Schema::TYPE_STRING,
+            ],
+        )->execute();
+
+        for ($i = 1; $i <= $rowsBeforeReset; ++$i) {
+            $db->createCommand()->insert(
+                $tableName,
+                ['description' => "before reset {$i}"],
+            )->execute();
+        }
+
+        if ($deleteBeforeReset) {
+            $db->createCommand()->delete($tableName)->execute();
+        }
+
+        $command = $db->createCommand();
+
+        if ($value === null) {
+            $command->resetSequence(
+                $tableName,
+            )->execute();
+        } else {
+            $command->resetSequence(
+                $tableName,
+                $value,
+            )->execute();
+        }
+
+        $db->createCommand()->insert(
+            $tableName,
+            ['description' => 'after reset'],
+        )->execute();
+
+        self::assertSame(
+            $expectedId,
+            (int) $db->createCommand(
+                <<<SQL
+                SELECT MAX([id]) FROM {$db->quoteTableName($rawTableName)}
+                SQL,
+            )->queryScalar(),
+            'The generated identity value must match the expected next value.',
+        );
+
+        $db->createCommand()->dropTable($rawTableName)->execute();
+    }
+
     public function testAlterColumn(): void
     {
         $db = $this->getConnection();

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -585,17 +585,18 @@ final class QueryBuilderTest extends BaseQueryBuilder
         ];
     }
 
-    public function testResetSequence(): void
+    #[DataProviderExternal(QueryBuilderProvider::class, 'resetSequence')]
+    public function testResetSequence(string $table, int|string|null $value, string $expected): void
     {
         $qb = $this->getQueryBuilder();
 
-        $expected = "DBCC CHECKIDENT ('[item]', RESEED, 5)";
-        $sql = $qb->resetSequence('item');
-        $this->assertEquals($expected, $sql);
+        $sql = $value === null ? $qb->resetSequence($table) : $qb->resetSequence($table, $value);
 
-        $expected = "DBCC CHECKIDENT ('[item]', RESEED, 4)";
-        $sql = $qb->resetSequence('item', 4);
-        $this->assertEquals($expected, $sql);
+        self::assertSame(
+            $expected,
+            $sql,
+            'Generated SQL must reseed SQL Server so the next identity value matches the requested value.',
+        );
     }
 
     public static function upsertProvider(): array

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -586,7 +586,7 @@ final class QueryBuilderTest extends BaseQueryBuilder
     }
 
     #[DataProviderExternal(QueryBuilderProvider::class, 'resetSequence')]
-    public function testResetSequence(string $table, int|string|null $value, string $expected): void
+    public function testResetSequence(string $table, int|null $value, string $expected): void
     {
         $qb = $this->getQueryBuilder();
 

--- a/tests/framework/db/mssql/providers/CommandProvider.php
+++ b/tests/framework/db/mssql/providers/CommandProvider.php
@@ -52,7 +52,7 @@ final class CommandProvider
     }
 
     /**
-     * @return array<string, array{string, string, int, bool, int|string|null, int}>
+     * @return array<string, array{string, string, int, bool, int|null, int}>
      */
     public static function resetSequence(): array
     {
@@ -73,6 +73,14 @@ final class CommandProvider
                 5,
                 5,
             ],
+            'new table with maximum integer reset' => [
+                'yii2_mssql_reset_sequence_int_max',
+                'yii2_mssql_reset_sequence_int_max',
+                0,
+                false,
+                2147483647,
+                2147483647,
+            ],
             'used table with default reset' => [
                 'yii2_mssql_reset_sequence_used_default',
                 'yii2_mssql_reset_sequence_used_default',
@@ -88,14 +96,6 @@ final class CommandProvider
                 false,
                 5,
                 5,
-            ],
-            'used table with numeric string reset' => [
-                'yii2_mssql_reset_sequence_used_numeric_string',
-                'yii2_mssql_reset_sequence_used_numeric_string',
-                1,
-                false,
-                '6',
-                6,
             ],
             'deleted table with default reset' => [
                 'yii2_mssql_reset_sequence_deleted_default',

--- a/tests/framework/db/mssql/providers/CommandProvider.php
+++ b/tests/framework/db/mssql/providers/CommandProvider.php
@@ -52,6 +52,87 @@ final class CommandProvider
     }
 
     /**
+     * @return array<string, array{string, string, int, bool, int|string|null, int}>
+     */
+    public static function resetSequence(): array
+    {
+        return [
+            'new table with default reset' => [
+                'yii2_mssql_reset_sequence_new_default',
+                'yii2_mssql_reset_sequence_new_default',
+                0,
+                false,
+                null,
+                1,
+            ],
+            'new table with explicit reset and quoted name' => [
+                '[yii2_mssql_reset_sequence_quoted]',
+                'yii2_mssql_reset_sequence_quoted',
+                0,
+                false,
+                5,
+                5,
+            ],
+            'used table with default reset' => [
+                'yii2_mssql_reset_sequence_used_default',
+                'yii2_mssql_reset_sequence_used_default',
+                2,
+                false,
+                null,
+                3,
+            ],
+            'used table with explicit reset' => [
+                'yii2_mssql_reset_sequence_used_explicit',
+                'yii2_mssql_reset_sequence_used_explicit',
+                1,
+                false,
+                5,
+                5,
+            ],
+            'used table with numeric string reset' => [
+                'yii2_mssql_reset_sequence_used_numeric_string',
+                'yii2_mssql_reset_sequence_used_numeric_string',
+                1,
+                false,
+                '6',
+                6,
+            ],
+            'deleted table with default reset' => [
+                'yii2_mssql_reset_sequence_deleted_default',
+                'yii2_mssql_reset_sequence_deleted_default',
+                1,
+                true,
+                null,
+                1,
+            ],
+            'deleted table with explicit reset and single quote name' => [
+                "yii2_mssql_reset_sequence_quote'",
+                "yii2_mssql_reset_sequence_quote'",
+                1,
+                true,
+                5,
+                5,
+            ],
+            'new table with explicit reset and spaces' => [
+                'yii2 mssql reset sequence',
+                'yii2 mssql reset sequence',
+                0,
+                false,
+                5,
+                5,
+            ],
+            'new table with explicit reset and unicode characters' => [
+                'yii2_mssql_reset_sequence_ñ_表',
+                'yii2_mssql_reset_sequence_ñ_表',
+                0,
+                false,
+                5,
+                5,
+            ],
+        ];
+    }
+
+    /**
      * @return array<string, array{string, string, string, string}>
      */
     public static function renameTable(): array

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -92,6 +92,428 @@ final class QueryBuilderProvider
     }
 
     /**
+     * @return array<string, array{string, int|string|null, string}>
+     */
+    public static function resetSequence(): array
+    {
+        return [
+            'already quoted table name' => [
+                '[item]',
+                2,
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[item]'
+                DECLARE @requestedNextValue DECIMAL(38, 0) = 2
+                DECLARE @identityColumn SYSNAME
+                DECLARE @seedValue DECIMAL(38, 0)
+                DECLARE @incrementValue DECIMAL(38, 0)
+                DECLARE @lastValue DECIMAL(38, 0)
+                DECLARE @maxValue DECIMAL(38, 0)
+                DECLARE @reseedValue DECIMAL(38, 0)
+                DECLARE @maxSql NVARCHAR(MAX)
+                DECLARE @checkIdentSql NVARCHAR(MAX)
+
+                SELECT
+                    @identityColumn = [name],
+                    @seedValue = CONVERT(DECIMAL(38, 0), [seed_value]),
+                    @incrementValue = CONVERT(DECIMAL(38, 0), [increment_value]),
+                    @lastValue = CONVERT(DECIMAL(38, 0), [last_value])
+                FROM [sys].[identity_columns]
+                WHERE [object_id] = OBJECT_ID(@tableName, N'U')
+
+                IF @identityColumn IS NULL
+                BEGIN
+                    THROW 50000, 'Identity column not found on table.', 1;
+                END
+
+                SET @maxSql = N'SELECT @maxValue = CONVERT(DECIMAL(38, 0), MAX('
+                    + QUOTENAME(@identityColumn)
+                    + N')) FROM '
+                    + @tableName
+
+                EXEC sp_executesql
+                    @maxSql,
+                    N'@maxValue DECIMAL(38, 0) OUTPUT',
+                    @maxValue OUTPUT
+
+                SET @reseedValue = CASE
+                    WHEN @requestedNextValue IS NOT NULL AND (@maxValue IS NOT NULL OR @lastValue IS NOT NULL)
+                        THEN @requestedNextValue - @incrementValue
+                    WHEN @requestedNextValue IS NOT NULL
+                        THEN @requestedNextValue
+                    WHEN @maxValue IS NOT NULL
+                        THEN @maxValue
+                    WHEN @lastValue IS NOT NULL
+                        THEN @seedValue - @incrementValue
+                    ELSE @seedValue
+                END
+
+                SET @checkIdentSql = N'DBCC CHECKIDENT (N'''
+                    + REPLACE(@tableName, '''', '''''')
+                    + N''', RESEED, '
+                    + CONVERT(NVARCHAR(50), @reseedValue)
+                    + N')'
+
+                EXEC (@checkIdentSql)
+                SQL,
+            ],
+            'catalog-qualified table name' => [
+                'yiitest.dbo.item',
+                null,
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[yiitest].[dbo].[item]'
+                DECLARE @requestedNextValue DECIMAL(38, 0) = NULL
+                DECLARE @identityColumn SYSNAME
+                DECLARE @seedValue DECIMAL(38, 0)
+                DECLARE @incrementValue DECIMAL(38, 0)
+                DECLARE @lastValue DECIMAL(38, 0)
+                DECLARE @maxValue DECIMAL(38, 0)
+                DECLARE @reseedValue DECIMAL(38, 0)
+                DECLARE @maxSql NVARCHAR(MAX)
+                DECLARE @checkIdentSql NVARCHAR(MAX)
+
+                SELECT
+                    @identityColumn = [name],
+                    @seedValue = CONVERT(DECIMAL(38, 0), [seed_value]),
+                    @incrementValue = CONVERT(DECIMAL(38, 0), [increment_value]),
+                    @lastValue = CONVERT(DECIMAL(38, 0), [last_value])
+                FROM [yiitest].[sys].[identity_columns]
+                WHERE [object_id] = OBJECT_ID(@tableName, N'U')
+
+                IF @identityColumn IS NULL
+                BEGIN
+                    THROW 50000, 'Identity column not found on table.', 1;
+                END
+
+                SET @maxSql = N'SELECT @maxValue = CONVERT(DECIMAL(38, 0), MAX('
+                    + QUOTENAME(@identityColumn)
+                    + N')) FROM '
+                    + @tableName
+
+                EXEC sp_executesql
+                    @maxSql,
+                    N'@maxValue DECIMAL(38, 0) OUTPUT',
+                    @maxValue OUTPUT
+
+                SET @reseedValue = CASE
+                    WHEN @requestedNextValue IS NOT NULL AND (@maxValue IS NOT NULL OR @lastValue IS NOT NULL)
+                        THEN @requestedNextValue - @incrementValue
+                    WHEN @requestedNextValue IS NOT NULL
+                        THEN @requestedNextValue
+                    WHEN @maxValue IS NOT NULL
+                        THEN @maxValue
+                    WHEN @lastValue IS NOT NULL
+                        THEN @seedValue - @incrementValue
+                    ELSE @seedValue
+                END
+
+                SET @checkIdentSql = N'DBCC CHECKIDENT (N'''
+                    + REPLACE(@tableName, '''', '''''')
+                    + N''', RESEED, '
+                    + CONVERT(NVARCHAR(50), @reseedValue)
+                    + N')'
+
+                EXEC (@checkIdentSql)
+                SQL,
+            ],
+            'default next value from existing rows' => [
+                'item',
+                null,
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[item]'
+                DECLARE @requestedNextValue DECIMAL(38, 0) = NULL
+                DECLARE @identityColumn SYSNAME
+                DECLARE @seedValue DECIMAL(38, 0)
+                DECLARE @incrementValue DECIMAL(38, 0)
+                DECLARE @lastValue DECIMAL(38, 0)
+                DECLARE @maxValue DECIMAL(38, 0)
+                DECLARE @reseedValue DECIMAL(38, 0)
+                DECLARE @maxSql NVARCHAR(MAX)
+                DECLARE @checkIdentSql NVARCHAR(MAX)
+
+                SELECT
+                    @identityColumn = [name],
+                    @seedValue = CONVERT(DECIMAL(38, 0), [seed_value]),
+                    @incrementValue = CONVERT(DECIMAL(38, 0), [increment_value]),
+                    @lastValue = CONVERT(DECIMAL(38, 0), [last_value])
+                FROM [sys].[identity_columns]
+                WHERE [object_id] = OBJECT_ID(@tableName, N'U')
+
+                IF @identityColumn IS NULL
+                BEGIN
+                    THROW 50000, 'Identity column not found on table.', 1;
+                END
+
+                SET @maxSql = N'SELECT @maxValue = CONVERT(DECIMAL(38, 0), MAX('
+                    + QUOTENAME(@identityColumn)
+                    + N')) FROM '
+                    + @tableName
+
+                EXEC sp_executesql
+                    @maxSql,
+                    N'@maxValue DECIMAL(38, 0) OUTPUT',
+                    @maxValue OUTPUT
+
+                SET @reseedValue = CASE
+                    WHEN @requestedNextValue IS NOT NULL AND (@maxValue IS NOT NULL OR @lastValue IS NOT NULL)
+                        THEN @requestedNextValue - @incrementValue
+                    WHEN @requestedNextValue IS NOT NULL
+                        THEN @requestedNextValue
+                    WHEN @maxValue IS NOT NULL
+                        THEN @maxValue
+                    WHEN @lastValue IS NOT NULL
+                        THEN @seedValue - @incrementValue
+                    ELSE @seedValue
+                END
+
+                SET @checkIdentSql = N'DBCC CHECKIDENT (N'''
+                    + REPLACE(@tableName, '''', '''''')
+                    + N''', RESEED, '
+                    + CONVERT(NVARCHAR(50), @reseedValue)
+                    + N')'
+
+                EXEC (@checkIdentSql)
+                SQL,
+            ],
+            'explicit first value after identity use' => [
+                'item',
+                1,
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[item]'
+                DECLARE @requestedNextValue DECIMAL(38, 0) = 1
+                DECLARE @identityColumn SYSNAME
+                DECLARE @seedValue DECIMAL(38, 0)
+                DECLARE @incrementValue DECIMAL(38, 0)
+                DECLARE @lastValue DECIMAL(38, 0)
+                DECLARE @maxValue DECIMAL(38, 0)
+                DECLARE @reseedValue DECIMAL(38, 0)
+                DECLARE @maxSql NVARCHAR(MAX)
+                DECLARE @checkIdentSql NVARCHAR(MAX)
+
+                SELECT
+                    @identityColumn = [name],
+                    @seedValue = CONVERT(DECIMAL(38, 0), [seed_value]),
+                    @incrementValue = CONVERT(DECIMAL(38, 0), [increment_value]),
+                    @lastValue = CONVERT(DECIMAL(38, 0), [last_value])
+                FROM [sys].[identity_columns]
+                WHERE [object_id] = OBJECT_ID(@tableName, N'U')
+
+                IF @identityColumn IS NULL
+                BEGIN
+                    THROW 50000, 'Identity column not found on table.', 1;
+                END
+
+                SET @maxSql = N'SELECT @maxValue = CONVERT(DECIMAL(38, 0), MAX('
+                    + QUOTENAME(@identityColumn)
+                    + N')) FROM '
+                    + @tableName
+
+                EXEC sp_executesql
+                    @maxSql,
+                    N'@maxValue DECIMAL(38, 0) OUTPUT',
+                    @maxValue OUTPUT
+
+                SET @reseedValue = CASE
+                    WHEN @requestedNextValue IS NOT NULL AND (@maxValue IS NOT NULL OR @lastValue IS NOT NULL)
+                        THEN @requestedNextValue - @incrementValue
+                    WHEN @requestedNextValue IS NOT NULL
+                        THEN @requestedNextValue
+                    WHEN @maxValue IS NOT NULL
+                        THEN @maxValue
+                    WHEN @lastValue IS NOT NULL
+                        THEN @seedValue - @incrementValue
+                    ELSE @seedValue
+                END
+
+                SET @checkIdentSql = N'DBCC CHECKIDENT (N'''
+                    + REPLACE(@tableName, '''', '''''')
+                    + N''', RESEED, '
+                    + CONVERT(NVARCHAR(50), @reseedValue)
+                    + N')'
+
+                EXEC (@checkIdentSql)
+                SQL,
+            ],
+            'explicit next value' => [
+                'item',
+                4,
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[item]'
+                DECLARE @requestedNextValue DECIMAL(38, 0) = 4
+                DECLARE @identityColumn SYSNAME
+                DECLARE @seedValue DECIMAL(38, 0)
+                DECLARE @incrementValue DECIMAL(38, 0)
+                DECLARE @lastValue DECIMAL(38, 0)
+                DECLARE @maxValue DECIMAL(38, 0)
+                DECLARE @reseedValue DECIMAL(38, 0)
+                DECLARE @maxSql NVARCHAR(MAX)
+                DECLARE @checkIdentSql NVARCHAR(MAX)
+
+                SELECT
+                    @identityColumn = [name],
+                    @seedValue = CONVERT(DECIMAL(38, 0), [seed_value]),
+                    @incrementValue = CONVERT(DECIMAL(38, 0), [increment_value]),
+                    @lastValue = CONVERT(DECIMAL(38, 0), [last_value])
+                FROM [sys].[identity_columns]
+                WHERE [object_id] = OBJECT_ID(@tableName, N'U')
+
+                IF @identityColumn IS NULL
+                BEGIN
+                    THROW 50000, 'Identity column not found on table.', 1;
+                END
+
+                SET @maxSql = N'SELECT @maxValue = CONVERT(DECIMAL(38, 0), MAX('
+                    + QUOTENAME(@identityColumn)
+                    + N')) FROM '
+                    + @tableName
+
+                EXEC sp_executesql
+                    @maxSql,
+                    N'@maxValue DECIMAL(38, 0) OUTPUT',
+                    @maxValue OUTPUT
+
+                SET @reseedValue = CASE
+                    WHEN @requestedNextValue IS NOT NULL AND (@maxValue IS NOT NULL OR @lastValue IS NOT NULL)
+                        THEN @requestedNextValue - @incrementValue
+                    WHEN @requestedNextValue IS NOT NULL
+                        THEN @requestedNextValue
+                    WHEN @maxValue IS NOT NULL
+                        THEN @maxValue
+                    WHEN @lastValue IS NOT NULL
+                        THEN @seedValue - @incrementValue
+                    ELSE @seedValue
+                END
+
+                SET @checkIdentSql = N'DBCC CHECKIDENT (N'''
+                    + REPLACE(@tableName, '''', '''''')
+                    + N''', RESEED, '
+                    + CONVERT(NVARCHAR(50), @reseedValue)
+                    + N')'
+
+                EXEC (@checkIdentSql)
+                SQL,
+            ],
+            'explicit numeric string next value' => [
+                'item',
+                '6',
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[item]'
+                DECLARE @requestedNextValue DECIMAL(38, 0) = 6
+                DECLARE @identityColumn SYSNAME
+                DECLARE @seedValue DECIMAL(38, 0)
+                DECLARE @incrementValue DECIMAL(38, 0)
+                DECLARE @lastValue DECIMAL(38, 0)
+                DECLARE @maxValue DECIMAL(38, 0)
+                DECLARE @reseedValue DECIMAL(38, 0)
+                DECLARE @maxSql NVARCHAR(MAX)
+                DECLARE @checkIdentSql NVARCHAR(MAX)
+
+                SELECT
+                    @identityColumn = [name],
+                    @seedValue = CONVERT(DECIMAL(38, 0), [seed_value]),
+                    @incrementValue = CONVERT(DECIMAL(38, 0), [increment_value]),
+                    @lastValue = CONVERT(DECIMAL(38, 0), [last_value])
+                FROM [sys].[identity_columns]
+                WHERE [object_id] = OBJECT_ID(@tableName, N'U')
+
+                IF @identityColumn IS NULL
+                BEGIN
+                    THROW 50000, 'Identity column not found on table.', 1;
+                END
+
+                SET @maxSql = N'SELECT @maxValue = CONVERT(DECIMAL(38, 0), MAX('
+                    + QUOTENAME(@identityColumn)
+                    + N')) FROM '
+                    + @tableName
+
+                EXEC sp_executesql
+                    @maxSql,
+                    N'@maxValue DECIMAL(38, 0) OUTPUT',
+                    @maxValue OUTPUT
+
+                SET @reseedValue = CASE
+                    WHEN @requestedNextValue IS NOT NULL AND (@maxValue IS NOT NULL OR @lastValue IS NOT NULL)
+                        THEN @requestedNextValue - @incrementValue
+                    WHEN @requestedNextValue IS NOT NULL
+                        THEN @requestedNextValue
+                    WHEN @maxValue IS NOT NULL
+                        THEN @maxValue
+                    WHEN @lastValue IS NOT NULL
+                        THEN @seedValue - @incrementValue
+                    ELSE @seedValue
+                END
+
+                SET @checkIdentSql = N'DBCC CHECKIDENT (N'''
+                    + REPLACE(@tableName, '''', '''''')
+                    + N''', RESEED, '
+                    + CONVERT(NVARCHAR(50), @reseedValue)
+                    + N')'
+
+                EXEC (@checkIdentSql)
+                SQL,
+            ],
+            'schema-qualified table name' => [
+                'dbo.item',
+                7,
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[dbo].[item]'
+                DECLARE @requestedNextValue DECIMAL(38, 0) = 7
+                DECLARE @identityColumn SYSNAME
+                DECLARE @seedValue DECIMAL(38, 0)
+                DECLARE @incrementValue DECIMAL(38, 0)
+                DECLARE @lastValue DECIMAL(38, 0)
+                DECLARE @maxValue DECIMAL(38, 0)
+                DECLARE @reseedValue DECIMAL(38, 0)
+                DECLARE @maxSql NVARCHAR(MAX)
+                DECLARE @checkIdentSql NVARCHAR(MAX)
+
+                SELECT
+                    @identityColumn = [name],
+                    @seedValue = CONVERT(DECIMAL(38, 0), [seed_value]),
+                    @incrementValue = CONVERT(DECIMAL(38, 0), [increment_value]),
+                    @lastValue = CONVERT(DECIMAL(38, 0), [last_value])
+                FROM [sys].[identity_columns]
+                WHERE [object_id] = OBJECT_ID(@tableName, N'U')
+
+                IF @identityColumn IS NULL
+                BEGIN
+                    THROW 50000, 'Identity column not found on table.', 1;
+                END
+
+                SET @maxSql = N'SELECT @maxValue = CONVERT(DECIMAL(38, 0), MAX('
+                    + QUOTENAME(@identityColumn)
+                    + N')) FROM '
+                    + @tableName
+
+                EXEC sp_executesql
+                    @maxSql,
+                    N'@maxValue DECIMAL(38, 0) OUTPUT',
+                    @maxValue OUTPUT
+
+                SET @reseedValue = CASE
+                    WHEN @requestedNextValue IS NOT NULL AND (@maxValue IS NOT NULL OR @lastValue IS NOT NULL)
+                        THEN @requestedNextValue - @incrementValue
+                    WHEN @requestedNextValue IS NOT NULL
+                        THEN @requestedNextValue
+                    WHEN @maxValue IS NOT NULL
+                        THEN @maxValue
+                    WHEN @lastValue IS NOT NULL
+                        THEN @seedValue - @incrementValue
+                    ELSE @seedValue
+                END
+
+                SET @checkIdentSql = N'DBCC CHECKIDENT (N'''
+                    + REPLACE(@tableName, '''', '''''')
+                    + N''', RESEED, '
+                    + CONVERT(NVARCHAR(50), @reseedValue)
+                    + N')'
+
+                EXEC (@checkIdentSql)
+                SQL,
+            ],
+        ];
+    }
+
+    /**
      * @return array<string, array{string, string, string}>
      */
     public static function renameTable(): array

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -92,7 +92,7 @@ final class QueryBuilderProvider
     }
 
     /**
-     * @return array<string, array{string, int|string|null, string}>
+     * @return array<string, array{string, int|null, string}>
      */
     public static function resetSequence(): array
     {
@@ -392,12 +392,12 @@ final class QueryBuilderProvider
                 EXEC (@checkIdentSql)
                 SQL,
             ],
-            'explicit numeric string next value' => [
+            'explicit maximum integer next value' => [
                 'item',
-                '6',
+                9223372036854775807,
                 <<<SQL
                 DECLARE @tableName NVARCHAR(MAX) = N'[item]'
-                DECLARE @requestedNextValue DECIMAL(38, 0) = 6
+                DECLARE @requestedNextValue DECIMAL(38, 0) = 9223372036854775807
                 DECLARE @identityColumn SYSNAME
                 DECLARE @seedValue DECIMAL(38, 0)
                 DECLARE @incrementValue DECIMAL(38, 0)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
