### PR TITLE
Delegate `CaptchaValidator::getClientOptions()` to `clientScript`; fix `generateValidationHash()` `@return` to `int`.

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -154,7 +154,8 @@ Yii Framework 2 Change Log
 - Bug #16043: Fix `yii\db\oci\Schema::findColumns()` to report `null` size for `DATE`, `TIMESTAMP` and `INTERVAL` columns instead of their internal storage byte length (terabytesoftw)
 - Bug #12763: Apply an explicitly configured PostgreSQL `defaultSchema` as the session `search_path` when opening the connection (terabytesoftw)
 - Bug #19852: Use the connection passed to `ActiveQuery` result methods for schema reflection and typecasting while populating records (terabytesoftw)
-- Bug #21110: Fix `ActiveField::checkbox()`/`radio()` dropping label for extensions with `enclosedByLabel=false` (terabytesoftw)
+- Bug #21057: Fix `ActiveField::checkbox()`/`radio()` dropping label for extensions with `enclosedByLabel=false` (terabytesoftw)
+- Chg #21059: Delegate `CaptchaValidator::getClientOptions()` to `clientScript`; fix `generateValidationHash()` `@return` to `int` (terabytesoftw)
 
 2.0.56 under development
 ------------------------

--- a/framework/UPGRADE-22.md
+++ b/framework/UPGRADE-22.md
@@ -181,9 +181,9 @@ ActiveForm::begin([
 ```
 
 If a subclass overrides `ActiveForm::getClientOptions()`, `ActiveField::getClientOptions()`,
-`Validator::clientValidateAttribute()`, `Captcha::registerClientScript()`, `Captcha::getClientOptions()`, or
-`CaptchaValidator::clientValidateAttribute()`, review the override because the default implementation now delegates to
-the configured strategy.
+`Validator::clientValidateAttribute()`, `Captcha::registerClientScript()`, `Captcha::getClientOptions()`,
+`CaptchaValidator::clientValidateAttribute()`, or `CaptchaValidator::getClientOptions()`, review the override because
+the default implementation now delegates to the configured strategy.
 
 ### `View::registerJs()` no longer assumes jQuery
 

--- a/framework/captcha/CaptchaAction.php
+++ b/framework/captcha/CaptchaAction.php
@@ -149,7 +149,7 @@ class CaptchaAction extends Action
     /**
      * Generates a hash code that can be used for client-side validation.
      * @param string $code the CAPTCHA code
-     * @return string a hash code generated from the CAPTCHA code
+     * @return int a hash code generated from the CAPTCHA code
      */
     public function generateValidationHash($code)
     {

--- a/framework/captcha/CaptchaValidator.php
+++ b/framework/captcha/CaptchaValidator.php
@@ -51,7 +51,6 @@ class CaptchaValidator extends Validator
      */
     public array|ClientValidatorScriptInterface|null $clientScript = null;
 
-
     /**
      * {@inheritdoc}
      */
@@ -117,21 +116,10 @@ class CaptchaValidator extends Validator
      */
     public function getClientOptions($model, $attribute)
     {
-        $captcha = $this->createCaptchaAction();
-        $code = $captcha->getVerifyCode(false);
-        $hash = $captcha->generateValidationHash($this->caseSensitive ? $code : strtolower($code));
-        $options = [
-            'hash' => $hash,
-            'hashKey' => 'yiiCaptcha/' . $captcha->getUniqueId(),
-            'caseSensitive' => $this->caseSensitive,
-            'message' => Yii::$app->getI18n()->format($this->message, [
-                'attribute' => $model->getAttributeLabel($attribute),
-            ], Yii::$app->language),
-        ];
-        if ($this->skipOnEmpty) {
-            $options['skipOnEmpty'] = 1;
+        if ($this->clientScript instanceof ClientValidatorScriptInterface) {
+            return $this->clientScript->getClientOptions($this, $model, $attribute);
         }
 
-        return $options;
+        return [];
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,12 +31,6 @@ parameters:
 			path: framework/caching/WinCache.php
 
 		-
-			message: '#^Method yii\\captcha\\CaptchaAction\:\:generateValidationHash\(\) should return string but returns int\.$#'
-			identifier: return.type
-			count: 1
-			path: framework/captcha/CaptchaAction.php
-
-		-
 			message: '#^PHPDoc tag @param references unknown parameter\: \$args$#'
 			identifier: parameter.notFound
 			count: 2
@@ -473,6 +467,12 @@ parameters:
 			identifier: property.notFound
 			count: 4
 			path: tests/framework/captcha/CaptchaTest.php
+
+		-
+			message: '#^Access to an undefined property yii\\validators\\Validator\:\:\$clientScript\.$#'
+			identifier: property.notFound
+			count: 3
+			path: tests/framework/captcha/CaptchaValidatorTest.php
 
 		-
 			message: '#^Return type \(void\) of method yiiunit\\framework\\console\\controllers\\FixtureConsoledController\:\:stdout\(\) should be compatible with return type \(bool\|int\) of method yii\\console\\Controller\<yii\\console\\Application\>\:\:stdout\(\)$#'

--- a/tests/framework/captcha/CaptchaValidatorTest.php
+++ b/tests/framework/captcha/CaptchaValidatorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\captcha;
+
+use PHPUnit\Framework\Attributes\Group;
+use yii\captcha\CaptchaValidator;
+use yii\validators\Validator;
+use yiiunit\framework\validators\ClientScriptDispatchTestTrait;
+use yiiunit\TestCase;
+
+/**
+ * Unit tests for the {@see CaptchaValidator} `clientScript` strategy dispatch.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 22.0
+ */
+#[Group('captcha')]
+#[Group('validators')]
+final class CaptchaValidatorTest extends TestCase
+{
+    use ClientScriptDispatchTestTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockWebApplication();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->destroyApplication();
+    }
+
+    protected function createValidatorInstance(array $config = []): Validator
+    {
+        return new CaptchaValidator($config);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
