### PR TITLE
Fix SQLite `checkIntegrity()` to reject foreign-key enforcement changes inside active transactions.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -124,6 +124,7 @@ Yii Framework 2 Change Log
 - Chg #20995: Use native atomic `INSERT ... ON CONFLICT` statements for `yii\db\sqlite\QueryBuilder::upsert()` (terabytesoftw)
 - Bug #20996: Fix `yii\db\pgsql\QueryBuilder::upsert()` with empty update columns (terabytesoftw)
 - Bug #20100: Fix `yii\db\pgsql\QueryBuilder::upsert()` generating an invalid conflict target when multiple unique constraints match (terabytesoftw)
+- Bug #20101: Fix SQLite `checkIntegrity()` to reject foreign-key enforcement changes inside active transactions (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/sqlite/Command.php
+++ b/framework/db/sqlite/Command.php
@@ -8,6 +8,7 @@
 
 namespace yii\db\sqlite;
 
+use yii\db\Exception;
 use yii\db\SqlToken;
 use yii\helpers\StringHelper;
 
@@ -22,24 +23,56 @@ use yii\helpers\StringHelper;
 class Command extends \yii\db\Command
 {
     /**
+     * Whether the command is an integrity check command.
+     */
+    private bool $_isIntegrityCheck = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkIntegrity($check = true, $schema = '', $table = '')
+    {
+        parent::checkIntegrity($check, $schema, $table);
+
+        $this->_isIntegrityCheck = true;
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function execute()
     {
+        if ($this->_isIntegrityCheck && $this->db->getMasterPdo()->inTransaction()) {
+            throw new Exception(
+                'SQLite cannot change foreign-key enforcement inside a transaction. '
+                . 'Execute this operation before BEGIN/SAVEPOINT or after COMMIT/ROLLBACK.'
+            );
+        }
+
         $sql = $this->getSql();
+
         $params = $this->params;
+
         $statements = $this->splitStatements($sql, $params);
+
         if ($statements === false) {
             return parent::execute();
         }
 
         $result = null;
+
         foreach ($statements as $statement) {
-            list($statementSql, $statementParams) = $statement;
+            [$statementSql, $statementParams] = $statement;
+
             $this->setSql($statementSql)->bindValues($statementParams);
+
             $result = parent::execute();
         }
+
         $this->setSql($sql)->bindValues($params);
+
         return $result;
     }
 
@@ -92,6 +125,15 @@ class Command extends \yii\db\Command
             $statements[] = [$statement->getSql(), $this->extractUsedParams($statement, $params)];
         }
         return $statements;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function reset()
+    {
+        parent::reset();
+        $this->_isIntegrityCheck = false;
     }
 
     /**

--- a/framework/db/sqlite/Command.php
+++ b/framework/db/sqlite/Command.php
@@ -42,7 +42,7 @@ class Command extends \yii\db\Command
     /**
      * {@inheritdoc}
      */
-    public function execute()
+    public function prepare($forRead = null)
     {
         if ($this->_isIntegrityCheck && $this->db->getMasterPdo()->inTransaction()) {
             throw new Exception(
@@ -51,28 +51,28 @@ class Command extends \yii\db\Command
             );
         }
 
+        parent::prepare($forRead);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute()
+    {
         $sql = $this->getSql();
-
         $params = $this->params;
-
         $statements = $this->splitStatements($sql, $params);
-
         if ($statements === false) {
             return parent::execute();
         }
 
         $result = null;
-
         foreach ($statements as $statement) {
-            [$statementSql, $statementParams] = $statement;
-
+            list($statementSql, $statementParams) = $statement;
             $this->setSql($statementSql)->bindValues($statementParams);
-
             $result = parent::execute();
         }
-
         $this->setSql($sql)->bindValues($params);
-
         return $result;
     }
 

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -174,15 +174,22 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * Enables or disables integrity check.
-     * @param bool $check whether to turn on or off the integrity check.
-     * @param string $schema the schema of the tables. Meaningless for SQLite.
-     * @param string $table the table name. Meaningless for SQLite.
-     * @return string the SQL statement for checking integrity
-     * @throws NotSupportedException this is not supported by SQLite
+     *
+     * @param bool $check Whether to turn on or off the integrity check.
+     * @param string $schema The schema of the tables. Meaningless for SQLite.
+     * @param string $table The table name. Meaningless for SQLite.
+     *
+     * @throws NotSupportedException this is not supported by SQLite.
+     *
+     * @return string The SQL statement for checking integrity.
      */
     public function checkIntegrity($check = true, $schema = '', $table = '')
     {
-        return 'PRAGMA foreign_keys=' . (int) $check;
+        $check = (int) $check;
+
+        return <<<SQL
+        PRAGMA foreign_keys={$check}
+        SQL;
     }
 
     /**

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -179,8 +179,6 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * @param string $schema The schema of the tables. Meaningless for SQLite.
      * @param string $table The table name. Meaningless for SQLite.
      *
-     * @throws NotSupportedException this is not supported by SQLite.
-     *
      * @return string The SQL statement for checking integrity.
      */
     public function checkIntegrity($check = true, $schema = '', $table = '')

--- a/tests/framework/db/sqlite/CommandTest.php
+++ b/tests/framework/db/sqlite/CommandTest.php
@@ -217,19 +217,20 @@ class CommandTest extends BaseCommand
         }
     }
 
