### PR TITLE
Load PostgreSQL expression-based column defaults, including non-primary-key `serial` sequences, as executable `yii\db\Expression`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -134,6 +134,7 @@ Yii Framework 2 Change Log
 - Bug #21013: Fix repeated execution of an Oracle `BLOB` command failing after its temporary LOB stream was closed (terabytesoftw)
 - Bug #20239: Add explicit `unionOrderBy()`, `addUnionOrderBy()`, `unionLimit()`, and `unionOffset()` query methods, and apply `ActiveDataProvider` sorting and pagination to the complete `UNION` result (terabytesoftw)
 - Bug #19747: Load MySQL expression-based column defaults (`DEFAULT_GENERATED`) as executable `yii\db\Expression` instead of raw strings, and expose MariaDB expression-form `TEXT`/`JSON` defaults as `yii\db\Expression` (terabytesoftw)
+- Bug #19747: Load PostgreSQL expression-based column defaults, including non-primary-key `serial` sequences, as executable `yii\db\Expression` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -624,6 +624,15 @@ defaults required by types such as `TEXT` and `JSON`. Review strict type checks,
 a `yii\db\Expression` as well, and a `JSON` default that is valid JSON is returned decoded. Expression defaults on
 other MariaDB column types still reflect as plain strings.
 
+On PostgreSQL, expression-based column defaults reported by `pg_get_expr()` — operator expressions, function calls,
+and the `nextval(...)` default of a non-primary-key `serial` column — now expose an executable `yii\db\Expression`
+through `ColumnSchema::$defaultValue`. Yii `2.0.x` mangled these values: `integer DEFAULT (1 + 2)` reflected as `1`,
+a `jsonb` expression default as `null`, and a non-primary-key `serial` default as a raw string. Reflected quoted
+string literals also unescape SQL-doubled quotes now (`'O''Reilly'` reflects as `O'Reilly`). Review strict type
+checks, schema snapshots, and code that calls `ActiveRecord::loadDefaultValues()` for models containing these
+columns; on a non-primary-key `serial` column, `loadDefaultValues()` now assigns an `Expression` that advances the
+sequence when the record is saved. Primary-key and identity column defaults keep their current behavior.
+
 ## Removed platform support
 
 ### HHVM

