### PR TITLE
Rework MSSQL `yii\db\mssql\QueryBuilder::checkIntegrity()` for trusted constraints and catalog-qualified names.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -571,28 +571,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -630,7 +631,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -640,13 +641,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/semver",
@@ -965,16 +962,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.9.0",
+            "version": "6.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "bd1bda2ebfc8bff418565941771ea8f03c557886"
+                "reference": "8b1308a9d7bdbdb20ce87ef920f82b4564bb2d33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/bd1bda2ebfc8bff418565941771ea8f03c557886",
-                "reference": "bd1bda2ebfc8bff418565941771ea8f03c557886",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/8b1308a9d7bdbdb20ce87ef920f82b4564bb2d33",
+                "reference": "8b1308a9d7bdbdb20ce87ef920f82b4564bb2d33",
                 "shasum": ""
             },
             "require": {
@@ -984,7 +981,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "3.3.0",
-                "json-schema/json-schema-test-suite": "^23.2",
+                "json-schema/json-schema-test-suite": "dev-main",
                 "marc-mabe/php-enum-phpstan": "^2.0",
                 "phpspec/prophecy": "^1.19",
                 "phpstan/phpstan": "^1.12",
@@ -1034,9 +1031,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.9.0"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.10.0"
             },
-            "time": "2026-06-05T14:05:24+00:00"
+            "time": "2026-06-16T20:50:26+00:00"
         },
         {
             "name": "marc-mabe/php-enum",
@@ -3165,16 +3162,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.11.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2"
+                "reference": "9a90eb5d32d5a500296bf43f946d60246444d5f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/1748aaf847fc731cfad7725aec413ee46f0cc3a2",
-                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9a90eb5d32d5a500296bf43f946d60246444d5f7",
+                "reference": "9a90eb5d32d5a500296bf43f946d60246444d5f7",
                 "shasum": ""
             },
             "require": {
@@ -3213,7 +3210,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.11.0"
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.12.1"
             },
             "funding": [
                 {
@@ -3225,7 +3222,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-11T14:55:45+00:00"
+            "time": "2026-06-12T11:32:29+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -4027,16 +4024,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -4088,7 +4085,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -4108,7 +4105,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php73",

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -99,6 +99,7 @@ Yii Framework 2 Change Log
 - Bug #20951: Fix MSSQL `QueryBuilder::addDefaultValue()` to generate valid `DEFAULT NULL` and `DEFAULT 0` SQL for `null` and `false` values (terabytesoftw)
 - Bug #20952: Restrict MSSQL `dropDefaultValue()` to default constraints and cover catalog-qualified `alterColumn()` constraint replacement (terabytesoftw)
 - Bug #20953: Fix MSSQL `QueryBuilder::resetSequence()` to reseed `DBCC CHECKIDENT` for the requested next identity value (terabytesoftw)
+- Enh #20957: Rework MSSQL `yii\db\mssql\QueryBuilder::checkIntegrity()` for trusted constraints and catalog-qualified names (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -331,6 +331,22 @@ abstract class Schema extends BaseObject
     }
 
     /**
+     * Resolves the table name and schema name (if any) without loading database metadata.
+     *
+     * @param string $name The table name.
+     *
+     * @throws NotSupportedException if this method is not supported by the DBMS.
+     *
+     * @return TableSchema TableSchema with resolved table, schema, etc. names.
+     *
+     * @since 22.0
+     */
+    public function resolveRawTableName($name): TableSchema
+    {
+        return $this->resolveTableName($name);
+    }
+
+    /**
      * Creates a query builder for the database.
      * This method may be overridden by child classes to create a DBMS-specific query builder.
      * @return QueryBuilder query builder instance

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -325,11 +325,10 @@ class QueryBuilder extends \yii\db\QueryBuilder
             $tableNameLiteral = str_replace("'", "''", $quotedTableName);
 
             $requestedNextValue = $value === null ? 'NULL' : (string) (int) $value;
-            $systemCatalogName = '[sys]';
 
-            if ($table instanceof TableSchema && $table->catalogName !== null) {
-                $systemCatalogName = $this->db->getSchema()->quoteSimpleTableName($table->catalogName) . '.[sys]';
-            }
+            $systemCatalogName = $this->qualifiedSystemCatalog(
+                $table instanceof TableSchema ? $table->catalogName : null,
+            );
 
             return <<<SQL
             DECLARE @tableName NVARCHAR(MAX) = N'{$tableNameLiteral}'
@@ -394,29 +393,68 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
-     * Builds a SQL statement for enabling or disabling integrity check.
-     * @param bool $check whether to turn on or off the integrity check.
-     * @param string $schema the schema of the tables.
-     * @param string $table the table name.
-     * @return string the SQL statement for checking integrity
+     * Builds a SQL statement for enabling or disabling integrity checks on table constraints.
+     *
+     * Resolves the table and schema names without loading metadata, so the statement is built without opening a
+     * database connection. A single table yields a direct `ALTER TABLE` statement; an empty table targets every base
+     * table in the schema, enumerated server-side from `sys.tables` (views excluded) and run in one batch.
+     *
+     * Enabling uses `WITH CHECK CHECK CONSTRAINT ALL`, re-validating existing rows and marking the constraints
+     * trusted; disabling uses `NOCHECK CONSTRAINT ALL`.
+     *
+     * @param bool $check Whether to enable (`true`) or disable (`false`) the integrity checks.
+     * @param string $schema The schema of the tables. Defaults to an empty string, meaning the default schema.
+     * @param string $table The table name. Defaults to an empty string, meaning every table in the schema.
+     *
+     * @return string The SQL statement for enabling or disabling the integrity checks.
+     *
+     * @see https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql
+     * @see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-tables-transact-sql
      */
     public function checkIntegrity($check = true, $schema = '', $table = '')
     {
-        /** @var Schema $dbSchema */
-        $dbSchema = $this->db->getSchema();
-        $enable = $check ? 'CHECK' : 'NOCHECK';
-        $schema = $schema ?: $dbSchema->defaultSchema;
-        $tableNames = $this->db->getTableSchema($table) ? [$table] : $dbSchema->getTableNames($schema);
-        $viewNames = $dbSchema->getViewNames($schema);
-        $tableNames = array_diff($tableNames, $viewNames);
-        $command = '';
+        $constraintCheck = $check ? 'WITH CHECK CHECK' : 'NOCHECK';
 
-        foreach ($tableNames as $tableName) {
-            $tableName = $this->db->quoteTableName("{$schema}.{$tableName}");
-            $command .= "ALTER TABLE $tableName $enable CONSTRAINT ALL; ";
+        if ($table !== '') {
+            $tableName = $this->db->quoteTableName($schema === '' ? $table : "{$schema}.{$table}");
+
+            return "ALTER TABLE {$tableName} {$constraintCheck} CONSTRAINT ALL";
         }
 
-        return $command;
+        /** @var Schema $dbSchema */
+        $dbSchema = $this->db->getSchema();
+
+        [$catalogName, $schemaName] = $dbSchema->resolveRawCatalogSchemaName($schema);
+        $systemCatalog = $this->qualifiedSystemCatalog($catalogName);
+
+        $catalogNameLiteral = $catalogName === null ? 'NULL' : "N'" . str_replace("'", "''", $catalogName) . "'";
+
+        $schemaNameLiteral = "N'" . str_replace("'", "''", $schemaName) . "'";
+
+        return <<<SQL
+        DECLARE @catalogName SYSNAME = {$catalogNameLiteral}
+        DECLARE @schemaName SYSNAME = {$schemaNameLiteral}
+        DECLARE @sql NVARCHAR(MAX)
+
+        SELECT @sql = STRING_AGG(
+            CONVERT(
+                NVARCHAR(MAX),
+                N'ALTER TABLE '
+                    + COALESCE(QUOTENAME(@catalogName) + N'.', N'')
+                    + QUOTENAME(@schemaName)
+                    + N'.'
+                    + QUOTENAME([t].[name])
+                    + N' {$constraintCheck} CONSTRAINT ALL'
+            ),
+            N'; '
+        )
+        FROM {$systemCatalog}.[tables] AS [t]
+        INNER JOIN {$systemCatalog}.[schemas] AS [s] ON [s].[schema_id] = [t].[schema_id]
+        WHERE [s].[name] = @schemaName
+
+        IF @sql IS NOT NULL
+            EXEC (@sql)
+        SQL;
     }
 
      /**
@@ -833,5 +871,19 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         return parent::buildWithQueries($withs, $params);
+    }
+
+    /**
+     * Returns the `[sys]` system catalog name, optionally qualified by the database catalog.
+     *
+     * @param string|null $catalogName The database catalog name, or `null` to target the current database.
+     *
+     * @return string The `[sys]` schema name, prefixed with the quoted catalog when one is provided.
+     */
+    private function qualifiedSystemCatalog(?string $catalogName): string
+    {
+        return $catalogName === null
+            ? '[sys]'
+            : $this->db->getSchema()->quoteSimpleTableName($catalogName) . '.[sys]';
     }
 }

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -950,4 +950,18 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
 
         return [null, $parts[0]];
     }
