### PR TITLE
Fix `yii\db\oci\Schema::findUniqueIndexes()` to respect the connection `PDO::ATTR_CASE` attribute when reading unique index metadata.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -147,6 +147,7 @@ Yii Framework 2 Change Log
 - Bug #8765: Preserve quote characters during PostgreSQL table name resolution so a name containing a stray double quote no longer resolves to a different existing object (terabytesoftw)
 - Bug #8765: Split dotted table names only on periods outside quoted identifier pairs so a name such as `"schema"."table.with.dot"` resolves correctly in all drivers (terabytesoftw)
 - Bug #16631: Fix `yii\db\oci\Schema::findConstraints()` to index table foreign keys by constraint name so all foreign keys are reflected instead of only the last one (terabytesoftw)
+- Bug #16447: Fix `yii\db\oci\Schema::findUniqueIndexes()` to respect the connection `PDO::ATTR_CASE` attribute when reading unique index metadata (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -509,7 +509,7 @@ SQL;
 
     /**
      * Returns all unique indexes for the given table.
-     * Each array element is of the following structure:.
+     * Each array element is of the following structure:
      *
      * ```
      * [
@@ -518,31 +518,36 @@ SQL;
      * ]
      * ```
      *
-     * @param TableSchema $table the table metadata
-     * @return array all unique indexes for the given table.
+     * @param TableSchema $table The table metadata.
+     *
+     * @return array All unique indexes for the given table.
      * @since 2.0.4
      */
     public function findUniqueIndexes($table)
     {
-        $query = <<<'SQL'
-SELECT
-    DIC.INDEX_NAME,
-    DIC.COLUMN_NAME
-FROM ALL_INDEXES DI
-    INNER JOIN ALL_IND_COLUMNS DIC ON DI.TABLE_NAME = DIC.TABLE_NAME AND DI.INDEX_NAME = DIC.INDEX_NAME
-WHERE
-    DI.UNIQUENESS = 'UNIQUE'
-    AND DIC.TABLE_OWNER = :schemaName
-    AND DIC.TABLE_NAME = :tableName
-ORDER BY DIC.TABLE_NAME, DIC.INDEX_NAME, DIC.COLUMN_POSITION
-SQL;
-        $result = [];
-        $command = $this->db->createCommand($query, [
+        $query = <<<SQL
+        SELECT
+            DIC.INDEX_NAME AS "index_name",
+            DIC.COLUMN_NAME AS "column_name"
+        FROM ALL_INDEXES DI
+            INNER JOIN ALL_IND_COLUMNS DIC ON DI.TABLE_NAME = DIC.TABLE_NAME AND DI.INDEX_NAME = DIC.INDEX_NAME
+        WHERE
+            DI.UNIQUENESS = 'UNIQUE'
+            AND DIC.TABLE_OWNER = :schemaName
+            AND DIC.TABLE_NAME = :tableName
+        ORDER BY DIC.TABLE_NAME, DIC.INDEX_NAME, DIC.COLUMN_POSITION
+        SQL;
+
+        $rows = $this->db->createCommand($query, [
             ':tableName' => $table->name,
             ':schemaName' => $table->schemaName,
-        ]);
-        foreach ($command->queryAll() as $row) {
-            $result[$row['INDEX_NAME']][] = $row['COLUMN_NAME'];
+        ])->queryAll();
+        $rows = $this->normalizePdoRowKeyCase($rows, true);
+
+        $result = [];
+
+        foreach ($rows as $row) {
+            $result[$row['index_name']][] = $row['column_name'];
         }
 
         return $result;

--- a/tests/framework/db/oci/CommandTest.php
+++ b/tests/framework/db/oci/CommandTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yiiunit\framework\db\oci;
 
 use Exception;
+use PDO;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use Throwable;
@@ -1080,8 +1081,47 @@ class CommandTest extends BaseCommand
 
     public function testColumnCase(): void
     {
-        $this->markTestSkipped(
-            "'pdo_oci' does not honor 'PDO::ATTR_CASE'; column names always keep their natural case.",
+        $db = $this->getConnection();
+
+        $pdo = $db->getSlavePdo(true);
+
+        self::assertSame(
+            PDO::CASE_NATURAL,
+            $pdo->getAttribute(PDO::ATTR_CASE),
+            'Default attribute must be `PDO::CASE_NATURAL`.',
+        );
+
+        // "order" fixture columns are quoted lowercase; the unquoted alias is natural uppercase in Oracle.
+        $sql = <<<SQL
+        SELECT [[customer_id]], [[total]], 1 AS NATURAL_UPPER FROM {{order}}
+        SQL;
+
+        $rows = $db->createCommand($sql)->queryAll();
+
+        self::assertSame(
+            ['customer_id', 'total', 'NATURAL_UPPER'],
+            array_keys($rows[0]),
+            'Natural case must be preserved.',
+        );
+
+        $pdo->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
+        $rows = $db->createCommand($sql)->queryAll();
+
+        self::assertSame(
+            ['customer_id', 'total', 'natural_upper'],
+            array_keys($rows[0]),
+            'Keys must fold to lowercase.',
+        );
+
+        // PDO core folds only when the requested case differs from the driver native case; 'pdo_oci' reports
+        // uppercase as native, so 'PDO::CASE_UPPER' performs no folding and lowercase names keep their case.
+        $pdo->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
+        $rows = $db->createCommand($sql)->queryAll();
+
+        self::assertSame(
+            ['customer_id', 'total', 'NATURAL_UPPER'],
+            array_keys($rows[0]),
+            "'PDO::CASE_UPPER' must perform no folding.",
         );
     }
 }

--- a/tests/framework/db/oci/SchemaConstraintsTest.php
+++ b/tests/framework/db/oci/SchemaConstraintsTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yiiunit\framework\db\oci;
 
 use Exception;
+use PDO;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use yii\db\Constraint;
@@ -157,6 +158,33 @@ final class SchemaConstraintsTest extends BaseSchemaConstraints
             ],
             $uniqueIndexes,
             "Unique indexes do not match after creating unique index on 'someCol3'.",
+        );
+
+        // Regression test for https://github.com/yiisoft/yii2/issues/16447.
+        $db->getSlavePdo(true)->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
+        $uniqueIndexes = $schema->findUniqueIndexes($schema->getTableSchema('uniqueIndex', true));
+
+        self::assertEquals(
+            [
+                'somecolUnique' => ['somecol'],
+                'someCol2Unique' => ['someCol2'],
+                'another unique index' => ['someCol3'],
+            ],
+            $uniqueIndexes,
+            "Unique indexes do not match with 'PDO::ATTR_CASE' set to 'PDO::CASE_LOWER'.",
+        );
+
+        $db->getSlavePdo(true)->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
+        $uniqueIndexes = $schema->findUniqueIndexes($schema->getTableSchema('uniqueIndex', true));
+
+        self::assertEquals(
+            [
+                'somecolUnique' => ['somecol'],
+                'someCol2Unique' => ['someCol2'],
+                'another unique index' => ['someCol3'],
+            ],
+            $uniqueIndexes,
+            "Unique indexes do not match with 'PDO::ATTR_CASE' set to 'PDO::CASE_UPPER'.",
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #16447 
