### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/actions/php-setup/action.yml
+++ b/.github/actions/php-setup/action.yml
@@ -58,7 +58,7 @@ runs:
   using: composite
   steps:
     - name: Install PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
       with:
         coverage: ${{ inputs.coverage-driver }}
         extensions: ${{ inputs.extensions }}
@@ -68,16 +68,29 @@ runs:
 
     - name: Update composer.
       shell: bash
-      run: composer self-update ${{ inputs.composer-version }}
+      env:
+        COMPOSER_VERSION: ${{ inputs.composer-version }}
+      run: |
+        command=(composer self-update)
+
+        if [ -n "$COMPOSER_VERSION" ]; then
+          command+=("$COMPOSER_VERSION")
+        fi
+
+        "${command[@]}"
 
     - name: Install dependencies with composer.
       shell: bash
-      run: >-
-        composer
-        ${{ inputs.composer-command }}
-        ${{ inputs.composer-flags }}
-        ${{
-          inputs.ignore-platform-reqs == 'true'
-          && '--ignore-platform-reqs'
-          || ''
-        }}
+      env:
+        COMPOSER_COMMAND: ${{ inputs.composer-command }}
+        COMPOSER_FLAGS: ${{ inputs.composer-flags }}
+        IGNORE_PLATFORM_REQS: ${{ inputs.ignore-platform-reqs }}
+      run: |
+        read -r -a composer_flags <<< "$COMPOSER_FLAGS"
+        command=(composer "$COMPOSER_COMMAND" "${composer_flags[@]}")
+
+        if [ "$IGNORE_PLATFORM_REQS" = "true" ]; then
+          command+=(--ignore-platform-reqs)
+        fi
+
+        "${command[@]}"

--- a/.github/actions/phpunit/action.yml
+++ b/.github/actions/phpunit/action.yml
@@ -62,31 +62,31 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Build PHPUnit command.
-      id: build-cmd
+    - name: Run PHPUnit tests on Linux.
+      if: runner.os != 'Windows'
       shell: bash
+      env:
+        ADDITIONAL_ARGS: ${{ inputs.additional-args }}
+        CONFIG_INPUT: ${{ inputs.configuration }}
+        COVERAGE_DRIVER: ${{ inputs.coverage-driver }}
+        COVERAGE_FILE: ${{ inputs.coverage-file }}
+        COVERAGE_FORMAT: ${{ inputs.coverage-format }}
+        DEBUG_INPUT: ${{ inputs.debug }}
+        EXCLUDE_GROUP_INPUT: ${{ inputs.exclude-group }}
+        GROUP_INPUT: ${{ inputs.group }}
+        PATH_INPUT: ${{ inputs.path }}
+        SUITE_INPUT: ${{ inputs.test-suite }}
       run: |
-        PATH_INPUT="${{ inputs.path }}"
-        CONFIG_INPUT="${{ inputs.configuration }}"
-        SUITE_INPUT="${{ inputs.test-suite }}"
-        GROUP_INPUT="${{ inputs.group }}"
-        EXCLUDE_GROUP_INPUT="${{ inputs.exclude-group }}"
-        DEBUG_INPUT="${{ inputs.debug }}"
-        ADDITIONAL_ARGS="${{ inputs.additional-args }}"
-        COVERAGE_DRIVER="${{ inputs.coverage-driver }}"
-        COVERAGE_FORMAT="${{ inputs.coverage-format }}"
-        COVERAGE_FILE="${{ inputs.coverage-file }}"
-
-        PHPUNIT_CMD="$PATH_INPUT --colors=always"
+        command=("$PATH_INPUT" "--colors=always")
 
         add_param() {
           if [ -n "$2" ]; then
-            PHPUNIT_CMD="$PHPUNIT_CMD $1 $2"
+            command+=("$1" "$2")
           fi
         }
 
         if [ -n "$COVERAGE_DRIVER" ] && [ "$COVERAGE_DRIVER" != "none" ]; then
