### PR TITLE
Fix #20217: Apply ActiveForm validation delay only while the user is typing.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -34,6 +34,7 @@ Yii Framework 2 Change Log
 - Bug #21042, #21046: Separate the `@property` annotations in case of different types in getters and setters (mspirkov)
 - Bug #21042: Separate the `@property` annotations in case of different types in getters and setters (mspirkov)
 - Bug #21047: Fix PHPDoc annotations in `Theme`, `AccessRule` and `View` (mspirkov)
+- Bug #20217: Apply `ActiveForm::$validationDelay` only while the user is typing, so validation on blur, change and manual trigger is no longer delayed (veksa)
 
 
 2.0.55 May 09, 2026

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -56,6 +56,10 @@ Upgrade from Yii 2.0.55
 
 * When using multiple `\yii\db\Expression`s with the same parameter names in a query, the parameters are renamed to avoid clashes.
   If your code relies on inspecting the SQL created by the query builder, you might need to change it.
+* Client-side validation in `ActiveForm` triggered by a change, by the input losing focus, or by a manual
+  `yiiActiveForm('validateAttribute', ...)` call is no longer delayed by 200 milliseconds. It is still scheduled
+  asynchronously, but with a zero-millisecond delay. `validationDelay` keeps applying while the user is typing,
+  which is the only case it is documented for.
 
 Upgrade from Yii 2.0.53
 -----------------------

--- a/framework/assets/yii.activeForm.js
+++ b/framework/assets/yii.activeForm.js
@@ -549,6 +549,14 @@
         findInput($form, attribute).off('.yiiActiveForm');
     };
 
+    /**
+     * Validates the form attributes that are pending validation.
+     * @param $form the form jQuery object
+     * @param attribute the attribute that triggered the validation
+     * @param forceValidate whether to validate even if no value has changed
+     * @param validationDelay number of milliseconds to delay the validation by. Only passed while the user is typing,
+     * every other case is scheduled asynchronously with a zero-millisecond delay.
+     */
     var validateAttribute = function ($form, attribute, forceValidate, validationDelay) {
         var data = $form.data('yiiActiveForm');
 
@@ -588,7 +596,7 @@
                 }
             });
             methods.validate.call($form);
-        }, validationDelay ? validationDelay : 200);
+        }, validationDelay || 0);
     };
 
     /**

--- a/tests/js/data/yii.activeForm.html
+++ b/tests/js/data/yii.activeForm.html
@@ -60,3 +60,10 @@
         <div class="help-block"></div>
     </div>
 </form>
+<form id="w4">
+    <div class="form-group field-test-text4 required">
+        <label class="control-label" for="test-text4">Test text</label>
+        <input type="text" id="test-text4" class="form-control" name="Test[text4]" aria-required="true">
+        <div class="help-block"></div>
+    </div>
+</form>

--- a/tests/js/tests/yii.activeForm.test.js
+++ b/tests/js/tests/yii.activeForm.test.js
@@ -323,4 +323,67 @@ describe('yii.activeForm', function () {
             });
         });
     });
+
+    // https://github.com/yiisoft/yii2/issues/20217
+
+    describe('validationDelay', function () {
+        var inputId = 'test-text4';
+        var $input;
+        var windowSetTimeoutStub;
+        var delays;
+
+        before(function () {
+            $activeForm = $('#w4');
+            $activeForm.yiiActiveForm([
+                {
+                    id: inputId,
+                    input: '#' + inputId,
+                    container: '.field-' + inputId,
+                    validateOnType: true,
+                    validationDelay: 500
+                }
+            ]);
+            $input = $('#' + inputId);
+        });
+
+        beforeEach(function () {
+            delays = [];
+            windowSetTimeoutStub = sinon.stub(window, 'setTimeout', function (callback, delay) {
+                delays.push(delay);
+                callback();
+            });
+        });
+
+        afterEach(function () {
+            windowSetTimeoutStub.restore();
+            $activeForm.yiiActiveForm('find', inputId).validationDelay = 500;
+        });
+
+        it('should be applied while the user is typing', function () {
+            $input.val('typed value').trigger('keyup');
+            assert.deepEqual([500], delays);
+        });
+
+        it('should be honored while the user is typing when it is set to 0', function () {
+            $activeForm.yiiActiveForm('find', inputId).validationDelay = 0;
+            $input.val('instantly validated value').trigger('keyup');
+            assert.deepEqual([0], delays);
+        });
+
+        it('should not be applied when the input loses focus', function () {
+            $input.val('blurred value').trigger('blur');
+            assert.deepEqual([0], delays);
+        });
+
+        it('should not be applied when a change is detected on the input', function () {
+            $input.val('changed value').trigger('change');
+            assert.deepEqual([0], delays);
+        });
+
+        it('should not be applied when the validation is triggered manually', function () {
+            $input.val('manually validated value');
+            $activeForm.yiiActiveForm('validateAttribute', inputId);
+            assert.deepEqual([0], delays);
+        });
+    });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #20217

`validationDelay` is documented as the delay applied "when the user types in the field and `validateOnType` is set `true`", but in practice it affected every validation path. Only the `keyup` handler passes the value to `validateAttribute()`; validation on `change`, on `blur` and through the public `yiiActiveForm('validateAttribute', id)` API called it without a delay argument and hit the hardcoded 200 ms fallback instead.

The same fallback also swallowed an explicitly configured `validationDelay` of `0`, since the check was for a truthy value rather than for a missing one.

Both are fixed by falling back to `0` instead of `200`, so the delay now applies only where it is documented to apply. I kept the `setTimeout()` call rather than removing it: it still defers to the next tick, so the existing `clearTimeout()` logic keeps collapsing a `change` and a `blur` fired by the same interaction into a single validation run.

I did not go with the alternative suggested in the issue (moving the timer into `watchAttribute()`), because that drops the part of `validateAttribute()` that marks every changed attribute as pending and cancels the previous timer.

Marked as breaking BC because the timing of client-side validation changes: on blur and change it now runs immediately instead of 200 ms later. Nothing in the public API changes, and the 200 ms was never documented, but it is observable, so I added an `UPGRADE.md` note.

Tests are in `tests/js/tests/yii.activeForm.test.js` and cover all four paths. Without the fix the three non-typing ones fail with the reported 200 ms, while the typing one keeps passing.

The original report is worth reading for the motivation: the delay makes a screen reader start announcing the next field before the validation error, even with `aria-live="assertive"`.
