### PR TITLE
Fix slow MySQL/MariaDB constraint metadata loading by replacing the `information_schema` `UNION` query with a single `STATISTICS` query and a dedicated foreign key query.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -138,6 +138,7 @@ Yii Framework 2 Change Log
 - Bug #19747: Load MSSQL expression-based column defaults, including sequence-backed `NEXT VALUE FOR` defaults, as executable `yii\db\Expression` instead of `null` (terabytesoftw)
 - Bug #19747: Load Oracle expression-based column defaults, including non-identity sequence `NEXTVAL` defaults, as executable `yii\db\Expression` instead of raw strings or `null` (terabytesoftw)
 - Bug #19747: Load SQLite expression-based column defaults as executable `yii\db\Expression` instead of mangled or raw values (terabytesoftw)
+- Bug #16265: Fix slow MySQL/MariaDB constraint metadata loading by replacing the `information_schema` `UNION` query with a single `STATISTICS` query and a dedicated foreign key query (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -150,7 +150,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function loadTablePrimaryKey($tableName)
     {
-        return $this->loadTableConstraints($tableName, 'primaryKey');
+        return $this->loadTableIndexMetadata($tableName, 'primaryKey');
     }
 
     /**
@@ -158,40 +158,61 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function loadTableForeignKeys($tableName)
     {
-        return $this->loadTableConstraints($tableName, 'foreignKeys');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function loadTableIndexes($tableName)
-    {
-        static $sql = <<<'SQL'
-SELECT
-    `s`.`INDEX_NAME` AS `name`,
-    `s`.`COLUMN_NAME` AS `column_name`,
-    `s`.`NON_UNIQUE` ^ 1 AS `index_is_unique`,
-    `s`.`INDEX_NAME` = 'PRIMARY' AS `index_is_primary`
-FROM `information_schema`.`STATISTICS` AS `s`
-WHERE `s`.`TABLE_SCHEMA` = COALESCE(:schemaName, DATABASE()) AND `s`.`INDEX_SCHEMA` = `s`.`TABLE_SCHEMA` AND `s`.`TABLE_NAME` = :tableName
-ORDER BY `s`.`SEQ_IN_INDEX` ASC
-SQL;
+        $sql = <<<SQL
+        SELECT
+            `kcu`.`CONSTRAINT_NAME` AS `name`,
+            `kcu`.`COLUMN_NAME` AS `column_name`,
+            CASE
+                WHEN :schemaName IS NULL AND `kcu`.`REFERENCED_TABLE_SCHEMA` = DATABASE() THEN NULL
+                ELSE `kcu`.`REFERENCED_TABLE_SCHEMA`
+            END AS `foreign_table_schema`,
+            `kcu`.`REFERENCED_TABLE_NAME` AS `foreign_table_name`,
+            `kcu`.`REFERENCED_COLUMN_NAME` AS `foreign_column_name`,
+            `rc`.`UPDATE_RULE` AS `on_update`,
+            `rc`.`DELETE_RULE` AS `on_delete`
+        FROM `information_schema`.`KEY_COLUMN_USAGE` AS `kcu`
+        INNER JOIN `information_schema`.`REFERENTIAL_CONSTRAINTS` AS `rc` ON
+            `rc`.`CONSTRAINT_SCHEMA` = COALESCE(:schemaName2, DATABASE())
+            AND `rc`.`TABLE_NAME` = :tableName1
+            AND `rc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME`
+        WHERE
+            `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName1, DATABASE())
+            AND `kcu`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA`
+            AND `kcu`.`TABLE_NAME` = :tableName
+        ORDER BY `kcu`.`ORDINAL_POSITION` ASC
+        SQL;
 
         $resolvedName = $this->resolveTableName($tableName);
-        $indexes = $this->db->createCommand($sql, [
-            ':schemaName' => $resolvedName->schemaName,
-            ':tableName' => $resolvedName->name,
-        ])->queryAll();
-        $indexes = $this->normalizePdoRowKeyCase($indexes, true);
-        $indexes = ArrayHelper::index($indexes, null, 'name');
+
+        $constraints = $this->db->createCommand(
+            $sql,
+            [
+                ':schemaName' => $resolvedName->schemaName,
+                ':schemaName1' => $resolvedName->schemaName,
+                ':schemaName2' => $resolvedName->schemaName,
+                ':tableName' => $resolvedName->name,
+                ':tableName1' => $resolvedName->name,
+            ],
+        )->queryAll();
+
+        $constraints = $this->normalizePdoRowKeyCase($constraints, true);
+
+        $constraints = ArrayHelper::index($constraints, null, 'name');
+
         $result = [];
-        foreach ($indexes as $name => $index) {
-            $result[] = new IndexConstraint([
-                'isPrimary' => (bool) $index[0]['index_is_primary'],
-                'isUnique' => (bool) $index[0]['index_is_unique'],
-                'name' => $name !== 'PRIMARY' ? $name : null,
-                'columnNames' => ArrayHelper::getColumn($index, 'column_name'),
-            ]);
+
+        foreach ($constraints as $name => $constraint) {
+            $result[] = new ForeignKeyConstraint(
+                [
+                    'name' => $name,
+                    'columnNames' => ArrayHelper::getColumn($constraint, 'column_name'),
+                    'foreignSchemaName' => $constraint[0]['foreign_table_schema'],
+                    'foreignTableName' => $constraint[0]['foreign_table_name'],
+                    'foreignColumnNames' => ArrayHelper::getColumn($constraint, 'foreign_column_name'),
+                    'onDelete' => $constraint[0]['on_delete'],
+                    'onUpdate' => $constraint[0]['on_update'],
+                ],
+            );
         }
 
         return $result;
@@ -200,9 +221,17 @@ SQL;
     /**
      * {@inheritdoc}
      */
