### PR TITLE
Fix `yii\db\pgsql\QueryBuilder::alterColumn()` corrupting compound column definitions by removing string parsing.

### DIFF
--- a/.github/workflows/ci-pgsql.yml
+++ b/.github/workflows/ci-pgsql.yml
@@ -46,7 +46,7 @@ jobs:
       database-image: postgres
       database-port: "5432"
       database-type: pgsql
-      database-versions: '["13","14","15","16","17","18","latest"]'
+      database-versions: '["14","15","16","17","18","latest"]'
       extensions: curl, intl, pdo, pdo_pgsql
       os: '["ubuntu-latest"]'
       php-version: '["8.5"]'

--- a/docs/guide/db-dao.md
+++ b/docs/guide/db-dao.md
@@ -14,7 +14,7 @@ In Yii 2.0, DAO supports the following databases out of the box:
 - [MySQL](https://www.mysql.com/): version 8.0 or higher
 - [MariaDB](https://mariadb.com/): version 10.6 or higher
 - [SQLite](https://sqlite.org/): version 3.35 or higher
-- [PostgreSQL](https://www.postgresql.org/): version 13 or higher
+- [PostgreSQL](https://www.postgresql.org/): version 14 or higher
 - [Oracle](https://www.oracle.com/database/)
 - [MSSQL](https://www.microsoft.com/en-us/sqlserver/default.aspx): version 2019 or higher.
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -128,6 +128,7 @@ Yii Framework 2 Change Log
 - Bug #20102: Make MSSQL `alterColumn()` roll back dropped constraints when the column alteration fails (terabytesoftw)
 - Bug #21004: Fix PostgreSQL `yii\db\pgsql\QueryBuilder::checkIntegrity()` changing the connection-wide PDO emulate-prepares setting (terabytesoftw)
 - Bug #21005: Fix `yii\db\mysql\QueryBuilder::renameColumn()` to use the native `ALTER TABLE ... RENAME COLUMN` statement instead of parsing `SHOW CREATE TABLE` output (terabytesoftw)
+- Bug #19929: Fix `yii\db\pgsql\QueryBuilder::alterColumn()` corrupting compound column definitions by removing string parsing (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -568,6 +568,8 @@ $this->alterColumn('foo1', 'bar', "string NOT NULL DEFAULT 'hello world'");
 
 `defaultValue(null)` does not remove an existing default. Use the explicit `'DROP DEFAULT'` action instead.
 `yii\db\ColumnSchemaBuilder` adds public getters for the column definition state used by query builders.
+Builder-path `CHECK` and `UNIQUE` constraints are created under stable names (`{table}_{column}_check`,
+`{table}_{column}_key`) and replace an existing constraint with the same name, so repeated migrations are idempotent.
 
 ### SQLite
 

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -31,7 +31,7 @@ The supported database versions are:
 | MariaDB              |          `10.6` | Pagination uses `OFFSET ... FETCH`.                                                         |
 | Microsoft SQL Server |          `2019` | Pagination and schema operations use modern SQL Server syntax and catalog views.            |
 | Oracle Database      |          `12.1` | New auto-increment columns use native identity columns; pagination uses `OFFSET ... FETCH`. |
-| PostgreSQL           |            `13` | Legacy upsert and identity-detection branches have been removed.                            |
+| PostgreSQL           |            `14` | Legacy upsert and identity-detection branches have been removed.                            |
 | SQLite               |          `3.35` | Upserts use native `INSERT ... ON CONFLICT`.                                                |
 
 CUBRID support has been removed. Applications using CUBRID must migrate to another database engine before upgrading.
@@ -505,6 +505,69 @@ calls or overrides of those protected methods.
 
 Reflected `bytea` values may now be returned as strings where Yii previously exposed a stream, including values read by
 `DbCache`. Code that deliberately handled the old stream representation should accept the normalized string value.
+
+`pgsql\QueryBuilder::alterColumn()` no longer parses `DEFAULT`, `NULL`, `CHECK`, or `UNIQUE` from compound strings. This
+avoids generating incorrect SQL for valid PostgreSQL expressions.
+
+A string containing only a type changes the column type while preserving its default and nullability:
+
+```php
+$this->alterColumn('foo1', 'bar', 'string');
+```
+
+Compound definitions must use a `ColumnSchemaBuilder`. In migrations, type helpers such as `$this->string()` create the
+builder:
+
+```php
+$this->alterColumn(
+    'foo1',
+    'bar',
+    $this->string()->notNull()->defaultValue('hello world')
+);
+```
+
+A builder without additional options also changes only the type:
+
+```php
+$this->alterColumn('foo1', 'bar', $this->string());
+```
+
+Outside migrations, create the builder through the database schema:
+
+```php
+$db = Yii::$app->db;
+
+$type = $db->getSchema()
+    ->createColumnSchemaBuilder(\yii\db\Schema::TYPE_STRING)
+    ->notNull()
+    ->defaultValue('hello world');
+
+$db->createCommand()
+    ->alterColumn('foo1', 'bar', $type)
+    ->execute();
+```
+
+PostgreSQL-specific actions beginning with `SET ...`, `DROP ...`, `RESET (...)`, `RESTART [WITH n]`, or
+`ADD GENERATED ...` can still be passed directly:
+
+```php
+$this->alterColumn('foo1', 'bar', "SET DEFAULT 'hello world'");
+$this->alterColumn('foo1', 'bar', 'DROP DEFAULT');
+$this->alterColumn('foo1', 'bar', 'SET NOT NULL');
+$this->alterColumn('foo1', 'bar', 'DROP NOT NULL');
+```
+
+These keywords cover the complete PostgreSQL `ALTER COLUMN` action grammar, and their contents are never parsed; complex
+defaults work through `SET DEFAULT ...` or `defaultExpression()`.
+
+The following compound string is no longer supported:
+
+```php
+$this->alterColumn('foo1', 'bar', "string NOT NULL DEFAULT 'hello world'");
+```
+
+`defaultValue(null)` does not remove an existing default. Use the explicit `'DROP DEFAULT'` action instead.
+`yii\db\ColumnSchemaBuilder` adds public getters for the column definition state used by query builders.
 
 ### SQLite
 

--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -352,7 +352,7 @@ class ColumnSchemaBuilder extends BaseObject implements Stringable
      * Builds the full string for the column's schema.
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         switch ($this->getTypeCategory()) {
             case self::CATEGORY_PK:

--- a/framework/db/ColumnSchemaBuilder.php
+++ b/framework/db/ColumnSchemaBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -8,6 +10,7 @@
 
 namespace yii\db;
 
+use Stringable;
 use yii\base\BaseObject;
 use yii\helpers\StringHelper;
 
@@ -21,7 +24,7 @@ use yii\helpers\StringHelper;
  * @author Vasenin Matvey <vaseninm@gmail.com>
  * @since 2.0.6
  */
-class ColumnSchemaBuilder extends BaseObject
+class ColumnSchemaBuilder extends BaseObject implements Stringable
 {
     // Internally used constants representing categories that abstract column types fall under.
     // See [[$categoryMap]] for mappings of abstract column types to category.
@@ -78,8 +81,6 @@ class ColumnSchemaBuilder extends BaseObject
      * @since 2.0.8
      */
     protected $isFirst;
-
-
     /**
      * @var array mapping of abstract column types (keys) to type categories (values).
      * @since 2.0.43
@@ -271,6 +272,80 @@ class ColumnSchemaBuilder extends BaseObject
     {
         $this->append = $sql;
         return $this;
+    }
+
+    /**
+     * Returns the abstract type together with its length or precision, without any constraint keywords.
+     *
+     * The result is intended for {@see QueryBuilder::getColumnType()} to resolve the physical column type.
+     *
+     * @return string abstract type plus optional length, for example `string(255)`.
+     *
+     * @since 22.0
+     */
+    public function getTypeDefinition(): string
+    {
+        return $this->type . $this->buildLengthString();
+    }
+
+    /**
+     * Returns the raw default value of the column.
+     *
+     * @return mixed scalar value, an {@see Expression} when {@see defaultExpression()} was used, or `null` when unset.
+     *
+     * @since 22.0
+     */
+    public function getDefault(): mixed
+    {
+        return $this->default;
+    }
+
+    /**
+     * Returns the nullability state of the column as a tri-state value.
+     *
+     * @return bool|null `true` for `NOT NULL`, `false` for `NULL`, or `null` when the nullability is unspecified.
+     *
+     * @since 22.0
+     */
+    public function isNotNull(): bool|null
+    {
+        return $this->isNotNull;
+    }
+
+    /**
+     * Returns whether the column carries a `UNIQUE` constraint.
+     *
+     * @return bool `true` when a `UNIQUE` constraint is set; `false` otherwise.
+     *
+     * @since 22.0
+     */
+    public function isUnique(): bool
+    {
+        return $this->isUnique;
+    }
+
+    /**
+     * Returns the raw `CHECK` constraint expression of the column.
+     *
+     * @return string|null `CHECK` expression, or `null` when no constraint is set.
+     *
+     * @since 22.0
+     */
+    public function getCheck(): string|null
+    {
+        return $this->check;
+    }
+
+    /**
+     * Returns the raw SQL fragment appended to the column definition.
+     *
+     * @return string|null appended SQL fragment, or `null` when none is set.
+     *
+     * @since 22.0
+     */
+    public function getAppend(): string|null
+    {
+        return $this->append;
     }
 
     /**

--- a/framework/db/mssql/ColumnSchemaBuilder.php
+++ b/framework/db/mssql/ColumnSchemaBuilder.php
@@ -68,12 +68,4 @@ class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
     {
         return $this->check !== null ? (string) $this->check : null;
     }
-
-    /**
-     * @return bool whether the column values should be unique. If this is `true`, a `UNIQUE` constraint will be added.
-     */
-    public function isUnique()
-    {
-        return $this->isUnique;
-    }
 }

--- a/framework/db/mssql/ColumnSchemaBuilder.php
+++ b/framework/db/mssql/ColumnSchemaBuilder.php
@@ -28,7 +28,7 @@ class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
      * Builds the full string for the column's schema.
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if ($this->getTypeCategory() === self::CATEGORY_PK) {
             $format = '{type}{check}{comment}{append}';

--- a/framework/db/mysql/ColumnSchemaBuilder.php
+++ b/framework/db/mysql/ColumnSchemaBuilder.php
@@ -55,7 +55,7 @@ class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString(): string
     {
         switch ($this->getTypeCategory()) {
             case self::CATEGORY_PK:

--- a/framework/db/oci/ColumnSchemaBuilder.php
+++ b/framework/db/oci/ColumnSchemaBuilder.php
@@ -30,7 +30,7 @@ class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString(): string
     {
         switch ($this->getTypeCategory()) {
             case self::CATEGORY_PK:

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -349,7 +349,9 @@ class QueryBuilder extends \yii\db\QueryBuilder
      *
      * Supports three input modes for `$type`.
      * - A {@see ColumnSchemaBuilder} produces a structured, multi-action `ALTER TABLE` statement that changes the
-     *   column type and applies any nullability, default, `CHECK`, and `UNIQUE` state carried by the builder.
+     *   column type and applies any nullability, default, `CHECK`, and `UNIQUE` state carried by the builder; `CHECK`
+     *   and `UNIQUE` constraints are recreated under stable names derived from the table and column, replacing
+     *   same-named constraints.
      * - A string starting with a PostgreSQL per-column action keyword; `SET ...`, `DROP ...`, `RESET (...)`,
      *   `RESTART [WITH n]`, or `ADD GENERATED ...`, is emitted verbatim as a single action; PostgreSQL parses its
      *   contents.
@@ -549,13 +551,35 @@ class QueryBuilder extends \yii\db\QueryBuilder
         string $column,
         ColumnSchemaBuilder $type,
     ): string {
+        $constraintPrefix = null;
+
         $default = $type->getDefault();
+        $check = $type->getCheck();
+        $isUnique = $type->isUnique();
+
+        if ($check !== null || $isUnique) {
+            $constraintPrefix = preg_replace('/[^a-z0-9_]/i', '', "{$table}_$column");
+        }
+
         $actions = [];
 
         // Drop the existing default first so an incompatible old default cannot fail the TYPE change.
         if ($default !== null) {
             $actions[] = <<<SQL
             ALTER COLUMN {$columnName} DROP DEFAULT
+            SQL;
+        }
+
+        // Drop stale same-named constraints first so they cannot fail the TYPE change.
+        if ($check !== null) {
+            $actions[] = <<<SQL
+            DROP CONSTRAINT IF EXISTS {$constraintPrefix}_check
+            SQL;
+        }
+
+        if ($isUnique) {
+            $actions[] = <<<SQL
+            DROP CONSTRAINT IF EXISTS {$constraintPrefix}_key
             SQL;
         }
 
@@ -593,19 +617,15 @@ class QueryBuilder extends \yii\db\QueryBuilder
             SQL;
         }
 
-        $check = $type->getCheck();
-
         if ($check !== null) {
-            $constraintPrefix = preg_replace('/[^a-z0-9_]/i', '', "{$table}_$column");
-
             $actions[] = <<<SQL
             ADD CONSTRAINT {$constraintPrefix}_check CHECK ({$check})
             SQL;
         }
 
-        if ($type->isUnique()) {
+        if ($isUnique) {
             $actions[] = <<<SQL
-            ADD UNIQUE ({$columnName})
+            ADD CONSTRAINT {$constraintPrefix}_key UNIQUE ({$columnName})
             SQL;
         }
 

--- a/framework/db/pgsql/QueryBuilder.php
+++ b/framework/db/pgsql/QueryBuilder.php
@@ -12,6 +12,7 @@ namespace yii\db\pgsql;
 
 use yii\base\InvalidArgumentException;
 use yii\db\ArrayExpression;
+use yii\db\ColumnSchemaBuilder;
 use yii\db\conditions\LikeCondition;
 use yii\db\Constraint;
 use yii\db\Expression;
@@ -25,19 +26,35 @@ use yii\helpers\StringHelper;
 use function array_diff;
 use function array_map;
 use function count;
+use function gettype;
 use function implode;
 use function is_bool;
+use function is_string;
+use function preg_match;
+use function preg_replace;
 use function str_contains;
 use function usort;
 
 /**
- * QueryBuilder is the query builder for PostgreSQL databases (version 13 and above).
+ * QueryBuilder is the query builder for PostgreSQL databases (version 14 and above).
  *
  * @author Gevik Babakhani <gevikb@gmail.com>
  * @since 2.0
  */
 class QueryBuilder extends \yii\db\QueryBuilder
 {
+    /**
+     * Anchored dispatch pattern for standalone PostgreSQL `ALTER COLUMN` action strings emitted verbatim.
+     */
+    private const string ALTER_COLUMN_ACTION_REGEX = <<<REGEX
+    /^(?:
+        SET (?: \s+ | \s*\( )
+      | DROP \s+
+      | RESET \s*\(
+      | RESTART (?: \s+ | $ )
+      | ADD \s+ GENERATED \s+
+    )/ix
+    REGEX;
     /**
      * Defines a UNIQUE index for [[createIndex()]].
      * @since 2.0.6
@@ -123,7 +140,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * @param int|ExpressionInterface|null $limit the LIMIT value. `null` or a negative value means no limit; `0` is
      * valid and emits `FETCH NEXT 0 ROWS ONLY`.
      * @param int|ExpressionInterface|null $offset the OFFSET value. `null` or `0` means no offset.
-     * @return string the LIMIT and OFFSET clauses built for PostgreSQL `13+`.
+     * @return string the LIMIT and OFFSET clauses built for PostgreSQL `14+`.
      */
     public function buildLimit($limit, $offset)
     {
@@ -329,62 +346,46 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * Builds a SQL statement for changing the definition of a column.
-     * @param string $table the table whose column is to be changed. The table name will be properly quoted by the method.
-     * @param string $column the name of the column to be changed. The name will be properly quoted by the method.
-     * @param string $type the new column type. The [[getColumnType()]] method will be invoked to convert abstract
-     * column type (if any) into the physical one. Anything that is not recognized as abstract type will be kept
-     * in the generated SQL. For example, 'string' will be turned into 'varchar(255)', while 'string not null'
-     * will become 'varchar(255) not null'. You can also use PostgreSQL-specific syntax such as `SET NOT NULL`.
-     * @return string the SQL statement for changing the definition of a column.
+     *
+     * Supports three input modes for `$type`.
+     * - A {@see ColumnSchemaBuilder} produces a structured, multi-action `ALTER TABLE` statement that changes the
+     *   column type and applies any nullability, default, `CHECK`, and `UNIQUE` state carried by the builder.
+     * - A string starting with a PostgreSQL per-column action keyword; `SET ...`, `DROP ...`, `RESET (...)`,
+     *   `RESTART [WITH n]`, or `ADD GENERATED ...`, is emitted verbatim as a single action; PostgreSQL parses its
+     *   contents.
+     * - Any other string changes only the column type and no longer implicitly drops `DEFAULT` or `NOT NULL`.
+     *
+     * @param string $table The table whose column is to be changed. The table name will be properly quoted by the
+     * method.
+     * @param string $column The name of the column to be changed. The name will be properly quoted by the method.
+     * @param ColumnSchemaBuilder|string $type The new column definition. A {@see ColumnSchemaBuilder} carries the
+     * structured column state; a string is resolved through {@see getColumnType()} to the physical column type unless
+     * it is a `SET`/`DROP`/`RESET`/`RESTART`/`ADD GENERATED` action, which is emitted verbatim.
+     *
+     * @return string The SQL statement for changing the definition of a column.
      */
     public function alterColumn($table, $column, $type)
     {
-        $columnName = $this->db->quoteColumnName($column);
         $tableName = $this->db->quoteTableName($table);
+        $columnName = $this->db->quoteColumnName($column);
 
         // https://github.com/yiisoft/yii2/issues/4492
         // https://www.postgresql.org/docs/current/sql-altertable.html
-        if (is_string($type) && preg_match('/^(DROP|SET|RESET)\s+/i', $type)) {
-            return "ALTER TABLE {$tableName} ALTER COLUMN {$columnName} {$type}";
+        if (is_string($type) && preg_match(self::ALTER_COLUMN_ACTION_REGEX, $type)) {
+            return <<<SQL
+            ALTER TABLE {$tableName} ALTER COLUMN {$columnName} {$type}
+            SQL;
         }
 
-        $type = 'TYPE ' . $this->getColumnType($type);
-
-        $multiAlterStatement = [];
-        $constraintPrefix = preg_replace('/[^a-z0-9_]/i', '', $table . '_' . $column);
-
-        if (preg_match('/\s+DEFAULT\s+(["\']?\w*["\']?)/i', $type, $matches)) {
-            $type = preg_replace('/\s+DEFAULT\s+(["\']?\w*["\']?)/i', '', $type);
-            $multiAlterStatement[] = "ALTER COLUMN {$columnName} SET DEFAULT {$matches[1]}";
-        } else {
-            // safe to drop default even if there was none in the first place
-            $multiAlterStatement[] = "ALTER COLUMN {$columnName} DROP DEFAULT";
+        if ($type instanceof ColumnSchemaBuilder) {
+            return $this->buildAlterColumnFromBuilder($tableName, $columnName, $table, $column, $type);
         }
 
-        $type = preg_replace('/\s+NOT\s+NULL/i', '', $type, -1, $count);
-        if ($count) {
-            $multiAlterStatement[] = "ALTER COLUMN {$columnName} SET NOT NULL";
-        } else {
-            // remove additional null if any
-            $type = preg_replace('/\s+NULL/i', '', $type);
-            // safe to drop not null even if there was none in the first place
-            $multiAlterStatement[] = "ALTER COLUMN {$columnName} DROP NOT NULL";
-        }
+        $columnType = $this->getColumnType($type);
 
-        if (preg_match('/\s+CHECK\s+\((.+)\)/i', $type, $matches)) {
-            $type = preg_replace('/\s+CHECK\s+\((.+)\)/i', '', $type);
-            $multiAlterStatement[] = "ADD CONSTRAINT {$constraintPrefix}_check CHECK ({$matches[1]})";
-        }
-
-        $type = preg_replace('/\s+UNIQUE/i', '', $type, -1, $count);
-        if ($count) {
-            $multiAlterStatement[] = "ADD UNIQUE ({$columnName})";
-        }
-
-        // add what's left at the beginning
-        array_unshift($multiAlterStatement, "ALTER COLUMN {$columnName} {$type}");
-
-        return 'ALTER TABLE ' . $tableName . ' ' . implode(', ', $multiAlterStatement);
+        return <<<SQL
+        ALTER TABLE {$tableName} ALTER COLUMN {$columnName} TYPE {$columnType}
+        SQL;
     }
 
     /**
@@ -528,6 +529,112 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
         return 'INSERT INTO ' . $schema->quoteTableName($table)
         . ' (' . implode(', ', $columns) . ') VALUES ' . implode(', ', $values);
+    }
+
+    /**
+     * Builds the multi-action `ALTER TABLE` statement for a {@see ColumnSchemaBuilder} column definition.
+     *
+     * @param string $tableName The quoted table name.
+     * @param string $columnName The quoted column name.
+     * @param string $table The unquoted table name.
+     * @param string $column The unquoted column name.
+     * @param ColumnSchemaBuilder $type The column definition builder.
+     *
+     * @return string The SQL statement for changing the definition of a column.
+     */
+    private function buildAlterColumnFromBuilder(
+        string $tableName,
+        string $columnName,
+        string $table,
+        string $column,
+        ColumnSchemaBuilder $type,
+    ): string {
+        $default = $type->getDefault();
+        $actions = [];
+
+        // Drop the existing default first so an incompatible old default cannot fail the TYPE change.
+        if ($default !== null) {
+            $actions[] = <<<SQL
+            ALTER COLUMN {$columnName} DROP DEFAULT
+            SQL;
+        }
+
+        $columnType = $this->getColumnType($type->getTypeDefinition());
+
+        $typeAction = <<<SQL
+        ALTER COLUMN {$columnName} TYPE {$columnType}
+        SQL;
+
+        $append = $type->getAppend();
+
+        if ($append !== null && $append !== '') {
+            $typeAction .= " {$append}";
+        }
+
+        $actions[] = $typeAction;
+
+        $notNull = $type->isNotNull();
+
+        if ($notNull === true) {
+            $actions[] = <<<SQL
+            ALTER COLUMN {$columnName} SET NOT NULL
+            SQL;
+        } elseif ($notNull === false) {
+            $actions[] = <<<SQL
+            ALTER COLUMN {$columnName} DROP NOT NULL
+            SQL;
+        }
+
+        if ($default !== null) {
+            $defaultValue = $this->buildAlterColumnDefault($default);
+
+            $actions[] = <<<SQL
+            ALTER COLUMN {$columnName} SET DEFAULT {$defaultValue}
+            SQL;
+        }
+
+        $check = $type->getCheck();
+
+        if ($check !== null) {
+            $constraintPrefix = preg_replace('/[^a-z0-9_]/i', '', "{$table}_$column");
+
+            $actions[] = <<<SQL
+            ADD CONSTRAINT {$constraintPrefix}_check CHECK ({$check})
+            SQL;
+        }
+
+        if ($type->isUnique()) {
+            $actions[] = <<<SQL
+            ADD UNIQUE ({$columnName})
+            SQL;
+        }
+
+        $actionsSql = implode(', ', $actions);
+
+        return <<<SQL
+        ALTER TABLE {$tableName} {$actionsSql}
+        SQL;
+    }
+
+    /**
+     * Renders a {@see ColumnSchemaBuilder} default value as a literal SQL fragment for `SET DEFAULT`.
+     *
+     * @param mixed $default The default value to render.
+     *
+     * @return string The SQL fragment for the default value.
+     */
+    private function buildAlterColumnDefault(mixed $default): string
+    {
+        if ($default instanceof Expression) {
+            return (string) $default;
+        }
+
+        return match (gettype($default)) {
+            'boolean' => $default ? 'TRUE' : 'FALSE',
+            'integer' => (string) $default,
+            'double' => StringHelper::floatToString($default),
+            default => $this->db->quoteValue((string) $default),
+        };
     }
 
     /**

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -28,7 +28,7 @@ use function str_replace;
 
 /**
  * Schema is the class for retrieving metadata from a PostgreSQL database
- * (version 13.0 and above).
+ * (version 14.0 and above).
  *
  * @author Gevik Babakhani <gevikb@gmail.com>
  * @since 2.0

--- a/framework/db/sqlite/ColumnSchemaBuilder.php
+++ b/framework/db/sqlite/ColumnSchemaBuilder.php
@@ -29,7 +29,7 @@ class ColumnSchemaBuilder extends AbstractColumnSchemaBuilder
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString(): string
     {
         switch ($this->getTypeCategory()) {
             case self::CATEGORY_PK:

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -15,6 +15,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\db\ArrayExpression;
+use yii\db\Connection;
 use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\IntegrityException;
@@ -541,8 +542,6 @@ PGSQL
         }
 
         $command = $db->createCommand();
-        /** @var Schema $schema */
-        $schema = $db->getSchema();
 
         $command->createTable(
             'alter_column',
@@ -565,7 +564,56 @@ PGSQL
             'DDL must report zero affected rows.',
         );
 
+        if (!empty($expected['repeatable'])) {
+            $command->alterColumn(
+                'alter_column',
+                'bar',
+                $type,
+            )->execute();
+        }
+
+        $this->assertAlterColumnExpectations($db, $expected);
+
+        DbHelper::dropTablesIfExist($db, ['alter_column']);
+    }
+
+    #[DataProviderExternal(CommandProvider::class, 'alterColumnFailing')]
+    public function testThrowExceptionForAlterColumnTypeStringThatIsNotAnAction(string $type, string $exceptionMessage): void
+    {
+        $db = $this->getConnection();
+
+        DbHelper::dropTablesIfExist($db, ['alter_column']);
+
+        $command = $db->createCommand();
+
+        $command->createTable(
+            'alter_column',
+            ['id' => 'pk', 'bar' => 'varchar(100)'],
+        )->execute();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(
+            $exceptionMessage,
+        );
+
+        $command->alterColumn(
+            'alter_column',
+            'bar',
+            $type,
+        )->execute();
+    }
+
+    /**
+     * Asserts the reflected schema state of the altered `bar` column against the expectation map.
+     *
+     * @param Connection $db Active connection whose refreshed schema is inspected.
+     * @param array $expected Expectation map; {@see CommandProvider::alterColumn()} describes the supported keys.
+     */
+    private function assertAlterColumnExpectations(Connection $db, array $expected): void
+    {
         $column = $db->getTableSchema('alter_column', true)->getColumn('bar');
+        /** @var Schema $schema */
+        $schema = $db->getSchema();
 
         if (isset($expected['type'])) {
             self::assertSame(
@@ -627,46 +675,19 @@ PGSQL
         }
 
         if (isset($expected['uniqueColumns'])) {
-            $found = false;
+            $matches = 0;
 
             foreach ($schema->getTableUniques('alter_column', true) as $unique) {
                 if ($unique->columnNames === $expected['uniqueColumns']) {
-                    $found = true;
+                    ++$matches;
                 }
             }
 
-            self::assertTrue(
-                $found,
-                'Unique constraint must exist.',
+            self::assertSame(
+                1,
+                $matches,
+                'Exactly one unique constraint must cover the column.',
             );
         }
-
-        DbHelper::dropTablesIfExist($db, ['alter_column']);
-    }
-
-    #[DataProviderExternal(CommandProvider::class, 'alterColumnFailing')]
-    public function testThrowExceptionForAlterColumnTypeStringThatIsNotAnAction(string $type, string $exceptionMessage): void
-    {
-        $db = $this->getConnection();
-
-        DbHelper::dropTablesIfExist($db, ['alter_column']);
-
-        $command = $db->createCommand();
-
-        $command->createTable(
-            'alter_column',
-            ['id' => 'pk', 'bar' => 'varchar(100)'],
-        )->execute();
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage(
-            $exceptionMessage,
-        );
-
-        $command->alterColumn(
-            'alter_column',
-            'bar',
-            $type,
-        )->execute();
     }
 }

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -541,6 +541,8 @@ PGSQL
         }
 
         $command = $db->createCommand();
+        /** @var Schema $schema */
+        $schema = $db->getSchema();
 
         $command->createTable(
             'alter_column',
@@ -612,7 +614,7 @@ PGSQL
         if (isset($expected['checkContains'])) {
             $found = false;
 
-            foreach ($db->getSchema()->getTableChecks('alter_column', true) as $check) {
+            foreach ($schema->getTableChecks('alter_column', true) as $check) {
                 if (str_contains($check->expression, $expected['checkContains'])) {
                     $found = true;
                 }
@@ -627,7 +629,7 @@ PGSQL
         if (isset($expected['uniqueColumns'])) {
             $found = false;
 
-            foreach ($db->getSchema()->getTableUniques('alter_column', true) as $unique) {
+            foreach ($schema->getTableUniques('alter_column', true) as $unique) {
                 if ($unique->columnNames === $expected['uniqueColumns']) {
                     $found = true;
                 }

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\db\pgsql;
 
+use Closure;
 use PDO;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
@@ -25,8 +26,10 @@ use yiiunit\framework\db\pgsql\providers\CommandProvider;
 use yiiunit\support\DbHelper;
 
 use function array_diff;
+use function array_key_exists;
 use function array_keys;
 use function count;
+use function str_contains;
 
 /**
  * Unit tests for {@see \yii\db\Command} functionality for the PostgreSQL driver.
@@ -524,5 +527,144 @@ PGSQL
 
 
         $this->assertSame(1, $db->createCommand()->delete('array_and_json_types')->execute());
+    }
+
+    #[DataProviderExternal(CommandProvider::class, 'alterColumn')]
+    public function testAlterColumn(string $startColumn, array $setupSql, string|Closure $type, array $expected): void
+    {
+        $db = $this->getConnection();
+
+        DbHelper::dropTablesIfExist($db, ['alter_column']);
+
+        foreach ($setupSql as $sql) {
+            $db->createCommand($sql)->execute();
+        }
+
+        $command = $db->createCommand();
+
+        $command->createTable(
+            'alter_column',
+            ['id' => 'pk', 'bar' => $startColumn],
+        )->execute();
+
+        if ($type instanceof Closure) {
+            $type = $type($db);
+        }
+
+        $result = $command->alterColumn(
+            'alter_column',
+            'bar',
+            $type,
+        )->execute();
+
+        self::assertSame(
+            0,
+            $result,
+            'DDL must report zero affected rows.',
+        );
+
+        $column = $db->getTableSchema('alter_column', true)->getColumn('bar');
+
+        if (isset($expected['type'])) {
+            self::assertSame(
+                $expected['type'],
+                $column->type,
+                'Abstract type must match.',
+            );
+        }
+
+        if (isset($expected['dbType'])) {
+            self::assertSame(
+                $expected['dbType'],
+                $column->dbType,
+                'Physical type must match.',
+            );
+        }
+
+        if (isset($expected['allowNull'])) {
+            self::assertSame(
+                $expected['allowNull'],
+                $column->allowNull,
+                'Nullability must match.',
+            );
+        }
+
+        if (array_key_exists('defaultValue', $expected)) {
+            self::assertSame(
+                $expected['defaultValue'],
+                $column->defaultValue,
+                $expected['defaultValue'] === null ? 'Default must be cleared.' : 'Default must match.',
+            );
+        }
+
+        if (isset($expected['defaultValueContains'])) {
+            self::assertNotNull(
+                $column->defaultValue,
+                'Default must be present.',
+            );
+            self::assertStringContainsString(
+                $expected['defaultValueContains'],
+                (string) $column->defaultValue,
+                'Default expression must be preserved.',
+            );
+        }
+
+        if (isset($expected['checkContains'])) {
+            $found = false;
+
+            foreach ($db->getSchema()->getTableChecks('alter_column', true) as $check) {
+                if (str_contains($check->expression, $expected['checkContains'])) {
+                    $found = true;
+                }
+            }
+
+            self::assertTrue(
+                $found,
+                'Check constraint must exist.',
+            );
+        }
+
+        if (isset($expected['uniqueColumns'])) {
+            $found = false;
+
+            foreach ($db->getSchema()->getTableUniques('alter_column', true) as $unique) {
+                if ($unique->columnNames === $expected['uniqueColumns']) {
+                    $found = true;
+                }
+            }
+
+            self::assertTrue(
+                $found,
+                'Unique constraint must exist.',
+            );
+        }
+
+        DbHelper::dropTablesIfExist($db, ['alter_column']);
+    }
+
+    #[DataProviderExternal(CommandProvider::class, 'alterColumnFailing')]
+    public function testThrowExceptionForAlterColumnTypeStringThatIsNotAnAction(string $type, string $exceptionMessage): void
+    {
+        $db = $this->getConnection();
+
+        DbHelper::dropTablesIfExist($db, ['alter_column']);
+
+        $command = $db->createCommand();
+
+        $command->createTable(
+            'alter_column',
+            ['id' => 'pk', 'bar' => 'varchar(100)'],
+        )->execute();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(
+            $exceptionMessage,
+        );
+
+        $command->alterColumn(
+            'alter_column',
+            'bar',
+            $type,
+        )->execute();
     }
 }

--- a/tests/framework/db/pgsql/QueryBuilderTest.php
+++ b/tests/framework/db/pgsql/QueryBuilderTest.php
@@ -348,53 +348,20 @@ final class QueryBuilderTest extends BaseQueryBuilder
         );
     }
 
-    public function testAlterColumn(): void
+    #[DataProviderExternal(QueryBuilderProvider::class, 'alterColumn')]
+    public function testAlterColumn(string|Closure $type, string $expected): void
     {
-        $qb = $this->getQueryBuilder();
+        $db = $this->getConnection(false, false);
 
-        $expected = 'ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" DROP NOT NULL';
-        $sql = $qb->alterColumn('foo1', 'bar', 'varchar(255)');
-        $this->assertEquals($expected, $sql);
+        if ($type instanceof Closure) {
+            $type = $type($this->getDb());
+        }
 
-        $expected = 'ALTER TABLE "foo1" ALTER COLUMN "bar" SET NOT null';
-        $sql = $qb->alterColumn('foo1', 'bar', 'SET NOT null');
-        $this->assertEquals($expected, $sql);
-
-        $expected = 'ALTER TABLE "foo1" ALTER COLUMN "bar" drop default';
-        $sql = $qb->alterColumn('foo1', 'bar', 'drop default');
-        $this->assertEquals($expected, $sql);
-
-        $expected = 'ALTER TABLE "foo1" ALTER COLUMN "bar" reset xyz';
-        $sql = $qb->alterColumn('foo1', 'bar', 'reset xyz');
-        $this->assertEquals($expected, $sql);
-
-        $expected = 'ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" DROP NOT NULL';
-        $sql = $qb->alterColumn('foo1', 'bar', $this->string(255));
-        $this->assertEquals($expected, $sql);
-
-        $expected = 'ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" SET NOT NULL';
-        $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->notNull());
-        $this->assertEquals($expected, $sql);
-
-        $expected = 'ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" DROP NOT NULL, ADD CONSTRAINT foo1_bar_check CHECK (char_length(bar) > 5)';
-        $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->check('char_length(bar) > 5'));
-        $this->assertEquals($expected, $sql);
-
-        $expected = 'ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" SET DEFAULT \'\', ALTER COLUMN "bar" DROP NOT NULL';
-        $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->defaultValue(''));
-        $this->assertEquals($expected, $sql);
-
-        $expected = 'ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" SET DEFAULT \'AbCdE\', ALTER COLUMN "bar" DROP NOT NULL';
-        $sql = $qb->alterColumn('foo1', 'bar', $this->string(255)->defaultValue('AbCdE'));
-        $this->assertEquals($expected, $sql);
-
-        $expected = 'ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE timestamp(0), ALTER COLUMN "bar" SET DEFAULT CURRENT_TIMESTAMP, ALTER COLUMN "bar" DROP NOT NULL';
-        $sql = $qb->alterColumn('foo1', 'bar', $this->timestamp()->defaultExpression('CURRENT_TIMESTAMP'));
-        $this->assertEquals($expected, $sql);
-
-        $expected = 'ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(30), ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" DROP NOT NULL, ADD UNIQUE ("bar")';
-        $sql = $qb->alterColumn('foo1', 'bar', $this->string(30)->unique());
-        $this->assertEquals($expected, $sql);
+        self::assertSame(
+            $expected,
+            $db->getQueryBuilder()->alterColumn('foo1', 'bar', $type),
+            'Generated SQL must match the expected statement.',
+        );
     }
 
     public static function indexesProvider(): array

--- a/tests/framework/db/pgsql/providers/CommandProvider.php
+++ b/tests/framework/db/pgsql/providers/CommandProvider.php
@@ -300,12 +300,12 @@ final class CommandProvider
                 [],
             ],
             'builder check' => [
-                'varchar(100)',
+                'varchar(100) CHECK (char_length(bar) > 1)',
                 [],
                 static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
                     ->check('char_length(bar) > 5'),
-                ['checkContains' => 'char_length'],
+                ['checkContains' => 'char_length', 'repeatable' => true],
             ],
             'builder default expression function' => [
                 'timestamp',
@@ -399,12 +399,12 @@ final class CommandProvider
                 ['type' => 'string'],
             ],
             'builder unique' => [
-                'varchar(100)',
+                'varchar(100) UNIQUE',
                 [],
                 static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 30)
                     ->unique(),
-                ['uniqueColumns' => ['bar']],
+                ['uniqueColumns' => ['bar'], 'repeatable' => true],
             ],
             'DROP DEFAULT action' => [
                 "varchar(100) DEFAULT 'x'",

--- a/tests/framework/db/pgsql/providers/CommandProvider.php
+++ b/tests/framework/db/pgsql/providers/CommandProvider.php
@@ -10,8 +10,12 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\db\pgsql\providers;
 
+use Closure;
+use yii\db\ColumnSchemaBuilder;
+use yii\db\Connection;
 use yii\db\Expression;
 use yii\db\Query;
+use yii\db\Schema;
 
 /**
  * Data provider for {@see \yiiunit\framework\db\pgsql\CommandTest} test cases.
@@ -273,6 +277,289 @@ final class CommandProvider
                     'address' => 'Earth',
                     'status' => 3,
                 ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, array<int, string>, Closure|string, array<string, mixed>}>
+     */
+    public static function alterColumn(): array
+    {
+        return [
+            'abstract type string' => [
+                'varchar(100)',
+                [],
+                'string',
+                ['type' => 'string'],
+            ],
+            'ADD GENERATED identity action' => [
+                'int NOT NULL',
+                [],
+                'ADD GENERATED ALWAYS AS IDENTITY',
+                [],
+            ],
+            'builder check' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->check('char_length(bar) > 5'),
+                ['checkContains' => 'char_length'],
+            ],
+            'builder default expression function' => [
+                'timestamp',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_TIMESTAMP)
+                    ->defaultExpression('NOW()'),
+                ['defaultValueContains' => 'now'],
+            ],
+            'builder default expression nextval' => [
+                'integer',
+                ['DROP SEQUENCE IF EXISTS "sequence"', 'CREATE SEQUENCE "sequence"'],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
+                    ->defaultExpression("nextval('public.sequence'::regclass)"),
+                ['defaultValueContains' => 'nextval'],
+            ],
+            'builder default expression with cast' => [
+                'timestamp',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_TIMESTAMP)
+                    ->defaultExpression("'now'::timestamp"),
+                // PostgreSQL evaluates `'now'::timestamp` once at DDL time; the reflected default is a frozen
+                // timestamp literal, so only the time separator is a stable substring.
+                ['defaultValueContains' => ':'],
+            ],
+            'builder default expression with comma' => [
+                'timestamp',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_TIMESTAMP)
+                    ->defaultExpression("date_trunc('day', CURRENT_TIMESTAMP)"),
+                ['defaultValueContains' => 'date_trunc'],
+            ],
+            'builder not null' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->notNull(),
+                ['allowNull' => false],
+            ],
+            'builder not null with default' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->notNull()
+                    ->defaultValue('hello world'),
+                ['allowNull' => false, 'defaultValue' => 'hello world'],
+            ],
+            'builder null' => [
+                'varchar(100) NOT NULL',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->null(),
+                ['allowNull' => true],
+            ],
+            'builder null default' => [
+                "varchar(100) NOT NULL DEFAULT 'x'",
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue(null),
+                ['allowNull' => true, 'defaultValue' => 'x'],
+            ],
+            'builder scalar default' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue('hello world'),
+                ['defaultValue' => 'hello world'],
+            ],
+            'builder scalar default with quote' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING)
+                    ->defaultValue("O'Reilly"),
+                // Reflected metadata keeps the SQL-escaped doubled quote; inserted rows receive the plain value.
+                ['defaultValue' => "O''Reilly"],
+            ],
+            'builder type only' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255),
+                ['type' => 'string'],
+            ],
+            'builder unique' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 30)
+                    ->unique(),
+                ['uniqueColumns' => ['bar']],
+            ],
+            'DROP DEFAULT action' => [
+                "varchar(100) DEFAULT 'x'",
+                [],
+                'DROP DEFAULT',
+                ['defaultValue' => null],
+            ],
+            'DROP IDENTITY action' => [
+                'integer',
+                [],
+                'DROP IDENTITY IF EXISTS',
+                [],
+            ],
+            'DROP NOT NULL action' => [
+                'varchar(100) NOT NULL',
+                [],
+                'DROP NOT NULL',
+                ['allowNull' => true],
+            ],
+            'lowercase action passthrough' => [
+                "varchar(100) DEFAULT 'x'",
+                [],
+                'drop default',
+                ['defaultValue' => null],
+            ],
+            'lowercase ADD GENERATED action' => [
+                'int NOT NULL',
+                [],
+                'add generated by default as identity',
+                [],
+            ],
+            'lowercase RESTART action' => [
+                'int GENERATED ALWAYS AS IDENTITY',
+                [],
+                'restart with 100',
+                [],
+            ],
+            'native type string' => [
+                'varchar(100)',
+                [],
+                'varchar(255)',
+                ['type' => 'string'],
+            ],
+            'native multi-word type string' => [
+                'timestamp NOT NULL DEFAULT now()',
+                [],
+                'timestamp with time zone',
+                ['allowNull' => false, 'defaultValueContains' => 'now'],
+            ],
+            'RESET attribute option action' => [
+                'varchar(100)',
+                [],
+                'RESET (n_distinct)',
+                [],
+            ],
+            'RESET attribute option without space action' => [
+                'varchar(100)',
+                [],
+                'RESET(n_distinct)',
+                [],
+            ],
+            'SET attribute option without space action' => [
+                'varchar(100)',
+                [],
+                'SET(n_distinct=4)',
+                [],
+            ],
+            'SET COMPRESSION action' => [
+                'varchar(100)',
+                [],
+                'SET COMPRESSION lz4',
+                [],
+            ],
+            'SET DEFAULT expression action' => [
+                'timestamp',
+                [],
+                'SET DEFAULT NOW()',
+                ['defaultValueContains' => 'now'],
+            ],
+            'SET DEFAULT nextval action' => [
+                'integer',
+                ['DROP SEQUENCE IF EXISTS foo_seq', 'CREATE SEQUENCE foo_seq'],
+                "SET DEFAULT nextval('foo_seq'::regclass)",
+                ['defaultValueContains' => 'foo_seq'],
+            ],
+            'SET DEFAULT parenthesized expression action' => [
+                'timestamp',
+                [],
+                "SET DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')",
+                ['defaultValueContains' => 'AT TIME ZONE'],
+            ],
+            'SET DEFAULT string literal action' => [
+                'varchar(100)',
+                [],
+                "SET DEFAULT 'hello world'",
+                ['defaultValue' => 'hello world'],
+            ],
+            'SET GENERATED action' => [
+                'int GENERATED ALWAYS AS IDENTITY',
+                [],
+                'SET GENERATED BY DEFAULT',
+                [],
+            ],
+            'SET NOT NULL action' => [
+                'varchar(100)',
+                [],
+                'SET NOT NULL',
+                ['allowNull' => false],
+            ],
+            'SET STATISTICS action' => [
+                'varchar(100)',
+                [],
+                'SET STATISTICS 1000',
+                [],
+            ],
+            'SET STORAGE action' => [
+                'varchar(100)',
+                [],
+                'SET STORAGE EXTENDED',
+                [],
+            ],
+            'type with USING conversion' => [
+                'varchar(36)',
+                [],
+                'uuid USING bar::uuid',
+                ['dbType' => 'uuid'],
+            ],
+            'RESTART bare action' => [
+                'int GENERATED ALWAYS AS IDENTITY',
+                [],
+                'RESTART',
+                [],
+            ],
+            'RESTART WITH action' => [
+                'int GENERATED ALWAYS AS IDENTITY',
+                [],
+                'RESTART WITH 100',
+                [],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function alterColumnFailing(): array
+    {
+        return [
+            'compound definition string is not parsed' => [
+                'timestamp NOT NULL DEFAULT NOW()',
+                'syntax error at or near "NOT"',
+            ],
+            'unsupported ADD action treated as type string' => [
+                'ADD UNIQUE',
+                'syntax error at or near "UNIQUE"',
             ],
         ];
     }

--- a/tests/framework/db/pgsql/providers/CommandProvider.php
+++ b/tests/framework/db/pgsql/providers/CommandProvider.php
@@ -299,6 +299,30 @@ final class CommandProvider
                 'ADD GENERATED ALWAYS AS IDENTITY',
                 [],
             ],
+            'builder append with USING conversion' => [
+                'varchar(36)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder('uuid')
+                    ->append('USING bar::uuid'),
+                ['dbType' => 'uuid'],
+            ],
+            'builder boolean false default' => [
+                'boolean',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_BOOLEAN)
+                    ->defaultValue(false),
+                ['defaultValue' => false],
+            ],
+            'builder boolean true default' => [
+                'boolean',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_BOOLEAN)
+                    ->defaultValue(true),
+                ['defaultValue' => true],
+            ],
             'builder check' => [
                 'varchar(100) CHECK (char_length(bar) > 1)',
                 [],
@@ -340,6 +364,22 @@ final class CommandProvider
                     ->createColumnSchemaBuilder(Schema::TYPE_TIMESTAMP)
                     ->defaultExpression("date_trunc('day', CURRENT_TIMESTAMP)"),
                 ['defaultValueContains' => 'date_trunc'],
+            ],
+            'builder float default' => [
+                'double',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_DOUBLE)
+                    ->defaultValue(1.5),
+                ['defaultValue' => 1.5],
+            ],
+            'builder integer default' => [
+                'integer',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
+                    ->defaultValue(42),
+                ['defaultValue' => 42],
             ],
             'builder not null' => [
                 'varchar(100)',

--- a/tests/framework/db/pgsql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/pgsql/providers/QueryBuilderProvider.php
@@ -10,8 +10,12 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\db\pgsql\providers;
 
+use Closure;
+use yii\db\ColumnSchemaBuilder;
+use yii\db\Connection;
 use yii\db\Expression;
 use yii\db\Query;
+use yii\db\Schema;
 
 /**
  * Data provider for {@see \yiiunit\framework\db\pgsql\QueryBuilderTest} test cases.
@@ -22,7 +26,10 @@ use yii\db\Query;
 final class QueryBuilderProvider
 {
     /**
-     * @return array<string, array{string, array<string, mixed>|Query, array<string, mixed>|bool, string, array<string, mixed>}>
+     * @return array<
+     *   string,
+     *   array{string, array<string, mixed>|Query, array<string, mixed>|bool, string, array<string, mixed>}
+     * >
      */
     public static function upsert(): array
     {
@@ -369,6 +376,285 @@ final class QueryBuilderProvider
                 [
                     ':qp0' => 'dynamic@example.com',
                 ],
+            ],
+        ];
+    }
+
+    /**
+     * Data provider for {@see \yiiunit\framework\db\pgsql\QueryBuilderTest::testAlterColumn()} test cases.
+     *
+     * Provides representative input/output pairs for the `ALTER COLUMN` statement.
+     *
+     * @return array<string, array{Closure|string, string}>
+     */
+    public static function alterColumn(): array
+    {
+        return [
+            'abstract type string' => [
+                'string',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255)
+                SQL,
+            ],
+            'ADD GENERATED identity action' => [
+                'ADD GENERATED ALWAYS AS IDENTITY',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" ADD GENERATED ALWAYS AS IDENTITY
+                SQL,
+            ],
+            'builder check' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->check('char_length(bar) > 5'),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255), ADD CONSTRAINT foo1_bar_check CHECK (char_length(bar) > 5)
+                SQL,
+            ],
+            'builder default expression function' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_TIMESTAMP)
+                    ->defaultExpression('NOW()'),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE timestamp(0), ALTER COLUMN "bar" SET DEFAULT NOW()
+                SQL,
+            ],
+            'builder default expression nextval' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
+                    ->defaultExpression("nextval('public.sequence'::regclass)"),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE integer, ALTER COLUMN "bar" SET DEFAULT nextval('public.sequence'::regclass)
+                SQL,
+            ],
+            'builder default expression with cast' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_TIMESTAMP)
+                    ->defaultExpression("'now'::timestamp"),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE timestamp(0), ALTER COLUMN "bar" SET DEFAULT 'now'::timestamp
+                SQL,
+            ],
+            'builder default expression with comma' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_TIMESTAMP)
+                    ->defaultExpression("date_trunc('day', CURRENT_TIMESTAMP)"),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE timestamp(0), ALTER COLUMN "bar" SET DEFAULT date_trunc('day', CURRENT_TIMESTAMP)
+                SQL,
+            ],
+            'builder not null' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->notNull(),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" SET NOT NULL
+                SQL,
+            ],
+            'builder not null with default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->notNull()
+                    ->defaultValue('hello world'),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" SET NOT NULL, ALTER COLUMN "bar" SET DEFAULT 'hello world'
+                SQL,
+            ],
+            'builder null' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->null(),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" DROP NOT NULL
+                SQL,
+            ],
+            'builder null default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue(null),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" DROP NOT NULL
+                SQL,
+            ],
+            'builder scalar default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue('hello world'),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" SET DEFAULT 'hello world'
+                SQL,
+            ],
+            'builder scalar default with quote' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING)
+                    ->defaultValue("O'Reilly"),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE varchar(255), ALTER COLUMN "bar" SET DEFAULT 'O''Reilly'
+                SQL,
+            ],
+            'builder type only' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255)
+                SQL,
+            ],
+            'builder unique' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 30)
+                    ->unique(),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(30), ADD UNIQUE ("bar")
+                SQL,
+            ],
+            'compound definition string is not parsed' => [
+                'timestamp NOT NULL DEFAULT NOW()',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE timestamp(0) NOT NULL DEFAULT NOW()
+                SQL,
+            ],
+            'DROP DEFAULT action' => [
+                'DROP DEFAULT',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT
+                SQL,
+            ],
+            'DROP IDENTITY action' => [
+                'DROP IDENTITY IF EXISTS',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP IDENTITY IF EXISTS
+                SQL,
+            ],
+            'DROP NOT NULL action' => [
+                'DROP NOT NULL',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP NOT NULL
+                SQL,
+            ],
+            'lowercase action passthrough' => [
+                'drop default',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" drop default
+                SQL,
+            ],
+            'lowercase ADD GENERATED action' => [
+                'add generated by default as identity',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" add generated by default as identity
+                SQL,
+            ],
+            'lowercase RESTART action' => [
+                'restart with 100',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" restart with 100
+                SQL,
+            ],
+            'native type string' => [
+                'varchar(255)',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255)
+                SQL,
+            ],
+            'native multi-word type string' => [
+                'timestamp with time zone',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE timestamp(0) with time zone
+                SQL,
+            ],
+            'RESET attribute option action' => [
+                'RESET (n_distinct)',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" RESET (n_distinct)
+                SQL,
+            ],
+            'RESET attribute option without space action' => [
+                'RESET(n_distinct)',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" RESET(n_distinct)
+                SQL,
+            ],
+            'SET attribute option without space action' => [
+                'SET(n_distinct=4)',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" SET(n_distinct=4)
+                SQL,
+            ],
+            'SET COMPRESSION action' => [
+                'SET COMPRESSION lz4',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" SET COMPRESSION lz4
+                SQL,
+            ],
+            'SET DEFAULT expression action' => [
+                'SET DEFAULT NOW()',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" SET DEFAULT NOW()
+                SQL,
+            ],
+            'SET DEFAULT nextval action' => [
+                "SET DEFAULT nextval('foo_seq'::regclass)",
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" SET DEFAULT nextval('foo_seq'::regclass)
+                SQL,
+            ],
+            'SET DEFAULT parenthesized expression action' => [
+                "SET DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')",
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" SET DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+                SQL,
+            ],
+            'SET DEFAULT string literal action' => [
+                "SET DEFAULT 'hello world'",
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" SET DEFAULT 'hello world'
+                SQL,
+            ],
+            'SET GENERATED action' => [
+                'SET GENERATED BY DEFAULT',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" SET GENERATED BY DEFAULT
+                SQL,
+            ],
+            'SET NOT NULL action' => [
+                'SET NOT NULL',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" SET NOT NULL
+                SQL,
+            ],
+            'SET STATISTICS action' => [
+                'SET STATISTICS 1000',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" SET STATISTICS 1000
+                SQL,
+            ],
+            'SET STORAGE action' => [
+                'SET STORAGE EXTENDED',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" SET STORAGE EXTENDED
+                SQL,
+            ],
+            'type with USING conversion' => [
+                'uuid USING bar::uuid',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE uuid USING bar::uuid
+                SQL,
+            ],
+            'RESTART bare action' => [
+                'RESTART',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" RESTART
+                SQL,
+            ],
+            'RESTART WITH action' => [
+                'RESTART WITH 100',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" RESTART WITH 100
+                SQL,
+            ],
+            'unsupported ADD action treated as type string' => [
+                'ADD UNIQUE',
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE ADD UNIQUE
+                SQL,
             ],
         ];
     }

