### PR TITLE
Add opt-in payload integrity protection to cache backends

### DIFF
--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -74,6 +74,19 @@ abstract class Cache extends Component implements CacheInterface
      */
     public $serializer;
     /**
+     * @var string|null a secret key used to sign the serialized payload of every cache entry
+     * with an HMAC. When this property is set, [[get()]] and [[multiGet()]] treat entries whose
+     * payload does not match its signature as missing, so an attacker who gained write access to
+     * the cache storage cannot stage deserialization gadget chains through crafted payloads.
+     *
+     * The key should be a random string of at least 32 characters. Note that enabling this option
+     * invalidates all entries written beforehand and adds one HMAC computation per cache access.
+     *
+     * This option has no effect when [[serializer]] is set to `false`.
+     * @since 2.0.56
+     */
+    public $integrityKey;
+    /**
      * @var int default duration in seconds before a cache entry will expire. Default value is 0, meaning infinity.
      * This value is used by [[set()]] if the duration is not explicitly given.
      * @since 2.0.11
@@ -135,6 +148,11 @@ abstract class Cache extends Component implements CacheInterface
         $value = $this->getValue($key);
         if ($value === false || $this->serializer === false) {
             return $value;
+        }
+
+        $value = $this->verifyPayload($value);
+        if ($value === false) {
+            return false;
         } elseif ($this->serializer === null) {
             $value = unserialize((string)$value);
         } else {
@@ -209,11 +227,14 @@ abstract class Cache extends Component implements CacheInterface
                 if ($this->serializer === false) {
                     $results[$key] = $values[$newKey];
                 } else {
-                    $value = $this->serializer === null ? unserialize($values[$newKey])
-                        : call_user_func($this->serializer[1], $values[$newKey]);
+                    $payload = $this->verifyPayload($values[$newKey]);
+                    if ($payload !== false) {
+                        $value = $this->serializer === null ? unserialize((string)$payload)
+                            : call_user_func($this->serializer[1], $payload);
 
-                    if (is_array($value) && !($value[1] instanceof Dependency && $value[1]->isChanged($this))) {
-                        $results[$key] = $value[0];
+                        if (is_array($value) && !($value[1] instanceof Dependency && $value[1]->isChanged($this))) {
+                            $results[$key] = $value[0];
+                        }
                     }
                 }
             }
@@ -251,6 +272,7 @@ abstract class Cache extends Component implements CacheInterface
         } elseif ($this->serializer !== false) {
             $value = call_user_func($this->serializer[0], [$value, $dependency]);
         }
+        $value = $this->signPayload($value);
         $key = $this->buildKey($key);
 
         return $this->setValue($key, $value, $duration);
@@ -357,12 +379,53 @@ abstract class Cache extends Component implements CacheInterface
             } elseif ($this->serializer !== false) {
                 $value = call_user_func($this->serializer[0], [$value, $dependency]);
             }
+            $value = $this->signPayload($value);
 
             $key = $this->buildKey($key);
             $data[$key] = $value;
         }
 
         return $data;
+    }
+
+    /**
+     * Prepends an HMAC signature to a serialized cache payload when [[integrityKey]] is set.
+     * @param mixed $value the serialized payload.
+     * @return mixed the signed payload.
+     * @since 2.0.56
+     */
+    protected function signPayload($value)
+    {
+        if ($this->integrityKey === null || !is_string($value)) {
+            return $value;
+        }
+
+        return hash_hmac('sha256', $value, $this->integrityKey) . $value;
+    }
+
+    /**
+     * Verifies and strips the HMAC signature of a serialized cache payload when [[integrityKey]]
+     * is set. Returns `false` when the signature is missing or does not match, so that tampered
+     * payloads are handled like missing cache entries.
+     * @param mixed $value the signed payload.
+     * @return mixed the unsigned payload or `false` on verification failure.
+     * @since 2.0.56
+     */
+    protected function verifyPayload($value)
+    {
+        if ($this->integrityKey === null) {
+            return $value;
+        }
+        if (!is_string($value) || StringHelper::byteLength($value) <= 64) {
+            return false;
+        }
+
+        $signature = hash_hmac('sha256', StringHelper::byteSubstr($value, 64), $this->integrityKey);
+        if (!hash_equals($signature, StringHelper::byteSubstr($value, 0, 64))) {
+            return false;
+        }
+
+        return StringHelper::byteSubstr($value, 64);
     }
 
     /**
@@ -387,6 +450,7 @@ abstract class Cache extends Component implements CacheInterface
         } elseif ($this->serializer !== false) {
             $value = call_user_func($this->serializer[0], [$value, $dependency]);
         }
+        $value = $this->signPayload($value);
         $key = $this->buildKey($key);
 
         return $this->addValue($key, $value, $duration);

--- a/framework/caching/Cache.php
+++ b/framework/caching/Cache.php
@@ -150,7 +150,7 @@ abstract class Cache extends Component implements CacheInterface
             return $value;
         }
 
-        $value = $this->verifyPayload($value);
+        $value = $this->verifyPayload($value, $key);
         if ($value === false) {
             return false;
         } elseif ($this->serializer === null) {
@@ -227,7 +227,7 @@ abstract class Cache extends Component implements CacheInterface
                 if ($this->serializer === false) {
                     $results[$key] = $values[$newKey];
                 } else {
-                    $payload = $this->verifyPayload($values[$newKey]);
+                    $payload = $this->verifyPayload($values[$newKey], $newKey);
                     if ($payload !== false) {
                         $value = $this->serializer === null ? unserialize((string)$payload)
                             : call_user_func($this->serializer[1], $payload);
@@ -272,8 +272,8 @@ abstract class Cache extends Component implements CacheInterface
         } elseif ($this->serializer !== false) {
             $value = call_user_func($this->serializer[0], [$value, $dependency]);
         }
-        $value = $this->signPayload($value);
         $key = $this->buildKey($key);
+        $value = $this->signPayload($value, $key);
 
         return $this->setValue($key, $value, $duration);
     }
@@ -379,7 +379,7 @@ abstract class Cache extends Component implements CacheInterface
             } elseif ($this->serializer !== false) {
                 $value = call_user_func($this->serializer[0], [$value, $dependency]);
             }
-            $value = $this->signPayload($value);
+            $value = $this->signPayload($value, $this->buildKey($key));
 
             $key = $this->buildKey($key);
             $data[$key] = $value;
@@ -390,17 +390,23 @@ abstract class Cache extends Component implements CacheInterface
 
     /**
      * Prepends an HMAC signature to a serialized cache payload when [[integrityKey]] is set.
+     * The signature covers both the payload and the normalized cache key, so a signed entry
+     * cannot be copied to a different key.
+     * The option has no effect when [[serializer]] is `false`, so this method leaves
+     * the value untouched in that case.
+     *
      * @param mixed $value the serialized payload.
+     * @param string $key the normalized cache key the payload is stored under.
      * @return mixed the signed payload.
      * @since 2.0.56
      */
