### PR TITLE
Fix `yii\db\oci\Schema::findColumns()` to report `null` size for `DATE`, `TIMESTAMP` and `INTERVAL` columns instead of their internal storage byte length.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -151,6 +151,7 @@ Yii Framework 2 Change Log
 - Bug #7843: Preserve defaults on non-auto-incrementing primary key columns in MySQL/MariaDB, PostgreSQL, SQLite, and MSSQL schema metadata, matching the existing Oracle driver behavior (terabytesoftw)
 - Bug #13631: Preserve referenced schema names in MySQL/MariaDB table foreign key metadata for cross-schema relations (terabytesoftw)
 - Bug #17545: Apply PostgreSQL transaction isolation levels after starting the transaction, via the new `yii\db\pgsql\Transaction` class resolved through `yii\db\Connection::$transactionMap` (terabytesoftw)
+- Bug #16043: Fix `yii\db\oci\Schema::findColumns()` to report `null` size for `DATE`, `TIMESTAMP` and `INTERVAL` columns instead of their internal storage byte length (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/db/oci/Schema.php
+++ b/framework/db/oci/Schema.php
@@ -303,7 +303,11 @@ SQL;
             A.DATA_PRECISION,
             A.DATA_SCALE,
             (
-            CASE A.CHAR_USED WHEN 'C' THEN A.CHAR_LENGTH
+            CASE
+                WHEN A.DATA_TYPE = 'DATE'
+                    OR A.DATA_TYPE LIKE 'TIMESTAMP%'
+                    OR A.DATA_TYPE LIKE 'INTERVAL%' THEN NULL
+                WHEN A.CHAR_USED = 'C' THEN A.CHAR_LENGTH
                 ELSE A.DATA_LENGTH
             END
             ) AS DATA_LENGTH,

--- a/tests/framework/db/oci/SchemaTest.php
+++ b/tests/framework/db/oci/SchemaTest.php
@@ -17,6 +17,7 @@ use yiiunit\base\db\BaseSchema;
 use yiiunit\support\DbHelper;
 
 use function array_filter;
+use function array_keys;
 use function array_values;
 
 /**
@@ -28,6 +29,49 @@ use function array_values;
 final class SchemaTest extends BaseSchema
 {
     public $driverName = 'oci';
+
+    public function testDateTimeAndIntervalColumnSizesDoNotExposeInternalStorageLength(): void
+    {
+        $db = $this->getConnection(false);
+
+        $tableName = 'datetime_column_length';
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
+
+        $columns = [
+            'date_value' => 'DATE',
+            'timestamp_value' => 'TIMESTAMP',
+            'timestamp_precise' => 'TIMESTAMP(9)',
+            'timestamp_tz' => 'TIMESTAMP WITH TIME ZONE',
+            'timestamp_ltz' => 'TIMESTAMP WITH LOCAL TIME ZONE',
+            'interval_ym' => 'INTERVAL YEAR TO MONTH',
+            'interval_ds' => 'INTERVAL DAY(5) TO SECOND(4)',
+        ];
+
+        $db->createCommand()->createTable($tableName, $columns)->execute();
+
+        $tableSchema = $db->getTableSchema($tableName, true);
+
+        foreach (array_keys($columns) as $columnName) {
+            self::assertNull(
+                $tableSchema->columns[$columnName]->size,
+                "Storage length must stay hidden for '{$columnName}'.",
+            );
+        }
+
+        self::assertSame(
+            'DATE',
+            $tableSchema->columns['date_value']->dbType,
+            'Type reflection must not drift.',
+        );
+        self::assertSame(
+            9,
+            $tableSchema->columns['timestamp_precise']->scale,
+            'Fractional seconds precision must survive.',
+        );
+
+        DbHelper::dropTablesIfExist($db, [$tableName]);
+    }
 
     public function testExpressionAndLiteralColumnDefaultValues(): void
     {

--- a/tests/framework/db/oci/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/oci/providers/ColumnSchemaProvider.php
@@ -395,7 +395,6 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
         $columns['numeric_col']['dbType'] = 'NUMBER';
         $columns['numeric_col']['size'] = 22;
         $columns['time']['dbType'] = 'TIMESTAMP(6)';
-        $columns['time']['size'] = 11;
         $columns['time']['scale'] = 6;
         $columns['time']['defaultValue'] = new Expression(
             "to_timestamp('2002-01-01 00:00:00', 'yyyy-mm-dd hh24:mi:ss')",
@@ -415,7 +414,6 @@ final class ColumnSchemaProvider extends \yiiunit\base\db\providers\ColumnSchema
         $columns['ts_default']['phpType'] = 'string';
         $columns['ts_default']['dbType'] = 'TIMESTAMP(6)';
         $columns['ts_default']['scale'] = 6;
-        $columns['ts_default']['size'] = 11;
         $columns['bit_col']['type'] = 'string';
         $columns['bit_col']['phpType'] = 'string';
         $columns['bit_col']['dbType'] = 'CHAR';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #16043
