### PR TITLE
Improve MSSQL, PGSQL `alterColumn()` test coverage with data-provider `Command` tests and shared `DbHelper` schema assertions.

### DIFF
--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -711,7 +711,7 @@ final class CommandTest extends BaseCommand
             'DDL must report zero affected rows.',
         );
 
-        if (!empty($expected['repeatable'])) {
+        if (($expected['repeatable'] ?? false) === true) {
             $command->alterColumn(
                 'alter_column',
                 'bar',

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\db\mssql;
 
+use Closure;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\db\Exception;
@@ -22,6 +23,7 @@ use yiiunit\base\db\BaseCommand;
 use yiiunit\framework\db\mssql\providers\CommandProvider;
 use yiiunit\support\DbHelper;
 
+use function array_key_exists;
 use function array_keys;
 use function json_encode;
 
@@ -675,48 +677,161 @@ final class CommandTest extends BaseCommand
         $db->createCommand()->dropTable($rawTableName)->execute();
     }
 
-    public function testAlterColumn(): void
+    #[DataProviderExternal(CommandProvider::class, 'alterColumn')]
+    public function testAlterColumn(string $startColumn, array $setupSql, string|Closure $type, array $expected): void
     {
         $db = $this->getConnection();
 
-        $db->createCommand()->alterColumn(
-            'foo1',
-            'bar',
-            'varchar(255)',
+        DbHelper::dropTablesIfExist($db, ['alter_column']);
+
+        foreach ($setupSql as $sql) {
+            $db->createCommand($sql)->execute();
+        }
+
+        $command = $db->createCommand();
+
+        $command->createTable(
+            'alter_column',
+            ['id' => 'pk', 'bar' => $startColumn],
         )->execute();
 
-        $tableSchema = $db->getTableSchema('foo1', true);
+        if ($type instanceof Closure) {
+            $type = $type($db);
+        }
 
-        self::assertSame(
-            'varchar(255)',
-            $tableSchema->getColumn('bar')->dbType,
-            'Column type must reflect the new definition.',
-        );
-        self::assertTrue(
-            $tableSchema->getColumn('bar')->allowNull,
-            'Column must stay nullable.',
-        );
-
-        $db->createCommand()->alterColumn(
-            'foo1',
+        $result = $command->alterColumn(
+            'alter_column',
             'bar',
-            $db
-                ->getSchema()
-                ->createColumnSchemaBuilder(Schema::TYPE_STRING, 128)
-                ->notNull(),
+            $type,
         )->execute();
 
-        $tableSchema = $db->getTableSchema('foo1', true);
-
         self::assertSame(
-            'nvarchar(128)',
-            $tableSchema->getColumn('bar')->dbType,
-            'Column type must reflect the new definition.',
+            0,
+            $result,
+            'DDL must report zero affected rows.',
         );
-        self::assertFalse(
-            $tableSchema->getColumn('bar')->allowNull,
-            'Column must be NOT NULL after the change.',
+
+        if (!empty($expected['repeatable'])) {
+            $command->alterColumn(
+                'alter_column',
+                'bar',
+                $type,
+            )->execute();
+        }
+
+        if (isset($expected['type'])) {
+            DbHelper::assertColumnType(
+                $db,
+                'alter_column',
+                'bar',
+                $expected['type'],
+            );
+        }
+
+        if (isset($expected['dbType'])) {
+            DbHelper::assertColumnDbType(
+                $db,
+                'alter_column',
+                'bar',
+                $expected['dbType'],
+            );
+        }
+
+        if (isset($expected['allowNull'])) {
+            DbHelper::assertColumnAllowNull(
+                $db,
+                'alter_column',
+                'bar',
+                $expected['allowNull'],
+            );
+        }
+
+        if (isset($expected['checkContains'])) {
+            DbHelper::assertCheckConstraintContains(
+                $db,
+                'alter_column',
+                $expected['checkContains'],
+            );
+        }
+
+        if (isset($expected['uniqueColumns'])) {
+            DbHelper::assertSingleUniqueConstraintCovers(
+                $db,
+                'alter_column',
+                $expected['uniqueColumns'],
+            );
+        }
+
+        if (isset($expected['defaultExpressionContains'])) {
+            DbHelper::assertDefaultConstraintContains(
+                $db,
+                'alter_column',
+                $expected['defaultExpressionContains'],
+            );
+        }
+
+        if (array_key_exists('defaultValue', $expected)) {
+            DbHelper::assertColumnDefaultValue(
+                $db,
+                'alter_column',
+                'bar',
+                $expected['defaultValue'],
+            );
+        }
+
+        if (array_key_exists('checkCount', $expected)) {
+            DbHelper::assertCheckConstraintCount(
+                $db,
+                'alter_column',
+                $expected['checkCount'],
+            );
+        }
+
+        if (array_key_exists('defaultCount', $expected)) {
+            DbHelper::assertDefaultConstraintCount(
+                $db,
+                'alter_column',
+                $expected['defaultCount'],
+            );
+        }
+
+        if (array_key_exists('uniqueCount', $expected)) {
+            DbHelper::assertUniqueConstraintCount(
+                $db,
+                'alter_column',
+                $expected['uniqueCount'],
+            );
+        }
+
+        DbHelper::dropTablesIfExist($db, ['alter_column']);
+    }
+
+    #[DataProviderExternal(CommandProvider::class, 'alterColumnFailing')]
+    public function testThrowExceptionForAlterColumnTypeStringWithConstraintClause(
+        string $type,
+        string $exceptionMessage,
+    ): void {
+        $db = $this->getConnection();
+
+        DbHelper::dropTablesIfExist($db, ['alter_column']);
+
+        $command = $db->createCommand();
+
+        $command->createTable(
+            'alter_column',
+            ['id' => 'pk', 'bar' => 'varchar(100)'],
+        )->execute();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(
+            $exceptionMessage,
         );
+
+        $command->alterColumn(
+            'alter_column',
+            'bar',
+            $type,
+        )->execute();
     }
 
     public function testAlterColumnRollsBackDroppedConstraintsWhenAlterationFails(): void

--- a/tests/framework/db/mssql/providers/CommandProvider.php
+++ b/tests/framework/db/mssql/providers/CommandProvider.php
@@ -10,8 +10,12 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\db\mssql\providers;
 
+use Closure;
+use yii\db\ColumnSchemaBuilder;
+use yii\db\Connection;
 use yii\db\Expression;
 use yii\db\Query;
+use yii\db\Schema;
 
 /**
  * Data provider for {@see \yiiunit\framework\db\mssql\CommandTest} test cases.
@@ -266,6 +270,178 @@ final class CommandProvider
                 'integer',
                 null,
                 '/^.*NULL.*$/i',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, array<int, string>, Closure|string, array<string, mixed>}>
+     */
+    public static function alterColumn(): array
+    {
+        return [
+            'abstract type string' => [
+                'varchar(100)',
+                [],
+                'string',
+                ['type' => 'string', 'dbType' => 'nvarchar(255)'],
+            ],
+            'abstract type string not null passthrough' => [
+                'varchar(100)',
+                [],
+                'string NOT NULL',
+                ['allowNull' => false],
+            ],
+            'builder check' => [
+                'varchar(100) CHECK (LEN(bar) > 1)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->check('LEN(bar) > 5'),
+                ['checkContains' => 'len', 'repeatable' => true],
+            ],
+            'builder default expression function' => [
+                'datetime',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_DATETIME)
+                    ->defaultExpression('GETDATE()'),
+                ['defaultExpressionContains' => 'getdate'],
+            ],
+            'builder default expression with comma' => [
+                'datetime',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_DATETIME)
+                    ->defaultExpression('DATEADD(day, 1, GETDATE())'),
+                ['defaultExpressionContains' => 'dateadd'],
+            ],
+            'builder float default' => [
+                'double',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_DOUBLE)
+                    ->defaultValue(1.5),
+                ['defaultValue' => 1.5],
+            ],
+            'builder integer default' => [
+                'integer',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
+                    ->defaultValue(42),
+                ['defaultValue' => 42],
+            ],
+            'builder not null' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->notNull(),
+                ['allowNull' => false],
+            ],
+            'builder not null with default' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->notNull()
+                    ->defaultValue('hello world'),
+                ['allowNull' => false, 'defaultValue' => 'hello world'],
+            ],
+            'builder null' => [
+                'varchar(100) NOT NULL',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->null(),
+                ['allowNull' => true],
+            ],
+            'builder null default' => [
+                "varchar(100) NOT NULL DEFAULT 'x'",
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue(null),
+                // MSSQL drops the old default and re-adds `DEFAULT NULL`, so the reflected default is `null`
+                // (PostgreSQL keeps the pre-existing literal because it never re-adds a default).
+                ['allowNull' => true, 'defaultValue' => null],
+            ],
+            'builder scalar default' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue('hello world'),
+                ['defaultValue' => 'hello world'],
+            ],
+            'builder type only' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255),
+                ['type' => 'string', 'dbType' => 'nvarchar(255)'],
+            ],
+            'builder unique' => [
+                'varchar(100)',
+                [],
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 30)
+                    ->unique(),
+                ['uniqueColumns' => ['bar'], 'repeatable' => true],
+            ],
+            'native type string' => [
+                'varchar(100)',
+                [],
+                'varchar(255)',
+                ['type' => 'string', 'dbType' => 'varchar(255)'],
+            ],
+            'string type drops existing check' => [
+                'varchar(100) CHECK (LEN(bar) > 1)',
+                [],
+                'varchar(255)',
+                ['checkCount' => 0],
+            ],
+            'string type drops existing default' => [
+                "varchar(100) DEFAULT 'x'",
+                [],
+                'varchar(255)',
+                ['defaultValue' => null, 'defaultCount' => 0],
+            ],
+            'string unique start dropped' => [
+                'varchar(100) UNIQUE',
+                [],
+                'varchar(255)',
+                ['uniqueCount' => 0],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function alterColumnFailing(): array
+    {
+        return [
+            'inline CHECK clause' => [
+                'varchar(255) CHECK (LEN(bar) > 1)',
+                "Incorrect syntax near the keyword 'CHECK'.",
+            ],
+            'inline DEFAULT clause' => [
+                "varchar(255) DEFAULT 'x'",
+                "Incorrect syntax near the keyword 'DEFAULT'.",
+            ],
+            'inline UNIQUE clause' => [
+                'varchar(255) UNIQUE',
+                "Incorrect syntax near the keyword 'UNIQUE'.",
+            ],
+            'PostgreSQL DROP DEFAULT action' => [
+                'DROP DEFAULT',
+                "Incorrect syntax near the keyword 'DEFAULT'.",
+            ],
+            'PostgreSQL SET NOT NULL action' => [
+                'SET NOT NULL',
+                "Incorrect syntax near the keyword 'SET'.",
             ],
         ];
     }

--- a/tests/framework/db/mssql/providers/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/providers/QueryBuilderProvider.php
@@ -1255,7 +1255,265 @@ final class QueryBuilderProvider
     public static function alterColumn(): array
     {
         return [
-            'integer null with default expression' => [
+            'abstract type string' => [
+                'string',
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
+                SQL,
+            ],
+            'abstract type string not null passthrough' => [
+                'string NOT NULL',
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255) NOT NULL
+                SQL,
+            ],
+            'builder check' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->check('LEN(bar) > 5'),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
+                ALTER TABLE [foo1] ADD CONSTRAINT [CK_foo1_bar] CHECK (LEN(bar) > 5)
+                SQL,
+            ],
+            'builder default expression function' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_DATETIME)
+                    ->defaultExpression('GETDATE()'),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] datetime
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT GETDATE() FOR [bar]
+                SQL,
+            ],
+            'builder default expression with comma' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_DATETIME)
+                    ->defaultExpression('DATEADD(day, 1, GETDATE())'),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] datetime
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT DATEADD(day, 1, GETDATE()) FOR [bar]
+                SQL,
+            ],
+            'builder empty string default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue(''),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT '' FOR [bar]
+                SQL,
+            ],
+            'builder expression object default' => [
                 static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
                     ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
                     ->null()
@@ -1300,11 +1558,54 @@ final class QueryBuilderProvider
                 ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CAST(GETDATE() AS INT) FOR [bar]
                 SQL,
             ],
