### PR TITLE
Remove unused legacy `getAllColumnNames()` method from `yii\db\mssql\QueryBuilder`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -111,6 +111,7 @@ Yii Framework 2 Change Log
 - Enh #12121: Add SQLSRV encoding constants to `yii\db\mssql\PDO` and `yii\db\mssql\SqlsrvPDO` (terabytesoftw)
 - Enh #9653: Support MSSQL `rowversion`/`timestamp` columns as `optimisticLock()` attributes in `yii\db\mssql\ColumnSchema` and `yii\db\mssql\QueryBuilder` (terabytesoftw)
 - Bug #18521: Fix "no more rows in the active result set" error in `yii\db\BatchQueryResult` for MSSQL when batching a plain `Query` without an explicit DB connection (terabytesoftw)
+- Chg #20972: Remove unused legacy `getAllColumnNames()` method from `yii\db\mssql\QueryBuilder` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/ColumnSchemaBuilder.php
+++ b/framework/db/mssql/ColumnSchemaBuilder.php
@@ -24,7 +24,6 @@ class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
 {
     protected $format = '{type}{length}{notnull}{unique}{default}{check}{append}';
 
-
     /**
      * Builds the full string for the column's schema.
      * @return string

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -613,22 +613,6 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
-     * Returns an array of column names given model name.
-     *
-     * @param string|null $modelClass name of the model class
-     * @return array|null array of column names
-     */
-    protected function getAllColumnNames($modelClass = null)
-    {
-        if (!$modelClass) {
-            return null;
-        }
-        /** @var \yii\db\ActiveRecord $modelClass */
-        $schema = $modelClass::getTableSchema();
-        return array_keys($schema->columns);
-    }
-
-    /**
      * {@inheritdoc}
      * @since 2.0.8
      */

--- a/framework/db/mssql/TableSchema.php
+++ b/framework/db/mssql/TableSchema.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -20,5 +22,5 @@ class TableSchema extends \yii\db\TableSchema
      * @var string|null name of the catalog (database) that this table belongs to.
      * Defaults to null, meaning no catalog (or the current database).
      */
-    public $catalogName;
+    public $catalogName = null;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
