### PR TITLE
Fix `yii\db\pgsql\QueryBuilder::upsert()` generating an invalid conflict target when multiple unique constraints match.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -123,6 +123,7 @@ Yii Framework 2 Change Log
 - Bug #20992: Preserve the identity column generation clause in `yii\db\oci\QueryBuilder::executeResetSequence()` (terabytesoftw)
 - Chg #20995: Use native atomic `INSERT ... ON CONFLICT` statements for `yii\db\sqlite\QueryBuilder::upsert()` (terabytesoftw)
 - Bug #20996: Fix `yii\db\pgsql\QueryBuilder::upsert()` with empty update columns (terabytesoftw)
+- Bug #20100: Fix `yii\db\pgsql\QueryBuilder::upsert()` generating an invalid conflict target when multiple unique constraints match (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -13,14 +13,20 @@ namespace yii\db\pgsql;
 use yii\base\InvalidArgumentException;
 use yii\db\ArrayExpression;
 use yii\db\conditions\LikeCondition;
+use yii\db\Constraint;
 use yii\db\Expression;
 use yii\db\ExpressionInterface;
+use yii\db\IndexConstraint;
 use yii\db\JsonExpression;
 use yii\db\Query;
 use yii\db\PdoValue;
 use yii\helpers\StringHelper;
 
+use function array_map;
+use function count;
+use function implode;
 use function is_bool;
+use function usort;
 
 /**
  * QueryBuilder is the query builder for PostgreSQL databases (version 13 and above).
@@ -381,6 +387,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
             $table,
             $insertColumns,
             $updateColumns,
+            $constraints,
         );
 
         if ($uniqueNames === []) {
@@ -401,7 +408,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
             static fn(string $quotedName): string => "EXCLUDED.{$quotedName}",
         );
 
-        $conflictTarget = implode(', ', $uniqueNames);
+        $conflictTarget = $this->resolveUpsertConflictTarget($constraints);
         $updateSql = implode(', ', $updates);
 
         return <<<SQL
@@ -496,5 +503,39 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
         return 'INSERT INTO ' . $schema->quoteTableName($table)
         . ' (' . implode(', ', $columns) . ') VALUES ' . implode(', ', $values);
+    }
+
+    /**
+     * Resolves the `ON CONFLICT` target from the uniqueness constraints matching the inserted columns.
+     *
+     * @param Constraint[] $constraints the matched uniqueness constraints. Must contain at least one entry.
+     * @return string the comma-separated, quoted column list of the selected arbiter constraint.
+     *
+     * @since 22.0
+     */
+    private function resolveUpsertConflictTarget(array $constraints): string
+    {
+        usort(
+            $constraints,
+            static fn(Constraint $a, Constraint $b): int => [
+                !($a instanceof IndexConstraint && $a->isPrimary),
+                $a instanceof IndexConstraint,
+                count($a->columnNames),
+                $a->name,
+            ] <=> [
+                !($b instanceof IndexConstraint && $b->isPrimary),
+                $b instanceof IndexConstraint,
+                count($b->columnNames),
+                $b->name,
+            ],
+        );
+
+        return implode(
+            ', ',
+            array_map(
+                [$this->db, 'quoteColumnName'],
+                $constraints[0]->columnNames,
+            ),
+        );
     }
 }

--- a/tests/data/postgres.sql
+++ b/tests/data/postgres.sql
@@ -36,6 +36,8 @@ DROP TABLE IF EXISTS "T_constraints_1";
 DROP TABLE IF EXISTS "fk_to_schema2" CASCADE;
 DROP TABLE IF EXISTS "T_upsert";
 DROP TABLE IF EXISTS "T_upsert_1";
+DROP TABLE IF EXISTS "T_upsert_2";
+DROP TABLE IF EXISTS "T_upsert_3";
 DROP TABLE IF EXISTS "generated" CASCADE;
 DROP TABLE IF EXISTS "item_12" CASCADE;
 DROP TABLE IF EXISTS "partitioned" CASCADE;
