### PR TITLE
Return `null` default values for nullable MySQL `BIT` columns during schema introspection.

### DIFF
--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -612,6 +612,10 @@ preserves MySQL `CURRENT_TIMESTAMP(0)`, recognizes Oracle `CURRENT_TIMESTAMP`, h
 parses SQLite `DEFAULT NULL` and escaped string literals consistently. Update schema snapshots or metadata assertions
 that encoded the previous values.
 
+MySQL `BIT` columns declared as nullable with `DEFAULT NULL` now expose `null` through
+`ColumnSchema::$defaultValue`; Yii `2.0.x` incorrectly reported `0`. Review code that compares reflected default values
+or calls `ActiveRecord::loadDefaultValues()` for models containing these columns.
+
 ## Removed platform support
 
 ### HHVM

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -18,6 +18,7 @@ use yii\db\TableSchema;
 use yii\db\mysql\ColumnSchema;
 use yii\db\mysql\Schema;
 use yiiunit\base\db\BaseSchema;
+use yiiunit\support\DbHelper;
 
 /**
  * Unit test for {@see \yii\db\mysql\Schema} schema reflection and metadata retrieval for the MySQL driver.
@@ -100,32 +101,46 @@ final class SchemaTest extends BaseSchema
 
     public function testLoadBitDefaultColumn(): void
     {
-        $sql = <<<SQL
-        CREATE TABLE IF NOT EXISTS `bit_default_test` (
-            `bit1` bit(1) NOT NULL DEFAULT b'1',
-            `bit5` bit(5) NOT NULL DEFAULT b'10101',
-            `bit8` bit(8) NOT NULL DEFAULT b'10000010'
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-        SQL;
+        $db = $this->getConnection();
 
-        $this->getConnection()->createCommand($sql)->execute();
+        DbHelper::dropTablesIfExist($db, ['bit_default_test']);
 
-        $schema = $this->getConnection()->getTableSchema('bit_default_test');
+        $db->createCommand()->createTable(
+            'bit_default_test',
+            [
+                'nullable_bit1' => 'bit(1) NULL DEFAULT NULL',
+                'nullable_bit8' => 'bit(8) NULL DEFAULT NULL',
+                'bit1' => "bit(1) NOT NULL DEFAULT b'1'",
+                'bit5' => "bit(5) NOT NULL DEFAULT b'10101'",
+                'bit8' => "bit(8) NOT NULL DEFAULT b'10000010'",
+            ],
+            'ENGINE=InnoDB DEFAULT CHARSET=utf8',
+        )->execute();
 
+        $schema = $db->getTableSchema('bit_default_test', true);
+
+        self::assertNull(
+            $schema->columns['nullable_bit1']->defaultValue,
+            "Nullable 'bit(1) DEFAULT NULL' must remain 'null'.",
+        );
+        self::assertNull(
+            $schema->columns['nullable_bit8']->defaultValue,
+            "Nullable 'bit(8) DEFAULT NULL' must remain 'null'.",
+        );
         self::assertSame(
             1,
             $schema->columns['bit1']->defaultValue,
-            "bit(1) `b\'1\'` must decode to '1'.",
+            "'bit(1)' must decode to '1'.",
         );
         self::assertSame(
             21,
             $schema->columns['bit5']->defaultValue,
-            "bit(5) `b\'10101\'` must decode to '21'.",
+            "'bit(5)' must decode to '21'.",
         );
         self::assertSame(
             130,
             $schema->columns['bit8']->defaultValue,
-            "bit(8) `b\'10000010\'` must decode to '130'.",
+            "'bit(8)' must decode to '130'.",
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #18113
