### PR TITLE
Fix `yii\db\mysql\QueryBuilder::renameColumn()` to use the native `ALTER TABLE ... RENAME COLUMN` statement instead of parsing `SHOW CREATE TABLE` output.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -127,6 +127,7 @@ Yii Framework 2 Change Log
 - Bug #20101: Fix SQLite `checkIntegrity()` to reject foreign-key enforcement changes inside active transactions (terabytesoftw)
 - Bug #20102: Make MSSQL `alterColumn()` roll back dropped constraints when the column alteration fails (terabytesoftw)
 - Bug #21004: Fix PostgreSQL `yii\db\pgsql\QueryBuilder::checkIntegrity()` changing the connection-wide PDO emulate-prepares setting (terabytesoftw)
+- Bug #21005: Fix `yii\db\mysql\QueryBuilder::renameColumn()` to use the native `ALTER TABLE ... RENAME COLUMN` statement instead of parsing `SHOW CREATE TABLE` output (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -85,29 +85,6 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
-     * Builds a SQL statement for renaming a column.
-     *
-     * @param string $table The table whose column is to be renamed. The name will be properly quoted by the method.
-     * @param string $oldName The old name of the column. The name will be properly quoted by the method.
-     * @param string $newName The new name of the column. The name will be properly quoted by the method.
-     *
-     * @throws Exception if the table does not exist or does not contain the column.
-     *
-     * @return string The SQL statement for renaming a DB column.
-     */
-    public function renameColumn($table, $oldName, $newName)
-    {
-        $quotedTable = $this->db->quoteTableName($table);
-        $definition = $this->getColumnDefinition($table, $oldName);
-        $oldNameQuoted = $this->db->quoteColumnName($oldName);
-        $newNameQuoted = $this->db->quoteColumnName($newName);
-
-        return <<<SQL
-        ALTER TABLE {$quotedTable} CHANGE {$oldNameQuoted} {$newNameQuoted} {$definition}
-        SQL;
-    }
-
-    /**
      * Builds a SQL statement for creating a new index.
      *
      * MySQL emits `ALTER TABLE ... ADD [UNIQUE] INDEX` instead of `CREATE INDEX`.

--- a/tests/framework/db/mysql/CommandTest.php
+++ b/tests/framework/db/mysql/CommandTest.php
@@ -265,11 +265,12 @@ final class CommandTest extends BaseCommand
     ): void {
         $db = $this->getConnection(false);
 
+        $command = $db->createCommand();
         $schema = $db->getSchema();
 
         DbHelper::dropTablesIfExist($db, [$table]);
 
-        $db->createCommand()->createTable(
+        $command->createTable(
             $table,
             [$oldColumnName => 'integer'],
         )->execute();
@@ -283,7 +284,7 @@ final class CommandTest extends BaseCommand
             'New column must not exist before renaming.',
         );
 
-        $db->createCommand()->renameColumn(
+        $command->renameColumn(
             $renameTarget,
             $oldColumnName,
             $newColumnName,
@@ -305,19 +306,17 @@ final class CommandTest extends BaseCommand
     {
         $db = $this->getConnection(false);
 
+        $command = $db->createCommand();
         $schema = $db->getSchema();
 
         DbHelper::dropTablesIfExist($db, ['rename_column_definition']);
 
-        $db->createCommand(
-            <<<SQL
-            CREATE TABLE `rename_column_definition` (
-              `old_col` varchar(255) NOT NULL DEFAULT 'keep' COMMENT 'Keep me.'
-            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-            SQL,
+        $command->createTable(
+            'rename_column_definition',
+            ['old_col' => "varchar(255) NOT NULL DEFAULT 'keep' COMMENT 'Keep me.'"],
+            'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
         )->execute();
-
-        $db->createCommand()->renameColumn(
+        $command->renameColumn(
             'rename_column_definition',
             'old_col',
             'new_col',
@@ -351,36 +350,93 @@ final class CommandTest extends BaseCommand
     {
         $db = $this->getConnection(false);
 
+        $command = $db->createCommand();
         /** @var QueryBuilder $qb */
         $qb = $db->getQueryBuilder();
 
