### PR TITLE
Apply PostgreSQL transaction isolation levels after starting the transaction, via the new `yii\db\pgsql\Transaction` class resolved through `yii\db\Connection::$transactionMap`.

### DIFF
--- a/docs/guide/db-dao.md
+++ b/docs/guide/db-dao.md
@@ -417,10 +417,6 @@ At the time of this writing, only MSSQL and SQLite are affected by this limitati
 > Note: SQLite only supports two isolation levels, so you can only use `READ UNCOMMITTED` and `SERIALIZABLE`.
 Usage of other levels will result in an exception being thrown.
 
-> Note: PostgreSQL does not allow setting the isolation level before the transaction starts so you can not
-specify the isolation level directly when starting the transaction.
-You have to call [[yii\db\Transaction::setIsolationLevel()]] in this case after the transaction has started.
-
 [isolation levels]: https://en.wikipedia.org/wiki/Isolation_%28database_systems%29#Isolation_levels
 
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -150,6 +150,7 @@ Yii Framework 2 Change Log
 - Bug #16447: Fix `yii\db\oci\Schema::findUniqueIndexes()` to respect the connection `PDO::ATTR_CASE` attribute when reading unique index metadata (terabytesoftw)
 - Bug #7843: Preserve defaults on non-auto-incrementing primary key columns in MySQL/MariaDB, PostgreSQL, SQLite, and MSSQL schema metadata, matching the existing Oracle driver behavior (terabytesoftw)
 - Bug #13631: Preserve referenced schema names in MySQL/MariaDB table foreign key metadata for cross-schema relations (terabytesoftw)
+- Bug #17545: Apply PostgreSQL transaction isolation levels after starting the transaction, via the new `yii\db\pgsql\Transaction` class resolved through `yii\db\Connection::$transactionMap` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -323,7 +323,8 @@ class Connection extends Component
         'dblib' => 'yii\db\mssql\Command', // dblib drivers on GNU/Linux (and maybe other OSes) hosts
     ];
     /**
-     * @var array<string, class-string> mapping between PDO driver names and {@see Transaction} classes.
+     * @var array<string, class-string<Transaction>|array<string, mixed>> mapping between PDO driver names and
+     * {@see Transaction} classes or configurations.
      *
      * The keys of the array are PDO driver names while the values are either the corresponding transaction class names
      * or configurations. Please refer to {@see Yii::createObject()} for details on how to specify a configuration.

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -17,6 +17,7 @@ use yii\caching\CacheInterface;
 
 use function constant;
 use function in_array;
+use function is_array;
 use function preg_match;
 use function str_contains;
 use function strtolower;
@@ -320,6 +321,29 @@ class Connection extends Component
         'oci' => 'yii\db\oci\Command', // Oracle driver
         'mssql' => 'yii\db\mssql\Command', // older MSSQL driver on MS Windows hosts
         'dblib' => 'yii\db\mssql\Command', // dblib drivers on GNU/Linux (and maybe other OSes) hosts
+    ];
+    /**
+     * @var array<string, class-string> mapping between PDO driver names and {@see Transaction} classes.
+     *
+     * The keys of the array are PDO driver names while the values are either the corresponding transaction class names
+     * or configurations. Please refer to {@see Yii::createObject()} for details on how to specify a configuration.
+     *
+     * This property is mainly used by {@see beginTransaction()} to start new database {@see Transaction} objects.
+     *
+     * You normally do not need to set this property unless you want to use your own {@see Transaction} class or support
+     * DBMS that is not supported by Yii.
+     * @since 22.0
+     */
+    public $transactionMap = [
+        'pgsql' => \yii\db\pgsql\Transaction::class, // PostgreSQL
+        'mysqli' => \yii\db\Transaction::class, // MySQL
+        'mysql' => \yii\db\Transaction::class, // MySQL
+        'sqlite' => \yii\db\Transaction::class, // sqlite 3
+        'sqlite2' => \yii\db\Transaction::class, // sqlite 2
+        'sqlsrv' => \yii\db\Transaction::class, // newer MSSQL driver on MS Windows hosts
+        'oci' => \yii\db\Transaction::class, // Oracle driver
+        'mssql' => \yii\db\Transaction::class, // older MSSQL driver on MS Windows hosts
+        'dblib' => \yii\db\Transaction::class, // dblib drivers on GNU/Linux (and maybe other OSes) hosts
     ];
     /**
      * @var bool whether to enable [savepoint](https://en.wikipedia.org/wiki/Savepoint).
@@ -801,8 +825,22 @@ class Connection extends Component
         $this->open();
 
         if (($transaction = $this->getTransaction()) === null) {
-            $transaction = $this->_transaction = new Transaction(['db' => $this]);
+            $driver = $this->getDriverName();
+
+            $config = ['class' => \yii\db\Transaction::class];
+
+            if (isset($this->transactionMap[$driver])) {
+                $config = !is_array($this->transactionMap[$driver])
+                    ? ['class' => $this->transactionMap[$driver]]
+                    : $this->transactionMap[$driver];
+            }
+
+            $config['db'] = $this;
+
+            /** @var Transaction $transaction */
+            $transaction = $this->_transaction = Yii::createObject($config);
         }
