### PR TITLE
Fix #19653: `Target::setLevels()` accepts bitmap values with invalid log level bits

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Bug #20873: Fix PHPDoc annotations for the `yii\log\Target::$enabled` (mspirkov)
 - Enh #20875: Clarify the type of the `yii\base\Model::$errors` (mspirkov)
 - Bug #20875: Fix `@return` annotation for `yii\base\Model::getErrors()` (mspirkov)
+- Bug #19653: Fix `yii\log\Target::setLevels()` accepting bitmap values containing bits of invalid log levels (KalimeroMK)
 - Bug #20875: Fix `@var` annotation for `yii\validators\CompareValidator::$message` (mspirkov)
 - Enh #20875: Add `@param-out` annotation for `$error` in `yii\validators\Validator::validate()` (mspirkov)
 - Enh #20878: Add `@param-out` annotation for `$models` in `yii\db\BaseActiveRecord::loadRelationsFor()` (mspirkov)

--- a/framework/log/Target.php
+++ b/framework/log/Target.php
@@ -255,7 +255,7 @@ abstract class Target extends Component
             $bitmapValues = array_reduce($levelMap, function ($carry, $item) {
                 return $carry | $item;
             });
-            if (!($bitmapValues & $levels) && $levels !== 0) {
+            if ($levels !== 0 && ($levels & ~$bitmapValues)) {
                 throw new InvalidConfigException("Incorrect $levels value");
             }
             $this->_levels = $levels;

--- a/tests/framework/log/TargetTest.php
+++ b/tests/framework/log/TargetTest.php
@@ -181,6 +181,18 @@ class TargetTest extends TestCase
         $target->setLevels(128);
     }
 
+    /**
+     * @covers \yii\log\Target::setLevels()
+     */
+    public function testSetupLevelsThroughBitmapWithInvalidBits(): void
+    {
+        $target = $this->getMockForAbstractClass(Target::class);
+
+        $this->expectException('yii\\base\\InvalidConfigException');
+        $this->expectExceptionMessage('Incorrect 17 value');
+        $target->setLevels(Logger::LEVEL_ERROR | 0x10);
+    }
+
     public function testGetEnabled(): void
     {
         $target = $this->getMockForAbstractClass(Target::class);


### PR DESCRIPTION
Fix #19653

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️ (only for configurations that were passing invalid level bits)
| Tests pass?   | ✔️
| Fixed issues  | #19653

### Problem

The validation in `Target::setLevels()` for a bitmap value only checked whether **any** valid level bit was present:

```php
if (!($bitmapValues & $levels) && $levels !== 0) {
```

So `Logger::LEVEL_ERROR | 0x10` was silently accepted, even though `0x10` is not a valid level bit.

### Fix

Reject values that contain **any** bit outside the valid level mask:

```php
if ($levels !== 0 && ($levels & ~$bitmapValues)) {
```

`Target::setLevels(Logger::LEVEL_ERROR | 0x10)` now throws `InvalidConfigException("Incorrect 17 value")`, as the issue requests.

Test added: `TargetTest::testSetupLevelsThroughBitmapWithInvalidBits()`.