### PR TITLE
Rework `yii\db\mysql\QueryBuilder::dropForeignKey()` to build the `ALTER TABLE ... DROP FOREIGN KEY` statement.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -116,6 +116,7 @@ Yii Framework 2 Change Log
 - Enh #20976: Rework `yii\db\mysql\QueryBuilder::getColumnDefinition()` and reuse it in `renameColumn()` (terabytesoftw)
 - Bug #20979: Document the `yii\db\mysql\QueryBuilder::renameColumn()` exception and reach 100% method coverage (terabytesoftw)
 - Enh #20982: Rework `yii\db\mysql\QueryBuilder::createIndex()` to build the `ALTER TABLE ... ADD [UNIQUE] INDEX` statement (terabytesoftw)
+- Enh #20983: Rework `yii\db\mysql\QueryBuilder::dropForeignKey()` to build the `ALTER TABLE ... DROP FOREIGN KEY` statement (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -139,14 +139,24 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * Builds a SQL statement for dropping a foreign key constraint.
-     * @param string $name the name of the foreign key constraint to be dropped. The name will be properly quoted by the method.
-     * @param string $table the table whose foreign is to be dropped. The name will be properly quoted by the method.
-     * @return string the SQL statement for dropping a foreign key constraint.
+     *
+     * MySQL emits `ALTER TABLE ... DROP FOREIGN KEY` instead of the standard `DROP CONSTRAINT`.
+     *
+     * @param string $name The name of the foreign key constraint to be dropped. The name will be properly quoted by
+     * the method.
+     * @param string $table The table whose foreign key is to be dropped. The name will be properly quoted by the
+     * method.
+     *
+     * @return string The SQL statement for dropping a foreign key constraint.
      */
     public function dropForeignKey($name, $table)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table)
-            . ' DROP FOREIGN KEY ' . $this->db->quoteColumnName($name);
+        $quotedTable = $this->db->quoteTableName($table);
+        $quotedName = $this->db->quoteColumnName($name);
+
+        return <<<SQL
+        ALTER TABLE {$quotedTable} DROP FOREIGN KEY {$quotedName}
+        SQL;
     }
 
     /**

--- a/tests/framework/db/mysql/CommandTest.php
+++ b/tests/framework/db/mysql/CommandTest.php
@@ -423,7 +423,7 @@ final class CommandTest extends BaseCommand
         $this->assertEmpty($schema->getTableChecks($tableName, true));
     }
 
-    #[DataProviderExternal(CommandProvider::class, 'createIndexWithQualifiedTableNames')]
+    #[DataProviderExternal(CommandProvider::class, 'createIndex')]
     public function testCreateIndexWithQualifiedTableNames(
         string $table,
         string $indexTarget,
@@ -486,6 +486,66 @@ final class CommandTest extends BaseCommand
         self::assertEmpty(
             $schema->getTableIndexes($table, true),
             'Index must be removed after drop.',
+        );
+
+        DbHelper::dropTablesIfExist($db, [$table]);
+    }
+
+    #[DataProviderExternal(CommandProvider::class, 'dropForeignKey')]
+    public function testDropForeignKeyWithQualifiedTableNames(
+        string $table,
+        string $fkTarget,
+        string $fkName,
+        array $fkColumns,
+        array $refColumns,
+    ): void {
+        $db = $this->getConnection(false);
+
+        /** @var Schema $schema */
+        $schema = $db->getSchema();
+
+        DbHelper::dropTablesIfExist($db, [$table]);
+
+        $db->createCommand()->createTable(
+            $table,
+            [
+                'int1' => 'integer not null unique',
+                'int2' => 'integer not null unique',
+                'int3' => 'integer not null unique',
+                'int4' => 'integer not null unique',
+                'unique ([[int1]], [[int2]])',
+                'unique ([[int3]], [[int4]])',
+            ],
+        )->execute();
+        $db->createCommand()->addForeignKey(
+            $fkName,
+            $fkTarget,
+            $fkColumns,
+            $fkTarget,
+            $refColumns,
+        )->execute();
+
+        $foreignKeys = $schema->getTableForeignKeys($table, true);
+
+        self::assertCount(
+            1,
+            $foreignKeys,
+            'Foreign key must exist before drop.',
+        );
+        self::assertSame(
+            $fkColumns,
+            $foreignKeys[0]->columnNames,
+            'Foreign key must cover the requested columns.',
+        );
+
+        $db->createCommand()->dropForeignKey(
+            $fkName,
+            $fkTarget,
+        )->execute();
+
+        self::assertEmpty(
+            $schema->getTableForeignKeys($table, true),
+            'Foreign key must be removed after drop.',
         );
 
         DbHelper::dropTablesIfExist($db, [$table]);

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -739,7 +739,7 @@ final class QueryBuilderTest extends BaseQueryBuilder
         DbHelper::dropTablesIfExist($db, [$table]);
     }
 
