### PR TITLE
Fix #21068: Add missing `create_sid()` and `validateId()` methods to `SessionHandler`

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #21020: Fix duplicate `@return` annotation for `yii\db\ActiveRecord::hasOne()` (nazard)
+- Bug #21068: Add missing `create_sid()` method to `yii\web\SessionHandler` fixing PHP 8.6 deprecation (KalimeroMK)
 - Bug #20873: Fix PHPDoc annotations for the `yii\log\Target::$enabled` (mspirkov)
 - Enh #20875: Clarify the type of the `yii\base\Model::$errors` (mspirkov)
 - Bug #20875: Fix `@return` annotation for `yii\base\Model::getErrors()` (mspirkov)

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 Change Log
 ------------------------
 
 - Bug #21020: Fix duplicate `@return` annotation for `yii\db\ActiveRecord::hasOne()` (nazard)
-- Bug #21068: Add missing `create_sid()` method to `yii\web\SessionHandler` fixing PHP 8.6 deprecation (KalimeroMK)
+- Bug #21068: Add missing `create_sid()` and `validateId()` methods to `yii\web\SessionHandler` fixing PHP 8.6 deprecation (KalimeroMK)
 - Bug #20873: Fix PHPDoc annotations for the `yii\log\Target::$enabled` (mspirkov)
 - Enh #20875: Clarify the type of the `yii\base\Model::$errors` (mspirkov)
 - Bug #20875: Fix `@return` annotation for `yii\base\Model::getErrors()` (mspirkov)

--- a/framework/web/SessionHandler.php
+++ b/framework/web/SessionHandler.php
@@ -64,11 +64,44 @@ class SessionHandler implements SessionHandlerInterface
 
     /**
      * @inheritDoc
+     *
+     * Generates the ID the same way as PHP's default session module does, honoring
+     * `session.sid_length` and `session.sid_bits_per_character` ini settings.
+     * `session_create_id()` can't be used here because it fails on PHP < 8 when
+     * a user save handler (such as this class) is registered.
      */
     #[\ReturnTypeWillChange]
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- method name is defined by SessionHandlerInterface
     public function create_sid()
     {
-        return session_create_id();
+        static $charsets = [
+            4 => '0123456789abcdef',
+            5 => '0123456789abcdefghijklmnopqrstuv',
+            6 => '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,-',
+        ];
+
+        $bits = (int) ini_get('session.sid_bits_per_character');
+        $charset = $charsets[$bits] ?? $charsets[5];
+        $length = (int) ini_get('session.sid_length');
+        if ($length < 22 || $length > 256) {
+            $length = 32;
+        }
+
+        $id = '';
+        $maxIndex = strlen($charset) - 1;
+        for ($i = 0; $i < $length; $i++) {
+            $id .= $charset[random_int(0, $maxIndex)];
+        }
+
+        return $id;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validateId($sessionId): bool
+    {
+        return $this->_session->readSession($sessionId) !== '';
     }
 
     /**

--- a/framework/web/SessionHandler.php
+++ b/framework/web/SessionHandler.php
@@ -80,12 +80,9 @@ class SessionHandler implements SessionHandlerInterface
             6 => '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,-',
         ];
 
-        $bits = (int) ini_get('session.sid_bits_per_character');
-        $charset = $charsets[$bits] ?? $charsets[5];
+        // both ini settings are validated by PHP on update, so only these values are possible
+        $charset = $charsets[(int) ini_get('session.sid_bits_per_character')];
         $length = (int) ini_get('session.sid_length');
-        if ($length < 22 || $length > 256) {
-            $length = 32;
-        }
 
         $id = '';
         $maxIndex = strlen($charset) - 1;

--- a/framework/web/SessionHandler.php
+++ b/framework/web/SessionHandler.php
@@ -66,6 +66,15 @@ class SessionHandler implements SessionHandlerInterface
      * @inheritDoc
      */
     #[\ReturnTypeWillChange]
+    public function create_sid()
+    {
+        return session_create_id();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[\ReturnTypeWillChange]
     public function read($id)
     {
         return $this->_session->readSession($id);

--- a/tests/framework/web/session/CacheSessionTest.php
+++ b/tests/framework/web/session/CacheSessionTest.php
@@ -74,6 +74,20 @@ class CacheSessionTest extends TestCase
         $this->assertNotSame($sid, $handler->create_sid());
     }
 
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/21068
+     */
+    public function testSessionHandlerValidateId(): void
+    {
+        $session = new CacheSession();
+        $handler = new SessionHandler($session);
+
+        $session->writeSession('test', 'sessionData');
+        $this->assertTrue($handler->validateId('test'));
+        $this->assertFalse($handler->validateId('not-exists'));
+        $session->destroySession('test');
+    }
+
     public function testUseStrictMode(): void
     {
         $this->useStrictModeTest(CacheSession::class);

--- a/tests/framework/web/session/CacheSessionTest.php
+++ b/tests/framework/web/session/CacheSessionTest.php
@@ -12,6 +12,7 @@ use yiiunit\TestCase;
 use Yii;
 use yii\caching\FileCache;
 use yii\web\CacheSession;
+use yii\web\SessionHandler;
 
 /**
  * @group web
@@ -59,6 +60,18 @@ class CacheSessionTest extends TestCase
     public function testInitUseStrictMode(): void
     {
         $this->initStrictModeTest(CacheSession::class);
+    }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/issues/21068
+     */
+    public function testSessionHandlerCreateSid(): void
+    {
+        $handler = new SessionHandler(new CacheSession());
+
+        $sid = $handler->create_sid();
+        $this->assertNotEmpty($sid);
+        $this->assertNotSame($sid, $handler->create_sid());
     }
 
     public function testUseStrictMode(): void


### PR DESCRIPTION
Fix #21068

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #21068

### Problem

PHP 8.6 snapshots emit deprecations for classes implementing `SessionHandlerInterface` without `create_sid()` and `validateId()` methods (both will be required in PHP 9.0):

```
Class yii\web\SessionHandler implementing SessionHandlerInterface is missing the create_sid() method which will be required in PHP 9.0
```

Yii's error handler converts the deprecation into an exception, which currently fails the `build / PHP 8.6` CI job on every open pull request (e.g. `CacheSessionTest::testNotWrittenSessionDestroying`).

### Fix

Add both methods to `yii\web\SessionHandler`:

- **`create_sid()`** generates the ID the same way as PHP's default session module, honoring `session.sid_length` and `session.sid_bits_per_character`. `session_create_id()` cannot be used: on PHP < 8 it fails with "Failed to create new ID" once a user save handler (such as this class) is registered — reproduced on PHP 7.4 in Docker.
- **`validateId($sessionId)`** delegates to `Session::readSession()`.

The method name `create_sid` is defined by the interface, so a targeted `phpcs:ignore` comment is added for the camel-caps sniff.

Tests added: `CacheSessionTest::testSessionHandlerCreateSid()`, `CacheSessionTest::testSessionHandlerValidateId()`. Verified on PHP 7.4 (Docker) and 8.5 locally.