### PR TITLE
Fix repeated execution of an Oracle `BLOB` command failing after its temporary LOB stream was closed.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -131,6 +131,7 @@ Yii Framework 2 Change Log
 - Bug #19929: Fix `yii\db\pgsql\QueryBuilder::alterColumn()` corrupting compound column definitions by removing string parsing (terabytesoftw)
 - Bug #21008: Fix `yii\db\oci\QueryBuilder::update()` to reject a `BLOB` update unless the condition covers a primary key or unique key, preventing multi-row data loss (terabytesoftw)
 - Bug #21109: Fix MSSQL `limit(0)` queries to use `TOP (0)` without derived-table column-name errors (terabytesoftw)
+- Bug #21013: Fix repeated execution of an Oracle `BLOB` command failing after its temporary LOB stream was closed (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/oci/Command.php
+++ b/framework/db/oci/Command.php
@@ -44,13 +44,11 @@ class Command extends \yii\db\Command
      */
     public function execute()
     {
-        try {
-            $result = parent::execute();
+        $this->rewindOwnedLobStreams();
 
-            return $this->_upsertAffected !== null ? (int) $this->_upsertAffected : $result;
-        } finally {
-            $this->closeOwnedLobStreams();
-        }
+        $result = parent::execute();
+
+        return $this->_upsertAffected !== null ? (int) $this->_upsertAffected : $result;
     }
 
     /**
@@ -153,6 +151,18 @@ class Command extends \yii\db\Command
         return is_string($name)
             && str_starts_with($name, QueryBuilder::UPSERT_AFFECTED_PARAM_PREFIX)
             && ($type & PDO::PARAM_INPUT_OUTPUT) === PDO::PARAM_INPUT_OUTPUT;
+    }
+
+    /**
+     * Rewinds temporary streams owned by this command before reusing the prepared statement.
+     */
+    private function rewindOwnedLobStreams(): void
+    {
+        foreach ($this->_ownedLobStreams as $stream) {
+            if (!is_resource($stream) || rewind($stream) === false) {
+                throw new RuntimeException('Unable to rewind an Oracle LOB stream.');
+            }
+        }
     }
 
     /**

--- a/tests/framework/db/oci/type/BlobTest.php
+++ b/tests/framework/db/oci/type/BlobTest.php
@@ -1234,6 +1234,67 @@ final class BlobTest extends DatabaseTestCase
         return $payload;
     }
 
+    public function testBlobUpdateCommandCanBeExecutedTwice(): void
+    {
+        $db = $this->getConnection();
+
+        $db->createCommand()->delete('type')->execute();
+        $db->createCommand()->addPrimaryKey(
+            'PK_type_blob_command_reuse',
+            'type',
+            'int_col',
+        )->execute();
+        $db->createCommand()->insert(
+            'type',
+            $this->rowValues(1, 'initial'),
+        )->execute();
+
+        $payload = $this->createPayload(65_536);
+
+        // It is essential to reuse this exact Command instance.
+        $updateCommand = $db->createCommand()->update(
+            'type',
+            ['blob_col' => $payload],
+            ['int_col' => 1],
+        );
+
+        self::assertSame(
+            1,
+            $updateCommand->execute(),
+            'First execution must update exactly one row.',
+        );
+        self::assertSame(
+            $payload,
+            $this->readBlob(1),
+            'First execution must write the complete BLOB.',
+        );
+
+        // Change the stored value without modifying or rebuilding $updateCommand.
+        $db->createCommand(
+            <<<SQL
+            UPDATE "type"
+            SET "blob_col" = EMPTY_BLOB()
+            WHERE "int_col" = 1
+            SQL,
+        )->execute();
+
+        self::assertSame(
+            '',
+            $this->readBlob(1),
+            'The BLOB must be empty before executing the prepared command again.',
+        );
+        self::assertSame(
+            1,
+            $updateCommand->execute(),
+            'Second execution of the same command must update exactly one row.',
+        );
+        self::assertSame(
+            $payload,
+            $this->readBlob(1),
+            'Second execution must write the complete BLOB again.',
+        );
+    }
+
     /**
      * @return array<string, mixed> Complete values for an Oracle `type` fixture row.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
