### PR TITLE
Fix #20208: Document ActiveForm `afterInit` event in the guide

### DIFF
--- a/docs/guide-ru/input-form-javascript.md
+++ b/docs/guide-ru/input-form-javascript.md
@@ -135,6 +135,28 @@ function (event, jqXHR, textStatus)
 - `jqXHR`: объект `jqXHR`
 - `textStatus`: статус запроса ("success", "notmodified", "error", "timeout", "abort", или "parsererror")
 
+### `afterInit`
+
+`afterInit` событие запускается после инициализации JavaScript плагина ActiveForm.
+
+Сигнатура обработчика события должна быть:
+
+```javascript
+function (event)
+```
+
+где событие является объектом `Event`.
+
+Обратите внимание, что плагин инициализируется самим виджетом, поэтому обработчик необходимо назначить до того, как это произойдёт.
+Регистрируйте свой код в позиции, которая выполняется раньше, чем [[yii\web\View::POS_READY|POS_READY]], например:
+
+```php
+$this->registerJs(
+    "jQuery('#contact-form').on('afterInit', function () { /* ... */ });",
+    \yii\web\View::POS_END
+);
+```
+
 ## Отправка формы через AJAX
 
 Хотя проверка может быть выполнена на стороне клиента или с помощью AJAX-запроса, сама отправка формы, по умолчанию, выполняется как обычный запрос.

--- a/docs/guide/input-form-javascript.md
+++ b/docs/guide/input-form-javascript.md
@@ -146,6 +146,29 @@ where
 - `textStatus`: the status of the request ("success", "notmodified", "error", "timeout",
 "abort", or "parsererror").
 
+### `afterInit`
+
+`afterInit` event is triggered after initializing the ActiveForm JavaScript plugin.
+
+The signature of the event handler should be:
+
+```javascript
+function (event)
+```
+
+where event is an Event object.
+
+Note that the plugin is initialized by the widget itself, so the handler has to be attached before
+that happens. Register your code with a position that is executed earlier than
+[[yii\web\View::POS_READY|POS_READY]], for example:
+
+```php
+$this->registerJs(
+    "jQuery('#contact-form').on('afterInit', function () { /* ... */ });",
+    \yii\web\View::POS_END
+);
+```
+
 ## Submitting the form via AJAX
 
 While validation can be made on client side or via AJAX request, the form submission itself is done


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20208

The "Extending ActiveForm on the Client Side" guide lists every ActiveForm event except `afterInit`, which was added in #12747. Right now the only way to find out it exists is to read `yii.activeForm.js`.

This adds the missing section after `ajaxComplete`, following the same order the events are declared in the JS file.

Apart from the signature, I added a short note about when the handler has to be attached, because that part is not obvious. `afterInit` is triggered synchronously at the end of `init()`, and the widget registers `yiiActiveForm()` through `registerJs()` without an explicit position, so it runs at `POS_READY`. Subscribing with a plain `registerJs()` call is therefore too late, the event has already fired by then. Registering at `POS_END` works because that block is rendered before the `jQuery(function ($) {...})` wrapper. Everything else in the new section is just what the PHPDoc in `yii.activeForm.js` already says.

The Russian translation is updated in the same commit. If it were done separately, `build translation` would immediately flag `docs/guide-ru/input-form-javascript.md` as outdated, since it diffs the source against the last commit that touched the translation.

Documentation only, so no CHANGELOG entry.
