### PR TITLE
Fix #21042: Separate the `@property` annotations in case of different types in getters and setters

### DIFF
--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -411,7 +411,7 @@ class PhpDocController extends ConsoleController
                     }
                     $docLine = preg_replace('/\s+/', ' ', $docLine);
                     $docLine = $this->fixParamTypes($docLine);
-                } elseif (preg_match('/^(~~~|```)/', $docLine)) {
+                } elseif (strpos('```', $docLine) !== false) {
                     $codeBlock = !$codeBlock;
                     $listIndent = '';
                 } elseif (preg_match('/^(\s*)([0-9]+\.|-|\*|\+) /', $docLine, $matches)) {

--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -833,7 +833,7 @@ class PhpDocController extends ConsoleController
                     continue;
                 }
 
-                $acr['comment'] = trim(preg_replace('#(^|\n)\s+\*\s?#', '$1 * ', $acr['comment']));
+                $acr['comment'] = trim(preg_replace('#(^|\n)\h+\*\h?#', '$1 * ', $acr['comment']));
                 $props[$acr['name']][$acr['kind']] = [
                     'type' => $acr['type'],
                     'comment' => $this->fixSentence($acr['comment']),
@@ -926,7 +926,10 @@ class PhpDocController extends ConsoleController
             return '';
         }
 
-        return strtoupper(substr($str, 0, 1)) . substr($str, 1) . ($str[\strlen($str) - 1] !== '.' ? '.' : '');
+        $endsWithCodeFence = substr($str, -3) === '```';
+        $suffix = !$endsWithCodeFence && $str[\strlen($str) - 1] !== '.' ? '.' : '';
+
+        return strtoupper(substr($str, 0, 1)) . substr($str, 1) . $suffix;
     }
 
     protected function getPropParam($prop, $param)
