### PR TITLE
Fix `@var` annotations for `BlameableBehavior` properties

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -24,6 +24,7 @@ Yii Framework 2 Change Log
 - Bug #20986: Fix `@param` annotation for `$behavior` in `yii\base\Component::attachBehavior()` (mspirkov)
 - Bug #20987: Fix `@var` annotations for `TimestampBehavior` properties (mspirkov)
 - Enh #20988: Add generics to `yii\db\Connection` and `yii\db\Schema` so `getSchema()` and `getQueryBuilder()` infer driver-specific types (terabytesoftw)
+- Bug #20994: Fix `@var` annotations for `BlameableBehavior` properties (mspirkov)
 
 
 2.0.55 May 09, 2026

--- a/framework/behaviors/BlameableBehavior.php
+++ b/framework/behaviors/BlameableBehavior.php
@@ -61,12 +61,12 @@ use yii\db\BaseActiveRecord;
 class BlameableBehavior extends AttributeBehavior
 {
     /**
-     * @var string the attribute that will receive current user ID value
+     * @var string|false the attribute that will receive current user ID value
      * Set this property to false if you do not want to record the creator ID.
      */
     public $createdByAttribute = 'created_by';
     /**
-     * @var string the attribute that will receive current user ID value
+     * @var string|false the attribute that will receive current user ID value
      * Set this property to false if you do not want to record the updater ID.
      */
     public $updatedByAttribute = 'updated_by';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

I tested [mspirkov/yii2-phpstan-rules](https://github.com/mspirkov/yii2-phpstan-rules) on [yiiframework.com](https://github.com/yiisoft-contrib/yiiframework.com) and found this error

<img width="1130" height="170" alt="image" src="https://github.com/user-attachments/assets/4fcd6d2d-0e00-4d06-8576-92038c1efbb4" />
