### PR TITLE
Preserve quote characters during Oracle table name resolution so a name containing a stray double quote no longer resolves to a different existing object.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -143,6 +143,7 @@ Yii Framework 2 Change Log
 - Bug #20275: Decode quoted MySQL/MariaDB column default literals (`text`/`blob` and any non-JSON `DEFAULT_GENERATED` string default) to their PHP value instead of an `Expression` or raw quoted string (terabytesoftw)
 - Bug #11191: Enable session `autocommit` on the migration connection when the MySQL/MariaDB server default disables it, so migration history stays complete and transactional migrations can start (terabytesoftw)
 - Bug #8765: Escape quote characters inside DB identifiers when quoting and preserve them during schema reflection (terabytesoftw)
+- Bug #8765: Preserve quote characters during Oracle table name resolution so a name containing a stray double quote no longer resolves to a different existing object (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -25,8 +25,8 @@ use yii\db\TableSchema;
 use yii\helpers\ArrayHelper;
 use yii\db\Schema as BaseSchema;
 
+use function array_map;
 use function explode;
-use function str_replace;
 
 /**
  * Schema is the class for retrieving metadata from an Oracle database.
@@ -81,10 +81,12 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function resolveTableName($name)
     {
-        $parts = explode('.', str_replace('"', '', $name));
+        $parts = array_map([$this, 'unquoteSimpleTableName'], explode('.', $name));
 
-        $tableName = $parts[1] ?? $parts[0];
-        $schemaName = isset($parts[1]) ? $parts[0] : $this->defaultSchema;
+        $hasSchemaName = isset($parts[1]);
+
+        $tableName = $hasSchemaName ? $parts[1] : $parts[0];
+        $schemaName = $hasSchemaName ? $parts[0] : $this->defaultSchema;
         $fullName = $schemaName !== $this->defaultSchema ? "{$schemaName}.{$tableName}" : $tableName;
 
         $resolvedName = new TableSchema();

--- a/tests/framework/db/oci/SchemaTest.php
+++ b/tests/framework/db/oci/SchemaTest.php
@@ -183,6 +183,45 @@ final class SchemaTest extends BaseSchema
         );
     }
 
+    public function testGetTableSchemaWithQuotedSchemaAndTableName(): void
+    {
+        $schema = $this->getConnection()->getSchema();
+
+        $schemaName = $schema->defaultSchema;
+
+        $tableSchema = $schema->getTableSchema('"' . $schemaName . '"."profile"', true);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $tableSchema,
+            'Table schema should be loadable with a quoted schema and table name.',
+        );
+        self::assertSame(
+            'profile',
+            $tableSchema->name,
+            'Loaded table name should not keep quote characters.',
+        );
+        self::assertSame(
+            $schemaName,
+            $tableSchema->schemaName,
+            'Loaded schema name should not keep quote characters.',
+        );
+    }
+
+    public function testGetTableSchemaWithStrayQuoteInName(): void
+    {
+        $schema = $this->getConnection()->getSchema();
+
+        self::assertNull(
+            $schema->getTableSchema('pro"file', true),
+            'A stray quote inside the table name must not resolve to another existing table.',
+        );
+        self::assertNull(
+            $schema->getTableSchema('SYS"TEM.profile', true),
+            'A stray quote inside the schema name must not resolve to another existing table.',
+        );
+    }
+
     public function testIntegerDataTypeColumn(): void
     {
         $table = $this->getConnection()->getSchema()->getTableSchema('employee');

--- a/tests/framework/db/oci/SchemaTest.php
+++ b/tests/framework/db/oci/SchemaTest.php
@@ -212,12 +212,14 @@ final class SchemaTest extends BaseSchema
     {
         $schema = $this->getConnection()->getSchema();
 
+        $schemaName = $schema->defaultSchema;
+
         self::assertNull(
             $schema->getTableSchema('pro"file', true),
             'A stray quote inside the table name must not resolve to another existing table.',
         );
         self::assertNull(
-            $schema->getTableSchema('SYS"TEM.profile', true),
+            $schema->getTableSchema($schemaName . '".profile', true),
             'A stray quote inside the schema name must not resolve to another existing table.',
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #8765 
