### PR TITLE
Rework MSSQL `yii\db\mssql\QueryBuilder::selectExists()` to return a named `[result]` existence column.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -103,6 +103,7 @@ Yii Framework 2 Change Log
 - Enh #20958: Add MSSQL `yii\db\mssql\Quoter::escapeLiteralValue()` and route literal escaping in `QueryBuilder` and `Schema` through it (terabytesoftw)
 - Enh #20959: Centralize MSSQL identifier bracket detection and qualified-name part extraction in `yii\db\mssql\Quoter` (terabytesoftw)
 - Enh #20960: Rework MSSQL `yii\db\mssql\QueryBuilder` comment builders to emit `MS_Description` extended-property SQL connection-free with catalog-qualified names (terabytesoftw)
+- Enh #20961: Rework MSSQL `yii\db\mssql\QueryBuilder::selectExists()` to return a named `[result]` existence column (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -630,7 +630,9 @@ class QueryBuilder extends \yii\db\QueryBuilder
      */
     public function selectExists($rawSql)
     {
-        return 'SELECT CASE WHEN EXISTS(' . $rawSql . ') THEN 1 ELSE 0 END';
+        return <<<SQL
+        SELECT CASE WHEN EXISTS($rawSql) THEN 1 ELSE 0 END AS [result]
+        SQL;
     }
 
     /**

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -41,6 +41,36 @@ final class CommandTest extends BaseCommand
         $this->assertEquals('SELECT [id], [t].[name] FROM [customer] t', $command->sql);
     }
 
+    public function testSelectExistsReturnsScalarExistenceFlag(): void
+    {
+        $db = $this->getConnection();
+
+        $qb = $db->getQueryBuilder();
+
+        self::assertSame(
+            1,
+            (int) $db->createCommand(
+                $qb->selectExists(
+                   <<<SQL
+                    SELECT 1 FROM [customer] WHERE [status] = 2
+                    SQL
+                ),
+            )->queryScalar(),
+            "Matching row must yield '1'.",
+        );
+        self::assertSame(
+            0,
+            (int) $db->createCommand(
+                $qb->selectExists(
+                    <<<SQL
+                    SELECT 1 FROM [customer] WHERE [status] = 3
+                    SQL
+                ),
+            )->queryScalar(),
+            "No matching row must yield '0'.",
+        );
+    }
+
     #[DataProviderExternal(CommandProvider::class, 'addCommentOnColumn')]
     public function testAddUpdateDropCommentOnColumn(string $tableName, string $commentTarget, string $columnName): void
     {

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -51,9 +51,9 @@ final class CommandTest extends BaseCommand
             1,
             (int) $db->createCommand(
                 $qb->selectExists(
-                   <<<SQL
+                    <<<SQL
                     SELECT 1 FROM [customer] WHERE [status] = 2
-                    SQL
+                    SQL,
                 ),
             )->queryScalar(),
             "Matching row must yield '1'.",
@@ -64,7 +64,7 @@ final class CommandTest extends BaseCommand
                 $qb->selectExists(
                     <<<SQL
                     SELECT 1 FROM [customer] WHERE [status] = 3
-                    SQL
+                    SQL,
                 ),
             )->queryScalar(),
             "No matching row must yield '0'.",

--- a/tests/framework/db/mssql/QueryBuilderTest.php
+++ b/tests/framework/db/mssql/QueryBuilderTest.php
@@ -725,9 +725,30 @@ final class QueryBuilderTest extends BaseQueryBuilder
 
     public function testSelectExists(): void
     {
-        $qb = $this->getQueryBuilder();
-        $sql = $qb->selectExists('SELECT 1 FROM [customer]');
-        $this->assertSame('SELECT CASE WHEN EXISTS(SELECT 1 FROM [customer]) THEN 1 ELSE 0 END', $sql);
+        $qb = $this->getQueryBuilder(false, false);
+
+        self::assertSame(
+            <<<SQL
+            SELECT CASE WHEN EXISTS(SELECT 1 FROM [customer]) THEN 1 ELSE 0 END AS [result]
+            SQL,
+            $qb->selectExists(
+                <<<SQL
+                SELECT 1 FROM [customer]
+                SQL,
+            ),
+            "Generated SQL must match the expected 'EXISTS()' statement with a simple subquery.",
+        );
+        self::assertSame(
+            <<<SQL
+            SELECT CASE WHEN EXISTS(SELECT 1 FROM [customer] WHERE [status] = 2) THEN 1 ELSE 0 END AS [result]
+            SQL,
+            $qb->selectExists(
+                <<<SQL
+                SELECT 1 FROM [customer] WHERE [status] = 2
+                SQL,
+            ),
+            "Generated SQL must match the expected 'EXISTS()' statement with a subquery containing a WHERE clause.",
+        );
     }
 
     #[DataProviderExternal(QueryBuilderProvider::class, 'checkIntegrity')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