+
+    /**
+     * Resolves a schema argument into optional catalog and schema names without loading database metadata.
+     *
+     * @param string $schema The schema argument.
+     *
+     * @return array{string|null, string} The catalog and schema names.
+     *
+     * @since 22.0
+     */
+    public function resolveRawCatalogSchemaName(string $schema): array
+    {
+        return $this->resolveCatalogSchemaName($schema);
+    }
 }

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -41,6 +41,83 @@ final class CommandTest extends BaseCommand
         $this->assertEquals('SELECT [id], [t].[name] FROM [customer] t', $command->sql);
     }
 
+    #[DataProviderExternal(CommandProvider::class, 'checkIntegrity')]
+    public function testThrowIntegrityExceptionWhenExistingRowsViolateForeignKey(string $tableName): void
+    {
+        $db = $this->getConnection();
+
+        $db->createCommand()->checkIntegrity(
+            false,
+            '',
+            $tableName,
+        )->execute();
+        $db->createCommand(
+            <<<SQL
+            INSERT INTO [T_constraints_3] ([C_id], [C_fk_id_1], [C_fk_id_2]) VALUES (1, 2, 3)
+            SQL,
+        )->execute();
+
+        $this->expectException(IntegrityException::class);
+        $this->expectExceptionMessageMatches(
+            '/FOREIGN KEY constraint/i',
+        );
+
+        $db->createCommand()->checkIntegrity(
+            true,
+            '',
+            $tableName,
+        )->execute();
+    }
+
+    #[DataProviderExternal(CommandProvider::class, 'checkIntegrity')]
+    public function testCheckIntegrityEnablesTrustedForeignKeyWhenExistingRowsAreValid(string $tableName): void
+    {
+        $db = $this->getConnection();
+
+        $db->createCommand(
+            <<<SQL
+            INSERT INTO [T_constraints_2] ([C_id_1], [C_id_2]) VALUES (2, 3)
+            SQL,
+        )->execute();
+        $db->createCommand()->checkIntegrity(
+            false,
+            '',
+            $tableName,
+        )->execute();
+        $db->createCommand(
+            <<<SQL
+            INSERT INTO [T_constraints_3] ([C_id], [C_fk_id_1], [C_fk_id_2]) VALUES (1, 2, 3)
+            SQL,
+        )->execute();
+        $db->createCommand()->checkIntegrity(
+            true,
+            '',
+            $tableName,
+        )->execute();
+        $constraintState = $db->createCommand(
+            <<<SQL
+            SELECT [is_disabled], [is_not_trusted]
+            FROM [sys].[foreign_keys]
+            WHERE [name] = 'CN_constraints_3'
+            SQL,
+        )->queryOne();
+
+        self::assertIsArray(
+            $constraintState,
+            'Constraint state row must be found.',
+        );
+        self::assertSame(
+            0,
+            (int) $constraintState['is_disabled'],
+            'Foreign key must be enabled.',
+        );
+        self::assertSame(
+            0,
+            (int) $constraintState['is_not_trusted'],
+            'Foreign key must be trusted.',
+        );
+    }
+
     #[DataProviderExternal(CommandProvider::class, 'renameTable')]
     public function testRenameTableWithQuotedNames(
         string $fromTableName,

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -842,27 +842,16 @@ final class QueryBuilderTest extends BaseQueryBuilder
         $this->assertSame('SELECT CASE WHEN EXISTS(SELECT 1 FROM [customer]) THEN 1 ELSE 0 END', $sql);
     }
 
