### PR TITLE
Fix boundary extraction from Content-Type with additional parameters

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Change Log
 2.0.56 under development
 ------------------------
 
+- Bug #21073: Fix `MultipartFormDataParser` boundary extraction when `Content-Type` has additional parameters (iliaal)
 - Bug #21020: Fix duplicate `@return` annotation for `yii\db\ActiveRecord::hasOne()` (nazard)
 - Bug #20873: Fix PHPDoc annotations for the `yii\log\Target::$enabled` (mspirkov)
 - Enh #20875: Clarify the type of the `yii\base\Model::$errors` (mspirkov)

--- a/framework/web/MultipartFormDataParser.php
+++ b/framework/web/MultipartFormDataParser.php
@@ -142,12 +142,8 @@ class MultipartFormDataParser extends BaseObject implements RequestParserInterfa
             return [];
         }
 
-        if (!preg_match('/boundary=(?:"([^"]*)"|([^;\s]*))/is', $contentType, $matches)) {
-            return [];
-        }
-
-        $boundary = isset($matches[1]) && $matches[1] !== '' ? $matches[1] : $matches[2];
-        if ($boundary === '') {
+        $boundary = $this->getMimeParameter($contentType, 'boundary');
+        if ($boundary === null || $boundary === '') {
             return [];
         }
 
@@ -212,6 +208,95 @@ class MultipartFormDataParser extends BaseObject implements RequestParserInterfa
         }
 
         return $bodyParams;
