### PR TITLE
Load Oracle expression-based column defaults, including non-identity sequence `NEXTVAL` defaults, as executable `yii\db\Expression` instead of raw strings or `null`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -136,6 +136,7 @@ Yii Framework 2 Change Log
 - Bug #19747: Load MySQL expression-based column defaults (`DEFAULT_GENERATED`) as executable `yii\db\Expression` instead of raw strings, and expose MariaDB expression-form `TEXT`/`JSON` defaults as `yii\db\Expression` (terabytesoftw)
 - Bug #19747: Load PostgreSQL expression-based column defaults, including non-primary-key `serial` sequences, as executable `yii\db\Expression` (terabytesoftw)
 - Bug #19747: Load MSSQL expression-based column defaults, including sequence-backed `NEXT VALUE FOR` defaults, as executable `yii\db\Expression` instead of `null` (terabytesoftw)
+- Bug #19747: Load Oracle expression-based column defaults, including non-identity sequence `NEXTVAL` defaults, as executable `yii\db\Expression` instead of raw strings or `null` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -639,6 +639,14 @@ of `null`. Note that SQL Server normalizes the stored definition (`CURRENT_TIMES
 `(1 + 2)` as `((1)+(2))`). Binary literal defaults (`(0x...)`) now decode to their byte string. Review strict type
 checks, schema snapshots, and code that calls `ActiveRecord::loadDefaultValues()` for models containing these columns.
 
+On Oracle, expression-based column defaults reported by `ALL_TAB_COLUMNS.DATA_DEFAULT` — datetime literals and
+keywords, function calls, operator expressions, and sequence `NEXTVAL` defaults on non-identity columns — now expose
+an executable `yii\db\Expression` through `ColumnSchema::$defaultValue`. Previously most reflected as raw strings,
+while `timestamp` column defaults containing `TIMESTAMP`, such as `SYSTIMESTAMP` or `TO_TIMESTAMP(...)`, were
+discarded as `null`. Regular and national quoted strings and numeric literals remain PHP values; Oracle empty-string
+literals reflect as `null`. Review strict type checks, schema snapshots, and code that calls
+`ActiveRecord::loadDefaultValues()` for models containing these columns. Identity defaults remain `null`.
+
 ## Removed platform support
 
 ### HHVM

--- a/framework/db/oci/ColumnSchema.php
+++ b/framework/db/oci/ColumnSchema.php
@@ -18,10 +18,6 @@ use function is_resource;
 use function is_string;
 use function preg_match;
 use function str_replace;
