### PR TITLE
Preserve defaults on non-auto-incrementing primary key columns in MySQL/MariaDB, PostgreSQL, SQLite, and MSSQL schema metadata, matching the existing Oracle driver behavior.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -148,6 +148,7 @@ Yii Framework 2 Change Log
 - Bug #8765: Split dotted table names only on periods outside quoted identifier pairs so a name such as `"schema"."table.with.dot"` resolves correctly in all drivers (terabytesoftw)
 - Bug #16631: Fix `yii\db\oci\Schema::findConstraints()` to index table foreign keys by constraint name so all foreign keys are reflected instead of only the last one (terabytesoftw)
 - Bug #16447: Fix `yii\db\oci\Schema::findUniqueIndexes()` to respect the connection `PDO::ATTR_CASE` attribute when reading unique index metadata (terabytesoftw)
+- Bug #7843: Preserve defaults on non-auto-incrementing primary key columns in MySQL/MariaDB, PostgreSQL, SQLite, and MSSQL schema metadata, matching the existing Oracle driver behavior (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -523,7 +523,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
                 $table->sequenceName = '';
             }
 
-            $column->defaultValue = $column->isPrimaryKey
+            $column->defaultValue = $column->isPrimaryKey && $column->autoIncrement
                 ? null
                 : $column->defaultPhpTypecast($column->defaultValue);
             $table->columns[$column->name] = $column;

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -401,7 +401,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
                 }
             }
 
-            $column->defaultValue = $column->isPrimaryKey
+            $column->defaultValue = $column->isPrimaryKey && $column->autoIncrement
                 ? null
                 : $column->defaultPhpTypecast($column->defaultValue);
             $table->columns[$column->name] = $column;

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -533,10 +533,10 @@ SQL;
                 if ($table->sequenceName === null) {
                     $table->sequenceName = $column->sequenceName;
                 }
-                $column->defaultValue = null;
-            } else {
-                $column->defaultValue = $column->defaultPhpTypecast($column->defaultValue);
             }
+            $column->defaultValue = $column->isPrimaryKey && $column->autoIncrement
+                ? null
+                : $column->defaultPhpTypecast($column->defaultValue);
         }
 
         return true;

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -251,6 +251,11 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
             $table->sequenceName = '';
             $table->columns[$table->primaryKey[0]]->autoIncrement = true;
         }
+        foreach ($table->columns as $column) {
+            $column->defaultValue = $column->isPrimaryKey && $column->autoIncrement
+                ? null
+                : $column->defaultPhpTypecast($column->defaultValue);
+        }
 
         return true;
     }
@@ -351,9 +356,8 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
         }
         $column->phpType = $this->getColumnPhpType($column);
 
-        $column->defaultValue = $column->isPrimaryKey
-            ? null
-            : $column->defaultPhpTypecast($info['dflt_value']);
+        // Store raw default for deferred resolution in `findColumns()`, where autoIncrement is known.
+        $column->defaultValue = $info['dflt_value'];
 
         return $column;
     }

--- a/tests/base/db/BaseActiveRecord.php
+++ b/tests/base/db/BaseActiveRecord.php
@@ -42,6 +42,7 @@ use yiiunit\data\ar\ProfileWithConstructor;
 use yiiunit\data\ar\Type;
 use yiiunit\data\ar\CroppedType;
 use yiiunit\framework\ar\ActiveRecordTestTrait;
+use yiiunit\support\DbHelper;
 
 abstract class BaseActiveRecord extends DatabaseTestCase
 {
@@ -1319,6 +1320,39 @@ abstract class BaseActiveRecord extends DatabaseTestCase
         $model = new CroppedType();
         $model->loadDefaultValues();
         $this->assertEquals(['int_col2' => 1], $model->toArray());
+    }
+
+    public function testLoadDefaultValuesForCompositePrimaryKey(): void
+    {
+        $db = $this->getConnection(false);
+
+        DbHelper::dropTablesIfExist($db, ['default_composite_pk']);
+
+        $db->createCommand()->createTable(
+            'default_composite_pk',
+            [
+                'filter_id' => 'integer NOT NULL',
+                'language_id' => 'smallint DEFAULT 1 NOT NULL',
+                'PRIMARY KEY ([[filter_id]], [[language_id]])',
+            ],
+        )->execute();
+
+        $model = new class extends ActiveRecord {
+            public static function tableName()
+            {
+                return 'default_composite_pk';
+            }
+        };
+
+        $model->loadDefaultValues();
+
+        self::assertSame(
+            1,
+            $model->getAttribute('language_id'),
+            'Non-identity PK default must be loaded.',
+        );
+
+        DbHelper::dropTablesIfExist($db, ['default_composite_pk']);
     }
 
     public function testUnlinkAllViaTable(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #7843 
