### PR TITLE
Use the connection passed to `ActiveQuery` result methods for schema reflection and typecasting while populating records.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -153,6 +153,7 @@ Yii Framework 2 Change Log
 - Bug #17545: Apply PostgreSQL transaction isolation levels after starting the transaction, via the new `yii\db\pgsql\Transaction` class resolved through `yii\db\Connection::$transactionMap` (terabytesoftw)
 - Bug #16043: Fix `yii\db\oci\Schema::findColumns()` to report `null` size for `DATE`, `TIMESTAMP` and `INTERVAL` columns instead of their internal storage byte length (terabytesoftw)
 - Bug #12763: Apply an explicitly configured PostgreSQL `defaultSchema` as the session `search_path` when opening the connection (terabytesoftw)
+- Bug #19852: Use the connection passed to `ActiveQuery::class` result methods for schema reflection and typecasting while populating records (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -153,7 +153,7 @@ Yii Framework 2 Change Log
 - Bug #17545: Apply PostgreSQL transaction isolation levels after starting the transaction, via the new `yii\db\pgsql\Transaction` class resolved through `yii\db\Connection::$transactionMap` (terabytesoftw)
 - Bug #16043: Fix `yii\db\oci\Schema::findColumns()` to report `null` size for `DATE`, `TIMESTAMP` and `INTERVAL` columns instead of their internal storage byte length (terabytesoftw)
 - Bug #12763: Apply an explicitly configured PostgreSQL `defaultSchema` as the session `search_path` when opening the connection (terabytesoftw)
-- Bug #19852: Use the connection passed to `ActiveQuery::class` result methods for schema reflection and typecasting while populating records (terabytesoftw)
+- Bug #19852: Use the connection passed to `ActiveQuery` result methods for schema reflection and typecasting while populating records (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -370,7 +370,8 @@ public static function populateRecord($record, $row, $db = null): void
 
 The attribute list still comes from `attributes()`, which reflects the schema through `getDb()` by default. A model
 whose table is only reachable through another connection must define that connection on the model by overriding
-`getDb()`, or declare its attribute list explicitly by overriding `attributes()`.
+`getDb()`, or declare its attribute list explicitly by overriding `attributes()`. The same applies to `primaryKey()`,
+which join deduplication and other primary-key dependent features resolve through the default schema.
 
 ### Composite `IN` and `NOT IN` conditions
 

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -317,6 +317,9 @@ Notable changes include:
   types; `getRawValuesFromTraversableObject()` was removed.
 - MSSQL `PDO`, `DBLibPDO`, and `SqlsrvPDO` overrides now declare native PDO-compatible parameter and return types.
 - `yii\rbac\DbManager` and its new cascade extension points declare native parameter and return types.
+- The database connection used to fetch query results is now passed through `Query::populate()`,
+  `ActiveQueryTrait::createModels()`, `ActiveRecord::populateRecord()`, and `ActiveRecord::getTableSchema()`. Overrides
+  of these methods must accept the new optional `$db` parameter and forward it when calling the parent implementation.
 
 Run the application's static analysis and test suite after upgrading. Pay particular attention to classes extending
 `Action`, `InlineAction`, `InConditionBuilder`, a database query builder, a database schema class, an MSSQL PDO wrapper,
