### PR TITLE
Fix `yii\db\oci\QueryBuilder::update()` to reject a `BLOB` update unless the condition covers a primary key or unique key, preventing multi-row data loss.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -129,6 +129,7 @@ Yii Framework 2 Change Log
 - Bug #21004: Fix PostgreSQL `yii\db\pgsql\QueryBuilder::checkIntegrity()` changing the connection-wide PDO emulate-prepares setting (terabytesoftw)
 - Bug #21005: Fix `yii\db\mysql\QueryBuilder::renameColumn()` to use the native `ALTER TABLE ... RENAME COLUMN` statement instead of parsing `SHOW CREATE TABLE` output (terabytesoftw)
 - Bug #19929: Fix `yii\db\pgsql\QueryBuilder::alterColumn()` corrupting compound column definitions by removing string parsing (terabytesoftw)
+- Bug #21008: Fix `yii\db\oci\QueryBuilder::update()` to reject a `BLOB` update unless the condition covers a primary key or unique key, preventing multi-row data loss (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/oci/QueryBuilder.php
+++ b/framework/db/oci/QueryBuilder.php
@@ -30,6 +30,7 @@ use function array_keys;
 use function count;
 use function is_array;
 use function is_float;
+use function is_scalar;
 use function is_string;
 use function strlen;
 use function substr;
@@ -269,12 +270,23 @@ class QueryBuilder extends \yii\db\QueryBuilder
     /**
      * {@inheritdoc}
      *
-     * The locator protocol supports only a single-row `BLOB` update.
+     * Oracle BLOB updates require a condition that guarantees at most one matched row.
+     *
+     * @throws NotSupportedException if the condition does not cover a unique key using non-null scalar values.
      */
     public function update($table, $columns, $condition, &$params)
     {
-        return parent::update($table, $columns, $condition, $params)
-            . $this->lobReturningClause($this->getLobReturning($params));
+        $sql = parent::update($table, $columns, $condition, $params);
+
+        $lobReturning = $this->getLobReturning($params);
+
+        if ($lobReturning !== [] && $this->conditionTargetsSingleRow($table, $condition) === false) {
+            throw new NotSupportedException(
+                'Oracle BLOB updates require non-null scalar equality values covering a primary key or unique key.',
+            );
+        }
+
+        return $sql . $this->lobReturningClause($lobReturning);
     }
 
     /**
@@ -647,6 +659,33 @@ class QueryBuilder extends \yii\db\QueryBuilder
         );
 
         return $placeholder;
+    }
+
+    /**
+     * Checks whether the condition guarantees at most one matched row.
+     *
+     * @param string $table Target table, passed to the schema exactly as received.
+     * @param mixed $condition The update condition to inspect.
+     *
+     * @return bool `true` when the condition is a safe single-row equality hash; `false` otherwise.
+     */
+    private function conditionTargetsSingleRow(string $table, mixed $condition): bool
+    {
+        if (!is_array($condition) || $condition === [] || isset($condition[0])) {
+            return false;
+        }
+
+        foreach ($condition as $value) {
+            if (!is_scalar($value) || $value === '') {
+                return false;
+            }
+        }
+
+        $constraints = [];
+
+        $this->prepareUpsertColumns($table, $condition, false, $constraints);
+
+        return $constraints !== [];
     }
 
     private function getIdentityGenerationClause(TableSchema $tableSchema): string

--- a/tests/framework/db/oci/type/BlobTest.php
+++ b/tests/framework/db/oci/type/BlobTest.php
@@ -75,6 +75,11 @@ final class BlobTest extends DatabaseTestCase
         $command = $db->createCommand();
 
         $command->delete('type')->execute();
+        $command->addPrimaryKey(
+            'PK_type_blob_update',
+            'type',
+            'int_col',
+        )->execute();
         $command->insert(
             'type',
             $this->rowValues(1, 'initial'),
@@ -98,46 +103,97 @@ final class BlobTest extends DatabaseTestCase
         }
     }
 
