### PR TITLE
Use `utf8mb4` by default for MySQL/MariaDB connections, add `yii\db\Connection::getEffectiveCharset()`, and make built-in migrations follow the effective connection charset.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -139,6 +139,7 @@ Yii Framework 2 Change Log
 - Bug #19747: Load Oracle expression-based column defaults, including non-identity sequence `NEXTVAL` defaults, as executable `yii\db\Expression` instead of raw strings or `null` (terabytesoftw)
 - Bug #19747: Load SQLite expression-based column defaults as executable `yii\db\Expression` instead of mangled or raw values (terabytesoftw)
 - Bug #16265: Fix slow MySQL/MariaDB constraint metadata loading by replacing the `information_schema` `UNION` query with a single `STATISTICS` query and a dedicated foreign key query (terabytesoftw)
+- Bug #16545: Use `utf8mb4` by default for MySQL/MariaDB connections, add `yii\db\Connection::getEffectiveCharset()`, and make built-in migrations follow the effective connection charset (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -435,6 +435,23 @@ MySQL integer display widths are no longer generated:
 `tinyint(1)` remains the representation of `TYPE_BOOLEAN`. Explicit sizes passed for integer abstract types, such as
 `primaryKey(8)`, no longer produce a display width.
 
+MySQL and MariaDB connections now use `utf8mb4` when neither `Connection::$charset` nor the DSN specifies a charset.
+The charset a connection effectively uses is exposed through `Connection::getEffectiveCharset()`. The built-in cache,
+i18n, log, RBAC, and session migrations no longer force `utf8` and `utf8_unicode_ci`; their tables use the effective
+connection character set — the collation follows the server default collation for that character set — while
+continuing to use the `InnoDB` storage engine.
+
+These migrations run once, so tables created before this change keep the explicit `utf8` character set and
+`utf8_unicode_ci` collation. To align such a table with the connection defaults, convert it manually using the
+character set and collation reported by `SELECT @@character_set_connection, @@collation_connection`:
+
+```sql
+ALTER TABLE `session` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+```
+
+Replace the table name, character set, and collation as needed. Review string column and index sizes first; the
+conversion rewrites every character column to the new character set.
+
 The following legacy extension points were removed:
 
 - `mysql\Schema::isOldMysql()` and `$_oldMysql`;

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -438,19 +438,20 @@ MySQL integer display widths are no longer generated:
 MySQL and MariaDB connections now use `utf8mb4` when neither `Connection::$charset` nor the DSN specifies a charset.
 The charset a connection effectively uses is exposed through `Connection::getEffectiveCharset()`. The built-in cache,
 i18n, log, RBAC, and session migrations no longer force `utf8` and `utf8_unicode_ci`; their tables use the effective
-connection character set — the collation follows the server default collation for that character set — while
+connection character set; the collation follows the server default collation for that character set; while
 continuing to use the `InnoDB` storage engine.
 
 These migrations run once, so tables created before this change keep the explicit `utf8` character set and
 `utf8_unicode_ci` collation. To align such a table with the connection defaults, convert it manually using the
-character set and collation reported by `SELECT @@character_set_connection, @@collation_connection`:
+effective connection character set; see `Connection::getEffectiveCharset()`; the server applies that character
+set's default collation:
 
 ```sql
-ALTER TABLE `session` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+ALTER TABLE `session` CONVERT TO CHARACTER SET utf8mb4;
 ```
 
-Replace the table name, character set, and collation as needed. Review string column and index sizes first; the
-conversion rewrites every character column to the new character set.
+Replace the table name and character set as needed. Review string column and index sizes first; the conversion
+rewrites every character column to the new character set.
 
 The following legacy extension points were removed:
 

