### PR TITLE
Escape quote characters inside DB identifiers when quoting and preserve them during schema reflection.

### DIFF
--- a/.github/workflows/ci-mysql-ansi.yml
+++ b/.github/workflows/ci-mysql-ansi.yml
@@ -1,0 +1,57 @@
+name: ci-mysql-ansi
+
+permissions:
+  contents: read
+
+on:
+  pull_request: &ignore-paths
+    paths-ignore:
+      - ".appveyor.yml"
+      - ".dockerignore"
+      - ".editorconfig"
+      - ".git-blame-ignore-revs"
+      - ".gitattributes"
+      - ".github/CONTRIBUTING.md"
+      - ".github/FUNDING.yml"
+      - ".github/ISSUE_TEMPLATE.md"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - ".github/SECURITY.md"
+      - ".gitignore"
+      - ".gitlab-ci.yml"
+      - "code-of-conduct.md"
+      - "docs/**"
+      - "framework/.gitignore"
+      - "framework/.phpstorm.meta.php"
+      - "framework/CHANGELOG.md"
+      - "framework/LICENSE.md"
+      - "framework/README.md"
+      - "framework/UPGRADE.md"
+      - "framework/UPGRADE-22.md"
+      - "eslint.config.js"
+      - "LICENSE.md"
+      - "README.md"
+      - "ROADMAP.md"
+
+  push: *ignore-paths
+
+jobs:
+  tests:
+    name: MySQL ANSI tests with coverage
+    uses: yiisoft/yii2-actions/.github/workflows/database.yml@f14284136c895c1af50b8ed5c80d83afa31461e7 # master
+    with:
+      concurrency-group: mysql-ansi-${{ github.ref }}
+      coverage-driver: pcov
+      database-env: '{"MYSQL_ROOT_PASSWORD":"root","MYSQL_DATABASE":"yiitest"}'
+      database-health-cmd: mysqladmin ping
+      database-image: mysql
+      database-port: "3306"
+      database-type: mysql
+      database-versions: '["latest"]'
+      extensions: curl, intl, pdo, pdo_mysql
+      hook: |
+        docker exec -i database mysql -uroot -proot -e "SET GLOBAL sql_mode = 'ANSI';"
+      os: '["ubuntu-latest"]'
+      php-version: '["8.5"]'
+      phpunit-group: mysql
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -142,6 +142,7 @@ Yii Framework 2 Change Log
 - Bug #16545: Use `utf8mb4` by default for MySQL/MariaDB connections, add `yii\db\Connection::getEffectiveCharset()`, and make built-in migrations follow the effective connection charset (terabytesoftw)
 - Bug #20275: Decode quoted MySQL/MariaDB column default literals (`text`/`blob` and any non-JSON `DEFAULT_GENERATED` string default) to their PHP value instead of an `Expression` or raw quoted string (terabytesoftw)
 - Bug #11191: Enable session `autocommit` on the migration connection when the MySQL/MariaDB server default disables it, so migration history stays complete and transactional migrations can start (terabytesoftw)
+- Bug #8765: Escape quote characters inside DB identifiers when quoting and preserve them during schema reflection (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -26,6 +26,7 @@ use function implode;
 use function is_string;
 use function mb_stripos;
 use function str_contains;
+use function str_ends_with;
 use function str_replace;
 use function str_starts_with;
 use function strlen;
@@ -519,7 +520,8 @@ abstract class Schema extends BaseObject
      * Quotes a table name for use in a query.
      *
      * If the table name contains schema prefix, the prefix will also be properly quoted.
-     * If the table name is already quoted or contains '(' or '{{', then this method will do nothing.
+     * If the table name is already fully enclosed in the quote characters, or contains '(' or '{{', then this method
+     * will do nothing.
      *
      * @param string $name Table name.
      * @return string The properly quoted table name.