-    public function testCheckIntegrityEnableForTable(): void
+    #[DataProviderExternal(QueryBuilderProvider::class, 'checkIntegrity')]
+    public function testCheckIntegrity(bool $check, string $schema, string $table, string $expectedSql): void
     {
-        $qb = $this->getQueryBuilder(true, true);
-        $sql = $qb->checkIntegrity(true, '', 'customer');
-        $this->assertSame('ALTER TABLE [dbo].[customer] CHECK CONSTRAINT ALL; ', $sql);
-    }
+        $qb = $this->getQueryBuilder(false, false);
 
-    public function testCheckIntegrityDisableForTable(): void
-    {
-        $qb = $this->getQueryBuilder(true, true);
-        $sql = $qb->checkIntegrity(false, '', 'customer');
-        $this->assertSame('ALTER TABLE [dbo].[customer] NOCHECK CONSTRAINT ALL; ', $sql);
-    }
-
-    public function testCheckIntegrityFiltersOutViews(): void
-    {
-        $qb = $this->getQueryBuilder(true, true);
-        $sql = $qb->checkIntegrity(true);
-        $this->assertStringContainsString('CHECK CONSTRAINT ALL', $sql);
-        $this->assertStringContainsString('[dbo].[customer]', $sql);
-        $this->assertStringNotContainsString('animal_view', $sql);
+        self::assertSame(
+            $expectedSql,
+            $qb->checkIntegrity($check, $schema, $table),
+            'Generated SQL must match the expected statement.',
+        );
     }
 
     public function testResetSequenceThrowsExceptionForNonExistentTable(): void

