### PR TITLE
Fix double @return attribute for ActiveRecord::hasOne

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.56 under development
 ------------------------
 
+- Bug #21020: Fix duplicate `@return` annotation for `yii\db\ActiveRecord::hasOne()` (nazard)
 - Bug #20873: Fix PHPDoc annotations for the `yii\log\Target::$enabled` (mspirkov)
 - Enh #20875: Clarify the type of the `yii\base\Model::$errors` (mspirkov)
 - Bug #20875: Fix `@return` annotation for `yii\base\Model::getErrors()` (mspirkov)

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -601,8 +601,6 @@ class ActiveRecord extends BaseActiveRecord
     /**
      * {@inheritdoc}
      *
-     * @return ActiveQuery
-     *
      * @template T of self
      *
      * @param class-string<T> $class the class name of the related record.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
