### PR TITLE
Load MSSQL expression-based column defaults, including sequence-backed `NEXT VALUE FOR` defaults, as executable `yii\db\Expression` instead of `null`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -135,6 +135,7 @@ Yii Framework 2 Change Log
 - Bug #20239: Add explicit `unionOrderBy()`, `addUnionOrderBy()`, `unionLimit()`, and `unionOffset()` query methods, and apply `ActiveDataProvider` sorting and pagination to the complete `UNION` result (terabytesoftw)
 - Bug #19747: Load MySQL expression-based column defaults (`DEFAULT_GENERATED`) as executable `yii\db\Expression` instead of raw strings, and expose MariaDB expression-form `TEXT`/`JSON` defaults as `yii\db\Expression` (terabytesoftw)
 - Bug #19747: Load PostgreSQL expression-based column defaults, including non-primary-key `serial` sequences, as executable `yii\db\Expression` (terabytesoftw)
+- Bug #19747: Load MSSQL expression-based column defaults, including sequence-backed `NEXT VALUE FOR` defaults, as executable `yii\db\Expression` instead of `null` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -633,6 +633,12 @@ checks, schema snapshots, and code that calls `ActiveRecord::loadDefaultValues()
 columns; on a non-primary-key `serial` column, `loadDefaultValues()` now assigns an `Expression` that advances the
 sequence when the record is saved. Primary-key and identity column defaults keep their current behavior.
 
+On MSSQL, expression-based column defaults reported by `sys.default_constraints` — such as `(getdate())`, `(newid())`,
+or `(NEXT VALUE FOR ...)` — now expose an executable `yii\db\Expression` through `ColumnSchema::$defaultValue` instead
+of `null`. Note that SQL Server normalizes the stored definition (`CURRENT_TIMESTAMP` reflects as `(getdate())`, and
+`(1 + 2)` as `((1)+(2))`). Binary literal defaults (`(0x...)`) now decode to their byte string. Review strict type
+checks, schema snapshots, and code that calls `ActiveRecord::loadDefaultValues()` for models containing these columns.
+
 ## Removed platform support
 
 ### HHVM

--- a/framework/db/mssql/ColumnSchema.php
+++ b/framework/db/mssql/ColumnSchema.php
@@ -15,6 +15,7 @@ use yii\db\ExpressionInterface;
 use yii\db\PdoValue;
 
 use function bin2hex;
+use function hex2bin;
 use function in_array;
 use function get_resource_type;
 use function is_resource;
