### PR TITLE
Fix #20262: Support schema names in the SQLite driver

### DIFF
--- a/docs/guide/db-dao.md
+++ b/docs/guide/db-dao.md
@@ -684,3 +684,22 @@ $table = Yii::$app->db->getTableSchema('post');
 The method returns a [[yii\db\TableSchema]] object which contains the information about the table's columns,
 primary keys, foreign keys, etc. All this information is mainly utilized by [query builder](db-query-builder.md) 
 and [active record](db-active-record.md) to help you write database-agnostic code. 
+
+A table name may be prefixed with the name of the schema it belongs to. You can also list the tables of a single
+schema, and, on MSSQL, Oracle, PostgreSQL and SQLite, the schemas of the database itself:
+
+```php
+$schema = Yii::$app->db->getSchema();
+
+$schemaNames = $schema->getSchemaNames();
+$tableNames = $schema->getTableNames('archive');
+$table = $schema->getTableSchema('archive.post');
+```
+
+[[yii\db\Schema::getSchemaNames()|getSchemaNames()]] throws a [[yii\base\NotSupportedException]] on the drivers that
+are left out of that list.
+
+> Note: In SQLite the schemas of a connection are the databases
+> [attached](https://sqlite.org/lang_attach.html) to it, `main` being the one the connection was opened with.
+> The `temp` schema holding temporary tables is left out of [[yii\db\Schema::getSchemaNames()|getSchemaNames()]],
+> but its tables can still be read by naming it.

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.56 under development
 ------------------------
 
+- Enh #20262: Support schema (attached database) names in the SQLite driver (veksa)
 - Bug #21020: Fix duplicate `@return` annotation for `yii\db\ActiveRecord::hasOne()` (nazard)
 - Bug #20873: Fix PHPDoc annotations for the `yii\log\Target::$enabled` (mspirkov)
 - Enh #20875: Clarify the type of the `yii\base\Model::$errors` (mspirkov)

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -54,6 +54,18 @@ for both A and B.
 Upgrade from Yii 2.0.55
 -----------------------
 
+* `yii\db\sqlite\Schema` now understands schema names, which in SQLite are the names of the
+  [attached databases](https://www.sqlite.org/lang_attach.html). As a consequence `yii\db\sqlite\Schema::$defaultSchema`
+  is set to `main` and the `schemaName` of a `yii\db\TableSchema` read from a SQLite connection is now `main` instead of
+  `null` for tables of the database the connection was opened with. `TableSchema::$fullName` is unchanged: the default
+  schema is never included in it, so `getTableSchema('main.customer')` and `getTableSchema('customer')` both give a
+  `fullName` of `customer`. `Schema::getTableNames()` and `Schema::getTableSchemas()` used to ignore the schema they
+  were given and always report on `main`; they now read the schema that was asked for, and passing the name of a
+  database that is not attached raises a `yii\db\Exception` instead of silently returning the tables of `main`.
+  `Schema::getSchemaNames()` leaves out the `temp` schema holding the temporary tables, since it is a system one,
+  but that schema can still be read by naming it.
+  `yii\db\sqlite\QueryBuilder::resetSequence()` follows suit and updates the `sqlite_sequence` table of the schema the
+  given table belongs to, every attached database having one of its own.
 * When using multiple `\yii\db\Expression`s with the same parameter names in a query, the parameters are renamed to avoid clashes.
   If your code relies on inspecting the SQL created by the query builder, you might need to change it.
 * Client-side validation in `ActiveForm` triggered by a change, by the input losing focus, or by a manual

--- a/framework/db/sqlite/QueryBuilder.php
+++ b/framework/db/sqlite/QueryBuilder.php
@@ -212,7 +212,15 @@ class QueryBuilder extends \yii\db\QueryBuilder
                 $value = (int) $value - 1;
             }
 
-            return "UPDATE sqlite_sequence SET seq='$value' WHERE name='{$table->name}'";
+            // every attached database keeps its own `sqlite_sequence` table
+            $sequenceTableName = 'sqlite_sequence';
+            if ($table->schemaName !== null && $table->schemaName !== $db->getSchema()->defaultSchema) {
+                $sequenceTableName = $db->quoteTableName($table->schemaName) . '.' . $sequenceTableName;
+            }
+
+            $sequenceName = $db->quoteValue($table->name);
+
+            return "UPDATE $sequenceTableName SET seq='$value' WHERE name=$sequenceName";
         } elseif ($table === null) {
             throw new InvalidArgumentException("Table not found: $tableName");
         }

--- a/framework/db/sqlite/Schema.php
+++ b/framework/db/sqlite/Schema.php
@@ -75,6 +75,14 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
     ];
 
     /**
+     * @var string the default schema name. In SQLite the schema name is the name of an
+     * [attached database](https://www.sqlite.org/lang_attach.html), `main` being the one the connection was
+     * opened with.
+     * @since 2.0.56
+     */
+    public $defaultSchema = 'main';
+
+    /**
      * {@inheritdoc}
      */
     protected $tableQuoteCharacter = '`';
