### PR TITLE
Load SQLite expression-based column defaults as executable `yii\db\Expression` instead of mangled or raw values.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -137,6 +137,7 @@ Yii Framework 2 Change Log
 - Bug #19747: Load PostgreSQL expression-based column defaults, including non-primary-key `serial` sequences, as executable `yii\db\Expression` (terabytesoftw)
 - Bug #19747: Load MSSQL expression-based column defaults, including sequence-backed `NEXT VALUE FOR` defaults, as executable `yii\db\Expression` instead of `null` (terabytesoftw)
 - Bug #19747: Load Oracle expression-based column defaults, including non-identity sequence `NEXTVAL` defaults, as executable `yii\db\Expression` instead of raw strings or `null` (terabytesoftw)
+- Bug #19747: Load SQLite expression-based column defaults as executable `yii\db\Expression` instead of mangled or raw values (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -647,6 +647,14 @@ discarded as `null`. Regular and national quoted strings and numeric literals re
 literals reflect as `null`. Review strict type checks, schema snapshots, and code that calls
 `ActiveRecord::loadDefaultValues()` for models containing these columns. Identity defaults remain `null`.
 
+On SQLite, expression-based column defaults reported by `PRAGMA table_info` — operator expressions, function calls,
+`CURRENT_DATE`, `CURRENT_TIME`, and `CURRENT_TIMESTAMP` — now expose an executable `yii\db\Expression` through
+`ColumnSchema::$defaultValue`. SQLite BLOB literals and hexadecimal integer literals are also exposed as expressions
+because their values are only preserved when parsed as SQL. Previously Yii2 mangled `integer DEFAULT (1 + 2)` to
+`1`, `integer DEFAULT 0x10` to `0`, and reflected function calls and BLOB literals as plain strings. Quoted,
+decimal, boolean, and SQLite bareword defaults remain PHP values. Review strict type checks, schema snapshots, and code
+that calls `ActiveRecord::loadDefaultValues()` for models containing these columns.
+
 ## Removed platform support
 
 ### HHVM

--- a/framework/db/sqlite/ColumnSchema.php
+++ b/framework/db/sqlite/ColumnSchema.php
@@ -13,10 +13,10 @@ namespace yii\db\sqlite;
 use yii\db\Expression;
 
 use function is_string;
+use function preg_match;
 use function str_replace;
 use function strcasecmp;
