### PR TITLE
Load MySQL expression-based column defaults (`DEFAULT_GENERATED`) as executable `yii\db\Expression` instead of raw strings, and expose MariaDB expression-form `TEXT`/`JSON` defaults as `yii\db\Expression`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -133,7 +133,7 @@ Yii Framework 2 Change Log
 - Bug #21109: Fix MSSQL `limit(0)` queries to use `TOP (0)` without derived-table column-name errors (terabytesoftw)
 - Bug #21013: Fix repeated execution of an Oracle `BLOB` command failing after its temporary LOB stream was closed (terabytesoftw)
 - Bug #20239: Add explicit `unionOrderBy()`, `addUnionOrderBy()`, `unionLimit()`, and `unionOffset()` query methods, and apply `ActiveDataProvider` sorting and pagination to the complete `UNION` result (terabytesoftw)
-- Bug #19747: Load MySQL expression-based column defaults (`DEFAULT_GENERATED`) as executable `yii\db\Expression` instead of raw strings (terabytesoftw)
+- Bug #19747: Load MySQL expression-based column defaults (`DEFAULT_GENERATED`) as executable `yii\db\Expression` instead of raw strings, and expose MariaDB expression-form `TEXT`/`JSON` defaults as `yii\db\Expression` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -133,6 +133,7 @@ Yii Framework 2 Change Log
 - Bug #21109: Fix MSSQL `limit(0)` queries to use `TOP (0)` without derived-table column-name errors (terabytesoftw)
 - Bug #21013: Fix repeated execution of an Oracle `BLOB` command failing after its temporary LOB stream was closed (terabytesoftw)
 - Bug #20239: Add explicit `unionOrderBy()`, `addUnionOrderBy()`, `unionLimit()`, and `unionOffset()` query methods, and apply `ActiveDataProvider` sorting and pagination to the complete `UNION` result (terabytesoftw)
+- Bug #19747: Load MySQL expression-based column defaults (`DEFAULT_GENERATED`) as executable `yii\db\Expression` instead of raw strings (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -620,7 +620,9 @@ On MySQL `8.0.13+`, expression-based column defaults reported as `DEFAULT_GENERA
 `yii\db\Expression` through `ColumnSchema::$defaultValue` instead of the raw string. This includes parenthesized literal
 defaults required by types such as `TEXT` and `JSON`. Review strict type checks, schema snapshots, and code that calls
 `ActiveRecord::loadDefaultValues()` for models containing these columns. MariaDB does not report the
-`DEFAULT_GENERATED` metadata, so its expression defaults still reflect as plain strings.
+`DEFAULT_GENERATED` metadata; its `TEXT` and `JSON` defaults, which MariaDB stores in expression form, are exposed as
+a `yii\db\Expression` as well, and a `JSON` default that is valid JSON is returned decoded. Expression defaults on
+other MariaDB column types still reflect as plain strings.
 
 ## Removed platform support
 

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -616,6 +616,12 @@ MySQL `BIT` columns declared as nullable with `DEFAULT NULL` now expose `null` t
 `ColumnSchema::$defaultValue`; Yii `2.0.x` incorrectly reported `0`. Review code that compares reflected default values
 or calls `ActiveRecord::loadDefaultValues()` for models containing these columns.
 
+On MySQL `8.0.13+`, expression-based column defaults reported as `DEFAULT_GENERATED` now expose a
+`yii\db\Expression` through `ColumnSchema::$defaultValue` instead of the raw string. This includes parenthesized literal
+defaults required by types such as `TEXT` and `JSON`. Review strict type checks, schema snapshots, and code that calls
+`ActiveRecord::loadDefaultValues()` for models containing these columns. MariaDB does not report the
+`DEFAULT_GENERATED` metadata, so its expression defaults still reflect as plain strings.
+
 ## Removed platform support
 
 ### HHVM

--- a/framework/db/mysql/ColumnSchema.php
+++ b/framework/db/mysql/ColumnSchema.php
@@ -77,6 +77,9 @@ class ColumnSchema extends \yii\db\ColumnSchema
      * - `CURRENT_TIMESTAMP` / `current_timestamp()` on temporal columns (`timestamp`, `datetime`, `date`, `time`) to an
      *   {@see Expression}, preserving any declared fractional-seconds precision such as `CURRENT_TIMESTAMP(3)`.
      * - expression defaults flagged through {@see $isDefaultExpression} to an {@see Expression}.