@@ -942,13 +945,49 @@ class PhpDocController extends ConsoleController
     ): string {
         $docLine = " * @property{$annotationSuffix} {$type} \${$propName} ";
 
+        $isExample = false;
         $commentLines = [];
+        $exampleLines = [];
         $rawCommentLines = explode("\n", $comment);
-        foreach ($rawCommentLines as $line) {
-            $commentLines[] = ltrim(rtrim($line), '* ');
+
+        foreach ($rawCommentLines as $lineIndex => $line) {
+            $isCodeFence = strpos($line, '* ```') !== false;
+            $formattedLine = ltrim(rtrim($line), '* ');
+
+            if ($isCodeFence) {
+                if (!$isExample) {
+                    $isExample = true;
+                    $exampleLines[] = "\n * {$formattedLine}";
+                    continue;
+                }
+
+                $exampleLines[] = " * {$formattedLine}";
+                $example = implode("\n", $exampleLines);
+
+                foreach (array_slice($rawCommentLines, $lineIndex + 1) as $remainingLine) {
+                    if (ltrim(rtrim($remainingLine), '* ') !== '') {
+                        $example .= "\n *";
+                        break;
+                    }
+                }
+
+                $commentLines[] = $example;
+                $exampleLines = [];
+                $isExample = false;
+                continue;
+            }
+
+            if ($isExample) {
+                $exampleLines[] = rtrim($line);
+            } elseif ($formattedLine !== '') {
+                $commentLines[] = $formattedLine;
+            }
         }
 
-        return wordwrap($docLine . implode(' ', $commentLines), 110, "\n * ") . "\n";
+        $propertyDoc = wordwrap($docLine . implode(' ', $commentLines), 110, "\n * ");
+        $propertyDoc = preg_replace('/\h+\n/', "\n", $propertyDoc) ?? $propertyDoc;
+
+        return $propertyDoc . "\n";
     }
 
     /**

--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -847,33 +847,41 @@ class PhpDocController extends ConsoleController
             ksort($props);
 
             foreach ($props as $propName => &$prop) {
-                $docLine = ' * @property';
-                $note = '';
+                $annotation = '';
                 if (isset($prop['get'], $prop['set'])) {
                     if ($prop['get']['type'] !== $prop['set']['type']) {
-                        $note = ' Note that the type of this property differs in getter and setter.'
-                            . ' See [[get' . ucfirst($propName) . '()]]'
-                            . ' and [[set' . ucfirst($propName) . '()]] for details.';
+                        $phpdoc .= $this->generatePropertyDocLine(
+                            '-read',
+                            $propName,
+                            $prop['get']['type'],
+                            $prop['get']['comment']
+                        );
+                        $phpdoc .= $this->generatePropertyDocLine(
+                            '-write',
+                            $propName,
+                            $prop['set']['type'],
+                            $prop['set']['comment']
+                        );
+                        continue;
                     }
                 } elseif (isset($prop['get'])) {
                     if (!$this->hasSetterInParents($className, $propName)) {
-                        $docLine .= '-read';
+                        $annotation = '-read';
                     }
                 } elseif (isset($prop['set'])) {
                     if (!$this->hasGetterInParents($className, $propName)) {
-                        $docLine .= '-write';
+                        $annotation = '-write';
                     }
                 } else {
                     continue;
                 }
-                $docLine .= ' ' . $this->getPropParam($prop, 'type') . " $$propName ";
-                $comment = explode("\n", $this->getPropParam($prop, 'comment') . $note);
-                foreach ($comment as &$cline) {
-                    $cline = ltrim(rtrim($cline), '* ');
-                }
-                $docLine = wordwrap($docLine . implode(' ', $comment), 110, "\n * ") . "\n";
 
-                $phpdoc .= $docLine;
+                $phpdoc .= $this->generatePropertyDocLine(
+                    $annotation,
+                    $propName,
+                    $this->getPropParam($prop, 'type'),
+                    $this->getPropParam($prop, 'comment')
+                );
             }
         }
 
@@ -924,6 +932,23 @@ class PhpDocController extends ConsoleController
     protected function getPropParam($prop, $param)
     {
         return isset($prop['property']) ? $prop['property'][$param] : (isset($prop['get']) ? $prop['get'][$param] : $prop['set'][$param]);
+    }
+
+    private function generatePropertyDocLine(
+        string $annotationSuffix,
+        string $propName,
+        string $type,
+        string $comment
+    ): string {
+        $docLine = " * @property{$annotationSuffix} {$type} \${$propName} ";
+
+        $commentLines = [];
+        $rawCommentLines = explode("\n", $comment);
+        foreach ($rawCommentLines as $line) {
+            $commentLines[] = ltrim(rtrim($line), '* ');
+        }
+
+        return wordwrap($docLine . implode(' ', $commentLines), 110, "\n * ") . "\n";
     }
 
     /**

--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -411,7 +411,7 @@ class PhpDocController extends ConsoleController
                     }
                     $docLine = preg_replace('/\s+/', ' ', $docLine);
                     $docLine = $this->fixParamTypes($docLine);
-                } elseif (strpos('```', $docLine) !== false) {
+                } elseif (strpos($docLine, '```') !== false) {
                     $codeBlock = !$codeBlock;
                     $listIndent = '';
                 } elseif (preg_match('/^(\s*)([0-9]+\.|-|\*|\+) /', $docLine, $matches)) {

--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -847,7 +847,7 @@ class PhpDocController extends ConsoleController
             ksort($props);
 
             foreach ($props as $propName => &$prop) {
-                $annotation = '';
+                $annotationSuffix = '';
                 if (isset($prop['get'], $prop['set'])) {
                     if ($prop['get']['type'] !== $prop['set']['type']) {
                         $phpdoc .= $this->generatePropertyDocLine(
@@ -866,18 +866,18 @@ class PhpDocController extends ConsoleController
                     }
                 } elseif (isset($prop['get'])) {
                     if (!$this->hasSetterInParents($className, $propName)) {
-                        $annotation = '-read';
+                        $annotationSuffix = '-read';
                     }
                 } elseif (isset($prop['set'])) {
                     if (!$this->hasGetterInParents($className, $propName)) {
-                        $annotation = '-write';
+                        $annotationSuffix = '-write';
                     }
                 } else {
                     continue;
                 }
 
                 $phpdoc .= $this->generatePropertyDocLine(
-                    $annotation,
+                    $annotationSuffix,
                     $propName,
                     $this->getPropParam($prop, 'type'),
                     $this->getPropParam($prop, 'comment')

--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -702,9 +702,14 @@ class PhpDocController extends ConsoleController
         foreach ($lines as $i => $line) {
             $line = trim($line);
             if (strncmp($line, '* @property', 11) === 0) {
+                if ($propertyPosition === false) {
+                    $propertyPosition = $i - 1;
+                }
                 $propertyPart = true;
             } elseif ($propertyPart && $line === '*') {
                 $propertyPosition = $i;
+                $propertyPart = false;
+            } elseif ($propertyPart && $line === '*/') {
                 $propertyPart = false;
             }
             if (strncmp($line, '* @author ', 10) === 0 && $propertyPosition === false) {

--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -676,7 +676,7 @@ class PhpDocController extends ConsoleController
         $n = \count($lines);
         for ($i = 0; $i < $n; $i++) {
             $lines[$i] = rtrim($lines[$i]);
-            if (trim($lines[$i]) == '*' && trim($lines[$i + 1]) == '*') {
+            if (trim($lines[$i]) == '*' && isset($lines[$i + 1]) && trim($lines[$i + 1]) == '*') {
                 unset($lines[$i]);
             }
         }

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -28,6 +28,7 @@ Yii Framework 2 Change Log
 - Enh #20988, #21040: Add generics to `yii\db\Connection` and `yii\db\Schema` so `getSchema()` and `getQueryBuilder()` infer driver-specific types (terabytesoftw, mspirkov)
 - Bug #20994: Fix `@var` annotations for `BlameableBehavior` properties (mspirkov)
 - Enh #20990: Show created migration file path on migrate create CLI command (flaviovs)
+- Bug #21042: Separate the `@property` annotations in case of different types in getters and setters (mspirkov)
 
 
 2.0.55 May 09, 2026

--- a/framework/base/Model.php
+++ b/framework/base/Model.php
@@ -55,8 +55,7 @@ use yii\validators\Validator;
  *
  * Empty array if no errors.
  * @property-read Validator[] $activeValidators The validators applicable to the current [[scenario]].
- * @property array<string, mixed> $attributes Attribute values (name => value). Note that the type of this
- * property differs in getter and setter. See [[getAttributes()]] and [[setAttributes()]] for details.
+ * @property array<string, mixed> $attributes Attribute values (name => value).
  * @property-read array<string, string> $firstErrors The first errors. The array keys are the attribute names,
  * and the array values are the corresponding error messages. An empty array will be returned if there is no
  * error.
@@ -744,7 +743,7 @@ class Model extends Component implements StaticInstanceInterface, IteratorAggreg
 
     /**
      * Sets the attribute values in a massive way.
-     * @param array $values attribute values (name => value) to be assigned to the model.
+     * @param array<string, mixed> $values attribute values (name => value) to be assigned to the model.
      * @param bool $safeOnly whether the assignments should only be done to the safe attributes.
      * A safe attribute is one that is associated with a validation rule in the current [[scenario]].
      * @see safeAttributes()

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -32,8 +32,10 @@ use yii\di\ServiceLocator;
  * @property string $layoutPath The root directory of layout files. Defaults to "[[viewPath]]/layouts".
  * @property array $modules The modules (indexed by their IDs).
  * @property-read string $uniqueId The unique ID of the module.
- * @property string $version The version of this module. Note that the type of this property differs in getter
- * and setter. See [[getVersion()]] and [[setVersion()]] for details.
+ * @property-read string $version The version of this module.
+ * @property-write string|callable|null $version The version of this module. Version can be specified as a PHP
+ * callback, which can accept module instance as an argument and should return the actual version. For example:
+ * ``` function (Module $module) { //return string } ```.
  * @property string $viewPath The root directory of view files. Defaults to "[[basePath]]/views".
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -35,7 +35,11 @@ use yii\di\ServiceLocator;
  * @property-read string $version The version of this module.
  * @property-write string|callable|null $version The version of this module. Version can be specified as a PHP
  * callback, which can accept module instance as an argument and should return the actual version. For example:
- * ``` function (Module $module) { //return string } ```.
+ * ```
+ * function (Module $module) {
+ *     //return string
+ * }
+ * ```
  * @property string $viewPath The root directory of view files. Defaults to "[[basePath]]/views".
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/base/Widget.php
+++ b/framework/base/Widget.php
@@ -190,7 +190,7 @@ class Widget extends Component implements ViewContextInterface
         $this->_id = $value;
     }
 
-    /** @var \yii\web\View */
+    /** @var \yii\web\View|null */
     private $_view;
 
     /**

--- a/framework/base/Widget.php
+++ b/framework/base/Widget.php
@@ -16,10 +16,9 @@ use Yii;
  *
  * For more details and usage information on Widget, see the [guide article on widgets](guide:structure-widgets).
  *
- * @property string|null $id ID of the widget. Note that the type of this property differs in getter and
- * setter. See [[getId()]] and [[setId()]] for details.
- * @property \yii\web\View $view The view object that can be used to render views or view files. Note that the
- * type of this property differs in getter and setter. See [[getView()]] and [[setView()]] for details.
+ * @property-read string|null $id ID of the widget.
+ * @property-write string $id Id of the widget.
+ * @property View $view The view object that can be used to render views or view files.
  * @property-read string $viewPath The directory containing the view files for this widget.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
@@ -198,7 +197,7 @@ class Widget extends Component implements ViewContextInterface
      * The [[render()]] and [[renderFile()]] methods will use
      * this view object to implement the actual view rendering.
      * If not set, it will default to the "view" application component.
-     * @return \yii\web\View the view object that can be used to render views or view files.
+     * @return View the view object that can be used to render views or view files.
      */
     public function getView()
     {

--- a/framework/base/Widget.php
+++ b/framework/base/Widget.php
@@ -18,7 +18,7 @@ use Yii;
  *
  * @property-read string|null $id ID of the widget.
  * @property-write string $id Id of the widget.
- * @property View $view The view object that can be used to render views or view files.
+ * @property \yii\web\View $view The view object that can be used to render views or view files.
  * @property-read string $viewPath The directory containing the view files for this widget.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
@@ -190,6 +190,7 @@ class Widget extends Component implements ViewContextInterface
         $this->_id = $value;
     }
 
+    /** @var \yii\web\View */
     private $_view;
 
     /**
@@ -197,12 +198,14 @@ class Widget extends Component implements ViewContextInterface
      * The [[render()]] and [[renderFile()]] methods will use
      * this view object to implement the actual view rendering.
      * If not set, it will default to the "view" application component.
-     * @return View the view object that can be used to render views or view files.
+     * @return \yii\web\View the view object that can be used to render views or view files.
      */
     public function getView()
     {
         if ($this->_view === null) {
-            $this->_view = Yii::$app->getView();
+            /** @var \yii\web\View $view */
+            $view = Yii::$app->getView();
+            $this->_view = $view;
         }
 
         return $this->_view;
@@ -210,7 +213,7 @@ class Widget extends Component implements ViewContextInterface
 
     /**
      * Sets the view object to be used by this widget.
-     * @param View $view the view object that can be used to render views or view files.
+     * @param \yii\web\View $view the view object that can be used to render views or view files.
      */
     public function setView($view)
     {

--- a/framework/caching/MemCache.php
+++ b/framework/caching/MemCache.php
@@ -58,8 +58,9 @@ use yii\base\InvalidConfigException;
  *
  * @property-read \Memcache|\Memcached $memcache The memcache (or memcached) object used by this cache
  * component.
- * @property MemCacheServer[] $servers List of memcache server configurations. Note that the type of this
- * property differs in getter and setter. See [[getServers()]] and [[setServers()]] for details.
+ * @property-read MemCacheServer[] $servers List of memcache server configurations.
+ * @property-write array $servers List of memcache or memcached server configurations. Each element must be an
+ * array with the following keys: host, port, persistent, weight, timeout, retryInterval, status.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/console/controllers/AssetController.php
+++ b/framework/console/controllers/AssetController.php
@@ -40,8 +40,9 @@ use yii\web\AssetBundle;
  * Note: by default this command relies on an external tools to perform actual files compression,
  * check [[jsCompressor]] and [[cssCompressor]] for more details.
  *
- * @property \yii\web\AssetManager $assetManager Asset manager instance. Note that the type of this property
- * differs in getter and setter. See [[getAssetManager()]] and [[setAssetManager()]] for details.
+ * @property-read \yii\web\AssetManager $assetManager Asset manager instance.
+ * @property-write \yii\web\AssetManager|array $assetManager Asset manager instance or its array
+ * configuration.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @author Paul Klimov <klimov.paul@gmail.com>

--- a/framework/data/BaseDataProvider.php
+++ b/framework/data/BaseDataProvider.php
@@ -23,8 +23,8 @@ use yii\base\InvalidArgumentException;
  * @property array $models The list of data models in the current page.
  * @property-read Pagination|false $pagination The pagination object. If this is false, it means the
  * pagination is disabled.
- * @property-write array|Pagination|bool $pagination The pagination to be used by this data provider. This can
- * be one of the following: - a configuration array for creating the pagination object. The "class" element
+ * @property-write array|Pagination|false $pagination The pagination to be used by this data provider. This
+ * can be one of the following: - a configuration array for creating the pagination object. The "class" element
  * defaults to 'yii\data\Pagination' - an instance of [[Pagination]] or its subclass - false, if pagination needs
  * to be disabled.
  * @property-read Sort|bool $sort The sorting object. If this is false, it means the sorting is disabled.
@@ -205,7 +205,7 @@ abstract class BaseDataProvider extends Component implements DataProviderInterfa
 
     /**
      * Sets the pagination for this data provider.
-     * @param array|Pagination|bool $value the pagination to be used by this data provider.
+     * @param array|Pagination|false $value the pagination to be used by this data provider.
      * This can be one of the following:
      *
      * - a configuration array for creating the pagination object. The "class" element defaults

--- a/framework/data/BaseDataProvider.php
+++ b/framework/data/BaseDataProvider.php
@@ -21,11 +21,17 @@ use yii\base\InvalidArgumentException;
  * @property array $keys The list of key values corresponding to [[models]]. Each data model in [[models]] is
  * uniquely identified by the corresponding key value in this array.
  * @property array $models The list of data models in the current page.
- * @property Pagination|false $pagination The pagination object. If this is false, it means the pagination is
- * disabled. Note that the type of this property differs in getter and setter. See [[getPagination()]] and
- * [[setPagination()]] for details.
- * @property Sort|bool $sort The sorting object. If this is false, it means the sorting is disabled. Note that
- * the type of this property differs in getter and setter. See [[getSort()]] and [[setSort()]] for details.
+ * @property-read Pagination|false $pagination The pagination object. If this is false, it means the
+ * pagination is disabled.
+ * @property-write array|Pagination|bool $pagination The pagination to be used by this data provider. This can
+ * be one of the following: - a configuration array for creating the pagination object. The "class" element
+ * defaults to 'yii\data\Pagination' - an instance of [[Pagination]] or its subclass - false, if pagination needs
+ * to be disabled.
+ * @property-read Sort|bool $sort The sorting object. If this is false, it means the sorting is disabled.
+ * @property-write array|Sort|bool $sort The sort definition to be used by this data provider. This can be one
+ * of the following: - a configuration array for creating the sort definition object. The "class" element
+ * defaults to 'yii\data\Sort' - an instance of [[Sort]] or its subclass - false, if sorting needs to be
+ * disabled.
  * @property int $totalCount Total number of possible data models.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/data/DataFilter.php
+++ b/framework/data/DataFilter.php
@@ -113,13 +113,14 @@ use yii\validators\Validator;
  *
  * @see ActiveDataFilter
  *
- * @property array $errorMessages Error messages in format `[errorKey => message]`. Note that the type of this
- * property differs in getter and setter. See [[getErrorMessages()]] and [[setErrorMessages()]] for details.
+ * @property-read array $errorMessages Error messages in format `[errorKey => message]`.
+ * @property-write array|\Closure $errorMessages Error messages in `[errorKey => message]` format, or a PHP
+ * callback returning them.
  * @property mixed $filter Raw filter value.
- * @property array $searchAttributeTypes Search attribute type map. Note that the type of this property
- * differs in getter and setter. See [[getSearchAttributeTypes()]] and [[setSearchAttributeTypes()]] for details.
- * @property Model $searchModel Model instance. Note that the type of this property differs in getter and
- * setter. See [[getSearchModel()]] and [[setSearchModel()]] for details.
+ * @property-read array $searchAttributeTypes Search attribute type map.
+ * @property-write array|null $searchAttributeTypes Search attribute type map.
+ * @property-read Model $searchModel Model instance.
+ * @property-write Model|array|string|callable $searchModel Model instance or its DI compatible configuration.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0.13

--- a/framework/data/Sort.php
+++ b/framework/data/Sort.php
@@ -69,9 +69,10 @@ use yii\web\Request;
  *
  * For more details and usage information on Sort, see the [guide article on sorting](guide:output-sorting).
  *
- * @property array $attributeOrders Sort directions indexed by attribute names. Sort direction can be either
- * `SORT_ASC` for ascending order or `SORT_DESC` for descending order. Note that the type of this property
- * differs in getter and setter. See [[getAttributeOrders()]] and [[setAttributeOrders()]] for details.
+ * @property-read array $attributeOrders Sort directions indexed by attribute names. Sort direction can be
+ * either `SORT_ASC` for ascending order or `SORT_DESC` for descending order.
+ * @property-write array|null $attributeOrders Sort directions indexed by attribute names. Sort direction can
+ * be either `SORT_ASC` for ascending order or `SORT_DESC` for descending order.
  * @property-read array $orders The columns (keys) and their corresponding sort directions (values). This can
  * be passed to [[\yii\db\Query::orderBy()]] to construct a DB query.
  *

--- a/framework/db/BaseActiveRecord.php
+++ b/framework/db/BaseActiveRecord.php
@@ -26,8 +26,9 @@ use yii\helpers\ArrayHelper;
  *
  * @property-read array $dirtyAttributes The changed attribute values (name-value pairs).
  * @property bool $isNewRecord Whether the record is new and should be inserted when calling [[save()]].
- * @property array $oldAttributes The old attribute values (name-value pairs). Note that the type of this
- * property differs in getter and setter. See [[getOldAttributes()]] and [[setOldAttributes()]] for details.
+ * @property-read array $oldAttributes The old attribute values (name-value pairs).
+ * @property-write array|null $oldAttributes Old attribute values to be set. If set to `null` this record is
+ * considered to be [[isNewRecord|new]].
  * @property-read mixed $oldPrimaryKey The old primary key value. An array (column name => column value) is
  * returned if the primary key is composite or `$asArray` is `true`. A string is returned otherwise (null will be
  * returned if the key value is null).

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -111,17 +111,16 @@ use yii\caching\CacheInterface;
  * ],
  * ```
  *
- * @property string|null $driverName Name of the DB driver. Note that the type of this property differs in
- * getter and setter. See [[getDriverName()]] and [[setDriverName()]] for details.
+ * @property-read string|null $driverName Name of the DB driver.
+ * @property-write string $driverName Name of the DB driver.
  * @property-read bool $isActive Whether the DB connection is established.
  * @property-read string $lastInsertID The row ID of the last row inserted, or the last value retrieved from
  * the sequence object.
  * @property-read Connection|null $master The currently active master connection. `null` is returned if there
  * is no master available.
  * @property-read PDO $masterPdo The PDO instance for the currently active master connection.
- * @property TQueryBuilder $queryBuilder The query builder for the current DB connection. Note that the type
- * of this property differs in getter and setter. See [[getQueryBuilder()]] and [[setQueryBuilder()]] for
- * details.
+ * @property-read TQueryBuilder $queryBuilder The query builder for the current DB connection.
+ * @property-write array $queryBuilder The [[QueryBuilder]] properties to be configured.
  * @property-read TSchema $schema The schema information for the database opened by this connection.
  * @property-read string $serverVersion Server version as a string.
  * @property-read Connection|null $slave The currently active slave connection. `null` is returned if there is

--- a/framework/i18n/I18N.php
+++ b/framework/i18n/I18N.php
@@ -18,9 +18,11 @@ use yii\base\InvalidConfigException;
  * I18N is configured as an application component in [[\yii\base\Application]] by default.
  * You can access that instance via `Yii::$app->i18n`.
  *
- * @property MessageFormatter $messageFormatter The message formatter to be used to format message via ICU
- * message format. Note that the type of this property differs in getter and setter. See
- * [[getMessageFormatter()]] and [[setMessageFormatter()]] for details.
+ * @property-read MessageFormatter $messageFormatter The message formatter to be used to format message via
+ * ICU message format.
+ * @property-write string|array|MessageFormatter $messageFormatter The message formatter to be used to format
+ * message via ICU message format. Can be given as array or string configuration that will be given to
+ * [[Yii::createObject]] to create an instance or a [[MessageFormatter]] instance.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -32,9 +32,9 @@ use yii\web\User;
  * of this property differs in getter and setter. See [[getEnabled()]] and [[setEnabled()]] for details.
  * @property-write bool|callable $enabled A boolean value or a callable to obtain the value from. Note that the type
  * of this property differs in getter and setter. See [[getEnabled()]] and [[setEnabled()]] for details.
- * @property int $levels The message levels that this target is interested in. This is a bitmap of level
- * values. Defaults to 0, meaning all available levels. Note that the type of this property differs in getter and
- * setter. See [[getLevels()]] and [[setLevels()]] for details.
+ * @property-read int $levels The message levels that this target is interested in. This is a bitmap of level
+ * values. Defaults to 0, meaning all available levels.
+ * @property-write array|int $levels Message levels that this target is interested in.
  *
  * For more details and usage information on Target, see the [guide article on logging & targets](guide:runtime-logging).
  *

--- a/framework/mail/BaseMailer.php
+++ b/framework/mail/BaseMailer.php
@@ -23,8 +23,9 @@ use yii\web\View;
  *
  * For more details and usage information on BaseMailer, see the [guide article on mailing](guide:tutorial-mailing).
  *
- * @property View $view View instance. Note that the type of this property differs in getter and setter. See
- * [[getView()]] and [[setView()]] for details.
+ * @property-read View $view View instance.
+ * @property-write array|View $view View instance or its array configuration that will be used to render
+ * message bodies.
  * @property string $viewPath The directory that contains the view files for composing mail messages Defaults
  * to '@app/mail'.
  *

--- a/framework/rbac/BaseManager.php
+++ b/framework/rbac/BaseManager.php
@@ -19,8 +19,8 @@ use yii\base\InvalidValueException;
  * For more details and usage information on DbManager, see the [guide article on security authorization](guide:security-authorization).
  *
  * @property-read Role[] $defaultRoleInstances Default roles. The array is indexed by the role names.
- * @property string[] $defaultRoles Default roles. Note that the type of this property differs in getter and
- * setter. See [[getDefaultRoles()]] and [[setDefaultRoles()]] for details.
+ * @property-read string[] $defaultRoles Default roles.
+ * @property-write string[]|\Closure $defaultRoles Either array of roles or a callable returning it.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/validators/IpValidator.php
+++ b/framework/validators/IpValidator.php
@@ -33,8 +33,14 @@ use yii\web\JsExpression;
  * ['ip_address', 'ip', 'expandIPv6' => true], // expands IPv6 address to a full notation format
  * ```
  *
- * @property array $ranges The IPv4 or IPv6 ranges that are allowed or forbidden. Note that the type of this
- * property differs in getter and setter. See [[getRanges()]] and [[setRanges()]] for details.
+ * @property-read array $ranges The IPv4 or IPv6 ranges that are allowed or forbidden.
+ * @property-write array|string|null $ranges The IPv4 or IPv6 ranges that are allowed or forbidden. When the
+ * array is empty, or the option not set, all IP addresses are allowed. Otherwise, the rules are checked
+ * sequentially until the first match is found. An IP address is forbidden, when it has not matched any of the
+ * rules. Example: ``` [ 'ranges' => [ '192.168.10.128' '!192.168.10.0/24', 'any' // allows any other IP
+ * addresses ] ] ``` In this example, access is allowed for all the IPv4 and IPv6 addresses excluding the
+ * `192.168.10.0/24` subnet. IPv4 address `192.168.10.128` is also allowed, because it is listed before the
+ * restriction.
  *
  * @author Dmitry Naumenko <d.naumenko.a@gmail.com>
  * @since 2.0.7

--- a/framework/validators/IpValidator.php
+++ b/framework/validators/IpValidator.php
@@ -37,10 +37,18 @@ use yii\web\JsExpression;
  * @property-write array|string|null $ranges The IPv4 or IPv6 ranges that are allowed or forbidden. When the
  * array is empty, or the option not set, all IP addresses are allowed. Otherwise, the rules are checked
  * sequentially until the first match is found. An IP address is forbidden, when it has not matched any of the
- * rules. Example: ``` [ 'ranges' => [ '192.168.10.128' '!192.168.10.0/24', 'any' // allows any other IP
- * addresses ] ] ``` In this example, access is allowed for all the IPv4 and IPv6 addresses excluding the
- * `192.168.10.0/24` subnet. IPv4 address `192.168.10.128` is also allowed, because it is listed before the
- * restriction.
+ * rules. Example:
+ * ```
+ * [
+ *      'ranges' => [
+ *          '192.168.10.128'
+ *          '!192.168.10.0/24',
+ *          'any' // allows any other IP addresses
+ *      ]
+ * ]
+ * ```
+ * In this example, access is allowed for all the IPv4 and IPv6 addresses excluding the `192.168.10.0/24` subnet.
+ * IPv4 address `192.168.10.128` is also allowed, because it is listed before the restriction.
  *
  * @author Dmitry Naumenko <d.naumenko.a@gmail.com>
  * @since 2.0.7

--- a/framework/web/AssetManager.php
+++ b/framework/web/AssetManager.php
@@ -34,8 +34,10 @@ use yii\helpers\Url;
  *
  * For more details and usage information on AssetManager, see the [guide article on assets](guide:structure-assets).
  *
- * @property AssetConverterInterface $converter The asset converter. Note that the type of this property
- * differs in getter and setter. See [[getConverter()]] and [[setConverter()]] for details.
+ * @property-read AssetConverterInterface $converter The asset converter.
+ * @property-write array|string|AssetConverterInterface $converter The asset converter. This can be either an
+ * object implementing the [[AssetConverterInterface]], or a configuration array that can be used to create the
+ * asset converter object, or a class name.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -55,8 +55,11 @@ use yii\rbac\CheckAccessInterface;
  * @property T|null $identity The identity object associated with the currently logged-in user. `null` is
  * returned if the user is not logged in (not authenticated).
  * @property-read bool $isGuest Whether the current user is a guest.
- * @property string $returnUrl The URL that the user should be redirected to after login. Note that the type
- * of this property differs in getter and setter. See [[getReturnUrl()]] and [[setReturnUrl()]] for details.
+ * @property-read string $returnUrl The URL that the user should be redirected to after login.
+ * @property-write string|array $returnUrl The URL that the user should be redirected to after login. If an
+ * array is given, [[UrlManager::createUrl()]] will be called to create the corresponding URL. The first element
+ * of the array should be the route, and the rest of the name-value pairs are GET parameters used to construct
+ * the URL. For example, ``` ['admin/index', 'ref' => 1] ```.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/framework/web/User.php
+++ b/framework/web/User.php
@@ -59,7 +59,10 @@ use yii\rbac\CheckAccessInterface;
  * @property-write string|array $returnUrl The URL that the user should be redirected to after login. If an
  * array is given, [[UrlManager::createUrl()]] will be called to create the corresponding URL. The first element
  * of the array should be the route, and the rest of the name-value pairs are GET parameters used to construct
- * the URL. For example, ``` ['admin/index', 'ref' => 1] ```.
+ * the URL. For example,
+ * ```
+ * ['admin/index', 'ref' => 1]
+ * ```
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0

--- a/tests/framework/rbac/ManagerTestCase.php
+++ b/tests/framework/rbac/ManagerTestCase.php
@@ -637,7 +637,6 @@ abstract class ManagerTestCase extends TestCase
     {
         $this->expectException('yii\base\InvalidValueException');
         $this->expectExceptionMessage('Default roles closure must return an array');
-        // @phpstan-ignore assign.propertyType (We intentionally use incorrect data here to test its processing)
         $this->auth->defaultRoles = function () {
             return 'test';
         };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