--- a/framework/db/ColumnSchema.php
+++ b/framework/db/ColumnSchema.php
@@ -94,9 +94,9 @@ class ColumnSchema extends BaseObject
     /**
      * Converts a raw column default value from the database metadata to its PHP representation.
      *
-     * The base implementation delegates to {@see phpTypecast()}. Driver-specific subclasses (MySQL, MSSQL, Oracle)
-     * override this method to normalize vendor-specific default formats such as `CURRENT_TIMESTAMP`, bit literals, or
-     * quote-wrapped expressions before delegating to `phpTypecast()`.
+     * The base implementation delegates to {@see phpTypecast()}. Driver-specific subclasses override this method to
+     * return a PHP literal for recognized literal defaults, or an {@see Expression} for defaults the engine reports
+     * as expression SQL, such as `CURRENT_TIMESTAMP` or `nextval(...)`.
      *
      * @param mixed $value Raw default value from the database schema metadata.
      *

--- a/framework/db/pgsql/ColumnSchema.php
+++ b/framework/db/pgsql/ColumnSchema.php
@@ -23,10 +23,9 @@ use function is_bool;
 use function is_resource;
 use function json_decode;
 use function preg_match;
+use function str_replace;
 use function stream_get_contents;
-use function strpos;
 use function strtolower;
-use function strtoupper;
 
 /**
  * Represents the metadata of a column in a PostgreSQL database table.
@@ -36,6 +35,13 @@ use function strtoupper;
  */
 class ColumnSchema extends \yii\db\ColumnSchema
 {
+    /**
+     * Pattern fragment matching the type suffix of a `pg_get_expr()` cast, such as `character varying(10)`, `"bit"`,
+     * `numeric(5,2)`, or `text[]`. Shared by every literal branch of {@see defaultPhpTypecast()} so the cast grammar
+     * cannot drift between them.
+     */
+    private const string CAST_SUFFIX = '[\w" .\[\](),]+';
+
     /**
      * @var int the dimension of array. Defaults to 0, means this column is not an array.
      */
@@ -135,16 +141,21 @@ class ColumnSchema extends \yii\db\ColumnSchema
     /**
      * Converts a PostgreSQL column default value to its PHP representation.
      *
-     * Handles PostgreSQL-specific default value formats:
-     * - `null` to `null`.
-     * - Temporal columns (`timestamp`, `date`, `time`) defaulting to `NOW()`, `CURRENT_TIMESTAMP`, `CURRENT_DATE`,
-     *   `CURRENT_TIME`, or any function-call expression (containing `(`) to an {@see Expression}.
-     * - Binary bit literals (`B'...'::`) to their integer value via `bindec()`.
-     * - Quoted bit literals (`'...'::"bit"`) to their integer value via `bindec()`.
-     * - Cast notation (`'value'::type`) to the unwrapped literal, delegated to {@see phpTypecast()}.
-     * - `boolean` columns: `'true'` to `true`, anything else to `false`.
-     * - Parenthesized values (`(value)::type`) to the unwrapped literal, with `NULL` detection, delegated to
+     * Recognizes the literal formats produced by `pg_get_expr()` and typecasts only those:
+     * - `NULL` or `(NULL)`, optionally followed by a direct type cast, to `null`.
+     * - Binary bit literals (`B'...'::`) to their integer value via `bindec()`; kept for backward compatibility,
+     *   `pg_get_expr()` reports bit defaults in the quoted form.
+     * - Quoted bit literals (`'...'::"bit"`) to their integer value via `bindec()`; `bit varying` defaults carry the
+     *   same `"bit"` cast label.
+     * - Quoted literals with a cast (`'value'::type`, including type modifiers such as `character varying(10)`) to
+     *   the unquoted value with doubled quotes unescaped, delegated to {@see phpTypecast()}.
+     * - Numeric literals, optionally parenthesized and optionally cast (`42`, `1.5`, `(0)::numeric`), delegated to
      *   {@see phpTypecast()}.
+     * - Bare `true`/`false` to booleans.
+     *
+     * Everything else — operator expressions, function calls, `nextval(...)`, `CURRENT_*` keywords — becomes an
+     * executable {@see Expression}. Branch order is significant: the bit branches must precede the generic
+     * quoted-literal branch, or bit strings would be typecast as plain integers.
      *
      * @param mixed $value Raw default value in PostgreSQL schema metadata format.
      *
@@ -158,40 +169,31 @@ class ColumnSchema extends \yii\db\ColumnSchema
             return null;
         }
 
-        if (
-            in_array($this->type, [Schema::TYPE_TIMESTAMP, Schema::TYPE_DATE, Schema::TYPE_TIME], true)
-            && (
-                in_array(strtoupper($value), ['NOW()', 'CURRENT_TIMESTAMP', 'CURRENT_DATE', 'CURRENT_TIME'], true)
-                || strpos($value, '(') !== false
-            )
-        ) {
-            return new Expression($value);
-        }
-
-        if (preg_match("/^B'(.*?)'::/", $value, $matches)) {
-            return bindec($matches[1]);
-        }
-
-        if (preg_match("/^'(\d+)'::\"bit\"$/", $value, $matches)) {
-            return bindec($matches[1]);
-        }
-
-        if (preg_match("/^'(.*?)'::/", $value, $matches)) {
-            return $this->phpTypecast($matches[1]);
-        }
-
-        if ($this->type === Schema::TYPE_BOOLEAN) {
-            return $value === 'true';
-        }
-
-        // matches bare values, parenthesized values, and cast notation.
-        preg_match('/^(\()?(.*?)(?(1)\))(?:::.+)?$/', $value, $matches);
-
-        if ($matches[2] === 'NULL') {
+        if (preg_match('/^(?:NULL|\(NULL\))(?:::' . self::CAST_SUFFIX . ')?$/i', $value)) {
             return null;
         }
 
-        return $this->phpTypecast($matches[2]);
+        if (preg_match("/^B'([01]*)'::/", $value, $matches)) {
+            return bindec($matches[1]);
+        }
+
+        if (preg_match("/^'([01]+)'::\"bit\"$/", $value, $matches)) {
+            return bindec($matches[1]);
+        }
+
+        if (preg_match("/^'((?:[^']|'')*)'::" . self::CAST_SUFFIX . '$/s', $value, $matches)) {
+            return $this->phpTypecast(str_replace("''", "'", $matches[1]));
+        }
+
+        if (preg_match('/^(\()?(-?\d+(?:\.\d+)?)(?(1)\))(?:::' . self::CAST_SUFFIX . ')?$/', $value, $matches)) {
+            return $this->phpTypecast($matches[2]);
+        }
+
+        if ($value === 'true' || $value === 'false') {
+            return $value === 'true';
+        }
+
+        return new Expression($value);
     }
 
     /**

--- a/framework/db/pgsql/ColumnSchema.php
+++ b/framework/db/pgsql/ColumnSchema.php
@@ -173,7 +173,7 @@ class ColumnSchema extends \yii\db\ColumnSchema
             return null;
         }
 
-        if (preg_match("/^B'([01]*)'::/", $value, $matches)) {
+        if (preg_match("/^B'([01]*)'::" . self::CAST_SUFFIX . '$/', $value, $matches)) {
             return bindec($matches[1]);
         }
 

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -532,7 +532,7 @@ SQL;
                     $table->sequenceName = $column->sequenceName;
                 }
                 $column->defaultValue = null;
-            } elseif ($column->defaultValue !== null && !$column->autoIncrement) {
+            } else {
                 $column->defaultValue = $column->defaultPhpTypecast($column->defaultValue);
             }
         }

--- a/tests/framework/db/pgsql/ColumnSchemaTest.php
+++ b/tests/framework/db/pgsql/ColumnSchemaTest.php
@@ -155,8 +155,9 @@ final class ColumnSchemaTest extends BaseColumnSchema
         string $phpType,
         mixed $value,
         mixed $expected,
+        int $dimension = 0,
     ): void {
-        $column = $this->createColumn($type, $dbType, $phpType);
+        $column = $this->createColumn($type, $dbType, $phpType, $dimension);
 
         $result = $column->defaultPhpTypecast($value);
 

--- a/tests/framework/db/pgsql/CommandTest.php
+++ b/tests/framework/db/pgsql/CommandTest.php
@@ -19,6 +19,7 @@ use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\IntegrityException;
 use yii\db\JsonExpression;
+use yii\db\pgsql\ColumnSchema;
 use yii\db\pgsql\Schema;
 use yii\db\Query;
 use yiiunit\base\db\BaseCommand;
@@ -28,6 +29,7 @@ use yiiunit\support\DbHelper;
 use function array_diff;
 use function array_key_exists;
 use function array_keys;
+use function array_map;
 use function count;
 
 /**
@@ -98,6 +100,53 @@ class CommandTest extends BaseCommand
                 ->one($db),
             'Conflict must apply the update behavior.',
         );
+    }
+
+    public function testInsertReflectedExpressionDefaults(): void
+    {
+        $db = $this->getConnection(false);
+
+        $command = $db->createCommand();
+
+        DbHelper::dropTablesIfExist($db, ['expression_default_command_test']);
+
+        $command->createTable(
+            'expression_default_command_test',
+            [
+                'int_expression' => 'integer NOT NULL DEFAULT (1 + 2)',
+                'text_expression' => "text NOT NULL DEFAULT upper('abc'::text)",
+                'jsonb_expression' => 'jsonb NOT NULL DEFAULT jsonb_build_array()',
+                'int_literal' => 'integer NOT NULL DEFAULT 42',
+                'text_literal' => "varchar(100) NOT NULL DEFAULT 'abc'",
+                'jsonb_literal' => 'jsonb NOT NULL DEFAULT \'{"a":1}\'',
+                'serial_col' => 'serial',
+            ],
+        )->execute();
+
+        $columns = $db->getTableSchema('expression_default_command_test', true)->columns;
+
+        $command->insert(
+            'expression_default_command_test',
+            array_map(static fn (ColumnSchema $column): mixed => $column->defaultValue, $columns),
+        )->execute();
+
+        self::assertSame(
+            [
+                'int_expression' => 3,
+                'text_expression' => 'ABC',
+                'jsonb_expression' => '[]',
+                'int_literal' => 42,
+                'text_literal' => 'abc',
+                'jsonb_literal' => '{"a": 1}',
+                'serial_col' => 1,
+            ],
+            (new Query())
+                ->from('expression_default_command_test')
+                ->one($db),
+            'Row must match the engine-applied defaults.',
+        );
+
+        DbHelper::dropTablesIfExist($db, ['expression_default_command_test']);
     }
 
     public function testThrowIntegrityExceptionWhenConflictMatchesNonArbiterConstraint(): void

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -22,6 +22,7 @@ use yiiunit\data\ar\EnumTypeInCustomSchema;
 use yiiunit\data\ar\Type;
 use yiiunit\base\db\BaseSchema;
 use yiiunit\framework\db\pgsql\providers\SchemaProvider;
+use yiiunit\support\DbHelper;
 
 use function fclose;
 use function print_r;
@@ -554,13 +555,78 @@ final class SchemaTest extends BaseSchema
         );
     }
 
+    public function testLoadDefaultExpressionColumn(): void
+    {
+        $db = $this->getConnection(false);
+
+        $command = $db->createCommand();
+
+        DbHelper::dropTablesIfExist($db, ['default_expression_test']);
+
+        $command->createTable(
+            'default_expression_test',
+            [
+                'int_expression' => 'integer NOT NULL DEFAULT (1 + 2)',
+                'text_expression' => "text NOT NULL DEFAULT upper('abc'::text)",
+                'jsonb_expression' => 'jsonb NOT NULL DEFAULT jsonb_build_array()',
+                'int_literal' => 'integer NOT NULL DEFAULT 42',
+                'text_literal' => "varchar(100) NOT NULL DEFAULT 'abc'",
+                'jsonb_literal' => 'jsonb NOT NULL DEFAULT \'{"a":1}\'',
+                'serial_col' => 'serial',
+            ],
+        )->execute();
+
+        DbHelper::assertColumnDefaultExpression(
+            $db,
+            'default_expression_test',
+            'int_expression',
+            '(1 + 2)',
+        );
+        DbHelper::assertColumnDefaultExpression(
+            $db,
+            'default_expression_test',
+            'text_expression',
+            "upper('abc'::text)",
+        );
+        DbHelper::assertColumnDefaultExpression(
+            $db,
+            'default_expression_test',
+            'jsonb_expression',
+            'jsonb_build_array()',
+        );
+        DbHelper::assertColumnDefaultValue(
+            $db,
+            'default_expression_test',
+            'int_literal',
+            42,
+        );
+        DbHelper::assertColumnDefaultValue(
+            $db,
+            'default_expression_test',
+            'text_literal',
+            'abc',
+        );
+        DbHelper::assertColumnDefaultValue(
+            $db,
+            'default_expression_test',
+            'jsonb_literal',
+            ['a' => 1],
+        );
+        DbHelper::assertColumnDefaultExpression(
+            $db,
+            'default_expression_test',
+            'serial_col',
+            "nextval('default_expression_test_serial_col_seq'::regclass)",
+        );
+
+        DbHelper::dropTablesIfExist($db, ['default_expression_test']);
+    }
+
     public function testNonPrimaryKeySequenceDefaultIsPreserved(): void
     {
         $db = $this->getConnection(false);
 
-        if ($db->schema->getTableSchema('test_default_nextval') !== null) {
-            $db->createCommand()->dropTable('test_default_nextval')->execute();
-        }
+        DbHelper::dropTablesIfExist($db, ['test_default_nextval']);
 
         $sql = <<<SQL
         CREATE TABLE {{test_default_nextval}} (id serial PRIMARY KEY, counter_col serial)
@@ -574,13 +640,14 @@ final class SchemaTest extends BaseSchema
             $column->autoIncrement,
             'Sequence-backed column must be flagged auto-increment.',
         );
-        self::assertIsString(
+        self::assertInstanceOf(
+            Expression::class,
             $column->defaultValue,
-            "Sequence default must be preserved, not typecast to '0'.",
+            'Default must be an Expression.',
         );
-        self::assertStringContainsString(
-            'nextval',
-            $column->defaultValue,
+        self::assertSame(
+            "nextval('test_default_nextval_counter_col_seq'::regclass)",
+            (string) $column->defaultValue,
             'Sequence expression must be preserved.',
         );
     }

--- a/tests/framework/db/pgsql/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/pgsql/providers/ColumnSchemaProvider.php
@@ -68,6 +68,13 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 "B'10101'::bit(5)",
                 21,
             ],
+            'bit concatenation becomes an Expression' => [
+                'integer',
+                'bit',
+                'integer',
+                "B'1'::bit(1) || B'0'::bit(1)",
+                new Expression("B'1'::bit(1) || B'0'::bit(1)"),
+            ],
             'boolean false bare' => [
                 'boolean',
                 'bool',

--- a/tests/framework/db/pgsql/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/pgsql/providers/ColumnSchemaProvider.php
@@ -18,11 +18,35 @@ use yii\db\Expression;
 final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchemaProvider
 {
     /**
-     * @return array<string, array{string, string, string, mixed, mixed}>
+     * @return array<string, array{string, string, string, mixed, mixed, 5?: int}>
      */
     public static function defaultPhpTypecast(): array
     {
         return [
+            'array constructor becomes an Expression' => [
+                'integer',
+                'int4',
+                'integer',
+                'ARRAY[]::integer[]',
+                new Expression('ARRAY[]::integer[]'),
+                1,
+            ],
+            'array literal parses to typed array' => [
+                'integer',
+                'int4',
+                'integer',
+                "'{1,2}'::integer[]",
+                [1, 2],
+                1,
+            ],
+            'array literal with escaped quote parses to array' => [
+                'text',
+                'text',
+                'string',
+                "'{a''s,b}'::text[]",
+                ["a's", 'b'],
+                1,
+            ],
             'bare integer cast to int' => [
                 'integer',
                 'int4',
@@ -36,13 +60,6 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 'integer',
                 '0',
                 0,
-            ],
-            'bare string kept verbatim' => [
-                'string',
-                'varchar',
-                'string',
-                'hello',
-                'hello',
             ],
             'binary bit B\'10101\' on bit(5)' => [
                 'integer',
@@ -100,6 +117,20 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 "'hello'::character varying",
                 'hello',
             ],
+            'cast notation string with typmod' => [
+                'string',
+                'varchar',
+                'string',
+                "'xy'::character varying(10)",
+                'xy',
+            ],
+            'cast of cast NULL becomes an Expression' => [
+                'string',
+                'varchar',
+                'string',
+                '(NULL::text)::character varying',
+                new Expression('(NULL::text)::character varying'),
+            ],
             'complex timezone literal expression' => [
                 'timestamp',
                 'timestamp',
@@ -128,6 +159,34 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 'CURRENT_TIMESTAMP',
                 new Expression('CURRENT_TIMESTAMP'),
             ],
+            'integer expression becomes an Expression' => [
+                'integer',
+                'int4',
+                'integer',
+                '(1 + 2)',
+                new Expression('(1 + 2)'),
+            ],
+            'jsonb expression becomes an Expression' => [
+                'json',
+                'jsonb',
+                'array',
+                'jsonb_build_array()',
+                new Expression('jsonb_build_array()'),
+            ],
+            'jsonb literal decodes to array' => [
+                'json',
+                'jsonb',
+                'array',
+                '\'{"a": 1}\'::jsonb',
+                ['a' => 1],
+            ],
+            'nextval sequence becomes an Expression' => [
+                'integer',
+                'int4',
+                'integer',
+                "nextval('t_seq'::regclass)",
+                new Expression("nextval('t_seq'::regclass)"),
+            ],
             'now() lowercase preserves original casing' => [
                 'timestamp',
                 'timestamp',
@@ -147,6 +206,13 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 'timestamp',
                 'string',
                 null,
+                null,
+            ],
+            'NULL cast notation returns null' => [
+                'string',
+                'varchar',
+                'string',
+                'NULL::character varying',
                 null,
             ],
             'parenthesized NULL returns null' => [
@@ -176,6 +242,20 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 'integer',
                 '\'101\'::"bit"',
                 5,
+            ],
+            'quoted literal unescapes doubled quotes' => [
+                'string',
+                'varchar',
+                'string',
+                "'O''Reilly'::character varying",
+                "O'Reilly",
+            ],
+            'text expression becomes an Expression' => [
+                'text',
+                'text',
+                'string',
+                "upper('abc'::text)",
+                new Expression("upper('abc'::text)"),
             ],
             'timestamp literal not wrapped in expression' => [
                 'timestamp',

--- a/tests/framework/db/pgsql/providers/CommandProvider.php
+++ b/tests/framework/db/pgsql/providers/CommandProvider.php
@@ -428,8 +428,8 @@ final class CommandProvider
                 static fn (Connection $db): ColumnSchemaBuilder => $db->getSchema()
                     ->createColumnSchemaBuilder(Schema::TYPE_STRING)
                     ->defaultValue("O'Reilly"),
-                // Reflected metadata keeps the SQL-escaped doubled quote; inserted rows receive the plain value.
-                ['defaultValue' => "O''Reilly"],
+                // Reflected metadata unescapes the SQL doubled quote back to the plain value.
+                ['defaultValue' => "O'Reilly"],
             ],
             'builder type only' => [
                 'varchar(100)',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19747 