-        DbHelper::dropTablesIfExist($db, ['rename_column_check']);
-
-        $db->createCommand(
-            <<<SQL
-            CREATE TABLE `rename_column_check` (`status` varchar(32) CHECK (`status` <> '('))
-            SQL,
-        )->execute();
-
-        $expectedMessage = "Check constraint 'rename_column_check_chk_1' uses column 'status', "
-            . 'hence column cannot be dropped or renamed.';
-
         if ($qb->isMariaDb()) {
-            $expectedMessage = "Unknown column 'status'";
+            self::markTestSkipped(
+                'MariaDB rewrites CHECK constraint expressions on native RENAME COLUMN (MDEV-13508).',
+            );
         }
 
-        // MySQL 8.0.16+ rejects with error 3959: the table-level CHECK still references the old column. MariaDB keeps
-        // the CHECK inline, so the restated column definition rejects with error 1054 for the now-missing column.
+        DbHelper::dropTablesIfExist($db, ['rename_column_check']);
+
+        $command->createTable(
+            'rename_column_check',
+            ['status' => "varchar(32) CHECK (`status` <> '(')"],
+        )->execute();
+
+        // MySQL 8.0.16+ rejects with error 3959 because the table-level CHECK still references the renamed column.
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(
-            $expectedMessage,
+            "Check constraint 'rename_column_check_chk_1' uses column 'status', hence column cannot be dropped or "
+            . 'renamed.',
         );
 
-        $db->createCommand()->renameColumn(
+        $command->renameColumn(
             'rename_column_check',
             'status',
             'new_status',
         )->execute();
+    }
+
+    public function testRenameColumnRewritesCheckConstraintExpression(): void
+    {
+        $db = $this->getConnection(false);
+
+        $command = $db->createCommand();
+        /** @var QueryBuilder $qb */
+        $qb = $db->getQueryBuilder();
+
+        if ($qb->isMariaDb() === false) {
+            self::markTestSkipped(
+                'MySQL rejects renaming a column referenced by a CHECK constraint (error 3959).',
+            );
+        }
+
+        DbHelper::dropTablesIfExist($db, ['rename_column_check']);
+
+        $command->createTable(
+            'rename_column_check',
+            ['status' => "varchar(32) CHECK (`status` <> '(')"],
+        )->execute();
+        $command->renameColumn(
+            'rename_column_check',
+            'status',
+            'new_status',
+        )->execute();
+
+        $schema = $db->getSchema();
+
+        self::assertInstanceOf(
+            ConstraintFinderInterface::class,
+            $schema,
+            'Schema must implement the constraint finder contract.',
+        );
+        self::assertNull(
+            $schema->getTableSchema('rename_column_check', true)->getColumn('status'),
+            'Old column must not exist after renaming.',
+        );
+        self::assertNotNull(
+            $schema->getTableSchema('rename_column_check', true)->getColumn('new_status'),
+            'New column must exist after renaming.',
+        );
+
+        $checks = $schema->getTableChecks('rename_column_check', true);
+
+        self::assertCount(
+            1,
+            $checks,
+            'Table must keep exactly one CHECK constraint.',
+        );
+        self::assertStringContainsString(
+            '`new_status`',
+            $checks[0]->expression,
+            'CHECK expression must reference the renamed column.',
+        );
+
+        DbHelper::dropTablesIfExist($db, ['rename_column_check']);
     }
 
     public function testThrowExceptionWhenRenamingMissingColumn(): void
@@ -389,22 +445,23 @@ final class CommandTest extends BaseCommand
 
         DbHelper::dropTablesIfExist($db, ['rename_missing_column']);
 
-        $db->createCommand(
-            <<<SQL
-            CREATE TABLE `rename_missing_column` (`id` int)
-            SQL,
+        $command = $db->createCommand();
+
+        $command->createTable(
+            'rename_missing_column',
+            ['id' => 'integer'],
         )->execute();
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(
-            "Unable to find column 'nonexistent' in table 'rename_missing_column'.",
+            "Unknown column 'nonexistent' in 'rename_missing_column'",
         );
 
-        $db->createCommand()->renameColumn(
+        $command->renameColumn(
             'rename_missing_column',
             'nonexistent',
             'new_col',
-        );
+        )->execute();
     }
 
     public function testThrowExceptionWhenRenamingColumnInMissingTable(): void
