### PR TITLE
Centralize MSSQL identifier bracket detection and qualified-name part extraction in `yii\db\mssql\Quoter`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -101,6 +101,7 @@ Yii Framework 2 Change Log
 - Bug #20953: Fix MSSQL `QueryBuilder::resetSequence()` to reseed `DBCC CHECKIDENT` for the requested next identity value (terabytesoftw)
 - Enh #20957: Rework MSSQL `yii\db\mssql\QueryBuilder::checkIntegrity()` for trusted constraints and catalog-qualified names (terabytesoftw)
 - Enh #20958: Add MSSQL `yii\db\mssql\Quoter::escapeLiteralValue()` and route literal escaping in `QueryBuilder` and `Schema` through it (terabytesoftw)
+- Enh #20959: Centralize MSSQL identifier bracket detection and qualified-name part extraction in `yii\db\mssql\Quoter` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -22,7 +22,6 @@ use function count;
 use function implode;
 use function preg_replace;
 use function strrpos;
-use function substr;
 
 /**
  * QueryBuilder is the query builder for MS SQL Server databases (version 2019 and above).
@@ -124,10 +123,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
         $newTableName = $this->db->quoteSql($this->db->quoteTableName($newName));
 
-        if (($pos = strrpos($newTableName, '].[')) !== false) {
-            $newTableName = substr($newTableName, $pos + 2);
-        }
-
+        $newTableName = Quoter::extractSimpleIdentifier($newTableName);
         $newTableName = Quoter::escapeLiteralValue($schema->unquoteSimpleTableName($newTableName));
 
         return <<<SQL
@@ -153,10 +149,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
         $newName = $this->db->quoteSql($this->db->quoteColumnName($newName));
 
-        if (($pos = strrpos($newName, '].[')) !== false) {
-            $newName = substr($newName, $pos + 2);
-        }
-
+        $newName = Quoter::extractSimpleIdentifier($newName);
         $newName = Quoter::escapeLiteralValue($schema->unquoteSimpleColumnName($newName));
 
         return <<<SQL
@@ -196,7 +189,6 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
         if ($type instanceof ColumnSchemaBuilder) {
             $type->setAlterColumnFormat();
-
             $defaultValue = $type->getDefaultValue();
 
             if ($defaultValue !== null) {
@@ -756,7 +748,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     protected function extractAlias($table)
     {
-        if (preg_match('/^\[.*\]$/', $table)) {
+        if (Quoter::isIdentifierBracketQuoted($table)) {
             return false;
         }
 

--- a/framework/db/mssql/Quoter.php
+++ b/framework/db/mssql/Quoter.php
@@ -65,7 +65,9 @@ class Quoter
      */
     public static function extractSimpleIdentifier(string $name): string
     {
-        if (($pos = strrpos($name, '].[')) !== false) {
+        $pos = strrpos($name, '].[');
+
+        if ($pos !== false) {
             return substr($name, $pos + 2);
         }
 

--- a/framework/db/mssql/Quoter.php
+++ b/framework/db/mssql/Quoter.php
@@ -10,13 +10,17 @@ declare(strict_types=1);
 
 namespace yii\db\mssql;
 
+use function str_ends_with;
 use function str_replace;
+use function str_starts_with;
+use function strrpos;
+use function substr;
 
 /**
- * Provides connection-free helpers for embedding values as Transact-SQL string literals when building MSSQL SQL.
+ * Provides connection-free helpers for quoting MSSQL values and identifiers when building SQL.
  *
- * Unlike {@see \yii\db\Schema::quoteValue()}, the helpers never open a database connection and never wrap the value in
- * quotes, so they are safe to call while {@see QueryBuilder} assembles dynamic SQL ahead of execution.
+ * Unlike {@see \yii\db\Schema::quoteValue()}, the helpers never open a database connection, so they are safe to call
+ * while {@see QueryBuilder} assembles dynamic SQL ahead of execution.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 22.0
@@ -42,5 +46,49 @@ class Quoter
     public static function escapeLiteralValue(string $value): string
     {
         return str_replace("'", "''", $value);
+    }
+
+    /**
+     * Returns the trailing single-part identifier of a bracket-quoted qualified name, keeping its brackets.
+     *
+     * Splits on the last `].[` boundary; a name without that boundary is returned unchanged.
+     *
+     * Usage example:
+     * ```php
+     * \yii\db\mssql\Quoter::extractSimpleIdentifier('[schema].[table]'); // [table]
+     * \yii\db\mssql\Quoter::extractSimpleIdentifier('[table]');          // [table]
+     * ```
+     *
+     * @param string $name Bracket-quoted qualified identifier.
+     *
+     * @return string Trailing single-part identifier with brackets preserved.
+     */
+    public static function extractSimpleIdentifier(string $name): string
+    {
+        if (($pos = strrpos($name, '].[')) !== false) {
+            return substr($name, $pos + 2);
+        }
+
+        return $name;
+    }
+
+    /**
+     * Returns whether an identifier is already wrapped in MSSQL square brackets (`[identifier]`).
+     *
+     * Canonical predicate for an already bracket-quoted identifier; the value starts with `[` and ends with `]`.
+     *
+     * Usage example:
+     * ```php
+     * \yii\db\mssql\Quoter::isIdentifierBracketQuoted('[user]'); // true
+     * \yii\db\mssql\Quoter::isIdentifierBracketQuoted('user');   // false
+     * ```
+     *
+     * @param string $identifier Identifier to inspect.
+     *
+     * @return bool Whether the identifier is already bracket-quoted.
+     */
+    public static function isIdentifierBracketQuoted(string $identifier): bool
+    {
+        return str_starts_with($identifier, '[') && str_ends_with($identifier, ']');
     }
 }

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -29,9 +29,7 @@ use function implode;
 use function preg_match;
 use function preg_match_all;
 use function strcasecmp;
-use function str_ends_with;
 use function str_replace;
-use function str_starts_with;
 use function ucfirst;
 
 /**
@@ -820,7 +818,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     public function quoteColumnName($name)
     {
-        if (str_starts_with($name, '[') && str_ends_with($name, ']')) {
+        if (Quoter::isIdentifierBracketQuoted($name)) {
             return $name;
         }
 

--- a/tests/framework/db/mssql/QuoterTest.php
+++ b/tests/framework/db/mssql/QuoterTest.php
@@ -17,7 +17,7 @@ use yiiunit\framework\db\mssql\providers\QuoterProvider;
 use yiiunit\TestCase;
 
 /**
- * Unit tests for {@see \yii\db\mssql\Quoter::escapeLiteralValue()} single-quote escaping for the MSSQL driver.
+ * Unit tests for {@see \yii\db\mssql\Quoter} for the MSSQL driver.
  *
  * {@see QuoterProvider} for test case data providers.
  *
@@ -36,6 +36,26 @@ final class QuoterTest extends TestCase
             $expected,
             Quoter::escapeLiteralValue($value),
             'Each single quote must be doubled.',
+        );
+    }
+
+    #[DataProviderExternal(QuoterProvider::class, 'extractSimpleIdentifier')]
+    public function testExtractSimpleIdentifierReturnsTrailingPart(string $name, string $expected): void
+    {
+        self::assertSame(
+            $expected,
+            Quoter::extractSimpleIdentifier($name),
+            'Trailing identifier must be returned.',
+        );
+    }
+
+    #[DataProviderExternal(QuoterProvider::class, 'isIdentifierBracketQuoted')]
+    public function testIsIdentifierBracketQuotedDetectsBracketedNames(string $identifier, bool $expected): void
+    {
+        self::assertSame(
+            $expected,
+            Quoter::isIdentifierBracketQuoted($identifier),
+            'Bracket-quoted state must match.',
         );
     }
 }

--- a/tests/framework/db/mssql/providers/QuoterProvider.php
+++ b/tests/framework/db/mssql/providers/QuoterProvider.php
@@ -32,4 +32,33 @@ final class QuoterProvider
             'unicode content preserved' => ["héllo' wörld", "héllo'' wörld"],
         ];
     }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function extractSimpleIdentifier(): array
+    {
+        return [
+            'catalog-qualified name' => ['[db].[schema].[table]', '[table]'],
+            'schema-qualified name' => ['[schema].[table]', '[table]'],
+            'simple bracketed name' => ['[table]', '[table]'],
+            'unqualified name' => ['table', 'table'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function isIdentifierBracketQuoted(): array
+    {
+        return [
+            'bracketed multi-part name' => ['[dbo].[user]', true],
+            'bracketed simple name' => ['[user]', true],
+            'empty brackets' => ['[]', true],
+            'empty string' => ['', false],
+            'name with alias' => ['[user] u', false],
+            'star' => ['*', false],
+            'unbracketed name' => ['user', false],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
