### PR TITLE
Make MSSQL `alterColumn()` roll back dropped constraints when the column alteration fails.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -125,6 +125,7 @@ Yii Framework 2 Change Log
 - Bug #20996: Fix `yii\db\pgsql\QueryBuilder::upsert()` with empty update columns (terabytesoftw)
 - Bug #20100: Fix `yii\db\pgsql\QueryBuilder::upsert()` generating an invalid conflict target when multiple unique constraints match (terabytesoftw)
 - Bug #20101: Fix SQLite `checkIntegrity()` to reject foreign-key enforcement changes inside active transactions (terabytesoftw)
+- Bug #20102: Make MSSQL `alterColumn()` roll back dropped constraints when the column alteration fails (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -281,9 +281,9 @@ class Connection extends Component
         'mysql' => 'yii\db\mysql\Schema', // MySQL
         'sqlite' => 'yii\db\sqlite\Schema', // sqlite 3
         'sqlite2' => 'yii\db\sqlite\Schema', // sqlite 2
-        'sqlsrv' => 'yii\db\mssql\Schema', // newer MSSQL driver on MS Windows hosts
+        'sqlsrv' => 'yii\db\mssql\Schema', // newer MSSQL driver
         'oci' => 'yii\db\oci\Schema', // Oracle driver
-        'mssql' => 'yii\db\mssql\Schema', // older MSSQL driver on MS Windows hosts
+        'mssql' => 'yii\db\mssql\Schema', // older MSSQL driver
         'dblib' => 'yii\db\mssql\Schema', // dblib drivers on GNU/Linux (and maybe other OSes) hosts
     ];
     /**
@@ -308,10 +308,10 @@ class Connection extends Component
         'mysql' => 'yii\db\Command', // MySQL
         'sqlite' => 'yii\db\sqlite\Command', // sqlite 3
         'sqlite2' => 'yii\db\sqlite\Command', // sqlite 2
-        'sqlsrv' => 'yii\db\Command', // newer MSSQL driver on MS Windows hosts
+        'sqlsrv' => 'yii\db\mssql\Command', // newer MSSQL driver on MS Windows hosts
         'oci' => 'yii\db\oci\Command', // Oracle driver
-        'mssql' => 'yii\db\Command', // older MSSQL driver on MS Windows hosts
-        'dblib' => 'yii\db\Command', // dblib drivers on GNU/Linux (and maybe other OSes) hosts
+        'mssql' => 'yii\db\mssql\Command', // older MSSQL driver on MS Windows hosts
+        'dblib' => 'yii\db\mssql\Command', // dblib drivers on GNU/Linux (and maybe other OSes) hosts
     ];
     /**
      * @var bool whether to enable [savepoint](https://en.wikipedia.org/wiki/Savepoint).

--- a/framework/db/mssql/Command.php
+++ b/framework/db/mssql/Command.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yii\db\mssql;
+
+/**
+ * Command represents an MSSQL SQL statement to be executed against a database.
+ *
+ * @since 22.0
+ */
+class Command extends \yii\db\Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function alterColumn($table, $column, $type)
+    {
+        parent::alterColumn($table, $column, $type);
+
+        $this->requireTransaction();
+
+        return $this;
+    }
+}

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -719,6 +719,176 @@ final class CommandTest extends BaseCommand
         );
     }
 
