### PR TITLE
Rework `yii\db\mysql\QueryBuilder::dropPrimaryKey()` to build the `ALTER TABLE ... DROP PRIMARY KEY` statement.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -117,6 +117,7 @@ Yii Framework 2 Change Log
 - Bug #20979: Document the `yii\db\mysql\QueryBuilder::renameColumn()` exception and reach 100% method coverage (terabytesoftw)
 - Enh #20982: Rework `yii\db\mysql\QueryBuilder::createIndex()` to build the `ALTER TABLE ... ADD [UNIQUE] INDEX` statement (terabytesoftw)
 - Enh #20983: Rework `yii\db\mysql\QueryBuilder::dropForeignKey()` to build the `ALTER TABLE ... DROP FOREIGN KEY` statement (terabytesoftw)
+- Enh #20984: Rework `yii\db\mysql\QueryBuilder::dropPrimaryKey()` to build the `ALTER TABLE ... DROP PRIMARY KEY` statement (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -160,14 +160,24 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
-     * Builds a SQL statement for removing a primary key constraint to an existing table.
-     * @param string $name the name of the primary key constraint to be removed.
-     * @param string $table the table that the primary key constraint will be removed from.
-     * @return string the SQL statement for removing a primary key constraint from an existing table.
+     * Builds a SQL statement for removing a primary key constraint from an existing table.
+     *
+     * MySQL emits `ALTER TABLE ... DROP PRIMARY KEY` and ignores the constraint name, since a MySQL primary key is
+     * always named `PRIMARY`.
+     *
+     * @param string $name The name of the primary key constraint to be removed. Ignored by MySQL.
+     * @param string $table The table that the primary key constraint will be removed from. The name will be properly
+     * quoted by the method.
+     *
+     * @return string The SQL statement for removing a primary key constraint from an existing table.
      */
     public function dropPrimaryKey($name, $table)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table) . ' DROP PRIMARY KEY';
+        $quotedTable = $this->db->quoteTableName($table);
+
+        return <<<SQL
+        ALTER TABLE {$quotedTable} DROP PRIMARY KEY
+        SQL;
     }
 
     /**

--- a/tests/framework/db/mysql/CommandTest.php
+++ b/tests/framework/db/mysql/CommandTest.php
@@ -584,9 +584,15 @@ final class CommandTest extends BaseCommand
             $pkColumns,
         )->execute();
 
+        $primaryKey = $schema->getTablePrimaryKey($table, true);
+
+        self::assertNotNull(
+            $primaryKey,
+            'Primary key must exist after creation.',
+        );
         self::assertSame(
             $pkColumns,
-            $schema->getTablePrimaryKey($table, true)->columnNames,
+            $primaryKey->columnNames,
             'Primary key must cover the requested columns.',
         );
 

--- a/tests/framework/db/mysql/CommandTest.php
+++ b/tests/framework/db/mysql/CommandTest.php
@@ -550,4 +550,56 @@ final class CommandTest extends BaseCommand
 
         DbHelper::dropTablesIfExist($db, [$table]);
     }
+
+    #[DataProviderExternal(CommandProvider::class, 'dropPrimaryKey')]
+    public function testDropPrimaryKeyWithQualifiedTableNames(
+        string $table,
+        string $pkTarget,
+        string $pkName,
+        array $pkColumns,
+    ): void {
+        $db = $this->getConnection(false);
+
+        /** @var Schema $schema */
+        $schema = $db->getSchema();
+
+        DbHelper::dropTablesIfExist($db, [$table]);
+
+        $db->createCommand()->createTable(
+            $table,
+            [
+                'int1' => 'integer not null',
+                'int2' => 'integer not null',
+            ],
+        )->execute();
+
+        self::assertNull(
+            $schema->getTablePrimaryKey($table, true),
+            'No primary key must exist before creation.',
+        );
+
+        $db->createCommand()->addPrimaryKey(
+            $pkName,
+            $pkTarget,
+            $pkColumns,
+        )->execute();
+
+        self::assertSame(
+            $pkColumns,
+            $schema->getTablePrimaryKey($table, true)->columnNames,
+            'Primary key must cover the requested columns.',
+        );
+
+        $db->createCommand()->dropPrimaryKey(
+            $pkName,
+            $pkTarget,
+        )->execute();
+
+        self::assertNull(
+            $schema->getTablePrimaryKey($table, true),
+            'Primary key must be removed after drop.',
+        );
+
+        DbHelper::dropTablesIfExist($db, [$table]);
+    }
 }

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -779,6 +779,24 @@ final class QueryBuilderTest extends BaseQueryBuilder
         );
     }
 
