### PR TITLE
Guard script-executing URL schemes in Html helpers

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.56 under development
 ------------------------
 
+- Bug #21070: Neutralize script-executing URL schemes in `Html::a()`, `Html::img()` and `Html::beginForm()` (iliaal)
 - Bug #21020: Fix duplicate `@return` annotation for `yii\db\ActiveRecord::hasOne()` (nazard)
 - Bug #20873: Fix PHPDoc annotations for the `yii\log\Target::$enabled` (mspirkov)
 - Enh #20875: Clarify the type of the `yii\base\Model::$errors` (mspirkov)

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -300,8 +300,10 @@ class BaseHtml
      * is opened by a browser (by default `javascript`, `vbscript` and `data`). Such URLs must
      * not be emitted in hyperlink or form targets that may contain end-user input.
      *
-     * Note that ASCII control characters are ignored by browsers when they determine the scheme
-     * of a URL, therefore they are stripped before the check.
+     * The check follows the WHATWG URL parser's preprocessing so it agrees with how browsers
+     * decide the scheme: leading and trailing C0 controls and spaces are stripped, then ASCII
+     * tab, LF and CR are removed from the remaining input. The scheme is the ASCII identifier
+     * anchored at the start of that result, not PHP's `parse_url()`.
      *
      * @param string $url the URL to check. Relative URLs and URLs without a scheme are considered safe.
      * @param string[] $unsafeSchemes the list of schemes considered unsafe.
@@ -314,17 +316,21 @@ class BaseHtml
             return false;
         }
 
-        $cleaned = preg_replace('/[\x00-\x1f\x7f]/', '', $url);
-        $scheme = strtolower((string)parse_url($cleaned, PHP_URL_SCHEME));
+        $url = preg_replace('/^[\x00-\x20]+|[\x00-\x20]+$/', '', $url);
+        $url = str_replace(["\t", "\n", "\r"], '', $url);
+        if (!preg_match('/^([A-Za-z][A-Za-z0-9+.-]*):/', $url, $matches)) {
+            return false;
+        }
 
