### PR TITLE
Fix #20456: `BaseHtml::escapeJsRegularExpression()` truncates patterns with paired delimiters

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #21020: Fix duplicate `@return` annotation for `yii\db\ActiveRecord::hasOne()` (nazard)
+- Bug #20456: Fix `yii\helpers\BaseHtml::escapeJsRegularExpression()` truncating patterns with paired delimiters (KalimeroMK)
 - Bug #20873: Fix PHPDoc annotations for the `yii\log\Target::$enabled` (mspirkov)
 - Enh #20875: Clarify the type of the `yii\base\Model::$errors` (mspirkov)
 - Bug #20875: Fix `@return` annotation for `yii\base\Model::getErrors()` (mspirkov)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -2395,7 +2395,8 @@ class BaseHtml
     {
         $pattern = preg_replace('/\\\\x\{?([0-9a-fA-F]+)\}?/', '\u$1', $regexp);
         $deliminator = substr($pattern, 0, 1);
-        $pos = strrpos($pattern, $deliminator, 1);
+        $closingDeliminator = strtr($deliminator, ['(' => ')', '[' => ']', '{' => '}', '<' => '>']);
+        $pos = strrpos($pattern, $closingDeliminator, 1);
         $flag = substr($pattern, $pos + 1);
         if ($deliminator !== '/') {
             $pattern = '/' . str_replace('/', '\\/', substr($pattern, 1, $pos - 1)) . '/';

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -2135,6 +2135,15 @@ EOD;
         $expected = '/([a-z0-9-]+)/ugim';
         $actual = Html::escapeJsRegularExpression('/([a-z0-9-]+)/dugimex');
         $this->assertSame($expected, $actual);
+
+        // Paired delimiters with nested brackets
+        $expected = '/a(b)c/';
+        $actual = Html::escapeJsRegularExpression('(a(b)c)');
+        $this->assertSame($expected, $actual);
+
+        $expected = '/a\/b/i';
+        $actual = Html::escapeJsRegularExpression('{a/b}i');
+        $this->assertSame($expected, $actual);
     }
 
     public function testActiveDropDownList(): void


### PR DESCRIPTION
Fix #20456

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #20456

### Problem

`escapeJsRegularExpression()` assumes the first character of the pattern is the delimiter and then searches for the last occurrence of **that same character**. For PCRE paired delimiters (`()`, `[]`, `{}`, `<>`) the closing character differs from the opening one, so patterns with nested brackets get truncated:

```php
Html::escapeJsRegularExpression('(a(b)c)');
// before: "/a/"
// after:  "/a(b)c/"
```

### Fix

When the delimiter is a paired bracket, search for the last occurrence of the matching **closing** character instead.

### Note on the issue's original example

The exact example from the issue, `([a-z_])([a-z0-9_])*`, is not a valid PCRE pattern (`preg_match` fails with "Internal error"), and treating the outer parentheses as literal rather than delimiters would contradict the existing test where `([a-z0-9-]+)` maps to `/[a-z0-9-]+/`. This PR fixes the underlying paired-delimiter bug while keeping that established behavior.

Tests added for nested paired delimiters and non-slash paired delimiters with flags.