@@ -413,21 +470,20 @@ final class CommandTest extends BaseCommand
 
         DbHelper::dropTablesIfExist($db, ['rename_absent_table']);
 
-        $expectedMessage = "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'yiitest.rename_absent_table' "
-            . "doesn't exist";
+        $command = $db->createCommand();
 
-        // Both MySQL and MariaDB surface the missing table as error 1146 (`ER_NO_SUCH_TABLE`) when the reworked
-        // `renameColumn()` inspects the table via `SHOW CREATE TABLE`.
+        // Both MySQL and MariaDB surface the missing table as error 1146 (`ER_NO_SUCH_TABLE`) when the native
+        // `ALTER TABLE ... RENAME COLUMN` statement executes.
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(
-            $expectedMessage,
+            "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'yiitest.rename_absent_table' doesn't exist",
         );
 
-        $db->createCommand()->renameColumn(
+        $command->renameColumn(
             'rename_absent_table',
             'old_col',
             'new_col',
-        );
+        )->execute();
     }
 
     public function testAddDropCheckSeveral(): void

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -727,14 +727,9 @@ final class QueryBuilderTest extends BaseQueryBuilder
         string $table,
         string $oldName,
         string $newName,
-        string $createSql,
-        string $expected
+        string $expected,
     ): void {
-        $db = $this->getConnection(false);
-
-        DbHelper::dropTablesIfExist($db, [$table]);
-
-        $db->createCommand($createSql)->execute();
+        $db = $this->getConnection(false, false);
 
         self::assertSame(
             $expected,
@@ -745,8 +740,6 @@ final class QueryBuilderTest extends BaseQueryBuilder
             ),
             'Generated SQL must match the expected RENAME COLUMN statement.',
         );
-
-        DbHelper::dropTablesIfExist($db, [$table]);
     }
 
     #[DataProviderExternal(QueryBuilderProvider::class, 'createIndex')]

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -743,7 +743,7 @@ final class QueryBuilderTest extends BaseQueryBuilder
                 $oldName,
                 $newName,
             ),
-            'Renamed column DDL must restate the preserved definition.',
+            'Generated SQL must match the expected RENAME COLUMN statement.',
         );
 
         DbHelper::dropTablesIfExist($db, [$table]);
@@ -807,38 +807,32 @@ final class QueryBuilderTest extends BaseQueryBuilder
         );
     }
 
-    public function testRenameColumnRetainsInlineCheckInGeneratedDefinition(): void
+    public function testRenameColumnBuildsNativeSqlForColumnWithInlineCheck(): void
     {
         $db = $this->getConnection(false);
 
-        /** @var QueryBuilder $qb */
-        $qb = $db->getQueryBuilder();
-
         DbHelper::dropTablesIfExist($db, ['rename_check']);
 
-        $db->createCommand(
-            <<<SQL
-            CREATE TABLE `rename_check` (`status` varchar(32) CHECK (`status` <> '('))
-            SQL,
+        $command = $db->createCommand();
+
+        $command->createTable(
+            'rename_check',
+            ['status' => "varchar(32) CHECK (`status` <> '(')"],
         )->execute();
 
-        $actual = $qb->renameColumn('rename_check', 'status', 'new_status');
+        $actual = $db->getQueryBuilder()->renameColumn('rename_check', 'status', 'new_status');
 
         DbHelper::dropTablesIfExist($db, ['rename_check']);
 
-        // MariaDB keeps the inline CHECK on the column line; MySQL 8.0+ promotes it to a table-level constraint.
-        $expected = $qb->isMariaDb()
-            ? <<<SQL
-            ALTER TABLE `rename_check` CHANGE `status` `new_status` varchar(32) DEFAULT NULL CHECK (`status` <> '(')
-            SQL
-            : <<<SQL
-            ALTER TABLE `rename_check` CHANGE `status` `new_status` varchar(32) DEFAULT NULL
-            SQL;
+        // Native RENAME COLUMN never restates the definition, so the inline CHECK cannot leak into the generated SQL.
+        $expected = <<<SQL
+        ALTER TABLE `rename_check` RENAME COLUMN `status` TO `new_status`
+        SQL;
 
         self::assertSame(
             $expected,
             $actual,
-            'Inline CHECK must be restated on MariaDB but absent on MySQL (promoted to table level).',
+            'Rename SQL must not restate the column definition even when an inline CHECK is present.',
         );
     }
 

--- a/tests/framework/db/mysql/QueryBuilderTest.php
+++ b/tests/framework/db/mysql/QueryBuilderTest.php
@@ -800,35 +800,6 @@ final class QueryBuilderTest extends BaseQueryBuilder
         );
     }
 
