### PR TITLE
Support MSSQL `rowversion`/`timestamp` columns as `optimisticLock()` attributes in `yii\db\mssql\ColumnSchema` and `yii\db\mssql\QueryBuilder`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -109,6 +109,7 @@ Yii Framework 2 Change Log
 - Bug #18318: Qualify MSSQL unqualified table names with the configured non `dbo` `defaultSchema` in `yii\db\mssql\Schema::quoteTableName()` (terabytesoftw)
 - Enh #20968: Consolidate MSSQL system-catalog quoting in `yii\db\mssql\Schema::quoteSystemCatalogName()` (terabytesoftw)
 - Enh #12121: Add SQLSRV encoding constants to `yii\db\mssql\PDO` and `yii\db\mssql\SqlsrvPDO` (terabytesoftw)
+- Enh #9653: Support MSSQL `rowversion`/`timestamp` columns as `optimisticLock()` attributes in `yii\db\mssql\ColumnSchema` and `yii\db\mssql\QueryBuilder` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/ColumnSchema.php
+++ b/framework/db/mssql/ColumnSchema.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yii\db\mssql;
 
 use yii\db\Expression;
+use yii\db\ExpressionInterface;
 use yii\db\PdoValue;
 
 use function bin2hex;
@@ -19,10 +20,13 @@ use function get_resource_type;
 use function is_resource;
 use function is_string;
 use function preg_match;
+use function sprintf;
 use function str_replace;
 use function str_starts_with;
+use function strlen;
 use function strtolower;
 use function stream_get_contents;
