### PR TITLE
Apply an explicitly configured PostgreSQL `defaultSchema` as the session `search_path` when opening the connection.

### DIFF
--- a/docs/guide/db-dao.md
+++ b/docs/guide/db-dao.md
@@ -67,6 +67,29 @@ for more details. Below are some examples:
 * MS SQL Server (via mssql driver): `mssql:host=localhost;dbname=mydatabase`
 * Oracle: `oci:dbname=//localhost:1521/mydatabase`
 
+To use a non-`public` PostgreSQL schema as the default for unqualified table names, configure it explicitly in
+[[yii\db\Connection::schemaMap|schemaMap]]:
+
+```php
+'db' => [
+    'class' => 'yii\db\Connection',
+    'dsn' => 'pgsql:host=localhost;dbname=mydatabase',
+    'username' => 'user',
+    'password' => 'password',
+    'schemaMap' => [
+        'pgsql' => [
+            'class' => 'yii\db\pgsql\Schema',
+            'defaultSchema' => 'myschema',
+        ],
+    ],
+],
+```
+
+Yii applies an explicitly configured `defaultSchema` as PostgreSQL's session `search_path` when the connection opens.
+This keeps schema metadata lookup, migrations, queries, and unqualified SQL on the same schema; objects in other
+schemas, including `public`, must then be referenced with schema-qualified names. The PostgreSQL server configuration
+remains unchanged when `defaultSchema` is not explicitly configured.
+
 Note that if you are connecting with a database via ODBC, you should configure the [[yii\db\Connection::driverName]]
 property so that Yii can know the actual database type. For example,
 

--- a/docs/guide/db-dao.md
+++ b/docs/guide/db-dao.md
@@ -90,6 +90,11 @@ This keeps schema metadata lookup, migrations, queries, and unqualified SQL on t
 schemas, including `public`, must then be referenced with schema-qualified names. The PostgreSQL server configuration
 remains unchanged when `defaultSchema` is not explicitly configured.
 
+When the connection uses [[yii\db\Connection::masters|masters]] or [[yii\db\Connection::slaves|slaves]], include the
+same `schemaMap` entry in [[yii\db\Connection::masterConfig|masterConfig]] or
+[[yii\db\Connection::slaveConfig|slaveConfig]]: pooled connections only apply their own configuration, matching how
+`charset` and `attributes` work for server pools.
+
 Note that if you are connecting with a database via ODBC, you should configure the [[yii\db\Connection::driverName]]
 property so that Yii can know the actual database type. For example,
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -152,6 +152,7 @@ Yii Framework 2 Change Log
 - Bug #13631: Preserve referenced schema names in MySQL/MariaDB table foreign key metadata for cross-schema relations (terabytesoftw)
 - Bug #17545: Apply PostgreSQL transaction isolation levels after starting the transaction, via the new `yii\db\pgsql\Transaction` class resolved through `yii\db\Connection::$transactionMap` (terabytesoftw)
 - Bug #16043: Fix `yii\db\oci\Schema::findColumns()` to report `null` size for `DATE`, `TIMESTAMP` and `INTERVAL` columns instead of their internal storage byte length (terabytesoftw)
+- Bug #12763: Apply an explicitly configured PostgreSQL `defaultSchema` as the session `search_path` when opening the connection (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -538,6 +538,11 @@ Oracle BLOB inserts, updates, and upserts now use native PDO_OCI LOB locators. A
 
 ### PostgreSQL
 