--- a/tests/framework/db/mssql/SchemaTest.php
+++ b/tests/framework/db/mssql/SchemaTest.php
@@ -304,14 +304,21 @@ final class SchemaTest extends BaseSchema
         string $expectedTable,
         string $expectedFullName
     ): void {
-        $schema = $this->getConnection()->getSchema();
+        $schema = $this->getConnection(false, false)->getSchema();
 
-        $result = $this->invokeMethod(
+        self::assertInstanceOf(
+            Schema::class,
             $schema,
-            'resolveTableName',
-            [$name],
+            'Schema should be an instance of ' . Schema::class . '.',
         );
 
+        $result = $schema->resolveRawTableName($name);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $result,
+            'Resolved table name should be an MSSQL table schema instance.',
+        );
         self::assertSame(
             $expectedCatalog,
             $result->catalogName,
@@ -331,6 +338,33 @@ final class SchemaTest extends BaseSchema
             $expectedFullName,
             $result->fullName,
             'Resolved full name should match expected value.',
+        );
+    }
+
+    public function testResolveRawCatalogSchemaName(): void
+    {
+        $schema = $this->getConnection(false, false)->getSchema();
+
+        self::assertInstanceOf(
+            Schema::class,
+            $schema,
+            'Schema should be an instance of ' . Schema::class . '.',
+        );
+
+        self::assertSame(
+            [null, 'dbo'],
+            $schema->resolveRawCatalogSchemaName(''),
+            'Empty schema should resolve to the default MSSQL schema.',
+        );
+        self::assertSame(
+            [null, 'sales'],
+            $schema->resolveRawCatalogSchemaName('sales'),
+            'Single-part schema should resolve without catalog.',
+        );
+        self::assertSame(
+            ['yiitest', 'sales'],
+            $schema->resolveRawCatalogSchemaName('yiitest.sales'),
+            'Two-part schema should resolve to catalog and schema.',
         );
     }
 