-    protected function signPayload($value)
+    protected function signPayload($value, $key)
     {
-        if ($this->integrityKey === null || !is_string($value)) {
+        if ($this->integrityKey === null || $this->serializer === false || !is_string($value)) {
             return $value;
         }
 
-        return hash_hmac('sha256', $value, $this->integrityKey) . $value;
+        return hash_hmac('sha256', $this->signatureContext($key, $value), $this->integrityKey) . $value;
     }
 
     /**
@@ -408,10 +414,11 @@ abstract class Cache extends Component implements CacheInterface
      * is set. Returns `false` when the signature is missing or does not match, so that tampered
      * payloads are handled like missing cache entries.
      * @param mixed $value the signed payload.
+     * @param string $key the normalized cache key the payload is expected under.
      * @return mixed the unsigned payload or `false` on verification failure.
      * @since 2.0.56
      */
-    protected function verifyPayload($value)
+    protected function verifyPayload($value, $key)
     {
         if ($this->integrityKey === null) {
             return $value;
@@ -420,12 +427,26 @@ abstract class Cache extends Component implements CacheInterface
             return false;
         }
 
-        $signature = hash_hmac('sha256', StringHelper::byteSubstr($value, 64), $this->integrityKey);
+        $payload = StringHelper::byteSubstr($value, 64);
+        $signature = hash_hmac('sha256', $this->signatureContext($key, $payload), $this->integrityKey);
         if (!hash_equals($signature, StringHelper::byteSubstr($value, 0, 64))) {
             return false;
         }
 
-        return StringHelper::byteSubstr($value, 64);
+        return $payload;
+    }
+
+    /**
+     * Builds an unambiguous message for the payload signature by prefixing it with the
+     * length-delimited normalized cache key.
+     * @param string $key the normalized cache key.
+     * @param string $value the serialized payload.
+     * @return string the message to sign.
+     * @since 2.0.56
+     */
+    private function signatureContext($key, $value)
+    {
+        return StringHelper::byteLength($key) . ':' . $key . ':' . $value;
     }
 
     /**
@@ -450,8 +471,8 @@ abstract class Cache extends Component implements CacheInterface
         } elseif ($this->serializer !== false) {
             $value = call_user_func($this->serializer[0], [$value, $dependency]);
         }
-        $value = $this->signPayload($value);
         $key = $this->buildKey($key);
+        $value = $this->signPayload($value, $key);
 
         return $this->addValue($key, $value, $duration);
     }

--- a/tests/framework/caching/CacheIntegrityTest.php
+++ b/tests/framework/caching/CacheIntegrityTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC

--- a/tests/framework/caching/CacheIntegrityTest.php
+++ b/tests/framework/caching/CacheIntegrityTest.php
@@ -12,6 +12,7 @@ use yii\caching\Cache;
 use yii\caching\Dependency;
 use yii\caching\ExpressionDependency;
 use yiiunit\TestCase;
+
 /**
  * In-memory cache backend using the default serializer, for testing [[Cache::$integrityKey]].
  */

--- a/tests/framework/caching/CacheIntegrityTest.php
+++ b/tests/framework/caching/CacheIntegrityTest.php
@@ -107,6 +107,28 @@ class CacheIntegrityTest extends TestCase
         $this->assertFalse($cache->get('k'));
     }
 
