### PR TITLE
Switch coverage driver from `xdebug` to `pcov` in CI configuration files for MariaDB, MSSQL, MySQL, PostgreSQL, and SQLite.

### DIFF
--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -40,7 +40,7 @@ jobs:
     uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mariadb-${{ github.ref }}
-      coverage-driver: xdebug
+      coverage-driver: pcov
       database-env: '{"MARIADB_ROOT_PASSWORD":"root","MARIADB_DATABASE":"yiitest"}'
       database-health-cmd: mariadb-admin ping
       database-image: mariadb

--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -40,7 +40,7 @@ jobs:
     uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mssql-${{ github.ref }}
-      coverage-driver: xdebug
+      coverage-driver: pcov
       database-env: '{"SA_PASSWORD":"YourStrong!Passw0rd","ACCEPT_EULA":"Y","MSSQL_PID":"Developer"}'
       database-health-cmd: /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P 'YourStrong!Passw0rd' -Q 'SELECT 1'
       database-image: mcr.microsoft.com/mssql/server

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -40,7 +40,7 @@ jobs:
     uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: mysql-${{ github.ref }}
-      coverage-driver: xdebug
+      coverage-driver: pcov
       database-env: '{"MYSQL_ROOT_PASSWORD":"root","MYSQL_DATABASE":"yiitest"}'
       database-health-cmd: mysqladmin ping
       database-image: mysql

--- a/.github/workflows/ci-pgsql.yml
+++ b/.github/workflows/ci-pgsql.yml
@@ -40,7 +40,7 @@ jobs:
     uses: yiisoft/yii2-actions/.github/workflows/database.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: pgsql-${{ github.ref }}
-      coverage-driver: xdebug
+      coverage-driver: pcov
       database-env: '{"POSTGRES_USER":"postgres","POSTGRES_PASSWORD":"postgres","POSTGRES_DB":"yiitest"}'
       database-health-cmd: pg_isready
       database-image: postgres

--- a/.github/workflows/ci-sqlite.yml
+++ b/.github/workflows/ci-sqlite.yml
@@ -40,7 +40,7 @@ jobs:
     uses: yiisoft/yii2-actions/.github/workflows/phpunit.yml@161a59a5e7d9c5b650c4a132f6e9292bacfcb5cc
     with:
       concurrency-group: sqlite-${{ github.ref }}
-      coverage-driver: xdebug
+      coverage-driver: pcov
       enable-concurrency: true
       extensions: curl, intl, pdo, pdo_sqlite
       os: '["ubuntu-latest","windows-latest"]'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