@@ -538,6 +540,10 @@ abstract class Schema extends BaseObject
 
         if (!str_contains($name, '.')) {
             return $this->quoteSimpleTableName($name);
+        }
+
+        if ($this->isFullyQuoted($name, $this->tableQuoteCharacter)) {
+            return $name;
         }
 
         return implode('.', array_map([$this, 'quoteSimpleTableName'], $this->getTableNameParts($name)));
@@ -561,7 +567,8 @@ abstract class Schema extends BaseObject
      * Quotes a column name for use in a query.
      *
      * If the column name contains prefix, the prefix will also be properly quoted.
-     * If the column name is already quoted or contains '(', '[[' or '{{', then this method will do nothing.
+     * If the column name is already fully enclosed in the quote characters, or contains '(', '[[' or '{{', then this
+     * method will do nothing.
      *
      * @param string $name Column name.
      *
@@ -580,6 +587,10 @@ abstract class Schema extends BaseObject
         }
 
         if (($pos = strrpos($name, '.')) !== false) {
+            if ($this->isFullyQuoted($name, $this->columnQuoteCharacter)) {
+                return $name;
+            }
+
             $prefix = $this->quoteTableName(substr($name, 0, $pos)) . '.';
 
             $name = substr($name, $pos + 1);
@@ -598,7 +609,8 @@ abstract class Schema extends BaseObject
      * Quotes a simple table name for use in a query.
      *
      * A simple table name should contain the table name only without any schema prefix.
-     * If the table name is already quoted, this method will do nothing.
+     * A name already fully enclosed in the quote characters is returned as is; otherwise the name is enclosed and any
+     * embedded ending quote character is escaped by doubling it.
      *
      * @param string $name Table name.
      *
@@ -606,22 +618,15 @@ abstract class Schema extends BaseObject
      */
     public function quoteSimpleTableName($name)
     {
-        if (is_string($this->tableQuoteCharacter)) {
-            $startingCharacter = $endingCharacter = $this->tableQuoteCharacter;
-        } else {
-            [$startingCharacter, $endingCharacter] = $this->tableQuoteCharacter;
-        }
-
-        return str_contains($name, $startingCharacter)
-            ? $name
-            : "{$startingCharacter}{$name}{$endingCharacter}";
+        return $this->quoteSimpleName($name, $this->tableQuoteCharacter);
     }
 
     /**
      * Quotes a simple column name for use in a query.
      *
      * A simple column name should contain the column name only without any prefix.
-     * If the column name is already quoted or is the asterisk character '*', this method will do nothing.
+     * The asterisk character '*' and a name already fully enclosed in the quote characters are returned as is;
+     * otherwise the name is enclosed and any embedded ending quote character is escaped by doubling it.
      *
      * @param string $name Column name.
      *
@@ -629,22 +634,19 @@ abstract class Schema extends BaseObject
      */
     public function quoteSimpleColumnName($name)
     {
-        if (is_string($this->columnQuoteCharacter)) {
-            $startingCharacter = $endingCharacter = $this->columnQuoteCharacter;
-        } else {
-            [$startingCharacter, $endingCharacter] = $this->columnQuoteCharacter;
+        if ($name === '*') {
+            return $name;
         }
 
-        return $name === '*' || str_contains($name, $startingCharacter)
-            ? $name
-            : "{$startingCharacter}{$name}{$endingCharacter}";
+        return $this->quoteSimpleName($name, $this->columnQuoteCharacter);
     }
 
     /**
      * Unquotes a simple table name.
      *
      * A simple table name should contain the table name only without any schema prefix.
-     * If the table name is not quoted, this method will do nothing.
+     * Only a name fully enclosed in the quote characters is unquoted: the enclosure is stripped and doubled ending
+     * quote characters are collapsed to a single one.
      *
      * @param string $name Table name.
      *
@@ -654,22 +656,15 @@ abstract class Schema extends BaseObject
      */
     public function unquoteSimpleTableName($name)
     {
-        if (is_string($this->tableQuoteCharacter)) {
-            $startingCharacter = $this->tableQuoteCharacter;
-        } else {
-            $startingCharacter = $this->tableQuoteCharacter[0];
-        }
-
-        return !str_contains($name, $startingCharacter)
-            ? $name
-            : substr($name, 1, -1);
+        return $this->unquoteSimpleName($name, $this->tableQuoteCharacter);
     }
 
     /**
      * Unquotes a simple column name.
      *
      * A simple column name should contain the column name only without any prefix.
-     * If the column name is not quoted or is the asterisk character '*', this method will do nothing.
+     * Only a name fully enclosed in the quote characters is unquoted: the enclosure is stripped and doubled ending
+     * quote characters are collapsed to a single one.
      *
      * @param string $name Column name.
      *
@@ -679,15 +674,86 @@ abstract class Schema extends BaseObject
      */
     public function unquoteSimpleColumnName($name)
     {
-        if (is_string($this->columnQuoteCharacter)) {
-            $startingCharacter = $this->columnQuoteCharacter;
-        } else {
-            $startingCharacter = $this->columnQuoteCharacter[0];
+        return $this->unquoteSimpleName($name, $this->columnQuoteCharacter);
+    }
+
+    /**
+     * Returns the starting and ending quote characters for the given quote character definition.
+     *
+     * @param string|array{string, string} $quoteCharacter Single quote character used on both sides, or a pair of
+     * starting and ending quote characters.
+     *
+     * @return array{string, string} Starting and ending quote characters.
+     */
+    private function resolveQuoteCharacter(string|array $quoteCharacter): array
+    {
+        return is_string($quoteCharacter) ? [$quoteCharacter, $quoteCharacter] : $quoteCharacter;
+    }
+
+    /**
+     * Returns whether the given name is fully enclosed in the given quote characters.
+     *
+     * @param string $name Name to check.
+     * @param string|array{string, string} $quoteCharacter Single quote character used on both sides, or a pair of
+     * starting and ending quote characters.
+     *
+     * @return bool Whether the name starts with the starting quote character and ends with the ending one.
+     */
+    private function isFullyQuoted(string $name, string|array $quoteCharacter): bool
+    {
+        [$startingCharacter, $endingCharacter] = $this->resolveQuoteCharacter($quoteCharacter);
+
+        return str_starts_with($name, $startingCharacter) && str_ends_with($name, $endingCharacter);
+    }
+
+    /**
+     * Encloses a simple name in the given quote characters.
+     *
+     * A name already fully enclosed in the quote characters is returned as is; otherwise embedded ending quote
+     * characters are escaped by doubling them.
+     *
+     * @param string $name Simple name to quote.
+     * @param string|array{string, string} $quoteCharacter Single quote character used on both sides, or a pair of
+     * starting and ending quote characters.
+     *
+     * @return string The properly quoted name.
+     */
+    private function quoteSimpleName(string $name, string|array $quoteCharacter): string
+    {
+        if ($this->isFullyQuoted($name, $quoteCharacter)) {
+            return $name;
         }
 
-        return !str_contains($name, $startingCharacter)
-            ? $name
-            : substr($name, 1, -1);
+        [$startingCharacter, $endingCharacter] = $this->resolveQuoteCharacter($quoteCharacter);
+
+        return $startingCharacter
+            . str_replace($endingCharacter, $endingCharacter . $endingCharacter, $name)
+            . $endingCharacter;
+    }
+
+    /**
+     * Removes the given quote characters from a simple name.
+     *
+     * Only a name fully enclosed in the quote characters is unquoted; doubled ending quote characters are collapsed
+     * to a single one.
+     *
+     * @param string $name Simple name to unquote.
+     * @param string|array{string, string} $quoteCharacter Single quote character used on both sides, or a pair of
+     * starting and ending quote characters.
+     *
+     * @return string Unquoted name.
+     */
+    private function unquoteSimpleName(string $name, string|array $quoteCharacter): string
+    {
+        if (!$this->isFullyQuoted($name, $quoteCharacter)) {
+            return $name;
+        }
+
+        [$startingCharacter, $endingCharacter] = $this->resolveQuoteCharacter($quoteCharacter);
+
+        $name = substr($name, strlen($startingCharacter), -strlen($endingCharacter));
+
+        return str_replace($endingCharacter . $endingCharacter, $endingCharacter, $name);
     }
 
     /**

--- a/framework/db/mysql/QueryBuilder.php
+++ b/framework/db/mysql/QueryBuilder.php
@@ -21,6 +21,7 @@ use function preg_match;
 use function preg_match_all;
 use function preg_replace;
 use function reset;
+use function str_replace;
 use function strlen;
 use function substr_replace;
 use function trim;
@@ -473,10 +474,16 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
         $createTable = $row['Create Table'] ?? array_values($row)[1];
 
-        if (preg_match_all('/^\s*[`"](.*?)[`"]\s+(.*?),?$/m', $createTable, $matches)) {
-            foreach ($matches[1] as $i => $c) {
-                if ($c === $column) {
-                    return $matches[2][$i];
+        $regexp = '/^\s*(?:`((?:``|[^`])+)`|"((?:""|[^"])+)")\s+(.*?),?$/m';
+
+        if (preg_match_all($regexp, $createTable, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $columnName = $match[1] !== ''
+                    ? str_replace('``', '`', $match[1])
+                    : str_replace('""', '"', $match[2]);
+
+                if ($columnName === $column) {
+                    return $match[3];
                 }
             }
         }

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -22,7 +22,10 @@ use yii\db\TableSchema;
 use yii\helpers\ArrayHelper;
 use yii\db\Schema as BaseSchema;
 
+use function array_map;
 use function explode;
+use function in_array;
+use function preg_match_all;
 use function str_replace;
 use function stripos;
 
@@ -100,7 +103,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function resolveTableName($name)
     {
-        $parts = explode('.', str_replace('`', '', $name));
+        $parts = array_map([$this, 'unquoteSimpleTableName'], explode('.', $name));
 
         $hasSchemaName = isset($parts[1]);
 
@@ -377,7 +380,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
                 $info = array_change_key_case($info, CASE_LOWER);
             }
 
-            if (\in_array($info['field'], $jsonColumns, true)) {
+            if (in_array($info['field'], $jsonColumns, true)) {
                 $info['type'] = static::TYPE_JSON;
             }
 
@@ -482,16 +485,10 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     public function findUniqueIndexes($table)
     {
-        $sql = $this->getCreateTableSql($table);
         $uniqueIndexes = [];
 
-        $regexp = '/UNIQUE KEY\s+[`"](.+)[`"]\s*\(([`"].+[`"])+\)/mi';
-        if (preg_match_all($regexp, $sql, $matches, PREG_SET_ORDER)) {
-            foreach ($matches as $match) {
-                $indexName = $match[1];
-                $indexColumns = array_map('trim', preg_split('/[`"],[`"]/', trim($match[2], '`"')));
-                $uniqueIndexes[$indexName] = $indexColumns;
-            }
+        foreach ($this->getTableUniques($table->fullName, true) as $constraint) {
+            $uniqueIndexes[$constraint->name] = $constraint->columnNames;
         }
 
         return $uniqueIndexes;
@@ -596,11 +593,13 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
         $sql = $this->getCreateTableSql($table);
         $result = [];
 
-        $regexp = '/json_valid\([\`"](.+)[\`"]\s*\)/mi';
+        $regexp = '/json_valid\(\s*(?:`((?:``|[^`])+)`|"((?:""|[^"])+)")\s*\)/mi';
 
-        if (\preg_match_all($regexp, $sql, $matches, PREG_SET_ORDER)) {
+        if (preg_match_all($regexp, $sql, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
-                $result[] = $match[1];
+                $result[] = $match[1] !== ''
+                    ? str_replace('``', '`', $match[1])
+                    : str_replace('""', '"', $match[2]);
             }
         }
 

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -273,14 +273,6 @@ SQL;
     /**
      * {@inheritdoc}
      */
-    public function quoteSimpleTableName($name)
-    {
-        return strpos($name, '"') !== false ? $name : '"' . $name . '"';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function createQueryBuilder()
     {
         return Yii::createObject(QueryBuilder::class, [$this->db]);

--- a/tests/base/db/BaseQueryBuilder.php
+++ b/tests/base/db/BaseQueryBuilder.php
@@ -180,11 +180,11 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 ],
             ],
             [
-                Schema::TYPE_CHAR . ' CHECK (value LIKE "test%")',
-                $this->char()->check('value LIKE "test%"'),
+                Schema::TYPE_CHAR . " CHECK (value LIKE 'test%')",
+                $this->char()->check("value LIKE 'test%'"),
                 [
-                    'mysql' => 'char(1) CHECK (value LIKE "test%")',
-                    'sqlite' => 'char(1) CHECK (value LIKE "test%")',
+                    'mysql' => "char(1) CHECK (value LIKE 'test%')",
+                    'sqlite' => "char(1) CHECK (value LIKE 'test%')",
                 ],
             ],
             [
@@ -198,11 +198,11 @@ abstract class BaseQueryBuilder extends DatabaseTestCase
                 ],
             ],
             [
-                Schema::TYPE_CHAR . '(6) CHECK (value LIKE "test%")',
-                $this->char(6)->check('value LIKE "test%"'),
+                Schema::TYPE_CHAR . "(6) CHECK (value LIKE 'test%')",
+                $this->char(6)->check("value LIKE 'test%'"),
                 [
-                    'mysql' => 'char(6) CHECK (value LIKE "test%")',
-                    'sqlite' => 'char(6) CHECK (value LIKE "test%")',
+                    'mysql' => "char(6) CHECK (value LIKE 'test%')",
+                    'sqlite' => "char(6) CHECK (value LIKE 'test%')",
                 ],
             ],
             [

--- a/tests/base/db/providers/SchemaProvider.php
+++ b/tests/base/db/providers/SchemaProvider.php
@@ -53,6 +53,7 @@ class SchemaProvider
             ['test.[[test]].test', '[[test]].[[test]].[[test]]'],
             ['test.test', '[[test]].[[test]]'],
             ['test.test.test', '[[test]].[[test]].[[test]]'],
+            ['[[a.b]]', '[[a.b]]'],
         ];
     }
 
@@ -78,6 +79,7 @@ class SchemaProvider
             ['[[table]].[[column]]', '[[table]].[[column]]'],
             ['schema.table.column', '[[schema]].[[table]].[[column]]'],
             ['{{table}}.column', '{{table}}.[[column]]'],
+            ['[[a.b]]', '[[a.b]]'],
         ];
     }
 