+    #[DataProviderExternal(QueryBuilderProvider::class, 'dropPrimaryKey')]
+    public function testDropPrimaryKeyWithQualifiedTableNames(
+        string $table,
+        string $pkName,
+        string $expected,
+    ): void {
+        $db = $this->getConnection(false, false);
+
+        self::assertSame(
+            $expected,
+            $db->getQueryBuilder()->dropPrimaryKey(
+                $pkName,
+                $table,
+            ),
+            'Generated SQL must match the expected ALTER TABLE statement.',
+        );
+    }
+
     public function testRenameColumnRetainsInlineCheckInGeneratedDefinition(): void
     {
         $db = $this->getConnection(false);

--- a/tests/framework/db/mysql/providers/CommandProvider.php
+++ b/tests/framework/db/mysql/providers/CommandProvider.php
@@ -152,6 +152,39 @@ final class CommandProvider
     }
 
     /**
+     * @return array<string, array{string, string, string, array<string>}>
+     */
+    public static function dropPrimaryKey(): array
+    {
+        return [
+            'database-qualified backtick-quoted name' => [
+                'drop_pk_qualified_bt',
+                '`yiitest`.`drop_pk_qualified_bt`',
+                'pk_qualified_bt',
+                ['int1'],
+            ],
+            'database-qualified name' => [
+                'drop_pk_qualified',
+                'yiitest.drop_pk_qualified',
+                'pk_qualified',
+                ['int1'],
+            ],
+            'multiple columns' => [
+                'drop_pk_multi',
+                'drop_pk_multi',
+                'pk_multi',
+                ['int1', 'int2'],
+            ],
+            'single column' => [
+                'drop_pk_single',
+                'drop_pk_single',
+                'pk_single',
+                ['int1'],
+            ],
+        ];
+    }
+
+    /**
      * @return array<string, array{string, string, string, string}>
      */
     public static function renameColumn(): array

--- a/tests/framework/db/mysql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mysql/providers/QueryBuilderProvider.php
@@ -456,4 +456,41 @@ final class QueryBuilderProvider
             ],
         ];
     }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function dropPrimaryKey(): array
+    {
+        return [
+            'database-qualified backtick-quoted name' => [
+                '`yiitest`.`drop_pk_qualified_bt`',
+                'pk_qualified_bt',
+                <<<SQL
+                ALTER TABLE `yiitest`.`drop_pk_qualified_bt` DROP PRIMARY KEY
+                SQL,
+            ],
+            'database-qualified name' => [
+                'yiitest.drop_pk_qualified',
+                'pk_qualified',
+                <<<SQL
+                ALTER TABLE `yiitest`.`drop_pk_qualified` DROP PRIMARY KEY
+                SQL,
+            ],
+            'multiple columns' => [
+                'drop_pk_multi',
+                'pk_multi',
+                <<<SQL
+                ALTER TABLE `drop_pk_multi` DROP PRIMARY KEY
+                SQL,
+            ],
+            'single column' => [
+                'drop_pk_single',
+                'pk_single',
+                <<<SQL
+                ALTER TABLE `drop_pk_single` DROP PRIMARY KEY
+                SQL,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