+    protected function loadTableIndexes($tableName)
+    {
+        return $this->loadTableIndexMetadata($tableName, 'indexes');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function loadTableUniques($tableName)
     {
-        return $this->loadTableConstraints($tableName, 'uniques');
+        return $this->loadTableIndexMetadata($tableName, 'uniques');
     }
 
     /**
@@ -477,104 +506,84 @@ SQL;
     }
 
     /**
-     * Loads multiple types of constraints and returns the specified ones.
-     * @param string $tableName table name.
-     * @param string $returnType return type:
-     * - primaryKey
-     * - foreignKeys
-     * - uniques
-     * @return mixed constraints.
+     * Loads primary key, index, and unique constraint metadata from a single `information_schema.STATISTICS` query
+     * and returns the requested type.
+     *
+     * All three metadata types are cached via {@see setTableMetadata()}, so a cold load of any one of them resolves
+     * the other two without additional queries.
+     *
+     * @param string $tableName Table name, optionally schema-qualified as `schema.table`.
+     * @param string $returnType Metadata type to return: `primaryKey`, `indexes`, or `uniques`.
+     *
+     * @return Constraint|Constraint[]|IndexConstraint[]|null Primary key constraint or `null` for `primaryKey`, index
+     * constraints for `indexes`, or unique constraints for `uniques`.
+     *
+     * @phpstan-return (
+     *   $returnType is 'primaryKey' ? Constraint|null : ($returnType is 'indexes' ? IndexConstraint[] : Constraint[])
+     * )
      */
-    private function loadTableConstraints($tableName, $returnType)
+    private function loadTableIndexMetadata(string $tableName, string $returnType): mixed
     {
-        static $sql = <<<'SQL'
-SELECT
-    `kcu`.`CONSTRAINT_NAME` AS `name`,
-    `kcu`.`COLUMN_NAME` AS `column_name`,
-    `tc`.`CONSTRAINT_TYPE` AS `type`,
-    CASE
-        WHEN :schemaName IS NULL AND `kcu`.`REFERENCED_TABLE_SCHEMA` = DATABASE() THEN NULL
-        ELSE `kcu`.`REFERENCED_TABLE_SCHEMA`
-    END AS `foreign_table_schema`,
-    `kcu`.`REFERENCED_TABLE_NAME` AS `foreign_table_name`,
-    `kcu`.`REFERENCED_COLUMN_NAME` AS `foreign_column_name`,
-    `rc`.`UPDATE_RULE` AS `on_update`,
-    `rc`.`DELETE_RULE` AS `on_delete`,
-    `kcu`.`ORDINAL_POSITION` AS `position`
-FROM
-    `information_schema`.`KEY_COLUMN_USAGE` AS `kcu`,
-    `information_schema`.`REFERENTIAL_CONSTRAINTS` AS `rc`,
-    `information_schema`.`TABLE_CONSTRAINTS` AS `tc`
-WHERE
-    `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName1, DATABASE()) AND `kcu`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `kcu`.`TABLE_NAME` = :tableName
-    AND `rc`.`CONSTRAINT_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `rc`.`TABLE_NAME` = :tableName1 AND `rc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME`
-    AND `tc`.`TABLE_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `tc`.`TABLE_NAME` = :tableName2 AND `tc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME` AND `tc`.`CONSTRAINT_TYPE` = 'FOREIGN KEY'
-UNION
-SELECT
-    `kcu`.`CONSTRAINT_NAME` AS `name`,
-    `kcu`.`COLUMN_NAME` AS `column_name`,
-    `tc`.`CONSTRAINT_TYPE` AS `type`,
-    NULL AS `foreign_table_schema`,
-    NULL AS `foreign_table_name`,
-    NULL AS `foreign_column_name`,
-    NULL AS `on_update`,
-    NULL AS `on_delete`,
-    `kcu`.`ORDINAL_POSITION` AS `position`
-FROM
-    `information_schema`.`KEY_COLUMN_USAGE` AS `kcu`,
-    `information_schema`.`TABLE_CONSTRAINTS` AS `tc`
-WHERE
-    `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName2, DATABASE()) AND `kcu`.`TABLE_NAME` = :tableName3
-    AND `tc`.`TABLE_SCHEMA` = `kcu`.`TABLE_SCHEMA` AND `tc`.`TABLE_NAME` = :tableName4 AND `tc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME` AND `tc`.`CONSTRAINT_TYPE` IN ('PRIMARY KEY', 'UNIQUE')
-ORDER BY `position` ASC
-SQL;
+        $sql = <<<SQL
+        SELECT
+            `s`.`INDEX_NAME` AS `name`,
+            `s`.`COLUMN_NAME` AS `column_name`,
+            `s`.`NON_UNIQUE` ^ 1 AS `index_is_unique`,
+            `s`.`INDEX_NAME` = 'PRIMARY' AS `index_is_primary`
+        FROM `information_schema`.`STATISTICS` AS `s`
+        WHERE `s`.`TABLE_SCHEMA` = COALESCE(:schemaName, DATABASE()) AND `s`.`INDEX_SCHEMA` = `s`.`TABLE_SCHEMA` AND `s`.`TABLE_NAME` = :tableName
+        ORDER BY `s`.`SEQ_IN_INDEX` ASC
+        SQL;
 
         $resolvedName = $this->resolveTableName($tableName);
-        $constraints = $this->db->createCommand($sql, [
-            ':schemaName' => $resolvedName->schemaName,
-            ':schemaName1' => $resolvedName->schemaName,
-            ':schemaName2' => $resolvedName->schemaName,
-            ':tableName' => $resolvedName->name,
-            ':tableName1' => $resolvedName->name,
-            ':tableName2' => $resolvedName->name,
-            ':tableName3' => $resolvedName->name,
-            ':tableName4' => $resolvedName->name
-        ])->queryAll();
-        $constraints = $this->normalizePdoRowKeyCase($constraints, true);
-        $constraints = ArrayHelper::index($constraints, null, ['type', 'name']);
+
+        $indexes = $this->db->createCommand(
+            $sql,
+            [
+                ':schemaName' => $resolvedName->schemaName,
+                ':tableName' => $resolvedName->name,
+            ],
+        )->queryAll();
+
+        $indexes = $this->normalizePdoRowKeyCase($indexes, true);
+
+        $indexes = ArrayHelper::index($indexes, null, 'name');
+
         $result = [
             'primaryKey' => null,
-            'foreignKeys' => [],
+            'indexes' => [],
             'uniques' => [],
         ];
-        foreach ($constraints as $type => $names) {
-            foreach ($names as $name => $constraint) {
-                switch ($type) {
-                    case 'PRIMARY KEY':
-                        $result['primaryKey'] = new Constraint([
-                            'columnNames' => ArrayHelper::getColumn($constraint, 'column_name'),
-                        ]);
-                        break;
-                    case 'FOREIGN KEY':
-                        $result['foreignKeys'][] = new ForeignKeyConstraint([
-                            'name' => $name,
-                            'columnNames' => ArrayHelper::getColumn($constraint, 'column_name'),
-                            'foreignSchemaName' => $constraint[0]['foreign_table_schema'],
-                            'foreignTableName' => $constraint[0]['foreign_table_name'],
-                            'foreignColumnNames' => ArrayHelper::getColumn($constraint, 'foreign_column_name'),
-                            'onDelete' => $constraint[0]['on_delete'],
-                            'onUpdate' => $constraint[0]['on_update'],
-                        ]);
-                        break;
-                    case 'UNIQUE':
-                        $result['uniques'][] = new Constraint([
-                            'name' => $name,
-                            'columnNames' => ArrayHelper::getColumn($constraint, 'column_name'),
-                        ]);
-                        break;
-                }
+
+        foreach ($indexes as $name => $index) {
+            $columnNames = ArrayHelper::getColumn($index, 'column_name');
+
+            $isPrimary = (bool) $index[0]['index_is_primary'];
+            $isUnique = (bool) $index[0]['index_is_unique'];
+
+            $result['indexes'][] = new IndexConstraint(
+                [
+                    'isPrimary' => $isPrimary,
+                    'isUnique' => $isUnique,
+                    'name' => $name !== 'PRIMARY' ? $name : null,
+                    'columnNames' => $columnNames,
+                ],
+            );
+
+            if ($isPrimary) {
+                $result['primaryKey'] = new Constraint(
+                    ['columnNames' => $columnNames],
+                );
+            } elseif ($isUnique) {
+                $result['uniques'][] = new Constraint(
+                    [
+                        'name' => $name,
+                        'columnNames' => $columnNames,
+                    ],
+                );
             }
         }
+
         foreach ($result as $type => $data) {
             $this->setTableMetadata($tableName, $type, $data);
         }

--- a/tests/data/mysql.sql
+++ b/tests/data/mysql.sql
@@ -3,6 +3,8 @@
  * The database setup in config.php is required to perform then relevant tests:
  */
 
+CREATE DATABASE IF NOT EXISTS `yiitest_cross`;
+
 DROP TABLE IF EXISTS `composite_fk` CASCADE;
 DROP TABLE IF EXISTS `order_item` CASCADE;
 DROP TABLE IF EXISTS `order_item_with_null_fk` CASCADE;
@@ -27,6 +29,10 @@ DROP TABLE IF EXISTS `storage`;
 DROP TABLE IF EXISTS `alpha`;
 DROP TABLE IF EXISTS `beta`;
 DROP VIEW IF EXISTS `animal_view`;
+DROP TABLE IF EXISTS `T_constraints_cross_ref` CASCADE;
+DROP TABLE IF EXISTS `yiitest_cross`.`T_constraints_cross_ref` CASCADE;
+DROP TABLE IF EXISTS `yiitest_cross`.`T_constraints_3` CASCADE;
+DROP TABLE IF EXISTS `yiitest_cross`.`T_constraints_2` CASCADE;
 DROP TABLE IF EXISTS `T_constraints_4` CASCADE;
 DROP TABLE IF EXISTS `T_constraints_3` CASCADE;
 DROP TABLE IF EXISTS `T_constraints_2` CASCADE;
@@ -385,6 +391,43 @@ CREATE TABLE `T_constraints_4`
     `C_col_1` INT NULL,
     `C_col_2` INT NOT NULL,
     CONSTRAINT `CN_constraints_4` UNIQUE (`C_col_1`, `C_col_2`)
+)
+ENGINE = 'InnoDB' DEFAULT CHARSET = 'utf8';
+
+CREATE TABLE `yiitest_cross`.`T_constraints_2`
+(
+    `C_cross_id` INT NOT NULL,
+    `C_cross_unique` INT NOT NULL,
+    `C_cross_index` INT NULL,
+    CONSTRAINT `CN_cross_unique` UNIQUE (`C_cross_unique`),
+    CONSTRAINT `CN_pk` PRIMARY KEY (`C_cross_id`)
+)
+ENGINE = 'InnoDB' DEFAULT CHARSET = 'utf8';
+
+CREATE INDEX `CN_cross_single` ON `yiitest_cross`.`T_constraints_2` (`C_cross_index`);
+
+CREATE TABLE `yiitest_cross`.`T_constraints_3`
+(
+    `C_id` INT NOT NULL,
+    `C_fk_id` INT NOT NULL,
+    CONSTRAINT `CN_cross_constraints_3` FOREIGN KEY (`C_fk_id`) REFERENCES `yiitest_cross`.`T_constraints_2` (`C_cross_id`) ON DELETE CASCADE ON UPDATE CASCADE
+)
+ENGINE = 'InnoDB' DEFAULT CHARSET = 'utf8';
+
+CREATE TABLE `T_constraints_cross_ref`
+(
+    `C_id` INT NOT NULL,
+    `C_cross_fk_id` INT NOT NULL,
+    CONSTRAINT `CN_constraints_cross_ref` FOREIGN KEY (`C_cross_fk_id`) REFERENCES `yiitest_cross`.`T_constraints_2` (`C_cross_id`) ON DELETE CASCADE ON UPDATE CASCADE
+)
+ENGINE = 'InnoDB' DEFAULT CHARSET = 'utf8';
+
+CREATE TABLE `yiitest_cross`.`T_constraints_cross_ref`
+(
+    `C_id` INT NOT NULL,
+    `C_fk_id_1` INT NOT NULL,
+    `C_fk_id_2` INT NOT NULL,
+    CONSTRAINT `CN_cross_constraints_cross_ref` FOREIGN KEY (`C_fk_id_1`, `C_fk_id_2`) REFERENCES `yiitest`.`T_constraints_2` (`C_id_1`, `C_id_2`) ON DELETE CASCADE ON UPDATE CASCADE
 )
 ENGINE = 'InnoDB' DEFAULT CHARSET = 'utf8';
 

--- a/tests/framework/db/mysql/SchemaConstraintsTest.php
+++ b/tests/framework/db/mysql/SchemaConstraintsTest.php
@@ -12,10 +12,18 @@ namespace yiiunit\framework\db\mysql;
 
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
+use Yii;
 use yii\db\Constraint;
+use yii\db\ForeignKeyConstraint;
+use yii\db\IndexConstraint;
 use yii\db\mysql\QueryBuilder;
+use yii\db\mysql\Schema;
 use yiiunit\base\db\BaseSchemaConstraints;
 use yiiunit\framework\db\mysql\providers\ConstraintsProvider;
+
+use function array_filter;
+use function array_values;
+use function strtoupper;
 
 /**
  * Unit tests for {@see \yii\db\mysql\Schema} constraint and index metadata retrieval for the MySQL driver.
@@ -28,6 +36,268 @@ use yiiunit\framework\db\mysql\providers\ConstraintsProvider;
 final class SchemaConstraintsTest extends BaseSchemaConstraints
 {
     public $driverName = 'mysql';
+
+    /**
+     * Regression test for https://github.com/yiisoft/yii2/issues/16265.
+     */
+    public function testIndexMetadataColdLoadExecutesSingleStatisticsQuery(): void
+    {
+        $db = $this->getConnection(false);
+
+        /** @var Schema $schema */
+        $schema = $db->getSchema();
+
+        $schema->refreshTableSchema('T_constraints_2');
+
+        $logger = Yii::getLogger();
+
+        $enableLogging = $db->enableLogging;
+        $enableProfiling = $db->enableProfiling;
+        $messages = $logger->messages;
+        $db->enableLogging = true;
+        $db->enableProfiling = false;
+        $logger->messages = [];
+
+        $schema->getTablePrimaryKey('T_constraints_2');
+        $schema->getTableIndexes('T_constraints_2');
+        $schema->getTableUniques('T_constraints_2');
+
+        $queryMessages = array_values(
+            array_filter(
+                $logger->messages,
+                static fn (array $message): bool => $message[2] === 'yii\\db\\Command::query',
+            ),
+        );
+
+        self::assertCount(
+            1,
+            $queryMessages,
+            'Cold load must execute exactly one query.',
+        );
+
+        $metadataSql = strtoupper($queryMessages[0][0]);
+
+        self::assertStringNotContainsString(
+            'UNION',
+            $metadataSql,
+            'Legacy union query must be gone.',
+        );
+        self::assertStringNotContainsString(
+            'TABLE_CONSTRAINTS',
+            $metadataSql,
+            'Constraint tables must not be scanned.',
+        );
+
+        $db->enableLogging = $enableLogging;
+        $db->enableProfiling = $enableProfiling;
+        $logger->messages = $messages;
+    }
+
+    /**
+     * @param string[] $expectedColumnNames Expected primary key column names.
+     */
+    #[DataProviderExternal(ConstraintsProvider::class, 'schemaQualifiedTablePrimaryKey')]
+    public function testSchemaQualifiedTablePrimaryKey(string $tableName, array $expectedColumnNames): void
+    {
+        /** @var Schema $schema */
+        $schema = $this->getConnection()->getSchema();
+
+        $primaryKey = $schema->getTablePrimaryKey($tableName, true);
+
+        self::assertInstanceOf(
+            Constraint::class,
+            $primaryKey,
+            'Qualified primary key must be reflected.',
+        );
+        self::assertNull(
+            $primaryKey->name,
+            "Primary key name must be 'null'.",
+        );
+        self::assertSame(
+            $expectedColumnNames,
+            $primaryKey->columnNames,
+            'Columns must come from the qualified table.',
+        );
+    }
+
+    /**
+     * @param string[] $expectedColumnNames Expected index column names.
+     */
+    #[DataProviderExternal(ConstraintsProvider::class, 'schemaQualifiedTableIndexes')]
+    public function testSchemaQualifiedTableIndexes(
+        string $tableName,
+        string $expectedName,
+        array $expectedColumnNames,
+    ): void {
+        /** @var Schema $schema */
+        $schema = $this->getConnection()->getSchema();
+
+        $indexes = $schema->getTableIndexes($tableName, true);
+
+        $index = $this->findConstraintByName($indexes, $expectedName);
+
+        self::assertInstanceOf(
+            IndexConstraint::class,
+            $index,
+            'Qualified index metadata must be reflected.',
+        );
+        self::assertSame(
+            $expectedColumnNames,
+            $index->columnNames,
+            'Columns must come from the qualified table.',
+        );
+        self::assertFalse(
+            $index->isPrimary,
+            'Plain index must not be primary.',
+        );
+        self::assertFalse(
+            $index->isUnique,
+            'Plain index must not be unique.',
+        );
+    }
+
+    /**
+     * @param string[] $expectedColumnNames Expected unique constraint column names.
+     */
+    #[DataProviderExternal(ConstraintsProvider::class, 'schemaQualifiedTableUniques')]
+    public function testSchemaQualifiedTableUniques(
+        string $tableName,
+        string $expectedName,
+        array $expectedColumnNames,
+    ): void {
+        /** @var Schema $schema */
+        $schema = $this->getConnection()->getSchema();
+
+        $uniques = $schema->getTableUniques($tableName, true);
+
+        $unique = $this->findConstraintByName($uniques, $expectedName);
+
+        self::assertInstanceOf(
+            Constraint::class,
+            $unique,
+            'Qualified unique constraint must be reflected.',
+        );
+        self::assertSame(
+            $expectedColumnNames,
+            $unique->columnNames,
+            'Columns must come from the qualified table.',
+        );
+    }
+
+    /**
+     * @param string[] $expectedColumnNames Expected foreign key column names.
+     * @param string[] $expectedForeignColumnNames Expected referenced column names.
+     */
+    #[DataProviderExternal(ConstraintsProvider::class, 'schemaQualifiedTableForeignKeys')]
+    public function testSchemaQualifiedTableForeignKeys(
+        string $tableName,
+        string $expectedName,
+        array $expectedColumnNames,
+        string|null $expectedForeignSchemaName,
+        string $expectedForeignTableName,
+        array $expectedForeignColumnNames,
+    ): void {
+        /** @var Schema $schema */
+        $schema = $this->getConnection()->getSchema();
+
+        $foreignKeys = $schema->getTableForeignKeys($tableName, true);
+
+        $foreignKey = $this->findConstraintByName($foreignKeys, $expectedName);
+
+        self::assertInstanceOf(
+            ForeignKeyConstraint::class,
+            $foreignKey,
+            'Qualified foreign key must be reflected.',
+        );
+        self::assertSame(
+            $expectedColumnNames,
+            $foreignKey->columnNames,
+            'Columns must come from the child table.',
+        );
+        self::assertSame(
+            $expectedForeignSchemaName,
+            $foreignKey->foreignSchemaName,
+            'Foreign schema must follow the qualified-name semantics.',
+        );
+        self::assertSame(
+            $expectedForeignTableName,
+            $foreignKey->foreignTableName,
+            'Foreign table must match the referenced table.',
+        );
+        self::assertSame(
+            $expectedForeignColumnNames,
+            $foreignKey->foreignColumnNames,
+            'Foreign columns must match the referenced key.',
+        );
+        self::assertSame(
+            'CASCADE',
+            $foreignKey->onDelete,
+            'Delete rule must be reflected.',
+        );
+        self::assertSame(
+            'CASCADE',
+            $foreignKey->onUpdate,
+            'Update rule must be reflected.',
+        );
+    }
+
+    public function testSchemaQualifiedTableMetadataIsolation(): void
+    {
+        /** @var Schema $schema */
+        $schema = $this->getConnection()->getSchema();
+
+        $currentPrimaryKey = $schema->getTablePrimaryKey('T_constraints_2', true);
+        $crossPrimaryKey = $schema->getTablePrimaryKey('yiitest_cross.T_constraints_2', true);
+
+        self::assertInstanceOf(
+            Constraint::class,
+            $currentPrimaryKey,
+            'Current twin primary key must be reflected.',
+        );
+        self::assertInstanceOf(
+            Constraint::class,
+            $crossPrimaryKey,
+            'Cross twin primary key must be reflected.',
+        );
+        self::assertSame(
+            ['C_id_1', 'C_id_2'],
+            $currentPrimaryKey->columnNames,
+            'Current twin must keep its own key.',
+        );
+        self::assertSame(
+            ['C_cross_id'],
+            $crossPrimaryKey->columnNames,
+            'Cross twin must keep its own key.',
+        );
+
+        $currentUniques = $schema->getTableUniques('T_constraints_2');
+        $crossUniques = $schema->getTableUniques('yiitest_cross.T_constraints_2');
+
+        self::assertCount(
+            1,
+            $currentUniques,
+            'Current twin must expose one unique constraint.',
+        );
+        self::assertSame(
+            'CN_constraints_2_multi',
+            $currentUniques[0]->name,
+            'Unique name must be database-local.',
+        );
+        self::assertCount(
+            1,
+            $crossUniques,
+            'Cross twin must expose one unique constraint.',
+        );
+        self::assertSame(
+            'CN_cross_unique',
+            $crossUniques[0]->name,
+            'Unique name must be database-local.',
+        );
+        self::assertNull(
+            $this->findConstraintByName($schema->getTableIndexes('T_constraints_2'), 'CN_cross_single'),
+            'Cross twin metadata must not bleed into the current twin.',
+        );
+    }
 
     /**
      * @param Constraint|bool|array<array-key, mixed>|null $expected Expected constraint metadata.
@@ -93,5 +363,19 @@ final class SchemaConstraintsTest extends BaseSchemaConstraints
                 $expected,
             ),
         );
+    }
+
+    /**
+     * @param Constraint[] $constraints Constraint metadata.
+     */
+    private function findConstraintByName(array $constraints, string $name): Constraint|null
+    {
+        foreach ($constraints as $constraint) {
+            if ($constraint->name === $name) {
+                return $constraint;
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/framework/db/mysql/providers/ConstraintsProvider.php
+++ b/tests/framework/db/mysql/providers/ConstraintsProvider.php
@@ -33,6 +33,92 @@ final class ConstraintsProvider extends \yiiunit\base\db\providers\ConstraintsPr
         return $result;
     }
 
+    /**
+     * @return array<string, array{string, string[]}>
+     */
+    public static function schemaQualifiedTablePrimaryKey(): array
+    {
+        return [
+            'current database qualified' => ['yiitest.T_constraints_2', ['C_id_1', 'C_id_2']],
+            'cross database qualified' => ['yiitest_cross.T_constraints_2', ['C_cross_id']],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string, string[]}>
+     */
+    public static function schemaQualifiedTableIndexes(): array
+    {
+        return [
+            'current database qualified' => ['yiitest.T_constraints_2', 'CN_constraints_2_single', ['C_index_1']],
+            'cross database qualified' => ['yiitest_cross.T_constraints_2', 'CN_cross_single', ['C_cross_index']],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string, string[]}>
+     */
+    public static function schemaQualifiedTableUniques(): array
+    {
+        return [
+            'current database qualified' => [
+                'yiitest.T_constraints_2',
+                'CN_constraints_2_multi',
+                ['C_index_2_1', 'C_index_2_2'],
+            ],
+            'cross database qualified' => ['yiitest_cross.T_constraints_2', 'CN_cross_unique', ['C_cross_unique']],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string, string[], string|null, string, string[]}>
+     */
+    public static function schemaQualifiedTableForeignKeys(): array
+    {
+        return [
+            'unqualified referencing current database' => [
+                'T_constraints_3',
+                'CN_constraints_3',
+                ['C_fk_id_1', 'C_fk_id_2'],
+                null,
+                'T_constraints_2',
+                ['C_id_1', 'C_id_2'],
+            ],
+            'qualified referencing current database' => [
+                'yiitest.T_constraints_3',
+                'CN_constraints_3',
+                ['C_fk_id_1', 'C_fk_id_2'],
+                'yiitest',
+                'T_constraints_2',
+                ['C_id_1', 'C_id_2'],
+            ],
+            'unqualified referencing cross database' => [
+                'T_constraints_cross_ref',
+                'CN_constraints_cross_ref',
+                ['C_cross_fk_id'],
+                'yiitest_cross',
+                'T_constraints_2',
+                ['C_cross_id'],
+            ],
+            'qualified referencing cross database' => [
+                'yiitest_cross.T_constraints_3',
+                'CN_cross_constraints_3',
+                ['C_fk_id'],
+                'yiitest_cross',
+                'T_constraints_2',
+                ['C_cross_id'],
+            ],
+            'qualified cross database child referencing current database' => [
+                'yiitest_cross.T_constraints_cross_ref',
+                'CN_cross_constraints_cross_ref',
+                ['C_fk_id_1', 'C_fk_id_2'],
+                'yiitest',
+                'T_constraints_2',
+                ['C_id_1', 'C_id_2'],
+            ],
+        ];
+    }
+
     public static function prepareConstraintsExpected(
         bool $isMariaDb,
         string $tableName,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #16265 