+    public function testAlterColumnRollsBackDroppedConstraintsWhenAlterationFails(): void
+    {
+        $db = $this->getConnection();
+
+        $command = $db->createCommand();
+
+        $command->alterColumn(
+            'foo1',
+            'bar',
+            $db
+                ->getSchema()
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)
+                ->defaultValue('fallback')
+                ->check('LEN(bar) > 0')
+                ->unique(),
+        )->execute();
+        $command->insert(
+            'foo1',
+            ['bar' => 'not numeric'],
+        )->execute();
+
+        /** @var Schema $schema */
+        $schema = $db->getSchema();
+
+        $originalDefaults = $schema->getTableDefaultValues('foo1', true);
+        $originalChecks = $schema->getTableChecks('foo1', true);
+        $originalUniques = $schema->getTableUniques('foo1', true);
+
+        self::assertCount(
+            1,
+            $originalDefaults,
+            'The test column must have one default constraint.',
+        );
+        self::assertCount(
+            1,
+            $originalChecks,
+            'The test column must have one check constraint.',
+        );
+        self::assertCount(
+            1,
+            $originalUniques,
+            'The test column must have one unique constraint.',
+        );
+        self::assertNull(
+            $db->getTransaction(),
+            'No explicit transaction should be active before altering the column.',
+        );
+        self::assertFalse(
+            $db->getMasterPdo()->inTransaction(),
+            'PDO should not have an active transaction before altering the column.',
+        );
+
+        $exception = null;
+
+        try {
+            $command->alterColumn(
+                'foo1',
+                'bar',
+                $schema->createColumnSchemaBuilder(Schema::TYPE_INTEGER),
+            )->execute();
+        } catch (Exception $e) {
+            $exception = $e;
+        }
+
+        self::assertInstanceOf(
+            Exception::class,
+            $exception,
+            'Converting a non-numeric value to INTEGER must fail with a database exception.',
+        );
+        self::assertNull(
+            $db->getTransaction(),
+            'The command-owned transaction must be closed after the failure.',
+        );
+        self::assertFalse(
+            $db->getMasterPdo()->inTransaction(),
+            'PDO must not retain the command-owned transaction after the failure.',
+        );
+
+        $tableSchema = $schema->getTableSchema('foo1', true);
+
+        self::assertSame(
+            'nvarchar(64)',
+            $tableSchema->getColumn('bar')->dbType,
+            'The original column type must be restored after the failed alteration.',
+        );
+
+        $defaults = $schema->getTableDefaultValues('foo1', true);
+        $checks = $schema->getTableChecks('foo1', true);
+        $uniques = $schema->getTableUniques('foo1', true);
+
+        self::assertCount(
+            1,
+            $defaults,
+            'The original default constraint must remain after the failure.',
+        );
+        self::assertSame(
+            $originalDefaults[0]->name,
+            $defaults[0]->name,
+            'The original default constraint must be restored.',
+        );
+        self::assertCount(
+            1,
+            $checks,
+            'The original check constraint must remain after the failure.',
+        );
+        self::assertSame(
+            $originalChecks[0]->name,
+            $checks[0]->name,
+            'The original check constraint must be restored.',
+        );
+        self::assertCount(
+            1,
+            $uniques,
+            'The original unique constraint must remain after the failure.',
+        );
+        self::assertSame(
+            $originalUniques[0]->name,
+            $uniques[0]->name,
+            'The original unique constraint must be restored.',
+        );
+    }
+
+    public function testAlterColumnDoesNotCommitExternalTransaction(): void
+    {
+        $db = $this->getConnection();
+
+        $command = $db->createCommand();
+        $schema = $db->getSchema();
+        $transaction = $db->beginTransaction();
+
+        try {
+            $command->alterColumn(
+                'foo1',
+                'bar',
+                $schema->createColumnSchemaBuilder(Schema::TYPE_STRING, 64),
+            )->execute();
+
+            self::assertSame(
+                $transaction,
+                $db->getTransaction(),
+                'Alter column must participate in the existing transaction.',
+            );
+            self::assertTrue(
+                $transaction->isActive,
+                'Alter column must not commit the existing transaction.',
+            );
+            self::assertSame(
+                'nvarchar(64)',
+                $db->getTableSchema('foo1', true)->getColumn('bar')->dbType,
+                'Alter column must be visible inside the existing transaction.',
+            );
+
+            $transaction->rollBack();
+        } finally {
+            if ($transaction->isActive) {
+                $transaction->rollBack();
+            }
+        }
+
+        self::assertNull(
+            $db->getTransaction(),
+            'No transaction should remain active after the external rollback.',
+        );
+        self::assertSame(
+            'varchar(32)',
+            $db->getTableSchema('foo1', true)->getColumn('bar')->dbType,
+            'Rolling back the external transaction must restore the original column type.',
+        );
+    }
+
     public function testAlterColumnWithCheckConstraint(): void
     {
         $db = $this->getConnection();

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -845,12 +845,18 @@ final class CommandTest extends BaseCommand
     {
         $db = $this->getConnection();
 
-        $command = $db->createCommand();
+        /** @var Schema $schema */
         $schema = $db->getSchema();
+
+        $originalColumnType = $schema
+            ->getTableSchema('foo1', true)
+            ->getColumn('bar')
+            ->dbType;
+
         $transaction = $db->beginTransaction();
 
         try {
-            $command->alterColumn(
+            $db->createCommand()->alterColumn(
                 'foo1',
                 'bar',
                 $schema->createColumnSchemaBuilder(Schema::TYPE_STRING, 64),
@@ -867,11 +873,9 @@ final class CommandTest extends BaseCommand
             );
             self::assertSame(
                 'nvarchar(64)',
-                $db->getTableSchema('foo1', true)->getColumn('bar')->dbType,
+                $schema->getTableSchema('foo1', true)->getColumn('bar')->dbType,
                 'Alter column must be visible inside the existing transaction.',
             );
-
-            $transaction->rollBack();
         } finally {
             if ($transaction->isActive) {
                 $transaction->rollBack();
@@ -882,10 +886,145 @@ final class CommandTest extends BaseCommand
             $db->getTransaction(),
             'No transaction should remain active after the external rollback.',
         );
+        self::assertFalse(
+            $db->getMasterPdo()->inTransaction(),
+            'PDO must not retain the external transaction after rollback.',
+        );
         self::assertSame(
-            'varchar(32)',
-            $db->getTableSchema('foo1', true)->getColumn('bar')->dbType,
+            $originalColumnType,
+            $schema->getTableSchema('foo1', true)->getColumn('bar')->dbType,
             'Rolling back the external transaction must restore the original column type.',
+        );
+    }
+
+    public function testFailedAlterColumnDoesNotRollBackExternalTransaction(): void
+    {
+        $db = $this->getConnection();
+
+        /** @var Schema $schema */
+        $schema = $db->getSchema();
+
+        $db->createCommand()->alterColumn(
+            'foo1',
+            'bar',
+            $schema
+                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 64)
+                ->defaultValue('fallback')
+                ->check('LEN(bar) > 0')
+                ->unique(),
+        )->execute();
+        $db->createCommand()->insert(
+            'foo1',
+            ['bar' => 'not numeric'],
+        )->execute();
+
+        $originalColumnType = $schema
+            ->getTableSchema('foo1', true)
+            ->getColumn('bar')
+            ->dbType;
+
+        $originalDefaults = $schema->getTableDefaultValues('foo1', true);
+        $originalChecks = $schema->getTableChecks('foo1', true);
+        $originalUniques = $schema->getTableUniques('foo1', true);
+
+        self::assertCount(
+            1,
+            $originalDefaults,
+            'The test column must have one default constraint.',
+        );
+        self::assertCount(
+            1,
+            $originalChecks,
+            'The test column must have one check constraint.',
+        );
+        self::assertCount(
+            1,
+            $originalUniques,
+            'The test column must have one unique constraint.',
+        );
+
+        $transaction = $db->beginTransaction();
+
+        try {
+            $exception = null;
+
+            try {
+                $db->createCommand()->alterColumn(
+                    'foo1',
+                    'bar',
+                    $schema->createColumnSchemaBuilder(Schema::TYPE_INTEGER),
+                )->execute();
+            } catch (Exception $e) {
+                $exception = $e;
+            }
+
+            self::assertInstanceOf(
+                Exception::class,
+                $exception,
+                'Converting a non-numeric value to INTEGER must fail with a database exception.',
+            );
+            self::assertSame(
+                $transaction,
+                $db->getTransaction(),
+                'A failed alter column must preserve the existing transaction.',
+            );
+            self::assertTrue(
+                $transaction->isActive,
+                'A failed alter column must leave rollback responsibility to the caller.',
+            );
+        } finally {
+            if ($transaction->isActive) {
+                $transaction->rollBack();
+            }
+        }
+
+        self::assertNull(
+            $db->getTransaction(),
+            'No transaction should remain active after the external rollback.',
+        );
+        self::assertFalse(
+            $db->getMasterPdo()->inTransaction(),
+            'PDO must not retain the external transaction after rollback.',
+        );
+        self::assertSame(
+            $originalColumnType,
+            $schema->getTableSchema('foo1', true)->getColumn('bar')->dbType,
+            'The external rollback must restore the original column type.',
+        );
+
+        $defaults = $schema->getTableDefaultValues('foo1', true);
+        $checks = $schema->getTableChecks('foo1', true);
+        $uniques = $schema->getTableUniques('foo1', true);
+
+        self::assertCount(
+            1,
+            $defaults,
+            'The external rollback must restore the original default constraint.',
+        );
+        self::assertSame(
+            $originalDefaults[0]->name,
+            $defaults[0]->name,
+            'The restored default constraint must preserve its original name.',
+        );
+        self::assertCount(
+            1,
+            $checks,
+            'The external rollback must restore the original check constraint.',
+        );
+        self::assertSame(
+            $originalChecks[0]->name,
+            $checks[0]->name,
+            'The restored check constraint must preserve its original name.',
+        );
+        self::assertCount(
+            1,
+            $uniques,
+            'The external rollback must restore the original unique constraint.',
+        );
+        self::assertSame(
+            $originalUniques[0]->name,
+            $uniques[0]->name,
+            'The restored unique constraint must preserve its original name.',
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