@@ -427,6 +429,23 @@ CREATE TABLE "T_upsert"
 CREATE TABLE "T_upsert_1"
 (
     "a" INT NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE "T_upsert_2"
+(
+    "a" INT NOT NULL UNIQUE,
+    "b" INT NOT NULL UNIQUE,
+    "c" VARCHAR(32) NULL
+);
+
+CREATE TABLE "T_upsert_3"
+(
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "a" INT NOT NULL,
+    "b" INT NOT NULL,
+    "c" VARCHAR(32) NULL,
+    "z" INT NULL UNIQUE,
+    UNIQUE ("a", "b")
 );
 
 CREATE TABLE "generated" (

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\db\ArrayExpression;
 use yii\db\Expression;
+use yii\db\IntegrityException;
 use yii\db\JsonExpression;
 use yii\db\Query;
 use yiiunit\base\db\BaseCommand;
@@ -89,6 +90,54 @@ class CommandTest extends BaseCommand
                 ->one($db),
             'Conflict must apply the update behavior.',
         );
+    }
+
+    public function testThrowIntegrityExceptionWhenConflictMatchesNonArbiterConstraint(): void
+    {
+        $db = $this->getConnection();
+
+        $command = $db->createCommand();
+
+        $command->upsert(
+            'T_upsert_2',
+            ['a' => 1, 'b' => 1, 'c' => 'first'],
+            true,
+        )->execute();
+
+        $this->expectException(IntegrityException::class);
+        $this->expectExceptionMessage(
+            'duplicate key value violates unique constraint "T_upsert_2_b_key"',
+        );
+
+        $command->upsert(
+            'T_upsert_2',
+            ['a' => 2, 'b' => 1, 'c' => 'second'],
+            true,
+        )->execute();
+    }
+
+    public function testThrowIntegrityExceptionWhenUniqueConflictMissesPrimaryKeyArbiter(): void
+    {
+        $db = $this->getConnection();
+
+        $command = $db->createCommand();
+
+        $command->upsert(
+            'T_upsert',
+            ['id' => 1, 'email' => 'unique@example.com', 'address' => 'first'],
+            true,
+        )->execute();
+
+        $this->expectException(IntegrityException::class);
+        $this->expectExceptionMessage(
+            'duplicate key value violates unique constraint "T_upsert_email_key"',
+        );
+
+        $command->upsert(
+            'T_upsert',
+            ['id' => 2, 'email' => 'unique@example.com', 'address' => 'second'],
+            true,
+        )->execute();
     }
 
     public function testAutoQuoting(): void