+
         $transaction->begin($isolationLevel);
 
         return $transaction;

--- a/framework/db/Transaction.php
+++ b/framework/db/Transaction.php
@@ -82,7 +82,6 @@ class Transaction extends \yii\base\BaseObject
      */
     private $_level = 0;
 
-
     /**
      * Returns a value indicating whether this transaction is active.
      * @return bool whether this transaction is active. Only an active transaction
@@ -99,9 +98,6 @@ class Transaction extends \yii\base\BaseObject
      * This can be one of [[READ_UNCOMMITTED]], [[READ_COMMITTED]], [[REPEATABLE_READ]] and [[SERIALIZABLE]] but
      * also a string containing DBMS specific syntax to be used after `SET TRANSACTION ISOLATION LEVEL`.
      * If not specified (`null`) the isolation level will not be set explicitly and the DBMS default will be used.
-     *
-     * > Note: This setting does not work for PostgreSQL, where setting the isolation level before the transaction
-     * has no effect. You have to call [[setIsolationLevel()]] in this case after the transaction has started.
      *
      * > Note: Some DBMS allow setting of the isolation level only for the whole connection so subsequent transactions
      * may get the same isolation level even if you did not specify any. When using this feature
@@ -121,32 +117,50 @@ class Transaction extends \yii\base\BaseObject
         if ($this->db === null) {
             throw new InvalidConfigException('Transaction::db must be set.');
         }
+
         $this->db->open();
 
         if ($this->_level === 0) {
             if ($isolationLevel !== null) {
                 $this->db->getSchema()->setTransactionIsolationLevel($isolationLevel);
             }
-            Yii::debug('Begin transaction' . ($isolationLevel ? ' with isolation level ' . $isolationLevel : ''), __METHOD__);
+
+            Yii::debug(
+                'Begin transaction' . ($isolationLevel ? " with isolation level {$isolationLevel}" : ''),
+                __METHOD__,
+            );
 
             $this->db->trigger(Connection::EVENT_BEGIN_TRANSACTION);
             $this->db->pdo->beginTransaction();
+
             $this->_level = 1;
 
             return;
         }
 
         $schema = $this->db->getSchema();
+
         if ($schema->supportsSavepoint()) {
-            Yii::debug('Set savepoint ' . $this->_level, __METHOD__);
+            Yii::debug(
+                "Set savepoint {$this->_level}",
+                __METHOD__,
+            );
+
             // make sure the transaction wasn't autocommitted
             if ($this->db->pdo->inTransaction()) {
-                $schema->createSavepoint('LEVEL' . $this->_level);
+                $schema->createSavepoint("LEVEL{$this->_level}");
             }
         } else {
-            Yii::info('Transaction not started: nested transaction not supported', __METHOD__);
-            throw new NotSupportedException('Transaction not started: nested transaction not supported.');
+            Yii::info(
+                'Transaction not started: nested transaction not supported',
+                __METHOD__,
+            );
+
+            throw new NotSupportedException(
+                'Transaction not started: nested transaction not supported.',
+            );
         }
+
         $this->_level++;
     }
 

--- a/framework/db/pgsql/Transaction.php
+++ b/framework/db/pgsql/Transaction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yii\db\pgsql;
+
+use Throwable;
+use yii\db\Transaction as BaseTransaction;
+
+/**
+ * Represents a PostgreSQL DB transaction.
+ *
+ * PostgreSQL discards `SET TRANSACTION` issued outside a transaction block, so the isolation level is applied through
+ * [[setIsolationLevel()]] right after the transaction starts, and the transaction is rolled back if the level is
+ * rejected.
+ *
+ * @see https://www.postgresql.org/docs/current/sql-set-transaction.html
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+class Transaction extends BaseTransaction
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function begin($isolationLevel = null)
+    {
+        if ($this->getLevel() > 0 || $isolationLevel === null) {
+            parent::begin($isolationLevel);
+
+            return;
+        }
+
+        parent::begin();
+
+        try {
+            $this->setIsolationLevel($isolationLevel);
+        } catch (Throwable $exception) {
+            $this->rollBack();
+
+            throw $exception;
+        }
+    }
+}

--- a/tests/framework/db/pgsql/ConnectionTest.php
+++ b/tests/framework/db/pgsql/ConnectionTest.php
@@ -10,6 +10,7 @@ namespace yiiunit\framework\db\pgsql;
 
 use PHPUnit\Framework\Attributes\Group;
 use yii\db\Connection;
+use yii\db\Exception;
 use yii\db\Transaction;
 use yiiunit\base\db\BaseConnection;
 
@@ -103,28 +104,88 @@ class ConnectionTest extends BaseConnection
 
     public function testTransactionIsolation(): void
     {
-        $connection = $this->getConnection(true);
+        $connection = $this->getConnection(false, false);
 
-        $transaction = $connection->beginTransaction();
-        $transaction->setIsolationLevel(Transaction::READ_UNCOMMITTED);
+        $levels = [
+            Transaction::READ_UNCOMMITTED => 'read uncommitted',
+            Transaction::READ_COMMITTED => 'read committed',
+            Transaction::REPEATABLE_READ => 'repeatable read',
+            Transaction::SERIALIZABLE => 'serializable',
+        ];
+
+        foreach ($levels as $isolationLevel => $expected) {
+            $transaction = $connection->beginTransaction($isolationLevel);
+
+            self::assertSame(
+                $expected,
+                $connection->createCommand(<<<SQL
+                SHOW transaction_isolation
+                SQL,
+                )->queryScalar(),
+                'Requested level must be active inside the transaction.',
+            );
+
+            $transaction->commit();
+        }
+
+        $transaction = $connection->beginTransaction(Transaction::SERIALIZABLE . ' READ ONLY DEFERRABLE');
+
+        self::assertSame(
+            'serializable',
+            $connection->createCommand('SHOW transaction_isolation')->queryScalar(),
+            'Compound level string must keep the level active.',
+        );
+        self::assertSame(
+            'on',
+            $connection->createCommand('SHOW transaction_read_only')->queryScalar(),
+            'Read-only mode must be active.',
+        );
+        self::assertSame(
+            'on',
+            $connection->createCommand('SHOW transaction_deferrable')->queryScalar(),
+            'Deferrable mode must be active.',
+        );
+
         $transaction->commit();
+    }
+
+    public function testSetTransactionIsolation(): void
+    {
+        $connection = $this->getConnection(false, false);
 
         $transaction = $connection->beginTransaction();
-        $transaction->setIsolationLevel(Transaction::READ_COMMITTED);
-        $transaction->commit();
 
-        $transaction = $connection->beginTransaction();
         $transaction->setIsolationLevel(Transaction::REPEATABLE_READ);
-        $transaction->commit();
 
-        $transaction = $connection->beginTransaction();
-        $transaction->setIsolationLevel(Transaction::SERIALIZABLE);
-        $transaction->commit();
+        self::assertSame(
+            'repeatable read',
+            $connection->createCommand('SHOW transaction_isolation')->queryScalar(),
+            'Level set mid-transaction must be active.',
+        );
 
-        $transaction = $connection->beginTransaction();
-        $transaction->setIsolationLevel(Transaction::SERIALIZABLE . ' READ ONLY DEFERRABLE');
         $transaction->commit();
+    }
 
-        $this->assertTrue(true); // No error occurred – assert passed.
+    public function testThrowExceptionWhenBeginTransactionIsolationLevelIsInvalid(): void
+    {
+        $connection = $this->getConnection(false, false);
+
+        try {
+            $connection->beginTransaction('INVALID LEVEL');
+
+            self::fail(
+                'Unknown isolation level must be rejected.',
+            );
+        } catch (Exception) {
+            // Expected: PostgreSQL rejects the unknown isolation level.
+        }
+
+        self::assertFalse(
+            $connection->pdo->inTransaction(),
+            'Failed begin must leave no open transaction.',
+        );
+
+        $transaction = $connection->beginTransaction(Transaction::SERIALIZABLE);
+        $transaction->commit();
     }
 }

--- a/tests/framework/db/pgsql/ConnectionTest.php
+++ b/tests/framework/db/pgsql/ConnectionTest.php
@@ -118,9 +118,10 @@ class ConnectionTest extends BaseConnection
 
             self::assertSame(
                 $expected,
-                $connection->createCommand(<<<SQL
-                SHOW transaction_isolation
-                SQL,
+                $connection->createCommand(
+                    <<<SQL
+                    SHOW transaction_isolation
+                    SQL,
                 )->queryScalar(),
                 'Requested level must be active inside the transaction.',
             );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #17545