@@ -110,12 +111,17 @@ class ColumnSchema extends \yii\db\ColumnSchema
     /**
      * Converts a MSSQL column default value to its PHP representation.
      *
-     * Handles MSSQL-specific default formats:
-     * - `null` or `(NULL)` to `null`.
-     * - `CURRENT_TIMESTAMP` on `timestamp` columns to `null` (server-managed value).
-     * - `('value')` / `(N'value')` string wrappers to the unwrapped literal with escaped quotes resolved.
-     * - `((number))` numeric wrapper to the unwrapped numeric string.
-     * - expression defaults such as `(getdate())` or `(newid())` to `null` (server-computed, not a literal).
+     * Recognizes the literal formats stored in `sys.default_constraints.definition` and typecasts only those:
+     * - `NULL` or any parenthesized form such as `(NULL)` to `null`.
+     * - Quoted strings (`('value')` / `(N'value')`, any parenthesis depth) to the unquoted value with doubled quotes
+     *   unescaped, delegated to {@see phpTypecast()}.
+     * - Parenthesized signed, decimal, or scientific numerics (`((0))`, `((-5))`, `((1.0e+005))`) delegated to
+     *   {@see phpTypecast()}.
+     * - Binary literals (`(0x...)`) to their byte string via `hex2bin()`.
+     *
+     * Everything else; function calls such as `(getdate())`, operator expressions such as `((1)+(2))`, or
+     * `(NEXT VALUE FOR ...)` sequences; becomes an executable {@see Expression}: the definition is SQL expression text
+     * and MSSQL exposes no literal-versus-expression metadata.
      *
      * @param mixed $value Default value in MSSQL `column_default` format.
      *
@@ -125,24 +131,23 @@ class ColumnSchema extends \yii\db\ColumnSchema
      */
     public function defaultPhpTypecast($value)
     {
-        if ($value === null || $value === '(NULL)') {
-            return null;
-        }
-
-        if ($this->type === Schema::TYPE_TIMESTAMP && $value === 'CURRENT_TIMESTAMP') {
+        if ($value === null) {
             return null;
         }
 
         if (is_string($value)) {
-            // String defaults: ('value') or unicode (N'value'); unwrap and resolve escaped single quotes.
-            if (preg_match("/^\(N?'(.*)'\)$/s", $value, $matches) === 1) {
-                $value = str_replace("''", "'", $matches[1]);
-            } elseif (preg_match('/^\(\((.+)\)\)$/s', $value, $matches) === 1) {
-                // Numeric defaults: ((`0`)), ((`42`)), ((`3.14`)).
-                $value = $matches[1];
-            } else {
-                // Expression defaults: (`getdate()`), (`newid()`); not representable as a PHP literal.
+            if (preg_match('/^(?:NULL|\(+NULL\)+)$/i', $value) === 1) {
                 return null;
+            }
+
+            if (preg_match("/^\(+N?'((?:''|[^'])*)'\)+$/is", $value, $matches) === 1) {
+                $value = str_replace("''", "'", $matches[1]);
+            } elseif (preg_match('/^\(+([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?)\)+$/i', $value, $matches) === 1) {
+                $value = $matches[1];
+            } elseif (preg_match('/^\(+0x((?:[0-9a-f]{2})*)\)+$/i', $value, $matches) === 1) {
+                $value = hex2bin($matches[1]);
+            } else {
+                return new Expression($value);
             }
         }
 

--- a/tests/framework/db/mssql/ColumnSchemaTest.php
+++ b/tests/framework/db/mssql/ColumnSchemaTest.php
@@ -94,10 +94,27 @@ final class ColumnSchemaTest extends BaseColumnSchema
             default => 'string',
         };
 
+        $result = $column->defaultPhpTypecast($value);
+
+        if (!$expected instanceof Expression) {
+            self::assertSame(
+                $expected,
+                $result,
+                'Converted default must match.',
+            );
+
+            return;
+        }
+
+        self::assertInstanceOf(
+            Expression::class,
+            $result,
+            'Default must yield an Expression.',
+        );
         self::assertSame(
-            $expected,
-            $column->defaultPhpTypecast($value),
-            'Converted default must match.',
+            $expected->expression,
+            $result->expression,
+            'Expression SQL must match.',
         );
     }
 

--- a/tests/framework/db/mssql/CommandTest.php
+++ b/tests/framework/db/mssql/CommandTest.php
@@ -13,6 +13,7 @@ namespace yiiunit\framework\db\mssql;
 use Closure;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
+use yii\db\ColumnSchema;
 use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\IntegrityException;
@@ -25,6 +26,7 @@ use yiiunit\support\DbHelper;
 
 use function array_key_exists;
 use function array_keys;
+use function array_map;
 use function json_encode;
 
 /**
@@ -46,6 +48,65 @@ final class CommandTest extends BaseCommand
         $sql = 'SELECT [[id]], [[t.name]] FROM {{customer}} t';
         $command = $db->createCommand($sql);
         $this->assertEquals('SELECT [id], [t].[name] FROM [customer] t', $command->sql);
+    }
+
+    public function testInsertReflectedExpressionDefaults(): void
+    {
+        $db = $this->getConnection(false);
+
+        $command = $db->createCommand();
+
+        $tableName = 'expression_default_command_test';
+        $sequenceName = 'expression_default_command_sequence';
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
+
+        $command->setSql(
+            <<<SQL
+            DROP SEQUENCE IF EXISTS [dbo].[{$sequenceName}]
+            SQL,
+        )->execute();
+        $command->setSql(
+            <<<SQL
+            CREATE SEQUENCE [dbo].[{$sequenceName}] AS bigint START WITH 1 INCREMENT BY 1
+            SQL,
+        )->execute();
+
+        $command->createTable(
+            $tableName,
+            [
+                'date_expression' => "date NOT NULL DEFAULT DATEADD(day, 2, CONVERT(date, '2011-11-11'))",
+                'text_expression' => "varchar(16) NOT NULL DEFAULT UPPER('abc')",
+                'int_expression' => 'int NOT NULL DEFAULT (1 + 2)',
+                'literal' => "nvarchar(32) NOT NULL DEFAULT N'O''Reilly'",
+                'serial_col' => "bigint NOT NULL DEFAULT NEXT VALUE FOR [dbo].[{$sequenceName}]",
+            ],
+        )->execute();
+
+        $columns = $db->getTableSchema($tableName, true)->columns;
+
+        $command->insert(
+            $tableName,
+            array_map(static fn (ColumnSchema $column): mixed => $column->defaultValue, $columns),
+        )->execute();
+
+        self::assertSame(
+            [
+                'date_expression' => '2011-11-13',
+                'text_expression' => 'ABC',
+                'int_expression' => '3',
+                'literal' => "O'Reilly",
+                'serial_col' => '1',
+            ],
+            (new Query())
+                ->from($tableName)
+                ->one($db),
+            'Row must match the engine-applied defaults.',
+        );
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
+
+        $command->setSql("DROP SEQUENCE IF EXISTS [dbo].[{$sequenceName}]")->execute();
     }
 
     public function testSelectExistsReturnsScalarExistenceFlag(): void

--- a/tests/framework/db/mssql/SchemaTest.php
+++ b/tests/framework/db/mssql/SchemaTest.php
@@ -21,6 +21,7 @@ use yii\db\mssql\Schema;
 use yii\db\mssql\TableSchema;
 use yiiunit\base\db\BaseSchema;
 use yiiunit\framework\db\mssql\providers\SchemaProvider;
+use yiiunit\support\DbHelper;
 
 use function array_diff;
 use function array_map;
@@ -483,9 +484,7 @@ final class SchemaTest extends BaseSchema
     {
         $db = $this->getConnection();
 
-        if ($db->getSchema()->getTableSchema('column_default') !== null) {
-            $db->createCommand()->dropTable('column_default')->execute();
-        }
+        DbHelper::dropTablesIfExist($db, ['column_default']);
 
         $db->createCommand()->createTable(
             'column_default',
@@ -494,6 +493,8 @@ final class SchemaTest extends BaseSchema
                 'created_getdate' => 'datetime DEFAULT GETDATE()',
                 'created_cts' => 'datetime DEFAULT CURRENT_TIMESTAMP',
                 'uuid' => 'uniqueidentifier DEFAULT NEWID()',
+                'number_expression' => 'int DEFAULT (1 + 2)',
+                'text_expression' => "varchar(32) DEFAULT ('a' + 'b')",
                 'status' => 'int DEFAULT 5',
                 'label' => "varchar(32) DEFAULT 'pending'",
                 'note' => "nvarchar(32) DEFAULT N'it''s'",
@@ -502,18 +503,23 @@ final class SchemaTest extends BaseSchema
 
         $table = $db->getSchema()->getTableSchema('column_default', true);
 
-        self::assertNull(
-            $table->getColumn('created_getdate')->defaultValue,
-            "Default must resolve to 'null'.",
-        );
-        self::assertNull(
-            $table->getColumn('created_cts')->defaultValue,
-            "Default must resolve to 'null'.",
-        );
-        self::assertNull(
-            $table->getColumn('uuid')->defaultValue,
-            "Default must resolve to 'null'.",
-        );
+        $expressionDefaults = [
+            'created_getdate' => '(getdate())',
+            'created_cts' => '(getdate())',
+            'uuid' => '(newid())',
+            'number_expression' => '((1)+(2))',
+            'text_expression' => "('a'+'b')",
+        ];
+
+        foreach ($expressionDefaults as $name => $expression) {
+            DbHelper::assertColumnDefaultExpression(
+                $db,
+                'column_default',
+                $name,
+                $expression,
+            );
+        }
+
         self::assertSame(
             5,
             $table->getColumn('status')->defaultValue,
@@ -530,7 +536,7 @@ final class SchemaTest extends BaseSchema
             'Escaped unicode default must unwrap.',
         );
 
-        $db->createCommand()->dropTable('column_default')->execute();
+        DbHelper::dropTablesIfExist($db, ['column_default']);
     }
 
     public function testInsertWithCompositePrimaryKey(): void

--- a/tests/framework/db/mssql/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/mssql/providers/ColumnSchemaProvider.php
@@ -119,30 +119,35 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
     public static function defaultPhpTypecast(): array
     {
         return [
-            'CURRENT_TIMESTAMP on timestamp column returns null' => [
-                Schema::TYPE_TIMESTAMP,
+            'bare token remains an expression' => [
+                Schema::TYPE_DATETIME,
                 'CURRENT_TIMESTAMP',
-                null,
+                new Expression('CURRENT_TIMESTAMP'),
+            ],
+            'binary literal is decoded' => [
+                Schema::TYPE_BINARY,
+                '(0x737472696E67)',
+                'string',
             ],
             'decimal default value unwrapped' => [
                 Schema::TYPE_DECIMAL,
                 '((3.14))',
                 '3.14',
             ],
-            'expression default getdate returns null' => [
+            'expression default getdate remains an expression' => [
                 Schema::TYPE_STRING,
                 '(getdate())',
-                null,
+                new Expression('(getdate())'),
             ],
-            'expression default newid returns null' => [
+            'expression default newid remains an expression' => [
                 Schema::TYPE_STRING,
                 '(newid())',
-                null,
+                new Expression('(newid())'),
             ],
-            'expression default sysdatetime returns null' => [
+            'expression default sysdatetime remains an expression' => [
                 Schema::TYPE_STRING,
                 '(sysdatetime())',
-                null,
+                new Expression('(sysdatetime())'),
             ],
             'integer default value unwrapped' => [
                 Schema::TYPE_INTEGER,
@@ -158,6 +163,31 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 Schema::TYPE_STRING,
                 null,
                 null,
+            ],
+            'numeric expression remains an expression' => [
+                Schema::TYPE_INTEGER,
+                '((1)+(2))',
+                new Expression('((1)+(2))'),
+            ],
+            'parenthesized null returns null' => [
+                Schema::TYPE_STRING,
+                '((NULL))',
+                null,
+            ],
+            'parenthesized unicode string with escaped single quotes' => [
+                Schema::TYPE_STRING,
+                "((N'O''Reilly'))",
+                "O'Reilly",
+            ],
+            'sequence default remains an expression' => [
+                Schema::TYPE_BIGINT,
+                '(NEXT VALUE FOR [dbo].[test_sequence])',
+                new Expression('(NEXT VALUE FOR [dbo].[test_sequence])'),
+            ],
+            'string concatenation remains an expression' => [
+                Schema::TYPE_STRING,
+                "('a'+'b')",
+                new Expression("('a'+'b')"),
             ],
             'string default value unwrapped' => [
                 Schema::TYPE_STRING,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19747 