--- a/tests/framework/db/mssql/providers/CommandProvider.php
+++ b/tests/framework/db/mssql/providers/CommandProvider.php
@@ -19,6 +19,17 @@ namespace yiiunit\framework\db\mssql\providers;
 final class CommandProvider
 {
     /**
+     * @return array<string, array{string}>
+     */
+    public static function checkIntegrity(): array
+    {
+        return [
+            'catalog-qualified table name' => ['yiitest.dbo.T_constraints_3'],
+            'simple table name' => ['T_constraints_3'],
+        ];
+    }
+
+    /**
      * @return array<string, array{string, string, string, string, mixed, string}>
      */
     public static function addDefaultValue(): array

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -92,6 +92,142 @@ final class QueryBuilderProvider
     }
 
     /**
+     * @return array<string, array{bool, string, string, string}>
+     */
+    public static function checkIntegrity(): array
+    {
+        return [
+            'all tables, catalog-qualified schema, enable' => [
+                true,
+                'yiitest.dbo',
+                '',
+                <<<SQL
+                DECLARE @catalogName SYSNAME = N'yiitest'
+                DECLARE @schemaName SYSNAME = N'dbo'
+                DECLARE @sql NVARCHAR(MAX)
+
+                SELECT @sql = STRING_AGG(
+                    CONVERT(
+                        NVARCHAR(MAX),
+                        N'ALTER TABLE '
+                            + COALESCE(QUOTENAME(@catalogName) + N'.', N'')
+                            + QUOTENAME(@schemaName)
+                            + N'.'
+                            + QUOTENAME([t].[name])
+                            + N' WITH CHECK CHECK CONSTRAINT ALL'
+                    ),
+                    N'; '
+                )
+                FROM [yiitest].[sys].[tables] AS [t]
+                INNER JOIN [yiitest].[sys].[schemas] AS [s] ON [s].[schema_id] = [t].[schema_id]
+                WHERE [s].[name] = @schemaName
+
+                IF @sql IS NOT NULL
+                    EXEC (@sql)
+                SQL,
+            ],
+            'all tables, default schema, disable' => [
+                false,
+                '',
+                '',
+                <<<SQL
+                DECLARE @catalogName SYSNAME = NULL
+                DECLARE @schemaName SYSNAME = N'dbo'
+                DECLARE @sql NVARCHAR(MAX)
+
+                SELECT @sql = STRING_AGG(
+                    CONVERT(
+                        NVARCHAR(MAX),
+                        N'ALTER TABLE '
+                            + COALESCE(QUOTENAME(@catalogName) + N'.', N'')
+                            + QUOTENAME(@schemaName)
+                            + N'.'
+                            + QUOTENAME([t].[name])
+                            + N' NOCHECK CONSTRAINT ALL'
+                    ),
+                    N'; '
+                )
+                FROM [sys].[tables] AS [t]
+                INNER JOIN [sys].[schemas] AS [s] ON [s].[schema_id] = [t].[schema_id]
+                WHERE [s].[name] = @schemaName
+
+                IF @sql IS NOT NULL
+                    EXEC (@sql)
+                SQL,
+            ],
+            'all tables, default schema, enable' => [
+                true,
+                '',
+                '',
+                <<<SQL
+                DECLARE @catalogName SYSNAME = NULL
+                DECLARE @schemaName SYSNAME = N'dbo'
+                DECLARE @sql NVARCHAR(MAX)
+
+                SELECT @sql = STRING_AGG(
+                    CONVERT(
+                        NVARCHAR(MAX),
+                        N'ALTER TABLE '
+                            + COALESCE(QUOTENAME(@catalogName) + N'.', N'')
+                            + QUOTENAME(@schemaName)
+                            + N'.'
+                            + QUOTENAME([t].[name])
+                            + N' WITH CHECK CHECK CONSTRAINT ALL'
+                    ),
+                    N'; '
+                )
+                FROM [sys].[tables] AS [t]
+                INNER JOIN [sys].[schemas] AS [s] ON [s].[schema_id] = [t].[schema_id]
+                WHERE [s].[name] = @schemaName
+
+                IF @sql IS NOT NULL
+                    EXEC (@sql)
+                SQL,
+            ],
+            'single table, catalog-qualified' => [
+                true,
+                '',
+                'yiitest.dbo.customer',
+                <<<SQL
+                ALTER TABLE [yiitest].[dbo].[customer] WITH CHECK CHECK CONSTRAINT ALL
+                SQL,
+            ],
+            'single table, disable' => [
+                false,
+                '',
+                'customer',
+                <<<SQL
+                ALTER TABLE [customer] NOCHECK CONSTRAINT ALL
+                SQL,
+            ],
+            'single table, enable' => [
+                true,
+                '',
+                'customer',
+                <<<SQL
+                ALTER TABLE [customer] WITH CHECK CHECK CONSTRAINT ALL
+                SQL,
+            ],
+            'single table, explicit schema' => [
+                true,
+                'dbo',
+                'customer',
+                <<<SQL
+                ALTER TABLE [dbo].[customer] WITH CHECK CHECK CONSTRAINT ALL
+                SQL,
+            ],
+            'single table, single-quoted identifiers' => [
+                true,
+                '',
+                "yiit's.dbo.customer's",
+                <<<SQL
+                ALTER TABLE [yiit's].[dbo].[customer's] WITH CHECK CHECK CONSTRAINT ALL
+                SQL,
+            ],
+        ];
+    }
+
+    /**
      * @return array<string, array{string, int|null, string}>
      */
     public static function resetSequence(): array

--- a/tests/framework/db/sqlite/SchemaTest.php
+++ b/tests/framework/db/sqlite/SchemaTest.php
@@ -47,7 +47,7 @@ final class SchemaTest extends BaseSchema
             Schema::class . ' does not support resolving table names.',
         );
 
-        $this->invokeMethod($schema, 'resolveTableName', ['profile']);
+        $schema->resolveRawTableName('profile');
     }
 
     public function testCurrentTimestampLowercaseDefaultValue(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