+use function unpack;
 
 /**
  * Represents the metadata of a column in a Microsoft SQL Server database table.
@@ -38,16 +42,22 @@ class ColumnSchema extends \yii\db\ColumnSchema
     public $isComputed = false;
 
     /**
-     * {@inheritdoc}
+     * Renders a `rowversion`/`timestamp` value as an 8-byte binary literal (`0x...`) for WHERE comparisons, and
+     * converts `varbinary` strings to `CONVERT(VARBINARY(MAX), 0x...)` expressions to avoid conversion errors.
      *
-     * Converts string values for `varbinary` columns to explicit `CONVERT(VARBINARY(MAX), 0x...)` expressions to avoid
-     * implicit `varchar` to `varbinary` conversion errors in SQL Server, particularly under `INSERT ... OUTPUT INTO`
-     * and `UPDATE`.
-     *
+     * @see https://github.com/yiisoft/yii2/issues/9653
      * @see https://github.com/yiisoft/yii2/issues/12599
      */
     public function dbTypecast($value)
     {
+        if ($this->isRowVersion() && $value !== null && !$value instanceof ExpressionInterface) {
+            $hex = is_string($value) && strlen($value) === 8
+                ? bin2hex($value) // raw 8-byte binary value.
+                : sprintf('%016x', (int) $value); // integer representation from `phpTypecast()`.
+
+            return new Expression("0x{$hex}");
+        }
+
         if ($this->isVarbinary()) {
             if ($value instanceof PdoValue && $value->getType() === \PDO::PARAM_LOB) {
                 $pdoValue = $value->getValue();
@@ -72,12 +82,22 @@ class ColumnSchema extends \yii\db\ColumnSchema
     /**
      * {@inheritdoc}
      *
-     * Converts `varbinary` streams returned by MSSQL PDO drivers to strings for consumers such as DbCache.
+     * Decodes a `rowversion`/`timestamp` token to its integer value, and reads `varbinary` streams into strings.
      */
     public function phpTypecast($value)
     {
         if ($value === null) {
             return null;
+        }
+
+        if ($this->isRowVersion()) {
+            if (is_resource($value) && get_resource_type($value) === 'stream') {
+                $value = stream_get_contents($value);
+            }
+
+            return is_string($value) && strlen($value) === 8
+                ? unpack('J', $value)[1]
+                : $value;
         }
 
         if ($this->isVarbinary() && is_resource($value) && get_resource_type($value) === 'stream') {
@@ -153,6 +173,16 @@ class ColumnSchema extends \yii\db\ColumnSchema
         }
 
         return $dbType;
+    }
+
+    /**
+     * Returns whether this column is a SQL Server `rowversion` (legacy synonym `timestamp`) auto-versioning column.
+     *
+     * @see https://learn.microsoft.com/en-us/sql/t-sql/data-types/rowversion-transact-sql
+     */
+    public function isRowVersion(): bool
+    {
+        return $this->isType(Schema::TYPE_TIMESTAMP);
     }
 
     /**

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -15,11 +15,13 @@ use yii\base\NotSupportedException;
 use yii\db\conditions\InCondition;
 use yii\db\conditions\LikeCondition;
 use yii\db\Expression;
+use yii\db\ExpressionInterface;
 
 use function array_flip;
 use function array_intersect_key;
 use function count;
 use function implode;
+use function is_array;
 use function ltrim;
 use function preg_replace;
 
@@ -639,6 +641,51 @@ class QueryBuilder extends \yii\db\QueryBuilder
     /**
      * {@inheritdoc}
      *
+     * Excludes server-managed `rowversion` columns from the `SET` clause and renders any `rowversion` in the WHERE as a
+     * binary literal, enabling a `rowversion` column to serve as the optimistic lock attribute.
+     *
+     * @see https://github.com/yiisoft/yii2/issues/9653
+     */
+    public function update($table, $columns, $condition, &$params)
+    {
+        $schema = $this->db->getTableSchema($table);
+
+        if ($schema !== null) {
+            foreach ($columns as $name => $value) {
+                $column = $schema->columns[$name] ?? null;
+
+                if ($column instanceof ColumnSchema && $column->isRowVersion()) {
+                    unset($columns[$name]); // server-managed; never in the SET clause.
+                }
+            }
+
+            $condition = $this->castRowVersionConditions($schema, $condition);
+        }
+
+        return parent::update($table, $columns, $condition, $params);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Renders any `rowversion` in the WHERE condition as a binary literal, enabling optimistic-lock deletes.
+     *
+     * @see https://github.com/yiisoft/yii2/issues/9653
+     */
+    public function delete($table, $condition, &$params)
+    {
+        $schema = $this->db->getTableSchema($table);
+
+        if ($schema !== null) {
+            $condition = $this->castRowVersionConditions($schema, $condition);
+        }
+
+        return parent::delete($table, $condition, $params);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * Wraps the `INSERT` with an `OUTPUT INSERTED.* INTO @temporary_inserted` block so that the inserted row
      * (including computed columns and `IDENTITY` values) can be retrieved by the caller.
      */
@@ -919,5 +966,32 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         return parent::buildWithQueries($withs, $params);
+    }
+
+    /**
+     * Converts `rowversion` values in a hash condition to `binary(8)` literals via {@see ColumnSchema::dbTypecast()}.
+     *
+     * Operator-format and non-array conditions are returned unchanged.
+     *
+     * @param TableSchema $schema The metadata of the table targeted by the statement.
+     * @param mixed $condition The condition passed to {@see update()} or {@see delete()}.
+     *
+     * @return mixed The condition with `rowversion` values converted, unchanged when it carries none.
+     */
+    private function castRowVersionConditions(TableSchema $schema, mixed $condition): mixed
+    {
+        if (!is_array($condition)) {
+            return $condition;
+        }
+
+        foreach ($condition as $name => $value) {
+            $column = $schema->columns[$name] ?? null;
+
+            if ($column instanceof ColumnSchema && $column->isRowVersion() && !$value instanceof ExpressionInterface) {
+                $condition[$name] = $column->dbTypecast($value);
+            }
+        }
+
+        return $condition;
     }
 }

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -19,6 +19,7 @@ use yii\db\ExpressionInterface;
 
 use function array_flip;
 use function array_intersect_key;
+use function array_map;
 use function count;
 use function implode;
 use function is_array;
@@ -644,6 +645,9 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * Excludes server-managed `rowversion` columns from the `SET` clause and renders any `rowversion` in the WHERE as a
      * binary literal, enabling a `rowversion` column to serve as the optimistic lock attribute.
      *
+     * Note: SQL Server regenerates the `rowversion` on every write and the in-memory attribute is not refreshed
+     * afterwards; reload the record before saving the same instance again to avoid a spurious `StaleObjectException`.
+     *
      * @see https://github.com/yiisoft/yii2/issues/9653
      */
     public function update($table, $columns, $condition, &$params)
@@ -651,7 +655,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         $schema = $this->db->getTableSchema($table);
 
         if ($schema !== null) {
-            foreach ($columns as $name => $value) {
+            foreach ($columns as $name => $_value) {
                 $column = $schema->columns[$name] ?? null;
 
                 if ($column instanceof ColumnSchema && $column->isRowVersion()) {
@@ -987,9 +991,14 @@ class QueryBuilder extends \yii\db\QueryBuilder
         foreach ($condition as $name => $value) {
             $column = $schema->columns[$name] ?? null;
 
-            if ($column instanceof ColumnSchema && $column->isRowVersion() && !$value instanceof ExpressionInterface) {
-                $condition[$name] = $column->dbTypecast($value);
+            if (!$column instanceof ColumnSchema || !$column->isRowVersion()) {
+                continue;
             }
+
+            // Cast each element of an array value individually so an `IN` condition keeps its shape.
+            $cast = static fn($item) => $item instanceof ExpressionInterface ? $item : $column->dbTypecast($item);
+
+            $condition[$name] = is_array($value) ? array_map($cast, $value) : $cast($value);
         }
 
         return $condition;

--- a/framework/db/mssql/RowVersionBehavior.php
+++ b/framework/db/mssql/RowVersionBehavior.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yii\db\mssql;
+
+use yii\base\Behavior;
+use yii\db\BaseActiveRecord;
+
+/**
+ * Refreshes a server-managed `rowversion` optimistic lock attribute from the database after each write.
+ *
+ * SQL Server regenerates the `rowversion` value server-side on every INSERT and UPDATE, so the in-memory attribute
+ * holds a guessed token afterwards. Attach this behavior to an ActiveRecord whose
+ * {@see BaseActiveRecord::optimisticLock()} returns a `rowversion` column to re-read the authoritative token after each
+ * write, so repeated saves on the same instance do not raise a spurious {@see \yii\db\StaleObjectException}.
+ *
+ * Usage example:
+ * ```php
+ * public function behaviors(): array
+ * {
+ *     return [\yii\db\mssql\RowVersionBehavior::class];
+ * }
+ * ```
+ *
+ * @see https://github.com/yiisoft/yii2/issues/9653
+ */
+class RowVersionBehavior extends Behavior
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function events()
+    {
+        return [
+            BaseActiveRecord::EVENT_AFTER_INSERT => 'refreshRowVersion',
+            BaseActiveRecord::EVENT_AFTER_UPDATE => 'refreshRowVersion',
+        ];
+    }
+
+    /**
+     * Re-reads the `rowversion` optimistic lock attribute from the database into the owner instance.
+     *
+     * Does nothing when optimistic locking is disabled or the lock column is not a `rowversion`.
+     */
+    public function refreshRowVersion(): void
+    {
+        /** @var \yii\db\ActiveRecord $owner */
+        $owner = $this->owner;
+
+        $lock = $owner->optimisticLock();
+
+        if ($lock === null) {
+            return;
+        }
+
+        $column = $owner::getTableSchema()->columns[$lock] ?? null;
+
+        if (!$column instanceof ColumnSchema || !$column->isRowVersion()) {
+            return;
+        }
+
+        $value = $owner::find()->select([$lock])->where($owner->getOldPrimaryKey(true))->scalar();
+
+        if ($value !== false && $value !== null) {
+            // `scalar()` returns the raw token; decode it as `findOne()` would so the attribute stays an integer.
+            $value = $column->phpTypecast($value);
+
+            $owner->$lock = $value;
+
+            $owner->setOldAttribute($lock, $value);
+        }
+    }
+}

--- a/tests/data/ar/OptimisticRowVersion.php
+++ b/tests/data/ar/OptimisticRowVersion.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar;
+
+/**
+ * ActiveRecord stub backed by an MSSQL `rowversion` optimistic lock column.
+ *
+ * @property int $id
+ * @property string $name
+ * @property int $rv rowversion token used as the optimistic lock attribute.
+ */
+final class OptimisticRowVersion extends ActiveRecord
+{
+    public static function tableName(): string
+    {
+        return 'test_optimistic_rowversion';
+    }
+
+    public function optimisticLock(): string
+    {
+        return 'rv';
+    }
+
+    public function rules(): array
+    {
+        return [
+            [['name'], 'required'],
+            [['name'], 'string', 'max' => 128],
+        ];
+    }
+}

--- a/tests/framework/db/mssql/ActiveRecordTest.php
+++ b/tests/framework/db/mssql/ActiveRecordTest.php
@@ -11,10 +11,13 @@ namespace yiiunit\framework\db\mssql;
 use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\IntegrityException;
+use yii\db\StaleObjectException;
+use yiiunit\data\ar\OptimisticRowVersion;
 use yiiunit\data\ar\TestTrigger;
 use yiiunit\data\ar\TestTriggerAlert;
 use yiiunit\data\ar\Type;
 use yiiunit\base\db\BaseActiveRecord;
+use yiiunit\support\DbHelper;
 
 /**
  * @group db
@@ -168,5 +171,184 @@ END';
         $this->assertTrue($record->save(false));
         $this->assertEquals(1, $record->id);
         $this->assertEquals('test', $record->stringcol);
+    }
+
+    public function testOptimisticRowVersionUpdateSucceeds(): void
+    {
+        $this->createOptimisticRowVersionTable();
+
+        $record = new OptimisticRowVersion();
+
+        $record->name = 'initial';
+
+        self::assertTrue(
+            $record->save(false),
+            'INSERT must succeed.',
+        );
+
+        $id = $record->id;
+
+        // Rowversion is server-managed and not returned by the INSERT path; fetch to read its initial value.
+        /** @var OptimisticRowVersion $fetched */
+        $fetched = OptimisticRowVersion::findOne($id);
+
+        $rvAfterInsert = $fetched->rv;
+
+        self::assertIsInt(
+            $rvAfterInsert,
+            'Rowversion must load as an integer token.',
+        );
+
+        $fetched->name = 'updated';
+
+        self::assertTrue(
+            $fetched->save(false),
+            'UPDATE must not throw.',
+        );
+
+        // The server bumps the rowversion; a fresh read confirms the change was persisted and advanced.
+        /** @var OptimisticRowVersion $reloaded */
+
+        $reloaded = OptimisticRowVersion::findOne($id);
+
+        self::assertSame(
+            'updated',
+            $reloaded->name,
+            'New value must be persisted.',
+        );
+        self::assertGreaterThan(
+            $rvAfterInsert,
+            $reloaded->rv,
+            'Persisted rowversion must advance.',
+        );
+
+        DbHelper::dropTablesIfExist($this->getConnection(), ['test_optimistic_rowversion']);
+    }
+
+    public function testOptimisticRowVersionDeleteSucceeds(): void
+    {
+        $this->createOptimisticRowVersionTable();
+
+        $record = new OptimisticRowVersion();
+
+        $record->name = 'to-delete';
+
+        self::assertTrue(
+            $record->save(false),
+            'INSERT must succeed.',
+        );
+
+        $id = $record->id;
+
+        /** @var OptimisticRowVersion $fetched */
+        $fetched = OptimisticRowVersion::findOne($id);
+
+        self::assertSame(
+            1,
+            $fetched->delete(),
+            'Exactly one row must be deleted.',
+        );
+        self::assertNull(
+            OptimisticRowVersion::findOne($id),
+            'Record must be absent after DELETE.',
+        );
+
+        DbHelper::dropTablesIfExist($this->getConnection(), ['test_optimistic_rowversion']);
+    }
+
+    public function testThrowStaleObjectExceptionWhenRowVersionConflictsOnUpdate(): void
+    {
+        $this->createOptimisticRowVersionTable();
+
+        $record = new OptimisticRowVersion();
+
+        $record->name = 'shared';
+
+        self::assertTrue(
+            $record->save(false),
+            'INSERT must succeed.',
+        );
+
+        $id = $record->id;
+
+        /** @var OptimisticRowVersion $record1 */
+        $record1 = OptimisticRowVersion::findOne($id);
+        /** @var OptimisticRowVersion $record2 */
+        $record2 = OptimisticRowVersion::findOne($id);
+
+        $record1->name = 'copy1';
+
+        self::assertTrue(
+            $record1->save(false),
+            'First UPDATE must succeed.',
+        );
+
+        $this->expectException(StaleObjectException::class);
+        $this->expectExceptionMessage(
+            'The object being updated is outdated.',
+        );
+
+        $record2->name = 'copy2';
+
+        $record2->save(false);
+
+        DbHelper::dropTablesIfExist($this->getConnection(), ['test_optimistic_rowversion']);
+    }
+
+    public function testThrowStaleObjectExceptionWhenRowVersionConflictsOnDelete(): void
+    {
+        $this->createOptimisticRowVersionTable();
+
+        $record = new OptimisticRowVersion();
+
+        $record->name = 'shared';
+
+        self::assertTrue(
+            $record->save(false),
+            'INSERT must succeed.',
+        );
+
+        $id = $record->id;
+
+        /** @var OptimisticRowVersion $record1 */
+        $record1 = OptimisticRowVersion::findOne($id);
+        /** @var OptimisticRowVersion $record2 */
+        $record2 = OptimisticRowVersion::findOne($id);
+
+        $record1->name = 'updated-before-delete';
+
+        self::assertTrue(
+            $record1->save(false),
+            'UPDATE must succeed before stale delete attempt.',
+        );
+
+        $this->expectException(StaleObjectException::class);
+        $this->expectExceptionMessage(
+            'The object being deleted is outdated.',
+        );
+
+        $record2->delete();
+
+        DbHelper::dropTablesIfExist($this->getConnection(), ['test_optimistic_rowversion']);
+    }
+
+    private function createOptimisticRowVersionTable(): void
+    {
+        $db = $this->getConnection();
+
+        DbHelper::dropTablesIfExist($db, ['test_optimistic_rowversion']);
+
+        $db->createCommand(
+            <<<SQL
+            CREATE TABLE [dbo].[test_optimistic_rowversion] (
+                [id]   INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+                [name] NVARCHAR(128)     NOT NULL,
+                [rv]   ROWVERSION        NOT NULL
+            )
+            SQL,
+        )->execute();
+
+        // Flush the cached `null` entry so `getTableSchema()` picks up the newly created table.
+        $db->getSchema()->refreshTableSchema('test_optimistic_rowversion');
     }
 }

--- a/tests/framework/db/mssql/ActiveRecordTest.php
+++ b/tests/framework/db/mssql/ActiveRecordTest.php
@@ -11,7 +11,9 @@ namespace yiiunit\framework\db\mssql;
 use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\IntegrityException;
+use yii\db\mssql\RowVersionBehavior;
 use yii\db\StaleObjectException;
+use yiiunit\data\ar\Document;
 use yiiunit\data\ar\OptimisticRowVersion;
 use yiiunit\data\ar\TestTrigger;
 use yiiunit\data\ar\TestTriggerAlert;
@@ -330,6 +332,225 @@ END';
         $record2->delete();
 
         DbHelper::dropTablesIfExist($this->getConnection(), ['test_optimistic_rowversion']);
+    }
+
+    public function testOptimisticRowVersionInConditionCastsEachToken(): void
+    {
+        $this->createOptimisticRowVersionTable();
+
+        $ids = [];
+
+        foreach (['a', 'b', 'c'] as $name) {
+            $record = new OptimisticRowVersion();
+
+            $record->name = $name;
+
+            $record->save(false);
+
+            $ids[$name] = $record->id;
+        }
+
+        $record1 = OptimisticRowVersion::findOne($ids['a'])->rv;
+        $record2 = OptimisticRowVersion::findOne($ids['b'])->rv;
+
+        // An array hash value builds an `IN` condition; each `rowversion` token must be cast individually.
+        $deleted = OptimisticRowVersion::deleteAll(['rv' => [$record1, $record2]]);
+
+        self::assertSame(
+            2,
+            $deleted,
+            'Both tokens in the `IN` list must match.',
+        );
+        self::assertNull(
+            OptimisticRowVersion::findOne($ids['a']),
+            'First listed row must be deleted.',
+        );
+        self::assertNull(
+            OptimisticRowVersion::findOne($ids['b']),
+            'Second listed row must be deleted.',
+        );
+        self::assertNotNull(
+            OptimisticRowVersion::findOne($ids['c']),
+            'Unlisted row must survive.',
+        );
+
+        DbHelper::dropTablesIfExist($this->getConnection(), ['test_optimistic_rowversion']);
+    }
+
+    /**
+     * Documents the `rowversion` refresh contract: SQL Server regenerates the token server-side, so the in-memory value
+     * is a guess after a save; reloading the record yields the authoritative token and lets the next save succeed.
+     */
+    public function testOptimisticRowVersionRepeatedSaveSucceedsAfterReload(): void
+    {
+        $this->createOptimisticRowVersionTable();
+
+        $db = $this->getConnection();
+
+        $record = new OptimisticRowVersion();
+
+        $record->name = 'initial';
+
+        self::assertTrue(
+            $record->save(false),
+            'INSERT must succeed.',
+        );
+
+        $id = $record->id;
+
+        // Unrelated write advances the database-wide rowversion counter, so the next token is not `old + 1`.
+        $db->createCommand(
+            <<<SQL
+            INSERT INTO [dbo].[test_optimistic_rowversion] ([name]) VALUES ('other')
+            SQL
+        )->execute();
+
+        /** @var OptimisticRowVersion $first */
+        $first = OptimisticRowVersion::findOne($id);
+
+        $first->name = 'first-update';
+
+        self::assertTrue(
+            $first->save(false),
+            'First UPDATE must succeed.',
+        );
+
+        // The server regenerated the rowversion; reload to pick up the authoritative token before saving again.
+        /** @var OptimisticRowVersion $reloaded */
+        $reloaded = OptimisticRowVersion::findOne($id);
+
+        $reloaded->name = 'second-update';
+
+        self::assertTrue(
+            $reloaded->save(false),
+            'UPDATE on the reloaded instance must not raise a stale conflict.',
+        );
+        self::assertSame(
+            'second-update',
+            OptimisticRowVersion::findOne($id)->name,
+            'Last write must be persisted.',
+        );
+
+        DbHelper::dropTablesIfExist($db, ['test_optimistic_rowversion']);
+    }
+
+    public function testRowVersionBehaviorRefreshesTokenForRepeatedSaveOnSameInstance(): void
+    {
+        $this->createOptimisticRowVersionTable();
+
+        $db = $this->getConnection();
+
+        $record = new OptimisticRowVersion();
+
+        $record->attachBehavior('rowVersion', new RowVersionBehavior());
+
+        $record->name = 'a';
+
+        self::assertTrue(
+            $record->save(false),
+            'INSERT must succeed.',
+        );
+        self::assertIsInt(
+            $record->rv,
+            'Token must be loaded after INSERT.',
+        );
+
+        // Unrelated write advances the database-wide counter, so `old + 1` would diverge from the real token.
+        $db->createCommand(
+            <<<SQL
+            INSERT INTO [dbo].[test_optimistic_rowversion] ([name]) VALUES ('other')
+            SQL
+        )->execute();
+
+        $record->name = 'b';
+
+        self::assertTrue(
+            $record->save(false),
+            'UPDATE on the same instance must succeed without a reload.',
+        );
+
+        $record->name = 'c';
+
+        self::assertTrue(
+            $record->save(false),
+            'Repeated UPDATE on the same instance must keep succeeding.',
+        );
+        self::assertSame(
+            'c',
+            OptimisticRowVersion::findOne($record->id)->name,
+            'Last write must be persisted.',
+        );
+
+        DbHelper::dropTablesIfExist($db, ['test_optimistic_rowversion']);
+    }
+
+    public function testRowVersionBehaviorIsInertWhenOptimisticLockIsDisabled(): void
+    {
+        $type = new Type();
+
+        $behavior = new RowVersionBehavior();
+
+        $behavior->attach($type);
+        $behavior->refreshRowVersion();
+
+        self::assertNull(
+            $type->optimisticLock(),
+            'Behavior must be inert when optimistic locking is disabled.',
+        );
+    }
+
+    public function testRowVersionBehaviorIsInertForNonRowVersionLockColumn(): void
+    {
+        $document = new Document();
+
+        $document->version = 5;
+
+        $behavior = new RowVersionBehavior();
+
+        $behavior->attach($document);
+        $behavior->refreshRowVersion();
+
+        self::assertSame(
+            5,
+            $document->version,
+            'Non-rowversion lock column must be left untouched.',
+        );
+    }
+
+    public function testRowVersionBehaviorSkipsRefreshWhenRowIsAbsent(): void
+    {
+        $this->createOptimisticRowVersionTable();
+
+        $db = $this->getConnection();
+
+        $record = new OptimisticRowVersion();
+
+        $record->name = 'gone';
+
+        $record->save(false);
+
+        $id = $record->id;
+
+        /** @var OptimisticRowVersion $loaded */
+        $loaded = OptimisticRowVersion::findOne($id);
+
+        $rvBefore = $loaded->rv;
+
+        // Remove the row so the refresh query returns no value.
+        $db->createCommand()->delete('test_optimistic_rowversion', ['id' => $id])->execute();
+
+        $behavior = new RowVersionBehavior();
+
+        $behavior->attach($loaded);
+        $behavior->refreshRowVersion();
+
+        self::assertSame(
+            $rvBefore,
+            $loaded->rv,
+            'In-memory token must be left untouched when the row is absent.',
+        );
+
+        DbHelper::dropTablesIfExist($db, ['test_optimistic_rowversion']);
     }
 
     private function createOptimisticRowVersionTable(): void

--- a/tests/framework/db/mssql/ColumnSchemaTest.php
+++ b/tests/framework/db/mssql/ColumnSchemaTest.php
@@ -21,6 +21,7 @@ use yiiunit\framework\db\mssql\providers\ColumnSchemaProvider;
 use function fclose;
 use function fopen;
 use function fwrite;
+use function hex2bin;
 use function rewind;
 
 /**
@@ -121,6 +122,28 @@ final class ColumnSchemaTest extends BaseColumnSchema
             'binary data',
             $result,
             'Varbinary streams must be converted to strings.',
+        );
+    }
+
+    public function testPhpTypecastRowVersionStreamReturnsInteger(): void
+    {
+        $column = new ColumnSchema();
+
+        $column->type = Schema::TYPE_TIMESTAMP;
+
+        $stream = fopen('php://memory', 'r+');
+
+        fwrite($stream, hex2bin('00000000000012e9'));
+        rewind($stream);
+
+        $result = $column->phpTypecast($stream);
+
+        fclose($stream);
+
+        self::assertSame(
+            4841,
+            $result,
+            'Rowversion streams must be decoded to the integer token.',
         );
     }
 

--- a/tests/framework/db/mssql/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/mssql/providers/ColumnSchemaProvider.php
@@ -17,6 +17,7 @@ use yii\db\PdoValue;
 
 use function array_walk;
 use function bin2hex;
+use function hex2bin;
 use function in_array;
 
 /**
@@ -32,12 +33,33 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
         $pdoValue = new PdoValue('binary data', PDO::PARAM_LOB);
 
         return [
+            'non-varbinary PDO LOB falls through to parent' => [
+                Schema::TYPE_BINARY,
+                'binary(8)',
+                true,
+                $pdoValue,
+                $pdoValue,
+            ],
             'non-varbinary string falls through to parent' => [
                 Schema::TYPE_STRING,
                 'varchar',
                 true,
                 'test',
                 'test',
+            ],
+            'rowversion integer to binary literal' => [
+                Schema::TYPE_TIMESTAMP,
+                'timestamp',
+                false,
+                4841,
+                new Expression('0x00000000000012e9'),
+            ],
+            'rowversion raw 8-byte binary to binary literal' => [
+                Schema::TYPE_TIMESTAMP,
+                'timestamp',
+                false,
+                hex2bin('00000000000012e9'),
+                new Expression('0x00000000000012e9'),
             ],
             'varbinary integer value falls through to parent' => [
                 Schema::TYPE_BINARY,
@@ -87,13 +109,6 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 true,
                 new PdoValue(null, PDO::PARAM_LOB),
                 new Expression('CAST(NULL AS VARBINARY(MAX))'),
-            ],
-            'non-varbinary PDO LOB falls through to parent' => [
-                Schema::TYPE_BINARY,
-                'binary(8)',
-                true,
-                $pdoValue,
-                $pdoValue,
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #9653
