### PR TITLE
Split dotted table names only on periods outside quoted identifier pairs so a name such as `"schema"."table.with.dot"` resolves correctly in all drivers.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -145,6 +145,7 @@ Yii Framework 2 Change Log
 - Bug #8765: Escape quote characters inside DB identifiers when quoting and preserve them during schema reflection (terabytesoftw)
 - Bug #8765: Preserve quote characters during Oracle table name resolution so a name containing a stray double quote no longer resolves to a different existing object (terabytesoftw)
 - Bug #8765: Preserve quote characters during PostgreSQL table name resolution so a name containing a stray double quote no longer resolves to a different existing object (terabytesoftw)
+- Bug #8765: Split dotted table names only on periods outside quoted identifier pairs so a name such as `"schema"."table.with.dot"` resolves correctly in all drivers (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/captcha/CaptchaValidator.php
+++ b/framework/captcha/CaptchaValidator.php
@@ -12,7 +12,9 @@ use Yii;
 use yii\base\InvalidConfigException;
 use yii\validators\client\ClientValidatorScriptInterface;
 use yii\validators\Validator;
+use yii\web\Application;
 use yii\web\Controller;
+use yii\web\IdentityInterface;
 
 /**
  * CaptchaValidator validates that the attribute value is the same as the verification code displayed in the CAPTCHA.
@@ -85,7 +87,7 @@ class CaptchaValidator extends Validator
     {
         $ca = Yii::$app->createController($this->captchaAction);
         if ($ca !== false) {
-            /** @var Controller $controller */
+            /** @var Controller<Application<IdentityInterface>> $controller */
             list($controller, $actionID) = $ca;
             /** @var CaptchaAction|null $action */
             $action = $controller->createAction($actionID);