-use function strlen;
-use function substr;
+use function strtoupper;
 use function trim;
 
 /**
@@ -31,11 +31,18 @@ class ColumnSchema extends \yii\db\ColumnSchema
      * Converts a SQLite column default value to its PHP representation.
      *
      * Handles SQLite-specific default formats reported by `PRAGMA table_info`:
-     * - `null`, empty string, or the `NULL` literal (any case) to `null`.
-     * - `CURRENT_TIMESTAMP` (any case) on `timestamp` columns to {@see Expression}.
-     * - single/double-quote-wrapped string defaults (`'value'`, `"value"`) to the unwrapped literal, resolving doubled
-     *   quotes (`''` to `'`, `""` to `"`).
-     * - non-string values and everything else delegate to {@see \yii\db\ColumnSchema::defaultPhpTypecast()}.
+     * - `null`, empty strings, and bare or parenthesized `NULL` to `null`.
+     * - `CURRENT_DATE`, `CURRENT_TIME`, and `CURRENT_TIMESTAMP` to {@see Expression}.
+     * - single, double, backtick, or bracket-quoted string literals to their unquoted PHP value.
+     * - signed decimal and scientific numeric literals through {@see \yii\db\ColumnSchema::phpTypecast()}.
+     * - `TRUE` and `FALSE` through {@see \yii\db\ColumnSchema::phpTypecast()} as `1` and `0` respectively.
+     * - bareword defaults to their literal text value, matching SQLite's non-parenthesized `DEFAULT word` behavior.
+     * - everything else to an executable {@see Expression}, including functions, operators, BLOB literals, and
+     *   hexadecimal integers whose meaning is only preserved when parsed as SQL text.
+     *
+     * Branch order is significant: `CURRENT_*` and `TRUE`/`FALSE` must precede the bareword fallthrough, or they would
+     * reflect as string literals. `PRAGMA table_info` strips one outer parenthesis level; paren-tolerant branches exist
+     * only for literals that are also legal inside a parenthesized default expression.
      *
      * @link https://www.sqlite.org/lang_createtable.html#the_default_clause
      *
@@ -50,19 +57,34 @@ class ColumnSchema extends \yii\db\ColumnSchema
         if (is_string($value)) {
             $value = trim($value);
 
-            if ($value === '' || strcasecmp($value, 'NULL') === 0) {
+            if ($value === '' || preg_match('/^\(*\s*NULL\s*\)*$/i', $value) === 1) {
                 return null;
             }
 
-            // `CURRENT_TIMESTAMP` is a case-independent keyword (consistency with all driver).
-            if ($this->type === Schema::TYPE_TIMESTAMP && strcasecmp($value, 'CURRENT_TIMESTAMP') === 0) {
-                return new Expression('CURRENT_TIMESTAMP');
+            if (preg_match('/^\(*\s*(CURRENT_DATE|CURRENT_TIME|CURRENT_TIMESTAMP)\s*\)*$/i', $value, $matches) === 1) {
+                return new Expression(strtoupper($matches[1]));
             }
 
-            // quote-wrapped defaults: 'value' / "value" -> unwrapped, resolving doubled quotes ('' -> ', "" -> ").
-            if (strlen($value) > 1 && ($value[0] === "'" || $value[0] === '"') && $value[-1] === $value[0]) {
-                $quote = $value[0];
-                $value = str_replace($quote . $quote, $quote, substr($value, 1, -1));
+            if (preg_match("/^\(*\s*'((?:''|[^'])*)'\s*\)*$/", $value, $matches) === 1) {
+                $value = str_replace("''", "'", $matches[1]);
+            } elseif (preg_match('/^\(*\s*"((?:""|[^"])*)"\s*\)*$/', $value, $matches) === 1) {
+                $value = str_replace('""', '"', $matches[1]);
+            } elseif (preg_match('/^`((?:``|[^`])*)`$/', $value, $matches) === 1) {
+                $value = str_replace('``', '`', $matches[1]);
+            } elseif (preg_match('/^\[([^]]*)]$/', $value, $matches) === 1) {
+                $value = $matches[1];
+            } elseif (
+                preg_match(
+                    '/^\(*\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?)\s*\)*$/i',
+                    $value,
+                    $matches,
+                ) === 1
+            ) {
+                $value = $matches[1];
+            } elseif (preg_match('/^\(*\s*(TRUE|FALSE)\s*\)*$/i', $value, $matches) === 1) {
+                $value = strcasecmp($matches[1], 'TRUE') === 0 ? 1 : 0;
+            } elseif (preg_match('/^[\p{L}_$][\p{L}\p{N}_$]*$/u', $value) !== 1) {
+                return new Expression($value);
             }
         }
 

--- a/tests/framework/db/sqlite/CommandTest.php
+++ b/tests/framework/db/sqlite/CommandTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\base\InvalidArgumentException;
 use yii\base\NotSupportedException;
+use yii\db\ColumnSchema;
 use yii\db\Connection;
 use yii\db\Exception;
 use yii\db\Expression;
@@ -25,6 +26,7 @@ use yiiunit\framework\db\sqlite\providers\CommandProvider;
 use yiiunit\support\DbHelper;
 
 use function array_keys;
+use function array_map;
 
 /**
  * Unit tests for {@see \yii\db\sqlite\Command} functionality for the SQLite driver.
@@ -103,6 +105,58 @@ class CommandTest extends BaseCommand
         $sql = 'SELECT [[id]], [[t.name]] FROM {{customer}} t';
         $command = $db->createCommand($sql);
         $this->assertEquals('SELECT `id`, `t`.`name` FROM `customer` t', $command->sql);
+    }
+
+    public function testInsertReflectedExpressionDefaults(): void
+    {
+        $db = $this->getConnection(false);
+
+        $command = $db->createCommand();
+        $tableName = 'expression_default_command_test';
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
+
+        $command->createTable(
+            $tableName,
+            [
+                'int_expression' => 'integer NOT NULL DEFAULT (1 + 2)',
+                'text_expression' => "text NOT NULL DEFAULT (upper('abc'))",
+                'date_expression' => "text NOT NULL DEFAULT (date('2011-11-11', '+2 days'))",
+                'blob_expression' => "blob NOT NULL DEFAULT x'414243'",
+                'hex_expression' => 'integer NOT NULL DEFAULT 0x10',
+                'int_literal' => 'integer NOT NULL DEFAULT 42',
+                'text_literal' => "text NOT NULL DEFAULT 'O''Reilly'",
+                'bool_literal' => 'boolean NOT NULL DEFAULT TRUE',
+                'bareword_literal' => 'text NOT NULL DEFAULT pending',
+            ],
+        )->execute();
+
+        $columns = $db->getTableSchema($tableName, true)->columns;
+
+        $command->insert(
+            $tableName,
+            array_map(static fn (ColumnSchema $column): mixed => $column->defaultValue, $columns),
+        )->execute();
+
+        self::assertSame(
+            [
+                'int_expression' => '3',
+                'text_expression' => 'ABC',
+                'date_expression' => '2011-11-13',
+                'blob_expression' => 'ABC',
+                'hex_expression' => '16',
+                'int_literal' => '42',
+                'text_literal' => "O'Reilly",
+                'bool_literal' => '1',
+                'bareword_literal' => 'pending',
+            ],
+            (new Query())
+                ->from($tableName)
+                ->one($db),
+            'Row must match the engine-applied defaults.',
+        );
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
     }
 
     public function testCheckIntegrityDisablesForeignKeysOutsideTransaction(): void

--- a/tests/framework/db/sqlite/SchemaTest.php
+++ b/tests/framework/db/sqlite/SchemaTest.php
@@ -17,6 +17,7 @@ use yii\db\Expression;
 use yii\db\Transaction;
 use yii\db\sqlite\Schema;
 use yiiunit\base\db\BaseSchema;
+use yiiunit\support\DbHelper;
 
 /**
  * Unit tests for {@see \yii\db\sqlite\Schema} schema reflection and metadata retrieval for the SQLite driver.
@@ -205,31 +206,85 @@ final class SchemaTest extends BaseSchema
         );
     }
 
-    public function testExpressionDefaultValueIsPreservedAsString(): void
+    public function testLoadDefaultExpressionColumn(): void
     {
         $db = $this->getConnection(false);
 
-        if ($db->schema->getTableSchema('test_default_expression') !== null) {
-            $db->createCommand()->dropTable('test_default_expression')->execute();
-        }
+        $tableName = 'default_expression_test';
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
 
         $db->createCommand()->createTable(
-            'test_default_expression',
+            $tableName,
             [
-                'id' => 'pk',
-                'expr_col' => "text DEFAULT (datetime('now'))",
+                'int_expression' => 'integer NOT NULL DEFAULT (1 + 2)',
+                'text_expression' => "text NOT NULL DEFAULT (upper('abc'))",
+                'date_expression' => "text NOT NULL DEFAULT (date('2011-11-11', '+2 days'))",
+                'blob_expression' => "blob NOT NULL DEFAULT x'414243'",
+                'hex_expression' => 'integer NOT NULL DEFAULT 0x10',
+                'int_literal' => 'integer NOT NULL DEFAULT 42',
+                'text_literal' => "text NOT NULL DEFAULT 'O''Reilly'",
+                'bool_literal' => 'boolean NOT NULL DEFAULT TRUE',
+                'bareword_literal' => 'text NOT NULL DEFAULT pending',
             ],
         )->execute();
 
-        $db->schema->refreshTableSchema('test_default_expression');
-
-        $tableSchema = $db->schema->getTableSchema('test_default_expression');
-
-        self::assertSame(
-            "datetime('now')",
-            $tableSchema->getColumn('expr_col')->defaultValue,
-            'Expression default must be preserved verbatim.',
+        DbHelper::assertColumnDefaultExpression(
+            $db,
+            $tableName,
+            'int_expression',
+            '1 + 2',
         );
+        DbHelper::assertColumnDefaultExpression(
+            $db,
+            $tableName,
+            'text_expression',
+            "upper('abc')",
+        );
+        DbHelper::assertColumnDefaultExpression(
+            $db,
+            $tableName,
+            'date_expression',
+            "date('2011-11-11', '+2 days')",
+        );
+        DbHelper::assertColumnDefaultExpression(
+            $db,
+            $tableName,
+            'blob_expression',
+            "x'414243'",
+        );
+        DbHelper::assertColumnDefaultExpression(
+            $db,
+            $tableName,
+            'hex_expression',
+            '0x10',
+        );
+        DbHelper::assertColumnDefaultValue(
+            $db,
+            $tableName,
+            'int_literal',
+            42,
+        );
+        DbHelper::assertColumnDefaultValue(
+            $db,
+            $tableName,
+            'text_literal',
+            "O'Reilly",
+        );
+        DbHelper::assertColumnDefaultValue(
+            $db,
+            $tableName,
+            'bool_literal',
+            true,
+        );
+        DbHelper::assertColumnDefaultValue(
+            $db,
+            $tableName,
+            'bareword_literal',
+            'pending',
+        );
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
     }
 
     public function testPrimaryKeyDefaultValueIsNull(): void

--- a/tests/framework/db/sqlite/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/sqlite/providers/ColumnSchemaProvider.php
@@ -44,12 +44,33 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 42,
                 42,
             ],
-            'blob literal passes through raw' => [
+            'arithmetic expression returns Expression' => [
+                'integer',
+                'integer',
+                'integer',
+                '1 + 2',
+                new Expression('1 + 2'),
+            ],
+            'backtick-quoted string resolves doubled quotes' => [
+                'string',
+                'varchar(32)',
+                'string',
+                '`do``uble`',
+                'do`uble',
+            ],
+            'bareword default remains a string literal' => [
+                'string',
+                'text',
+                'string',
+                'pending',
+                'pending',
+            ],
+            'blob literal remains an expression' => [
                 'binary',
                 'blob',
                 'resource',
                 "x'414243'",
-                "x'414243'",
+                new Expression("x'414243'"),
             ],
             'boolean keyword FALSE returns false' => [
                 'boolean',
@@ -79,19 +100,26 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 '0',
                 false,
             ],
-            'CURRENT_DATE on date column passes through as string' => [
-                'date',
-                'date',
+            'bracket-quoted string is unwrapped' => [
                 'string',
-                'CURRENT_DATE',
-                'CURRENT_DATE',
+                'varchar(32)',
+                'string',
+                '[hello world]',
+                'hello world',
             ],
-            'CURRENT_TIME on time column passes through as string' => [
+            'CURRENT_DATE on date column returns Expression' => [
+                'date',
+                'date',
+                'string',
+                'CURRENT_DATE',
+                new Expression('CURRENT_DATE'),
+            ],
+            'CURRENT_TIME on time column returns Expression' => [
                 'time',
                 'time',
                 'string',
                 'CURRENT_TIME',
-                'CURRENT_TIME',
+                new Expression('CURRENT_TIME'),
             ],
             'CURRENT_TIMESTAMP lowercase on timestamp column returns Expression' => [
                 'timestamp',
@@ -107,19 +135,19 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 'Current_Timestamp',
                 new Expression('CURRENT_TIMESTAMP'),
             ],
-            'CURRENT_TIMESTAMP on datetime column passes through as string' => [
+            'CURRENT_TIMESTAMP on datetime column returns Expression' => [
                 'datetime',
                 'datetime',
                 'string',
                 'CURRENT_TIMESTAMP',
-                'CURRENT_TIMESTAMP',
+                new Expression('CURRENT_TIMESTAMP'),
             ],
-            'CURRENT_TIMESTAMP on string column passes through as string' => [
+            'CURRENT_TIMESTAMP on string column returns Expression' => [
                 'string',
                 'varchar',
                 'string',
                 'CURRENT_TIMESTAMP',
-                'CURRENT_TIMESTAMP',
+                new Expression('CURRENT_TIMESTAMP'),
             ],
             'CURRENT_TIMESTAMP on timestamp column returns Expression' => [
                 'timestamp',
@@ -170,6 +198,13 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 '',
                 null,
             ],
+            'expression default returns Expression' => [
+                'text',
+                'text',
+                'string',
+                "datetime('now')",
+                new Expression("datetime('now')"),
+            ],
             'Expression object passes through without string coercion' => [
                 'integer',
                 'integer',
@@ -177,12 +212,12 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 new Expression('1 + 2'),
                 new Expression('1 + 2'),
             ],
-            'expression default passes through as string' => [
-                'text',
-                'text',
-                'string',
-                "datetime('now')",
-                "datetime('now')",
+            'hexadecimal integer remains an expression' => [
+                'integer',
+                'integer',
+                'integer',
+                '0x10',
+                new Expression('0x10'),
             ],
             'integer default' => [
                 'integer',
@@ -233,6 +268,34 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 null,
                 null,
             ],
+            'parenthesized blob literal remains an expression' => [
+                'binary',
+                'blob',
+                'resource',
+                "(x'414243')",
+                new Expression("(x'414243')"),
+            ],
+            'parenthesized integer default is unwrapped and cast' => [
+                'integer',
+                'integer',
+                'integer',
+                '(42)',
+                42,
+            ],
+            'parenthesized NULL literal returns null' => [
+                'string',
+                'varchar(32)',
+                'string',
+                '(NULL)',
+                null,
+            ],
+            'parenthesized string default is unwrapped' => [
+                'string',
+                'varchar(32)',
+                'string',
+                "('hello')",
+                'hello',
+            ],
             'plus-signed integer default' => [
                 'integer',
                 'integer',
@@ -261,6 +324,13 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 "'-123'",
                 -123,
             ],
+            'scientific numeric default is cast' => [
+                'double',
+                'double',
+                'double',
+                '1.25e2',
+                125.0,
+            ],
             'single-quoted string default is unwrapped' => [
                 'string',
                 'varchar(32)',
@@ -274,6 +344,13 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
                 'string',
                 "'it''s'",
                 "it's",
+            ],
+            'string concatenation returns Expression' => [
+                'text',
+                'text',
+                'string',
+                "'a' || 'b'",
+                new Expression("'a' || 'b'"),
             ],
             'timestamp literal default is unwrapped' => [
                 'timestamp',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #19747 

