### PR TITLE
Fix #20987: Fix `@var` annotations for `TimestampBehavior` properties

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -22,6 +22,7 @@ Yii Framework 2 Change Log
 - Bug #20978: Fix `AssetManager::appendTimestamp` triggering `filemtime()` stat warnings for timestamped asset URLs (terabytesoftw)
 - Bug #20986: Fix `@return` annotation for `yii\base\Component::behaviors()` (mspirkov)
 - Bug #20986: Fix `@param` annotation for `$behavior` in `yii\base\Component::attachBehavior()` (mspirkov)
+- Bug #20987: Fix `@var` annotations for `TimestampBehavior` properties (mspirkov)
 
 
 2.0.55 May 09, 2026

--- a/framework/behaviors/TimestampBehavior.php
+++ b/framework/behaviors/TimestampBehavior.php
@@ -76,12 +76,12 @@ use yii\db\BaseActiveRecord;
 class TimestampBehavior extends AttributeBehavior
 {
     /**
-     * @var string the attribute that will receive timestamp value
+     * @var string|false the attribute that will receive timestamp value
      * Set this property to false if you do not want to record the creation time.
      */
     public $createdAtAttribute = 'created_at';
     /**
-     * @var string the attribute that will receive timestamp value.
+     * @var string|false the attribute that will receive timestamp value.
      * Set this property to false if you do not want to record the update time.
      */
     public $updatedAtAttribute = 'updated_at';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