-    /**
-     * Documented limitation: Oracle `RETURNING lob INTO :p` binds one scalar locator, so a multi-row UPDATE fills
-     * only one matched row. Multi-row BLOB UPDATE is unsupported and is deliberately not split into N statements.
-     */
-    public function testMultiRowBlobUpdateFillsOnlyOneMatchedRow(): void
+    public function testThrowNotSupportedExceptionWhenBlobUpdateMatchesMultipleRows(): void
     {
         $db = $this->getConnection();
 
         $command = $db->createCommand();
 
         $command->delete('type')->execute();
+        $command->addPrimaryKey(
+            'PK_type_blob_multi',
+            'type',
+            'int_col',
+        )->execute();
+
+        $first = $this->createPayload(1_024);
+
+        $second = strrev($this->createPayload(2_048));
+
         $command->insert(
             'type',
-            $this->rowValues(1, 'first'),
+            $this->rowValues(1, $first),
         )->execute();
         $command->insert(
             'type',
-            $this->rowValues(2, 'second'),
+            $this->rowValues(2, $second),
         )->execute();
 
-        $payload = $this->createPayload(65_536);
+        try {
+            $command->update(
+                'type',
+                ['blob_col' => $this->createPayload(65_536)],
+                ['int_col' => [1, 2]],
+            );
 
-        $command->update(
-            'type',
-            ['blob_col' => $payload],
-            ['int_col' => [1, 2]],
-        )->execute();
-
-        $filled = 0;
-
-        foreach ([1, 2] as $id) {
-            if ($this->readBlob($id) === $payload) {
-                $filled++;
-            }
+            self::fail(
+                'Multi-row BLOB update must be rejected before execution.',
+            );
+        } catch (NotSupportedException $e) {
+            self::assertSame(
+                'Oracle BLOB updates require non-null scalar equality values covering a primary key or unique key.',
+                $e->getMessage(),
+                'Rejection must state the unique-key equality contract.',
+            );
         }
 
-        self::assertLessThan(
-            2,
-            $filled,
-            'Multi-row BLOB update must not fill every matched row.',
+        self::assertSame(
+            $first,
+            $this->readBlob(1),
+            'Row `1` BLOB must survive intact.',
+        );
+        self::assertSame(
+            $second,
+            $this->readBlob(2),
+            'Row `2` BLOB must survive intact.',
+        );
+    }
+
+    public function testThrowNotSupportedExceptionWhenBlobUpdateTargetsNonUniqueColumn(): void
+    {
+        $db = $this->getConnection();
+
+        $command = $db->createCommand();
+
+        $command->delete('type')->execute();
+
+        $seed = $this->createPayload(1_024);
+
+        $command->insert(
+            'type',
+            $this->rowValues(1, $seed),
+        )->execute();
+
+        try {
+            $command->update(
+                'type',
+                ['blob_col' => $this->createPayload(4_096)],
+                ['int_col' => 1],
+            );
+
+            self::fail('A non-unique equality must be rejected.');
+        } catch (NotSupportedException $e) {
+            self::assertSame(
+                'Oracle BLOB updates require non-null scalar equality values covering a primary key or unique key.',
+                $e->getMessage(),
+                'Rejection must state the unique-key equality contract.',
+            );
+        }
+
+        self::assertSame(
+            $seed,
+            $this->readBlob(1),
+            'BLOB must stay untouched without a unique key.',
         );
     }
 
@@ -880,7 +936,7 @@ final class BlobTest extends DatabaseTestCase
         );
     }
 
-    public function testInsertRoundTripsMultipleBlobColumns(): void
+    public function testMultipleBlobColumnsRoundTripOnInsertAndSingleRowUpdate(): void
     {
         $db = $this->getConnection();
 
@@ -890,7 +946,7 @@ final class BlobTest extends DatabaseTestCase
 
         $command->createTable(
             'blob_multi',
-            ['id' => 'integer', 'blob_a' => 'binary', 'blob_b' => 'binary'],
+            ['id' => 'integer PRIMARY KEY', 'blob_a' => 'binary', 'blob_b' => 'binary'],
         )->execute();
 
         $payloadA = $this->createPayload(65_536);
@@ -918,6 +974,7 @@ final class BlobTest extends DatabaseTestCase
                 'blob_multi',
                 ['id' => 1, 'blob_a' => $payloadA, 'blob_b' => $payloadB],
             )->execute(),
+            'Exactly one row must be inserted.',
         );
 
         $selectBlob = static fn(string $column): mixed => (new Query())
@@ -936,6 +993,30 @@ final class BlobTest extends DatabaseTestCase
             $payloadB,
             $selectBlob('blob_b'),
             'Second BLOB column must round-trip.',
+        );
+
+        $updatedA = $this->createPayload(16_384);
+
+        $updatedB = strrev($this->createPayload(8_192));
+
+        self::assertSame(
+            1,
+            $command->update(
+                'blob_multi',
+                ['blob_a' => $updatedA, 'blob_b' => $updatedB],
+                ['id' => 1],
+            )->execute(),
+            'Exactly one row must be updated.',
+        );
+        self::assertSame(
+            $updatedA,
+            $selectBlob('blob_a'),
+            'First BLOB column must round-trip after the update.',
+        );
+        self::assertSame(
+            $updatedB,
+            $selectBlob('blob_b'),
+            'Second BLOB column must round-trip after the update.',
         );
 
         DbHelper::dropTablesIfExist($db, ['blob_multi']);

--- a/tests/framework/db/oci/type/BlobTest.php
+++ b/tests/framework/db/oci/type/BlobTest.php
@@ -197,6 +197,59 @@ final class BlobTest extends DatabaseTestCase
         );
     }
 
+    public function testThrowNotSupportedExceptionWhenBlobUpdateConditionIsNotHash(): void
+    {
+        $db = $this->getConnection();
+
+        $command = $db->createCommand();
+
+        $command->delete('type')->execute();
+        $command->addPrimaryKey(
+            'PK_type_blob_shape',
+            'type',
+            'int_col',
+        )->execute();
+
+        $seed = $this->createPayload(1_024);
+
+        $command->insert(
+            'type',
+            $this->rowValues(1, $seed),
+        )->execute();
+
+        $conditions = [
+            'raw SQL string' => '"int_col" = 1',
+            'empty condition' => [],
+            'operator format' => ['or', ['int_col' => 1], ['int_col' => 2]],
+        ];
+
+        foreach ($conditions as $shape => $condition) {
+            try {
+                $command->update(
+                    'type',
+                    ['blob_col' => $this->createPayload(4_096)],
+                    $condition,
+                );
+
+                self::fail(
+                    "Shape '{$shape}' must be rejected.",
+                );
+            } catch (NotSupportedException $e) {
+                self::assertSame(
+                    'Oracle BLOB updates require non-null scalar equality values covering a primary key or unique key.',
+                    $e->getMessage(),
+                    "Shape '{$shape}' must state the unique-key equality contract.",
+                );
+            }
+        }
+
+        self::assertSame(
+            $seed,
+            $this->readBlob(1),
+            'Non-hash conditions must leave the BLOB intact.',
+        );
+    }
+
     public function testPdoValueStringAndStreamRoundTrip(): void
     {
         $db = $this->getConnection();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
