### PR TITLE
Fix `ActiveField::checkbox()`/`radio()` dropping label for extensions with `enclosedByLabel=false`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -154,6 +154,7 @@ Yii Framework 2 Change Log
 - Bug #16043: Fix `yii\db\oci\Schema::findColumns()` to report `null` size for `DATE`, `TIMESTAMP` and `INTERVAL` columns instead of their internal storage byte length (terabytesoftw)
 - Bug #12763: Apply an explicitly configured PostgreSQL `defaultSchema` as the session `search_path` when opening the connection (terabytesoftw)
 - Bug #19852: Use the connection passed to `ActiveQuery` result methods for schema reflection and typecasting while populating records (terabytesoftw)
+- Bug #21110: Fix `ActiveField::checkbox()`/`radio()` dropping label for extensions with `enclosedByLabel=false` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -575,7 +575,7 @@ class ActiveField extends Component
         $this->addAriaAttributes($options);
         $this->adjustLabelFor($options);
 
-        if ($enclosedByLabel) {
+        if ($enclosedByLabel || (array_key_exists('label', $options) && $options['label'] === false)) {
             $this->parts['{label}'] ??= '';
         } else {
             $options = $this->generateLabel($options);
@@ -622,7 +622,7 @@ class ActiveField extends Component
         $this->addAriaAttributes($options);
         $this->adjustLabelFor($options);
 
-        if ($enclosedByLabel) {
+        if ($enclosedByLabel || (array_key_exists('label', $options) && $options['label'] === false)) {
             $this->parts['{label}'] ??= '';
         } else {
             $options = $this->generateLabel($options);

--- a/framework/widgets/ActiveField.php
+++ b/framework/widgets/ActiveField.php
@@ -575,11 +575,11 @@ class ActiveField extends Component
         $this->addAriaAttributes($options);
         $this->adjustLabelFor($options);
 
-        if (!$enclosedByLabel) {
+        if ($enclosedByLabel) {
+            $this->parts['{label}'] ??= '';
+        } else {
             $options = $this->generateLabel($options);
         }
-
-        $this->parts['{label}'] ??= '';
 
         $this->parts['{input}'] = Html::activeRadio($this->model, $this->attribute, $options);
 
@@ -622,11 +622,11 @@ class ActiveField extends Component
         $this->addAriaAttributes($options);
         $this->adjustLabelFor($options);
 
-        if (!$enclosedByLabel) {
+        if ($enclosedByLabel) {
+            $this->parts['{label}'] ??= '';
+        } else {
             $options = $this->generateLabel($options);
         }
-
-        $this->parts['{label}'] ??= '';
 
         $this->parts['{input}'] = Html::activeCheckbox($this->model, $this->attribute, $options);
 

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -1028,6 +1028,28 @@ class ActiveFieldTest extends TestCase
         );
     }
 
+    public function testRadioEnclosedByLabelFalseWithoutLabelOption(): void
+    {
+        $this->activeField->radio([], false);
+
+        self::assertArrayNotHasKey(
+            '{label}',
+            $this->activeField->parts,
+            'Label part must remain unset so render() generates it from the model.',
+        );
+    }
+
+    public function testCheckboxEnclosedByLabelFalseWithoutLabelOption(): void
+    {
+        $this->activeField->checkbox([], false);
+
+        self::assertArrayNotHasKey(
+            '{label}',
+            $this->activeField->parts,
+            'Label part must remain unset so render() generates it from the model.',
+        );
+    }
+
     public function testRadioEnclosedByLabelFalsePreservesExistingLabel(): void
     {
         $this->activeField->label('Existing Label');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