+     * - `json` defaults without the flag to their decoded value when the string is valid JSON, or to an
+     *   {@see Expression} otherwise — MariaDB reports expression-form defaults without metadata.
+     * - `text` defaults without the flag to an {@see Expression}, preserving MariaDB's expression-form SQL.
      * - bit defaults (`b'...'`) when `$dbType` starts with `bit` to their integer value via `bindec()`.
      * - everything else delegates to {@see phpTypecast()}.
      *
@@ -107,6 +110,18 @@ class ColumnSchema extends \yii\db\ColumnSchema
 
         if ($this->isDefaultExpression && is_string($value)) {
             return new Expression(strtr($value, ['\\\\' => '\\', "\\'" => "'"]));
+        }
+
+        if ($this->type === Schema::TYPE_JSON && is_string($value)) {
+            $decoded = json_decode($value, true);
+
+            return json_last_error() === JSON_ERROR_NONE
+                ? $decoded
+                : new Expression($value);
+        }
+
+        if ($this->type === Schema::TYPE_TEXT && is_string($value)) {
+            return new Expression($value);
         }
 
         if (is_string($value) && strncasecmp($this->dbType, 'bit', 3) === 0) {

--- a/framework/db/mysql/ColumnSchema.php
+++ b/framework/db/mysql/ColumnSchema.php
@@ -16,6 +16,7 @@ use yii\db\JsonExpression;
 
 use function in_array;
 use function is_string;
+use function strtr;
 
 /**
  * Represents the metadata of a column in a MySQL database table.
@@ -25,6 +26,13 @@ use function is_string;
  */
 class ColumnSchema extends \yii\db\ColumnSchema
 {
+    /**
+     * @var bool whether MySQL reports the column default as an expression (`DEFAULT_GENERATED`).
+     *
+     * @since 22.0
+     */
+    public $isDefaultExpression = false;
+
     /**
      * {@inheritdoc}
      */
@@ -68,8 +76,12 @@ class ColumnSchema extends \yii\db\ColumnSchema
      * - `null` to `null`.
      * - `CURRENT_TIMESTAMP` / `current_timestamp()` on temporal columns (`timestamp`, `datetime`, `date`, `time`) to an
      *   {@see Expression}, preserving any declared fractional-seconds precision such as `CURRENT_TIMESTAMP(3)`.
+     * - expression defaults flagged through {@see $isDefaultExpression} to an {@see Expression}.
      * - bit defaults (`b'...'`) when `$dbType` starts with `bit` to their integer value via `bindec()`.
      * - everything else delegates to {@see phpTypecast()}.
+     *
+     * Branch order is significant: MySQL also flags plain `CURRENT_TIMESTAMP` defaults as `DEFAULT_GENERATED`, so the
+     * normalization above must win over the generic expression wrapping.
      *
      * @param mixed $value default value in the format reported by `SHOW FULL COLUMNS`.
      *
@@ -91,6 +103,10 @@ class ColumnSchema extends \yii\db\ColumnSchema
             $precision = $matches[1] ?? '';
 
             return new Expression('CURRENT_TIMESTAMP' . ($precision !== '' ? "({$precision})" : ''));
+        }
+
+        if ($this->isDefaultExpression && is_string($value)) {
+            return new Expression(strtr($value, ['\\\\' => '\\', "\\'" => "'"]));
         }
 
         if (is_string($value) && strncasecmp($this->dbType, 'bit', 3) === 0) {

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -24,6 +24,7 @@ use yii\db\Schema as BaseSchema;
 
 use function explode;
 use function str_replace;
+use function stripos;
 
 /**
  * Schema is the class for retrieving metadata from a MySQL database (version 8.0 and later).
@@ -272,6 +273,7 @@ SQL;
         $column->allowNull = $info['null'] === 'YES';
         $column->isPrimaryKey = strpos($info['key'], 'PRI') !== false;
         $column->autoIncrement = stripos($info['extra'], 'auto_increment') !== false;
+        $column->isDefaultExpression = stripos($info['extra'], 'DEFAULT_GENERATED') !== false;
         $column->comment = $info['comment'];
 
         $column->dbType = $info['type'];

--- a/tests/framework/db/mysql/ColumnSchemaTest.php
+++ b/tests/framework/db/mysql/ColumnSchemaTest.php
@@ -49,12 +49,14 @@ final class ColumnSchemaTest extends BaseColumnSchema
         string $phpType,
         mixed $value,
         mixed $expected,
+        bool $isDefaultExpression = false,
     ): void {
         $column = new ColumnSchema();
 
         $column->type = $type;
         $column->dbType = $dbType;
         $column->phpType = $phpType;
+        $column->isDefaultExpression = $isDefaultExpression;
 
         $result = $column->defaultPhpTypecast($value);
 

--- a/tests/framework/db/mysql/CommandTest.php
+++ b/tests/framework/db/mysql/CommandTest.php
@@ -118,13 +118,13 @@ final class CommandTest extends BaseCommand
         $columns = $db->getTableSchema('expression_default_command_test', true)->columns;
 
         if ($qb->isMariaDb()) {
-            // MariaDB reflects expression defaults as plain strings that cannot round-trip through an insert:
-            // omit them so the engine applies the stored defaults, and expect the reflected quotes verbatim.
+            // MariaDB reflects the date expression default as a plain string that cannot round-trip through an
+            // insert: omit it and let the engine apply the stored default.
             $insert = [
                 'text_expression' => $columns['text_expression']->defaultValue,
+                'json_expression' => $columns['json_expression']->defaultValue,
                 'literal' => $columns['literal']->defaultValue,
             ];
-            $expectedText = "'abc'";
         } else {
             $insert = [
                 'date_expression' => $columns['date_expression']->defaultValue,
@@ -132,7 +132,6 @@ final class CommandTest extends BaseCommand
                 'json_expression' => $columns['json_expression']->defaultValue,
                 'literal' => $columns['literal']->defaultValue,
             ];
-            $expectedText = 'abc';
         }
 
         $command->insert(
@@ -147,7 +146,7 @@ final class CommandTest extends BaseCommand
                     SELECT CURRENT_DATE + INTERVAL 2 YEAR
                     SQL
                 )->queryScalar(),
-                'text_expression' => $expectedText,
+                'text_expression' => 'abc',
                 'json_expression' => '[]',
                 'literal' => '2011-11-11',
             ],

--- a/tests/framework/db/mysql/CommandTest.php
+++ b/tests/framework/db/mysql/CommandTest.php
@@ -94,6 +94,72 @@ final class CommandTest extends BaseCommand
         );
     }
 
+    public function testInsertReflectedExpressionDefaults(): void
+    {
+        $db = $this->getConnection(false);
+
+        $command = $db->createCommand();
+        /** @var QueryBuilder $qb */
+        $qb = $db->getQueryBuilder();
+
+        DbHelper::dropTablesIfExist($db, ['expression_default_command_test']);
+
+        $command->createTable(
+            'expression_default_command_test',
+            [
+                'date_expression' => 'date NOT NULL DEFAULT (CURRENT_DATE + INTERVAL 2 YEAR)',
+                'text_expression' => "text NOT NULL DEFAULT ('abc')",
+                'json_expression' => 'json NOT NULL DEFAULT (JSON_ARRAY())',
+                'literal' => "date NOT NULL DEFAULT '2011-11-11'",
+            ],
+            'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+        )->execute();
+
+        $columns = $db->getTableSchema('expression_default_command_test', true)->columns;
+
+        if ($qb->isMariaDb()) {
+            // MariaDB reflects expression defaults as plain strings that cannot round-trip through an insert:
+            // omit them so the engine applies the stored defaults, and expect the reflected quotes verbatim.
+            $insert = [
+                'text_expression' => $columns['text_expression']->defaultValue,
+                'literal' => $columns['literal']->defaultValue,
+            ];
+            $expectedText = "'abc'";
+        } else {
+            $insert = [
+                'date_expression' => $columns['date_expression']->defaultValue,
+                'text_expression' => $columns['text_expression']->defaultValue,
+                'json_expression' => $columns['json_expression']->defaultValue,
+                'literal' => $columns['literal']->defaultValue,
+            ];
+            $expectedText = 'abc';
+        }
+
+        $command->insert(
+            'expression_default_command_test',
+            $insert,
+        )->execute();
+
+        self::assertSame(
+            [
+                'date_expression' => $command->setSql(
+                    <<<SQL
+                    SELECT CURRENT_DATE + INTERVAL 2 YEAR
+                    SQL
+                )->queryScalar(),
+                'text_expression' => $expectedText,
+                'json_expression' => '[]',
+                'literal' => '2011-11-11',
+            ],
+            (new Query())
+                ->from('expression_default_command_test')
+                ->one($db),
+            'Row must match the engine-applied defaults.',
+        );
+
+        DbHelper::dropTablesIfExist($db, ['expression_default_command_test']);
+    }
+
     #[DataProviderExternal(CommandProvider::class, 'addCommentOnColumn')]
     public function testAddUpdateDropCommentOnColumn(string $table, string $commentTarget, string $columnName): void
     {

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -122,25 +122,25 @@ final class SchemaTest extends BaseSchema
         )->execute();
 
         if ($qb->isMariaDb()) {
-            // MariaDB reports no `DEFAULT_GENERATED` metadata: expression defaults reflect as plain strings,
-            // parenthesized literals keep their quotes, and the JSON expression fails `json_decode()` to `null`.
+            // MariaDB reports no `DEFAULT_GENERATED` metadata: `text`/`json` defaults reflect in expression form,
+            // while expression defaults on other column types reflect as plain strings.
             DbHelper::assertColumnDefaultValue(
                 $db,
                 'default_expression_test',
                 'date_expression',
                 '(curdate() + interval 2 year)',
             );
-            DbHelper::assertColumnDefaultValue(
+            DbHelper::assertColumnDefaultExpression(
                 $db,
                 'default_expression_test',
                 'text_expression',
                 "'abc'",
             );
-            DbHelper::assertColumnDefaultValue(
+            DbHelper::assertColumnDefaultExpression(
                 $db,
                 'default_expression_test',
                 'json_expression',
-                null,
+                'json_array()',
             );
         } else {
             DbHelper::assertColumnDefaultExpression(

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -16,6 +16,7 @@ use yii\db\ConstraintFinderInterface;
 use yii\db\Expression;
 use yii\db\TableSchema;
 use yii\db\mysql\ColumnSchema;
+use yii\db\mysql\QueryBuilder;
 use yii\db\mysql\Schema;
 use yiiunit\base\db\BaseSchema;
 use yiiunit\support\DbHelper;
@@ -97,6 +98,79 @@ final class SchemaTest extends BaseSchema
             (string) $ts->defaultValue,
             "Expression must normalize to 'CURRENT_TIMESTAMP(3)'.",
         );
+    }
+
+    public function testLoadDefaultExpressionColumn(): void
+    {
+        $db = $this->getConnection();
+
+        $command = $db->createCommand();
+        /** @var QueryBuilder $qb */
+        $qb = $db->getQueryBuilder();
+
+        DbHelper::dropTablesIfExist($db, ['default_expression_test']);
+
+        $command->createTable(
+            'default_expression_test',
+            [
+                'date_expression' => 'date NOT NULL DEFAULT (CURRENT_DATE + INTERVAL 2 YEAR)',
+                'text_expression' => "text NOT NULL DEFAULT ('abc')",
+                'json_expression' => 'json NOT NULL DEFAULT (JSON_ARRAY())',
+                'literal' => "date NOT NULL DEFAULT '2011-11-11'",
+            ],
+            'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+        )->execute();
+
+        if ($qb->isMariaDb()) {
+            // MariaDB reports no `DEFAULT_GENERATED` metadata: expression defaults reflect as plain strings,
+            // parenthesized literals keep their quotes, and the JSON expression fails `json_decode()` to `null`.
+            DbHelper::assertColumnDefaultValue(
+                $db,
+                'default_expression_test',
+                'date_expression',
+                '(curdate() + interval 2 year)',
+            );
+            DbHelper::assertColumnDefaultValue(
+                $db,
+                'default_expression_test',
+                'text_expression',
+                "'abc'",
+            );
+            DbHelper::assertColumnDefaultValue(
+                $db,
+                'default_expression_test',
+                'json_expression',
+                null,
+            );
+        } else {
+            DbHelper::assertColumnDefaultExpression(
+                $db,
+                'default_expression_test',
+                'date_expression',
+                '(curdate() + interval 2 year)',
+            );
+            DbHelper::assertColumnDefaultExpression(
+                $db,
+                'default_expression_test',
+                'text_expression',
+                "_utf8mb4'abc'",
+            );
+            DbHelper::assertColumnDefaultExpression(
+                $db,
+                'default_expression_test',
+                'json_expression',
+                'json_array()',
+            );
+        }
+
+        DbHelper::assertColumnDefaultValue(
+            $db,
+            'default_expression_test',
+            'literal',
+            '2011-11-11',
+        );
+
+        DbHelper::dropTablesIfExist($db, ['default_expression_test']);
     }
 
     public function testLoadBitDefaultColumn(): void

--- a/tests/framework/db/mysql/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/mysql/providers/ColumnSchemaProvider.php
@@ -18,7 +18,7 @@ use yii\db\Expression;
 final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchemaProvider
 {
     /**
-     * @return array<string, array{string, string, string, mixed, mixed}>
+     * @return array<string, array{string, string, string, mixed, mixed, 5?: bool}>
      */
     public static function defaultPhpTypecast(): array
     {
@@ -127,6 +127,38 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 'string',
                 'CURRENT_TIMESTAMP(6)',
                 new Expression('CURRENT_TIMESTAMP(6)'),
+            ],
+            'generated CURRENT_TIMESTAMP remains normalized' => [
+                'timestamp',
+                'timestamp',
+                'string',
+                'current_timestamp()',
+                new Expression('CURRENT_TIMESTAMP'),
+                true,
+            ],
+            'generated date expression remains an expression' => [
+                'date',
+                'date',
+                'string',
+                '(CURRENT_DATE + INTERVAL 2 YEAR)',
+                new Expression('(CURRENT_DATE + INTERVAL 2 YEAR)'),
+                true,
+            ],
+            'generated text literal remains an expression' => [
+                'text',
+                'text',
+                'string',
+                "_utf8mb4\\'abc\\'",
+                new Expression("_utf8mb4'abc'"),
+                true,
+            ],
+            'generated JSON default bypasses JSON decoding' => [
+                'json',
+                'json',
+                'array',
+                '(json_array())',
+                new Expression('(json_array())'),
+                true,
             ],
             'decimal default kept as string' => [
                 'decimal',

--- a/tests/framework/db/mysql/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/mysql/providers/ColumnSchemaProvider.php
@@ -160,6 +160,27 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 new Expression('(json_array())'),
                 true,
             ],
+            'MariaDB bare JSON expression becomes an Expression' => [
+                'json',
+                'json',
+                'array',
+                'json_array()',
+                new Expression('json_array()'),
+            ],
+            'MariaDB quoted JSON literal becomes an Expression' => [
+                'json',
+                'json',
+                'array',
+                '\'{"a":1}\'',
+                new Expression('\'{"a":1}\''),
+            ],
+            'MariaDB quoted text literal becomes an Expression' => [
+                'text',
+                'text',
+                'string',
+                "'abc'",
+                new Expression("'abc'"),
+            ],
             'decimal default kept as string' => [
                 'decimal',
                 'decimal(5,2)',

--- a/tests/support/DbHelper.php
+++ b/tests/support/DbHelper.php
@@ -13,6 +13,7 @@ namespace yiiunit\support;
 use PHPUnit\Framework\Assert;
 use yii\db\Connection;
 use yii\db\ConstraintFinderInterface;
+use yii\db\Expression;
 
 use function str_contains;
 
@@ -120,6 +121,34 @@ final class DbHelper
             $needle,
             (string) $defaultValue,
             'Default expression must be preserved.',
+        );
+    }
+
+    /**
+     * Asserts the refreshed default value of the given column is an {@see Expression} with the given SQL text.
+     *
+     * @param Connection $db Database connection.
+     * @param string $table Table name.
+     * @param string $column Column name.
+     * @param string $expression Expected default expression SQL.
+     */
+    public static function assertColumnDefaultExpression(
+        Connection $db,
+        string $table,
+        string $column,
+        string $expression,
+    ): void {
+        $defaultValue = $db->getTableSchema($table, true)->getColumn($column)->defaultValue;
+
+        Assert::assertInstanceOf(
+            Expression::class,
+            $defaultValue,
+            'Default must be an Expression.',
+        );
+        Assert::assertSame(
+            $expression,
+            (string) $defaultValue,
+            'Default expression SQL must match.',
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #19747 