-use function strcasecmp;
-use function stripos;
-use function strlen;
-use function substr;
 use function trim;
 
 /**
@@ -62,13 +58,13 @@ class ColumnSchema extends \yii\db\ColumnSchema
      * Converts an Oracle column default value to its PHP representation.
      *
      * Handles Oracle-specific default formats:
-     * - `null`, empty/whitespace string, or the `NULL` literal (any case) to `null`.
-     * - `CURRENT_TIMESTAMP[(precision)]` on `timestamp` columns to {@see Expression}, preserving precision.
-     * - server-managed timestamp defaults (`SYSTIMESTAMP`, `LOCALTIMESTAMP`, `TIMESTAMP 'literal'`,
-     *   `to_timestamp(...)`) on `timestamp` columns to `null`.
-     * - single-quote-wrapped string defaults (`'value'`) to the unwrapped literal, resolving doubled single quotes
-     *   (`''` to `'`).
-     * - everything else delegates to {@see \yii\db\ColumnSchema::defaultPhpTypecast()}.
+     * - `null`, empty/whitespace strings, and bare or parenthesized `NULL` to `null`.
+     * - regular and national string literals (`'value'` / `N'value'`) to their unquoted value, resolving doubled
+     *   single quotes (`''` to `'`). Oracle treats an empty string literal as `null`.
+     * - signed, decimal, scientific, `BINARY_FLOAT`, and `BINARY_DOUBLE` numeric literals through
+     *   {@see \yii\db\ColumnSchema::phpTypecast()}.
+     * - everything else to an executable {@see Expression}, including datetime literals, function calls, operator
+     *   expressions, alternative-quoted strings, and sequence `NEXTVAL` defaults.
      *
      * @param mixed $value Default value in Oracle `DATA_DEFAULT` format.
      *
@@ -82,30 +78,24 @@ class ColumnSchema extends \yii\db\ColumnSchema
             return null;
         }
 
-        $value = trim((string) $value);
+        if (is_string($value)) {
+            $value = trim($value);
 
-        if ($value === '' || strcasecmp($value, 'NULL') === 0) {
-            return null;
-        }
+            if ($value === '' || preg_match('/^(?:NULL|\(NULL\))$/i', $value) === 1) {
+                return null;
+            }
 
-        // `CURRENT_TIMESTAMP[(precision)]` on timestamp columns -> Expression (consistency with MySQL driver).
-        if (
-            $this->type === Schema::TYPE_TIMESTAMP
-            && preg_match('/^current_timestamp(?:\(([0-9]*)\))?$/i', $value, $matches) === 1
-        ) {
-            $precision = $matches[1] ?? '';
+            if (preg_match("/^N?'((?:''|[^'])*)'$/is", $value, $matches) === 1) {
+                $value = str_replace("''", "'", $matches[1]);
 
-            return new Expression('CURRENT_TIMESTAMP' . ($precision !== '' ? "({$precision})" : ''));
-        }
-
-        // server-managed timestamp defaults: `SYSTIMESTAMP`, `LOCALTIMESTAMP`, `TIMESTAMP` 'literal', to_timestamp(...).
-        if ($this->type === Schema::TYPE_TIMESTAMP && stripos($value, 'timestamp') !== false) {
-            return null;
-        }
-
-        // single-quote-wrapped string defaults: 'value' -> value, resolving doubled quotes ('' -> ').
-        if (strlen($value) > 2 && $value[0] === "'" && $value[-1] === "'") {
-            $value = str_replace("''", "'", substr($value, 1, -1));
+                if ($value === '') {
+                    return null;
+                }
+            } elseif (preg_match('/^([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?)[fd]?$/i', $value, $matches) === 1) {
+                $value = $matches[1];
+            } else {
+                return new Expression($value);
+            }
         }
 
         return parent::defaultPhpTypecast($value);

--- a/tests/data/ar/Type.php
+++ b/tests/data/ar/Type.php
@@ -23,6 +23,7 @@ namespace yiiunit\data\ar;
  * @property string $blob_col
  * @property float $numeric_col DEFAULT '33.22'
  * @property string $time DEFAULT '2002-01-01 00:00:00'
+ * @property string $ts_default DEFAULT CURRENT_TIMESTAMP
  * @property 1|0|'1'|'0'|bool $bool_col
  * @property 1|0|'1'|'0'|bool $bool_col2 DEFAULT 1
  */

--- a/tests/framework/db/oci/ActiveRecordTest.php
+++ b/tests/framework/db/oci/ActiveRecordTest.php
@@ -8,7 +8,9 @@
 
 namespace yiiunit\framework\db\oci;
 
+use PHPUnit\Framework\Attributes\Group;
 use yii\db\ActiveQuery;
+use yii\db\Expression;
 use yiiunit\data\ar\BitValues;
 use yiiunit\data\ar\DefaultPk;
 use yiiunit\data\ar\DefaultMultiplePk;
@@ -17,9 +19,13 @@ use yiiunit\data\ar\Type;
 use yiiunit\base\db\BaseActiveRecord;
 
 /**
- * @group db
- * @group oci
+ * Unit tests for {@see \yii\db\ActiveRecord} functionality for the Oracle driver.
+ *
+ * {@see CommandProvider} for test case data providers.
  */
