### PR TITLE
Fix PostgreSQL `yii\db\pgsql\QueryBuilder::checkIntegrity()` changing the connection-wide PDO emulate-prepares setting.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -126,6 +126,7 @@ Yii Framework 2 Change Log
 - Bug #20100: Fix `yii\db\pgsql\QueryBuilder::upsert()` generating an invalid conflict target when multiple unique constraints match (terabytesoftw)
 - Bug #20101: Fix SQLite `checkIntegrity()` to reject foreign-key enforcement changes inside active transactions (terabytesoftw)
 - Bug #20102: Make MSSQL `alterColumn()` roll back dropped constraints when the column alteration fails (terabytesoftw)
+- Bug #21004: Fix PostgreSQL `yii\db\pgsql\QueryBuilder::checkIntegrity()` changing the connection-wide PDO emulate-prepares setting (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -22,10 +22,12 @@ use yii\db\Query;
 use yii\db\PdoValue;
 use yii\helpers\StringHelper;
 
+use function array_diff;
 use function array_map;
 use function count;
 use function implode;
 use function is_bool;
+use function str_contains;
 use function usort;
 
 /**
@@ -263,32 +265,55 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
-     * Builds a SQL statement for enabling or disabling integrity check.
-     * @param bool $check whether to turn on or off the integrity check.
-     * @param string $schema the schema of the tables.
-     * @param string $table the table name.
-     * @return string the SQL statement for checking integrity
+     * Builds a SQL statement for enabling or disabling integrity checks.
+     *
+     * @param bool $check Whether to enable or disable integrity checks.
+     * @param string $schema The schema containing the tables.
+     * @param string $table The table name. An empty string applies the operation to all tables in the schema.
+     *
+     * @return string The SQL statement for changing the integrity-check state.
      */
     public function checkIntegrity($check = true, $schema = '', $table = '')
     {
         /** @var Schema $dbSchema */
         $dbSchema = $this->db->getSchema();
-        $enable = $check ? 'ENABLE' : 'DISABLE';
-        $schema = $schema ?: $dbSchema->defaultSchema;
-        $tableNames = $table ? [$table] : $dbSchema->getTableNames($schema);
+
+        $action = $check ? 'ENABLE' : 'DISABLE';
+        $schema = $schema === '' ? $dbSchema->defaultSchema : $schema;
+
+        $tableNames = $table === '' ? $dbSchema->getTableNames($schema) : [$table];
         $viewNames = $dbSchema->getViewNames($schema);
         $tableNames = array_diff($tableNames, $viewNames);
-        $command = '';
+
+        $commands = [];
 
         foreach ($tableNames as $tableName) {
             $tableName = $this->db->quoteTableName("{$schema}.{$tableName}");
-            $command .= "ALTER TABLE $tableName $enable TRIGGER ALL; ";
+
+            $commands[] = "ALTER TABLE {$tableName} {$action} TRIGGER ALL;";
         }
 
-        // enable to have ability to alter several tables
-        $this->db->getMasterPdo()->setAttribute(\PDO::ATTR_EMULATE_PREPARES, true);
+        if ($commands === []) {
+            return '';
+        }
 
-        return $command;
+        $command = implode("\n", $commands);
+
+        $tag = 'yii';
+        $delimiter = "\$$tag\$";
+
+        while (str_contains($command, $delimiter)) {
+            $tag .= '_';
+            $delimiter = "\$$tag\$";
+        }
+
+        return <<<SQL
+        DO $delimiter
+        BEGIN
+        $command
+        END;
+        $delimiter;
+        SQL;
     }
 
     /**

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -22,6 +22,7 @@ use yii\db\pgsql\Schema;
 use yii\db\Query;
 use yiiunit\base\db\BaseCommand;
 use yiiunit\framework\db\pgsql\providers\CommandProvider;
+use yiiunit\support\DbHelper;
 
 use function array_diff;
 use function array_keys;
@@ -329,6 +330,43 @@ class CommandTest extends BaseCommand
         );
 
         $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
+    }
+
+    public function testCheckIntegrityReturnsEmptyCommandWhenTableIsView(): void
+    {
+        $db = $this->getConnection();
+
+        $command = $db->createCommand()->checkIntegrity(true, 'public', 'animal_view');
+
+        self::assertSame(
+            '',
+            $command->getSql(),
+            'A view must not produce an integrity-check statement.',
+        );
+        self::assertSame(
+            0,
+            $command->execute(),
+            'Executing an empty integrity-check command must be a no-op.',
+        );
+    }
+
+    public function testCheckIntegrityExecutesWhenTableNameContainsDollarQuoteDelimiter(): void
+    {
+        $db = $this->getConnection();
+
+        $tableName = 'check_integrity_$yii$_table';
+
+        $command = $db->createCommand()->createTable($tableName, ['id' => 'pk']);
+
+        $command->execute();
+
+        self::assertSame(
+            0,
+            $command->checkIntegrity(true, 'public', $tableName)->execute(),
+            'Integrity checks must execute when a table name contains the initial dollar-quote delimiter.',
+        );
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
     }
 
     public function testBooleanValuesInsert(): void

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -10,12 +10,15 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\db\pgsql;
 
+use PDO;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\db\ArrayExpression;
+use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\IntegrityException;
 use yii\db\JsonExpression;
+use yii\db\pgsql\Schema;
 use yii\db\Query;
 use yiiunit\base\db\BaseCommand;
 use yiiunit\framework\db\pgsql\providers\CommandProvider;
@@ -147,6 +150,174 @@ class CommandTest extends BaseCommand
         $sql = 'SELECT [[id]], [[t.name]] FROM {{customer}} t';
         $command = $db->createCommand($sql);
         $this->assertEquals('SELECT "id", "t"."name" FROM "customer" t', $command->sql);
+    }
+
+    public function testCheckIntegrityPreservesNativePreparesDuringExecution(): void
+    {
+        $db = $this->getConnection();
+        $pdo = $db->getMasterPdo();
+        $originalEmulatePrepares = $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
+
+        try {
+            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+
+            $db->createCommand()->checkIntegrity(false, '', 'item')->execute();
+
+            self::assertFalse(
+                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+                'Disabling integrity checks must not enable emulated prepares.',
+            );
+            self::assertSame(
+                1,
+                $db->createCommand()->insert('item', [
+                    'name' => 'invalid category while disabled',
+                    'category_id' => -1,
+                ])->execute(),
+                'Disabling integrity checks must disable the foreign key trigger.',
+            );
+
+            $db->createCommand()->checkIntegrity(true, '', 'item')->execute();
+
+            self::assertFalse(
+                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+                'Enabling integrity checks must preserve native prepares.',
+            );
+
+            $integrityExceptionThrown = false;
+
+            try {
+                $db->createCommand()->insert('item', [
+                    'name' => 'invalid category while enabled',
+                    'category_id' => -2,
+                ])->execute();
+            } catch (IntegrityException) {
+                $integrityExceptionThrown = true;
+            }
+
+            self::assertTrue(
+                $integrityExceptionThrown,
+                'Enabling integrity checks must enable the foreign key trigger.',
+            );
+        } finally {
+            try {
+                $db->createCommand()->checkIntegrity(true, '', 'item')->execute();
+            } finally {
+                $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
+            }
+        }
+    }
+
+    public function testCheckIntegrityPreservesEmulatedPrepares(): void
+    {
+        $db = $this->getConnection();
+        $pdo = $db->getMasterPdo();
+        $originalEmulatePrepares = $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
+
+        try {
+            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+
+            $command = $db->createCommand()->checkIntegrity(true, 'schema1', 'profile');
+
+            self::assertTrue(
+                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+                'Building the command must preserve emulated prepares.',
+            );
+
+            $command->execute();
+
+            self::assertTrue(
+                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+                'Executing the command must preserve emulated prepares.',
+            );
+        } finally {
+            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
+        }
+    }
+
+    public function testCheckIntegrityPreservesNativePreparesWhenExecutionFails(): void
+    {
+        $db = $this->getConnection();
+        $pdo = $db->getMasterPdo();
+        $originalEmulatePrepares = $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
+
+        try {
+            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+            $command = $db->createCommand()->checkIntegrity(false, '', 'missing_check_integrity_table');
+
+            try {
+                $command->execute();
+                self::fail('Executing checkIntegrity() for a missing table must fail.');
+            } catch (Exception) {
+                self::assertFalse(
+                    $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+                    'A failed command must preserve native prepares.',
+                );
+            }
+        } finally {
+            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
+        }
+    }
+
+    public function testCheckIntegritySupportsMultipleTablesWithNativePrepares(): void
+    {
+        $db = $this->getConnection();
+        $schema = $db->getSchema();
+
+        self::assertInstanceOf(Schema::class, $schema);
+
+        $viewNames = $schema->getViewNames('public');
+        $tableNames = array_diff($schema->getTableNames('public'), $viewNames);
+        $pdo = $db->getMasterPdo();
+        $originalEmulatePrepares = $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
+
+        self::assertGreaterThan(1, count($tableNames), 'The fixture must contain multiple tables.');
+        self::assertContains('animal_view', $viewNames, 'The fixture must contain a view to exclude.');
+
+        try {
+            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+            $command = $db->createCommand()->checkIntegrity(true, 'public');
+
+            self::assertFalse(
+                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+                'Building a schema-wide command must preserve native prepares.',
+            );
+
+            $command->prepare();
+
+            self::assertFalse(
+                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+                'Preparing a schema-wide command must preserve native prepares.',
+            );
+
+            $command->execute();
+
+            self::assertFalse(
+                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+                'Executing a schema-wide command must preserve native prepares.',
+            );
+        } finally {
+            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
+        }
+    }
+
+    public function testBuildingCheckIntegrityDoesNotChangeNativePrepares(): void
+    {
+        $db = $this->getConnection();
+        $pdo = $db->getMasterPdo();
+        $originalEmulatePrepares = $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
+
+        try {
+            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+
+            $db->createCommand()->checkIntegrity(false, '', 'item');
+
+            self::assertFalse(
+                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+                'Building the command must not change the PDO attribute.',
+            );
+        } finally {
+            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
+        }
     }
 
     public function testBooleanValuesInsert(): void

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -23,7 +23,9 @@ use yii\db\Query;
 use yiiunit\base\db\BaseCommand;
 use yiiunit\framework\db\pgsql\providers\CommandProvider;
 
+use function array_diff;
 use function array_keys;
+use function count;
 
 /**
  * Unit tests for {@see \yii\db\Command} functionality for the PostgreSQL driver.
@@ -152,16 +154,18 @@ class CommandTest extends BaseCommand
         $this->assertEquals('SELECT "id", "t"."name" FROM "customer" t', $command->sql);
     }
 
-    public function testCheckIntegrityPreservesNativePreparesDuringExecution(): void
+    public function testThrowIntegrityExceptionWhenCheckIntegrityEnablesTriggersWithoutChangingNativePrepares(): void
     {
         $db = $this->getConnection();
+
+        $command = $db->createCommand();
         $pdo = $db->getMasterPdo();
+
         $originalEmulatePrepares = $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
 
         try {
             $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
-
-            $db->createCommand()->checkIntegrity(false, '', 'item')->execute();
+            $command->checkIntegrity(false, '', 'item')->execute();
 
             self::assertFalse(
                 $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
@@ -169,155 +173,162 @@ class CommandTest extends BaseCommand
             );
             self::assertSame(
                 1,
-                $db->createCommand()->insert('item', [
-                    'name' => 'invalid category while disabled',
-                    'category_id' => -1,
-                ])->execute(),
+                $command->insert(
+                    'item',
+                    ['name' => 'invalid category while disabled', 'category_id' => -1],
+                )->execute(),
                 'Disabling integrity checks must disable the foreign key trigger.',
             );
 
-            $db->createCommand()->checkIntegrity(true, '', 'item')->execute();
+            $command->checkIntegrity(true, '', 'item')->execute();
 
             self::assertFalse(
                 $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
                 'Enabling integrity checks must preserve native prepares.',
             );
 
-            $integrityExceptionThrown = false;
-
-            try {
-                $db->createCommand()->insert('item', [
-                    'name' => 'invalid category while enabled',
-                    'category_id' => -2,
-                ])->execute();
-            } catch (IntegrityException) {
-                $integrityExceptionThrown = true;
-            }
-
-            self::assertTrue(
-                $integrityExceptionThrown,
-                'Enabling integrity checks must enable the foreign key trigger.',
+            $this->expectException(IntegrityException::class);
+            $this->expectExceptionMessage(
+                'insert or update on table "item" violates foreign key constraint "item_category_id_fkey"',
             );
+
+            $command->insert(
+                'item',
+                ['name' => 'invalid category while enabled', 'category_id' => -2],
+            )->execute();
         } finally {
-            try {
-                $db->createCommand()->checkIntegrity(true, '', 'item')->execute();
-            } finally {
-                $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
-            }
+            $command->checkIntegrity(true, '', 'item')->execute();
+            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
         }
     }
 
     public function testCheckIntegrityPreservesEmulatedPrepares(): void
     {
         $db = $this->getConnection();
+
         $pdo = $db->getMasterPdo();
+
         $originalEmulatePrepares = $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
 
-        try {
-            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+        $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+        $command = $db->createCommand()->checkIntegrity(true, 'schema1', 'profile');
 
-            $command = $db->createCommand()->checkIntegrity(true, 'schema1', 'profile');
+        self::assertTrue(
+            $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+            'Building the command must preserve emulated prepares.',
+        );
 
-            self::assertTrue(
-                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
-                'Building the command must preserve emulated prepares.',
-            );
+        $command->execute();
 
-            $command->execute();
+        self::assertTrue(
+            $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+            'Executing the command must preserve emulated prepares.',
+        );
 
-            self::assertTrue(
-                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
-                'Executing the command must preserve emulated prepares.',
-            );
-        } finally {
-            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
-        }
+        $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
     }
 
-    public function testCheckIntegrityPreservesNativePreparesWhenExecutionFails(): void
+    public function testThrowExceptionWhenCheckIntegrityTargetsMissingTableWithoutChangingNativePrepares(): void
     {
         $db = $this->getConnection();
+
         $pdo = $db->getMasterPdo();
+
         $originalEmulatePrepares = $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
 
         try {
             $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
             $command = $db->createCommand()->checkIntegrity(false, '', 'missing_check_integrity_table');
 
-            try {
-                $command->execute();
-                self::fail('Executing checkIntegrity() for a missing table must fail.');
-            } catch (Exception) {
-                self::assertFalse(
-                    $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
-                    'A failed command must preserve native prepares.',
-                );
-            }
+            $this->expectException(Exception::class);
+            $this->expectExceptionMessage(
+                'relation "public.missing_check_integrity_table" does not exist',
+            );
+
+            $command->execute();
         } finally {
+            $emulatePrepares = $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
+
             $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
+
+            self::assertFalse(
+                $emulatePrepares,
+                'A failed command must preserve native prepares.',
+            );
         }
     }
 
     public function testCheckIntegritySupportsMultipleTablesWithNativePrepares(): void
     {
         $db = $this->getConnection();
+
         $schema = $db->getSchema();
 
-        self::assertInstanceOf(Schema::class, $schema);
+        self::assertInstanceOf(
+            Schema::class,
+            $schema,
+            'The connection must return a PostgreSQL schema instance.',
+        );
 
         $viewNames = $schema->getViewNames('public');
+
         $tableNames = array_diff($schema->getTableNames('public'), $viewNames);
+
         $pdo = $db->getMasterPdo();
         $originalEmulatePrepares = $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
 
-        self::assertGreaterThan(1, count($tableNames), 'The fixture must contain multiple tables.');
-        self::assertContains('animal_view', $viewNames, 'The fixture must contain a view to exclude.');
+        self::assertGreaterThan(
+            1,
+            count($tableNames),
+            'The fixture must contain multiple tables.',
+        );
+        self::assertContains(
+            'animal_view',
+            $viewNames,
+            'The fixture must contain a view to exclude.',
+        );
 
-        try {
-            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
-            $command = $db->createCommand()->checkIntegrity(true, 'public');
+        $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+        $command = $db->createCommand()->checkIntegrity(true, 'public');
 
-            self::assertFalse(
-                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
-                'Building a schema-wide command must preserve native prepares.',
-            );
+        self::assertFalse(
+            $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+            'Building a schema-wide command must preserve native prepares.',
+        );
 
-            $command->prepare();
+        $command->prepare();
 
-            self::assertFalse(
-                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
-                'Preparing a schema-wide command must preserve native prepares.',
-            );
+        self::assertFalse(
+            $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+            'Preparing a schema-wide command must preserve native prepares.',
+        );
 
-            $command->execute();
+        $command->execute();
 
-            self::assertFalse(
-                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
-                'Executing a schema-wide command must preserve native prepares.',
-            );
-        } finally {
-            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
-        }
+        self::assertFalse(
+            $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+            'Executing a schema-wide command must preserve native prepares.',
+        );
+
+        $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
     }
 
     public function testBuildingCheckIntegrityDoesNotChangeNativePrepares(): void
     {
         $db = $this->getConnection();
+
         $pdo = $db->getMasterPdo();
         $originalEmulatePrepares = $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
 
-        try {
-            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+        $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+        $db->createCommand()->checkIntegrity(false, '', 'item');
 
-            $db->createCommand()->checkIntegrity(false, '', 'item');
+        self::assertFalse(
+            $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
+            'Building the command must not change the PDO attribute.',
+        );
 
-            self::assertFalse(
-                $pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES),
-                'Building the command must not change the PDO attribute.',
-            );
-        } finally {
-            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
-        }
+        $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $originalEmulatePrepares);
     }
 
     public function testBooleanValuesInsert(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