+An explicitly configured `pgsql\Schema::$defaultSchema` in `Connection::$schemaMap` is now applied as the PostgreSQL
+session `search_path` when the connection opens. Unqualified migration, query-builder, Active Record, and raw SQL table
+names therefore use the configured schema. Remove an `afterOpen` handler that only issued the same `SET search_path`
+statement; configurations that do not explicitly set `defaultSchema` keep the server-provided search path unchanged.
+
 `pgsql\QueryBuilder::oldUpsert()` and `newUpsert()` have been removed. `upsert()` now uses `ON CONFLICT` directly. Remove
 calls or overrides of those protected methods.
 

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -542,6 +542,8 @@ An explicitly configured `pgsql\Schema::$defaultSchema` in `Connection::$schemaM
 session `search_path` when the connection opens. Unqualified migration, query-builder, Active Record, and raw SQL table
 names therefore use the configured schema. Remove an `afterOpen` handler that only issued the same `SET search_path`
 statement; configurations that do not explicitly set `defaultSchema` keep the server-provided search path unchanged.
+Pooled master and slave connections apply the `search_path` only when `masterConfig`/`slaveConfig` includes the same
+`schemaMap` entry, matching the existing pool configuration contract.
 
 `pgsql\QueryBuilder::oldUpsert()` and `newUpsert()` have been removed. `upsert()` now uses `ON CONFLICT` directly. Remove
 calls or overrides of those protected methods.

--- a/framework/db/Connection.php
+++ b/framework/db/Connection.php
@@ -753,6 +753,7 @@ class Connection extends Component
      * The default implementation turns on `PDO::ATTR_EMULATE_PREPARES`
      * if [[emulatePrepare]] is true, and sets the database [[charset]] if it is not empty. MySQL and MariaDB
      * connections fall back to `utf8mb4` when neither [[charset]] nor the [[dsn]] specifies a charset.
+     * For PostgreSQL, an explicitly configured `Schema::$defaultSchema` is applied as the session `search_path`.
      * It then triggers an [[EVENT_AFTER_OPEN]] event.
      */
     protected function initConnection()
@@ -781,6 +782,12 @@ class Connection extends Component
             && !str_contains(strtolower((string) $this->dsn), 'charset=')
         ) {
             $this->pdo->exec('SET NAMES ' . $this->pdo->quote('utf8mb4'));
+        }
+
+        if ($driverName === 'pgsql' && isset($this->schemaMap['pgsql']['defaultSchema'])) {
+            $schema = $this->getSchema();
+
+            $this->pdo->exec('SET search_path TO ' . $schema->quoteSimpleTableName($schema->defaultSchema));
         }
 
         $this->trigger(self::EVENT_AFTER_OPEN);

--- a/framework/db/pgsql/Schema.php
+++ b/framework/db/pgsql/Schema.php
@@ -43,7 +43,10 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
 
     public const TYPE_JSONB = 'jsonb';
     /**
-     * @var string the default schema used for the current session.
+     * @var string the schema used for unqualified table metadata lookups. When explicitly configured through
+     * {@see \yii\db\Connection::$schemaMap} before the connection opens, it is also applied as the PostgreSQL session
+     * `search_path`.
+     * @see https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH
      */
     public $defaultSchema = 'public';
     /**

--- a/tests/framework/db/pgsql/ConnectionTest.php
+++ b/tests/framework/db/pgsql/ConnectionTest.php
@@ -11,8 +11,10 @@ namespace yiiunit\framework\db\pgsql;
 use PHPUnit\Framework\Attributes\Group;
 use yii\db\Connection;
 use yii\db\Exception;
+use yii\db\pgsql\Schema;
 use yii\db\Transaction;
 use yiiunit\base\db\BaseConnection;
+use yiiunit\support\DbHelper;
 
 /**
  * Unit tests for {@see \yii\db\pgsql\Connection} functionality for the PostgreSQL driver.
@@ -45,6 +47,58 @@ class ConnectionTest extends BaseConnection
     public function testConnection(): void
     {
         $this->assertIsObject($this->getConnection(true));
+    }
+
+    public function testConfiguredDefaultSchemaIsAppliedToSession(): void
+    {
+        $connection = $this->getConnection(true);
+
+        self::assertSame(
+            'public',
+            $connection->createCommand(
+                <<<SQL
+                SELECT current_schema()
+                SQL,
+            )->queryScalar(),
+            'Default schemaMap must leave the server search path untouched.',
+        );
+
+        $connection->close();
+
+        $connection->schemaMap['pgsql'] = [
+            'class' => Schema::class,
+            'defaultSchema' => 'schema1',
+        ];
+
+        $connection->open();
+
+        self::assertSame(
+            'schema1',
+            $connection->createCommand(
+                <<<SQL
+                SELECT current_schema()
+                SQL,
+            )->queryScalar(),
+            'The configured default schema must be the PostgreSQL current schema.',
+        );
+
+        DbHelper::dropTablesIfExist($connection, ['yii2_issue_12763']);
+
+        $connection->createCommand()->createTable('yii2_issue_12763', ['id' => Schema::TYPE_PK])->execute();
+
+        $tableSchema = $connection->getTableSchema('yii2_issue_12763');
+
+        self::assertNotNull(
+            $tableSchema,
+            'Metadata for the unqualified table name must resolve.',
+        );
+        self::assertSame(
+            'schema1',
+            $tableSchema->schemaName,
+            'Table must be created in the configured schema.',
+        );
+
+        DbHelper::dropTablesIfExist($connection, ['yii2_issue_12763']);
     }
 
     public function testQuoteValue(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #12763 