--- a/framework/console/controllers/HelpController.php
+++ b/framework/console/controllers/HelpController.php
@@ -86,7 +86,7 @@ class HelpController extends Controller
     {
         foreach ($this->getCommandDescriptions() as $command => $description) {
             $result = Yii::$app->createController($command);
-            /** @var Controller<Application> $controller */
+            /** @var Controller<ConsoleApplication> $controller */
             list($controller, $actionID) = $result;
             $actions = $this->getActions($controller);
             $prefix = $controller->getUniqueId();
@@ -114,7 +114,7 @@ class HelpController extends Controller
             return;
         }
 
-        /** @var Controller<Application> $controller */
+        /** @var Controller<ConsoleApplication> $controller */
         list($controller, $actionID) = $result;
         $action = $controller->createAction($actionID);
         if ($action === null) {
@@ -147,7 +147,7 @@ class HelpController extends Controller
             return;
         }
 
-        /** @var Controller<Application> $controller */
+        /** @var Controller<ConsoleApplication> $controller */
         list($controller, $actionID) = $result;
         $action = $controller->createAction($actionID);
         if ($action === null) {
@@ -185,7 +185,7 @@ class HelpController extends Controller
             if ($result === false || !$result[0] instanceof Controller) {
                 return false;
             }
-            /** @var Controller<Application> $controller */
+            /** @var Controller<ConsoleApplication> $controller */
             list($controller, $actionID) = $result;
             $actions = $this->getActions($controller);
             return $actions !== [];
@@ -201,7 +201,7 @@ class HelpController extends Controller
         $descriptions = [];
         foreach ($this->getCommands() as $command) {
             $result = Yii::$app->createController($command);
-            /** @var Controller<Application> $controller */
+            /** @var Controller<ConsoleApplication> $controller */
             list($controller, $actionID) = $result;
             $descriptions[$command] = $controller->getHelpSummary();
         }
@@ -310,7 +310,7 @@ class HelpController extends Controller
         $maxLength = 0;
         foreach ($commands as $command => $description) {
             $result = Yii::$app->createController($command);
-            /** @var Controller<Application> $controller */
+            /** @var Controller<ConsoleApplication> $controller */
             list($controller, $actionID) = $result;
             $actions = $this->getActions($controller);
             $prefix = $controller->getUniqueId();
@@ -324,7 +324,7 @@ class HelpController extends Controller
         }
         foreach ($commands as $command => $description) {
             $result = Yii::$app->createController($command);
-            /** @var Controller<Application> $controller */
+            /** @var Controller<ConsoleApplication> $controller */
             list($controller, $actionID) = $result;
             $actions = $this->getActions($controller);
             $this->stdout('- ' . $this->ansiFormat($command, Console::FG_YELLOW));

--- a/framework/db/Schema.php
+++ b/framework/db/Schema.php
@@ -560,7 +560,36 @@ abstract class Schema extends BaseObject
      */
     protected function getTableNameParts($name)
     {
-        return explode('.', $name);
+        [$startChar, $endChar] = $this->resolveQuoteCharacter($this->tableQuoteCharacter);
+
+        if (!str_contains($name, $startChar)) {
+            return explode('.', $name);
+        }
+
+        $parts = [];
+        $current = '';
+        $inQuotes = false;
+
+        for ($i = 0, $len = strlen($name); $i < $len; $i++) {
+            $c = $name[$i];
+
+            if (!$inQuotes && $c === $startChar) {
+                $inQuotes = true;
+                $current .= $c;
+            } elseif ($inQuotes && $c === $endChar) {
+                $inQuotes = false;
+                $current .= $c;
+            } elseif (!$inQuotes && $c === '.') {
+                $parts[] = $current;
+                $current = '';
+            } else {
+                $current .= $c;
+            }
+        }
+
+        $parts[] = $current;
+
+        return $parts;
     }
 
     /**

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -103,7 +103,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function resolveTableName($name)
     {
-        $parts = array_map([$this, 'unquoteSimpleTableName'], explode('.', $name));
+        $parts = array_map([$this, 'unquoteSimpleTableName'], $this->getTableNameParts($name));
 
         $hasSchemaName = isset($parts[1]);
 
@@ -359,16 +359,25 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function findColumns($table)
     {
-        $sql = 'SHOW FULL COLUMNS FROM ' . $this->quoteTableName($table->fullName);
+        $quotedRef = $table->schemaName !== null
+            ? $this->quoteSimpleTableName($table->schemaName) . '.' . $this->quoteSimpleTableName($table->name)
+            : $this->quoteSimpleTableName($table->name);
+
+        $sql = <<<SQL
+        SHOW FULL COLUMNS FROM {$quotedRef}
+        SQL;
+
         try {
             $columns = $this->db->createCommand($sql)->queryAll();
         } catch (\Exception $e) {
             $previous = $e->getPrevious();
+
             if ($previous instanceof \PDOException && strpos($previous->getMessage(), 'SQLSTATE[42S02') !== false) {
                 // table does not exist
                 // https://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html#error_er_bad_table_error
                 return false;
             }
+
             throw $e;
         }
 
@@ -391,6 +400,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
                     $table->sequenceName = '';
                 }
             }
+
             $column->defaultValue = $column->isPrimaryKey
                 ? null
                 : $column->defaultPhpTypecast($column->defaultValue);
@@ -407,7 +417,16 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function getCreateTableSql($table)
     {
-        $row = $this->db->createCommand('SHOW CREATE TABLE ' . $this->quoteTableName($table->fullName))->queryOne();
+        $quotedRef = $table->schemaName !== null
+            ? $this->quoteSimpleTableName($table->schemaName) . '.' . $this->quoteSimpleTableName($table->name)
+            : $this->quoteSimpleTableName($table->name);
+
+        $sql = <<<SQL
+        SHOW CREATE TABLE {$quotedRef}
+        SQL;
+
+        $row = $this->db->createCommand($sql)->queryOne();
+
         if (isset($row['Create Table'])) {
             $sql = $row['Create Table'];
         } else {
@@ -487,7 +506,10 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
     {
         $uniqueIndexes = [];
 
-        foreach ($this->getTableUniques($table->fullName, true) as $constraint) {
+        $quotedRef = $table->schemaName !== null
+            ? $this->quoteSimpleTableName($table->schemaName) . '.' . $this->quoteSimpleTableName($table->name)
+            : $this->quoteSimpleTableName($table->name);
+        foreach ($this->getTableUniques($quotedRef, true) as $constraint) {
             $uniqueIndexes[$constraint->name] = $constraint->columnNames;
         }
 

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -26,7 +26,6 @@ use yii\helpers\ArrayHelper;
 use yii\db\Schema as BaseSchema;
 
 use function array_map;
-use function explode;
 
 /**
  * Schema is the class for retrieving metadata from an Oracle database.
@@ -81,7 +80,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function resolveTableName($name)
     {
-        $parts = array_map([$this, 'unquoteSimpleTableName'], explode('.', $name));
+        $parts = array_map([$this, 'unquoteSimpleTableName'], $this->getTableNameParts($name));
 
         $hasSchemaName = isset($parts[1]);
 

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -144,7 +144,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function resolveTableName($name)
     {
-        $parts = array_map([$this, 'unquoteSimpleTableName'], explode('.', $name));
+        $parts = array_map([$this, 'unquoteSimpleTableName'], $this->getTableNameParts($name));
 
         $hasSchemaName = isset($parts[1]);
 

--- a/tests/base/db/providers/SchemaProvider.php
+++ b/tests/base/db/providers/SchemaProvider.php
@@ -54,6 +54,7 @@ class SchemaProvider
             ['test.test', '[[test]].[[test]]'],
             ['test.test.test', '[[test]].[[test]].[[test]]'],
             ['[[a.b]]', '[[a.b]]'],
+            ['schema.[[a.b]]', '[[schema]].[[a.b]]'],
         ];
     }
 

--- a/tests/framework/db/mysql/SchemaTest.php
+++ b/tests/framework/db/mysql/SchemaTest.php
@@ -376,6 +376,47 @@ final class SchemaTest extends BaseSchema
         DbHelper::dropTablesIfExist($db, [$childTable, $parentTable]);
     }
 
+    public function testGetTableSchemaWithDotInsideQuotedTableName(): void
+    {
+        $db = $this->getConnection(false);
+
+        $schema = $db->getSchema();
+
+        $tableName = 'yii2_table.with.dot';
+        $quotedTableName = '`yii2_table.with.dot`';
+
+        DbHelper::dropTablesIfExist($db, [$quotedTableName]);
+
+        $db->createCommand()->createTable(
+            $quotedTableName,
+            ['x' => 'integer'],
+        )->execute();
+
+        $table = $schema->getTableSchema($quotedTableName, true);
+
+        self::assertInstanceOf(
+            TableSchema::class,
+            $table,
+            'Table schema must load when the table name contains a dot.',
+        );
+        self::assertSame(
+            $tableName,
+            $table->name,
+            'Reflected table name must keep every dot.',
+        );
+        self::assertNull(
+            $table->schemaName,
+            'Schema name must be `null` for a simple table reference.',
+        );
+        self::assertArrayHasKey(
+            'x',
+            $table->columns,
+            'Reflected columns must come from the dotted table.',
+        );
+
+        DbHelper::dropTablesIfExist($db, [$quotedTableName]);
+    }
+
     /**
      * When displayed in the INFORMATION_SCHEMA.COLUMNS table, a default CURRENT TIMESTAMP is displayed
      * as CURRENT_TIMESTAMP up until MariaDB 10.2.2, and as current_timestamp() from MariaDB 10.2.3.

--- a/tests/framework/db/oci/SchemaTest.php
+++ b/tests/framework/db/oci/SchemaTest.php
@@ -224,6 +224,52 @@ final class SchemaTest extends BaseSchema
         );
     }
 
+    public function testGetTableSchemaWithDotInsideQuotedTableName(): void
+    {
+        $db = $this->getConnection(false);
+
+        $schema = $db->getSchema();
+
+        $schemaName = $schema->defaultSchema;
+
+        $tableName = 'yii2_table.with.dot';
+        $quotedTableName = '"yii2_table.with.dot"';
+
+        DbHelper::dropTablesIfExist($db, [$quotedTableName]);
+
+        $db->createCommand()->createTable(
+            $quotedTableName,
+            ['x' => 'integer'],
+        )->execute();
+
+        foreach ([$quotedTableName, '"' . $schemaName . '".' . $quotedTableName] as $lookupName) {
+            $table = $schema->getTableSchema($lookupName, true);
+
+            self::assertInstanceOf(
+                TableSchema::class,
+                $table,
+                'Table schema must load when the table name contains a dot.',
+            );
+            self::assertSame(
+                $tableName,
+                $table->name,
+                'Reflected table name must keep every dot.',
+            );
+            self::assertSame(
+                $schemaName,
+                $table->schemaName,
+                'Schema name must not be taken from the dotted table name.',
+            );
+            self::assertArrayHasKey(
+                'x',
+                $table->columns,
+                'Reflected columns must come from the dotted table.',
+            );
+        }
+
+        DbHelper::dropTablesIfExist($db, [$quotedTableName]);
+    }
+
     public function testIntegerDataTypeColumn(): void
     {
         $table = $this->getConnection()->getSchema()->getTableSchema('employee');

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -293,6 +293,52 @@ final class SchemaTest extends BaseSchema
         );
     }
 
+    public function testGetTableSchemaWithDotInsideQuotedTableName(): void
+    {
+        $db = $this->getConnection(false);
+
+        $schema = $db->getSchema();
+
+        $tableName = 'yii2_table.with.dot';
+        $quotedTableName = '"yii2_table.with.dot"';
+
+        DbHelper::dropTablesIfExist($db, [$quotedTableName]);
+
+        $db->createCommand()->createTable(
+            $quotedTableName,
+            ['x' => 'integer'],
+        )->execute();
+
+        $defaultSchema = $schema->defaultSchema;
+
+        foreach ([$quotedTableName, '"' . $defaultSchema . '"."yii2_table.with.dot"'] as $lookupName) {
+            $table = $schema->getTableSchema($lookupName, true);
+
+            self::assertInstanceOf(
+                TableSchema::class,
+                $table,
+                'Table schema must load when the table name contains a dot.',
+            );
+            self::assertSame(
+                $tableName,
+                $table->name,
+                'Reflected table name must keep every dot.',
+            );
+            self::assertSame(
+                $defaultSchema,
+                $table->schemaName,
+                'Schema name must not be taken from the dotted table name.',
+            );
+            self::assertArrayHasKey(
+                'x',
+                $table->columns,
+                'Reflected columns must come from the dotted table.',
+            );
+        }
+
+        DbHelper::dropTablesIfExist($db, [$quotedTableName]);
+    }
+
     /**
      * @param int|float $bigint Bigint value to test.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #8765 
