### PR TITLE
Fix #17085: DateValidator fails to parse Formatter output for `php:` formats with localized month names

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.56 under development
 ------------------------
 
+- Bug #17085: Fix `yii\validators\DateValidator` failing to parse values produced by `yii\i18n\Formatter` for `php:` formats when intl outputs localized month names (KalimeroMK)
 - Bug #21020: Fix duplicate `@return` annotation for `yii\db\ActiveRecord::hasOne()` (nazard)
 - Bug #20873: Fix PHPDoc annotations for the `yii\log\Target::$enabled` (mspirkov)
 - Enh #20875: Clarify the type of the `yii\base\Model::$errors` (mspirkov)

--- a/framework/validators/DateValidator.php
+++ b/framework/validators/DateValidator.php
@@ -358,6 +358,14 @@ class DateValidator extends Validator
         }
         if (strncmp($format, 'php:', 4) === 0) {
             $format = substr($format, 4);
+            $timestamp = $this->parseDateValuePHP($value, $format);
+            if ($timestamp === false && extension_loaded('intl')) {
+                // the value may have been produced by Formatter which uses intl for `php:` formats
+                // and may output localized month names that the PHP parser can't read, see #17085
+                return $this->parseDateValueIntl($value, FormatConverter::convertDatePhpToIcu($format));
+            }
+
+            return $timestamp;
         } else {
             if (extension_loaded('intl')) {
                 return $this->parseDateValueIntl($value, $format);

--- a/framework/validators/DateValidator.php
+++ b/framework/validators/DateValidator.php
@@ -361,8 +361,9 @@ class DateValidator extends Validator
             $timestamp = $this->parseDateValuePHP($value, $format);
             if ($timestamp === false && extension_loaded('intl')) {
                 // the value may have been produced by Formatter which uses intl for `php:` formats
-                // and may output localized month names that the PHP parser can't read, see #17085
-                return $this->parseDateValueIntl($value, FormatConverter::convertDatePhpToIcu($format));
+                // and may output localized month names that the PHP parser can't read, see #17085.
+                // Strict round-trip check is enforced to not broaden the accepted input beyond that.
+                return $this->parseDateValueIntl($value, FormatConverter::convertDatePhpToIcu($format), true);
             }
 
             return $timestamp;
@@ -382,10 +383,12 @@ class DateValidator extends Validator
      * Parses a date value using the IntlDateFormatter::parse().
      * @param string $value string representing date
      * @param string $format the expected date format
+     * @param bool|null $strictDateFormat whether the re-formatted parsed date must exactly match the input.
+     * Defaults to [[strictDateFormat]].
      * @return int|bool a UNIX timestamp or `false` on failure.
      * @throws InvalidConfigException
      */
-    private function parseDateValueIntl($value, $format)
+    private function parseDateValueIntl($value, $format, $strictDateFormat = null)
     {
         $formatter = $this->getIntlDateFormatter($format);
         // enable strict parsing to avoid getting invalid date values
@@ -395,8 +398,9 @@ class DateValidator extends Validator
         // See https://github.com/yiisoft/yii2/issues/5962 and https://bugs.php.net/bug.php?id=68528
         $parsePos = 0;
         $parsedDate = @$formatter->parse($value, $parsePos);
+        $strictDateFormat = $strictDateFormat ?? $this->strictDateFormat;
         $valueLength = mb_strlen($value, Yii::$app ? Yii::$app->charset : 'UTF-8');
-        if ($parsedDate === false || $parsePos !== $valueLength || ($this->strictDateFormat && $formatter->format($parsedDate) !== $value)) {
+        if ($parsedDate === false || $parsePos !== $valueLength || ($strictDateFormat && $formatter->format($parsedDate) !== $value)) {
             return false;
         }
 

--- a/tests/framework/validators/DateValidatorTest.php
+++ b/tests/framework/validators/DateValidatorTest.php
@@ -249,6 +249,11 @@ class DateValidatorTest extends TestCase
         $val = new DateValidator(['format' => 'php:d M Y', 'locale' => 'fr-FR']);
         $this->assertTrue($val->validate('01 févr. 2019'));
 
+        // the fallback enforces an exact round-trip, so normalized or invalid input is still rejected
+        $val = new DateValidator(['format' => 'php:d M Y', 'locale' => 'de-DE']);
+        $this->assertFalse($val->validate('01 Februar 2019'));
+        $this->assertFalse($val->validate('32 Feb. 2019'));
+
         // the PHP parser remains the primary path and still rejects invalid values
         $val = new DateValidator(['format' => 'php:d M Y']);
         $this->assertTrue($val->validate('02 Feb 2019'));

--- a/tests/framework/validators/DateValidatorTest.php
+++ b/tests/framework/validators/DateValidatorTest.php
@@ -236,6 +236,25 @@ class DateValidatorTest extends TestCase
         $this->assertFalse($model->hasErrors('attr_date'));
     }
 
+    /**
+     * Values produced by Formatter for `php:` formats use intl and may contain localized
+     * month names that the PHP parser can't read, so intl is used as a fallback.
+     * @see https://github.com/yiisoft/yii2/issues/17085
+     */
+    public function testIntlPhpFormatWithLocalizedMonth(): void
+    {
+        $val = new DateValidator(['format' => 'php:d M Y', 'locale' => 'de-DE']);
+        $this->assertTrue($val->validate('01 Feb. 2019'));
+
+        $val = new DateValidator(['format' => 'php:d M Y', 'locale' => 'fr-FR']);
+        $this->assertTrue($val->validate('01 févr. 2019'));
+
+        // the PHP parser remains the primary path and still rejects invalid values
+        $val = new DateValidator(['format' => 'php:d M Y']);
+        $this->assertTrue($val->validate('02 Feb 2019'));
+        $this->assertFalse($val->validate('32 Feb 2019'));
+    }
+
     public static function provideTimezones(): array
     {
         return [


### PR DESCRIPTION
Fix #17085

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #17085

### Problem

`Formatter` converts `php:` date formats to ICU and formats via `IntlDateFormatter` when the intl extension is installed. In some locales (e.g. `de-DE`, `fr-FR`) the short month name then includes a period: `01 Feb. 2019`, `01 févr. 2019`.

`DateValidator` with the same `php:` format, however, always uses the PHP parser (`DateTime::createFromFormat`), which only understands English month names — so the value the Formatter just produced is rejected as invalid:

```php
Yii::$app->language = 'de-DE';
$date = Yii::$app->formatter->asDate(1549026000, 'php:d M Y'); // "01 Feb. 2019"
$validator = new DateValidator(['format' => 'php:d M Y']);
$validator->validate($date); // false
```

### Fix

In `DateValidator::parseDateValueFormat()`, when PHP parsing of a `php:` format fails and intl is available, fall back to `IntlDateFormatter` with the PHP→ICU converted format — mirroring what `Formatter` did when producing the value.

The PHP parser stays the primary (documented, stricter) path; the intl fallback only accepts values that were previously impossible to produce-and-validate round-trip. Strict parsing (`setLenient(false)`) and `strictDateFormat` behavior of the intl path are unchanged.

Test added: `DateValidatorTest::testIntlPhpFormatWithLocalizedMonth()` (de-DE and fr-FR round-trips, plus asserting the PHP path still rejects invalid input like `32 Feb 2019`).