@@ -93,6 +95,8 @@ class SchemaProvider
             ['(test)', '[[(test)]]'],
             ['current-table-name', '[[current-table-name]]'],
             ["te'st", "[[te'st]]"],
+            ['a]]b', '[[a]]]]b]]'],
+            ['[[a]]]]b]]', '[[a]]]]b]]'],
         ];
     }
 
@@ -105,6 +109,8 @@ class SchemaProvider
             ['*', '*'],
             ['[[column]]', '[[column]]'],
             ['column', '[[column]]'],
+            ['a]]b', '[[a]]]]b]]'],
+            ['[[a]]]]b]]', '[[a]]]]b]]'],
         ];
     }
 
@@ -116,6 +122,8 @@ class SchemaProvider
         return [
             ['[[test]]', 'test'],
             ['test', 'test'],
+            ['a]]b', 'a]]b'],
+            ['[[a]]]]b]]', 'a]]b'],
         ];
     }
 
@@ -128,6 +136,8 @@ class SchemaProvider
             ['*', '*'],
             ['[[column]]', 'column'],
             ['column', 'column'],
+            ['a]]b', 'a]]b'],
+            ['[[a]]]]b]]', 'a]]b'],
         ];
     }
 

--- a/tests/framework/db/mssql/providers/SchemaProvider.php
+++ b/tests/framework/db/mssql/providers/SchemaProvider.php
@@ -92,7 +92,7 @@ final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
     {
         return [
             ...parent::quoteSimpleTableName(),
-            ['a[b', 'a[b'],
+            ['a[b', '[a[b]'],
         ];
     }
 