-        return in_array($scheme, $unsafeSchemes, true);
+        return in_array(strtolower($matches[1]), $unsafeSchemes, true);
     }
 
     /**
      * Removes candidates with an unsafe URL scheme from a string-form `srcset` value.
      *
-     * Like browsers when they parse the attribute, the value is treated as a comma-separated
-     * list of candidates where each candidate consists of an image URL followed by optional
+     * Tokenization follows the HTML `srcset` attribute parser: ASCII whitespace (including
+     * form-feed) and commas separate candidates, but a comma that is not preceded by
+     * whitespace is part of the URL token. Each candidate is an image URL plus optional
      * descriptors. Candidates whose URL is unsafe are dropped entirely so that no dangling
      * descriptors remain.
      *
@@ -335,19 +341,61 @@ class BaseHtml
     protected static function filterUnsafeSrcSetCandidates($srcset)
     {
         $candidates = [];
-        foreach (explode(',', $srcset) as $candidate) {
-            $candidate = trim($candidate);
-            if ($candidate === '') {
-                continue;
+        $length = strlen($srcset);
+        $i = 0;
+        while ($i < $length) {
+            while ($i < $length && self::isSrcsetCandidateSeparator($srcset[$i])) {
+                $i++;
             }
-            // the image URL of a candidate is everything up to the first whitespace
-            $url = preg_split('/\s+/', $candidate, 2)[0];
-            if (!static::hasUnsafeUrlScheme($url, ['javascript', 'vbscript'])) {
-                $candidates[] = $candidate;
+            if ($i >= $length) {
+                break;
+            }
+            $urlStart = $i;
+            while ($i < $length && !self::isHtmlAsciiWhitespace($srcset[$i])) {
+                $i++;
+            }
+            $url = substr($srcset, $urlStart, $i - $urlStart);
+            $parenDepth = 0;
+            $restStart = $i;
+            while ($i < $length) {
+                $char = $srcset[$i];
+                if ($char === '(') {
+                    $parenDepth++;
+                } elseif ($char === ')' && $parenDepth > 0) {
+                    $parenDepth--;
+                } elseif ($char === ',' && $parenDepth === 0) {
+                    break;
+                }
+                $i++;
+            }
+            $rest = substr($srcset, $restStart, $i - $restStart);
+            if ($i < $length && $srcset[$i] === ',') {
+                $i++;
+            }
+            if ($url !== '' && !static::hasUnsafeUrlScheme($url, ['javascript', 'vbscript'])) {
+                $candidates[] = $url . $rest;
             }
         }
 
         return implode(',', $candidates);
+    }
+
+    /**
+     * @param string $char a single character
+     * @return bool whether the character is HTML ASCII whitespace
+     */
+    private static function isHtmlAsciiWhitespace($char)
+    {
+        return $char === "\t" || $char === "\n" || $char === "\x0c" || $char === "\r" || $char === ' ';
+    }
+
+    /**
+     * @param string $char a single character
+     * @return bool whether the character separates `srcset` candidates
+     */
+    private static function isSrcsetCandidateSeparator($char)
+    {
+        return $char === ',' || self::isHtmlAsciiWhitespace($char);
     }
 
     /**
@@ -538,7 +586,7 @@ class BaseHtml
                 foreach ($options['srcset'] as $descriptor => $url) {
                     $candidate = Url::to($url);
                     if (static::hasUnsafeUrlScheme($candidate, ['javascript', 'vbscript'])) {
-                        $candidate = '';
+                        continue;
                     }
                     $srcset[] = $candidate . ' ' . $descriptor;
                 }

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -296,6 +296,31 @@ class BaseHtml
     }
 
     /**
+     * Returns whether the given URL uses a scheme that allows script execution when the URL
+     * is opened by a browser (by default `javascript`, `vbscript` and `data`). Such URLs must
+     * not be emitted in hyperlink or form targets that may contain end-user input.
+     *
+     * Note that ASCII control characters are ignored by browsers when they determine the scheme
+     * of a URL, therefore they are stripped before the check.
+     *
+     * @param string $url the URL to check. Relative URLs and URLs without a scheme are considered safe.
+     * @param string[] $unsafeSchemes the list of schemes considered unsafe.
+     * @return bool whether the URL uses an unsafe scheme.
+     * @since 2.0.56
+     */
+    public static function hasUnsafeUrlScheme($url, $unsafeSchemes = ['javascript', 'vbscript', 'data'])
+    {
+        if (!is_string($url)) {
+            return false;
+        }
+
+        $cleaned = preg_replace('/[\x00-\x1f\x7f]/', '', $url);
+        $scheme = strtolower((string)parse_url($cleaned, PHP_URL_SCHEME));
+
+        return in_array($scheme, $unsafeSchemes, true);
+    }
+
+    /**
      * Wraps given content into conditional comments for IE, e.g., `lt IE 9`.
      * @param string $content raw HTML content.
      * @param string $condition condition string.
@@ -348,6 +373,9 @@ class BaseHtml
     public static function beginForm($action = '', $method = 'post', $options = [])
     {
         $action = Url::to($action);
+        if (static::hasUnsafeUrlScheme($action)) {
+            $action = '#';
+        }
 
         $hiddenInputs = [];
 
@@ -428,6 +456,9 @@ class BaseHtml
     {
         if ($url !== null) {
             $options['href'] = Url::to($url);
+            if (static::hasUnsafeUrlScheme($options['href'])) {
+                $options['href'] = '#';
+            }
         }
 
         return static::tag('a', $text, $options);
@@ -467,11 +498,18 @@ class BaseHtml
     public static function img($src, $options = [])
     {
         $options['src'] = Url::to($src);
+        if (static::hasUnsafeUrlScheme($options['src'], ['javascript', 'vbscript'])) {
+            $options['src'] = '';
+        }
 
         if (isset($options['srcset']) && is_array($options['srcset'])) {
             $srcset = [];
             foreach ($options['srcset'] as $descriptor => $url) {
-                $srcset[] = Url::to($url) . ' ' . $descriptor;
+                $candidate = Url::to($url);
+                if (static::hasUnsafeUrlScheme($candidate, ['javascript', 'vbscript'])) {
+                    $candidate = '';
+                }
+                $srcset[] = $candidate . ' ' . $descriptor;
             }
             $options['srcset'] = implode(',', $srcset);
         }

--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -321,6 +321,36 @@ class BaseHtml
     }
 
     /**
+     * Removes candidates with an unsafe URL scheme from a string-form `srcset` value.
+     *
+     * Like browsers when they parse the attribute, the value is treated as a comma-separated
+     * list of candidates where each candidate consists of an image URL followed by optional
+     * descriptors. Candidates whose URL is unsafe are dropped entirely so that no dangling
+     * descriptors remain.
+     *
+     * @param string $srcset the raw `srcset` attribute value.
+     * @return string the filtered `srcset` attribute value.
+     * @since 2.0.56
+     */
+    protected static function filterUnsafeSrcSetCandidates($srcset)
+    {
+        $candidates = [];
+        foreach (explode(',', $srcset) as $candidate) {
+            $candidate = trim($candidate);
+            if ($candidate === '') {
+                continue;
+            }
+            // the image URL of a candidate is everything up to the first whitespace
+            $url = preg_split('/\s+/', $candidate, 2)[0];
+            if (!static::hasUnsafeUrlScheme($url, ['javascript', 'vbscript'])) {
+                $candidates[] = $candidate;
+            }
+        }
+
+        return implode(',', $candidates);
+    }
+
+    /**
      * Wraps given content into conditional comments for IE, e.g., `lt IE 9`.
      * @param string $content raw HTML content.
      * @param string $condition condition string.
@@ -502,16 +532,20 @@ class BaseHtml
             $options['src'] = '';
         }
 
-        if (isset($options['srcset']) && is_array($options['srcset'])) {
-            $srcset = [];
-            foreach ($options['srcset'] as $descriptor => $url) {
-                $candidate = Url::to($url);
-                if (static::hasUnsafeUrlScheme($candidate, ['javascript', 'vbscript'])) {
-                    $candidate = '';
+        if (isset($options['srcset'])) {
+            if (is_array($options['srcset'])) {
+                $srcset = [];
+                foreach ($options['srcset'] as $descriptor => $url) {
+                    $candidate = Url::to($url);
+                    if (static::hasUnsafeUrlScheme($candidate, ['javascript', 'vbscript'])) {
+                        $candidate = '';
+                    }
+                    $srcset[] = $candidate . ' ' . $descriptor;
                 }
-                $srcset[] = $candidate . ' ' . $descriptor;
+                $options['srcset'] = implode(',', $srcset);
+            } elseif (is_string($options['srcset'])) {
+                $options['srcset'] = static::filterUnsafeSrcSetCandidates($options['srcset']);
             }
-            $options['srcset'] = implode(',', $srcset);
         }
 
         if (!isset($options['alt'])) {

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -256,6 +256,10 @@ class HtmlTest extends TestCase
         $this->assertEquals('<a href="#">something</a>', Html::a('something', 'javascript://%0aalert(document.domain)'));
         $this->assertEquals('<a href="#">something</a>', Html::a('something', 'vbscript:MsgBox(1)'));
         $this->assertEquals('<a href="#">something</a>', Html::a('something', 'data:text/html,<script>alert(1)</script>'));
+        $this->assertEquals('<a href="#">something</a>', Html::a('something', ' javascript:alert(1)'));
+        $this->assertEquals('<a href="#">something</a>', Html::a('something', 'javascript:///%0aalert(1)'));
+        // browsers only strip HT/LF/CR inside the URL, so an internal BEL does not make this javascript:
+        $this->assertStringNotContainsString('href="#"', Html::a('something', "java\x07script:alert(1)"));
     }
 
     public function testBeginFormUnsafeUrlScheme(): void
@@ -370,7 +374,7 @@ class HtmlTest extends TestCase
     public function testImgUnsafeUrlScheme(): void
     {
         $this->assertEquals('<img src="" alt="x">', Html::img('javascript:alert(1)', ['alt' => 'x']));
-        $this->assertEquals('<img src="" srcset=" 2x,pic.png 3x" alt="">', Html::img('vbscript:MsgBox(1)', ['srcset' => ['2x' => 'javascript:alert(1)', '3x' => 'pic.png']]));
+        $this->assertEquals('<img src="" srcset="pic.png 3x" alt="">', Html::img('vbscript:MsgBox(1)', ['srcset' => ['2x' => 'javascript:alert(1)', '3x' => 'pic.png']]));
         // data URIs are a legitimate way to embed images and are safe in an image context
         $this->assertEquals('<img src="data:image/png;base64,AAAA" alt="">', Html::img('data:image/png;base64,AAAA'));
     }
@@ -391,11 +395,19 @@ class HtmlTest extends TestCase
             "<img src=\"/base-url\" srcset=\"jav\tascript:alert(1)\" alt=\"\">",
             Html::img('/base-url', ['srcset' => "jav\tascript:alert(1)"])
         );
-        // commas inside candidates are candidate separators for browsers as well (HTML srcset parsing),
-        // so splitting on them matches how the value is interpreted downstream
         $this->assertEquals(
             '<img src="/base-url" srcset="data:image/png;base64,AAAA 1x" alt="">',
             Html::img('/base-url', ['srcset' => 'data:image/png;base64,AAAA 1x'])
+        );
+        // form-feed is HTML whitespace, so it starts a new candidate the way browsers do
+        $this->assertEquals(
+            '<img src="/base-url" srcset="safe.png 2x" alt="">',
+            Html::img('/base-url', ['srcset' => "\x0cjavascript:alert(1) 1x,safe.png 2x"])
+        );
+        // commas belong to the URL token until ASCII whitespace, matching HTML srcset parsing
+        $this->assertEquals(
+            '<img src="/base-url" srcset="https://example.test/image,javascript:variant 1x" alt="">',
+            Html::img('/base-url', ['srcset' => 'https://example.test/image,javascript:variant 1x'])
         );
     }
 

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -248,6 +248,22 @@ class HtmlTest extends TestCase
         $this->assertEquals('<a href="https://www.example.com/index.php?r=site%2Ftest">Test page</a>', Html::a('Test page', Url::to(['/site/test'], 'https')));
     }
 
+    public function testAUnsafeUrlScheme(): void
+    {
+        $this->assertEquals('<a href="#">something</a>', Html::a('something', 'javascript:alert(1)'));
+        $this->assertEquals('<a href="#">something</a>', Html::a('something', 'JAVASCRIPT:alert(1)'));
+        $this->assertEquals('<a href="#">something</a>', Html::a('something', "jav\tascript:alert(1)"));
+        $this->assertEquals('<a href="#">something</a>', Html::a('something', 'javascript://%0aalert(document.domain)'));
+        $this->assertEquals('<a href="#">something</a>', Html::a('something', 'vbscript:MsgBox(1)'));
+        $this->assertEquals('<a href="#">something</a>', Html::a('something', 'data:text/html,<script>alert(1)</script>'));
+    }
+
+    public function testBeginFormUnsafeUrlScheme(): void
+    {
+        $form = Html::beginForm('javascript:alert(1)');
+        $this->assertStringNotContainsString('javascript:', $form);
+    }
+
     public function testMailto(): void
     {
         $this->assertEquals('<a href="mailto:test&lt;&gt;">test<></a>', Html::mailto('test<>'));
@@ -349,6 +365,14 @@ class HtmlTest extends TestCase
     public function testImg($expected, $src, $options): void
     {
         $this->assertEquals($expected, Html::img($src, $options));
+    }
+
+    public function testImgUnsafeUrlScheme(): void
+    {
+        $this->assertEquals('<img src="" alt="x">', Html::img('javascript:alert(1)', ['alt' => 'x']));
+        $this->assertEquals('<img src="" srcset=" 2x,pic.png 3x" alt="">', Html::img('vbscript:MsgBox(1)', ['srcset' => ['2x' => 'javascript:alert(1)', '3x' => 'pic.png']]));
+        // data URIs are a legitimate way to embed images and are safe in an image context
+        $this->assertEquals('<img src="data:image/png;base64,AAAA" alt="">', Html::img('data:image/png;base64,AAAA'));
     }
 
     public function testLabel(): void

--- a/tests/framework/helpers/HtmlTest.php
+++ b/tests/framework/helpers/HtmlTest.php
@@ -375,6 +375,30 @@ class HtmlTest extends TestCase
         $this->assertEquals('<img src="data:image/png;base64,AAAA" alt="">', Html::img('data:image/png;base64,AAAA'));
     }
 
+    public function testImgStringSrcsetUnsafeUrlScheme(): void
+    {
+        $this->assertEquals(
+            '<img src="/base-url" srcset="safe.png 1x" alt="">',
+            Html::img('/base-url', ['srcset' => 'safe.png 1x,javascript:alert(1) 2x'])
+        );
+        $this->assertEquals(
+            '<img src="/base-url" srcset="safe.png 2x" alt="">',
+            Html::img('/base-url', ['srcset' => "javascript:alert(1) 1x,\nsafe.png 2x"])
+        );
+        // whitespace inside a candidate splits it for browsers as well (HTML srcset parsing),
+        // so "jav\tascript:..." is an invalid candidate downstream and needs no filtering
+        $this->assertEquals(
+            "<img src=\"/base-url\" srcset=\"jav\tascript:alert(1)\" alt=\"\">",
+            Html::img('/base-url', ['srcset' => "jav\tascript:alert(1)"])
+        );
+        // commas inside candidates are candidate separators for browsers as well (HTML srcset parsing),
+        // so splitting on them matches how the value is interpreted downstream
+        $this->assertEquals(
+            '<img src="/base-url" srcset="data:image/png;base64,AAAA 1x" alt="">',
+            Html::img('/base-url', ['srcset' => 'data:image/png;base64,AAAA 1x'])
+        );
+    }
+
     public function testLabel(): void
     {
         $this->assertEquals('<label>something<></label>', Html::label('something<>'));


### PR DESCRIPTION
### Motivation

`Html::a()`, `Html::img()` and `Html::beginForm()` emit `href`/`src`/`srcset`/`action` targets without any scheme inspection. When end-user input flows into these helpers (DB fields, query params, widget options merged from request data), the entity encoding of attribute *values* does not neutralize URL *schemes*, so executable links can be rendered:

```php
Html::a('click', 'javascript:alert(1)');
// <a href="javascript:alert(1)">click</a>

// The "://"-heuristic in Formatter::asUrl() is also bypassed:
Formatter::asUrl("javascript://%0aalert(document.domain)");
// <a href="javascript://%0aalert(document.domain)">...</a>  (%0A terminates the JS comment on click)
```

Browsers additionally ignore ASCII control characters when parsing the scheme, so `jav\tascript:` variants evade naive string checks.

### Changes

* New `BaseHtml::hasUnsafeUrlScheme($url, $unsafeSchemes = ['javascript', 'vbscript', 'data'])`: strips ASCII control characters, parses the scheme case-insensitively and reports whether it is in the unsafe list.
* `Html::a()` replaces an unsafe `href` with `#`; `Html::beginForm()` does the same for the form action.
* `Html::img()` replaces unsafe `src` entries with an empty string; `data:` URIs stay allowed for images because they cannot execute script in an image context.
* All downstream consumers (`Menu`, GridView columns with `format = 'url'`, `Formatter::asUrl()`, active-form markup) are covered automatically through the shared chokepoints.

Relative URLs, custom application schemes (e.g. `tel:`, deep links) and `http(s)`/`mailto` are unaffected. `cssFile()`/`jsFile()` were deliberately left untouched since their arguments are developer-owned asset configuration.

An alternative design would be throwing an exception on unsafe schemes; silent neutralization was chosen so that attacker-controlled stored data cannot turn a page render into a 500.

### Tests

New cases in `tests/framework/helpers/HtmlTest.php` cover scheme casing, control-character smuggling, the `%0A` comment bypass, srcset handling and the `data:` image exemption.
