### PR TITLE
Rework MSSQL `yii\db\mssql\QueryBuilder` comment builders to emit `MS_Description` extended-property SQL connection-free with catalog-qualified names.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -102,6 +102,7 @@ Yii Framework 2 Change Log
 - Enh #20957: Rework MSSQL `yii\db\mssql\QueryBuilder::checkIntegrity()` for trusted constraints and catalog-qualified names (terabytesoftw)
 - Enh #20958: Add MSSQL `yii\db\mssql\Quoter::escapeLiteralValue()` and route literal escaping in `QueryBuilder` and `Schema` through it (terabytesoftw)
 - Enh #20959: Centralize MSSQL identifier bracket detection and qualified-name part extraction in `yii\db\mssql\Quoter` (terabytesoftw)
+- Enh #20960: Rework MSSQL `yii\db\mssql\QueryBuilder` comment builders to emit `MS_Description` extended-property SQL connection-free with catalog-qualified names (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -294,9 +294,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * or the next value after the current maximum identity value.
      *
      * @param string $tableName The name of the table whose primary key sequence will be reset.
-     * @param int|null $value The integer value for the primary key of the next new row inserted.
-     * If this is not set, the next new row's primary key will have the next value after the current maximum identity
-     * value.
+     * @param int|null $value The integer value for the primary key of the next new row inserted. If this is not set,
+     * the next new row's primary key will have the next value after the current maximum identity value.
      *
      * @throws InvalidArgumentException if the table does not exist or there is no sequence associated with the table.
      *
@@ -391,8 +390,8 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * database connection. A single table yields a direct `ALTER TABLE` statement; an empty table targets every base
      * table in the schema, enumerated server-side from `sys.tables` (views excluded) and run in one batch.
      *
-     * Enabling uses `WITH CHECK CHECK CONSTRAINT ALL`, re-validating existing rows and marking the constraints
-     * trusted; disabling uses `NOCHECK CONSTRAINT ALL`.
+     * Enabling uses `WITH CHECK CHECK CONSTRAINT ALL`, re-validating existing rows and marking the constraints trusted;
+     * disabling uses `NOCHECK CONSTRAINT ALL`.
      *
      * @param bool $check Whether to enable (`true`) or disable (`false`) the integrity checks.
      * @param string $schema The schema of the tables. Defaults to an empty string, meaning the default schema.
@@ -451,53 +450,88 @@ class QueryBuilder extends \yii\db\QueryBuilder
         SQL;
     }
 