+    public function testSignedEntryCopiedToAnotherKeyIsRejected()
+    {
+        $cache = $this->createCache();
+        $cache->set('legit', 'value');
+
+        $cache->store[$cache->buildKey('other')] = $cache->store[$cache->buildKey('legit')];
+        $this->assertFalse($cache->get('other'));
+        $this->assertSame('value', $cache->get('legit'));
+    }
+
+    public function testSerializerFalseIsNotSigned()
+    {
+        $cache = $this->createCache();
+        $cache->serializer = false;
+        $cache->set('k', 'plain-string');
+        $this->assertSame('plain-string', $cache->get('k'));
+        $this->assertSame('plain-string', $cache->multiGet(['k'])['k']);
+        // foreign values are returned as-is, matching the documented no-integrity behavior
+        $cache->store[$cache->buildKey('f')] = 'foreign';
+        $this->assertSame('foreign', $cache->get('f'));
+    }
+
     public function testUnsignedPayloadIsRejected()
     {
         $cache = $this->createCache();

--- a/tests/framework/caching/CacheIntegrityTest.php
+++ b/tests/framework/caching/CacheIntegrityTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\caching;
+
+use yii\caching\Cache;
+use yii\caching\Dependency;
+use yii\caching\ExpressionDependency;
+use yiiunit\TestCase;
+/**
+ * In-memory cache backend using the default serializer, for testing [[Cache::$integrityKey]].
+ */
+class IntegrityTestCache extends Cache
+{
+    public $store = [];
+
+    protected function getValue($key)
+    {
+        return $this->store[$key] ?? false;
+    }
+
+    protected function setValue($key, $value, $duration)
+    {
+        $this->store[$key] = $value;
+
+        return true;
+    }
+
+    protected function addValue($key, $value, $duration)
+    {
+        if (isset($this->store[$key])) {
+            return false;
+        }
+        $this->store[$key] = $value;
+
+        return true;
+    }
+
+    protected function deleteValue($key)
+    {
+        unset($this->store[$key]);
+
+        return true;
+    }
+
+    protected function flushValues()
+    {
+        $this->store = [];
+
+        return true;
+    }
+}
+
+/**
+ * Tests for the payload integrity protection of [[yii\caching\Cache]].
+ */
+class CacheIntegrityTest extends TestCase
+{
+    /**
+     * @return IntegrityTestCache
+     */
+    private function createCache()
+    {
+        $cache = new IntegrityTestCache();
+        $cache->integrityKey = 'unit-test-integrity-key-0123456789abcdef';
+
+        return $cache;
+    }
+
+    public function testGetSetRoundTrip()
+    {
+        $cache = $this->createCache();
+        $cache->set('k', ['hello' => 'world']);
+        $this->assertSame(['hello' => 'world'], $cache->get('k'));
+        $this->assertSame(['hello' => 'world'], $cache->multiGet(['k'])['k']);
+        $this->assertTrue($cache->exists('k'));
+    }
+
+    public function testDependencyRoundTrip()
+    {
+        $cache = $this->createCache();
+        $dependency = new MutableDependency();
+        $cache->set('k', 'value', 0, $dependency);
+        $this->assertSame('value', $cache->get('k'));
+
+        $dependency->evaluateDependency($cache);
+        MutableDependency::$sourceValue = 2;
+        $this->assertFalse($cache->get('k'));
+    }
+
+    public function testTamperedPayloadIsTreatedAsMissing()
+    {
+        $cache = $this->createCache();
+        $cache->set('k', 'original');
+        $key = $cache->buildKey('k');
+        $raw = $cache->store[$key];
+
+        $cache->store[$key] = substr($raw, 0, 60) . 'X' . substr($raw, 61);
+        $this->assertFalse($cache->get('k'));
+        $this->assertFalse($cache->multiGet(['k'])['k']);
+
+        $cache->store[$key] = $raw . 'tail';
+        $this->assertFalse($cache->get('k'));
+    }
+
+    public function testUnsignedPayloadIsRejected()
+    {
+        $cache = $this->createCache();
+        $cache->store[$cache->buildKey('k')] = serialize(['unsigned', null]);
+        $this->assertFalse($cache->get('k'));
+    }
+
+    public function testPoisonedDependencyPayloadDoesNotEvaluate()
+    {
+        $cache = $this->createCache();
+        $evilDependency = new ExpressionDependency();
+        $evilDependency->expression = "throw new \\Exception('payload executed')";
+        $cache->store[$cache->buildKey('k')] = serialize(['poisoned', $evilDependency]);
+
+        $this->assertFalse($cache->get('k'));
+        $this->assertFalse($cache->multiGet(['k'])['k']);
+    }
+
+    public function testCustomSerializerWithIntegrityKey()
+    {
+        $cache = $this->createCache();
+        $cache->serializer = [
+            function ($value) {
+                return base64_encode(json_encode($value));
+            },
+            function ($value) {
+                return json_decode(base64_decode($value), true);
+            },
+        ];
+        $cache->set('k', ['a' => 1]);
+        $this->assertSame(['a' => 1], $cache->get('k'));
+
+        $cache->store[$cache->buildKey('k')] = base64_encode(json_encode(['tampered' => true]));
+        $this->assertFalse($cache->get('k'));
+    }
+
+    public function testDisabledIntegrityKeyKeepsDefaultBehavior()
+    {
+        $cache = new IntegrityTestCache();
+        $cache->set('k', 'plain');
+        $key = $cache->buildKey('k');
+
+        $this->assertStringStartsWith('a:2:', $cache->store[$key]);
+        $this->assertSame('plain', $cache->get('k'));
+
+        $cache->store[$key] = serialize(['foreign', null]);
+        $this->assertSame('foreign', $cache->get('k'));
+    }
+}
+
+/**
+ * Dependency whose generated data can be changed externally after being attached to a cache entry.
+ */
+class MutableDependency extends Dependency
+{
+    /**
+     * @var int external data source returned by [[generateDependencyData()]].
+     */
+    public static $sourceValue = 1;
+
+    protected function generateDependencyData($cache)
+    {
+        return self::$sourceValue;
+    }
+}


### PR DESCRIPTION
### Motivation

`Cache::get()` unserializes whatever bytes the cache storage returns. Any principal that can write cache entries — a shared memcached/redis server without authentication, a neighboring application on a shared host, or cache poisoning through user-keyed entries — can instantiate arbitrary framework objects on the next read of that entry.

Because `Dependency` objects ride inside the same serialized payload as the value, this is worse than generic POP-gadget exposure: a poisoned entry containing an `ExpressionDependency` evaluates its expression via `eval()` during the dependency check, and a `CallbackDependency` invokes its restored callback. Cache write access therefore becomes deterministic remote code execution using only first-party, always-loaded classes — no third-party gadget chain required. (This is the same bug class as CVE-2020-15148, but reached through the framework's own default read path rather than application-level `unserialize()`.)

Demonstrated end-to-end on the current master with a payload of the shape

```
serialize(['pwned', $dep]) // where $dep is ExpressionDependency{expression: "system('...')"}
```

written directly to the backend storage: the next `$cache->get()` executes the expression.

### Changes

Introduce an opt-in `Cache::$integrityKey`. When set:

* payloads written through `set()`, `add()`, `multiSet()` and `multiAdd()` are prefixed with an HMAC-SHA256 signature;
* `get()` and `multiGet()` treat entries whose signature is missing or invalid like missing entries instead of unserializing them, which also covers tampered bytes and foreign unsigned payloads.

The option is off by default, so existing behavior (including `serializer => false` backends such as `ArrayCache`) is unchanged; enabling it adds one HMAC computation per access and invalidates entries written beforehand. The guide already documents that cache backends must stay write-protected; this option provides integrity enforcement for deployments where that cannot be guaranteed.

### Tests

New `tests/framework/caching/CacheIntegrityTest.php` covers: round-trip reads/writes with a key enabled, dependency evaluation and invalidation over signed payloads, byte-tampered payloads treated as misses, unsigned payloads rejected, a poisoned `ExpressionDependency` payload no longer evaluating, custom serializers combined with the signature, and unchanged default behavior when the key is not set.
