### PR TITLE
Fix #21042, #21046: Separate the `@property` annotations in case of different types in getters and setters

### DIFF
--- a/build/controllers/PhpDocController.php
+++ b/build/controllers/PhpDocController.php
@@ -10,17 +10,12 @@ namespace yii\build\controllers;
 
 use Yii;
 use yii\base\Model;
-use yii\base\Module;
 use yii\console\Application;
 use yii\console\Controller as ConsoleController;
-use yii\db\QueryBuilder;
 use yii\helpers\Console;
 use yii\helpers\FileHelper;
 use yii\helpers\Json;
-use yii\log\Dispatcher;
-use yii\log\Target;
 use yii\web\Controller as WebController;
-use yii\web\Request as WebRequest;
 
 /**
  * PhpDocController is there to help to maintain PHPDoc annotation in class files.
@@ -51,22 +46,6 @@ class PhpDocController extends ConsoleController
         ],
         Model::class => [
             'errors',
-        ],
-        Module::class => [
-            'aliases',
-        ],
-        Dispatcher::class => [
-            'flushInterval',
-            'logger',
-        ],
-        Target::class => [
-            'enabled',
-        ],
-        WebRequest::class => [
-            'hostInfo',
-        ],
-        QueryBuilder::class => [
-            'conditionClasses',
         ],
     ];
 

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -29,7 +29,7 @@ Yii Framework 2 Change Log
 - Bug #20994: Fix `@var` annotations for `BlameableBehavior` properties (mspirkov)
 - Enh #20990: Show created migration file path on migrate create CLI command (flaviovs)
 - Bug #21045: Fix union types in PHPDoc annotations (mspirkov)
-- Bug #21042: Separate the `@property` annotations in case of different types in getters and setters (mspirkov)
+- Bug #21042, #21046: Separate the `@property` annotations in case of different types in getters and setters (mspirkov)
 
 
 2.0.55 May 09, 2026

--- a/framework/base/Module.php
+++ b/framework/base/Module.php
@@ -25,8 +25,13 @@ use yii\di\ServiceLocator;
  * For more details and usage information on Module, see the [guide article on modules](guide:structure-modules).
  *
  * @property-write array $aliases List of path aliases to be defined. The array keys are alias names (must
- * start with `@`) and the array values are the corresponding paths or aliases. See [[setAliases()]] for an
- * example.
+ * start with `@`) and the array values are the corresponding paths or aliases. For example,
+ * ```
+ * [
+ *     '@models' => '@app/models', // an existing alias
+ *     '@backend' => __DIR__ . '/../backend',  // a directory
+ * ]
+ * ```
  * @property string $basePath The root directory of the module.
  * @property string $controllerPath The directory that contains the controller classes.
  * @property string $layoutPath The root directory of layout files. Defaults to "[[viewPath]]/layouts".

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -24,7 +24,6 @@ use yii\helpers\StringHelper;
  * For more details and usage information on QueryBuilder, see the [guide article on query builders](guide:db-query-builder).
  *
  * @property-write string[] $conditionClasses Map of condition aliases to condition classes. For example:
- *
  * ```
  * ['LIKE' => yii\db\condition\LikeCondition::class]
  * ```

--- a/framework/log/Dispatcher.php
+++ b/framework/log/Dispatcher.php
@@ -51,10 +51,13 @@ use yii\base\ErrorHandler;
  * Yii::$app->log->targets['file']->enabled = false;
  * ```
  *
- * @property int $flushInterval How many messages should be logged before they are sent to targets. See
- * [[getFlushInterval()]] and [[setFlushInterval()]] for details.
- * @property Logger $logger The logger. If not set, [[Yii::getLogger()]] will be used. Note that the type of
- * this property differs in getter and setter. See [[getLogger()]] and [[setLogger()]] for details.
+ * @property int $flushInterval How many messages should be logged before they are sent to targets. This
+ * method returns the value of [[Logger::flushInterval]].
+ * @property-read Logger $logger The logger.
+ * @property-write Logger|string|array $logger The logger to be used. This can either be a logger instance or
+ * a configuration that will be used to create one using [[Yii::createObject()]]. If you are providing custom
+ * logger configuration and would like it to be used for the whole application and not just for the dispatcher
+ * you should use [[Yii::setLogger()]] instead.
  * @property int $traceLevel How many application call stacks should be logged together with each message.
  * This method returns the value of [[Logger::traceLevel]]. Defaults to 0.
  *

--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -28,10 +28,16 @@ use yii\web\User;
  * satisfying both filter conditions will be handled. Additionally, you
  * may specify [[except]] to exclude messages of certain categories.
  *
- * @property-read bool $enabled Indicates whether this log target is enabled. Defaults to true. Note that the type
- * of this property differs in getter and setter. See [[getEnabled()]] and [[setEnabled()]] for details.
- * @property-write bool|callable $enabled A boolean value or a callable to obtain the value from. Note that the type
- * of this property differs in getter and setter. See [[getEnabled()]] and [[setEnabled()]] for details.
+ * @property-read bool $enabled A value indicating whether this log target is enabled.
+ * @property-write bool|callable $enabled A boolean value or a callable to obtain the value from. The callable
+ * value is available since version 2.0.13. A callable may be used to determine whether the log target should be
+ * enabled in a dynamic way. For example, to only enable a log if the current user is logged in you can configure
+ * the target as follows:
+ * ```
+ * 'enabled' => function() {
+ *     return !Yii::$app->user->isGuest;
+ * }
+ * ```
  * @property-read int $levels The message levels that this target is interested in. This is a bitmap of level
  * values. Defaults to 0, meaning all available levels.
  * @property-write array|int $levels Message levels that this target is interested in.

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -24,9 +24,6 @@ use yii\validators\IpValidator;
  *
  * For more details and usage information on Request, see the [guide article on requests](guide:runtime-requests).
  *
- * @property string|null $hostInfo Schema and hostname part (with port number if needed) of the request URL
- * (e.g. `https://www.yiiframework.com`), null if can't be obtained from `$_SERVER` and wasn't set. See
- * [[getHostInfo()]] for security related notes on this property.
  * @property-read string $absoluteUrl The currently requested absolute URL.
  * @property array $acceptableContentTypes The content types ordered by the quality score. Types with the
  * highest scores will be returned first. The array keys are the content types, while the array values are the
@@ -51,6 +48,8 @@ use yii\validators\IpValidator;
  * returned if no such header is sent.
  * @property-read array $eTags The entity tags.
  * @property-read HeaderCollection $headers The header collection.
+ * @property string|null $hostInfo Schema and hostname part (with port number if needed) of the request URL
+ * (e.g. `https://www.yiiframework.com`), null if can't be obtained from `$_SERVER` and wasn't set.
  * @property-read string|null $hostName Hostname part of the request URL (e.g. `www.yiiframework.com`).
  * @property-read bool $isAjax Whether this is an AJAX (XMLHttpRequest) request.
  * @property-read bool $isDelete Whether this is a DELETE request.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
