### PR TITLE
Fix #20456: Handle bracket style delimiters in Html::escapeJsRegularExpression()

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -36,6 +36,8 @@ Yii Framework 2 Change Log
 - Bug #21047: Fix PHPDoc annotations in `Theme`, `AccessRule` and `View` (mspirkov)
 - Bug #20217: Apply `ActiveForm::$validationDelay` only while the user is typing, so validation on blur, change and manual trigger is no longer delayed (veksa)
 - Bug #19865: Ignore validators with a `when` condition while `AttributeTypecastBehavior` detects `attributeTypes` automatically (veksa)
+- Bug #20322: Pad hex escapes to four digits in `yii\helpers\Html::escapeJsRegularExpression()` so that they stay valid in JavaScript (veksa)
+- Bug #20456: Fix `yii\helpers\Html::escapeJsRegularExpression()` truncating patterns that use bracket style delimiters (veksa)
 
 
 2.0.55 May 09, 2026

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2387,15 +2387,30 @@ class BaseHtml
 
     /**
      * Escapes regular expression to use in JavaScript.
-     * @param string $regexp the regular expression to be escaped.
+     * @param string $regexp the regular expression to be escaped. It is expected to be a valid PCRE pattern,
+     * that is, wrapped in delimiters and optionally followed by modifiers. Bracket style delimiters
+     * (`()`, `{}`, `[]` and `<>`) are supported as well.
      * @return string the escaped result.
      * @since 2.0.6
      */
     public static function escapeJsRegularExpression($regexp)
     {
-        $pattern = preg_replace('/\\\\x\{?([0-9a-fA-F]+)\}?/', '\u$1', $regexp);
+        // JavaScript expects exactly four hex digits after `\u`, while PCRE takes at most two without braces
+        // and any amount within them. Code points above the BMP have to use the `\u{...}` form, which in turn
+        // requires the `u` modifier, kept below among the supported ones.
+        $pattern = preg_replace_callback(
+            '/\\\\x(?:\{([0-9a-fA-F]+)\}|([0-9a-fA-F]{1,2}))/',
+            function ($matches) {
+                $code = hexdec($matches[1] !== '' ? $matches[1] : $matches[2]);
+
+                return $code > 0xFFFF ? sprintf('\u{%X}', $code) : sprintf('\u%04X', $code);
+            },
+            $regexp
+        );
         $deliminator = substr($pattern, 0, 1);
-        $pos = strrpos($pattern, $deliminator, 1);
+        // for bracket style delimiters the pattern is closed by the matching bracket, not by the opening one
+        $closingDeliminator = strtr($deliminator, '({[<', ')}]>');
+        $pos = strrpos($pattern, $closingDeliminator, 1);
         $flag = substr($pattern, $pos + 1);
         if ($deliminator !== '/') {
             $pattern = '/' . str_replace('/', '\\/', substr($pattern, 1, $pos - 1)) . '/';

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -2137,6 +2137,55 @@ EOD;
         $this->assertSame($expected, $actual);
     }
 
+    /**
+     * Bracket style delimiters are closed by the matching bracket, so an unrelated occurrence of the opening
+     * one must not be treated as the end of the pattern.
+     *
+     * @see https://github.com/yiisoft/yii2/issues/20456
+     *
+     * @dataProvider dataEscapeJsRegularExpressionBracketStyleDelimiters
+     */
+    public function testEscapeJsRegularExpressionBracketStyleDelimiters(string $expected, string $regexp): void
+    {
+        $this->assertSame($expected, Html::escapeJsRegularExpression($regexp));
+    }
+
+    public static function dataEscapeJsRegularExpressionBracketStyleDelimiters(): array
+    {
+        return [
+            ['/^\d{3}$/', '{^\d{3}$}'],
+            ['/^(\d+)(\.\d+)?$/', '(^(\d+)(\.\d+)?$)'],
+            ['/^[a-z]+$/i', '<^[a-z]+$>i'],
+            ['/^[a-z]+$/', '[^[a-z]+$]'],
+            ['/^a\/b$/', '{^a/b$}'],
+        ];
+    }
+
+    /**
+     * A JavaScript `\u` escape takes exactly four hex digits, so the PCRE ones have to be padded.
+     *
+     * @see https://github.com/yiisoft/yii2/issues/20322
+     *
+     * @dataProvider dataEscapeJsRegularExpressionHexEscapes
+     */
+    public function testEscapeJsRegularExpressionHexEscapes(string $expected, string $regexp): void
+    {
+        $this->assertSame($expected, Html::escapeJsRegularExpression($regexp));
+    }
+
+    public static function dataEscapeJsRegularExpressionHexEscapes(): array
+    {
+        return [
+            ['/^[\u0000-\u00FF]{8,72}$/', '/^[\x00-\xFF]{8,72}$/'],
+            ['/^[\u00A1-\u00FE]{2}$/u', '/^[\x{A1}-\x{FE}]{2}$/u'],
+            ['/\u0000\u000A/', '/\x{0}\x{a}/'],
+            // without braces PCRE reads at most two hex digits, the rest stays literal
+            ['/\u0041abc/', '/\x41abc/'],
+            // code points above the BMP can only be expressed with the `\u{...}` form
+            ['/[\u{1F600}-\u{1F64F}]/u', '/[\x{1F600}-\x{1F64F}]/u'],
+        ];
+    }
+
     public function testActiveDropDownList(): void
     {
         $expected = <<<'HTML'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #20322, #20456

Two separate defects in `escapeJsRegularExpression()`. They're in adjacent lines of the same short method, so I put them in one PR rather than have the second one conflict with the first.

### Hex escapes (#20322)

A JavaScript `\u` escape takes exactly four hex digits. The replacement didn't pad, so `\xFF` came out as `\uFF`, which JS reads as `\u00` followed by a literal `F`. Two more problems in the same line: `[0-9a-fA-F]+` is greedy while PCRE reads at most two digits without braces, so `\x41abc` swallowed the `abc`; and code points above the BMP need the `\u{...}` form, which the old code never produced.

| pattern | before | after |
| --- | --- | --- |
| `/^[\x00-\xFF]{8,72}$/` | `/^[\u00-\uFF]{8,72}$/` | `/^[\u0000-\u00FF]{8,72}$/` |
| `/^[\x{A1}-\x{FE}]{2}$/u` | `/^[\uA1-\uFE]{2}$/u` | `/^[\u00A1-\u00FE]{2}$/u` |
| `/\x41abc/` | `/\u41abc/` | `/\u0041abc/` |
| `/[\x{1F600}-\x{1F64F}]/u` | `/[\u1F600-\u1F64F]/u` | `/[\u{1F600}-\u{1F64F}]/u` |

The `\u{...}` form needs the `u` flag, which the existing modifier filter already keeps. The second row is the case raised in #20330.

### Bracket style delimiters (#20456)

The end of the pattern is found by searching for the last occurrence of the delimiter. That's fine for `/`, `#` or `~`, but PHP also allows the pairs `()`, `{}`, `[]` and `<>`, which are closed by the matching bracket. So the search lands in the middle of the pattern and the rest is cut off:

| pattern | before | after |
| --- | --- | --- |
| `{^\d{3}$}` | `/^\d/` | `/^\d{3}$/` |
| `(^(\d+)(\.\d+)?$)` | `/^(\d+)/` | `/^(\d+)(\.\d+)?$/` |
| `<^[a-z]+$>i` | `/^[a-z]+$>/i` | `/^[a-z]+$/i` |
| `[^[a-z]+$]` | `/^/` | `/^[a-z]+$/` |

Either way the result is a regex that no longer means what the server-side rule means, so client-side validation quietly accepts values the server rejects.

### One note on #20456

The report gives `([a-z_])([a-z0-9_])*` as input and expects `/([a-z_])([a-z0-9_])*/`. That input isn't a valid PCRE pattern: with `(` as the delimiter the matching `)` closes it right after `[a-z_]`, and the rest is parsed as modifiers, so `preg_match()` errors out. Producing the expected output would mean treating a delimiter-less string as the pattern body, which is not what any caller passes in and would change the existing `('([a-z0-9-]+)')` assertion. Happy to look at that separately if you want the helper to accept those too.

I also added a sentence to the PHPDoc saying the argument is expected to be a valid PCRE pattern, since that was never written down.