--- a/tests/framework/db/mysql/SchemaQuoteTest.php
+++ b/tests/framework/db/mysql/SchemaQuoteTest.php
@@ -29,12 +29,6 @@ final class SchemaQuoteTest extends BaseSchemaQuote
     protected $driverName = 'mysql';
     protected static string $driverNameStatic = 'mysql';
 
-    #[DataProviderExternal(SchemaProvider::class, 'quoteSimpleTableName')]
-    public function testQuoteSimpleTableName(string $name, string $expectedName): void
-    {
-        parent::testQuoteSimpleTableName($name, $expectedName);
-    }
-
     #[DataProviderExternal(SchemaProvider::class, 'quoteValue')]
     public function testQuoteValueQuotesString(string $value, string $expectedValue): void
     {

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -288,6 +288,90 @@ final class SchemaTest extends BaseSchema
     }
 
     /**
+     * Regression test for https://github.com/yiisoft/yii2/issues/8765.
+     */
+    public function testSchemaMetadataWithBackticksInIdentifiers(): void
+    {
+        $db = $this->getConnection(false);
+        $schema = $db->getSchema();
+
+        $parentTable = 'yii2_issue_8765`parent';
+        $childTable = 'yii2_issue_8765`child';
+        $parentColumn = 'c"d';
+        $foreignColumn = 'parent`id';
+        $jsonColumn = 'json`data';
+        $uniqueIndex = 'unique`json';
+        $foreignKey = 'fk`parent';
+
+        DbHelper::dropTablesIfExist($db, [$childTable, $parentTable]);
+
+        $db->createCommand(
+            <<<SQL
+            CREATE TABLE `yii2_issue_8765``parent` (
+                `c"d` int NOT NULL,
+                PRIMARY KEY (`c"d`)
+            )
+            SQL,
+        )->execute();
+        $db->createCommand(
+            <<<SQL
+            CREATE TABLE `yii2_issue_8765``child` (
+                `parent``id` int NOT NULL,
+                `json``data` json,
+                UNIQUE KEY `unique``json` (`parent``id`),
+                CONSTRAINT `fk``parent`
+                    FOREIGN KEY (`parent``id`) REFERENCES `yii2_issue_8765``parent` (`c"d`)
+            )
+            SQL,
+        )->execute();
+
+        $table = $schema->getTableSchema($childTable, true);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $table,
+            'Table schema must load when the table name contains a backtick.',
+        );
+        self::assertSame(
+            $childTable,
+            $table->name,
+            'Reflected table name must preserve its backtick.',
+        );
+        self::assertArrayHasKey(
+            $foreignColumn,
+            $table->columns,
+            'Reflected column name must preserve its backtick.',
+        );
+        self::assertSame(
+            Schema::TYPE_JSON,
+            $table->columns[$jsonColumn]->type,
+            'JSON reflection must preserve a backtick in the column name.',
+        );
+        self::assertSame(
+            [$parentTable, $foreignColumn => $parentColumn],
+            $table->foreignKeys[$foreignKey],
+            'Foreign key metadata must preserve backticks in all identifiers.',
+        );
+        self::assertSame(
+            [$uniqueIndex => [$foreignColumn]],
+            $schema->findUniqueIndexes($table),
+            'Unique index metadata must preserve backticks in index and column names.',
+        );
+
+        $db->createCommand()
+            ->addCommentOnColumn($childTable, $foreignColumn, 'Issue #8765')
+            ->execute();
+
+        self::assertSame(
+            'Issue #8765',
+            $schema->getTableSchema($childTable, true)->columns[$foreignColumn]->comment,
+            'Column definition lookup must decode doubled backticks.',
+        );
+
+        DbHelper::dropTablesIfExist($db, [$childTable, $parentTable]);
+    }
+
+    /**
      * When displayed in the INFORMATION_SCHEMA.COLUMNS table, a default CURRENT TIMESTAMP is displayed
      * as CURRENT_TIMESTAMP up until MariaDB 10.2.2, and as current_timestamp() from MariaDB 10.2.3.
      *

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -342,10 +342,15 @@ final class SchemaTest extends BaseSchema
             $table->columns,
             'Reflected column name must preserve its backtick.',
         );
+        self::assertArrayHasKey(
+            $jsonColumn,
+            $table->columns,
+            'JSON column name must preserve its backtick.',
+        );
         self::assertSame(
             Schema::TYPE_JSON,
             $table->columns[$jsonColumn]->type,
-            'JSON reflection must preserve a backtick in the column name.',
+            'JSON detection must survive a backtick in the column name.',
         );
         self::assertSame(
             [$parentTable, $foreignColumn => $parentColumn],

--- a/tests/framework/db/mysql/providers/SchemaProvider.php
+++ b/tests/framework/db/mysql/providers/SchemaProvider.php
@@ -25,15 +25,4 @@ final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
             ["It's interesting", "'It\\'s interesting'"],
         ];
     }
-
-    /**
-     * @return list<array{string, string}>
-     */
-    public static function quoteSimpleTableName(): array
-    {
-        return [
-            ...parent::quoteSimpleTableName(),
-            ['a`b', 'a`b'],
-        ];
-    }
 }

