### PR TITLE
Add generics to `yii\db\Connection` and `yii\db\Schema` so `getSchema()` and `getQueryBuilder()` infer driver-specific types.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -23,6 +23,7 @@ Yii Framework 2 Change Log
 - Bug #20986: Fix `@return` annotation for `yii\base\Component::behaviors()` (mspirkov)
 - Bug #20986: Fix `@param` annotation for `$behavior` in `yii\base\Component::attachBehavior()` (mspirkov)
 - Bug #20987: Fix `@var` annotations for `TimestampBehavior` properties (mspirkov)
+- Enh #20988: Add PHPStan generics to `yii\db\Connection` and `yii\db\Schema` so `getSchema()` and `getQueryBuilder()` infer driver-specific types (terabytesoftw)
 
 
 2.0.55 May 09, 2026

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -23,7 +23,7 @@ Yii Framework 2 Change Log
 - Bug #20986: Fix `@return` annotation for `yii\base\Component::behaviors()` (mspirkov)
 - Bug #20986: Fix `@param` annotation for `$behavior` in `yii\base\Component::attachBehavior()` (mspirkov)
 - Bug #20987: Fix `@var` annotations for `TimestampBehavior` properties (mspirkov)
-- Enh #20988: Add PHPStan generics to `yii\db\Connection` and `yii\db\Schema` so `getSchema()` and `getQueryBuilder()` infer driver-specific types (terabytesoftw)
+- Enh #20988: Add generics to `yii\db\Connection` and `yii\db\Schema` so `getSchema()` and `getQueryBuilder()` infer driver-specific types (terabytesoftw)
 
 
 2.0.55 May 09, 2026

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -132,6 +132,9 @@ use yii\caching\CacheInterface;
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
+ *
+ * @template TSchema of Schema = Schema
+ * @template TQueryBuilder of QueryBuilder = QueryBuilder
  */
 class Connection extends Component
 {
@@ -853,6 +856,7 @@ class Connection extends Component
     /**
      * Returns the schema information for the database opened by this connection.
      * @return Schema the schema information for the database opened by this connection.
+     * @phpstan-return TSchema
      * @throws NotSupportedException if there is no support for the current driver type
      */
     public function getSchema()
@@ -878,6 +882,7 @@ class Connection extends Component
     /**
      * Returns the query builder for the current DB connection.
      * @return QueryBuilder the query builder for the current DB connection.
+     * @phpstan-return TQueryBuilder
      */
     public function getQueryBuilder()
     {

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -855,8 +855,7 @@ class Connection extends Component
 
     /**
      * Returns the schema information for the database opened by this connection.
-     * @return Schema the schema information for the database opened by this connection.
-     * @phpstan-return TSchema
+     * @return TSchema the schema information for the database opened by this connection.
      * @throws NotSupportedException if there is no support for the current driver type
      */
     public function getSchema()
@@ -881,8 +880,7 @@ class Connection extends Component
 
     /**
      * Returns the query builder for the current DB connection.
-     * @return QueryBuilder the query builder for the current DB connection.
-     * @phpstan-return TQueryBuilder
+     * @return TQueryBuilder the query builder for the current DB connection.
      */
     public function getQueryBuilder()
     {

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -242,8 +242,7 @@ abstract class Schema extends BaseObject
     }
 
     /**
-     * @return QueryBuilder the query builder for this connection.
-     * @phpstan-return TQueryBuilder
+     * @return TQueryBuilder the query builder for this connection.
      */
     public function getQueryBuilder()
     {
@@ -313,8 +312,7 @@ abstract class Schema extends BaseObject
     /**
      * Creates a query builder for the database.
      * This method may be overridden by child classes to create a DBMS-specific query builder.
-     * @return QueryBuilder query builder instance
-     * @phpstan-return TQueryBuilder
+     * @return TQueryBuilder query builder instance
      */
     public function createQueryBuilder()
     {

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -40,6 +40,7 @@ use yii\caching\TagDependency;
  * @since 2.0
  *
  * @template T of ColumnSchema = ColumnSchema
+ * @template TQueryBuilder of QueryBuilder = QueryBuilder
  */
 abstract class Schema extends BaseObject
 {
@@ -118,7 +119,7 @@ abstract class Schema extends BaseObject
      */
     private $_tableMetadata = [];
     /**
-     * @var QueryBuilder the query builder for this database
+     * @var TQueryBuilder|null the query builder for this database
      */
     private $_builder;
     /**
@@ -242,6 +243,7 @@ abstract class Schema extends BaseObject
 
     /**
      * @return QueryBuilder the query builder for this connection.
+     * @phpstan-return TQueryBuilder
      */
     public function getQueryBuilder()
     {
@@ -312,6 +314,7 @@ abstract class Schema extends BaseObject
      * Creates a query builder for the database.
      * This method may be overridden by child classes to create a DBMS-specific query builder.
      * @return QueryBuilder query builder instance
+     * @phpstan-return TQueryBuilder
      */
     public function createQueryBuilder()
     {

--- a/framework/db/cubrid/Schema.php
+++ b/framework/db/cubrid/Schema.php
@@ -29,7 +29,7 @@ use yii\db\Schema as BaseSchema;
  * @since 2.0
  *
  * @template T of ColumnSchema = ColumnSchema
- * @extends BaseSchema<T>
+ * @extends BaseSchema<T, QueryBuilder>
  */
 class Schema extends BaseSchema implements ConstraintFinderInterface
 {

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -27,7 +27,7 @@ use yii\db\Schema as BaseSchema;
  * @since 2.0
  *
  * @template T of ColumnSchema = ColumnSchema
- * @extends BaseSchema<T>
+ * @extends BaseSchema<T, QueryBuilder>
  */
 class Schema extends BaseSchema implements ConstraintFinderInterface
 {

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -30,7 +30,7 @@ use yii\db\Schema as BaseSchema;
  * @since 2.0
  *
  * @template T of ColumnSchema = ColumnSchema
- * @extends BaseSchema<T>
+ * @extends BaseSchema<T, QueryBuilder>
  */
 class Schema extends BaseSchema implements ConstraintFinderInterface
 {

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -34,7 +34,7 @@ use yii\db\Schema as BaseSchema;
  * @since 2.0
  *
  * @template T of ColumnSchema = ColumnSchema
- * @extends BaseSchema<T>
+ * @extends BaseSchema<T, QueryBuilder>
  */
 class Schema extends BaseSchema implements ConstraintFinderInterface
 {

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -30,7 +30,7 @@ use yii\db\Schema as BaseSchema;
  * @since 2.0
  *
  * @template T of ColumnSchema = ColumnSchema
- * @extends BaseSchema<T>
+ * @extends BaseSchema<T, QueryBuilder>
  */
 class Schema extends BaseSchema implements ConstraintFinderInterface
 {

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -34,7 +34,7 @@ use yii\db\Schema as BaseSchema;
  * @since 2.0
  *
  * @template T of ColumnSchema = ColumnSchema
- * @extends BaseSchema<T>
+ * @extends BaseSchema<T, QueryBuilder>
  */
 class Schema extends BaseSchema implements ConstraintFinderInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