-          PHPUNIT_CMD="$PHPUNIT_CMD --coverage-$COVERAGE_FORMAT=$COVERAGE_FILE"
+          command+=("--coverage-$COVERAGE_FORMAT=$COVERAGE_FILE")
         fi
 
         add_param "--configuration" "$CONFIG_INPUT"
@@ -95,35 +95,75 @@ runs:
         add_param "--exclude-group" "$EXCLUDE_GROUP_INPUT"
 
         if [ -n "$DEBUG_INPUT" ]; then
-          PHPUNIT_CMD="$PHPUNIT_CMD $DEBUG_INPUT"
+          read -r -a debug_args <<< "$DEBUG_INPUT"
+          command+=("${debug_args[@]}")
         fi
 
         if [ -n "$ADDITIONAL_ARGS" ]; then
-          PHPUNIT_CMD="$PHPUNIT_CMD $ADDITIONAL_ARGS"
+          read -r -a additional_args <<< "$ADDITIONAL_ARGS"
+          command+=("${additional_args[@]}")
         fi
 
-        echo "command=$PHPUNIT_CMD" >> $GITHUB_OUTPUT
-        echo "PHPUnit command: $PHPUNIT_CMD"
+        printf 'PHPUnit command:'
+        printf ' %q' "${command[@]}"
+        printf '\n'
 
-    - name: Run PHPUnit tests on Linux.
-      shell: bash
-      if: runner.os != 'Windows'
-      run: ${{ steps.build-cmd.outputs.command }}
+        "${command[@]}"
 
     - name: Run PHPUnit tests on Windows.
-      shell: pwsh
       if: runner.os == 'Windows'