-    #[DataProviderExternal(QueryBuilderProvider::class, 'createIndexWithQualifiedTableNames')]
+    #[DataProviderExternal(QueryBuilderProvider::class, 'createIndex')]
     public function testCreateIndexWithQualifiedTableNames(
         string $table,
         string $indexName,
@@ -756,6 +756,24 @@ final class QueryBuilderTest extends BaseQueryBuilder
                 $table,
                 $columns,
                 $unique,
+            ),
+            'Generated SQL must match the expected ALTER TABLE statement.',
+        );
+    }
+
+    #[DataProviderExternal(QueryBuilderProvider::class, 'dropForeignKey')]
+    public function testDropForeignKeyWithQualifiedTableNames(
+        string $table,
+        string $fkName,
+        string $expected,
+    ): void {
+        $db = $this->getConnection(false, false);
+
+        self::assertSame(
+            $expected,
+            $db->getQueryBuilder()->dropForeignKey(
+                $fkName,
+                $table,
             ),
             'Generated SQL must match the expected ALTER TABLE statement.',
         );

--- a/tests/framework/db/mysql/providers/CommandProvider.php
+++ b/tests/framework/db/mysql/providers/CommandProvider.php
@@ -45,7 +45,7 @@ final class CommandProvider
     /**
      * @return array<string, array{string, string, string, array<string>|string, bool, array<string>, bool}>
      */
-    public static function createIndexWithQualifiedTableNames(): array
+    public static function createIndex(): array
     {
         return [
             'columns as comma-separated string' => [
@@ -110,6 +110,43 @@ final class CommandProvider
                 true,
                 ['int1'],
                 true,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string, string, array<string>, array<string>}>
+     */
+    public static function dropForeignKey(): array
+    {
+        return [
+            'database-qualified backtick-quoted name' => [
+                'drop_fk_qualified_bt',
+                '`yiitest`.`drop_fk_qualified_bt`',
+                'fk_qualified_bt',
+                ['int1'],
+                ['int3'],
+            ],
+            'database-qualified name' => [
+                'drop_fk_qualified',
+                'yiitest.drop_fk_qualified',
+                'fk_qualified',
+                ['int1'],
+                ['int3'],
+            ],
+            'multiple columns' => [
+                'drop_fk_multi',
+                'drop_fk_multi',
+                'fk_multi',
+                ['int1', 'int2'],
+                ['int3', 'int4'],
+            ],
+            'single column' => [
+                'drop_fk_single',
+                'drop_fk_single',
+                'fk_single',
+                ['int1'],
+                ['int3'],
             ],
         ];
     }

--- a/tests/framework/db/mysql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mysql/providers/QueryBuilderProvider.php
@@ -351,7 +351,7 @@ final class QueryBuilderProvider
     /**
      * @return array<string, array{string, string, array<string>|string, bool, string}>
      */
-    public static function createIndexWithQualifiedTableNames(): array
+    public static function createIndex(): array
     {
         return [
             'columns as comma-separated string' => [
@@ -415,6 +415,43 @@ final class QueryBuilderProvider
                 true,
                 <<<SQL
                 ALTER TABLE `create_index_unique_single` ADD UNIQUE INDEX `idx_unique_single` (`int1`)
+                SQL,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function dropForeignKey(): array
+    {
+        return [
+            'database-qualified backtick-quoted name' => [
+                '`yiitest`.`drop_fk_qualified_bt`',
+                'fk_qualified_bt',
+                <<<SQL
+                ALTER TABLE `yiitest`.`drop_fk_qualified_bt` DROP FOREIGN KEY `fk_qualified_bt`
+                SQL,
+            ],
+            'database-qualified name' => [
+                'yiitest.drop_fk_qualified',
+                'fk_qualified',
+                <<<SQL
+                ALTER TABLE `yiitest`.`drop_fk_qualified` DROP FOREIGN KEY `fk_qualified`
+                SQL,
+            ],
+            'multiple columns' => [
+                'drop_fk_multi',
+                'fk_multi',
+                <<<SQL
+                ALTER TABLE `drop_fk_multi` DROP FOREIGN KEY `fk_multi`
+                SQL,
+            ],
+            'single column' => [
+                'drop_fk_single',
+                'fk_single',
+                <<<SQL
+                ALTER TABLE `drop_fk_single` DROP FOREIGN KEY `fk_single`
                 SQL,
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