@@ -86,11 +94,68 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * The returned names are the names of the databases attached to the connection, `main` included.
+     * The `temp` database holding temporary tables is skipped as a system schema.
+     *
+     * @since 2.0.56
+     */
+    protected function findSchemaNames()
+    {
+        $databases = $this->db->createCommand('PRAGMA DATABASE_LIST')->queryAll();
+        $databases = $this->normalizePdoRowKeyCase($databases, true);
+
+        $schemaNames = [];
+        foreach ($databases as $database) {
+            if ($database['name'] !== 'temp') {
+                $schemaNames[] = $database['name'];
+            }
+        }
+
+        return $schemaNames;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     protected function findTableNames($schema = '')
     {
-        $sql = "SELECT DISTINCT tbl_name FROM sqlite_master WHERE tbl_name<>'sqlite_sequence' ORDER BY tbl_name";
+        $sql = 'SELECT DISTINCT tbl_name FROM ' . $this->quoteSchemaPrefix($schema) . 'sqlite_master'
+            . " WHERE tbl_name<>'sqlite_sequence' ORDER BY tbl_name";
+
         return $this->db->createCommand($sql)->queryColumn();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @since 2.0.56
+     */
+    protected function resolveTableName($name)
+    {
+        $resolvedName = new TableSchema();
+        $this->resolveTableNames($resolvedName, $name);
+
+        return $resolvedName;
+    }
+
+    /**
+     * Resolves the table name and schema name (if any) of the given table.
+     * @param TableSchema $table the table metadata object.
+     * @param string $name the table name.
+     * @since 2.0.56
+     */
+    protected function resolveTableNames($table, $name)
+    {
+        $parts = $this->getTableNameParts($name);
+        if (isset($parts[1])) {
+            $table->schemaName = $parts[0];
+            $table->name = $parts[1];
+        } else {
+            $table->schemaName = $this->defaultSchema;
+            $table->name = $parts[0];
+        }
+
+        $table->fullName = $this->composeFullName($table->name, $table->schemaName);
     }
 
     /**
@@ -99,8 +164,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
     protected function loadTableSchema($name)
     {
         $table = new TableSchema();
-        $table->name = $name;
-        $table->fullName = $name;
+        $this->resolveTableNames($table, $name);
 
         if ($this->findColumns($table)) {
             $this->findConstraints($table);
@@ -123,7 +187,10 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function loadTableForeignKeys($tableName)
     {
-        $foreignKeys = $this->db->createCommand('PRAGMA FOREIGN_KEY_LIST (' . $this->quoteValue($tableName) . ')')->queryAll();
+        $resolvedName = $this->resolveTableName($tableName);
+        $foreignKeys = $this->db->createCommand(
+            $this->pragma('FOREIGN_KEY_LIST', $resolvedName->name, $resolvedName->schemaName)
+        )->queryAll();
         $foreignKeys = $this->normalizePdoRowKeyCase($foreignKeys, true);
         $foreignKeys = ArrayHelper::index($foreignKeys, null, 'table');
         ArrayHelper::multisort($foreignKeys, 'seq', SORT_ASC, SORT_NUMERIC);
@@ -131,6 +198,8 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
         foreach ($foreignKeys as $table => $foreignKey) {
             $result[] = new ForeignKeyConstraint([
                 'columnNames' => ArrayHelper::getColumn($foreignKey, 'from'),
+                // SQLite foreign keys never cross databases, so the referenced table lives in the same schema
+                'foreignSchemaName' => $resolvedName->schemaName,
                 'foreignTableName' => $table,
                 'foreignColumnNames' => ArrayHelper::getColumn($foreignKey, 'to'),
                 'onDelete' => isset($foreignKey[0]['on_delete']) ? $foreignKey[0]['on_delete'] : null,
@@ -162,9 +231,12 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function loadTableChecks($tableName)
     {
-        $sql = $this->db->createCommand('SELECT `sql` FROM `sqlite_master` WHERE name = :tableName', [
-            ':tableName' => $tableName,
-        ])->queryScalar();
+        $resolvedName = $this->resolveTableName($tableName);
+        $sql = $this->db->createCommand(
+            'SELECT `sql` FROM ' . $this->quoteSchemaPrefix($resolvedName->schemaName) . '`sqlite_master`'
+            . ' WHERE name = :tableName',
+            [':tableName' => $resolvedName->name]
+        )->queryScalar();
         /** @var SqlToken[]|SqlToken[][]|SqlToken[][][] $code */
         $code = (new SqlTokenizer($sql))->tokenize();
         $pattern = (new SqlTokenizer('any CREATE any TABLE any()'))->tokenize();
@@ -231,7 +303,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function findColumns($table)
     {
-        $sql = 'PRAGMA table_info(' . $this->quoteSimpleTableName($table->name) . ')';
+        $sql = $this->pragma('table_info', $table->name, $table->schemaName);
         $columns = $this->db->createCommand($sql)->queryAll();
         if (empty($columns)) {
             return false;
@@ -258,12 +330,14 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     protected function findConstraints($table)
     {
-        $sql = 'PRAGMA foreign_key_list(' . $this->quoteSimpleTableName($table->name) . ')';
+        $sql = $this->pragma('foreign_key_list', $table->name, $table->schemaName);
         $keys = $this->db->createCommand($sql)->queryAll();
         foreach ($keys as $key) {
             $id = (int) $key['id'];
             if (!isset($table->foreignKeys[$id])) {
-                $table->foreignKeys[$id] = [$key['table'], $key['from'] => $key['to']];
+                // SQLite foreign keys never cross databases, so the referenced table lives in the same schema
+                $foreignTableName = $this->composeFullName($key['table'], $table->schemaName);
+                $table->foreignKeys[$id] = [$foreignTableName, $key['from'] => $key['to']];
             } else {
                 // composite FK
                 $table->foreignKeys[$id][$key['from']] = $key['to'];
@@ -288,13 +362,15 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     public function findUniqueIndexes($table)
     {
-        $sql = 'PRAGMA index_list(' . $this->quoteSimpleTableName($table->name) . ')';
+        $sql = $this->pragma('index_list', $table->name, $table->schemaName);
         $indexes = $this->db->createCommand($sql)->queryAll();
         $uniqueIndexes = [];
 
         foreach ($indexes as $index) {
             $indexName = $index['name'];
-            $indexInfo = $this->db->createCommand('PRAGMA index_info(' . $this->quoteValue($index['name']) . ')')->queryAll();
+            $indexInfo = $this->db->createCommand(
+                $this->pragma('index_info', $index['name'], $table->schemaName)
+            )->queryAll();
 
             if ($index['unique']) {
                 $uniqueIndexes[$indexName] = [];
@@ -387,11 +463,12 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
     /**
      * Returns table columns info.
      * @param string $tableName table name
+     * @param string|null $schemaName the schema (attached database) the table belongs to.
      * @return array
      */
-    private function loadTableColumnsInfo($tableName)
+    private function loadTableColumnsInfo($tableName, $schemaName = null)
     {
-        $tableColumns = $this->db->createCommand('PRAGMA TABLE_INFO (' . $this->quoteValue($tableName) . ')')->queryAll();
+        $tableColumns = $this->db->createCommand($this->pragma('TABLE_INFO', $tableName, $schemaName))->queryAll();
         $tableColumns = $this->normalizePdoRowKeyCase($tableColumns, true);
 
         return ArrayHelper::index($tableColumns, 'cid');
@@ -408,7 +485,11 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
      */
     private function loadTableConstraints($tableName, $returnType)
     {
-        $indexes = $this->db->createCommand('PRAGMA INDEX_LIST (' . $this->quoteValue($tableName) . ')')->queryAll();
+        $resolvedName = $this->resolveTableName($tableName);
+        $schemaName = $resolvedName->schemaName;
+        $indexes = $this->db->createCommand(
+            $this->pragma('INDEX_LIST', $resolvedName->name, $schemaName)
+        )->queryAll();
         $indexes = $this->normalizePdoRowKeyCase($indexes, true);
         $tableColumns = null;
         if (!empty($indexes) && !isset($indexes[0]['origin'])) {
@@ -416,7 +497,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
              * SQLite may not have an "origin" column in INDEX_LIST
              * See https://www.sqlite.org/src/info/2743846cdba572f6
              */
-            $tableColumns = $this->loadTableColumnsInfo($tableName);
+            $tableColumns = $this->loadTableColumnsInfo($resolvedName->name, $schemaName);
         }
         $result = [
             'primaryKey' => null,
@@ -424,7 +505,9 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
             'uniques' => [],
         ];
         foreach ($indexes as $index) {
-            $columns = $this->db->createCommand('PRAGMA INDEX_INFO (' . $this->quoteValue($index['name']) . ')')->queryAll();
+            $columns = $this->db->createCommand(
+                $this->pragma('INDEX_INFO', $index['name'], $schemaName)
+            )->queryAll();
             $columns = $this->normalizePdoRowKeyCase($columns, true);
             ArrayHelper::multisort($columns, 'seqno', SORT_ASC, SORT_NUMERIC);
             if ($tableColumns !== null) {
@@ -460,7 +543,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
              * See https://www.sqlite.org/lang_createtable.html#primkeyconst
              */
             if ($tableColumns === null) {
-                $tableColumns = $this->loadTableColumnsInfo($tableName);
+                $tableColumns = $this->loadTableColumnsInfo($resolvedName->name, $schemaName);
             }
             foreach ($tableColumns as $tableColumn) {
                 if ($tableColumn['pk'] > 0) {
@@ -477,6 +560,128 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
         }
 
         return $result[$returnType];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Only the dots that separate the identifiers are split on, so a schema or a table name that holds a dot keeps
+     * it as long as it is quoted. The quotes are stripped off the parts that are returned, a doubled quote character
+     * standing for a literal one.
+     *
+     * @since 2.0.56
+     */
+    protected function getTableNameParts($name)
+    {
+        $parts = [];
+        $part = '';
+        $quoteCharacter = null;
+        for ($i = 0, $length = strlen($name); $i < $length; $i++) {
+            $character = $name[$i];
+            if ($quoteCharacter !== null) {
+                if ($character !== $quoteCharacter) {
+                    $part .= $character;
+                } elseif (isset($name[$i + 1]) && $name[$i + 1] === $quoteCharacter) {
+                    $part .= $character;
+                    $i++;
+                } else {
+                    $quoteCharacter = null;
+                }
+            } elseif ($character === '`' || $character === '"') {
+                $quoteCharacter = $character;
+            } elseif ($character === '.') {
+                $parts[] = $part;
+                $part = '';
+            } else {
+                $part .= $character;
+            }
+        }
+        $parts[] = $part;
+
+        return $parts;
+    }
+
+    /**
+     * Builds a `PRAGMA` statement, qualifying it with the schema name when it is not the default one.
+     * @param string $name the pragma name, e.g. `TABLE_INFO`.
+     * @param string $argument the pragma argument, e.g. a table or an index name.
+     * @param string|null $schemaName the schema (attached database) name. `null`, an empty string or
+     * [[defaultSchema]] means no qualification is needed.
+     * @return string the `PRAGMA` statement.
+     * @since 2.0.56
+     */
+    private function pragma($name, $argument, $schemaName = null)
+    {
+        return 'PRAGMA ' . $this->quoteSchemaPrefix($schemaName) . $name . ' (' . $this->quoteValue($argument) . ')';
+    }
+
+    /**
+     * Returns the quoted schema name followed by a dot, to be used as a prefix of a table name or a pragma name.
+     * @param string|null $schemaName the schema (attached database) name. `null`, an empty string or
+     * [[defaultSchema]] result in an empty prefix, since those all refer to the default schema.
+     * @return string the prefix, an empty string when no qualification is needed.
+     * @since 2.0.56
+     */
+    private function quoteSchemaPrefix($schemaName)
+    {
+        if ($schemaName === null || $schemaName === '' || $schemaName === $this->defaultSchema) {
+            return '';
+        }
+
+        return $this->quoteIdentifier($schemaName) . '.';
+    }
+
+    /**
+     * Quotes an identifier, doubling the quote characters it holds.
+     *
+     * Unlike [[quoteSimpleTableName()]] this does not leave a name that already holds a quote character alone,
+     * which would let it break out of the quoting.
+     *
+     * @param string $identifier the identifier to quote.
+     * @return string the quoted identifier.
+     * @since 2.0.56
+     */
+    private function quoteIdentifier($identifier)
+    {
+        return '`' . str_replace('`', '``', $identifier) . '`';
+    }
+
+    /**
+     * Composes the full name of a table out of its name and the schema it belongs to, the default schema being
+     * left out.
+     *
+     * A part holding a dot or a quote character is quoted, so that the result can be handed back to
+     * [[getTableSchema()]] and its like without being split at the wrong dot.
+     *
+     * @param string $tableName the table name without a schema prefix.
+     * @param string|null $schemaName the schema (attached database) name.
+     * @return string the full name of the table.
+     * @since 2.0.56
+     */
+    private function composeFullName($tableName, $schemaName)
+    {
+        $fullName = $this->quoteAmbiguousIdentifier($tableName);
+        if ($schemaName !== null && $schemaName !== '' && $schemaName !== $this->defaultSchema) {
+            $fullName = $this->quoteAmbiguousIdentifier($schemaName) . '.' . $fullName;
+        }
+
+        return $fullName;
+    }
+
+    /**
+     * Quotes an identifier that [[getTableNameParts()]] would otherwise not read back as a single part, leaving
+     * the ordinary ones untouched.
+     * @param string $identifier the identifier to quote.
+     * @return string the identifier, quoted only when it holds a dot or a quote character.
+     * @since 2.0.56
+     */
+    private function quoteAmbiguousIdentifier($identifier)
+    {
+        if (strpbrk($identifier, '.`"') === false) {
+            return $identifier;
+        }
+
+        return $this->quoteIdentifier($identifier);
     }
 
     /**

--- a/tests/framework/db/sqlite/QueryBuilderTest.php
+++ b/tests/framework/db/sqlite/QueryBuilderTest.php
@@ -227,6 +227,25 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
         $this->assertEquals($expected, $sql);
     }
 
+    /**
+     * Every attached database keeps its own `sqlite_sequence` table, so the one of the table's schema has to be
+     * updated rather than the one of `main`, which holds an unrelated `item` table.
+     */
+    public function testResetSequenceForAttachedSchema(): void
+    {
+        $qb = $this->getQueryBuilder(true, true);
+        $db = $qb->db;
+
+        $db->createCommand("ATTACH DATABASE ':memory:' AS `second_schema`")->execute();
+        $db->createCommand(
+            'CREATE TABLE second_schema.item (id INTEGER PRIMARY KEY AUTOINCREMENT, name varchar(64) NOT NULL)'
+        )->execute();
+
+        $expected = "UPDATE `second_schema`.sqlite_sequence SET seq='3' WHERE name='item'";
+        $sql = $qb->resetSequence('second_schema.item', 4);
+        $this->assertEquals($expected, $sql);
+    }
+
     public static function upsertProvider(): array
     {
         $concreteData = [

--- a/tests/framework/db/sqlite/SchemaTest.php
+++ b/tests/framework/db/sqlite/SchemaTest.php
@@ -8,8 +8,16 @@
 
 namespace yiiunit\framework\db\sqlite;
 
+use ReflectionMethod;
 use yii\base\NotSupportedException;
+use yii\db\CheckConstraint;
+use yii\db\Connection;
 use yii\db\Constraint;
+use yii\db\ConstraintFinderInterface;
+use yii\db\Exception;
+use yii\db\ForeignKeyConstraint;
+use yii\db\IndexConstraint;
+use yii\db\TableSchema;
 use yiiunit\framework\db\AnyValue;
 
 /**
@@ -20,10 +28,10 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
 {
     protected $driverName = 'sqlite';
 
-    public function testGetSchemaNames(): void
-    {
-        $this->markTestSkipped('Schemas are not supported in SQLite.');
-    }
+    /**
+     * The name the additional in-memory database is attached under by [[attachSecondSchema()]].
+     */
+    private const ATTACHED_SCHEMA = 'second_schema';
 
     public function getExpectedColumns()
     {
@@ -72,6 +80,7 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         $result['2: index'][2][2]->name = AnyValue::getInstance();
 
         $result['3: foreign key'][2][0]->name = null;
+        $result['3: foreign key'][2][0]->foreignSchemaName = 'main';
         $result['3: index'][2] = [];
 
         $result['4: primary key'][2]->name = null;
@@ -108,5 +117,426 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
             ['`test`.`test`', '`test`.`test`'],
             ['test.`test`.test', '`test`.`test`.`test`'],
         ];
+    }
+
+    public function testGetSchemaNames(): void
+    {
+        $db = $this->getConnection();
+
+        $this->assertSame(['main'], $db->getSchema()->getSchemaNames());
+
+        $this->attachSecondSchema($db);
+
+        $this->assertSame(['main', self::ATTACHED_SCHEMA], $db->getSchema()->getSchemaNames(true));
+    }
+
+    /**
+     * The `temp` database is a system schema, so it must not show up among the schema names even once it exists.
+     */
+    public function testGetSchemaNamesSkipsTempSchema(): void
+    {
+        $db = $this->getConnection();
+        $db->createCommand('CREATE TEMPORARY TABLE temp_customer (id INTEGER NOT NULL PRIMARY KEY)')->execute();
+
+        $this->assertSame(['main'], $db->getSchema()->getSchemaNames(true));
+    }
+
+    /**
+     * Table names used to be read from the `main` schema no matter which schema was asked for.
+     *
+     * @see https://github.com/yiisoft/yii2/issues/20262
+     */
+    public function testGetTableNamesFromAttachedSchema(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+        $schema = $db->getSchema();
+
+        $this->assertSame(['attached_item', 'customer'], $schema->getTableNames(self::ATTACHED_SCHEMA));
+
+        $defaultSchemaTableNames = $schema->getTableNames();
+        $this->assertContains('customer', $defaultSchemaTableNames);
+        $this->assertContains('profile', $defaultSchemaTableNames);
+        $this->assertNotContains('attached_item', $defaultSchemaTableNames);
+    }
+
+    /**
+     * Asking for the default schema explicitly must give the same result as not naming a schema at all.
+     */
+    public function testGetTableNamesFromDefaultSchema(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+        $schema = $db->getSchema();
+
+        $this->assertSame($schema->getTableNames(), $schema->getTableNames('main'));
+    }
+
+    public function testGetTableSchemaFromAttachedSchema(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+
+        $table = $db->getSchema()->getTableSchema(self::ATTACHED_SCHEMA . '.attached_item');
+
+        $this->assertNotNull($table);
+        $this->assertSame(self::ATTACHED_SCHEMA, $table->schemaName);
+        $this->assertSame('attached_item', $table->name);
+        $this->assertSame(self::ATTACHED_SCHEMA . '.attached_item', $table->fullName);
+        $this->assertSame(['id', 'customer_id', 'slug'], $table->getColumnNames());
+        $this->assertSame(['id'], $table->primaryKey);
+        $this->assertSame(
+            [[self::ATTACHED_SCHEMA . '.customer', 'customer_id' => 'id']],
+            $table->foreignKeys
+        );
+    }
+
+    /**
+     * Both schemas hold a `customer` table with different columns, so reading the wrong one is easy to spot.
+     */
+    public function testGetTableSchemaTellsApartSameNamedTables(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+        $schema = $db->getSchema();
+
+        $attachedCustomer = $schema->getTableSchema(self::ATTACHED_SCHEMA . '.customer');
+        $this->assertSame(['id', 'code'], $attachedCustomer->getColumnNames());
+
+        $mainCustomer = $schema->getTableSchema('customer');
+        $this->assertSame(
+            ['id', 'email', 'name', 'address', 'status', 'profile_id'],
+            $mainCustomer->getColumnNames()
+        );
+    }
+
+    /**
+     * The default schema is never repeated in [[TableSchema::$fullName]], the same way the other drivers behave.
+     */
+    public function testGetTableSchemaWithDefaultSchemaPrefix(): void
+    {
+        $schema = $this->getConnection()->getSchema();
+
+        $table = $schema->getTableSchema('main.customer');
+
+        $this->assertNotNull($table);
+        $this->assertSame('main', $table->schemaName);
+        $this->assertSame('customer', $table->name);
+        $this->assertSame('customer', $table->fullName);
+        $this->assertSame($schema->getTableSchema('customer')->getColumnNames(), $table->getColumnNames());
+    }
+
+    public function testGetTableSchemasFromAttachedSchema(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+
+        $tableSchemas = $db->getSchema()->getTableSchemas(self::ATTACHED_SCHEMA);
+
+        $this->assertCount(2, $tableSchemas);
+        foreach ($tableSchemas as $tableSchema) {
+            $this->assertSame(self::ATTACHED_SCHEMA, $tableSchema->schemaName);
+        }
+        $this->assertSame(
+            [self::ATTACHED_SCHEMA . '.attached_item', self::ATTACHED_SCHEMA . '.customer'],
+            array_map(static function (TableSchema $tableSchema) {
+                return $tableSchema->fullName;
+            }, $tableSchemas)
+        );
+
+        // a full name is a name the schema can be asked for again
+        foreach ($tableSchemas as $tableSchema) {
+            $roundTripped = $db->getSchema()->getTableSchema($tableSchema->fullName);
+            $this->assertNotNull($roundTripped);
+            $this->assertSame($tableSchema->schemaName, $roundTripped->schemaName);
+            $this->assertSame($tableSchema->name, $roundTripped->name);
+        }
+    }
+
+    /**
+     * A quote character inside a schema name has to be doubled, or it breaks out of the quoting and the
+     * schema-qualified metadata queries turn into invalid SQL.
+     */
+    public function testSchemaNameHoldingAQuoteCharacter(): void
+    {
+        $db = $this->getConnection();
+        $db->createCommand("ATTACH DATABASE ':memory:' AS `my``schema`")->execute();
+        $db->createCommand('CREATE TABLE `my``schema`.customer (id INTEGER NOT NULL PRIMARY KEY, code varchar(32))')
+            ->execute();
+        $schema = $db->getSchema();
+
+        $this->assertSame(['main', 'my`schema'], $schema->getSchemaNames(true));
+        $this->assertSame(['customer'], $schema->getTableNames('my`schema'));
+
+        $table = $schema->getTableSchema('`my``schema`.customer');
+
+        $this->assertNotNull($table);
+        $this->assertSame('my`schema', $table->schemaName);
+        $this->assertSame('customer', $table->name);
+        $this->assertSame('`my``schema`.customer', $table->fullName);
+        $this->assertSame(['id', 'code'], $table->getColumnNames());
+    }
+
+    /**
+     * A dot inside a schema or a table name would make the full name ambiguous, so those names are quoted back
+     * and keep resolving to the table they were read from.
+     */
+    public function testFullNameOfNamesHoldingADotResolvesBack(): void
+    {
+        $db = $this->getConnection();
+        $db->createCommand("ATTACH DATABASE ':memory:' AS `my.schema`")->execute();
+        $db->createCommand(
+            'CREATE TABLE `my.schema`.`my.customer` (id INTEGER NOT NULL PRIMARY KEY, note varchar(32))'
+        )->execute();
+        $schema = $db->getSchema();
+
+        $table = $schema->getTableSchema('`my.schema`.`my.customer`');
+
+        $this->assertNotNull($table);
+        $this->assertSame('my.schema', $table->schemaName);
+        $this->assertSame('my.customer', $table->name);
+        $this->assertSame('`my.schema`.`my.customer`', $table->fullName);
+
+        $roundTripped = $schema->getTableSchema($table->fullName);
+        $this->assertNotNull($roundTripped);
+        $this->assertSame('my.schema', $roundTripped->schemaName);
+        $this->assertSame('my.customer', $roundTripped->name);
+        $this->assertSame(['id', 'note'], $roundTripped->getColumnNames());
+    }
+
+    public function testGetTablePrimaryKeyFromAttachedSchema(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+
+        $schema = $db->getSchema();
+        $this->assertInstanceOf(ConstraintFinderInterface::class, $schema);
+
+        $primaryKey = $schema->getTablePrimaryKey(self::ATTACHED_SCHEMA . '.attached_item');
+
+        $this->assertInstanceOf(Constraint::class, $primaryKey);
+        $this->assertSame(['id'], $primaryKey->columnNames);
+    }
+
+    public function testGetTableForeignKeysFromAttachedSchema(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+
+        $schema = $db->getSchema();
+        $this->assertInstanceOf(ConstraintFinderInterface::class, $schema);
+
+        $foreignKeys = $schema->getTableForeignKeys(self::ATTACHED_SCHEMA . '.attached_item');
+
+        $this->assertCount(1, $foreignKeys);
+        $this->assertInstanceOf(ForeignKeyConstraint::class, $foreignKeys[0]);
+        $this->assertSame(['customer_id'], $foreignKeys[0]->columnNames);
+        // foreign keys never cross databases in SQLite, so the referenced table is in the same schema
+        $this->assertSame(self::ATTACHED_SCHEMA, $foreignKeys[0]->foreignSchemaName);
+        $this->assertSame('customer', $foreignKeys[0]->foreignTableName);
+        $this->assertSame(['id'], $foreignKeys[0]->foreignColumnNames);
+    }
+
+    public function testGetTableIndexesFromAttachedSchema(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+
+        $schema = $db->getSchema();
+        $this->assertInstanceOf(ConstraintFinderInterface::class, $schema);
+
+        $indexes = $schema->getTableIndexes(self::ATTACHED_SCHEMA . '.attached_item');
+
+        $this->assertCount(2, $indexes);
+        foreach ($indexes as $index) {
+            $this->assertInstanceOf(IndexConstraint::class, $index);
+        }
+        $indexedColumnNames = [];
+        foreach ($indexes as $index) {
+            $indexedColumnNames[$index->name] = $index->columnNames;
+        }
+        $this->assertSame(['customer_id'], $indexedColumnNames['idx_attached_item_customer_id']);
+    }
+
+    public function testGetTableUniquesFromAttachedSchema(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+
+        $schema = $db->getSchema();
+        $this->assertInstanceOf(ConstraintFinderInterface::class, $schema);
+
+        $uniques = $schema->getTableUniques(self::ATTACHED_SCHEMA . '.attached_item');
+
+        $this->assertCount(1, $uniques);
+        $this->assertSame(['slug'], $uniques[0]->columnNames);
+    }
+
+    public function testGetTableChecksFromAttachedSchema(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+
+        $schema = $db->getSchema();
+        $this->assertInstanceOf(ConstraintFinderInterface::class, $schema);
+
+        $checks = $schema->getTableChecks(self::ATTACHED_SCHEMA . '.attached_item');
+
+        $this->assertCount(1, $checks);
+        $this->assertInstanceOf(CheckConstraint::class, $checks[0]);
+        $this->assertSame("slug <> ''", $checks[0]->expression);
+    }
+
+    public function testFindUniqueIndexesFromAttachedSchema(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+        $schema = $db->getSchema();
+
+        $table = $schema->getTableSchema(self::ATTACHED_SCHEMA . '.attached_item');
+        $uniqueIndexes = $schema->findUniqueIndexes($table);
+
+        $this->assertCount(1, $uniqueIndexes);
+        $this->assertSame([['slug']], array_values($uniqueIndexes));
+    }
+
+    /**
+     * The `temp` schema is hidden from [[Schema::getSchemaNames()]] but still reachable by name.
+     */
+    public function testGetTableSchemaFromTempSchema(): void
+    {
+        $db = $this->getConnection();
+        $db->createCommand(
+            'CREATE TEMPORARY TABLE temp_customer (id INTEGER NOT NULL PRIMARY KEY, note varchar(32))'
+        )->execute();
+
+        $table = $db->getSchema()->getTableSchema('temp.temp_customer');
+
+        $this->assertNotNull($table);
+        $this->assertSame('temp', $table->schemaName);
+        $this->assertSame('temp_customer', $table->name);
+        $this->assertSame(['id', 'note'], $table->getColumnNames());
+    }
+
+    public function testGetTableSchemaReturnsNullForMissingTableInAttachedSchema(): void
+    {
+        $db = $this->getConnection();
+        $this->attachSecondSchema($db);
+
+        $this->assertNull($db->getSchema()->getTableSchema(self::ATTACHED_SCHEMA . '.no_such_table'));
+    }
+
+    /**
+     * An unknown schema is a different thing from a missing table: SQLite reports it and we let that through.
+     */
+    public function testGetTableSchemaFailsForUnknownSchema(): void
+    {
+        $schema = $this->getConnection()->getSchema();
+
+        $this->expectException(Exception::class);
+
+        $schema->getTableSchema('no_such_schema.customer');
+    }
+
+    /**
+     * @dataProvider resolveTableNameDataProvider
+     */
+    public function testResolveTableName(
+        string $name,
+        string $expectedSchemaName,
+        string $expectedName,
+        string $expectedFullName
+    ): void {
+        $schema = $this->getConnection()->getSchema();
+        $method = new ReflectionMethod($schema, 'resolveTableName');
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $resolvedName = $method->invoke($schema, $name);
+
+        $this->assertSame($expectedSchemaName, $resolvedName->schemaName);
+        $this->assertSame($expectedName, $resolvedName->name);
+        $this->assertSame($expectedFullName, $resolvedName->fullName);
+    }
+
+    public static function resolveTableNameDataProvider(): array
+    {
+        return [
+            'no schema' => ['customer', 'main', 'customer', 'customer'],
+            'default schema' => ['main.customer', 'main', 'customer', 'customer'],
+            'attached schema' => ['second_schema.customer', 'second_schema', 'customer', 'second_schema.customer'],
+            'quoted with backticks' => [
+                '`second_schema`.`customer`',
+                'second_schema',
+                'customer',
+                'second_schema.customer',
+            ],
+            'quoted with double quotes' => [
+                '"second_schema"."customer"',
+                'second_schema',
+                'customer',
+                'second_schema.customer',
+            ],
+            // a part holding a dot or a quote character is quoted back, so that the full name stays unambiguous
+            'quoted table name holding a dot' => ['`my.customer`', 'main', 'my.customer', '`my.customer`'],
+            'quoted schema name holding a dot' => [
+                '`my.schema`.`customer`',
+                'my.schema',
+                'customer',
+                '`my.schema`.customer',
+            ],
+            'quote character escaped by doubling' => ['`my``customer`', 'main', 'my`customer', '`my``customer`'],
+        ];
+    }
+
+    /**
+     * A table whose name holds a dot is reachable as long as the name is quoted.
+     */
+    public function testGetTableSchemaOfTableNameHoldingADot(): void
+    {
+        $db = $this->getConnection();
+        $db->createCommand('CREATE TABLE `my.customer` (id INTEGER NOT NULL PRIMARY KEY, note varchar(32))')
+            ->execute();
+
+        $table = $db->getSchema()->getTableSchema('`my.customer`');
+
+        $this->assertNotNull($table);
+        $this->assertSame('main', $table->schemaName);
+        $this->assertSame('my.customer', $table->name);
+        $this->assertSame('`my.customer`', $table->fullName);
+        $this->assertSame(['id', 'note'], $table->getColumnNames());
+    }
+
+    /**
+     * Attaches an additional in-memory database as the `second_schema` schema and fills it with tables.
+     *
+     * Its `customer` table shares its name with the one in the `main` schema but holds different columns, so that
+     * tests can tell which of the two was actually read.
+     *
+     * @param Connection $db the connection to attach the database to.
+     */
+    private function attachSecondSchema($db)
+    {
+        $db->createCommand("ATTACH DATABASE ':memory:' AS `" . self::ATTACHED_SCHEMA . '`')->execute();
+        $db->createCommand(
+            'CREATE TABLE ' . self::ATTACHED_SCHEMA . '.customer (
+                id INTEGER NOT NULL,
+                code varchar(32) NOT NULL,
+                PRIMARY KEY (id)
+            )'
+        )->execute();
+        $db->createCommand(
+            'CREATE TABLE ' . self::ATTACHED_SCHEMA . ".attached_item (
+                id INTEGER NOT NULL PRIMARY KEY,
+                customer_id INTEGER NOT NULL,
+                slug varchar(64) NOT NULL UNIQUE,
+                CHECK (slug <> ''),
+                CONSTRAINT fk_attached_item_customer FOREIGN KEY (customer_id) REFERENCES customer (id)
+            )"
+        )->execute();
+        $db->createCommand(
+            'CREATE INDEX ' . self::ATTACHED_SCHEMA . '.idx_attached_item_customer_id ON attached_item (customer_id)'
+        )->execute();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #20262

In SQLite a schema is the name of an [attached database](https://www.sqlite.org/lang_attach.html). The driver did not
know about them: `findTableNames()` ignored the schema it was given and always read `main`'s `sqlite_master`, and a
qualified name such as `second_schema.post` was taken verbatim as the table name, so its metadata could not be read at
all.

`Schema` now splits a table name into its schema and table parts, keeps them in `TableSchema`, and qualifies every
`sqlite_master` query and `PRAGMA` with the schema when it is not the default one. `findSchemaNames()` lists the
attached databases through `PRAGMA DATABASE_LIST`, skipping the system `temp` schema, which stays reachable by name.

`QueryBuilder::resetSequence()` needed the same treatment: every attached database has its own `sqlite_sequence`
table, so it has to update the one of the schema the table belongs to rather than `main`'s.

Two decisions worth a look:

* `$defaultSchema` is now `main`, which lines SQLite up with the other drivers. `TableSchema::$schemaName` is
  therefore `main` instead of `null` for the tables of the database the connection was opened with. `fullName` is
  unchanged — the default schema is never part of it, so `getTableSchema('main.post')` and `getTableSchema('post')`
  both give `post`.
* Naming a database that is not attached raises a `yii\db\Exception` rather than returning `null`. PostgreSQL would
  quietly return nothing here. The only cheap way to match that is to check `getSchemaNames()` first, but that list is
  cached, so a database attached later in the request would be reported as missing. Pinned with a test; happy to
  change it if you would rather have the softer behaviour.

Documented in the DB guide and in `UPGRADE.md`.