-      run: Invoke-Expression "${{ steps.build-cmd.outputs.command }}"
+      shell: pwsh
+      env:
+        ADDITIONAL_ARGS: ${{ inputs.additional-args }}
+        CONFIG_INPUT: ${{ inputs.configuration }}
+        COVERAGE_DRIVER: ${{ inputs.coverage-driver }}
+        COVERAGE_FILE: ${{ inputs.coverage-file }}
+        COVERAGE_FORMAT: ${{ inputs.coverage-format }}
+        DEBUG_INPUT: ${{ inputs.debug }}
+        EXCLUDE_GROUP_INPUT: ${{ inputs.exclude-group }}
+        GROUP_INPUT: ${{ inputs.group }}
+        PATH_INPUT: ${{ inputs.path }}
+        SUITE_INPUT: ${{ inputs.test-suite }}
+      run: |
+        $command = @($env:PATH_INPUT, '--colors=always')
+
+        function Add-Param([string] $Name, [string] $Value) {
+          if ($Value) {
+            $script:command += @($Name, $Value)
+          }
+        }
+
+        if ($env:COVERAGE_DRIVER -and $env:COVERAGE_DRIVER -ne 'none') {
+          $command += "--coverage-$($env:COVERAGE_FORMAT)=$($env:COVERAGE_FILE)"
+        }
+
+        Add-Param '--configuration' $env:CONFIG_INPUT
+        Add-Param '--testsuite' $env:SUITE_INPUT
+        Add-Param '--group' $env:GROUP_INPUT
+        Add-Param '--exclude-group' $env:EXCLUDE_GROUP_INPUT
+
+        if ($env:DEBUG_INPUT) {
+          $command += $env:DEBUG_INPUT -split ' '
+        }
+
+        if ($env:ADDITIONAL_ARGS) {
+          $command += $env:ADDITIONAL_ARGS -split ' '
+        }
+
+        Write-Host "PHPUnit command: $($command -join ' ')"
+        $executable = $command[0]
+        $arguments = $command[1..($command.Count - 1)]
+        & $executable @arguments
 
     - name: Upload test results to Codecov.
       if: ${{ !cancelled() && inputs.coverage-driver != 'none' }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
       with:
         token: ${{ inputs.coverage-token }}
 
     - name: Upload coverage to Codecov.
       if: ${{ !cancelled() && inputs.coverage-driver != 'none' }}
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
       with:
         files: ./${{ inputs.coverage-file }}
         token: ${{ inputs.coverage-token }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "yiisoft/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: build
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request: &ignore-paths
@@ -57,7 +56,7 @@ jobs:
 
     services: &memcached-service
       memcached:
-        image: memcached:latest
+        image: memcached:1
         ports:
           - 11211:11211
         options: >-
@@ -73,7 +72,9 @@ jobs:
 
     steps: &build-steps
       - name: Checkout.
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
 
       - name: Generate french locale.
         run: sudo locale-gen fr_FR.UTF-8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
 
     services: &memcached-service
       memcached:
-        image: memcached:1
+        image: memcached:1.6@sha256:e2a8683c7fbb73d12dce8082525adf9df857765970e639bd9f4705acc31dfcba
         ports:
           - 11211:11211
         options: >-
@@ -72,7 +72,7 @@ jobs:
 
     steps: &build-steps
       - name: Checkout.
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: MariaDB tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mariadb-${{ github.ref }}
       coverage-driver: xdebug
@@ -55,7 +55,7 @@ jobs:
 
   tests-dev:
     name: MariaDB tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mariadb-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -2,7 +2,6 @@ name: ci-mariadb
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request: &ignore-paths
@@ -37,7 +36,7 @@ on:
 jobs:
   tests:
     name: MariaDB tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mariadb-${{ github.ref }}
       coverage-driver: xdebug
@@ -56,7 +55,7 @@ jobs:
 
   tests-dev:
     name: MariaDB tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mariadb-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: MariaDB tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
     with:
       concurrency-group: mariadb-${{ github.ref }}
       coverage-driver: xdebug
@@ -55,7 +55,7 @@ jobs:
 
   tests-dev:
     name: MariaDB tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
     with:
       concurrency-group: mariadb-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: MSSQL tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mssql-${{ github.ref }}
       coverage-driver: xdebug
@@ -58,7 +58,7 @@ jobs:
 
   tests-dev:
     name: MSSQL tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mssql-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: MSSQL tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
     with:
       concurrency-group: mssql-${{ github.ref }}
       coverage-driver: xdebug
@@ -58,7 +58,7 @@ jobs:
 
   tests-dev:
     name: MSSQL tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
     with:
       concurrency-group: mssql-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -2,7 +2,6 @@ name: ci-mssql
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request: &ignore-paths
@@ -37,7 +36,7 @@ on:
 jobs:
   tests:
     name: MSSQL tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mssql-${{ github.ref }}
       coverage-driver: xdebug
@@ -59,7 +58,7 @@ jobs:
 
   tests-dev:
     name: MSSQL tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mssql-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: MySQL tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mysql-${{ github.ref }}
       coverage-driver: xdebug
@@ -55,7 +55,7 @@ jobs:
 
   tests-dev:
     name: MySQL tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mysql-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: MySQL tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
     with:
       concurrency-group: mysql-${{ github.ref }}
       coverage-driver: xdebug
@@ -55,7 +55,7 @@ jobs:
 
   tests-dev:
     name: MySQL tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
     with:
       concurrency-group: mysql-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -2,7 +2,6 @@ name: ci-mysql
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request: &ignore-paths
@@ -37,7 +36,7 @@ on:
 jobs:
   tests:
     name: MySQL tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mysql-${{ github.ref }}
       coverage-driver: xdebug
@@ -56,7 +55,7 @@ jobs:
 
   tests-dev:
     name: MySQL tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mysql-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 name: build-node
 
 on:
@@ -39,16 +42,21 @@ concurrency:
 jobs:
   test:
     name: NPM 10 on ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
 
     runs-on: ubuntu-22.04
 
     steps:
       - name: Monitor action permissions.
         if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289
 
       - name: Checkout.
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
 
       - name: Install dependencies.
         run: composer update $DEFAULT_COMPOSER_FLAGS
@@ -57,7 +65,7 @@ jobs:
         run: composer require "bower-asset/jquery:3.6.*@stable"
 
       - name: Install node.js.
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 20
 

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -42,16 +42,13 @@ concurrency:
 jobs:
   test:
     name: NPM 10 on ubuntu-22.04
-    permissions:
-      contents: read
-      pull-requests: write
 
     runs-on: ubuntu-22.04
 
     steps:
 
       - name: Checkout.
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 
@@ -62,7 +59,7 @@ jobs:
         run: composer require "bower-asset/jquery:3.6.*@stable"
 
       - name: Install node.js.
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -49,9 +49,6 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Monitor action permissions.
-        if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289
 
       - name: Checkout.
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd

--- a/.github/workflows/ci-oracle.yml
+++ b/.github/workflows/ci-oracle.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: Oracle tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
     with:
       concurrency-group: oracle-${{ github.ref }}
       coverage-driver: xdebug

--- a/.github/workflows/ci-oracle.yml
+++ b/.github/workflows/ci-oracle.yml
@@ -2,7 +2,6 @@ name: ci-oracle
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request: &ignore-paths
@@ -37,7 +36,7 @@ on:
 jobs:
   tests:
     name: Oracle tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: oracle-${{ github.ref }}
       coverage-driver: xdebug

--- a/.github/workflows/ci-oracle.yml
+++ b/.github/workflows/ci-oracle.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: Oracle tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: oracle-${{ github.ref }}
       coverage-driver: xdebug

--- a/.github/workflows/ci-pgsql.yml
+++ b/.github/workflows/ci-pgsql.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: PostgreSQL tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
     with:
       concurrency-group: pgsql-${{ github.ref }}
       coverage-driver: xdebug
@@ -55,7 +55,7 @@ jobs:
 
   tests-dev:
     name: PostgreSQL tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
     with:
       concurrency-group: pgsql-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-pgsql.yml
+++ b/.github/workflows/ci-pgsql.yml
@@ -2,7 +2,6 @@ name: ci-pgsql
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request: &ignore-paths
@@ -37,7 +36,7 @@ on:
 jobs:
   tests:
     name: PostgreSQL tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: pgsql-${{ github.ref }}
       coverage-driver: xdebug
@@ -56,7 +55,7 @@ jobs:
 
   tests-dev:
     name: PostgreSQL tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: pgsql-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-pgsql.yml
+++ b/.github/workflows/ci-pgsql.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: PostgreSQL tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: pgsql-${{ github.ref }}
       coverage-driver: xdebug
@@ -55,7 +55,7 @@ jobs:
 
   tests-dev:
     name: PostgreSQL tests
-    uses: yiisoft/yii2-actions/.github/workflows/database.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: pgsql-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-sqlite.yml
+++ b/.github/workflows/ci-sqlite.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: SQLite tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@master
     with:
       concurrency-group: sqlite-${{ github.ref }}
       coverage-driver: xdebug
@@ -50,7 +50,7 @@ jobs:
 
   tests-dev:
     name: SQLite tests
-    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@master
     with:
       concurrency-group: sqlite-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-sqlite.yml
+++ b/.github/workflows/ci-sqlite.yml
@@ -2,7 +2,6 @@ name: ci-sqlite
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request: &ignore-paths
@@ -37,7 +36,7 @@ on:
 jobs:
   tests:
     name: SQLite tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: sqlite-${{ github.ref }}
       coverage-driver: xdebug
@@ -51,7 +50,7 @@ jobs:
 
   tests-dev:
     name: SQLite tests
-    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: sqlite-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/ci-sqlite.yml
+++ b/.github/workflows/ci-sqlite.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   tests:
     name: SQLite tests with coverage
-    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: sqlite-${{ github.ref }}
       coverage-driver: xdebug
@@ -50,7 +50,7 @@ jobs:
 
   tests-dev:
     name: SQLite tests
-    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: sqlite-dev-${{ github.ref }}
       coverage-driver: none

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -35,6 +35,6 @@ on:
 
 jobs:
   phpcs:
-    uses: yiisoft/yii2-actions/.github/workflows/linter.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/linter.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       php-version: '["7.4", "8.5"]'

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -2,7 +2,6 @@ name: linter
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request: &ignore-paths
@@ -36,6 +35,6 @@ on:
 
 jobs:
   phpcs:
-    uses: yiisoft/yii2-actions/.github/workflows/linter.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/linter.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       php-version: '["7.4", "8.5"]'

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -35,6 +35,6 @@ on:
 
 jobs:
   phpcs:
-    uses: yiisoft/yii2-actions/.github/workflows/linter.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/linter.yml@master
     with:
       php-version: '["7.4", "8.5"]'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,7 +2,6 @@ name: static analysis
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request: &ignore-paths
@@ -36,7 +35,7 @@ on:
 
 jobs:
   phpstan:
-    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       configuration: phpstan.dist.neon
       concurrency-group: phpstan-${{ github.ref }}
@@ -44,7 +43,7 @@ jobs:
       php-version: '["8.5"]'
 
   phpstan-7x:
-    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       configuration: phpstan-7x.dist.neon
       concurrency-group: phpstan7x-${{ github.ref }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   phpstan:
-    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@master
     with:
       configuration: phpstan.dist.neon
       concurrency-group: phpstan-${{ github.ref }}
@@ -43,7 +43,7 @@ jobs:
       php-version: '["8.5"]'
 
   phpstan-7x:
-    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
+    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@master
     with:
       configuration: phpstan-7x.dist.neon
       concurrency-group: phpstan7x-${{ github.ref }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   phpstan:
-    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       configuration: phpstan.dist.neon
       concurrency-group: phpstan-${{ github.ref }}
@@ -43,7 +43,7 @@ jobs:
       php-version: '["8.5"]'
 
   phpstan-7x:
-    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@master
+    uses: yiisoft/yii2-actions/.github/workflows/phpstan.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       configuration: phpstan-7x.dist.neon
       concurrency-group: phpstan7x-${{ github.ref }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,8 +14,8 @@ on:
       - '.github/**.yaml'
 
 permissions:
-  actions: read
-  contents: read
+  actions: read # Required by zizmor when reading workflow metadata through the API.
+  contents: read # Required to read workflow files.
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   zizmor:
-    uses: yiisoft/actions/.github/workflows/zizmor.yml@master
+    uses: yiisoft/actions/.github/workflows/zizmor.yml@b5ae289e9c8ace77fb2791ad5716f90f748608bc

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,37 +1,15 @@
 name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - '.github/**.yml'
-            - '.github/**.yaml'
-    pull_request:
-        paths:
-            - '.github/**.yml'
-            - '.github/**.yaml'
-
-concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
-
-permissions:
-    contents: read
+  push:
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+  pull_request:
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
 
 jobs:
-    zizmor:
-        name: Run zizmor 🌈
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  persist-credentials: false
-
-            - name: Run zizmor 🌈
-              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
-              with:
-                  advanced-security: false
-                  annotations: true
-                  persona: 'pedantic'
+  zizmor:
+    uses: yiisoft/actions/.github/workflows/zizmor.yml@master

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "yiisoft/*": any

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "yiisoft/*": any


### PR DESCRIPTION
## Summary
- pin third-party GitHub Actions and reusable workflow refs to immutable SHAs
- add explicit workflow permissions
- disable checkout credential persistence where applicable

## Testing
- zizmor --no-progress --no-exit-codes .github/workflows
- git diff --check