-            'integer null with null default value' => [
+            'builder float default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_DOUBLE)
+                    ->defaultValue(1.5),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] float
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT 1.5 FOR [bar]
+                SQL,
+            ],
+            'builder integer default' => [
                 static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
                     ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
-                    ->null()
-                    ->defaultValue(null),
+                    ->defaultValue(42),
                 <<<SQL
                 DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
@@ -1341,52 +1642,11 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
-                ALTER TABLE [foo1] ALTER COLUMN [bar] int NULL
-                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT NULL FOR [bar]
+                ALTER TABLE [foo1] ALTER COLUMN [bar] int
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT 42 FOR [bar]
                 SQL,
             ],
-            'plain string type' => [
-                'varchar(255)',
-                <<<SQL
-                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
-                DECLARE @columnName NVARCHAR(MAX) = N'bar'
-                DECLARE @dropCommands NVARCHAR(MAX)
-
-                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
-                FROM (
-                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
-                    FROM [sys].[default_constraints] AS [dc]
-                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
-                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
-                    UNION
-                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
-                    FROM [sys].[check_constraints] AS [cc]
-                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
-                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
-                        AND (
-                            [cc].[parent_column_id]=[c].[column_id]
-                            OR EXISTS (
-                                SELECT 1
-                                FROM [sys].[sql_expression_dependencies] AS [sed]
-                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
-                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
-                                    AND [sed].[referenced_minor_id]=[c].[column_id]
-                            )
-                        )
-                    UNION
-                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
-                    FROM [sys].[key_constraints] AS [kc]
-                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
-                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
-                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
-                ) AS [cons]
-
-                IF @dropCommands IS NOT NULL
-                    EXEC (@dropCommands)
-                ALTER TABLE [foo1] ALTER COLUMN [bar] varchar(255)
-                SQL,
-            ],
-            'string not null' => [
+            'builder not null' => [
                 static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
                     ->notNull(),
@@ -1429,7 +1689,226 @@ final class QueryBuilderProvider
                 ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255) NOT NULL
                 SQL,
             ],