--- a/tests/framework/db/pgsql/providers/CommandProvider.php
+++ b/tests/framework/db/pgsql/providers/CommandProvider.php
@@ -36,12 +36,87 @@ final class CommandProvider
     public static function upsert(): array
     {
         return [
+            'composite unique constraint conflict' => [
+                'T_upsert_3',
+                [
+                    'a' => 1,
+                    'b' => 1,
+                    'c' => 'first',
+                ],
+                [
+                    'a' => 1,
+                    'b' => 1,
+                    'c' => 'second',
+                ],
+                true,
+                [
+                    'a' => 1,
+                    'b' => 1,
+                    'c' => 'second',
+                ],
+            ],
+            'independent unique constraints conflict on arbiter' => [
+                'T_upsert_2',
+                [
+                    'a' => 1,
+                    'b' => 1,
+                    'c' => 'first',
+                ],
+                [
+                    'a' => 1,
+                    'b' => 2,
+                    'c' => 'second',
+                ],
+                true,
+                [
+                    'a' => 1,
+                    'b' => 1,
+                    'c' => 'second',
+                ],
+            ],
+            'multiple matching constraints without update part' => [
+                'T_upsert',
+                [
+                    'id' => 1,
+                    'email' => 'a@example.com',
+                ],
+                [
+                    'id' => 1,
+                    'email' => 'b@example.com',
+                ],
+                false,
+                [
+                    'id' => 1,
+                    'email' => 'a@example.com',
+                ],
+            ],
             'no columns to update' => [
                 'T_upsert_1',
                 ['a' => 1],
                 ['a' => 1],
                 true,
                 ['a' => 1],
+            ],
+            'primary key and separate unique constraint' => [
+                'T_upsert',
+                [
+                    'id' => 1,
+                    'email' => 'a@example.com',
+                    'address' => 'first address',
+                ],
+                [
+                    'id' => 1,
+                    'email' => 'b@example.com',
+                    'address' => 'second address',
+                ],
+                [
+                    'address' => 'updated address',
+                ],
+                [
+                    'id' => 1,
+                    'email' => 'a@example.com',
+                    'address' => 'updated address',
+                ],
             ],
             'query' => [
                 'T_upsert',

--- a/tests/framework/db/pgsql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/pgsql/providers/QueryBuilderProvider.php
@@ -27,6 +27,74 @@ final class QueryBuilderProvider
     public static function upsert(): array
     {
         return [
+            'composite unique constraint used whole' => [
+                'T_upsert_3',
+                [
+                    'a' => 1,
+                    'b' => 2,
+                    'c' => 'c',
+                ],
+                true,
+                <<<SQL
+                INSERT INTO "T_upsert_3" ("a", "b", "c") VALUES (:qp0, :qp1, :qp2) ON CONFLICT ("a", "b") DO UPDATE SET "c"=EXCLUDED."c"
+                SQL,
+                [
+                    ':qp0' => 1,
+                    ':qp1' => 2,
+                    ':qp2' => 'c',
+                ],
+            ],
+            'composite unique constraint via declared table constraint' => [
+                'T_constraints_2',
+                [
+                    'C_index_1' => 1,
+                    'C_index_2_1' => 2,
+                    'C_index_2_2' => 3,
+                ],
+                true,
+                <<<SQL
+                INSERT INTO "T_constraints_2" ("C_index_1", "C_index_2_1", "C_index_2_2") VALUES (:qp0, :qp1, :qp2) ON CONFLICT ("C_index_2_1", "C_index_2_2") DO UPDATE SET "C_index_1"=EXCLUDED."C_index_1"
+                SQL,
+                [
+                    ':qp0' => 1,
+                    ':qp1' => 2,
+                    ':qp2' => 3,
+                ],
+            ],
+            'multiple matching constraints without update part' => [
+                'T_upsert',
+                [
+                    'id' => 1,
+                    'email' => 'test@example.com',
+                ],
+                false,
+                <<<SQL
+                INSERT INTO "T_upsert" ("id", "email") VALUES (:qp0, :qp1) ON CONFLICT DO NOTHING
+                SQL,
+                [
+                    ':qp0' => 1,
+                    ':qp1' => 'test@example.com',
+                ],
+            ],
+            'narrower constraint selected before name order' => [
+                'T_upsert_3',
+                [
+                    'a' => 1,
+                    'b' => 2,
+                    'z' => 3,
+                    'c' => 'c',
+                ],
+                true,
+                <<<SQL
+                INSERT INTO "T_upsert_3" ("a", "b", "z", "c") VALUES (:qp0, :qp1, :qp2, :qp3) ON CONFLICT ("z") DO UPDATE SET "c"=EXCLUDED."c"
+                SQL,
+                [
+                    ':qp0' => 1,
+                    ':qp1' => 2,
+                    ':qp2' => 3,
+                    ':qp3' => 'c',
+                ],
+            ],
             'no columns to update' => [
                 'T_upsert_1',
                 [
@@ -38,6 +106,23 @@ final class QueryBuilderProvider
                 SQL,
                 [
                     ':qp0' => 1,
+                ],
+            ],
+            'primary key arbiter preferred over unique constraint' => [
+                'T_upsert',
+                [
+                    'id' => 1,
+                    'email' => 'test@example.com',
+                    'address' => 'bar {{city}}',
+                ],
+                true,
+                <<<SQL
+                INSERT INTO "T_upsert" ("id", "email", "address") VALUES (:qp0, :qp1, :qp2) ON CONFLICT ("id") DO UPDATE SET "address"=EXCLUDED."address"
+                SQL,
+                [
+                    ':qp0' => 1,
+                    ':qp1' => 'test@example.com',
+                    ':qp2' => 'bar {{city}}',
                 ],
             ],
             'query' => [
@@ -205,6 +290,40 @@ final class QueryBuilderProvider
                     ':qp1' => 'bar {{city}}',
                     ':qp2' => 1,
                     ':qp3' => null,
+                ],
+            ],
+            'two overlapping unique constraints without matching primary key' => [
+                'T_upsert',
+                [
+                    'email' => 'test@example.com',
+                    'recovery_email' => 'recovery@example.com',
+                    'address' => 'bar {{city}}',
+                ],
+                true,
+                <<<SQL
+                INSERT INTO "T_upsert" ("email", "recovery_email", "address") VALUES (:qp0, :qp1, :qp2) ON CONFLICT ("email") DO UPDATE SET "address"=EXCLUDED."address"
+                SQL,
+                [
+                    ':qp0' => 'test@example.com',
+                    ':qp1' => 'recovery@example.com',
+                    ':qp2' => 'bar {{city}}',
+                ],
+            ],
+            'two independent unique constraints without primary key' => [
+                'T_upsert_2',
+                [
+                    'a' => 1,
+                    'b' => 2,
+                    'c' => 'c',
+                ],
+                true,
+                <<<SQL
+                INSERT INTO "T_upsert_2" ("a", "b", "c") VALUES (:qp0, :qp1, :qp2) ON CONFLICT ("a") DO UPDATE SET "c"=EXCLUDED."c"
+                SQL,
+                [
+                    ':qp0' => 1,
+                    ':qp1' => 2,
+                    ':qp2' => 'c',
                 ],
             ],
             'values and expressions' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