@@ -347,6 +350,27 @@ Yii2 `22.0` adds standalone action discovery through `Module::$actionMap`, `Modu
   `actionMap`.
 
 ## Database abstraction layer
+
+### Active Record population uses the query connection
+
+Passing a connection to `ActiveQuery::all()`, `one()`, `batch()`, or `each()` now uses the same connection for schema
+reflection and column typecasting. Previously, the rows were fetched from the supplied connection but
+`ActiveRecord::populateRecord()` reflected the schema through `ActiveRecord::getDb()`.
+
+Custom overrides of `populateRecord()` must accept and forward the connection:
+
+```php
+public static function populateRecord($record, $row, $db = null): void
+{
+    parent::populateRecord($record, $row, $db);
+
+    // Custom population logic.
+}
+```
+
+The attribute list still comes from `attributes()`, which reflects the schema through `getDb()` by default. A model
+whose table is only reachable through another connection must define that connection on the model by overriding
+`getDb()`, or declare its attribute list explicitly by overriding `attributes()`.
 
 ### Composite `IN` and `NOT IN` conditions
 

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -10,6 +10,8 @@ namespace yii\db;
 
 use yii\base\InvalidConfigException;
 
+use function reset;
+
 /**
  * ActiveQuery represents a DB query associated with an Active Record class.
  *
@@ -220,16 +222,18 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     /**
      * {@inheritdoc}
      */
-    public function populate($rows)
+    public function populate($rows, $db = null)
     {
         if (empty($rows)) {
             return [];
         }
 
-        $models = $this->createModels($rows);
+        $models = $this->createModels($rows, $db);
+
         if (!empty($this->join) && $this->indexBy === null) {
             $models = $this->removeDuplicatedModels($models);
         }
+
         if (!empty($this->with)) {
             $this->findWith($this->with, $models);
         }
@@ -244,7 +248,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             }
         }
 
-        return parent::populate($models);
+        return parent::populate($models, $db);
     }
 
     /**
@@ -303,17 +307,20 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 
     /**
      * Executes query and returns a single row of result.
-     * @param Connection|null $db the DB connection used to create the DB command.
-     * If `null`, the DB connection returned by [[modelClass]] will be used.
-     * @return T|null a single row of query result. Depending on the setting of [[asArray]],
-     * the query result may be either an array or an ActiveRecord object. `null` will be returned
-     * if the query results in nothing.
+     *
+     * @param Connection|null $db the DB connection used to create the DB command. If `null`, the DB connection returned
+     * by [[modelClass]] will be used.
+     *
+     * @return T|null a single row of query result. Depending on the setting of [[asArray]], the query result may be
+     * either an array or an ActiveRecord object. `null` will be returned if the query results in nothing.
      */
     public function one($db = null)
     {
         $row = parent::one($db);
+
         if ($row !== false) {
-            $models = $this->populate([$row]);
+            $models = $this->populate([$row], $db);
+
             return reset($models) ?: null;
         }
 

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -8,8 +8,6 @@
 
 namespace yii\db;
 
-use function get_class;
-
 /**
  * ActiveQueryTrait implements the common methods and properties for active record query classes.
  *
@@ -112,8 +110,8 @@ trait ActiveQueryTrait
      * @param array $rows The rows to be converted into model instances. Each array element represents a row of data.
      * @param Connection|null $db The database connection used to retrieve the rows.
      *
-     * @return array|ActiveRecord[] The model instances created from the rows. If [[asArray]] is true, the rows will be
-     * returned as is.
+     * @return array|BaseActiveRecord[] The model instances created from the rows. If [[asArray]] is true, the rows
+     * will be returned as is.
      * @since 2.0.11
      */
     protected function createModels($rows, $db = null)
@@ -122,17 +120,16 @@ trait ActiveQueryTrait
             return $rows;
         } else {
             $models = [];
-            /** @var ActiveRecord $class */
+            /** @var class-string<BaseActiveRecord> $class */
             $class = $this->modelClass;
 
             foreach ($rows as $row) {
                 $model = $class::instantiate($row);
-                $modelClass = get_class($model);
 
                 if ($model instanceof ActiveRecord) {
-                    $modelClass::populateRecord($model, $row, $db);
+                    $model::populateRecord($model, $row, $db);
                 } else {
-                    $modelClass::populateRecord($model, $row);
+                    $model::populateRecord($model, $row);
                 }
 
                 $models[] = $model;

--- a/framework/db/ActiveQueryTrait.php
+++ b/framework/db/ActiveQueryTrait.php
@@ -8,6 +8,8 @@
 
 namespace yii\db;
 
+use function get_class;
+
 /**
  * ActiveQueryTrait implements the common methods and properties for active record query classes.
  *
@@ -106,11 +108,15 @@ trait ActiveQueryTrait
 
     /**
      * Converts found rows into model instances.
-     * @param array $rows
-     * @return array|ActiveRecord[]
+     *
+     * @param array $rows The rows to be converted into model instances. Each array element represents a row of data.
+     * @param Connection|null $db The database connection used to retrieve the rows.
+     *
+     * @return array|ActiveRecord[] The model instances created from the rows. If [[asArray]] is true, the rows will be
+     * returned as is.
      * @since 2.0.11
      */
-    protected function createModels($rows)
+    protected function createModels($rows, $db = null)
     {
         if ($this->asArray) {
             return $rows;
@@ -118,12 +124,20 @@ trait ActiveQueryTrait
             $models = [];
             /** @var ActiveRecord $class */
             $class = $this->modelClass;
+
             foreach ($rows as $row) {
                 $model = $class::instantiate($row);
                 $modelClass = get_class($model);
-                $modelClass::populateRecord($model, $row);
+
+                if ($model instanceof ActiveRecord) {
+                    $modelClass::populateRecord($model, $row, $db);
+                } else {
+                    $modelClass::populateRecord($model, $row);
+                }
+
                 $models[] = $model;
             }
+
             return $models;
         }
     }

--- a/framework/db/ActiveRecord.php
+++ b/framework/db/ActiveRecord.php
@@ -425,12 +425,19 @@ class ActiveRecord extends BaseActiveRecord
 
     /**
      * Returns the schema information of the DB table associated with this AR class.
-     * @return TableSchema the schema information of the DB table associated with this AR class.
+     *
+     * @param Connection|null $db The database connection used to retrieve the schema. If `null`, the connection
+     * returned by [[getDb()]] will be used.
+     *
      * @throws InvalidConfigException if the table for the AR class does not exist.
+     *
+     * @return TableSchema The schema information of the DB table associated with this AR class.
      */
-    public static function getTableSchema()
+    public static function getTableSchema($db = null)
     {
-        $tableSchema = static::getDb()
+        $db = $db ?? static::getDb();
+
+        $tableSchema = $db
             ->getSchema()
             ->getTableSchema(static::tableName());
 
@@ -503,15 +510,19 @@ class ActiveRecord extends BaseActiveRecord
 
     /**
      * {@inheritdoc}
+     *
+     * @param Connection|null $db The database connection used to retrieve the row and its schema.
      */
-    public static function populateRecord($record, $row)
+    public static function populateRecord($record, $row, $db = null)
     {
-        $columns = static::getTableSchema()->columns;
+        $columns = static::getTableSchema($db)->columns;
+
         foreach ($row as $name => $value) {
             if (isset($columns[$name])) {
                 $row[$name] = $columns[$name]->phpTypecast($value);
             }
         }
+
         parent::populateRecord($record, $row);
     }
 

--- a/framework/db/BatchQueryResult.php
+++ b/framework/db/BatchQueryResult.php
@@ -172,7 +172,7 @@ class BatchQueryResult extends Component implements \Iterator
 
         $rows = $this->getRows();
 
-        return $this->query->populate($rows);
+        return $this->query->populate($rows, $this->db);
     }
 
     /**

--- a/framework/db/Query.php
+++ b/framework/db/Query.php
@@ -272,22 +272,28 @@ class Query extends Component implements QueryInterface, ExpressionInterface
 
         $rows = $this->createCommand($db)->queryAll();
 
-        return $this->populate($rows);
+        return $this->populate($rows, $db);
     }
 
     /**
      * Converts the raw query results into the format as specified by this query.
-     * This method is internally used to convert the data fetched from database
-     * into the format as required by this query.
-     * @param array $rows the raw query result from database
-     * @return array the converted query result
+     *
+     * This method is internally used to convert the data fetched from database into the format as required by this
+     * query.
+     *
+     * @param array $rows The raw query result from database.
+     * @param Connection|null $db The database connection used to retrieve the rows.
+     *
+     * @return array The converted query result.
      */
-    public function populate($rows)
+    public function populate($rows, $db = null)
     {
         if ($this->indexBy === null) {
             return $rows;
         }
+
         $result = [];
+
         foreach ($rows as $row) {
             $result[ArrayHelper::getValue($row, $this->indexBy)] = $row;
         }

--- a/tests/base/db/BaseActiveQuery.php
+++ b/tests/base/db/BaseActiveQuery.php
@@ -405,8 +405,8 @@ abstract class BaseActiveQuery extends DatabaseTestCase
             $query
                 ->orderBy(['id' => SORT_ASC])
                 ->batch(1, $db),
-                false,
-            );
+            false,
+        );
 
         self::assertCount(
             2,
@@ -444,8 +444,8 @@ abstract class BaseActiveQuery extends DatabaseTestCase
             $query
                 ->orderBy(['id' => SORT_ASC])
                 ->each(1, $db),
-                false,
-            );
+            false,
+        );
 
         self::assertCount(
             2,

--- a/tests/base/db/BaseActiveQuery.php
+++ b/tests/base/db/BaseActiveQuery.php
@@ -15,6 +15,7 @@ use yii\db\ActiveQuery;
 use yii\db\Connection;
 use yii\db\QueryBuilder;
 use yiiunit\data\ar\ActiveRecord;
+use yiiunit\data\ar\AlternativeConnectionRecord;
 use yiiunit\data\ar\Category;
 use yiiunit\data\ar\Customer;
 use yiiunit\data\ar\Order;
@@ -313,5 +314,184 @@ abstract class BaseActiveQuery extends DatabaseTestCase
         $this->assertEquals(1, count($orders));
         $this->assertInstanceOf(Order::class, $orders[0]);
         $this->assertEquals(2, $orders[0]->id);
+    }
+
+    public function testExplicitConnectionIsUsedToPopulateModels(): void
+    {
+        $db = $this->createAlternativeConnection();
+
+        /** @var ActiveQuery<AlternativeConnectionRecord> $query */
+        $query = new ActiveQuery(AlternativeConnectionRecord::class);
+
+        $models = $query
+            ->orderBy(['id' => SORT_ASC])
+            ->all($db);
+
+        self::assertCount(
+            2,
+            $models,
+            'Record count mismatch.',
+        );
+        self::assertSame(
+            1,
+            $models[0]->id,
+            "First record id must be '1'.",
+        );
+        self::assertSame(
+            2,
+            $models[1]->id,
+            "Second record id must be '2'.",
+        );
+        self::assertSame(
+            'first',
+            $models[0]->name,
+            'First record name must match.',
+        );
+        self::assertSame(
+            'second',
+            $models[1]->name,
+            'Second record name must match.',
+        );
+        self::assertTrue(
+            $models[0]->populated,
+            "First record populated flag must be 'true'.",
+        );
+        self::assertTrue(
+            $models[1]->populated,
+            "Second record populated flag must be 'true'.",
+        );
+    }
+
+    public function testExplicitConnectionIsUsedToPopulateOneModel(): void
+    {
+        $db = $this->createAlternativeConnection();
+
+        /** @var ActiveQuery<AlternativeConnectionRecord> $query */
+        $query = new ActiveQuery(AlternativeConnectionRecord::class);
+
+        $model = $query
+            ->where(['id' => 2])
+            ->one($db);
+
+        self::assertInstanceOf(
+            AlternativeConnectionRecord::class,
+            $model,
+            'Model type mismatch.',
+        );
+        self::assertSame(
+            2,
+            $model->id,
+            "Model id must be '2'.",
+        );
+        self::assertSame(
+            'second',
+            $model->name,
+            'Model name must match.',
+        );
+        self::assertTrue(
+            $model->populated,
+            "Populated flag must be 'true'.",
+        );
+    }
+
+    public function testExplicitConnectionIsUsedToPopulateBatches(): void
+    {
+        $db = $this->createAlternativeConnection();
+
+        /** @var ActiveQuery<AlternativeConnectionRecord> $query */
+        $query = new ActiveQuery(AlternativeConnectionRecord::class);
+
+        $batches = iterator_to_array(
+            $query
+                ->orderBy(['id' => SORT_ASC])
+                ->batch(1, $db),
+                false,
+            );
+
+        self::assertCount(
+            2,
+            $batches,
+            'Batch count mismatch.',
+        );
+        self::assertSame(
+            1,
+            $batches[0][0]->id,
+            "First batch model id must be '1'.",
+        );
+        self::assertSame(
+            2,
+            $batches[1][0]->id,
+            "Second batch model id must be '2'.",
+        );
+        self::assertTrue(
+            $batches[0][0]->populated,
+            "First batch populated flag must be 'true'.",
+        );
+        self::assertTrue(
+            $batches[1][0]->populated,
+            "Second batch populated flag must be 'true'.",
+        );
+    }
+
+    public function testExplicitConnectionIsUsedToPopulateEachModel(): void
+    {
+        $db = $this->createAlternativeConnection();
+
+        /** @var ActiveQuery<AlternativeConnectionRecord> $query */
+        $query = new ActiveQuery(AlternativeConnectionRecord::class);
+
+        $models = iterator_to_array(
+            $query
+                ->orderBy(['id' => SORT_ASC])
+                ->each(1, $db),
+                false,
+            );
+
+        self::assertCount(
+            2,
+            $models,
+            'Model count mismatch.',
+        );
+        self::assertSame(
+            1,
+            $models[0]->id,
+            "First model id must be '1'.",
+        );
+        self::assertSame(
+            2,
+            $models[1]->id,
+            "Second model id must be '2'.",
+        );
+        self::assertTrue(
+            $models[0]->populated,
+            "First model populated flag must be 'true'.",
+        );
+        self::assertTrue(
+            $models[1]->populated,
+            "Second model populated flag must be 'true'.",
+        );
+    }
+
+    private function createAlternativeConnection(): Connection
+    {
+        $db = new Connection(['dsn' => 'sqlite::memory:']);
+
+        $db->open();
+        $db->createCommand(
+            <<<'SQL'
+            CREATE TABLE alternative_connection_record (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL
+            )
+            SQL,
+        )->execute();
+        $db->createCommand(
+            <<<'SQL'
+            INSERT INTO alternative_connection_record (id, name)
+            VALUES (1, 'first'), (2, 'second')
+            SQL,
+        )->execute();
+
+        return $db;
     }
 }

--- a/tests/base/db/BaseActiveQuery.php
+++ b/tests/base/db/BaseActiveQuery.php
@@ -16,6 +16,7 @@ use yii\db\Connection;
 use yii\db\QueryBuilder;
 use yiiunit\data\ar\ActiveRecord;
 use yiiunit\data\ar\AlternativeConnectionRecord;
+use yiiunit\data\ar\BaseOnlyRecord;
 use yiiunit\data\ar\Category;
 use yiiunit\data\ar\Customer;
 use yiiunit\data\ar\Order;
@@ -469,6 +470,48 @@ abstract class BaseActiveQuery extends DatabaseTestCase
         self::assertTrue(
             $models[1]->populated,
             "Second model populated flag must be 'true'.",
+        );
+    }
+
+    public function testPopulateWithExplicitConnectionSupportsBaseActiveRecordModels(): void
+    {
+        $db = new Connection(['dsn' => 'sqlite::memory:']);
+
+        $query = new ActiveQuery(BaseOnlyRecord::class);
+
+        $models = $query->populate(
+            [
+                ['id' => 1, 'name' => 'first'],
+            ],
+            $db,
+        );
+
+        self::assertCount(
+            1,
+            $models,
+            'Record count mismatch.',
+        );
+
+        $model = $models[0];
+
+        self::assertInstanceOf(
+            BaseOnlyRecord::class,
+            $model,
+            'Model type mismatch.',
+        );
+        self::assertSame(
+            1,
+            $model->id,
+            "Model id must be '1'.",
+        );
+        self::assertSame(
+            'first',
+            $model->name,
+            'Model name must match.',
+        );
+        self::assertTrue(
+            $model->populated,
+            "Populated flag must be 'true'.",
         );
     }
 

--- a/tests/base/db/BaseActiveQuery.php
+++ b/tests/base/db/BaseActiveQuery.php
@@ -473,6 +473,39 @@ abstract class BaseActiveQuery extends DatabaseTestCase
         );
     }
 
+    public function testExplicitConnectionIsUsedToDeduplicateJoinedModels(): void
+    {
+        $db = $this->createAlternativeConnection();
+
+        /** @var ActiveQuery<AlternativeConnectionRecord> $query */
+        $query = new ActiveQuery(AlternativeConnectionRecord::class);
+
+        $models = $query
+            ->join(
+                'LEFT JOIN',
+                ['dup' => 'alternative_connection_record'],
+                '{{dup}}.[[id]] >= {{alternative_connection_record}}.[[id]]',
+            )
+            ->orderBy(['alternative_connection_record.id' => SORT_ASC])
+            ->all($db);
+
+        self::assertCount(
+            2,
+            $models,
+            'Join duplicates must be removed.',
+        );
+        self::assertSame(
+            1,
+            $models[0]->id,
+            "First model id must be '1'.",
+        );
+        self::assertSame(
+            2,
+            $models[1]->id,
+            "Second model id must be '2'.",
+        );
+    }
+
     public function testPopulateWithExplicitConnectionSupportsBaseActiveRecordModels(): void
     {
         $db = new Connection(['dsn' => 'sqlite::memory:']);

--- a/tests/base/db/BaseActiveQuery.php
+++ b/tests/base/db/BaseActiveQuery.php
@@ -11,6 +11,7 @@ namespace yiiunit\base\db;
 use yiiunit\framework\db\DatabaseTestCase;
 use yiiunit\framework\db\GetTablesAliasTestTrait;
 use yii\base\Event;
+use yii\base\InvalidConfigException;
 use yii\db\ActiveQuery;
 use yii\db\Connection;
 use yii\db\QueryBuilder;
@@ -19,6 +20,7 @@ use yiiunit\data\ar\AlternativeConnectionRecord;
 use yiiunit\data\ar\BaseOnlyRecord;
 use yiiunit\data\ar\Category;
 use yiiunit\data\ar\Customer;
+use yiiunit\data\ar\DefaultSchemaRecord;
 use yiiunit\data\ar\Order;
 use yiiunit\data\ar\Profile;
 
@@ -546,6 +548,20 @@ abstract class BaseActiveQuery extends DatabaseTestCase
             $model->populated,
             "Populated flag must be 'true'.",
         );
+    }
+
+    public function testThrowInvalidConfigExceptionWhenModelReliesOnDefaultSchemaReflection(): void
+    {
+        $db = $this->createAlternativeConnection();
+
+        $query = new ActiveQuery(DefaultSchemaRecord::class);
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage(
+            'The table does not exist: alternative_connection_record',
+        );
+
+        $query->all($db);
     }
 
     private function createAlternativeConnection(): Connection

--- a/tests/data/ar/AlternativeConnectionRecord.php
+++ b/tests/data/ar/AlternativeConnectionRecord.php
@@ -31,6 +31,11 @@ class AlternativeConnectionRecord extends ActiveRecord
         return 'alternative_connection_record';
     }
 
+    public static function primaryKey()
+    {
+        return ['id'];
+    }
+
     public function attributes()
     {
         return ['id', 'name'];

--- a/tests/data/ar/AlternativeConnectionRecord.php
+++ b/tests/data/ar/AlternativeConnectionRecord.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar;
+
+use yii\db\Connection;
+
+/**
+ * Test Active Record fixture whose table exists only on an explicitly supplied connection, tracking calls to
+ * {@see \yii\db\ActiveRecord::populateRecord()}.
+ *
+ * @property int $id
+ * @property string $name
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+class AlternativeConnectionRecord extends ActiveRecord
+{
+    public bool $populated = false;
+
+    public static function tableName()
+    {
+        return 'alternative_connection_record';
+    }
+
+    public function attributes()
+    {
+        return ['id', 'name'];
+    }
+
+    /**
+     * @param self $record
+     * @param array $row
+     * @param Connection|null $db
+     */
+    public static function populateRecord($record, $row, $db = null): void
+    {
+        parent::populateRecord($record, $row, $db);
+
+        $record->populated = true;
+    }
+}

--- a/tests/data/ar/BaseOnlyRecord.php
+++ b/tests/data/ar/BaseOnlyRecord.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar;
+
+use yii\base\NotSupportedException;
+use yii\db\ActiveQuery;
+use yii\db\BaseActiveRecord;
+
+/**
+ * Test Active Record fixture extending {@see BaseActiveRecord} directly, keeping the two-argument
+ * {@see BaseActiveRecord::populateRecord()} signature to exercise the non-SQL dispatch in
+ * {@see \yii\db\ActiveQueryTrait::createModels()}.
+ *
+ * @property int $id
+ * @property string $name
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+class BaseOnlyRecord extends BaseActiveRecord
+{
+    public bool $populated = false;
+
+    public static function find(): ActiveQuery
+    {
+        return new ActiveQuery(static::class);
+    }
+
+    public static function getDb(): never
+    {
+        throw new NotSupportedException(__METHOD__ . ' is not supported.');
+    }
+
+    public static function primaryKey(): array
+    {
+        return ['id'];
+    }
+
+    public function attributes(): array
+    {
+        return ['id', 'name'];
+    }
+
+    public function insert($runValidation = true, $attributes = null): never
+    {
+        throw new NotSupportedException(__METHOD__ . ' is not supported.');
+    }
+
+    /**
+     * @param self $record
+     * @param array $row
+     */
+    public static function populateRecord($record, $row): void
+    {
+        parent::populateRecord($record, $row);
+
+        $record->populated = true;
+    }
+}

--- a/tests/data/ar/Cat.php
+++ b/tests/data/ar/Cat.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yiiunit\data\ar;
 
 use Exception;
+use yii\db\Connection;
 
 /**
  * Class Cat.
@@ -23,10 +24,11 @@ class Cat extends Animal
     /**
      * @param self $record
      * @param array $row
+     * @param Connection|null $db
      */
-    public static function populateRecord($record, $row): void
+    public static function populateRecord($record, $row, $db = null): void
     {
-        parent::populateRecord($record, $row);
+        parent::populateRecord($record, $row, $db);
 
         $record->does = 'meow';
     }

--- a/tests/data/ar/DefaultSchemaRecord.php
+++ b/tests/data/ar/DefaultSchemaRecord.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar;
+
+/**
+ * Test Active Record fixture that relies on the default schema reflection through [[getDb()]] while its table exists
+ * only on an explicitly supplied connection.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+class DefaultSchemaRecord extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'alternative_connection_record';
+    }
+}

--- a/tests/data/ar/Dog.php
+++ b/tests/data/ar/Dog.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace yiiunit\data\ar;
 
+use yii\db\Connection;
+
 /**
  * Class Dog.
  *
@@ -21,10 +23,11 @@ class Dog extends Animal
     /**
      * @param self $record
      * @param array $row
+     * @param Connection|null $db
      */
-    public static function populateRecord($record, $row): void
+    public static function populateRecord($record, $row, $db = null): void
     {
-        parent::populateRecord($record, $row);
+        parent::populateRecord($record, $row, $db);
 
         $record->does = 'bark';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #19852