+#[Group('db')]
+#[Group('oci')]
+#[Group('active-record')]
 class ActiveRecordTest extends BaseActiveRecord
 {
     protected $driverName = 'oci';
@@ -58,26 +64,78 @@ class ActiveRecordTest extends BaseActiveRecord
     public function testDefaultValues(): void
     {
         $model = new Type();
-        $model->loadDefaultValues();
-        $this->assertEquals(1, $model->int_col2);
-        $this->assertEquals('something', $model->char_col2);
-        $this->assertEquals(1.23, $model->float_col2);
-        $this->assertEquals(33.22, $model->numeric_col);
-        $this->assertEquals('1', $model->bool_col2);
 
-        // not testing $model->time, because oci\Schema can't read default value
+        $model->loadDefaultValues();
+
+        self::assertEquals(
+            1,
+            $model->int_col2,
+            'Integer default must be applied.',
+        );
+        self::assertEquals(
+            'something',
+            $model->char_col2,
+            'String default must be applied.',
+        );
+        self::assertEquals(
+            1.23,
+            $model->float_col2,
+            'Float default must be applied.',
+        );
+        self::assertEquals(
+            33.22,
+            $model->numeric_col,
+            'Numeric default must be applied.',
+        );
+        self::assertEquals(
+            '1',
+            $model->bool_col2,
+            'Boolean-like default must be applied.',
+        );
+        self::assertInstanceOf(
+            Expression::class,
+            $model->time,
+            'Default must be an Expression.',
+        );
+        self::assertSame(
+            "to_timestamp('2002-01-01 00:00:00', 'yyyy-mm-dd hh24:mi:ss')",
+            (string) $model->time,
+            'Default expression SQL must match.',
+        );
+        self::assertInstanceOf(
+            Expression::class,
+            $model->ts_default,
+            'Default must be an Expression.',
+        );
+        self::assertSame(
+            'CURRENT_TIMESTAMP',
+            (string) $model->ts_default,
+            'Default expression SQL must match.',
+        );
 
         $model = new Type();
+
         $model->char_col2 = 'not something';
 
         $model->loadDefaultValues();
-        $this->assertEquals('not something', $model->char_col2);
+
+        self::assertEquals(
+            'not something',
+            $model->char_col2,
+            'Assigned value must not be overwritten.',
+        );
 
         $model = new Type();
+
         $model->char_col2 = 'not something';
 
         $model->loadDefaultValues(false);
-        $this->assertEquals('something', $model->char_col2);
+
+        self::assertEquals(
+            'something',
+            $model->char_col2,
+            'Default must overwrite the assigned value.',
+        );
     }
 
     public function testFindAsArray(): void

--- a/tests/framework/db/oci/CommandTest.php
+++ b/tests/framework/db/oci/CommandTest.php
@@ -15,14 +15,17 @@ use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use Throwable;
 use yii\caching\ArrayCache;
+use yii\db\ColumnSchema;
 use yii\db\Connection;
 use yii\db\Expression;
 use yii\db\Query;
 use yii\db\Schema;
 use yiiunit\base\db\BaseCommand;
 use yiiunit\framework\db\oci\providers\CommandProvider;
+use yiiunit\support\DbHelper;
 
 use function array_keys;
+use function array_map;
 use function count;
 
 /**
@@ -102,6 +105,88 @@ class CommandTest extends BaseCommand
         $sql = 'SELECT [[id]], [[t.name]] FROM {{customer}} t';
         $command = $db->createCommand($sql);
         $this->assertEquals('SELECT "id", "t"."name" FROM "customer" t', $command->sql);
+    }
+
+    public function testInsertReflectedExpressionDefaults(): void
+    {
+        $db = $this->getConnection(false);
+
+        $command = $db->createCommand();
+
+        $tableName = 'expression_default_command_test';
+        $sequenceName = 'expression_default_command_sequence';
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
+
+        $command->setSql(
+            <<<SQL
+            BEGIN
+                EXECUTE IMMEDIATE 'DROP SEQUENCE "{$sequenceName}"';
+            EXCEPTION
+                WHEN OTHERS THEN
+                    IF SQLCODE != -2289 THEN
+                        RAISE;
+                    END IF;
+            END;
+            SQL,
+        )->execute();
+        $command->setSql(
+            <<<SQL
+            CREATE SEQUENCE "{$sequenceName}" START WITH 1 INCREMENT BY 1
+            SQL,
+        )->execute();
+
+        $command->createTable(
+            $tableName,
+            [
+                'date_expression' => "DATE DEFAULT (DATE '2011-11-11' + 2) NOT NULL",
+                'text_expression' => "VARCHAR2(16) DEFAULT UPPER('abc') NOT NULL",
+                'int_expression' => 'NUMBER(10, 0) DEFAULT (1 + 2) NOT NULL',
+                'timestamp_expression' => "TIMESTAMP DEFAULT TIMESTAMP '2011-11-11 12:34:56' NOT NULL",
+                'literal' => "VARCHAR2(32) DEFAULT 'O''Reilly' NOT NULL",
+                'serial_col' => "NUMBER(10, 0) DEFAULT \"{$sequenceName}\".NEXTVAL NOT NULL",
+            ],
+        )->execute();
+
+        $columns = $db->getTableSchema($tableName, true)->columns;
+
+        $command->insert(
+            $tableName,
+            array_map(static fn (ColumnSchema $column): mixed => $column->defaultValue, $columns),
+        )->execute();
+
+        self::assertSame(
+            [
+                'date_expression' => '2011-11-13',
+                'text_expression' => 'ABC',
+                'int_expression' => '3',
+                'timestamp_expression' => '2011-11-11 12:34:56',
+                'literal' => "O'Reilly",
+                'serial_col' => '1',
+            ],
+            (new Query())
+                ->select(
+                    [
+                        'date_expression' => new Expression(
+                            "TO_CHAR([[date_expression]], 'YYYY-MM-DD')",
+                        ),
+                        'text_expression',
+                        'int_expression',
+                        'timestamp_expression' => new Expression(
+                            "TO_CHAR([[timestamp_expression]], 'YYYY-MM-DD HH24:MI:SS')",
+                        ),
+                        'literal',
+                        'serial_col',
+                    ],
+                )
+                ->from($tableName)
+                ->one($db),
+            'Row must match the engine-applied defaults.',
+        );
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
+
+        $command->setSql("DROP SEQUENCE \"{$sequenceName}\"")->execute();
     }
 
     public function testBlobUpsertAffectedPrefixInStringLiteralDoesNotEnableOutputBinding(): void

--- a/tests/framework/db/oci/SchemaTest.php
+++ b/tests/framework/db/oci/SchemaTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\Group;
 use yii\db\ConstraintFinderInterface;
 use yii\db\TableSchema;
 use yiiunit\base\db\BaseSchema;
+use yiiunit\support\DbHelper;
 
 use function array_filter;
 use function array_values;
@@ -27,6 +28,58 @@ use function array_values;
 final class SchemaTest extends BaseSchema
 {
     public $driverName = 'oci';
+
+    public function testExpressionAndLiteralColumnDefaultValues(): void
+    {
+        $db = $this->getConnection(false);
+
+        $tableName = 'column_default';
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
+
+        $db->createCommand()->createTable(
+            $tableName,
+            [
+                'date_expression' => "DATE DEFAULT (DATE '2011-11-11' + 2)",
+                'text_expression' => "VARCHAR2(16) DEFAULT UPPER('abc')",
+                'number_expression' => 'NUMBER(10, 0) DEFAULT (1 + 2)',
+                'timestamp_expression' => "TIMESTAMP DEFAULT TIMESTAMP '2011-11-11 12:34:56'",
+                'number_literal' => 'NUMBER(10, 0) DEFAULT 42',
+                'text_literal' => "VARCHAR2(32) DEFAULT 'O''Reilly'",
+            ],
+        )->execute();
+
+        $expressionDefaults = [
+            'date_expression' => "(DATE '2011-11-11' + 2)",
+            'text_expression' => "UPPER('abc')",
+            'number_expression' => '(1 + 2)',
+            'timestamp_expression' => "TIMESTAMP '2011-11-11 12:34:56'",
+        ];
+
+        foreach ($expressionDefaults as $column => $expression) {
+            DbHelper::assertColumnDefaultExpression(
+                $db,
+                $tableName,
+                $column,
+                $expression,
+            );
+        }
+
+        DbHelper::assertColumnDefaultValue(
+            $db,
+            $tableName,
+            'number_literal',
+            42,
+        );
+        DbHelper::assertColumnDefaultValue(
+            $db,
+            $tableName,
+            'text_literal',
+            "O'Reilly",
+        );
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
+    }
 
     public function testGetTableSequenceNameResolvesIdentityColumnForModernTable(): void
     {

--- a/tests/framework/db/oci/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/oci/providers/ColumnSchemaProvider.php
@@ -58,12 +58,26 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
     public static function defaultPhpTypecast(): array
     {
         return [
-            'CURRENT_TIMESTAMP on non-timestamp column stays a literal' => [
+            'alternative-quoted string remains an expression' => [
+                'string',
+                'VARCHAR2',
+                'string',
+                "q'[O'Reilly]'",
+                new Expression("q'[O'Reilly]'"),
+            ],
+            'binary double suffix is removed before typecasting' => [
+                'double',
+                'BINARY_DOUBLE',
+                'double',
+                '1.25D',
+                1.25,
+            ],
+            'CURRENT_TIMESTAMP on non-timestamp column remains an expression' => [
                 'string',
                 'VARCHAR2',
                 'string',
                 'CURRENT_TIMESTAMP',
-                'CURRENT_TIMESTAMP',
+                new Expression('CURRENT_TIMESTAMP'),
             ],
             'CURRENT_TIMESTAMP on timestamp column returns Expression' => [
                 'timestamp',
@@ -107,19 +121,19 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 '33.22',
                 '33.22',
             ],
-            'doubled single quotes inside string are collapsed' => [
-                'string',
-                'VARCHAR2',
-                'string',
-                "'it''s'",
-                "it's",
-            ],
             'double default cast to float' => [
                 'double',
                 'FLOAT',
                 'double',
                 '1.23',
                 1.23,
+            ],
+            'doubled single quotes inside string are collapsed' => [
+                'string',
+                'VARCHAR2',
+                'string',
+                "'it''s'",
+                "it's",
             ],
             'empty string returns null' => [
                 'string',
@@ -135,47 +149,19 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 "''''",
                 "'",
             ],
-            'LOCALTIMESTAMP on timestamp column returns null' => [
+            'LOCALTIMESTAMP on timestamp column remains an expression' => [
                 'timestamp',
                 'TIMESTAMP(6)',
                 'string',
                 'LOCALTIMESTAMP',
-                null,
+                new Expression('LOCALTIMESTAMP'),
             ],
             'lowercase current_timestamp on timestamp column returns Expression' => [
                 'timestamp',
                 'TIMESTAMP(6)',
                 'string',
                 'current_timestamp',
-                new Expression('CURRENT_TIMESTAMP'),
-            ],
-            'negative decimal default kept as string' => [
-                'decimal',
-                'NUMBER',
-                'string',
-                '-33.22',
-                '-33.22',
-            ],
-            'negative integer default cast to int' => [
-                'integer',
-                'NUMBER',
-                'integer',
-                '-123',
-                -123,
-            ],
-            'null value returns null' => [
-                'timestamp',
-                'TIMESTAMP(6)',
-                'string',
-                null,
-                null,
-            ],
-            'NULL literal returns null' => [
-                'string',
-                'VARCHAR2',
-                'string',
-                'NULL',
-                null,
+                new Expression('current_timestamp'),
             ],
             'lowercase null literal returns null' => [
                 'string',
@@ -191,12 +177,40 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 'Null',
                 null,
             ],
-            'quoted null string literal is preserved' => [
+            'national string default is unwrapped' => [
+                'string',
+                'NVARCHAR2',
+                'string',
+                "N'O''Reilly'",
+                "O'Reilly",
+            ],
+            'negative decimal default kept as string' => [
+                'decimal',
+                'NUMBER',
+                'string',
+                '-33.22',
+                '-33.22',
+            ],
+            'negative integer default cast to int' => [
+                'integer',
+                'NUMBER',
+                'integer',
+                '-123',
+                -123,
+            ],
+            'NULL literal returns null' => [
                 'string',
                 'VARCHAR2',
                 'string',
-                "'null'",
-                'null',
+                'NULL',
+                null,
+            ],
+            'null value returns null' => [
+                'timestamp',
+                'TIMESTAMP(6)',
+                'string',
+                null,
+                null,
             ],
             'numeric char default kept as string' => [
                 'string',
@@ -204,6 +218,34 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 'string',
                 '130',
                 '130',
+            ],
+            'operator expression remains an expression' => [
+                'integer',
+                'NUMBER',
+                'integer',
+                '(1 + 2)',
+                new Expression('(1 + 2)'),
+            ],
+            'parenthesized NULL literal returns null' => [
+                'string',
+                'VARCHAR2',
+                'string',
+                '(NULL)',
+                null,
+            ],
+            'quoted empty string returns null' => [
+                'string',
+                'VARCHAR2',
+                'string',
+                "''",
+                null,
+            ],
+            'quoted null string literal is preserved' => [
+                'string',
+                'VARCHAR2',
+                'string',
+                "'null'",
+                'null',
             ],
             'quoted string containing timestamp keyword is preserved' => [
                 'string',
@@ -219,6 +261,20 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 '42',
                 42,
             ],
+            'scientific numeric default is typecast' => [
+                'double',
+                'FLOAT',
+                'double',
+                '1.25e2',
+                125.0,
+            ],
+            'sequence NEXTVAL remains an expression' => [
+                'integer',
+                'NUMBER',
+                'integer',
+                'test_sequence.NEXTVAL',
+                new Expression('test_sequence.NEXTVAL'),
+            ],
             'single-quoted char default is unwrapped' => [
                 'string',
                 'CHAR',
@@ -233,33 +289,47 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 "'something'",
                 'something',
             ],
-            'SYSTIMESTAMP on timestamp column returns null' => [
+            'string concatenation is not mistaken for a quoted literal' => [
+                'string',
+                'VARCHAR2',
+                'string',
+                "'a' || 'b'",
+                new Expression("'a' || 'b'"),
+            ],
+            'SYSDATE on date column remains an expression' => [
+                'string',
+                'DATE',
+                'string',
+                'SYSDATE',
+                new Expression('SYSDATE'),
+            ],
+            'SYSTIMESTAMP on timestamp column remains an expression' => [
                 'timestamp',
                 'TIMESTAMP(6)',
                 'string',
                 'SYSTIMESTAMP',
-                null,
+                new Expression('SYSTIMESTAMP'),
             ],
-            'TIMESTAMP literal on timestamp column returns null' => [
+            'TIMESTAMP literal on timestamp column remains an expression' => [
                 'timestamp',
                 'TIMESTAMP(6)',
                 'string',
                 "TIMESTAMP '2002-01-01 00:00:00'",
-                null,
+                new Expression("TIMESTAMP '2002-01-01 00:00:00'"),
             ],
-            'to_timestamp expression on timestamp column returns null' => [
+            'to_timestamp expression on timestamp column remains an expression' => [
                 'timestamp',
                 'TIMESTAMP(6)',
                 'string',
                 "to_timestamp('2002-01-01 00:00:00', 'yyyy-mm-dd hh24:mi:ss')",
-                null,
+                new Expression("to_timestamp('2002-01-01 00:00:00', 'yyyy-mm-dd hh24:mi:ss')"),
             ],
-            'unquoted string default kept verbatim' => [
+            'unquoted string default remains an expression' => [
                 'string',
                 'VARCHAR2',
                 'string',
                 'hello',
-                'hello',
+                new Expression('hello'),
             ],
             'whitespace-only string returns null' => [
                 'string',
@@ -327,7 +397,9 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
         $columns['time']['dbType'] = 'TIMESTAMP(6)';
         $columns['time']['size'] = 11;
         $columns['time']['scale'] = 6;
-        $columns['time']['defaultValue'] = null;
+        $columns['time']['defaultValue'] = new Expression(
+            "to_timestamp('2002-01-01 00:00:00', 'yyyy-mm-dd hh24:mi:ss')",
+        );
         $columns['bool_col']['type'] = 'string';
         $columns['bool_col']['phpType'] = 'string';
         $columns['bool_col']['dbType'] = 'CHAR';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19747 
