### PR TITLE
Preserve quote characters during PostgreSQL table name resolution so a name containing a stray double quote no longer resolves to a different existing object.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -144,6 +144,7 @@ Yii Framework 2 Change Log
 - Bug #11191: Enable session `autocommit` on the migration connection when the MySQL/MariaDB server default disables it, so migration history stays complete and transactional migrations can start (terabytesoftw)
 - Bug #8765: Escape quote characters inside DB identifiers when quoting and preserve them during schema reflection (terabytesoftw)
 - Bug #8765: Preserve quote characters during Oracle table name resolution so a name containing a stray double quote no longer resolves to a different existing object (terabytesoftw)
+- Bug #8765: Preserve quote characters during PostgreSQL table name resolution so a name containing a stray double quote no longer resolves to a different existing object (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -23,8 +23,8 @@ use yii\db\ViewFinderTrait;
 use yii\helpers\ArrayHelper;
 use yii\db\Schema as BaseSchema;
 
+use function array_map;
 use function explode;
-use function str_replace;
 
 /**
  * Schema is the class for retrieving metadata from a PostgreSQL database
@@ -144,10 +144,12 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function resolveTableName($name)
     {
-        $parts = explode('.', str_replace('"', '', $name));
+        $parts = array_map([$this, 'unquoteSimpleTableName'], explode('.', $name));
 
-        $tableName = $parts[1] ?? $parts[0];
-        $schemaName = isset($parts[1]) ? $parts[0] : $this->defaultSchema;
+        $hasSchemaName = isset($parts[1]);
+
+        $tableName = $hasSchemaName ? $parts[1] : $parts[0];
+        $schemaName = $hasSchemaName ? $parts[0] : $this->defaultSchema;
         $fullName = $schemaName !== $this->defaultSchema ? "{$schemaName}.{$tableName}" : $tableName;
 
         $resolvedName = new TableSchema();

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -215,6 +215,84 @@ final class SchemaTest extends BaseSchema
         }
     }
 
+    public function testSchemaMetadataWithDoubleQuotesInIdentifiers(): void
+    {
+        $db = $this->getConnection(false);
+
+        $schema = $db->getSchema();
+
+        $tableName = 'yii2_issue_8765"table';
+        $columnName = 'column"name';
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
+
+        $db->createCommand()->createTable(
+            $tableName,
+            [
+                $columnName => 'integer',
+            ],
+        )->execute();
+
+        foreach ([$tableName, $schema->quoteTableName($tableName)] as $lookupName) {
+            $table = $schema->getTableSchema($lookupName, true);
+
+            self::assertInstanceOf(
+                TableSchema::class,
+                $table,
+                'Table schema must load when the table name contains a double quote.',
+            );
+            self::assertSame(
+                $tableName,
+                $table->name,
+                'Reflected table name must preserve its double quote.',
+            );
+            self::assertArrayHasKey(
+                $columnName,
+                $table->columns,
+                'Reflected column name must preserve its double quote.',
+            );
+        }
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
+    }
+
+    public function testGetTableSchemaWithQuotedSchemaAndTableName(): void
+    {
+        $schema = $this->getConnection()->getSchema();
+
+        $tableSchema = $schema->getTableSchema('"public"."profile"', true);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $tableSchema,
+            'Table schema should be loadable with a quoted schema and table name.',
+        );
+        self::assertSame(
+            'profile',
+            $tableSchema->name,
+            'Loaded table name should not keep quote characters.',
+        );
+        self::assertSame(
+            'public',
+            $tableSchema->schemaName,
+            'Loaded schema name should not keep quote characters.',
+        );
+    }
+
+    public function testGetTableSchemaWithStrayQuoteInName(): void
+    {
+        $schema = $this->getConnection()->getSchema();
+
+        self::assertNull(
+            $schema->getTableSchema('pro"file', true),
+            'A stray quote inside the table name must not resolve to another existing table.',
+        );
+        self::assertNull(
+            $schema->getTableSchema('public".profile', true),
+            'A stray quote inside the schema name must not resolve to another existing table.',
+        );
+    }
+
     /**
      * @param int|float $bigint Bigint value to test.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #8765
