### PR TITLE
Fix `yii\db\oci\Schema::findConstraints()` to index table foreign keys by constraint name so all foreign keys are reflected instead of only the last one.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -146,6 +146,7 @@ Yii Framework 2 Change Log
 - Bug #8765: Preserve quote characters during Oracle table name resolution so a name containing a stray double quote no longer resolves to a different existing object (terabytesoftw)
 - Bug #8765: Preserve quote characters during PostgreSQL table name resolution so a name containing a stray double quote no longer resolves to a different existing object (terabytesoftw)
 - Bug #8765: Split dotted table names only on periods outside quoted identifier pairs so a name such as `"schema"."table.with.dot"` resolves correctly in all drivers (terabytesoftw)
+- Bug #16631: Fix `yii\db\oci\Schema::findConstraints()` to index table foreign keys by constraint name so all foreign keys are reflected instead of only the last one (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -502,9 +502,7 @@ SQL;
             $constraints[$name]['columns'][$row['COLUMN_NAME']] = $row['COLUMN_REF'];
         }
 
-        foreach ($constraints as $constraint) {
-            $name = current(array_keys($constraint));
-
+        foreach ($constraints as $name => $constraint) {
             $table->foreignKeys[$name] = array_merge([$constraint['tableName']], $constraint['columns']);
         }
     }

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -503,7 +503,7 @@ SQL;
         }
 
         foreach ($constraints as $name => $constraint) {
-            $table->foreignKeys[$name] = array_merge([$constraint['tableName']], $constraint['columns']);
+            $table->foreignKeys[$name] = [$constraint['tableName'], ...$constraint['columns']];
         }
     }
 

--- a/tests/framework/db/oci/SchemaConstraintsTest.php
+++ b/tests/framework/db/oci/SchemaConstraintsTest.php
@@ -17,6 +17,9 @@ use yii\db\Constraint;
 use yiiunit\base\db\BaseSchemaConstraints;
 use yiiunit\framework\db\oci\providers\ConstraintsProvider;
 
+use function array_values;
+use function usort;
+
 /**
  * Unit tests for {@see \yii\db\oci\Schema} constraint and index metadata retrieval for the Oracle driver.
  *
@@ -35,7 +38,7 @@ final class SchemaConstraintsTest extends BaseSchemaConstraints
 
         $table = $schema->getTableSchema('composite_fk');
 
-        $foreignKey = 'tableName';
+        $foreignKey = 'FK_COMPOSITE_FK_ORDER_ITEM';
 
         self::assertCount(
             1,
@@ -60,6 +63,36 @@ final class SchemaConstraintsTest extends BaseSchemaConstraints
             'item_id',
             $table->foreignKeys[$foreignKey]['item_id'],
             "Referenced column name for foreign key '{$foreignKey}' does not match the expected value.",
+        );
+    }
+
+    /**
+     * Regression test for https://github.com/yiisoft/yii2/issues/16631.
+     */
+    public function testMultipleForeignKeys(): void
+    {
+        $schema = $this->getConnection()->getSchema();
+
+        $table = $schema->getTableSchema('order_item');
+
+        self::assertCount(
+            2,
+            $table->foreignKeys,
+            'Number of foreign keys does not match the expected count.',
+        );
+
+        // FK names are system generated (`SYS_C...`), so sort by referenced table for a deterministic comparison.
+        $foreignKeys = array_values($table->foreignKeys);
+
+        usort($foreignKeys, static fn (array $a, array $b): int => $a[0] <=> $b[0]);
+
+        self::assertSame(
+            [
+                ['item', 'item_id' => 'id'],
+                ['order', 'order_id' => 'id'],
+            ],
+            $foreignKeys,
+            'Foreign key definitions do not match the expected values.',
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #16631 