-    public function testRenameColumnBuildsNativeSqlForColumnWithInlineCheck(): void
-    {
-        $db = $this->getConnection(false);
-
-        DbHelper::dropTablesIfExist($db, ['rename_check']);
-
-        $command = $db->createCommand();
-
-        $command->createTable(
-            'rename_check',
-            ['status' => "varchar(32) CHECK (`status` <> '(')"],
-        )->execute();
-
-        $actual = $db->getQueryBuilder()->renameColumn('rename_check', 'status', 'new_status');
-
-        DbHelper::dropTablesIfExist($db, ['rename_check']);
-
-        // Native RENAME COLUMN never restates the definition, so the inline CHECK cannot leak into the generated SQL.
-        $expected = <<<SQL
-        ALTER TABLE `rename_check` RENAME COLUMN `status` TO `new_status`
-        SQL;
-
-        self::assertSame(
-            $expected,
-            $actual,
-            'Rename SQL must not restate the column definition even when an inline CHECK is present.',
-        );
-    }
-
     /**
      * @see https://github.com/yiisoft/yii2/issues/17449
      */

--- a/tests/framework/db/mysql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mysql/providers/QueryBuilderProvider.php
@@ -407,6 +407,14 @@ final class QueryBuilderProvider
                 ALTER TABLE `qb_rename'table` RENAME COLUMN `old'col` TO `new'col`
                 SQL,
             ],
+            'names with spaces' => [
+                'qb rename table',
+                'old col',
+                'new col',
+                <<<SQL
+                ALTER TABLE `qb rename table` RENAME COLUMN `old col` TO `new col`
+                SQL,
+            ],
             'names with unicode characters' => [
                 'qb_rename_unicode',
                 'old_ñ_表',

--- a/tests/framework/db/mysql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mysql/providers/QueryBuilderProvider.php
@@ -385,7 +385,7 @@ final class QueryBuilderProvider
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
                 SQL,
                 <<<SQL
-                ALTER TABLE `qb_rename_comment` CHANGE `old_col` `new_col` varchar(255) NOT NULL COMMENT 'Keep me.'
+                ALTER TABLE `qb_rename_comment` RENAME COLUMN `old_col` TO `new_col`
                 SQL,
             ],
             'column with default' => [
@@ -398,7 +398,7 @@ final class QueryBuilderProvider
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
                 SQL,
                 <<<SQL
-                ALTER TABLE `qb_rename_default` CHANGE `old_col` `new_col` varchar(255) DEFAULT 'something'
+                ALTER TABLE `qb_rename_default` RENAME COLUMN `old_col` TO `new_col`
                 SQL,
             ],
             'database-qualified table name' => [
@@ -411,7 +411,7 @@ final class QueryBuilderProvider
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
                 SQL,
                 <<<SQL
-                ALTER TABLE `yiitest`.`qb_rename_qualified` CHANGE `old_col` `new_col` varchar(255) NOT NULL
+                ALTER TABLE `yiitest`.`qb_rename_qualified` RENAME COLUMN `old_col` TO `new_col`
                 SQL,
             ],
             'not null column' => [
@@ -424,7 +424,7 @@ final class QueryBuilderProvider
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
                 SQL,
                 <<<SQL
-                ALTER TABLE `qb_rename_notnull` CHANGE `old_col` `new_col` varchar(255) NOT NULL
+                ALTER TABLE `qb_rename_notnull` RENAME COLUMN `old_col` TO `new_col`
                 SQL,
             ],
             'simple column' => [
@@ -437,7 +437,7 @@ final class QueryBuilderProvider
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
                 SQL,
                 <<<SQL
-                ALTER TABLE `qb_rename_simple` CHANGE `old_col` `new_col` varchar(255) DEFAULT NULL
+                ALTER TABLE `qb_rename_simple` RENAME COLUMN `old_col` TO `new_col`
                 SQL,
             ],
         ];

