### PR TITLE
Fix "no more rows in the active result set" error in `yii\db\BatchQueryResult` for MSSQL when batching a plain `Query` without an explicit DB connection.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -110,6 +110,7 @@ Yii Framework 2 Change Log
 - Enh #20968: Consolidate MSSQL system-catalog quoting in `yii\db\mssql\Schema::quoteSystemCatalogName()` (terabytesoftw)
 - Enh #12121: Add SQLSRV encoding constants to `yii\db\mssql\PDO` and `yii\db\mssql\SqlsrvPDO` (terabytesoftw)
 - Enh #9653: Support MSSQL `rowversion`/`timestamp` columns as `optimisticLock()` attributes in `yii\db\mssql\ColumnSchema` and `yii\db\mssql\QueryBuilder` (terabytesoftw)
+- Bug #18521: Fix "no more rows in the active result set" error in `yii\db\BatchQueryResult` for MSSQL when batching a plain `Query` without an explicit DB connection (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/BatchQueryResult.php
+++ b/framework/db/BatchQueryResult.php
@@ -72,6 +72,10 @@ class BatchQueryResult extends Component implements \Iterator
     public $each = false;
 
     /**
+     * @var string|null The driver name of the connection resolved when the batch query is executed.
+     */
+    private string|null $_driverName = null;
+    /**
      * @var DataReader|null the data reader associated with this batch query.
      */
     private $_dataReader;
@@ -87,7 +91,6 @@ class BatchQueryResult extends Component implements \Iterator
      * @var TKey|null the key for the current iteration
      */
     private $_key;
-
 
     /**
      * Destructor.
@@ -160,7 +163,11 @@ class BatchQueryResult extends Component implements \Iterator
     protected function fetchData()
     {
         if ($this->_dataReader === null) {
-            $this->_dataReader = $this->query->createCommand($this->db)->query();
+            $command = $this->query->createCommand($this->db);
+
+            $this->_driverName = $command->db->driverName;
+
+            $this->_dataReader = $command->query();
         }
 
         $rows = $this->getRows();
@@ -190,7 +197,7 @@ class BatchQueryResult extends Component implements \Iterator
             }
         } catch (\PDOException $e) {
             $errorCode = isset($e->errorInfo[1]) ? $e->errorInfo[1] : null;
-            if ($this->getDbDriverName() !== 'sqlsrv' || $errorCode !== self::MSSQL_NO_MORE_ROWS_ERROR_CODE) {
+            if ($this->_driverName !== 'sqlsrv' || $errorCode !== self::MSSQL_NO_MORE_ROWS_ERROR_CODE) {
                 throw $e;
             }
         }
@@ -229,27 +236,6 @@ class BatchQueryResult extends Component implements \Iterator
     public function valid()
     {
         return !empty($this->_batch);
-    }
-
-    /**
-     * Gets db driver name from the db connection that is passed to the `batch()`, if it is not passed it uses
-     * connection from the active record model
-     * @return string|null
-     */
-    private function getDbDriverName()
-    {
-        if (isset($this->db->driverName)) {
-            return $this->db->driverName;
-        }
-
-        if (!empty($this->_batch)) {
-            $key = array_keys($this->_batch)[0];
-            if (isset($this->_batch[$key]->db->driverName)) {
-                return $this->_batch[$key]->db->driverName;
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/tests/base/db/BaseBatchQueryResult.php
+++ b/tests/base/db/BaseBatchQueryResult.php
@@ -8,6 +8,7 @@
 
 namespace yiiunit\base\db;
 
+use Yii;
 use yiiunit\framework\db\DatabaseTestCase;
 use yii\db\BatchQueryResult;
 use yii\db\Query;
@@ -128,6 +129,67 @@ abstract class BaseBatchQueryResult extends DatabaseTestCase
         $this->assertEquals('user1', $customers[0]->name);
         $this->assertEquals('user2', $customers[1]->name);
         $this->assertEquals('user3', $customers[2]->name);
+    }
+
+    public function testBatchWithoutDbParameterOnPlainQuery(): void
+    {
+        $db = $this->getConnection();
+
+        Yii::$app->set('db', $db);
+
+        // `batch()`: customer has `3` rows; batchSize `2` forces the extra fetch past the end that triggers
+        // MSSQL error `-13`.
+
+        $query = (new Query())->from('customer')->orderBy('id');
+
+        $allRows = $this->getAllRowsFromBatch($query->batch(2));
+
+        self::assertCount(
+            3,
+            $allRows,
+            'Batch must return all rows without an explicit connection.',
+        );
+        self::assertSame(
+            'user1',
+            $allRows[0]['name'],
+            'First record must be returned.',
+        );
+        self::assertSame(
+            'user2',
+            $allRows[1]['name'],
+            'Second record must be returned.',
+        );
+        self::assertSame(
+            'user3',
+            $allRows[2]['name'],
+            'Third record must be returned.',
+        );
+
+        // `each()`: same path, single-row iteration.
+        $query = (new Query())->from('customer')->orderBy('id');
+
+        $allRows = $this->getAllRowsFromEach($query->each(2));
+
+        self::assertCount(
+            3,
+            $allRows,
+            'Each must return all rows without an explicit connection.',
+        );
+        self::assertSame(
+            'user1',
+            $allRows[0]['name'],
+            'First record must be returned.',
+        );
+        self::assertSame(
+            'user2',
+            $allRows[1]['name'],
+            'Second record must be returned.',
+        );
+        self::assertSame(
+            'user3',
+            $allRows[2]['name'],
+            'Third record must be returned.',
+        );
     }
 
     protected function getAllRowsFromBatch(BatchQueryResult $batch)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #18521 