-            'string unique' => [
+            'builder not null with default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->notNull()
+                    ->defaultValue('hello world'),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255) NOT NULL
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT 'hello world' FOR [bar]
+                SQL,
+            ],
+            'builder null' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->null(),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255) NULL
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT NULL FOR [bar]
+                SQL,
+            ],
+            'builder null default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue(null),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255) NULL
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT NULL FOR [bar]
+                SQL,
+            ],
+            'builder scalar default' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
+                    ->defaultValue('hello world'),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
+                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT 'hello world' FOR [bar]
+                SQL,
+            ],
+            'builder type only' => [
+                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
+                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255),
+                <<<SQL
+                DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
+                DECLARE @columnName NVARCHAR(MAX) = N'bar'
+                DECLARE @dropCommands NVARCHAR(MAX)
+
+                SELECT @dropCommands = STRING_AGG(CONVERT(NVARCHAR(MAX), [cons].[sql]), N'; ') WITHIN GROUP (ORDER BY [cons].[ord], [cons].[sql])
+                FROM (
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([dc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[default_constraints] AS [dc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[dc].[parent_object_id] AND [c].[column_id]=[dc].[parent_column_id] AND [c].[name]=@columnName
+                    WHERE [dc].[parent_object_id] = OBJECT_ID(@tableName)
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([cc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[check_constraints] AS [cc]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[cc].[parent_object_id] AND [c].[name]=@columnName
+                    WHERE [cc].[parent_object_id] = OBJECT_ID(@tableName)
+                        AND (
+                            [cc].[parent_column_id]=[c].[column_id]
+                            OR EXISTS (
+                                SELECT 1
+                                FROM [sys].[sql_expression_dependencies] AS [sed]
+                                WHERE [sed].[referencing_class]=1 AND [sed].[referencing_id]=[cc].[object_id]
+                                    AND [sed].[referenced_class]=1 AND [sed].[referenced_id]=[cc].[parent_object_id]
+                                    AND [sed].[referenced_minor_id]=[c].[column_id]
+                            )
+                        )
+                    UNION
+                    SELECT N'ALTER TABLE ' + @tableName + N' DROP CONSTRAINT ' + QUOTENAME([kc].[name]) AS [sql], 1 AS [ord]
+                    FROM [sys].[key_constraints] AS [kc]
+                    JOIN [sys].[index_columns] AS [ic] ON [ic].[object_id]=[kc].[parent_object_id] AND [ic].[index_id]=[kc].[unique_index_id]
+                    JOIN [sys].[columns] AS [c] ON [c].[object_id]=[kc].[parent_object_id] AND [c].[column_id]=[ic].[column_id] AND [c].[name]=@columnName
+                    WHERE [kc].[parent_object_id] = OBJECT_ID(@tableName) AND [kc].[type] = N'UQ'
+                ) AS [cons]
+
+                IF @dropCommands IS NOT NULL
+                    EXEC (@dropCommands)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
+                SQL,
+            ],
+            'builder unique' => [
                 static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING, 30)
                     ->unique(),
@@ -1473,10 +1952,8 @@ final class QueryBuilderProvider
                 ALTER TABLE [foo1] ADD CONSTRAINT [UQ_foo1_bar] UNIQUE ([bar])
                 SQL,
             ],
-            'string with check constraint' => [
-                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
-                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
-                    ->check('LEN(bar) > 5'),
+            'native type string' => [
+                'varchar(255)',
                 <<<SQL
                 DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
@@ -1513,14 +1990,11 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
-                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-                ALTER TABLE [foo1] ADD CONSTRAINT [CK_foo1_bar] CHECK (LEN(bar) > 5)
+                ALTER TABLE [foo1] ALTER COLUMN [bar] varchar(255)
                 SQL,
             ],
-            'string with default value' => [
-                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
-                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
-                    ->defaultValue('AbCdE'),
+            'string type drops existing check' => [
+                'varchar(255)',
                 <<<SQL
                 DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
@@ -1557,14 +2031,11 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
-                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT 'AbCdE' FOR [bar]
+                ALTER TABLE [foo1] ALTER COLUMN [bar] varchar(255)
                 SQL,
             ],
-            'string with empty default value' => [
-                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
-                    ->createColumnSchemaBuilder(Schema::TYPE_STRING, 255)
-                    ->defaultValue(''),
+            'string type drops existing default' => [
+                'varchar(255)',
                 <<<SQL
                 DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
@@ -1601,14 +2072,11 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
-                ALTER TABLE [foo1] ALTER COLUMN [bar] nvarchar(255)
-                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT '' FOR [bar]
+                ALTER TABLE [foo1] ALTER COLUMN [bar] varchar(255)
                 SQL,
             ],
-            'timestamp with default expression' => [
-                static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
-                    ->createColumnSchemaBuilder(Schema::TYPE_TIMESTAMP)
-                    ->defaultExpression('CURRENT_TIMESTAMP'),
+            'string unique start dropped' => [
+                'varchar(255)',
                 <<<SQL
                 DECLARE @tableName NVARCHAR(MAX) = N'[foo1]'
                 DECLARE @columnName NVARCHAR(MAX) = N'bar'
@@ -1645,8 +2113,7 @@ final class QueryBuilderProvider
 
                 IF @dropCommands IS NOT NULL
                     EXEC (@dropCommands)
-                ALTER TABLE [foo1] ALTER COLUMN [bar] datetime
-                ALTER TABLE [foo1] ADD CONSTRAINT [DF_foo1_bar] DEFAULT CURRENT_TIMESTAMP FOR [bar]
+                ALTER TABLE [foo1] ALTER COLUMN [bar] varchar(255)
                 SQL,
             ],
         ];

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -15,7 +15,6 @@ use PDO;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\db\ArrayExpression;
-use yii\db\Connection;
 use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\IntegrityException;
@@ -30,7 +29,6 @@ use function array_diff;
 use function array_key_exists;
 use function array_keys;
 use function count;
-use function str_contains;
 
 /**
  * Unit tests for {@see \yii\db\Command} functionality for the PostgreSQL driver.
@@ -572,14 +570,75 @@ PGSQL
             )->execute();
         }
 
-        $this->assertAlterColumnExpectations($db, $expected);
+        if (isset($expected['type'])) {
+            DbHelper::assertColumnType(
+                $db,
+                'alter_column',
+                'bar',
+                $expected['type'],
+            );
+        }
+
+        if (isset($expected['dbType'])) {
+            DbHelper::assertColumnDbType(
+                $db,
+                'alter_column',
+                'bar',
+                $expected['dbType'],
+            );
+        }
+
+        if (isset($expected['allowNull'])) {
+            DbHelper::assertColumnAllowNull(
+                $db,
+                'alter_column',
+                'bar',
+                $expected['allowNull'],
+            );
+        }
+
+        if (array_key_exists('defaultValue', $expected)) {
+            DbHelper::assertColumnDefaultValue(
+                $db,
+                'alter_column',
+                'bar',
+                $expected['defaultValue'],
+            );
+        }
+
+        if (isset($expected['defaultValueContains'])) {
+            DbHelper::assertColumnDefaultValueContains(
+                $db,
+                'alter_column',
+                'bar',
+                $expected['defaultValueContains'],
+            );
+        }
+
+        if (isset($expected['checkContains'])) {
+            DbHelper::assertCheckConstraintContains(
+                $db,
+                'alter_column',
+                $expected['checkContains'],
+            );
+        }
+
+        if (isset($expected['uniqueColumns'])) {
+            DbHelper::assertSingleUniqueConstraintCovers(
+                $db,
+                'alter_column',
+                $expected['uniqueColumns'],
+            );
+        }
 
         DbHelper::dropTablesIfExist($db, ['alter_column']);
     }
 
     #[DataProviderExternal(CommandProvider::class, 'alterColumnFailing')]
-    public function testThrowExceptionForAlterColumnTypeStringThatIsNotAnAction(string $type, string $exceptionMessage): void
-    {
+    public function testThrowExceptionForAlterColumnTypeStringThatIsNotAnAction(
+        string $type,
+        string $exceptionMessage,
+    ): void {
         $db = $this->getConnection();
 
         DbHelper::dropTablesIfExist($db, ['alter_column']);
@@ -601,93 +660,5 @@ PGSQL
             'bar',
             $type,
         )->execute();
-    }
-
-    /**
-     * Asserts the reflected schema state of the altered `bar` column against the expectation map.
-     *
-     * @param Connection $db Active connection whose refreshed schema is inspected.
-     * @param array $expected Expectation map; {@see CommandProvider::alterColumn()} describes the supported keys.
-     */
-    private function assertAlterColumnExpectations(Connection $db, array $expected): void
-    {
-        $column = $db->getTableSchema('alter_column', true)->getColumn('bar');
-        /** @var Schema $schema */
-        $schema = $db->getSchema();
-
-        if (isset($expected['type'])) {
-            self::assertSame(
-                $expected['type'],
-                $column->type,
-                'Abstract type must match.',
-            );
-        }
-
-        if (isset($expected['dbType'])) {
-            self::assertSame(
-                $expected['dbType'],
-                $column->dbType,
-                'Physical type must match.',
-            );
-        }
-
-        if (isset($expected['allowNull'])) {
-            self::assertSame(
-                $expected['allowNull'],
-                $column->allowNull,
-                'Nullability must match.',
-            );
-        }
-
-        if (array_key_exists('defaultValue', $expected)) {
-            self::assertSame(
-                $expected['defaultValue'],
-                $column->defaultValue,
-                $expected['defaultValue'] === null ? 'Default must be cleared.' : 'Default must match.',
-            );
-        }
-
-        if (isset($expected['defaultValueContains'])) {
-            self::assertNotNull(
-                $column->defaultValue,
-                'Default must be present.',
-            );
-            self::assertStringContainsString(
-                $expected['defaultValueContains'],
-                (string) $column->defaultValue,
-                'Default expression must be preserved.',
-            );
-        }
-
-        if (isset($expected['checkContains'])) {
-            $found = false;
-
-            foreach ($schema->getTableChecks('alter_column', true) as $check) {
-                if (str_contains($check->expression, $expected['checkContains'])) {
-                    $found = true;
-                }
-            }
-
-            self::assertTrue(
-                $found,
-                'Check constraint must exist.',
-            );
-        }
-
-        if (isset($expected['uniqueColumns'])) {
-            $matches = 0;
-
-            foreach ($schema->getTableUniques('alter_column', true) as $unique) {
-                if ($unique->columnNames === $expected['uniqueColumns']) {
-                    ++$matches;
-                }
-            }
-
-            self::assertSame(
-                1,
-                $matches,
-                'Exactly one unique constraint must cover the column.',
-            );
-        }
     }
 }

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -562,7 +562,7 @@ PGSQL
             'DDL must report zero affected rows.',
         );
 
-        if (!empty($expected['repeatable'])) {
+        if (($expected['repeatable'] ?? false) === true) {
             $command->alterColumn(
                 'alter_column',
                 'bar',

--- a/tests/support/DbHelper.php
+++ b/tests/support/DbHelper.php
@@ -10,7 +10,11 @@ declare(strict_types=1);
 
 namespace yiiunit\support;
 
+use PHPUnit\Framework\Assert;
 use yii\db\Connection;
+use yii\db\ConstraintFinderInterface;
+
+use function str_contains;
 
 /**
  * Common database utilities for test support code.
@@ -20,6 +24,241 @@ use yii\db\Connection;
  */
 final class DbHelper
 {
+    /**
+     * Asserts the refreshed abstract type of the given column matches the expected value.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param string $column Column name.
+     * @param string $type Expected abstract type.
+     */
+    public static function assertColumnType(Connection $db, string $table, string $column, string $type): void
+    {
+        Assert::assertSame(
+            $type,
+            $db->getTableSchema($table, true)->getColumn($column)->type,
+            'Abstract type must match.',
+        );
+    }
+
+    /**
+     * Asserts the refreshed physical type of the given column matches the expected value.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param string $column Column name.
+     * @param string $dbType Expected physical type.
+     */
+    public static function assertColumnDbType(Connection $db, string $table, string $column, string $dbType): void
+    {
+        Assert::assertSame(
+            $dbType,
+            $db->getTableSchema($table, true)->getColumn($column)->dbType,
+            'Physical type must match.',
+        );
+    }
+
+    /**
+     * Asserts the refreshed nullability of the given column matches the expected value.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param string $column Column name.
+     * @param bool $allowNull Expected nullability.
+     */
+    public static function assertColumnAllowNull(Connection $db, string $table, string $column, bool $allowNull): void
+    {
+        Assert::assertSame(
+            $allowNull,
+            $db->getTableSchema($table, true)->getColumn($column)->allowNull,
+            'Nullability must match.',
+        );
+    }
+
+    /**
+     * Asserts the refreshed default value of the given column matches the expected value.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param string $column Column name.
+     * @param mixed $defaultValue Expected default value, or `null` when the default must be cleared.
+     */
+    public static function assertColumnDefaultValue(
+        Connection $db,
+        string $table,
+        string $column,
+        mixed $defaultValue,
+    ): void {
+        Assert::assertSame(
+            $defaultValue,
+            $db->getTableSchema($table, true)->getColumn($column)->defaultValue,
+            $defaultValue === null ? 'Default must be cleared.' : 'Default must match.',
+        );
+    }
+
+    /**
+     * Asserts the refreshed default value of the given column is present and contains the given substring.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param string $column Column name.
+     * @param string $needle Substring the default value must contain.
+     */
+    public static function assertColumnDefaultValueContains(
+        Connection $db,
+        string $table,
+        string $column,
+        string $needle,
+    ): void {
+        $defaultValue = $db->getTableSchema($table, true)->getColumn($column)->defaultValue;
+
+        Assert::assertNotNull(
+            $defaultValue,
+            'Default must be present.',
+        );
+        Assert::assertStringContainsString(
+            $needle,
+            (string) $defaultValue,
+            'Default expression must be preserved.',
+        );
+    }
+
+    /**
+     * Asserts at least one refreshed default value constraint on the table contains the given substring.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param string $needle Substring the default value constraint must contain.
+     */
+    public static function assertDefaultConstraintContains(Connection $db, string $table, string $needle): void
+    {
+        $schema = $db->getSchema();
+
+        /** @var ConstraintFinderInterface $schema */
+        $found = false;
+
+        foreach ($schema->getTableDefaultValues($table, true) as $default) {
+            if (str_contains((string) $default->value, $needle)) {
+                $found = true;
+            }
+        }
+
+        Assert::assertTrue(
+            $found,
+            'Default expression must be preserved.',
+        );
+    }
+
+    /**
+     * Asserts at least one refreshed check constraint on the table contains the given substring.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param string $needle Substring the check expression must contain.
+     */
+    public static function assertCheckConstraintContains(Connection $db, string $table, string $needle): void
+    {
+        $schema = $db->getSchema();
+
+        /** @var ConstraintFinderInterface $schema */
+        $found = false;
+
+        foreach ($schema->getTableChecks($table, true) as $check) {
+            if (str_contains($check->expression, $needle)) {
+                $found = true;
+            }
+        }
+
+        Assert::assertTrue(
+            $found,
+            'Check constraint must exist.',
+        );
+    }
+
+    /**
+     * Asserts exactly one refreshed unique constraint on the table covers the given columns.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param array $columns Column names the unique constraint must cover.
+     */
+    public static function assertSingleUniqueConstraintCovers(Connection $db, string $table, array $columns): void
+    {
+        $schema = $db->getSchema();
+
+        /** @var ConstraintFinderInterface $schema */
+        $matches = 0;
+
+        foreach ($schema->getTableUniques($table, true) as $unique) {
+            if ($unique->columnNames === $columns) {
+                ++$matches;
+            }
+        }
+
+        Assert::assertSame(
+            1,
+            $matches,
+            'Exactly one unique constraint must cover the column.',
+        );
+    }
+
+    /**
+     * Asserts the number of refreshed check constraints on the table matches the expected count.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param int $count Expected number of check constraints.
+     */
+    public static function assertCheckConstraintCount(Connection $db, string $table, int $count): void
+    {
+        $schema = $db->getSchema();
+
+        /** @var ConstraintFinderInterface $schema */
+        Assert::assertCount(
+            $count,
+            $schema->getTableChecks($table, true),
+            'Check must be dropped with the column alteration.',
+        );
+    }
+
+    /**
+     * Asserts the number of refreshed default value constraints on the table matches the expected count.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param int $count Expected number of default value constraints.
+     */
+    public static function assertDefaultConstraintCount(Connection $db, string $table, int $count): void
+    {
+        $schema = $db->getSchema();
+
+        /** @var ConstraintFinderInterface $schema */
+        Assert::assertCount(
+            $count,
+            $schema->getTableDefaultValues($table, true),
+            'Default must be dropped with the column alteration.',
+        );
+    }
+
+    /**
+     * Asserts the number of refreshed unique constraints on the table matches the expected count.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param int $count Expected number of unique constraints.
+     */
+    public static function assertUniqueConstraintCount(Connection $db, string $table, int $count): void
+    {
+        $schema = $db->getSchema();
+
+        /** @var ConstraintFinderInterface $schema */
+        Assert::assertCount(
+            $count,
+            $schema->getTableUniques($table, true),
+            'Unique constraint must be dropped with the column alteration.',
+        );
+    }
+
     /**
      * Drops the given tables when they exist, skipping the ones that are absent.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