+    }
+
+    /**
+     * Returns a MIME header parameter (RFC 2045), or `null` if it is absent.
+     *
+     * `;` and `name=value` inside quoted-strings are not treated as delimiters.
+     *
+     * @param string $header Content-Type (or similar) header value
+     * @param string $name parameter name (matched case-insensitively)
+     * @return string|null
+     */
+    private function getMimeParameter($header, $name)
+    {
+        $name = strtolower($name);
+        $length = strlen($header);
+        $i = 0;
+
+        while ($i < $length) {
+            if ($header[$i] === '"') {
+                $i++;
+                while ($i < $length) {
+                    if ($header[$i] === '\\') {
+                        $i += ($i + 1 < $length) ? 2 : 1;
+                        continue;
+                    }
+                    if ($header[$i] === '"') {
+                        $i++;
+                        break;
+                    }
+                    $i++;
+                }
+                continue;
+            }
+
+            if ($header[$i] !== ';') {
+                $i++;
+                continue;
+            }
+
+            $i++;
+            while ($i < $length && ($header[$i] === ' ' || $header[$i] === "\t")) {
+                $i++;
+            }
+
+            $attrStart = $i;
+            while ($i < $length && $header[$i] !== '=' && $header[$i] !== ';') {
+                $i++;
+            }
+            $attr = strtolower(trim(substr($header, $attrStart, $i - $attrStart)));
+
+            if ($attr === '' || $i >= $length || $header[$i] !== '=') {
+                continue;
+            }
+
+            $i++;
+            while ($i < $length && ($header[$i] === ' ' || $header[$i] === "\t")) {
+                $i++;
+            }
+
+            if ($i < $length && $header[$i] === '"') {
+                $i++;
+                $value = '';
+                while ($i < $length) {
+                    if ($header[$i] === '\\' && $i + 1 < $length) {
+                        $value .= $header[$i + 1];
+                        $i += 2;
+                        continue;
+                    }
+                    if ($header[$i] === '"') {
+                        $i++;
+                        break;
+                    }
+                    $value .= $header[$i];
+                    $i++;
+                }
+            } else {
+                $valueStart = $i;
+                while ($i < $length && $header[$i] !== ';' && $header[$i] !== ' ' && $header[$i] !== "\t") {
+                    $i++;
+                }
+                $value = substr($header, $valueStart, $i - $valueStart);
+            }
+
+            if ($attr === $name) {
+                return $value;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/framework/web/MultipartFormDataParser.php
+++ b/framework/web/MultipartFormDataParser.php
@@ -142,11 +142,14 @@ class MultipartFormDataParser extends BaseObject implements RequestParserInterfa
             return [];
         }
 
-        if (!preg_match('/boundary="?(.*)"?$/is', $contentType, $matches)) {
+        if (!preg_match('/boundary=(?:"([^"]*)"|([^;\s]*))/is', $contentType, $matches)) {
             return [];
         }
 
-        $boundary = trim($matches[1], '"');
+        $boundary = isset($matches[1]) && $matches[1] !== '' ? $matches[1] : $matches[2];
+        if ($boundary === '') {
+            return [];
+        }
 
         $bodyParts = preg_split('/\\R?-+' . preg_quote($boundary, '/') . '/s', $rawBody);
         array_pop($bodyParts); // last block always has no data, contains boundary ending like `--`

--- a/tests/framework/web/MultipartFormDataParserTest.php
+++ b/tests/framework/web/MultipartFormDataParserTest.php
@@ -13,6 +13,33 @@ use yiiunit\TestCase;
 
 class MultipartFormDataParserTest extends TestCase
 {
+    public function testParseWithBoundaryFollowedByAdditionalParameters(): void
+    {
+        $parser = new MultipartFormDataParser();
+
+        $boundary = '---------------------------22472926011618';
+        $rawBody = "--{$boundary}\nContent-Disposition: form-data; name=\"title\"\r\n\r\ntest-title";
+        $rawBody .= "\r\n--{$boundary}--";
+
+        foreach (
+            [
+                'multipart/form-data; boundary=' . $boundary . '; charset=utf-8',
+                'multipart/form-data; boundary="' . $boundary . '"; charset=utf-8',
+            ] as $contentType
+        ) {
+            $bodyParams = $parser->parse($rawBody, $contentType);
+            $this->assertSame(['title' => 'test-title'], $bodyParams, 'Content-Type: ' . $contentType);
+        }
+    }
+
+    public function testParseWithoutBoundary(): void
+    {
+        $parser = new MultipartFormDataParser();
+
+        $this->assertSame([], $parser->parse("--irrelevant\r\n\r\ndata", 'multipart/form-data'));
+        $this->assertSame([], $parser->parse('--irrelevant', 'multipart/form-data; boundary='));
+    }
+
     public function testParse(): void
     {
         if (defined('HHVM_VERSION')) {

--- a/tests/framework/web/MultipartFormDataParserTest.php
+++ b/tests/framework/web/MultipartFormDataParserTest.php
@@ -25,6 +25,10 @@ class MultipartFormDataParserTest extends TestCase
             [
                 'multipart/form-data; boundary=' . $boundary . '; charset=utf-8',
                 'multipart/form-data; boundary="' . $boundary . '"; charset=utf-8',
+                'multipart/form-data; x-boundary=wrong; boundary=' . $boundary,
+                'multipart/form-data; foo="a; boundary=wrong"; boundary=' . $boundary,
+                'multipart/form-data; charset="boundary=abc"; boundary=' . $boundary,
+                'multipart/form-data; charset="boundary=abc"; boundary="' . $boundary . '"',
             ] as $contentType
         ) {
             $bodyParams = $parser->parse($rawBody, $contentType);
@@ -38,6 +42,8 @@ class MultipartFormDataParserTest extends TestCase
 
         $this->assertSame([], $parser->parse("--irrelevant\r\n\r\ndata", 'multipart/form-data'));
         $this->assertSame([], $parser->parse('--irrelevant', 'multipart/form-data; boundary='));
+        $this->assertSame([], $parser->parse('--irrelevant', 'multipart/form-data; boundary=""'));
+        $this->assertSame([], $parser->parse('--irrelevant', 'multipart/form-data; boundary=""; charset=utf-8'));
     }
 
     public function testParse(): void


### PR DESCRIPTION
### Motivation

`MultipartFormDataParser::parse()` extracts the boundary with a greedy pattern:

```php
preg_match('/boundary="?(.*)"?$/is', $contentType, $matches)
```

For a header like `multipart/form-data; boundary=ABC; charset=utf-8` it captures `ABC; charset=utf-8` as the boundary, `preg_split` finds no delimiters and parsing returns no parts — real-world servers and clients do append additional Content-Type parameters. Quoted boundaries with trailing parameters (`boundary="ABC"; charset=utf-8`) fail the same way.

### Changes

Match either a quoted boundary string or an unquoted token terminated by the next parameter separator or whitespace (per the MIME parameter syntax), and bail out on an empty boundary:

```php
preg_match('/boundary=(?:"([^"]*)"|([^;\s]*))/is', $contentType, $matches)
```

Existing behavior for plain and quoted boundaries without trailing parameters is unchanged.

### Tests

New cases in `tests/framework/web/MultipartFormDataParserTest.php`: boundary followed by `; charset=utf-8` (unquoted and quoted forms) parses all parts; missing/empty boundary returns no parts.
