### PR TITLE
Fix #19865: Skip conditional validators in AttributeTypecastBehavior type detection

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -34,6 +34,7 @@ Yii Framework 2 Change Log
 - Bug #21042, #21046: Separate the `@property` annotations in case of different types in getters and setters (mspirkov)
 - Bug #21042: Separate the `@property` annotations in case of different types in getters and setters (mspirkov)
 - Bug #21047: Fix PHPDoc annotations in `Theme`, `AccessRule` and `View` (mspirkov)
+- Bug #19865: Ignore validators with a `when` condition while `AttributeTypecastBehavior` detects `attributeTypes` automatically (veksa)
 
 
 2.0.55 May 09, 2026

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -56,6 +56,11 @@ Upgrade from Yii 2.0.55
 
 * When using multiple `\yii\db\Expression`s with the same parameter names in a query, the parameters are renamed to avoid clashes.
   If your code relies on inspecting the SQL created by the query builder, you might need to change it.
+* `yii\behaviors\AttributeTypecastBehavior` no longer takes validators that have a
+  `yii\validators\Validator::$when` condition into account while detecting `attributeTypes` automatically.
+  The detection result is composed once per owner class, so such a condition can not be resolved there, and an
+  attribute covered by conditional rules only is now left out of the map instead of being type-casted according
+  to the first matching rule. Set `attributeTypes` explicitly if you rely on those attributes being type-casted.
 
 Upgrade from Yii 2.0.53
 -----------------------

--- a/framework/behaviors/AttributeTypecastBehavior.php
+++ b/framework/behaviors/AttributeTypecastBehavior.php
@@ -287,12 +287,23 @@ class AttributeTypecastBehavior extends Behavior
 
     /**
      * Composes default value for [[attributeTypes]] from the owner validation rules.
+     *
+     * Validators that have a [[\yii\validators\Validator::$when|when]] condition are ignored: the detection
+     * result is composed once per owner class, while such a condition can only be resolved against a particular
+     * model instance at validation time. Type-casting an attribute whose rule may not even be applied would
+     * convert a value that has never been validated, so attributes covered by conditional rules only are left
+     * out of the map. Specify [[attributeTypes]] explicitly if you need them to be type-casted.
+     *
      * @return array attribute type map.
      */
     protected function detectAttributeTypes()
     {
         $attributeTypes = [];
         foreach ($this->owner->getValidators() as $validator) {
+            if ($validator->when !== null) {
+                continue;
+            }
+
             $type = null;
             if ($validator instanceof BooleanValidator) {
                 $type = self::TYPE_BOOLEAN;

--- a/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
+++ b/tests/framework/behaviors/AttributeTypecastBehaviorTest.php
@@ -305,6 +305,36 @@ class AttributeTypecastBehaviorTest extends TestCase
     }
 
     /**
+     * @depends testAutoDetectAttributeTypes
+     *
+     * @see https://github.com/yiisoft/yii2/issues/19865
+     */
+    public function testAutoDetectAttributeTypesSkipsConditionalRules(): void
+    {
+        $condition = function () {
+            return true;
+        };
+
+        $model = (new DynamicModel(['name' => null, 'amount' => null, 'price' => null]))
+            ->addRule('name', 'string')
+            ->addRule('amount', 'integer', ['when' => $condition])
+            ->addRule('amount', 'string', ['when' => $condition])
+            ->addRule('price', 'number', ['when' => $condition])
+            ->addRule('price', 'string');
+
+        $behavior = new AttributeTypecastBehavior();
+
+        $behavior->attach($model);
+
+        $expectedAttributeTypes = [
+            'name' => AttributeTypecastBehavior::TYPE_STRING,
+            // 'amount' is covered by conditional rules only, so its type can not be detected
+            'price' => AttributeTypecastBehavior::TYPE_STRING,
+        ];
+        $this->assertEquals($expectedAttributeTypes, $behavior->attributeTypes);
+    }
+
+    /**
      * @depends testSkipNull
      *
      * @see https://github.com/yiisoft/yii2/issues/12880


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #19865

The report asks for `detectAttributeTypes()` to check the validator's `when` condition. That can't be done where the detection happens, for two reasons: it runs from `attach()`, when the model is still empty, and the result is cached in a static map keyed by owner class, shared by every instance. A `when` closure reads attributes of one particular instance, so there is nothing sensible to evaluate at that point and nothing safe to cache.

What can be fixed is the assumption behind the detection. Mapping "validated as integer" to "cast to integer" only holds if the rule always applies. When it doesn't, the behavior casts a value that was never validated, and `'abc'` quietly becomes `0` on its way into the database. So validators with a `when` condition are now skipped during detection.

A nice side effect: an attribute that has both a conditional and an unconditional rule now takes its type from the unconditional one instead of whichever came first.

Attributes covered only by conditional rules are no longer type-cast at all, which is why this is marked as breaking BC. There's an `UPGRADE.md` note pointing at `attributeTypes` for anyone who needs them cast.

If you think that's too broad, the narrower option is to skip a conditional validator only when it conflicts with another rule for the same attribute. It touches fewer applications but is harder to describe in the docs, so I went with the straightforward version. Happy to switch.