-     /**
-      * Builds a SQL command for adding or updating a comment to a table or a column. The command built will check if a comment
-      * already exists. If so, it will be updated, otherwise, it will be added.
-      *
-      * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
-      * @param string $table the table to be commented or whose column is to be commented. The table name will be
-      * properly quoted by the method.
-      * @param string|null $column optional. The name of the column to be commented. If empty, the command will add the
-      * comment to the table instead. The column name will be properly quoted by the method.
-      * @return string the SQL statement for adding a comment.
-      * @throws InvalidArgumentException if the table does not exist.
-      * @since 2.0.24
-      */
-    protected function buildAddCommentSql($comment, $table, $column = null)
+    /**
+     * Resolves a table name into the literals shared by the extended-property statements, without loading metadata.
+     *
+     * @param string $table Target table. May be 'catalog-', 'schema-', or bracket-qualified.
+     * @param string|null $column Target column, or `null` for the table itself.
+     *
+     * @return array{string, string, string, string, string} Catalog prefix (`[catalog].` or empty), schema-name
+     * literal, table-name literal, the `fn_listextendedproperty` level-2 arguments, and the stored-procedure level-2
+     * parameter line.
+     */
+    private function resolveCommentParts($table, $column): array
     {
-        $tableSchema = $this->db->schema->getTableSchema($table);
+        $schema = $this->db->getSchema();
 
-        if ($tableSchema === null) {
-            throw new InvalidArgumentException("Table not found: $table");
+        $resolved = $schema->resolveRawTableName($table);
+
+        $catalogName = $resolved instanceof TableSchema ? $resolved->catalogName : null;
+
+        $listLevel2 = 'DEFAULT, DEFAULT';
+        $paramLevel2 = '';
+
+        if ($column !== null) {
+            $columnLiteral = "N'" . Quoter::escapeLiteralValue($column) . "'";
+            $listLevel2 = "'COLUMN', {$columnLiteral}";
+            $paramLevel2 = ",\n        @level2type = 'COLUMN', @level2name = {$columnLiteral}";
         }
 
-        $schemaName = $tableSchema->schemaName ? "N'" . $tableSchema->schemaName . "'" : 'SCHEMA_NAME()';
-        $tableName = 'N' . $this->db->quoteValue($tableSchema->name);
-        $columnName = $column ? 'N' . $this->db->quoteValue($column) : null;
-        $comment = 'N' . $this->db->quoteValue($comment);
+        return [
+            $catalogName === null ? '' : $schema->quoteSimpleTableName($catalogName) . '.',
+            "N'" . Quoter::escapeLiteralValue($resolved->schemaName) . "'",
+            "N'" . Quoter::escapeLiteralValue($resolved->name) . "'",
+            $listLevel2,
+            $paramLevel2,
+        ];
+    }
 
-        $functionParams = "
-            @name = N'MS_description',
-            @value = $comment,
-            @level0type = N'SCHEMA', @level0name = $schemaName,
-            @level1type = N'TABLE', @level1name = $tableName"
-            . ($column ? ", @level2type = N'COLUMN', @level2name = $columnName" : '') . ';';
+    /**
+     * Builds the SQL to add or update the `MS_Description` extended property of a table or column.
+     *
+     * Resolves the table name without loading metadata, so the statement is assembled without opening a database
+     * connection. The comment is added when the property is absent and updated otherwise, and the extended-property
+     * routines are qualified with the catalog when the name includes one.
+     *
+     * @param string $comment Comment text. Escaped and wrapped as an `N'...'` literal by the method.
+     * @param string $table Target table. May be 'catalog-', 'schema-', or bracket-qualified.
+     * @param string|null $column Target column, or `null` to comment the table itself.
+     *
+     * @return string SQL statement that adds or updates the comment.
+     *
+     * @since 2.0.24
+     */
+    protected function buildAddCommentSql($comment, $table, $column = null)
+    {
+        [$catalog, $schemaLiteral, $tableLiteral, $listLevel2, $paramLevel2] = $this->resolveCommentParts(
+            $table,
+            $column,
+        );
 
-        return "
-            IF NOT EXISTS (
-                    SELECT 1
-                    FROM fn_listextendedproperty (
-                        N'MS_description',
-                        'SCHEMA', $schemaName,
-                        'TABLE', $tableName,
-                        " . ($column ? "'COLUMN', $columnName " : ' DEFAULT, DEFAULT ') . "
-                    )
+        $valueLiteral = "N'" . Quoter::escapeLiteralValue($comment) . "'";
+
+        return <<<SQL
+        IF NOT EXISTS (
+            SELECT 1
+            FROM {$catalog}sys.fn_listextendedproperty(
+                N'MS_Description',
+                'SCHEMA', {$schemaLiteral},
+                'TABLE', {$tableLiteral},
+                {$listLevel2}
             )
-                EXEC sys.sp_addextendedproperty $functionParams
-            ELSE
-                EXEC sys.sp_updateextendedproperty $functionParams
-        ";
+        )
+            EXEC {$catalog}sys.sp_addextendedproperty
+                @name = N'MS_Description',
+                @value = {$valueLiteral},
+                @level0type = 'SCHEMA', @level0name = {$schemaLiteral},
+                @level1type = 'TABLE', @level1name = {$tableLiteral}{$paramLevel2}
+        ELSE
+            EXEC {$catalog}sys.sp_updateextendedproperty
+                @name = N'MS_Description',
+                @value = {$valueLiteral},
+                @level0type = 'SCHEMA', @level0name = {$schemaLiteral},
+                @level1type = 'TABLE', @level1name = {$tableLiteral}{$paramLevel2}
+        SQL;
     }
 
     /**
@@ -519,44 +553,41 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
-     * Builds a SQL command for removing a comment from a table or a column. The command built will check if a comment
-     * already exists before trying to perform the removal.
+     * Builds the SQL to remove the `MS_Description` extended property from a table or column.
      *
-     * @param string $table the table that will have the comment removed or whose column will have the comment removed.
-     * The table name will be properly quoted by the method.
-     * @param string|null $column optional. The name of the column whose comment will be removed. If empty, the command
-     * will remove the comment from the table instead. The column name will be properly quoted by the method.
-     * @return string the SQL statement for removing the comment.
-     * @throws InvalidArgumentException if the table does not exist.
+     * Resolves the table name without loading metadata, so the statement is assembled without opening a database
+     * connection. The property is dropped only when present, and the extended-property routines are qualified with the
+     * catalog when the name includes one.
+     *
+     * @param string $table Target table. May be 'catalog-', 'schema-', or bracket-qualified.
+     * @param string|null $column Target column, or `null` to remove the table comment.
+     *
+     * @return string SQL statement that removes the comment.
+     *
      * @since 2.0.24
      */
     protected function buildRemoveCommentSql($table, $column = null)
     {
-        $tableSchema = $this->db->schema->getTableSchema($table);
+        [$catalog, $schemaLiteral, $tableLiteral, $listLevel2, $paramLevel2] = $this->resolveCommentParts(
+            $table,
+            $column,
+        );
 
-        if ($tableSchema === null) {
-            throw new InvalidArgumentException("Table not found: $table");
-        }
-
-        $schemaName = $tableSchema->schemaName ? "N'" . $tableSchema->schemaName . "'" : 'SCHEMA_NAME()';
-        $tableName = 'N' . $this->db->quoteValue($tableSchema->name);
-        $columnName = $column ? 'N' . $this->db->quoteValue($column) : null;
-
-        return "
-            IF EXISTS (
-                    SELECT 1
-                    FROM fn_listextendedproperty (
-                        N'MS_description',
-                        'SCHEMA', $schemaName,
-                        'TABLE', $tableName,
-                        " . ($column ? "'COLUMN', $columnName " : ' DEFAULT, DEFAULT ') . "
-                    )
+        return <<<SQL
+        IF EXISTS (
+            SELECT 1
+            FROM {$catalog}sys.fn_listextendedproperty(
+                N'MS_Description',
+                'SCHEMA', {$schemaLiteral},
+                'TABLE', {$tableLiteral},
+                {$listLevel2}
             )
-                EXEC sys.sp_dropextendedproperty
-                    @name = N'MS_description',
-                    @level0type = N'SCHEMA', @level0name = $schemaName,
-                    @level1type = N'TABLE', @level1name = $tableName"
-                    . ($column ? ", @level2type = N'COLUMN', @level2name = $columnName" : '') . ';';
+        )
+            EXEC {$catalog}sys.sp_dropextendedproperty
+                @name = N'MS_Description',
+                @level0type = 'SCHEMA', @level0name = {$schemaLiteral},
+                @level1type = 'TABLE', @level1name = {$tableLiteral}{$paramLevel2}
+        SQL;
     }
 
     /**

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -41,6 +41,65 @@ final class CommandTest extends BaseCommand
         $this->assertEquals('SELECT [id], [t].[name] FROM [customer] t', $command->sql);
     }
 
+    #[DataProviderExternal(CommandProvider::class, 'addCommentOnColumn')]
+    public function testAddUpdateDropCommentOnColumn(string $tableName, string $commentTarget, string $columnName): void
+    {
+        $db = $this->getConnection(false);
+
+        /** @var Schema $schema */
+        $schema = $db->getSchema();
+
+        if ($schema->getTableSchema($tableName) !== null) {
+            $db->createCommand()->dropTable($tableName)->execute();
+        }
+
+        $db->createCommand()->createTable(
+            $tableName,
+            [
+                'id' => 'integer',
+                $columnName => 'string',
+            ],
+        )->execute();
+
+        $db->createCommand()->addCommentOnColumn(
+            $commentTarget,
+            $columnName,
+            'Initial column comment.',
+        )->execute();
+
+        self::assertSame(
+            'Initial column comment.',
+            $schema->getTableSchema($tableName, true)->getColumn($columnName)->comment,
+            'Column comment must be created.',
+        );
+
+        $db->createCommand()->addCommentOnColumn(
+            $commentTarget,
+            $columnName,
+            'Updated column comment.',
+        )->execute();
+
+        self::assertSame(
+            'Updated column comment.',
+            $schema->getTableSchema($tableName, true)->getColumn($columnName)->comment,
+            'Column comment must be updated.',
+        );
+
+        $db->createCommand()->dropCommentFromColumn(
+            $commentTarget,
+            $columnName,
+        )->execute();
+
+        self::assertEmpty(
+            $schema->getTableSchema($tableName, true)->getColumn($columnName)->comment,
+            'Column comment must be removed.',
+        );
+
+        if ($schema->getTableSchema($tableName, true) !== null) {
+            $db->createCommand()->dropTable($tableName)->execute();
+        }
+    }
+
     #[DataProviderExternal(CommandProvider::class, 'checkIntegrity')]
     public function testThrowIntegrityExceptionWhenExistingRowsViolateForeignKey(string $tableName): void
     {

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -293,178 +293,66 @@ final class QueryBuilderTest extends BaseQueryBuilder
         );
     }
 
-    protected function getCommmentsFromTable($table)
-    {
-        $db = $this->getConnection(false, false);
-        $sql = "SELECT *
-            FROM fn_listextendedproperty (
-                N'MS_description',
-                'SCHEMA', N'dbo',
-                'TABLE', N" . $db->quoteValue($table) . ',
-                DEFAULT, DEFAULT
-        )';
-        return $db->createCommand($sql)->queryAll();
-    }
-
-    protected function getCommentsFromColumn($table, $column)
-    {
-        $db = $this->getConnection(false, false);
-        $sql = "SELECT *
-            FROM fn_listextendedproperty (
-                N'MS_description',
-                'SCHEMA', N'dbo',
-                'TABLE', N" . $db->quoteValue($table) . ",
-                'COLUMN', N" . $db->quoteValue($column) . '
-        )';
-        return $db->createCommand($sql)->queryAll();
-    }
-
-    protected function runAddCommentOnTable($comment, $table)
-    {
-        $qb = $this->getQueryBuilder();
-        $db = $this->getConnection(false, false);
-        $sql = $qb->addCommentOnTable($table, $comment);
-        return $db->createCommand($sql)->execute();
-    }
-
-    protected function runAddCommentOnColumn($comment, $table, $column)
-    {
-        $qb = $this->getQueryBuilder();
-        $db = $this->getConnection(false, false);
-        $sql = $qb->addCommentOnColumn($table, $column, $comment);
-        return $db->createCommand($sql)->execute();
-    }
-
-    protected function runDropCommentFromTable($table)
-    {
-        $qb = $this->getQueryBuilder();
-        $db = $this->getConnection(false, false);
-        $sql = $qb->dropCommentFromTable($table);
-        return $db->createCommand($sql)->execute();
-    }
-
-    protected function runDropCommentFromColumn($table, $column)
-    {
-        $qb = $this->getQueryBuilder();
-        $db = $this->getConnection(false, false);
-        $sql = $qb->dropCommentFromColumn($table, $column);
-        return $db->createCommand($sql)->execute();
-    }
-
-    public function testCommentAdditionOnTableAndOnColumn(): void
-    {
-        $table = 'profile';
-        $tableComment = 'A comment for profile table.';
-        $this->runAddCommentOnTable($tableComment, $table);
-        $resultTable = $this->getCommmentsFromTable($table);
-        $this->assertEquals([
-            'objtype' => 'TABLE',
-            'objname' => $table,
-            'name' => 'MS_description',
-            'value' => $tableComment,
-        ], $resultTable[0]);
-
-        $column = 'description';
-        $columnComment = 'A comment for description column in profile table.';
-        $this->runAddCommentOnColumn($columnComment, $table, $column);
-        $resultColumn = $this->getCommentsFromColumn($table, $column);
-        $this->assertEquals([
-            'objtype' => 'COLUMN',
-            'objname' => $column,
-            'name' => 'MS_description',
-            'value' => $columnComment,
-        ], $resultColumn[0]);
-
-        // Add another comment to the same table to test update
-        $tableComment2 = 'Another comment for profile table.';
-        $this->runAddCommentOnTable($tableComment2, $table);
-        $result = $this->getCommmentsFromTable($table);
-        $this->assertEquals([
-            'objtype' => 'TABLE',
-            'objname' => $table,
-            'name' => 'MS_description',
-            'value' => $tableComment2,
-        ], $result[0]);
-
-        // Add another comment to the same column to test update
-        $columnComment2 = 'Another comment for description column in profile table.';
-        $this->runAddCommentOnColumn($columnComment2, $table, $column);
-        $result = $this->getCommentsFromColumn($table, $column);
-        $this->assertEquals([
-            'objtype' => 'COLUMN',
-            'objname' => $column,
-            'name' => 'MS_description',
-            'value' => $columnComment2,
-        ], $result[0]);
-    }
-
-    public function testCommentAdditionOnQuotedTableOrColumn(): void
-    {
-        $table = 'stranger \'table';
-        $tableComment = 'A comment for stranger \'table.';
-        $this->runAddCommentOnTable($tableComment, $table);
-        $resultTable = $this->getCommmentsFromTable($table);
-        $this->assertEquals([
-            'objtype' => 'TABLE',
-            'objname' => $table,
-            'name' => 'MS_description',
-            'value' => $tableComment,
-        ], $resultTable[0]);
-
-        $column = 'stranger \'field';
-        $columnComment = 'A comment for stranger \'field column in stranger \'table.';
-        $this->runAddCommentOnColumn($columnComment, $table, $column);
-        $resultColumn = $this->getCommentsFromColumn($table, $column);
-        $this->assertEquals([
-            'objtype' => 'COLUMN',
-            'objname' => $column,
-            'name' => 'MS_description',
-            'value' => $columnComment,
-        ], $resultColumn[0]);
-    }
-
-    public function testCommentRemovalFromTableAndFromColumn(): void
-    {
-        $table = 'profile';
-        $tableComment = 'A comment for profile table.';
-        $this->runAddCommentOnTable($tableComment, $table);
-        $this->runDropCommentFromTable($table);
-        $result = $this->getCommmentsFromTable($table);
-        $this->assertEquals([], $result);
-
-        $column = 'description';
-        $columnComment = 'A comment for description column in profile table.';
-        $this->runAddCommentOnColumn($columnComment, $table, $column);
-        $this->runDropCommentFromColumn($table, $column);
-        $result = $this->getCommentsFromColumn($table, $column);
-        $this->assertEquals([], $result);
-    }
-
-    public function testCommentRemovalFromQuotedTableOrColumn(): void
-    {
-        $table = 'stranger \'table';
-        $tableComment = 'A comment for stranger \'table.';
-        $this->runAddCommentOnTable($tableComment, $table);
-        $this->runDropCommentFromTable($table);
-        $result = $this->getCommmentsFromTable($table);
-        $this->assertEquals([], $result);
-
-        $column = 'stranger \'field';
-        $columnComment = 'A comment for stranger \'field in stranger \'table.';
-        $this->runAddCommentOnColumn($columnComment, $table, $column);
-        $this->runDropCommentFromColumn($table, $column);
-        $result = $this->getCommentsFromColumn($table, $column);
-        $this->assertEquals([], $result);
-    }
-
     public function testCommentColumn(): void
     {
-        $this->markTestSkipped('Testing the behavior, not sql generation anymore.');
+        self::markTestSkipped(
+            "Covered by 'testAddCommentOnColumn()' and 'testDropCommentFromColumn()'.",
+        );
     }
 
     public function testCommentTable(): void
     {
-        $this->markTestSkipped('Testing the behavior, not sql generation anymore.');
+        self::markTestSkipped(
+            "Covered by 'testAddCommentOnTable()' and 'testDropCommentFromTable()'.",
+        );
+    }
+
+    #[DataProviderExternal(QueryBuilderProvider::class, 'addCommentOnTable')]
+    public function testAddCommentOnTable(string $table, string $comment, string $expected): void
+    {
+        $qb = $this->getQueryBuilder(false, false);
+
+        self::assertSame(
+            $expected,
+            $qb->addCommentOnTable($table, $comment),
+            'Generated extended-property SQL must match the expected statement.',
+        );
+    }
+
+    #[DataProviderExternal(QueryBuilderProvider::class, 'addCommentOnColumn')]
+    public function testAddCommentOnColumn(string $table, string $column, string $comment, string $expected): void
+    {
+        $qb = $this->getQueryBuilder(false, false);
+
+        self::assertSame(
+            $expected,
+            $qb->addCommentOnColumn($table, $column, $comment),
+            'Generated extended-property SQL must match the expected statement.',
+        );
+    }
+
+    #[DataProviderExternal(QueryBuilderProvider::class, 'dropCommentFromTable')]
+    public function testDropCommentFromTable(string $table, string $expected): void
+    {
+        $qb = $this->getQueryBuilder(false, false);
+
+        self::assertSame(
+            $expected,
+            $qb->dropCommentFromTable($table),
+            'Generated extended-property SQL must match the expected statement.',
+        );
+    }
+
+    #[DataProviderExternal(QueryBuilderProvider::class, 'dropCommentFromColumn')]
+    public function testDropCommentFromColumn(string $table, string $column, string $expected): void
+    {
+        $qb = $this->getQueryBuilder(false, false);
+
+        self::assertSame(
+            $expected,
+            $qb->dropCommentFromColumn($table, $column),
+            'Generated extended-property SQL must match the expected statement.',
+        );
     }
 
     /**
@@ -886,21 +774,5 @@ final class QueryBuilderTest extends BaseQueryBuilder
         $condition = ['in', ['id', 'name'], (new Query())->select(['id', 'name'])->from('users')];
         $this->expectException('yii\base\NotSupportedException');
         $qb->buildCondition($condition, $params);
-    }
-
-    public function testAddCommentOnNonExistentTableThrowsException(): void
-    {
-        $qb = $this->getQueryBuilder(true, true);
-        $this->expectException('yii\base\InvalidArgumentException');
-        $this->expectExceptionMessage('Table not found: non_existent_table');
-        $qb->addCommentOnColumn('non_existent_table', 'col', 'comment');
-    }
-
-    public function testDropCommentFromNonExistentTableThrowsException(): void
-    {
-        $qb = $this->getQueryBuilder(true, true);
-        $this->expectException('yii\base\InvalidArgumentException');
-        $this->expectExceptionMessage('Table not found: non_existent_table');
-        $qb->dropCommentFromColumn('non_existent_table', 'col');
     }
 }

--- a/tests/framework/db/mssql/providers/CommandProvider.php
+++ b/tests/framework/db/mssql/providers/CommandProvider.php
@@ -30,6 +30,30 @@ final class CommandProvider
     }
 
     /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function addCommentOnColumn(): array
+    {
+        return [
+            'catalog-qualified table name' => [
+                'yii2_mssql_comment_column_catalog',
+                'yiitest.dbo.yii2_mssql_comment_column_catalog',
+                'comment_column',
+            ],
+            'column name with single quote' => [
+                "yii2_mssql_comment_column'",
+                "yii2_mssql_comment_column'",
+                "comment column'",
+            ],
+            'simple table name' => [
+                'yii2_mssql_comment_column',
+                'yii2_mssql_comment_column',
+                'comment_column',
+            ],
+        ];
+    }
+
+    /**
      * @return array<string, array{string, string, string, string, mixed, string}>
      */
     public static function addDefaultValue(): array

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -652,6 +652,414 @@ final class QueryBuilderProvider
     /**
      * @return array<string, array{string, string, string}>
      */
+    public static function addCommentOnTable(): array
+    {
+        return [
+            'catalog-qualified table name' => [
+                'yiitest.dbo.profile',
+                'A profile comment.',
+                <<<SQL
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM [yiitest].sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'profile',
+                        DEFAULT, DEFAULT
+                    )
+                )
+                    EXEC [yiitest].sys.sp_addextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A profile comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile'
+                ELSE
+                    EXEC [yiitest].sys.sp_updateextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A profile comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile'
+                SQL,
+            ],
+            'schema-qualified table name' => [
+                'myschema.profile',
+                'A profile comment.',
+                <<<SQL
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'myschema',
+                        'TABLE', N'profile',
+                        DEFAULT, DEFAULT
+                    )
+                )
+                    EXEC sys.sp_addextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A profile comment.',
+                        @level0type = 'SCHEMA', @level0name = N'myschema',
+                        @level1type = 'TABLE', @level1name = N'profile'
+                ELSE
+                    EXEC sys.sp_updateextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A profile comment.',
+                        @level0type = 'SCHEMA', @level0name = N'myschema',
+                        @level1type = 'TABLE', @level1name = N'profile'
+                SQL,
+            ],
+            'simple table name' => [
+                'profile',
+                'A profile comment.',
+                <<<SQL
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'profile',
+                        DEFAULT, DEFAULT
+                    )
+                )
+                    EXEC sys.sp_addextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A profile comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile'
+                ELSE
+                    EXEC sys.sp_updateextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A profile comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile'
+                SQL,
+            ],
+            'table name and comment with single quotes' => [
+                'stranger\'s table',
+                'It\'s a table comment.',
+                <<<SQL
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'stranger''s table',
+                        DEFAULT, DEFAULT
+                    )
+                )
+                    EXEC sys.sp_addextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'It''s a table comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'stranger''s table'
+                ELSE
+                    EXEC sys.sp_updateextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'It''s a table comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'stranger''s table'
+                SQL,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string, string, string}>
+     */
+    public static function addCommentOnColumn(): array
+    {
+        return [
+            'catalog-qualified table name' => [
+                'yiitest.dbo.profile',
+                'description',
+                'A column comment.',
+                <<<SQL
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM [yiitest].sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'profile',
+                        'COLUMN', N'description'
+                    )
+                )
+                    EXEC [yiitest].sys.sp_addextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A column comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile',
+                        @level2type = 'COLUMN', @level2name = N'description'
+                ELSE
+                    EXEC [yiitest].sys.sp_updateextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A column comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile',
+                        @level2type = 'COLUMN', @level2name = N'description'
+                SQL,
+            ],
+            'column and comment with single quotes' => [
+                'stranger\'s table',
+                'stranger\'s field',
+                'It\'s a column comment.',
+                <<<SQL
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'stranger''s table',
+                        'COLUMN', N'stranger''s field'
+                    )
+                )
+                    EXEC sys.sp_addextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'It''s a column comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'stranger''s table',
+                        @level2type = 'COLUMN', @level2name = N'stranger''s field'
+                ELSE
+                    EXEC sys.sp_updateextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'It''s a column comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'stranger''s table',
+                        @level2type = 'COLUMN', @level2name = N'stranger''s field'
+                SQL,
+            ],
+            'schema-qualified table name' => [
+                'myschema.profile',
+                'description',
+                'A column comment.',
+                <<<SQL
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'myschema',
+                        'TABLE', N'profile',
+                        'COLUMN', N'description'
+                    )
+                )
+                    EXEC sys.sp_addextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A column comment.',
+                        @level0type = 'SCHEMA', @level0name = N'myschema',
+                        @level1type = 'TABLE', @level1name = N'profile',
+                        @level2type = 'COLUMN', @level2name = N'description'
+                ELSE
+                    EXEC sys.sp_updateextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A column comment.',
+                        @level0type = 'SCHEMA', @level0name = N'myschema',
+                        @level1type = 'TABLE', @level1name = N'profile',
+                        @level2type = 'COLUMN', @level2name = N'description'
+                SQL,
+            ],
+            'simple table name' => [
+                'profile',
+                'description',
+                'A column comment.',
+                <<<SQL
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'profile',
+                        'COLUMN', N'description'
+                    )
+                )
+                    EXEC sys.sp_addextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A column comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile',
+                        @level2type = 'COLUMN', @level2name = N'description'
+                ELSE
+                    EXEC sys.sp_updateextendedproperty
+                        @name = N'MS_Description',
+                        @value = N'A column comment.',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile',
+                        @level2type = 'COLUMN', @level2name = N'description'
+                SQL,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function dropCommentFromTable(): array
+    {
+        return [
+            'catalog-qualified table name' => [
+                'yiitest.dbo.profile',
+                <<<SQL
+                IF EXISTS (
+                    SELECT 1
+                    FROM [yiitest].sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'profile',
+                        DEFAULT, DEFAULT
+                    )
+                )
+                    EXEC [yiitest].sys.sp_dropextendedproperty
+                        @name = N'MS_Description',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile'
+                SQL,
+            ],
+            'schema-qualified table name' => [
+                'myschema.profile',
+                <<<SQL
+                IF EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'myschema',
+                        'TABLE', N'profile',
+                        DEFAULT, DEFAULT
+                    )
+                )
+                    EXEC sys.sp_dropextendedproperty
+                        @name = N'MS_Description',
+                        @level0type = 'SCHEMA', @level0name = N'myschema',
+                        @level1type = 'TABLE', @level1name = N'profile'
+                SQL,
+            ],
+            'simple table name' => [
+                'profile',
+                <<<SQL
+                IF EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'profile',
+                        DEFAULT, DEFAULT
+                    )
+                )
+                    EXEC sys.sp_dropextendedproperty
+                        @name = N'MS_Description',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile'
+                SQL,
+            ],
+            'table name with single quote' => [
+                'stranger\'s table',
+                <<<SQL
+                IF EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'stranger''s table',
+                        DEFAULT, DEFAULT
+                    )
+                )
+                    EXEC sys.sp_dropextendedproperty
+                        @name = N'MS_Description',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'stranger''s table'
+                SQL,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function dropCommentFromColumn(): array
+    {
+        return [
+            'catalog-qualified table name' => [
+                'yiitest.dbo.profile',
+                'description',
+                <<<SQL
+                IF EXISTS (
+                    SELECT 1
+                    FROM [yiitest].sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'profile',
+                        'COLUMN', N'description'
+                    )
+                )
+                    EXEC [yiitest].sys.sp_dropextendedproperty
+                        @name = N'MS_Description',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile',
+                        @level2type = 'COLUMN', @level2name = N'description'
+                SQL,
+            ],
+            'column with single quote' => [
+                'stranger\'s table',
+                'stranger\'s field',
+                <<<SQL
+                IF EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'stranger''s table',
+                        'COLUMN', N'stranger''s field'
+                    )
+                )
+                    EXEC sys.sp_dropextendedproperty
+                        @name = N'MS_Description',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'stranger''s table',
+                        @level2type = 'COLUMN', @level2name = N'stranger''s field'
+                SQL,
+            ],
+            'simple table name' => [
+                'profile',
+                'description',
+                <<<SQL
+                IF EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'dbo',
+                        'TABLE', N'profile',
+                        'COLUMN', N'description'
+                    )
+                )
+                    EXEC sys.sp_dropextendedproperty
+                        @name = N'MS_Description',
+                        @level0type = 'SCHEMA', @level0name = N'dbo',
+                        @level1type = 'TABLE', @level1name = N'profile',
+                        @level2type = 'COLUMN', @level2name = N'description'
+                SQL,
+            ],
+            'schema-qualified table name' => [
+                'myschema.profile',
+                'description',
+                <<<SQL
+                IF EXISTS (
+                    SELECT 1
+                    FROM sys.fn_listextendedproperty(
+                        N'MS_Description',
+                        'SCHEMA', N'myschema',
+                        'TABLE', N'profile',
+                        'COLUMN', N'description'
+                    )
+                )
+                    EXEC sys.sp_dropextendedproperty
+                        @name = N'MS_Description',
+                        @level0type = 'SCHEMA', @level0name = N'myschema',
+                        @level1type = 'TABLE', @level1name = N'profile',
+                        @level2type = 'COLUMN', @level2name = N'description'
+                SQL,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
     public static function renameTable(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