--- a/framework/caching/migrations/m150909_153426_cache_init.php
+++ b/framework/caching/migrations/m150909_153426_cache_init.php
@@ -42,8 +42,7 @@ class m150909_153426_cache_init extends Migration
 
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            // https://stackoverflow.com/questions/766809/whats-the-difference-between-utf8-general-ci-and-utf8-unicode-ci
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = sprintf('CHARACTER SET %s ENGINE=InnoDB', $this->db->effectiveCharset);
         }
 
         $this->createTable($cache->cacheTable, [

--- a/framework/caching/migrations/m150909_153426_cache_init.php
+++ b/framework/caching/migrations/m150909_153426_cache_init.php
@@ -41,7 +41,7 @@ class m150909_153426_cache_init extends Migration
         $this->db = $cache->db;
 
         $tableOptions = null;
-        if ($this->db->driverName === 'mysql') {
+        if (in_array($this->db->driverName, ['mysql', 'mysqli'], true)) {
             $tableOptions = sprintf('CHARACTER SET %s ENGINE=InnoDB', $this->db->effectiveCharset);
         }
 

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -15,6 +15,12 @@ use yii\base\InvalidConfigException;
 use yii\base\NotSupportedException;
 use yii\caching\CacheInterface;
 
+use function constant;
+use function in_array;
+use function preg_match;
+use function str_contains;
+use function strtolower;
+
 /**
  * Connection represents a connection to a database via [PDO](https://www.php.net/manual/en/book.pdo.php).
  *
@@ -106,13 +112,15 @@ use yii\caching\CacheInterface;
  *         'dsn' => 'mysql:host=127.0.0.1;dbname=demo',
  *         'username' => 'root',
  *         'password' => '',
- *         'charset' => 'utf8',
+ *         'charset' => 'utf8mb4',
  *     ],
  * ],
  * ```
  *
  * @property string|null $driverName Name of the DB driver. Note that the type of this property differs in
  * getter and setter. See [[getDriverName()]] and [[setDriverName()]] for details.
+ * @property-read string|null $effectiveCharset The charset the connection effectively uses, or `null` when the
+ * connection relies on the database server defaults.
  * @property-read bool $isActive Whether the DB connection is established.
  * @property-read string $lastInsertID The row ID of the last row inserted, or the last value retrieved from
  * the sequence object.
@@ -240,15 +248,15 @@ class Connection extends Component
      */
     public $queryCache = 'cache';
     /**
-     * @var string|null the charset used for database connection. The property is only used
-     * for MySQL and PostgreSQL databases. Defaults to null, meaning using default charset
-     * as configured by the database.
+     * @var string|null the charset used for database connection. The property is only used for MySQL and PostgreSQL
+     * databases. Defaults to `null`. MySQL and MariaDB connections use `utf8mb4` when neither this property nor the
+     * [[dsn]] specifies a charset. PostgreSQL connections use the default charset configured by the database.
      *
-     * For Oracle Database, the charset must be specified in the [[dsn]], for example for UTF-8 by appending `;charset=UTF-8`
-     * to the DSN string.
+     * For Oracle Database, the charset must be specified in the [[dsn]], for example for UTF-8 by appending
+     * `;charset=UTF-8` to the DSN string.
      *
-     * The same applies for if you're using GBK or BIG5 charset with MySQL, then it's highly recommended to
-     * specify charset via [[dsn]] like `'mysql:dbname=mydatabase;host=127.0.0.1;charset=GBK;'`.
+     * The same applies for if you're using GBK or BIG5 charset with MySQL, then it's highly recommended to specify
+     * charset via [[dsn]] like `'mysql:dbname=mydatabase;host=127.0.0.1;charset=GBK;'`.
      */
     public $charset;
     /**
@@ -718,28 +726,38 @@ class Connection extends Component
      * Initializes the DB connection.
      * This method is invoked right after the DB connection is established.
      * The default implementation turns on `PDO::ATTR_EMULATE_PREPARES`
-     * if [[emulatePrepare]] is true, and sets the database [[charset]] if it is not empty.
+     * if [[emulatePrepare]] is true, and sets the database [[charset]] if it is not empty. MySQL and MariaDB
+     * connections fall back to `utf8mb4` when neither [[charset]] nor the [[dsn]] specifies a charset.
      * It then triggers an [[EVENT_AFTER_OPEN]] event.
      */
     protected function initConnection()
     {
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $driverName = $this->getDriverName();
+
         if ($this->emulatePrepare !== null && constant('PDO::ATTR_EMULATE_PREPARES')) {
-            if ($this->driverName !== 'sqlsrv') {
+            if ($driverName !== 'sqlsrv') {
                 $this->pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, $this->emulatePrepare);
             }
         }
 
-        if (in_array($this->getDriverName(), ['sqlite', 'oci'], true)) {
+        if (in_array($driverName, ['sqlite', 'oci'], true)) {
             $this->pdo->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
         }
 
-        if (!$this->isSybase && in_array($this->getDriverName(), ['mssql', 'dblib'], true)) {
+        if (!$this->isSybase && in_array($driverName, ['mssql', 'dblib'], true)) {
             $this->pdo->exec('SET ANSI_NULL_DFLT_ON ON');
         }
-        if ($this->charset !== null && in_array($this->getDriverName(), ['pgsql', 'mysql', 'mysqli'], true)) {
+
+        if ($this->charset !== null && in_array($driverName, ['pgsql', 'mysql', 'mysqli'], true)) {
             $this->pdo->exec('SET NAMES ' . $this->pdo->quote($this->charset));
+        } elseif (
+            in_array($driverName, ['mysql', 'mysqli'], true)
+            && !str_contains(strtolower((string) $this->dsn), 'charset=')
+        ) {
+            $this->pdo->exec('SET NAMES ' . $this->pdo->quote('utf8mb4'));
         }
+
         $this->trigger(self::EVENT_AFTER_OPEN);
     }
 
@@ -1017,6 +1035,34 @@ class Connection extends Component
     public function setDriverName($driverName)
     {
         $this->_driverName = strtolower($driverName);
+    }
+
+    /**
+     * Returns the charset the connection effectively uses.
+     *
+     * Resolution order: [[charset]] when set, then a `charset` element in the [[dsn]], then `utf8mb4` for MySQL and
+     * MariaDB. The value derives from the configuration only, so it is available before the connection is opened.
+     *
+     * @return string|null The effective connection charset, or `null` when the connection relies on the database server
+     * defaults.
+     *
+     * @since 22.0
+     */
+    public function getEffectiveCharset(): string|null
+    {
+        if ($this->charset !== null) {
+            return $this->charset;
+        }
+
+        if (preg_match('/charset=([^;]+)/i', (string) $this->dsn, $matches) === 1) {
+            return $matches[1];
+        }
+
+        if (in_array($this->getDriverName(), ['mysql', 'mysqli'], true)) {
+            return 'utf8mb4';
+        }
+
+        return null;
     }
 
     /**

--- a/framework/i18n/migrations/m150207_210500_i18n_init.php
+++ b/framework/i18n/migrations/m150207_210500_i18n_init.php
@@ -22,8 +22,7 @@ class m150207_210500_i18n_init extends Migration
     {
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            // https://stackoverflow.com/questions/766809/whats-the-difference-between-utf8-general-ci-and-utf8-unicode-ci
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = sprintf('CHARACTER SET %s ENGINE=InnoDB', $this->db->effectiveCharset);
         }
 
         $this->createTable('{{%source_message}}', [

--- a/framework/i18n/migrations/m150207_210500_i18n_init.php
+++ b/framework/i18n/migrations/m150207_210500_i18n_init.php
@@ -21,7 +21,7 @@ class m150207_210500_i18n_init extends Migration
     public function up()
     {
         $tableOptions = null;
-        if ($this->db->driverName === 'mysql') {
+        if (in_array($this->db->driverName, ['mysql', 'mysqli'], true)) {
             $tableOptions = sprintf('CHARACTER SET %s ENGINE=InnoDB', $this->db->effectiveCharset);
         }
 

--- a/framework/log/migrations/m141106_185632_log_init.php
+++ b/framework/log/migrations/m141106_185632_log_init.php
@@ -65,7 +65,7 @@ class m141106_185632_log_init extends Migration
             $this->db = $target->db;
 
             $tableOptions = null;
-            if ($this->db->driverName === 'mysql') {
+            if (in_array($this->db->driverName, ['mysql', 'mysqli'], true)) {
                 $tableOptions = sprintf('CHARACTER SET %s ENGINE=InnoDB', $this->db->effectiveCharset);
             }
 

--- a/framework/log/migrations/m141106_185632_log_init.php
+++ b/framework/log/migrations/m141106_185632_log_init.php
@@ -66,8 +66,7 @@ class m141106_185632_log_init extends Migration
 
             $tableOptions = null;
             if ($this->db->driverName === 'mysql') {
-                // https://stackoverflow.com/questions/766809/whats-the-difference-between-utf8-general-ci-and-utf8-unicode-ci
-                $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+                $tableOptions = sprintf('CHARACTER SET %s ENGINE=InnoDB', $this->db->effectiveCharset);
             }
 
             $this->createTable($target->logTable, [

--- a/framework/rbac/migrations/m140506_102106_rbac_init.php
+++ b/framework/rbac/migrations/m140506_102106_rbac_init.php
@@ -56,7 +56,7 @@ class m140506_102106_rbac_init extends \yii\db\Migration
 
         $tableOptions = null;
 
-        if ($this->db->driverName === 'mysql') {
+        if (in_array($this->db->driverName, ['mysql', 'mysqli'], true)) {
             $tableOptions = sprintf('CHARACTER SET %s ENGINE=InnoDB', $this->db->effectiveCharset);
         }
 

--- a/framework/rbac/migrations/m140506_102106_rbac_init.php
+++ b/framework/rbac/migrations/m140506_102106_rbac_init.php
@@ -57,8 +57,7 @@ class m140506_102106_rbac_init extends \yii\db\Migration
         $tableOptions = null;
 
         if ($this->db->driverName === 'mysql') {
-            // https://stackoverflow.com/questions/766809/whats-the-difference-between-utf8-general-ci-and-utf8-unicode-ci
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = sprintf('CHARACTER SET %s ENGINE=InnoDB', $this->db->effectiveCharset);
         }
 
         $this->createTable(

--- a/framework/web/migrations/m160313_153426_session_init.php
+++ b/framework/web/migrations/m160313_153426_session_init.php
@@ -24,8 +24,7 @@ class m160313_153426_session_init extends Migration
         $tableOptions = null;
 
         if ($this->db->driverName === 'mysql') {
-            // https://stackoverflow.com/questions/766809/whats-the-difference-between-utf8-general-ci-and-utf8-unicode-ci
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = sprintf('CHARACTER SET %s ENGINE=InnoDB', $this->db->effectiveCharset);
         }
 
         $this->createTable(

--- a/framework/web/migrations/m160313_153426_session_init.php
+++ b/framework/web/migrations/m160313_153426_session_init.php
@@ -23,7 +23,7 @@ class m160313_153426_session_init extends Migration
     {
         $tableOptions = null;
 
-        if ($this->db->driverName === 'mysql') {
+        if (in_array($this->db->driverName, ['mysql', 'mysqli'], true)) {
             $tableOptions = sprintf('CHARACTER SET %s ENGINE=InnoDB', $this->db->effectiveCharset);
         }
 

--- a/tests/framework/db/mssql/ConnectionTest.php
+++ b/tests/framework/db/mssql/ConnectionTest.php
@@ -8,15 +8,29 @@
 
 namespace yiiunit\framework\db\mssql;
 
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\Connection;
 use yiiunit\base\db\BaseConnection;
 
 /**
- * @group db
- * @group mssql
+ * Unit tests for {@see \yii\db\mssql\Connection} functionality for the MSSQL driver.
  */
+#[Group('db')]
+#[Group('mssql')]
+#[Group('connection')]
 class ConnectionTest extends BaseConnection
 {
     protected $driverName = 'sqlsrv';
+
+    public function testGetEffectiveCharsetReturnsNull(): void
+    {
+        $db = new Connection(['dsn' => 'sqlsrv:Server=127.0.0.1,1433;Database=yiitest;Encrypt=no']);
+
+        self::assertNull(
+            $db->effectiveCharset,
+            "No charset source means 'null'.",
+        );
+    }
 
     public function testQuoteValue(): void
     {

--- a/tests/framework/db/mysql/ConnectionTest.php
+++ b/tests/framework/db/mysql/ConnectionTest.php
@@ -8,16 +8,88 @@
 
 namespace yiiunit\framework\db\mysql;
 
+use PHPUnit\Framework\Attributes\Group;
+use PDO;
 use yii\db\Connection;
 use yiiunit\base\db\BaseConnection;
 
 /**
- * @group db
- * @group mysql
+ * Unit tests for {@see \yii\db\mysql\Connection} functionality for the MySQL driver.
  */
+#[Group('db')]
+#[Group('mysql')]
+#[Group('connection')]
 class ConnectionTest extends BaseConnection
 {
     protected $driverName = 'mysql';
+
+    public function testGetEffectiveCharsetResolutionOrder(): void
+    {
+        $db = new Connection(['dsn' => 'mysql:host=127.0.0.1;dbname=yiitest', 'charset' => 'latin1']);
+
+        self::assertSame(
+            'latin1',
+            $db->effectiveCharset,
+            'Explicit charset must win.',
+        );
+
+        $db = new Connection(['dsn' => 'mysql:host=127.0.0.1;dbname=yiitest;charset=utf8mb3']);
+
+        self::assertSame(
+            'utf8mb3',
+            $db->effectiveCharset,
+            "DSN charset must be used when the property is 'null'.",
+        );
+
+        $db = new Connection(['dsn' => 'mysql:host=127.0.0.1;dbname=yiitest']);
+
+        self::assertSame(
+            'utf8mb4',
+            $db->effectiveCharset,
+            "Fallback must be 'utf8mb4'.",
+        );
+    }
+
+    public function testInitConnectionDefaultsToUtf8mb4WhenNoCharsetIsConfigured(): void
+    {
+        $pdo = $this->createMock(PDO::class);
+
+        $pdo->expects(self::once())
+            ->method('setAttribute')
+            ->with(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->expects(self::once())
+            ->method('quote')
+            ->with('utf8mb4')
+            ->willReturn("'utf8mb4'");
+        $pdo->expects(self::once())
+            ->method('exec')
+            ->with("SET NAMES 'utf8mb4'");
+
+        $db = new Connection(['dsn' => 'mysql:host=127.0.0.1;dbname=yiitest']);
+
+        $db->pdo = $pdo;
+
+        $this->invokeMethod($db, 'initConnection');
+    }
+
+    public function testInitConnectionDoesNotOverrideDsnCharset(): void
+    {
+        $pdo = $this->createMock(PDO::class);
+
+        $pdo->expects(self::once())
+            ->method('setAttribute')
+            ->with(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->expects(self::never())
+            ->method('quote');
+        $pdo->expects(self::never())
+            ->method('exec');
+
+        $db = new Connection(['dsn' => 'mysql:host=127.0.0.1;dbname=yiitest;charset=utf8mb3']);
+
+        $db->pdo = $pdo;
+
+        $this->invokeMethod($db, 'initConnection');
+    }
 
     /**
      * @doesNotPerformAssertions

--- a/tests/framework/db/oci/ConnectionTest.php
+++ b/tests/framework/db/oci/ConnectionTest.php
@@ -8,17 +8,39 @@
 
 namespace yiiunit\framework\db\oci;
 
+use PHPUnit\Framework\Attributes\Group;
 use yii\db\Connection;
 use yii\db\Transaction;
 use yiiunit\base\db\BaseConnection;
 
 /**
- * @group db
- * @group oci
+ * Unit tests for {@see \yii\db\oci\Connection} functionality for the OCI driver.
  */
+#[Group('db')]
+#[Group('oci')]
+#[Group('connection')]
 class ConnectionTest extends BaseConnection
 {
     protected $driverName = 'oci';
+
+    public function testGetEffectiveCharsetReadsDsnCharset(): void
+    {
+        $db = new Connection(['dsn' => 'oci:dbname=localhost/FREE;charset=AL32UTF8;']);
+
+        self::assertSame(
+            'AL32UTF8',
+            $db->effectiveCharset,
+            'DSN charset must be extracted.',
+        );
+
+        $db = new Connection(['dsn' => 'oci:dbname=localhost/FREE;charset=AL32UTF8;', 'charset' => 'UTF8']);
+
+        self::assertSame(
+            'UTF8',
+            $db->effectiveCharset,
+            'Explicit charset must win over the DSN.',
+        );
+    }
 
     public function testSerialize(): void
     {

--- a/tests/framework/db/pgsql/ConnectionTest.php
+++ b/tests/framework/db/pgsql/ConnectionTest.php
@@ -8,16 +8,38 @@
 
 namespace yiiunit\framework\db\pgsql;
 
+use PHPUnit\Framework\Attributes\Group;
+use yii\db\Connection;
 use yii\db\Transaction;
 use yiiunit\base\db\BaseConnection;
 
 /**
- * @group db
- * @group pgsql
+ * Unit tests for {@see \yii\db\pgsql\Connection} functionality for the PostgreSQL driver.
  */
+#[Group('db')]
+#[Group('pgsql')]
+#[Group('connection')]
 class ConnectionTest extends BaseConnection
 {
     protected $driverName = 'pgsql';
+
+    public function testGetEffectiveCharsetReturnsConfiguredCharsetOrNull(): void
+    {
+        $db = new Connection(['dsn' => 'pgsql:host=localhost;dbname=yiitest;port=5432;', 'charset' => 'utf8']);
+
+        self::assertSame(
+            'utf8',
+            $db->effectiveCharset,
+            'Configured charset must be returned.',
+        );
+
+        $db = new Connection(['dsn' => 'pgsql:host=localhost;dbname=yiitest;port=5432;']);
+
+        self::assertNull(
+            $db->effectiveCharset,
+            "No charset source means 'null'.",
+        );
+    }
 
     public function testConnection(): void
     {

--- a/tests/framework/db/sqlite/ConnectionTest.php
+++ b/tests/framework/db/sqlite/ConnectionTest.php
@@ -8,21 +8,34 @@
 
 namespace yiiunit\framework\db\sqlite;
 
+use PHPUnit\Framework\Attributes\Group;
 use Yii;
 use yii\db\Connection;
 use yii\db\Exception;
 use yii\db\Transaction;
+use yiiunit\base\db\BaseConnection;
 use yiiunit\data\ar\ActiveRecord;
 use yiiunit\data\ar\Customer;
-use yiiunit\base\db\BaseConnection;
 
 /**
- * @group db
- * @group sqlite
+ * Unit tests for {@see \yii\db\sqlite\Connection} functionality for the SQLite driver.
  */
+#[Group('db')]
+#[Group('sqlite')]
+#[Group('connection')]
 class ConnectionTest extends BaseConnection
 {
     protected $driverName = 'sqlite';
+
+    public function testGetEffectiveCharsetReturnsNull(): void
+    {
+        $db = new Connection(['dsn' => 'sqlite::memory:']);
+
+        self::assertNull(
+            $db->effectiveCharset,
+            "No charset source means 'null'.",
+        );
+    }
 
     public function testConstruct(): void
     {

--- a/tests/framework/web/session/mysql/DbSessionTest.php
+++ b/tests/framework/web/session/mysql/DbSessionTest.php
@@ -8,6 +8,7 @@
 
 namespace yiiunit\framework\web\session\mysql;
 
+use Yii;
 use yiiunit\base\web\session\BaseDbSession;
 
 /**
@@ -24,5 +25,65 @@ class DbSessionTest extends BaseDbSession
     protected function getDriverNames()
     {
         return ['mysql'];
+    }
+
+    public function testMigrationUsesDefaultConnectionCharsetAndCollation(): void
+    {
+        $db = Yii::$app->db;
+
+        $connectionCollation = $db->createCommand(
+            <<<SQL
+            SELECT @@collation_connection
+            SQL,
+        )->queryScalar();
+        $tableCollation = $db->createCommand(
+            <<<SQL
+            SELECT TABLE_COLLATION
+            FROM information_schema.TABLES
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'session'
+            SQL,
+        )->queryScalar();
+
+        self::assertStringStartsWith(
+            'utf8mb4_',
+            $tableCollation,
+            "Collation must belong to 'utf8mb4'.",
+        );
+        self::assertSame(
+            $connectionCollation,
+            $tableCollation,
+            'Table must inherit the connection collation.',
+        );
+    }
+
+    public function testMigrationUsesConfiguredConnectionCharsetAndCollation(): void
+    {
+        $db = Yii::$app->db;
+
+        $db->close();
+
+        $db->charset = 'latin1';
+
+        $this->dropTableSession();
+        $this->createTableSession();
+
+        $connectionCollation = $db->createCommand(
+            <<<SQL
+            SELECT @@collation_connection
+            SQL,
+        )->queryScalar();
+        $tableCollation = $db->createCommand(
+            <<<SQL
+            SELECT TABLE_COLLATION
+            FROM information_schema.TABLES
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'session'
+            SQL,
+        )->queryScalar();
+
+        self::assertSame(
+            $connectionCollation,
+            $tableCollation,
+            "Configured 'latin1' must drive the table collation.",
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #16545 
