### PR TITLE
Declare native return types on MSSQL `yii\db\mssql\PDO`, `yii\db\mssql\DBLibPDO`, and `yii\db\mssql\SqlsrvPDO` method overrides and remove `#[\ReturnTypeWillChange]`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -105,6 +105,7 @@ Yii Framework 2 Change Log
 - Enh #20960: Rework MSSQL `yii\db\mssql\QueryBuilder` comment builders to emit `MS_Description` extended-property SQL connection-free with catalog-qualified names (terabytesoftw)
 - Enh #20961: Rework MSSQL `yii\db\mssql\QueryBuilder::selectExists()` to return a named `[result]` existence column (terabytesoftw)
 - Enh #20962: Rework MSSQL `yii\db\mssql\QueryBuilder::upsert()` (terabytesoftw)
+- Enh #20964: Declare native return types on MSSQL `yii\db\mssql\PDO`, `yii\db\mssql\DBLibPDO`, and `yii\db\mssql\SqlsrvPDO` method overrides and remove `#[\ReturnTypeWillChange]` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/DBLibPDO.php
+++ b/framework/db/mssql/DBLibPDO.php
@@ -62,7 +62,10 @@ class DBLibPDO extends PDO
         } catch (PDOException $e) {
             switch ($attribute) {
                 case self::ATTR_SERVER_VERSION:
+                    // Reached only on the `dblib` driver (throws on `getAttribute()`); never on `sqlsrv`/CI.
+                    // @codeCoverageIgnoreStart
                     return $this->query($sql)->fetchColumn();
+                    // @codeCoverageIgnoreEnd
                 default:
                     throw $e;
             }

--- a/framework/db/mssql/DBLibPDO.php
+++ b/framework/db/mssql/DBLibPDO.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,6 +10,9 @@
 
 namespace yii\db\mssql;
 
+use PDO;
+use PDOException;
+
 /**
  * This is an extension of the default PDO class of DBLIB drivers.
  * It provides workarounds for improperly implemented functionalities of the DBLIB drivers.
@@ -15,37 +20,49 @@ namespace yii\db\mssql;
  * @author Bert Brunekreeft <bbrunekreeft@gmail.com>
  * @since 2.0.41
  */
-class DBLibPDO extends \PDO
+class DBLibPDO extends PDO
 {
     /**
      * Returns value of the last inserted ID.
-     * @param string|null $name the sequence name. Defaults to null.
-     * @return string|false last inserted ID value.
+     *
+     * @param string|null $name The sequence name. Defaults to null.
+     *
+     * @return string|false Last inserted ID value.
      */
-    #[\ReturnTypeWillChange]
-    public function lastInsertId($name = null)
+    public function lastInsertId(string|null $name = null): string|false
     {
-        return $this->query('SELECT CAST(COALESCE(SCOPE_IDENTITY(), @@IDENTITY) AS bigint)')->fetchColumn();
+        $sql = <<<SQL
+        SELECT CAST(COALESCE(SCOPE_IDENTITY(), @@IDENTITY) AS bigint)
+        SQL;
+
+        $id = $this->query($sql)->fetchColumn();
+
+        return $id === null ? false : (string) $id;
     }
 
     /**
      * Retrieve a database connection attribute.
      *
-     * It is necessary to override PDO's method as some MSSQL PDO driver (e.g. dblib) does not
-     * support getting attributes.
+     * It is necessary to override PDO's method as some MSSQL PDO driver (for example, dblib) does not support getting
+     * attributes.
+     *
      * @param int $attribute One of the PDO::ATTR_* constants.
-     * @return mixed A successful call returns the value of the requested PDO attribute.
-     * An unsuccessful call returns null.
+     *
+     * @return mixed A successful call returns the value of the requested PDO attribute. An unsuccessful call returns
+     * `null`.
      */
-    #[\ReturnTypeWillChange]
-    public function getAttribute($attribute)
+    public function getAttribute($attribute): mixed
     {
+        $sql = <<<SQL
+        SELECT CAST(SERVERPROPERTY('productversion') AS VARCHAR)
+        SQL;
+
         try {
             return parent::getAttribute($attribute);
-        } catch (\PDOException $e) {
+        } catch (PDOException $e) {
             switch ($attribute) {
                 case self::ATTR_SERVER_VERSION:
-                    return $this->query("SELECT CAST(SERVERPROPERTY('productversion') AS VARCHAR)")->fetchColumn();
+                    return $this->query($sql)->fetchColumn();
                 default:
                     throw $e;
             }

--- a/framework/db/mssql/PDO.php
+++ b/framework/db/mssql/PDO.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,8 +10,11 @@
 
 namespace yii\db\mssql;
 
+use PDOException;
+
 /**
  * This is an extension of the default PDO class of MSSQL and DBLIB drivers.
+ *
  * It provides workarounds for improperly implemented functionalities of the MSSQL and DBLIB drivers.
  *
  * @author Timur Ruziev <resurtm@gmail.com>
@@ -19,22 +24,29 @@ class PDO extends \PDO
 {
     /**
      * Returns value of the last inserted ID.
-     * @param string|null $sequence the sequence name. Defaults to null.
-     * @return string|false last inserted ID value.
+     *
+     * @param string|null $sequence The sequence name. Defaults to `null`.
+     *
+     * @return string|false Last inserted ID value.
      */
-    #[\ReturnTypeWillChange]
-    public function lastInsertId($sequence = null)
+    public function lastInsertId(string|null $sequence = null): string|false
     {
-        return $this->query('SELECT CAST(COALESCE(SCOPE_IDENTITY(), @@IDENTITY) AS bigint)')->fetchColumn();
+        $sql = <<<SQL
+        SELECT CAST(COALESCE(SCOPE_IDENTITY(), @@IDENTITY) AS bigint)
+        SQL;
+
+        $id = $this->query($sql)->fetchColumn();
+
+        return $id === null ? false : (string) $id;
     }
 
     /**
-     * Starts a transaction. It is necessary to override PDO's method as MSSQL PDO driver does not
-     * natively support transactions.
-     * @return bool the result of a transaction start.
+     * Starts a transaction. It is necessary to override PDO's method as MSSQL PDO driver does not natively support
+     * transactions.
+     *
+     * @return bool The result of a transaction start.
      */
-    #[\ReturnTypeWillChange]
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         $this->exec('BEGIN TRANSACTION');
 
@@ -42,12 +54,12 @@ class PDO extends \PDO
     }
 
     /**
-     * Commits a transaction. It is necessary to override PDO's method as MSSQL PDO driver does not
-     * natively support transactions.
-     * @return bool the result of a transaction commit.
+     * Commits a transaction. It is necessary to override PDO's method as MSSQL PDO driver does not natively support
+     * transactions.
+     *
+     * @return bool The result of a transaction commit.
      */
-    #[\ReturnTypeWillChange]
-    public function commit()
+    public function commit(): bool
     {
         $this->exec('COMMIT TRANSACTION');
 
@@ -55,12 +67,12 @@ class PDO extends \PDO
     }
 
     /**
-     * Rollbacks a transaction. It is necessary to override PDO's method as MSSQL PDO driver does not
-     * natively support transactions.
-     * @return bool the result of a transaction roll back.
+     * Rollbacks a transaction. It is necessary to override PDO's method as MSSQL PDO driver does not natively support
+     * transactions.
+     *
+     * @return bool The result of a transaction roll back.
      */
-    #[\ReturnTypeWillChange]
-    public function rollBack()
+    public function rollBack(): bool
     {
         $this->exec('ROLLBACK TRANSACTION');
 
@@ -70,21 +82,26 @@ class PDO extends \PDO
     /**
      * Retrieve a database connection attribute.
      *
-     * It is necessary to override PDO's method as some MSSQL PDO driver (e.g. dblib) does not
-     * support getting attributes.
+     * It is necessary to override PDO's method as some MSSQL PDO driver (for example, dblib) does not support getting
+     * attributes.
+     *
      * @param int $attribute One of the PDO::ATTR_* constants.
-     * @return mixed A successful call returns the value of the requested PDO attribute.
-     * An unsuccessful call returns null.
+     *
+     * @return mixed A successful call returns the value of the requested PDO attribute. An unsuccessful call returns
+     * `null`.
      */
-    #[\ReturnTypeWillChange]
-    public function getAttribute($attribute)
+    public function getAttribute(int $attribute): mixed
     {
+        $sql = <<<SQL
+        SELECT CAST(SERVERPROPERTY('productversion') AS VARCHAR)
+        SQL;
+
         try {
             return parent::getAttribute($attribute);
-        } catch (\PDOException $e) {
+        } catch (PDOException $e) {
             switch ($attribute) {
                 case self::ATTR_SERVER_VERSION:
-                    return $this->query("SELECT CAST(SERVERPROPERTY('productversion') AS VARCHAR)")->fetchColumn();
+                    return $this->query($sql)->fetchColumn();
                 default:
                     throw $e;
             }

--- a/framework/db/mssql/PDO.php
+++ b/framework/db/mssql/PDO.php
@@ -101,7 +101,10 @@ class PDO extends \PDO
         } catch (PDOException $e) {
             switch ($attribute) {
                 case self::ATTR_SERVER_VERSION:
+                    // Reached only on the `dblib` driver (throws on `getAttribute()`); never on `sqlsrv`/CI.
+                    // @codeCoverageIgnoreStart
                     return $this->query($sql)->fetchColumn();
+                    // @codeCoverageIgnoreEnd
                 default:
                     throw $e;
             }

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -770,6 +770,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
     public function getColumnType($type)
     {
         $columnType = parent::getColumnType($type);
+        
         // remove unsupported keywords
         $columnType = preg_replace("/\s*comment '.*'/i", '', $columnType);
         $columnType = preg_replace('/ first$/i', '', $columnType);

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -770,7 +770,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
     public function getColumnType($type)
     {
         $columnType = parent::getColumnType($type);
-        
+
         // remove unsupported keywords
         $columnType = preg_replace("/\s*comment '.*'/i", '', $columnType);
         $columnType = preg_replace('/ first$/i', '', $columnType);

--- a/framework/db/mssql/SqlsrvPDO.php
+++ b/framework/db/mssql/SqlsrvPDO.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types= 1);
+declare(strict_types=1);
 
 /**
  * @link https://www.yiiframework.com/

--- a/framework/db/mssql/SqlsrvPDO.php
+++ b/framework/db/mssql/SqlsrvPDO.php
@@ -36,6 +36,10 @@ class SqlsrvPDO extends PDO
      */
     public function lastInsertId(string|null $sequence = null): string|false
     {
-        return !$sequence ? parent::lastInsertId() : parent::lastInsertId($sequence);
+        if ($sequence === null || $sequence === '') {
+            return parent::lastInsertId();
+        }
+
+        return parent::lastInsertId($sequence);
     }
 }

--- a/framework/db/mssql/SqlsrvPDO.php
+++ b/framework/db/mssql/SqlsrvPDO.php
@@ -10,8 +10,6 @@ declare(strict_types=1);
 
 namespace yii\db\mssql;
 
-use PDO;
-
 /**
  * This is an extension of the default PDO class of SQLSRV driver.
  *
@@ -20,7 +18,7 @@ use PDO;
  * @author Timur Ruziev <resurtm@gmail.com>
  * @since 2.0
  */
-class SqlsrvPDO extends PDO
+class SqlsrvPDO extends \PDO
 {
     /**
      * Returns value of the last inserted ID.

--- a/framework/db/mssql/SqlsrvPDO.php
+++ b/framework/db/mssql/SqlsrvPDO.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types= 1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,27 +10,31 @@
 
 namespace yii\db\mssql;
 
+use PDO;
+
 /**
  * This is an extension of the default PDO class of SQLSRV driver.
+ *
  * It provides workarounds for improperly implemented functionalities of the SQLSRV driver.
  *
  * @author Timur Ruziev <resurtm@gmail.com>
  * @since 2.0
  */
-class SqlsrvPDO extends \PDO
+class SqlsrvPDO extends PDO
 {
     /**
      * Returns value of the last inserted ID.
      *
      * SQLSRV driver implements [[PDO::lastInsertId()]] method but with a single peculiarity:
-     * when `$sequence` value is a null or an empty string it returns an empty string.
-     * But when parameter is not specified it works as expected and returns actual
-     * last inserted ID (like the other PDO drivers).
-     * @param string|null $sequence the sequence name. Defaults to null.
-     * @return string|false last inserted ID value.
+     * - when `$sequence` value is a null or an empty string it returns an empty string.
+     * - but when parameter is not specified it works as expected and returns actual
+     * - last inserted ID (like the other PDO drivers).
+     *
+     * @param string|null $sequence The sequence name. Defaults to `null`.
+     *
+     * @return string|false Last inserted ID value.
      */
-    #[\ReturnTypeWillChange]
-    public function lastInsertId($sequence = null)
+    public function lastInsertId(string|null $sequence = null): string|false
     {
         return !$sequence ? parent::lastInsertId() : parent::lastInsertId($sequence);
     }

--- a/tests/framework/db/mssql/DBLibPDOTest.php
+++ b/tests/framework/db/mssql/DBLibPDOTest.php
@@ -43,7 +43,7 @@ final class DBLibPDOTest extends DatabaseTestCase
         );
         self::assertNotEmpty(
             $version,
-            "Version must not be empty.",
+            'Version must not be empty.',
         );
     }
 

--- a/tests/framework/db/mssql/DBLibPDOTest.php
+++ b/tests/framework/db/mssql/DBLibPDOTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mssql;
+
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\mssql\DBLibPDO;
+use yiiunit\framework\db\DatabaseTestCase;
+
+/**
+ * Unit tests for {@see \yii\db\mssql\DBLibPDO} last-insert-id and attribute workarounds for the MSSQL driver.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('db')]
+#[Group('mssql')]
+#[Group('pdo')]
+final class DBLibPDOTest extends DatabaseTestCase
+{
+    protected $driverName = 'sqlsrv';
+
+    public function testGetAttributeReturnsServerVersion(): void
+    {
+        $db = $this->getConnection();
+
+        $pdo = new DBLibPDO($db->dsn, $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $version = $pdo->getAttribute(\PDO::ATTR_SERVER_VERSION);
+
+        self::assertIsString(
+            $version,
+            "Version must be a 'string'.",
+        );
+        self::assertNotEmpty(
+            $version,
+            "Version must not be empty.",
+        );
+    }
+
+    public function testLastInsertIdReturnsInsertedRowId(): void
+    {
+        $db = $this->getConnection();
+
+        $pdo = new DBLibPDO($db->dsn, $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            <<<SQL
+            INSERT INTO [dbo].[profile] ([description]) VALUES ('dblib last insert id')
+            SQL,
+        );
+
+        $id = $pdo->lastInsertId();
+
+        $expectedId = $pdo
+            ->query(
+                <<<SQL
+                SELECT [id] FROM [dbo].[profile] WHERE [description] = 'dblib last insert id'
+                SQL,
+            )
+            ->fetchColumn();
+
+        self::assertIsString(
+            $id,
+            "Result must be a 'string'.",
+        );
+        self::assertSame(
+            (string) $expectedId,
+            $id,
+            'Returned id must match the inserted row id.',
+        );
+    }
+}

--- a/tests/framework/db/mssql/DBLibPDOTest.php
+++ b/tests/framework/db/mssql/DBLibPDOTest.php
@@ -27,6 +27,37 @@ final class DBLibPDOTest extends DatabaseTestCase
 {
     protected $driverName = 'sqlsrv';
 
+    public function testLastInsertIdReturnsFalseWithoutInsert(): void
+    {
+        $db = $this->getConnection();
+
+        $pdo = new DBLibPDO($db->dsn, $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        self::assertFalse(
+            $pdo->lastInsertId(),
+            "No prior insert must yield 'false'.",
+        );
+    }
+
+    public function testThrowPDOExceptionWhenAttributeUnsupported(): void
+    {
+        $db = $this->getConnection();
+
+        $pdo = new DBLibPDO($db->dsn, $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessageMatches(
+            '/^SQLSTATE\[IM001\]: Driver does not support this function: driver does not support that attribute/',
+        );
+
+        // An unsupported attribute other than `ATTR_SERVER_VERSION` must propagate through the `default` branch.
+        $pdo->getAttribute(\PDO::ATTR_AUTOCOMMIT);
+    }
+
     public function testGetAttributeReturnsServerVersion(): void
     {
         $db = $this->getConnection();
@@ -35,6 +66,7 @@ final class DBLibPDOTest extends DatabaseTestCase
 
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
+        // `sqlsrv` supports `ATTR_SERVER_VERSION` natively, so the dblib `catch` fallback is not reached here.
         $version = $pdo->getAttribute(\PDO::ATTR_SERVER_VERSION);
 
         self::assertIsString(
@@ -54,21 +86,18 @@ final class DBLibPDOTest extends DatabaseTestCase
         $pdo = new DBLibPDO($db->dsn, $db->username, $db->password);
 
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<SQL
-            INSERT INTO [dbo].[profile] ([description]) VALUES ('dblib last insert id')
-            SQL,
-        );
 
-        $id = $pdo->lastInsertId();
-
+        // `OUTPUT INSERTED.[id]` returns the new id from the `INSERT` itself, so the assertion is independent of the
+        // table contents.
         $expectedId = $pdo
             ->query(
                 <<<SQL
-                SELECT [id] FROM [dbo].[profile] WHERE [description] = 'dblib last insert id'
+                INSERT INTO [dbo].[profile] ([description]) OUTPUT INSERTED.[id] VALUES ('dblib last insert id')
                 SQL,
             )
             ->fetchColumn();
+
+        $id = $pdo->lastInsertId();
 
         self::assertIsString(
             $id,

--- a/tests/framework/db/mssql/PDOTest.php
+++ b/tests/framework/db/mssql/PDOTest.php
@@ -27,6 +27,37 @@ final class PDOTest extends DatabaseTestCase
 {
     protected $driverName = 'sqlsrv';
 
+    public function testLastInsertIdReturnsFalseWithoutInsert(): void
+    {
+        $db = $this->getConnection();
+
+        $pdo = new MssqlPdo($db->dsn, $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        self::assertFalse(
+            $pdo->lastInsertId(),
+            "No prior insert must yield 'false'.",
+        );
+    }
+
+    public function testThrowPDOExceptionWhenAttributeUnsupported(): void
+    {
+        $db = $this->getConnection();
+
+        $pdo = new MssqlPdo($db->dsn, $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessageMatches(
+            '/^SQLSTATE\[IM001\]: Driver does not support this function: driver does not support that attribute/',
+        );
+
+        // An unsupported attribute other than `ATTR_SERVER_VERSION` must propagate through the `default` branch.
+        $pdo->getAttribute(\PDO::ATTR_AUTOCOMMIT);
+    }
+
     public function testBeginTransactionAndCommitPersistsInsert(): void
     {
         $db = $this->getConnection();
@@ -41,7 +72,7 @@ final class PDOTest extends DatabaseTestCase
 
         self::assertTrue(
             $started,
-            "Start must report 'true0'.",
+            "Start must report 'true'.",
         );
 
         $pdo->exec(
@@ -151,21 +182,17 @@ final class PDOTest extends DatabaseTestCase
 
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
-        $pdo->exec(
-            <<<SQL
-            INSERT INTO [dbo].[profile] ([description]) VALUES ('pdo last insert id')
-            SQL,
-        );
-
-        $id = $pdo->lastInsertId();
-
+        // `OUTPUT INSERTED.[id]` returns the new id from the `INSERT` itself, so the assertion is independent of the
+        // table contents.
         $expectedId = $pdo
             ->query(
                 <<<SQL
-                SELECT [id] FROM [dbo].[profile] WHERE [description] = 'pdo last insert id'
+                INSERT INTO [dbo].[profile] ([description]) OUTPUT INSERTED.[id] VALUES ('pdo last insert id')
                 SQL,
             )
             ->fetchColumn();
+
+        $id = $pdo->lastInsertId();
 
         self::assertIsString(
             $id,

--- a/tests/framework/db/mssql/PDOTest.php
+++ b/tests/framework/db/mssql/PDOTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mssql;
+
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\mssql\PDO as MssqlPdo;
+use yiiunit\framework\db\DatabaseTestCase;
+
+/**
+ * Unit tests for {@see \yii\db\mssql\PDO} last-insert-id, transaction, and attribute workarounds for the MSSQL driver.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('db')]
+#[Group('mssql')]
+#[Group('pdo')]
+final class PDOTest extends DatabaseTestCase
+{
+    protected $driverName = 'sqlsrv';
+
+    public function testBeginTransactionAndCommitPersistsInsert(): void
+    {
+        $db = $this->getConnection();
+
+        // The raw `BEGIN TRANSACTION` workaround targets the non-MARS `mssql`/`dblib` drivers; `sqlsrv` enables MARS by
+        // default, which forbids an open transaction at the end of a batch, so disable MARS for this handle.
+        $pdo = new MssqlPdo($db->dsn . ';MultipleActiveResultSets=false', $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $started = $pdo->beginTransaction();
+
+        self::assertTrue(
+            $started,
+            "Start must report 'true0'.",
+        );
+
+        $pdo->exec(
+            <<<SQL
+            INSERT INTO [dbo].[profile] ([description]) VALUES ('pdo commit row')
+            SQL,
+        );
+
+        $committed = $pdo->commit();
+
+        self::assertTrue(
+            $committed,
+            "Commit must report 'true'.",
+        );
+
+        $count = (int) $pdo
+            ->query(
+                <<<SQL
+                SELECT COUNT(*) FROM [dbo].[profile] WHERE [description] = 'pdo commit row'
+                SQL,
+            )
+            ->fetchColumn();
+
+        self::assertSame(
+            1,
+            $count,
+            'Committed row must persist.',
+        );
+
+        $pdo->exec(
+            <<<SQL
+            DELETE FROM [dbo].[profile] WHERE [description] = 'pdo commit row'
+            SQL,
+        );
+    }
+
+    public function testBeginTransactionAndRollBackRevertsInsert(): void
+    {
+        $db = $this->getConnection();
+
+        // The raw `BEGIN TRANSACTION` workaround targets the non-MARS `mssql`/`dblib` drivers; `sqlsrv` enables MARS by
+        // default, which forbids an open transaction at the end of a batch, so disable MARS for this handle.
+        $pdo = new MssqlPdo($db->dsn . ';MultipleActiveResultSets=false', $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $started = $pdo->beginTransaction();
+
+        self::assertTrue(
+            $started,
+            "Start must report 'true'.",
+        );
+
+        $pdo->exec(
+            <<<SQL
+            INSERT INTO [dbo].[profile] ([description]) VALUES ('pdo rollback row')
+            SQL,
+        );
+
+        $rolledBack = $pdo->rollBack();
+
+        self::assertTrue(
+            $rolledBack,
+            "Roll back must report 'true'.",
+        );
+
+        $count = (int) $pdo
+            ->query(
+                <<<SQL
+                SELECT COUNT(*) FROM [dbo].[profile] WHERE [description] = 'pdo rollback row'
+                SQL,
+            )
+            ->fetchColumn();
+
+        self::assertSame(
+            0,
+            $count,
+            'Rolled-back row must not persist.',
+        );
+    }
+
+    public function testGetAttributeReturnsServerVersion(): void
+    {
+        $db = $this->getConnection();
+
+        $pdo = new MssqlPdo($db->dsn, $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $version = $pdo->getAttribute(\PDO::ATTR_SERVER_VERSION);
+
+        self::assertIsString(
+            $version,
+            "Version must be a 'string'.",
+        );
+        self::assertNotEmpty(
+            $version,
+            'Version must not be empty.',
+        );
+    }
+
+    public function testLastInsertIdReturnsInsertedRowId(): void
+    {
+        $db = $this->getConnection();
+
+        $pdo = new MssqlPdo($db->dsn, $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $pdo->exec(
+            <<<SQL
+            INSERT INTO [dbo].[profile] ([description]) VALUES ('pdo last insert id')
+            SQL,
+        );
+
+        $id = $pdo->lastInsertId();
+
+        $expectedId = $pdo
+            ->query(
+                <<<SQL
+                SELECT [id] FROM [dbo].[profile] WHERE [description] = 'pdo last insert id'
+                SQL,
+            )
+            ->fetchColumn();
+
+        self::assertIsString(
+            $id,
+            "Result must be a 'string'.",
+        );
+        self::assertSame(
+            (string) $expectedId,
+            $id,
+            'Returned id must match the inserted row id.',
+        );
+    }
+}

--- a/tests/framework/db/mssql/SqlsrvPDOTest.php
+++ b/tests/framework/db/mssql/SqlsrvPDOTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\db\mssql;
+
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\mssql\SqlsrvPDO;
+use yiiunit\framework\db\DatabaseTestCase;
+
+/**
+ * Unit tests for {@see \yii\db\mssql\SqlsrvPDO} last-insert-id workaround for the MSSQL driver.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('db')]
+#[Group('mssql')]
+#[Group('pdo')]
+final class SqlsrvPDOTest extends DatabaseTestCase
+{
+    protected $driverName = 'sqlsrv';
+
+    public function testLastInsertIdReturnsInsertedRowId(): void
+    {
+        $db = $this->getConnection();
+
+        $pdo = new SqlsrvPDO($db->dsn, $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $pdo->exec(
+            <<<SQL
+            INSERT INTO [dbo].[profile] ([description]) VALUES ('sqlsrv last insert id')
+            SQL,
+        );
+
+        $id = $pdo->lastInsertId();
+
+        $expectedId = $pdo
+            ->query(
+                <<<SQL
+                SELECT [id] FROM [dbo].[profile] WHERE [description] = 'sqlsrv last insert id'
+                SQL,
+            )
+            ->fetchColumn();
+
+        self::assertIsString(
+            $id,
+            "Result must be a 'string'.",
+        );
+        self::assertSame(
+            (string) $expectedId,
+            $id,
+            'Returned id must match the inserted row id.',
+        );
+    }
+}

--- a/tests/framework/db/mssql/SqlsrvPDOTest.php
+++ b/tests/framework/db/mssql/SqlsrvPDOTest.php
@@ -27,6 +27,22 @@ final class SqlsrvPDOTest extends DatabaseTestCase
 {
     protected $driverName = 'sqlsrv';
 
+    public function testLastInsertIdForwardsSequenceNameToParent(): void
+    {
+        $db = $this->getConnection();
+
+        $pdo = new SqlsrvPDO($db->dsn, $db->username, $db->password);
+
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        // A non-empty sequence name is forwarded to the native driver, which reports an empty string for `sqlsrv`.
+        self::assertSame(
+            '',
+            $pdo->lastInsertId('non_existent_sequence'),
+            'Explicit sequence name must be forwarded to the parent driver.',
+        );
+    }
+
     public function testLastInsertIdReturnsInsertedRowId(): void
     {
         $db = $this->getConnection();
@@ -35,21 +51,17 @@ final class SqlsrvPDOTest extends DatabaseTestCase
 
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
-        $pdo->exec(
-            <<<SQL
-            INSERT INTO [dbo].[profile] ([description]) VALUES ('sqlsrv last insert id')
-            SQL,
-        );
-
-        $id = $pdo->lastInsertId();
-
+        // `OUTPUT INSERTED.[id]` returns the new id from the `INSERT` itself, so the assertion is independent of the
+        // table contents.
         $expectedId = $pdo
             ->query(
                 <<<SQL
-                SELECT [id] FROM [dbo].[profile] WHERE [description] = 'sqlsrv last insert id'
+                INSERT INTO [dbo].[profile] ([description]) OUTPUT INSERTED.[id] VALUES ('sqlsrv last insert id')
                 SQL,
             )
             ->fetchColumn();
+
+        $id = $pdo->lastInsertId();
 
         self::assertIsString(
             $id,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