-    public function testCheckIntegrityCommandBuiltBeforeTransactionFailsWhenExecutedInsideIt(): void
+    public function testCheckIntegrityExplicitPrepareInsideTransactionThrows(): void
     {
         $db = $this->getConnection(false);
 
         $this->setForeignKeys($db, true);
 
-        $command = $db->createCommand()->checkIntegrity(false);
         $transaction = $db->beginTransaction();
+        $command = $db->createCommand()->checkIntegrity(false);
 
         try {
-            $command->execute();
+            $command->prepare();
+
             self::fail(
-                'Expected an exception when changing SQLite foreign-key enforcement inside a transaction.',
+                'Expected an exception when preparing a SQLite integrity-check command inside a transaction.',
             );
         } catch (Exception $e) {
             self::assertSame(
@@ -244,7 +245,88 @@ class CommandTest extends BaseCommand
                     PRAGMA foreign_keys
                     SQL,
                 )->queryScalar(),
-                "Foreign keys must remain enabled after 'checkIntegrity(false)' inside a transaction.",
+                'Foreign keys must remain enabled after preparation fails inside a transaction.',
+            );
+        } finally {
+            $transaction->rollBack();
+        }
+    }
+
+    public function testCheckIntegrityCommandPreparedBeforeTransactionFailsWhenExecutedInsideIt(): void
+    {
+        $db = $this->getConnection(false);
+
+        $this->setForeignKeys($db, true);
+
+        $command = $db->createCommand()->checkIntegrity(false);
+        $command->prepare();
+
+        self::assertSame(
+            0,
+            (int) $db->createCommand(
+                <<<SQL
+                PRAGMA foreign_keys
+                SQL,
+            )->queryScalar(),
+            'Preparing the command outside a transaction must apply the PRAGMA.',
+        );
+
+        $transaction = $db->beginTransaction();
+
+        try {
+            $command->execute();
+            self::fail(
+                'Expected an exception when changing SQLite foreign-key enforcement inside a transaction.',
+            );
+        } catch (Exception $e) {
+            self::assertSame(
+                'SQLite cannot change foreign-key enforcement inside a transaction. '
+                . 'Execute this operation before BEGIN/SAVEPOINT or after COMMIT/ROLLBACK.',
+                $e->getMessage(),
+            );
+            self::assertSame(
+                0,
+                (int) $db->createCommand(
+                    <<<SQL
+                    PRAGMA foreign_keys
+                    SQL,
+                )->queryScalar(),
+                'Foreign keys must retain the value applied during preparation.',
+            );
+        } finally {
+            $transaction->rollBack();
+        }
+    }
+
+    public function testCheckIntegrityQueryMethodInsideTransactionThrows(): void
+    {
+        $db = $this->getConnection(false);
+
+        $this->setForeignKeys($db, true);
+
+        $transaction = $db->beginTransaction();
+        $command = $db->createCommand()->checkIntegrity(false);
+
+        try {
+            $command->queryScalar();
+
+            self::fail(
+                'Expected an exception when querying with a SQLite integrity-check command inside a transaction.',
+            );
+        } catch (Exception $e) {
+            self::assertSame(
+                'SQLite cannot change foreign-key enforcement inside a transaction. '
+                . 'Execute this operation before BEGIN/SAVEPOINT or after COMMIT/ROLLBACK.',
+                $e->getMessage(),
+            );
+            self::assertSame(
+                1,
+                (int) $command->setSql(
+                    <<<SQL
+                    PRAGMA foreign_keys
+                    SQL,
+                )->queryScalar(),
+                'Foreign keys must remain enabled when a query method is rejected inside a transaction.',
             );
         } finally {
             $transaction->rollBack();

--- a/tests/framework/db/sqlite/CommandTest.php
+++ b/tests/framework/db/sqlite/CommandTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\base\InvalidArgumentException;
 use yii\base\NotSupportedException;
+use yii\db\Connection;
+use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\IntegrityException;
 use yii\db\Query;
@@ -101,6 +103,303 @@ class CommandTest extends BaseCommand
         $sql = 'SELECT [[id]], [[t.name]] FROM {{customer}} t';
         $command = $db->createCommand($sql);
         $this->assertEquals('SELECT `id`, `t`.`name` FROM `customer` t', $command->sql);
+    }
+
+    public function testCheckIntegrityDisablesForeignKeysOutsideTransaction(): void
+    {
+        $db = $this->getConnection(false);
+
+        $this->setForeignKeys($db, true);
+
+        $command = $db->createCommand();
+
+        $command->checkIntegrity(false)->execute();
+
+        self::assertSame(
+            0,
+            (int) $command->setSql(
+                <<<SQL
+                PRAGMA foreign_keys
+                SQL,
+            )->queryScalar(),
+            "Foreign keys must be disabled after 'checkIntegrity(false)' outside a transaction.",
+        );
+    }
+
+    public function testCheckIntegrityEnablesForeignKeysOutsideTransaction(): void
+    {
+        $db = $this->getConnection(false);
+
+        $this->setForeignKeys($db, false);
+
+        $command = $db->createCommand();
+
+        $command->checkIntegrity(true)->execute();
+
+        self::assertSame(
+            1,
+            (int) $command->setSql(
+                <<<SQL
+                PRAGMA foreign_keys
+                SQL,
+            )->queryScalar(),
+            "Foreign keys must be enabled after 'checkIntegrity(true)' outside a transaction.",
+        );
+    }
+
+    public function testCheckIntegrityCannotDisableForeignKeysInsideYiiTransaction(): void
+    {
+        $db = $this->getConnection(false);
+
+        $this->setForeignKeys($db, true);
+
+        $transaction = $db->beginTransaction();
+        $command = $db->createCommand();
+
+        try {
+            $command->checkIntegrity(false)->execute();
+
+            self::fail(
+                'Expected an exception when changing SQLite foreign-key enforcement inside a transaction.',
+            );
+        } catch (Exception $e) {
+            self::assertSame(
+                'SQLite cannot change foreign-key enforcement inside a transaction. '
+                . 'Execute this operation before BEGIN/SAVEPOINT or after COMMIT/ROLLBACK.',
+                $e->getMessage(),
+            );
+            self::assertSame(
+                1,
+                (int) $command->setSql(
+                    <<<SQL
+                    PRAGMA foreign_keys
+                    SQL,
+                )->queryScalar(),
+                "Foreign keys must remain enabled after 'checkIntegrity(false)' inside a transaction.",
+            );
+        } finally {
+            $transaction->rollBack();
+        }
+    }
+
+    public function testCheckIntegrityCannotEnableForeignKeysInsideYiiTransaction(): void
+    {
+        $db = $this->getConnection(false);
+
+        $this->setForeignKeys($db, false);
+
+        $transaction = $db->beginTransaction();
+        $command = $db->createCommand();
+
+        try {
+            $command->checkIntegrity(true)->execute();
+
+            self::fail(
+                'Expected an exception when changing SQLite foreign-key enforcement inside a transaction.',
+            );
+        } catch (Exception $e) {
+            self::assertSame(
+                'SQLite cannot change foreign-key enforcement inside a transaction. '
+                . 'Execute this operation before BEGIN/SAVEPOINT or after COMMIT/ROLLBACK.',
+                $e->getMessage(),
+            );
+            self::assertSame(
+                0,
+                (int) $command->setSql(
+                    <<<SQL
+                    PRAGMA foreign_keys
+                    SQL,
+                )->queryScalar(),
+                "Foreign keys must remain disabled after 'checkIntegrity(true)' inside a transaction.",
+            );
+        } finally {
+            $transaction->rollBack();
+        }
+    }
+
+    public function testCheckIntegrityCommandBuiltBeforeTransactionFailsWhenExecutedInsideIt(): void
+    {
+        $db = $this->getConnection(false);
+
+        $this->setForeignKeys($db, true);
+
+        $command = $db->createCommand()->checkIntegrity(false);
+        $transaction = $db->beginTransaction();
+
+        try {
+            $command->execute();
+            self::fail(
+                'Expected an exception when changing SQLite foreign-key enforcement inside a transaction.',
+            );
+        } catch (Exception $e) {
+            self::assertSame(
+                'SQLite cannot change foreign-key enforcement inside a transaction. '
+                . 'Execute this operation before BEGIN/SAVEPOINT or after COMMIT/ROLLBACK.',
+                $e->getMessage(),
+            );
+            self::assertSame(
+                1,
+                (int) $command->setSql(
+                    <<<SQL
+                    PRAGMA foreign_keys
+                    SQL,
+                )->queryScalar(),
+                "Foreign keys must remain enabled after 'checkIntegrity(false)' inside a transaction.",
+            );
+        } finally {
+            $transaction->rollBack();
+        }
+    }
+
+    public function testCheckIntegrityCommandBuiltInsideTransactionSucceedsAfterRollback(): void
+    {
+        $db = $this->getConnection(false);
+
+        $this->setForeignKeys($db, true);
+
+        $transaction = $db->beginTransaction();
+
+        try {
+            $command = $db->createCommand()->checkIntegrity(false);
+        } finally {
+            $transaction->rollBack();
+        }
+
+        $command->execute();
+
+        self::assertSame(
+            0,
+            (int) $command->setSql(
+                <<<SQL
+                PRAGMA foreign_keys
+                SQL,
+            )->queryScalar(),
+            "Foreign keys must be disabled after 'checkIntegrity(false)' outside a transaction.",
+        );
+    }
+
+    public function testCheckIntegrityDetectsTransactionStartedDirectlyThroughPdo(): void
+    {
+        $db = $this->getConnection(false);
+
+        $this->setForeignKeys($db, true);
+
+        $pdo = $db->getMasterPdo();
+
+        $command = $db->createCommand();
+        $pdo->beginTransaction();
+
+        try {
+            self::assertNull(
+                $db->getTransaction(),
+                'PDO transaction started directly through the PDO connection must not be visible to the Yii Connection.',
+            );
+
+            $command->checkIntegrity(false)->execute();
+
+            self::fail(
+                'Expected an exception when changing SQLite foreign-key enforcement inside a transaction.',
+            );
+        } catch (Exception $e) {
+            self::assertSame(
+                'SQLite cannot change foreign-key enforcement inside a transaction. '
+                . 'Execute this operation before BEGIN/SAVEPOINT or after COMMIT/ROLLBACK.',
+                $e->getMessage(),
+            );
+            self::assertSame(
+                1,
+                (int) $command->setSql(
+                    <<<SQL
+                    PRAGMA foreign_keys
+                    SQL,
+                )->queryScalar(),
+                "Foreign keys must remain enabled after 'checkIntegrity(false)' inside a transaction.",
+            );
+        } finally {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+        }
+    }
+
+    public function testCheckIntegrityDetectsPendingRawSavepointWhenSupportedByPdo(): void
+    {
+        $db = $this->getConnection(false);
+
+        $this->setForeignKeys($db, true);
+
+        $command = $db->createCommand();
+        $pdo = $db->getMasterPdo();
+
+        $pdo->exec('SAVEPOINT check_integrity_test');
+
+        try {
+            if (!$pdo->inTransaction()) {
+                $this->markTestSkipped(
+                    'This PDO SQLite version does not expose transactions started through raw SQL.',
+                );
+            }
+
+            self::assertNull(
+                $db->getTransaction(),
+                'PDO savepoint started directly through the PDO connection must not be visible to the Yii Connection.',
+            );
+
+            $command->checkIntegrity(false)->execute();
+
+            self::fail(
+                'Expected an exception when changing SQLite foreign-key enforcement inside a transaction.',
+            );
+        } catch (Exception $e) {
+            self::assertSame(
+                'SQLite cannot change foreign-key enforcement inside a transaction. '
+                . 'Execute this operation before BEGIN/SAVEPOINT or after COMMIT/ROLLBACK.',
+                $e->getMessage(),
+            );
+            self::assertSame(
+                1,
+                (int) $command->setSql(
+                    <<<SQL
+                    PRAGMA foreign_keys
+                    SQL,
+                )->queryScalar(),
+                "Foreign keys must remain enabled after 'checkIntegrity(false)' inside a transaction.",
+            );
+        } finally {
+            $pdo->exec('ROLLBACK');
+        }
+    }
+
+    public function testCheckIntegrityStateDoesNotLeakWhenCommandSqlChanges(): void
+    {
+        $db = $this->getConnection(false);
+
+        $this->setForeignKeys($db, true);
+
+        $command = $db->createCommand()->checkIntegrity(false);
+        $transaction = $db->beginTransaction();
+
+        try {
+            self::assertSame(
+                0,
+                $command->setSql(
+                    <<<SQL
+                    SELECT 1; SELECT 2
+                    SQL,
+                )->execute(),
+            );
+            self::assertSame(
+                1,
+                (int) $command->setSql(
+                    <<<SQL
+                    PRAGMA foreign_keys
+                    SQL,
+                )->queryScalar(),
+                'Foreign keys must remain enabled after the integrity-check command SQL changes.',
+            );
+        } finally {
+            $transaction->rollBack();
+        }
     }
 
     public function testUpsertUsesAnyUniqueConstraint(): void
@@ -487,5 +786,27 @@ class CommandTest extends BaseCommand
                 $e->getMessage(),
             );
         }