--- a/tests/framework/db/mysql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mysql/providers/QueryBuilderProvider.php
@@ -370,35 +370,25 @@ final class QueryBuilderProvider
     }
 
     /**
-     * @return array<string, array{string, string, string, string, string}>
+     * @return array<string, array{string, string, string, string}>
      */
     public static function renameColumn(): array
     {
         return [
-            'column preserves comment' => [
-                'qb_rename_comment',
-                'old_col',
-                'new_col',
+            'already quoted names' => [
+                '`qb_rename_quoted`',
+                '`old_col`',
+                '`new_col`',
                 <<<SQL
-                CREATE TABLE `qb_rename_comment` (
-                  `old_col` varchar(255) NOT NULL COMMENT 'Keep me.'
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-                SQL,
-                <<<SQL
-                ALTER TABLE `qb_rename_comment` RENAME COLUMN `old_col` TO `new_col`
+                ALTER TABLE `qb_rename_quoted` RENAME COLUMN `old_col` TO `new_col`
                 SQL,
             ],
-            'column with default' => [
-                'qb_rename_default',
-                'old_col',
-                'new_col',
+            'curly brace table and square bracket column placeholders' => [
+                '{{qb_rename_placeholder}}',
+                '[[old_col]]',
+                '[[new_col]]',
                 <<<SQL
-                CREATE TABLE `qb_rename_default` (
-                  `old_col` varchar(255) DEFAULT 'something'
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-                SQL,
-                <<<SQL
-                ALTER TABLE `qb_rename_default` RENAME COLUMN `old_col` TO `new_col`
+                ALTER TABLE {{qb_rename_placeholder}} RENAME COLUMN [[old_col]] TO [[new_col]]
                 SQL,
             ],
             'database-qualified table name' => [
@@ -406,38 +396,39 @@ final class QueryBuilderProvider
                 'old_col',
                 'new_col',
                 <<<SQL
-                CREATE TABLE `yiitest`.`qb_rename_qualified` (
-                  `old_col` varchar(255) NOT NULL
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-                SQL,
-                <<<SQL
                 ALTER TABLE `yiitest`.`qb_rename_qualified` RENAME COLUMN `old_col` TO `new_col`
                 SQL,
             ],
-            'not null column' => [
-                'qb_rename_notnull',
-                'old_col',
-                'new_col',
+            'names with single quotes' => [
+                "qb_rename'table",
+                "old'col",
+                "new'col",
                 <<<SQL
-                CREATE TABLE `qb_rename_notnull` (
-                  `old_col` varchar(255) NOT NULL
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-                SQL,
-                <<<SQL
-                ALTER TABLE `qb_rename_notnull` RENAME COLUMN `old_col` TO `new_col`
+                ALTER TABLE `qb_rename'table` RENAME COLUMN `old'col` TO `new'col`
                 SQL,
             ],
-            'simple column' => [
+            'names with unicode characters' => [
+                'qb_rename_unicode',
+                'old_ñ_表',
+                'new_ñ_表',
+                <<<SQL
+                ALTER TABLE `qb_rename_unicode` RENAME COLUMN `old_ñ_表` TO `new_ñ_表`
+                SQL,
+            ],
+            'simple names' => [
                 'qb_rename_simple',
                 'old_col',
                 'new_col',
                 <<<SQL
-                CREATE TABLE `qb_rename_simple` (
-                  `old_col` varchar(255)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-                SQL,
-                <<<SQL
                 ALTER TABLE `qb_rename_simple` RENAME COLUMN `old_col` TO `new_col`
+                SQL,
+            ],
+            'table prefix placeholder' => [
+                '{{%qb_rename_prefixed}}',
+                'old_col',
+                'new_col',
+                <<<SQL
+                ALTER TABLE {{%qb_rename_prefixed}} RENAME COLUMN `old_col` TO `new_col`
                 SQL,
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
