### PR TITLE
Use full 64 bit keyspace for PgSQL advisory lock keys

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -36,6 +36,7 @@ Yii Framework 2 Change Log
 - Bug #21047: Fix PHPDoc annotations in `Theme`, `AccessRule` and `View` (mspirkov)
 - Bug #20217: Apply `ActiveForm::$validationDelay` only while the user is typing, so validation on blur, change and manual trigger is no longer delayed (veksa)
 - Bug #19865: Ignore validators with a `when` condition while `AttributeTypecastBehavior` detects `attributeTypes` automatically (veksa)
+- Bug #21072: Use the full 64-bit keyspace for PostgreSQL advisory lock keys in `PgsqlMutex` (iliaal)
 
 
 2.0.55 May 09, 2026

--- a/framework/UPGRADE.md
+++ b/framework/UPGRADE.md
@@ -65,6 +65,11 @@ Upgrade from Yii 2.0.55
   The detection result is composed once per owner class, so such a condition can not be resolved there, and an
   attribute covered by conditional rules only is now left out of the map instead of being type-casted according
   to the first matching rule. Set `attributeTypes` explicitly if you rely on those attributes being type-casted.
+* `yii\mutex\PgsqlMutex` now maps each lock name to two 32-bit advisory-lock keys (a 64-bit keyspace)
+  instead of two 16-bit keys. Existing lock names therefore produce different PostgreSQL keys than in 2.0.55.
+  If you acquire a `PgsqlMutex` lock across a rolling deployment, drain workers that still run 2.0.55 or
+  earlier before starting workers on 2.0.56. An old worker and a new worker can otherwise hold different
+  advisory locks for the same lock name at the same time.
 
 Upgrade from Yii 2.0.53
 -----------------------

--- a/framework/mutex/PgsqlMutex.php
+++ b/framework/mutex/PgsqlMutex.php
@@ -52,13 +52,19 @@ class PgsqlMutex extends DbMutex
     }
 
     /**
-     * Converts a string into two 16 bit integer keys using the SHA1 hash function.
+     * Converts a string into two 32 bit integer keys using the first 8 bytes of the SHA1 hash function.
      * @param string $name
-     * @return array contains two 16 bit integer keys
+     * @return array contains two 32 bit integer keys
      */
     private function getKeysFromName($name)
     {
-        return array_values(unpack('n2', sha1($name, true)));
+        $keys = unpack('N2', substr(sha1($name, true), 0, 8));
+
+        // PostgreSQL advisory locks accept two signed 4-byte integers, while unpack('N')
+        // produces unsigned values. Convert values above the signed range accordingly.
+        return array_values(array_map(static function ($key) {
+            return $key > 0x7FFFFFFF ? $key - 0x100000000 : $key;
+        }, $keys));
     }
 
     /**

--- a/tests/framework/mutex/PgsqlMutexKeyTest.php
+++ b/tests/framework/mutex/PgsqlMutexKeyTest.php
@@ -35,11 +35,7 @@ class PgsqlMutexKeyTest extends TestCase
      */
     private function getKeys($name)
     {
-        $mutex = $this->createMutex();
-        $method = new \ReflectionMethod(PgsqlMutex::class, 'getKeysFromName');
-        $method->setAccessible(true);
-
-        return $method->invoke($mutex, $name);
+        return $this->invokeMethod($this->createMutex(), 'getKeysFromName', [$name]);
     }
 
     public function testKeysAreDeterministic()

--- a/tests/framework/mutex/PgsqlMutexKeyTest.php
+++ b/tests/framework/mutex/PgsqlMutexKeyTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\framework\mutex;
+
+use yii\db\Connection;
+use yii\mutex\PgsqlMutex;
+use yiiunit\TestCase;
+
+/**
+ * Unit tests for PgsqlMutex lock name to key mapping that do not require a live PostgreSQL server.
+ *
+ * @group mutex
+ * @group db
+ * @group pgsql
+ */
+class PgsqlMutexKeyTest extends TestCase
+{
+    /**
+     * @return PgsqlMutex
+     */
+    private function createMutex()
+    {
+        return new PgsqlMutex(['db' => new Connection(['driverName' => 'pgsql'])]);
+    }
+
+    /**
+     * @param string $name
+     * @return array
+     */
+    private function getKeys($name)
+    {
+        $mutex = $this->createMutex();
+        $method = new \ReflectionMethod(PgsqlMutex::class, 'getKeysFromName');
+        $method->setAccessible(true);
+
+        return $method->invoke($mutex, $name);
+    }
+
+    public function testKeysAreDeterministic()
+    {
+        $this->assertSame($this->getKeys('app:job:send-mail'), $this->getKeys('app:job:send-mail'));
+    }
+
+    public function testKnownVector()
+    {
+        $this->assertSame([1132950929, -43075096], $this->getKeys('app:job:send-mail'));
+    }
+
+    public function testKeysFitSigned32BitRange()
+    {
+        for ($i = 0; $i < 500; ++$i) {
+            foreach ($this->getKeys('name-' . $i) as $key) {
+                $this->assertGreaterThanOrEqual(-2147483648, $key);
+                $this->assertLessThanOrEqual(2147483647, $key);
+            }
+        }
+    }
+
+    public function testDistinctNamesProduceDistinctKeyPairs()
+    {
+        $pairs = [];
+        for ($i = 0; $i < 500; ++$i) {
+            $pairs[implode(',', $this->getKeys('lock-name-' . $i))] = true;
+        }
+        $this->assertCount(500, $pairs);
+    }
+}


### PR DESCRIPTION
### Motivation

`PgsqlMutex::getKeysFromName()` derived the two PostgreSQL advisory-lock integers from only the first 4 bytes of the SHA-1 hash (`unpack('n2', ...)` = two unsigned 16-bit values), leaving a 32-bit effective keyspace. Distinct lock names therefore collide with ~50% probability at roughly 65k concurrent lock names (birthday bound), and two unrelated operations can simultaneously believe they hold the same exclusive lock.

PostgreSQL advisory locks accept two signed 4-byte integers, i.e. a full 64-bit keyspace that this mapping never used.

### Changes

* Derive the two keys from the first 8 hash bytes (`unpack('N2', substr($hash, 0, 8))`), raising the keyspace to 64 bits.
* Map values above `0x7FFFFFFF` into the signed range so they remain valid `int4` arguments for `pg_try_advisory_lock(int, int)`.

Locks are session-scoped and transient, so no migration is needed. Note for rolling deployments: old and new workers map the same lock name to different keys until every worker runs the new version.

### Tests

New `tests/framework/mutex/PgsqlMutexKeyTest.php` exercises the key mapping without requiring a live PostgreSQL server: determinism, a pinned known vector, int4 range bounds over 500 names, and uniqueness of key pairs across 500 distinct names.