--- a/tests/framework/db/pgsql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/pgsql/providers/QueryBuilderProvider.php
@@ -402,6 +402,30 @@ final class QueryBuilderProvider
                 ALTER TABLE "foo1" ALTER COLUMN "bar" ADD GENERATED ALWAYS AS IDENTITY
                 SQL,
             ],
+            'builder append with USING conversion' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder('uuid')
+                    ->append('USING bar::uuid'),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE uuid USING bar::uuid
+                SQL,
+            ],
+            'builder boolean false default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_BOOLEAN)
+                    ->defaultValue(false),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE boolean, ALTER COLUMN "bar" SET DEFAULT FALSE
+                SQL,
+            ],
+            'builder boolean true default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_BOOLEAN)
+                    ->defaultValue(true),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE boolean, ALTER COLUMN "bar" SET DEFAULT TRUE
+                SQL,
+            ],
             'builder check' => [
                 static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
@@ -440,6 +464,22 @@ final class QueryBuilderProvider
                     ->defaultExpression("date_trunc('day', CURRENT_TIMESTAMP)"),
                 <<<SQL
                 ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE timestamp(0), ALTER COLUMN "bar" SET DEFAULT date_trunc('day', CURRENT_TIMESTAMP)
+                SQL,
+            ],
+            'builder float default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_DOUBLE)
+                    ->defaultValue(1.5),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE double precision, ALTER COLUMN "bar" SET DEFAULT 1.5
+                SQL,
+            ],
+            'builder integer default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
+                    ->defaultValue(42),
+                <<<SQL
+                ALTER TABLE "foo1" ALTER COLUMN "bar" DROP DEFAULT, ALTER COLUMN "bar" TYPE integer, ALTER COLUMN "bar" SET DEFAULT 42
                 SQL,
             ],
             'builder not null' => [

--- a/tests/framework/db/pgsql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/pgsql/providers/QueryBuilderProvider.php
@@ -407,7 +407,7 @@ final class QueryBuilderProvider
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
                     ->check('char_length(bar) > 5'),
                 <<<SQL
-                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(255), ADD CONSTRAINT foo1_bar_check CHECK (char_length(bar) > 5)
+                ALTER TABLE "foo1" DROP CONSTRAINT IF EXISTS foo1_bar_check, ALTER COLUMN "bar" TYPE varchar(255), ADD CONSTRAINT foo1_bar_check CHECK (char_length(bar) > 5)
                 SQL,
             ],
             'builder default expression function' => [
@@ -503,7 +503,7 @@ final class QueryBuilderProvider
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 30)
                     ->unique(),
                 <<<SQL
-                ALTER TABLE "foo1" ALTER COLUMN "bar" TYPE varchar(30), ADD UNIQUE ("bar")
+                ALTER TABLE "foo1" DROP CONSTRAINT IF EXISTS foo1_bar_key, ALTER COLUMN "bar" TYPE varchar(30), ADD CONSTRAINT foo1_bar_key UNIQUE ("bar")
                 SQL,
             ],
             'compound definition string is not parsed' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #19929 
