### PR TITLE
Preserve referenced schema names in MySQL/MariaDB table foreign key metadata for cross-schema relations.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -149,6 +149,7 @@ Yii Framework 2 Change Log
 - Bug #16631: Fix `yii\db\oci\Schema::findConstraints()` to index table foreign keys by constraint name so all foreign keys are reflected instead of only the last one (terabytesoftw)
 - Bug #16447: Fix `yii\db\oci\Schema::findUniqueIndexes()` to respect the connection `PDO::ATTR_CASE` attribute when reading unique index metadata (terabytesoftw)
 - Bug #7843: Preserve defaults on non-auto-incrementing primary key columns in MySQL/MariaDB, PostgreSQL, SQLite, and MSSQL schema metadata, matching the existing Oracle driver behavior (terabytesoftw)
+- Bug #13631: Preserve referenced schema names in MySQL/MariaDB table foreign key metadata for cross-schema relations (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/mysql/Schema.php
+++ b/framework/db/mysql/Schema.php
@@ -444,46 +444,26 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function findConstraints($table)
     {
-        $sql = <<<SQL
-        SELECT
-            `kcu`.`CONSTRAINT_NAME` AS `constraint_name`,
-            `kcu`.`COLUMN_NAME` AS `column_name`,
-            `kcu`.`REFERENCED_TABLE_NAME` AS `referenced_table_name`,
-            `kcu`.`REFERENCED_COLUMN_NAME` AS `referenced_column_name`
-        FROM `information_schema`.`REFERENTIAL_CONSTRAINTS` AS `rc`
-        JOIN `information_schema`.`KEY_COLUMN_USAGE` AS `kcu` ON
-            (
-                `kcu`.`CONSTRAINT_CATALOG` = `rc`.`CONSTRAINT_CATALOG` OR
-                (`kcu`.`CONSTRAINT_CATALOG` IS NULL AND `rc`.`CONSTRAINT_CATALOG` IS NULL)
-            ) AND
-            `kcu`.`CONSTRAINT_SCHEMA` = `rc`.`CONSTRAINT_SCHEMA` AND
-            `kcu`.`CONSTRAINT_NAME` = `rc`.`CONSTRAINT_NAME`
-        WHERE `rc`.`CONSTRAINT_SCHEMA` = database() AND `kcu`.`TABLE_SCHEMA` = database()
-        AND `rc`.`TABLE_NAME` = :tableName AND `kcu`.`TABLE_NAME` = :tableName1
-        SQL;
+        $tableName = $this->quoteSimpleTableName($table->name);
 
-        $rows = $this->db->createCommand(
-            $sql,
-            [
-                ':tableName' => $table->name,
-                ':tableName1' => $table->name,
-            ],
-        )->queryAll();
-
-        $constraints = [];
-
-        foreach ($rows as $row) {
-            $constraints[$row['constraint_name']]['referenced_table_name'] = $row['referenced_table_name'];
-            $constraints[$row['constraint_name']]['columns'][$row['column_name']] = $row['referenced_column_name'];
+        if ($table->schemaName !== null) {
+            $tableName = $this->quoteSimpleTableName($table->schemaName) . '.' . $tableName;
         }
 
         $table->foreignKeys = [];
 
-        foreach ($constraints as $name => $constraint) {
-            $table->foreignKeys[$name] = [
-                $constraint['referenced_table_name'],
-                ...$constraint['columns']
-            ];
+        foreach ($this->loadTableForeignKeys($tableName) as $foreignKey) {
+            $foreignTableName = $foreignKey->foreignSchemaName !== null
+                ? $foreignKey->foreignSchemaName . '.' . $foreignKey->foreignTableName
+                : $foreignKey->foreignTableName;
+
+            $columns = [];
+
+            foreach ($foreignKey->columnNames as $index => $columnName) {
+                $columns[$columnName] = $foreignKey->foreignColumnNames[$index];
+            }
+
+            $table->foreignKeys[$foreignKey->name] = [$foreignTableName, ...$columns];
         }
     }
 

--- a/tests/framework/db/mysql/SchemaConstraintsTest.php
+++ b/tests/framework/db/mysql/SchemaConstraintsTest.php
@@ -241,6 +241,30 @@ final class SchemaConstraintsTest extends BaseSchemaConstraints
         );
     }
 
+    /**
+     * Regression test for https://github.com/yiisoft/yii2/issues/13631.
+     *
+     * @param array<string, string> $expectedColumns Expected child-to-parent column map.
+     */
+    #[DataProviderExternal(ConstraintsProvider::class, 'crossSchemaTableSchemaForeignKeys')]
+    public function testCrossSchemaTableSchemaForeignKeys(
+        string $tableName,
+        string $expectedName,
+        string $expectedForeignTableName,
+        array $expectedColumns,
+    ): void {
+        /** @var Schema $schema */
+        $schema = $this->getConnection()->getSchema();
+
+        $table = $schema->getTableSchema($tableName, true);
+
+        self::assertSame(
+            [$expectedForeignTableName, ...$expectedColumns],
+            $table->foreignKeys[$expectedName],
+            'Table schema foreign keys must preserve cross-schema references.',
+        );
+    }
+
     public function testSchemaQualifiedTableMetadataIsolation(): void
     {
         /** @var Schema $schema */

--- a/tests/framework/db/mysql/providers/ConstraintsProvider.php
+++ b/tests/framework/db/mysql/providers/ConstraintsProvider.php
@@ -119,6 +119,27 @@ final class ConstraintsProvider extends \yiiunit\base\db\providers\ConstraintsPr
         ];
     }
 
+    /**
+     * @return array<string, array{string, string, string, array<string, string>}>
+     */
+    public static function crossSchemaTableSchemaForeignKeys(): array
+    {
+        return [
+            'current database referencing cross database' => [
+                'T_constraints_cross_ref',
+                'CN_constraints_cross_ref',
+                'yiitest_cross.T_constraints_2',
+                ['C_cross_fk_id' => 'C_cross_id'],
+            ],
+            'cross database referencing current database' => [
+                'yiitest_cross.T_constraints_cross_ref',
+                'CN_cross_constraints_cross_ref',
+                'yiitest.T_constraints_2',
+                ['C_fk_id_1' => 'C_id_1', 'C_fk_id_2' => 'C_id_2'],
+            ],
+        ];
+    }
+
     public static function prepareConstraintsExpected(
         bool $isMariaDb,
         string $tableName,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #13631 
