### PR TITLE
Show created migration file path on migrate create CLI command

### DIFF
--- a/framework/console/controllers/BaseMigrateController.php
+++ b/framework/console/controllers/BaseMigrateController.php
@@ -685,7 +685,7 @@ abstract class BaseMigrateController extends Controller
 
             FileHelper::changeOwnership($file, $this->newFileOwnership, $this->newFileMode);
 
-            $this->stdout("New migration created successfully.\n", Console::FG_GREEN);
+            $this->stdout("New migration created successfully: $file\n", Console::FG_GREEN);
         }
 
         return ExitCode::OK;

--- a/tests/framework/console/controllers/MigrateControllerTestTrait.php
+++ b/tests/framework/console/controllers/MigrateControllerTestTrait.php
@@ -228,11 +228,12 @@ CODE;
     public function testCreate(): void
     {
         $migrationName = 'test_migration';
-        $this->runMigrateControllerAction('create', [$migrationName]);
+        $output = $this->runMigrateControllerAction('create', [$migrationName]);
         $this->assertSame(ExitCode::OK, $this->getExitCode());
         $files = FileHelper::findFiles($this->migrationPath);
         $this->assertCount(1, $files, 'Unable to create new migration!');
         $this->assertStringContainsString($migrationName, basename($files[0]), 'Wrong migration name!');
+        $this->assertStringContainsString(basename($files[0]), $output);
     }
 
     public function testUp(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | n/a

# The issue

When creating migrations with `yii migrate/create xyz --interactive=0`, there's no way to determine the generated migration file name other than checking the migration directory.

This is specially detrimental when using AI agents to create migrations, since the agent now has to inspect the directory to determine the name of the file created. This adds round trip tool calls, spend tokens unnecessarily, and slows down the task (specially on large migration directories).

# How this PR helps

The change updates `migrate/create` to include the created migration file path in its success message, making it easier to see exactly which file was generated.