--- a/tests/framework/db/oci/providers/SchemaProvider.php
+++ b/tests/framework/db/oci/providers/SchemaProvider.php
@@ -15,14 +15,4 @@ namespace yiiunit\framework\db\oci\providers;
  */
 final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
 {
-    /**
-     * @return list<array{string, string}>
-     */
-    public static function quoteSimpleTableName(): array
-    {
-        return [
-            ...parent::quoteSimpleTableName(),
-            ['a"b', 'a"b'],
-        ];
-    }
 }

--- a/tests/framework/db/pgsql/providers/SchemaProvider.php
+++ b/tests/framework/db/pgsql/providers/SchemaProvider.php
@@ -31,18 +31,4 @@ final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
             [-9_223_372_036_854_775_808.0],
         ];
     }
-
-    /**
-     * Extends the shared cases with a name embedding a double quote (the driver's own quote character), passed through
-     * unchanged.
-     *
-     * @return list<array{string, string}>
-     */
-    public static function quoteSimpleTableName(): array
-    {
-        return [
-            ...parent::quoteSimpleTableName(),
-            ['a"b', 'a"b'],
-        ];
-    }
 }

--- a/tests/framework/db/sqlite/providers/SchemaProvider.php
+++ b/tests/framework/db/sqlite/providers/SchemaProvider.php
@@ -15,14 +15,4 @@ namespace yiiunit\framework\db\sqlite\providers;
  */
 final class SchemaProvider extends \yiiunit\base\db\providers\SchemaProvider
 {
-    /**
-     * @return list<array{string, string}>
-     */
-    public static function quoteSimpleTableName(): array
-    {
-        return [
-            ...parent::quoteSimpleTableName(),
-            ['a`b', 'a`b'],
-        ];
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #8765