+    }
+
+    private function setForeignKeys(Connection $db, bool $enabled): void
+    {
+        $command = $db->createCommand();
+        $enabled = (int) $enabled;
+
+        $command->setSql(
+            <<<SQL
+            PRAGMA foreign_keys={$enabled}
+            SQL,
+        )->execute();
+
+        self::assertSame(
+            $enabled,
+            (int) $command->setSql(
+                <<<SQL
+                PRAGMA foreign_keys
+                SQL,
+            )->queryScalar(),
+            "Foreign-key enforcement must be explicitly initialized to '{$enabled}'.",
+        );
     }
 }

--- a/tests/framework/db/sqlite/QueryBuilderTest.php
+++ b/tests/framework/db/sqlite/QueryBuilderTest.php
@@ -297,6 +297,24 @@ final class QueryBuilderTest extends BaseQueryBuilder
         $this->assertEquals('ALTER TABLE `table_from` RENAME TO `table_to`', $sql);
     }
 
+    public function testCheckIntegrity(): void
+    {
+        $queryBuilder = $this->getQueryBuilder();
+
+        self::assertSame(
+            <<<SQL
+            PRAGMA foreign_keys=0
+            SQL,
+            $queryBuilder->checkIntegrity(false)
+        );
+        self::assertSame(
+            <<<SQL
+            PRAGMA foreign_keys=1
+            SQL,
+            $queryBuilder->checkIntegrity(true)
+        );
+    }
+
     public function testResetSequence(): void
     {
         $qb = $this->getQueryBuilder(true, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
