### PR TITLE
Fix PO file escaping of backslashes and parsing of escaped quotes

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -36,6 +36,7 @@ Yii Framework 2 Change Log
 - Bug #21047: Fix PHPDoc annotations in `Theme`, `AccessRule` and `View` (mspirkov)
 - Bug #20217: Apply `ActiveForm::$validationDelay` only while the user is typing, so validation on blur, change and manual trigger is no longer delayed (veksa)
 - Bug #19865: Ignore validators with a `when` condition while `AttributeTypecastBehavior` detects `attributeTypes` automatically (veksa)
+- Bug #21074: Fix Gettext PO file escaping of backslashes and parsing of escaped quotes (iliaal)
 
 
 2.0.55 May 09, 2026

--- a/framework/i18n/GettextPoFile.php
+++ b/framework/i18n/GettextPoFile.php
@@ -19,6 +19,13 @@ use Yii;
 class GettextPoFile extends GettextFile
 {
     /**
+     * Quoted PO string that stays on one physical line, including the surrounding quotes.
+     * Excluding CR/LF prevents a legacy entry that ends with a single backslash from consuming
+     * the next entry's closing quote.
+     */
+    private const QUOTED_STRING_PATTERN = '"(?:[^"\\\\\r\n]|\\\\[^\r\n])*"';
+
+    /**
      * Loads messages from a PO file.
      * @param string $filePath file path
      * @param string $context message context
@@ -27,14 +34,15 @@ class GettextPoFile extends GettextFile
      */
     public function load($filePath, $context)
     {
-        $pattern = '/(msgctxt\s+"((?:[^"\\\\]|\\\\.)*)")?\s*msgid\s*((?:"(?:[^"\\\\]|\\\\.)*"\s*)+)\s*msgstr\s*((?:"(?:[^"\\\\]|\\\\.)*"\s*)+)/'; // message ID and translated string
+        $quoted = self::QUOTED_STRING_PATTERN;
+        $pattern = '/(msgctxt\s+((?:' . $quoted . '\s*)+))?\s*msgid\s*((?:' . $quoted . '\s*)+)\s*msgstr\s*((?:' . $quoted . '\s*)+)/';
         $content = file_get_contents($filePath);
         $matches = [];
         $matchCount = preg_match_all($pattern, $content, $matches);
 
         $messages = [];
         for ($i = 0; $i < $matchCount; ++$i) {
-            if ($matches[2][$i] === $context) {
+            if ($this->decode($matches[2][$i]) === $context) {
                 $id = $this->decode($matches[3][$i]);
                 $message = $this->decode($matches[4][$i]);
                 $messages[$id] = $message;
@@ -71,7 +79,7 @@ class GettextPoFile extends GettextFile
         foreach ($messages as $id => $message) {
             $separatorPosition = strpos($id, chr(4));
             if ($separatorPosition !== false) {
-                $content .= 'msgctxt "' . substr($id, 0, $separatorPosition) . "\"\n";
+                $content .= 'msgctxt "' . $this->encode(substr($id, 0, $separatorPosition)) . "\"\n";
                 $id = substr($id, $separatorPosition + 1);
             }
             $content .= 'msgid "' . $this->encode($id) . "\"\n";
@@ -101,24 +109,30 @@ class GettextPoFile extends GettextFile
      */
     protected function decode($string)
     {
-        $string = preg_replace('/"\s+"/', '', $string);
-        $string = preg_replace_callback('/\\\\(.)/s', static function ($matches) {
-            switch ($matches[1]) {
-                case 'n':
-                    return "\n";
-                case 'r':
-                    return "\r";
-                case 't':
-                    return "\t";
-                case '"':
-                    return '"';
-                case '\\':
-                    return '\\';
-            }
+        if (!preg_match_all('/' . self::QUOTED_STRING_PATTERN . '/', $string, $matches)) {
+            return '';
+        }
 
-            return $matches[0];
-        }, $string);
+        $decoded = '';
+        foreach ($matches[0] as $fragment) {
+            $decoded .= preg_replace_callback('/\\\\(.)/', static function ($escapeMatches) {
+                switch ($escapeMatches[1]) {
+                    case 'n':
+                        return "\n";
+                    case 'r':
+                        return "\r";
+                    case 't':
+                        return "\t";
+                    case '"':
+                        return '"';
+                    case '\\':
+                        return '\\';
+                }
 
-        return substr(rtrim($string), 1, -1);
+                return $escapeMatches[0];
+            }, substr($fragment, 1, -1));
+        }
+
+        return $decoded;
     }
 }

--- a/framework/i18n/GettextPoFile.php
+++ b/framework/i18n/GettextPoFile.php
@@ -27,9 +27,7 @@ class GettextPoFile extends GettextFile
      */
     public function load($filePath, $context)
     {
-        $pattern = '/(msgctxt\s+"(.*?(?<!\\\\))")?\s+' // context
-            . 'msgid\s+((?:".*(?<!\\\\)"\s*)+)\s+' // message ID, i.e. original string
-            . 'msgstr\s+((?:".*(?<!\\\\)"\s*)+)/'; // translated string
+        $pattern = '/(msgctxt\s+"((?:[^"\\\\]|\\\\.)*)")?\s*msgid\s*((?:"(?:[^"\\\\]|\\\\.)*"\s*)+)\s*msgstr\s*((?:"(?:[^"\\\\]|\\\\.)*"\s*)+)/'; // message ID and translated string
         $content = file_get_contents($filePath);
         $matches = [];
         $matchCount = preg_match_all($pattern, $content, $matches);
@@ -90,8 +88,8 @@ class GettextPoFile extends GettextFile
     protected function encode($string)
     {
         return str_replace(
-            ['"', "\n", "\t", "\r"],
-            ['\\"', '\\n', '\\t', '\\r'],
+            ['\\', '"', "\n", "\t", "\r"],
+            ['\\\\', '\\"', '\\n', '\\t', '\\r'],
             $string
         );
     }
@@ -103,11 +101,23 @@ class GettextPoFile extends GettextFile
      */
     protected function decode($string)
     {
-        $string = preg_replace(
-            ['/"\s+"/', '/\\\\n/', '/\\\\r/', '/\\\\t/', '/\\\\"/'],
-            ['', "\n", "\r", "\t", '"'],
-            $string
-        );
+        $string = preg_replace('/"\s+"/', '', $string);
+        $string = preg_replace_callback('/\\\\(.)/s', static function ($matches) {
+            switch ($matches[1]) {
+                case 'n':
+                    return "\n";
+                case 'r':
+                    return "\r";
+                case 't':
+                    return "\t";
+                case '"':
+                    return '"';
+                case '\\':
+                    return '\\';
+            }
+
+            return $matches[0];
+        }, $string);
 
         return substr(rtrim($string), 1, -1);
     }

--- a/tests/framework/i18n/GettextPoFileTest.php
+++ b/tests/framework/i18n/GettextPoFileTest.php
@@ -114,13 +114,14 @@ class GettextPoFileTest extends TestCase
         $poFile = new GettextPoFile();
         $filePath = Yii::getAlias('@yiiunit/runtime') . '/po-roundtrip-' . getmypid() . '.po';
 
-        $context = 'roundtrip';
+        $context = 'round\\trip"ctx';
         $rawMessages = [
             'msg1' => 'back\\slash',
             'msg2' => 'trailing\\',
             'msg3' => 'quote"inside',
             'msg4' => "new\nline",
             'msg5' => 'C:\\temp\\file "q"\nend',
+            'msg6' => 'quote" ',
         ];
         $messages = [];
         foreach ($rawMessages as $id => $message) {
@@ -131,6 +132,27 @@ class GettextPoFileTest extends TestCase
         $loaded = $poFile->load($filePath, $context);
 
         $this->assertSame($rawMessages, $loaded);
+
+        unlink($filePath);
+    }
+
+    public function testLoadDoesNotLoseFollowingEntryAfterMalformedQuotedString(): void
+    {
+        $poFile = new GettextPoFile();
+        $filePath = Yii::getAlias('@yiiunit/runtime') . '/po-malformed-' . getmypid() . '.po';
+
+        $content = <<<'PO'
+msgid "first"
+msgstr "broken\"
+
+msgid "valid"
+msgstr "ok"
+PO;
+        file_put_contents($filePath, $content . "\n");
+
+        $loaded = $poFile->load($filePath, '');
+
+        $this->assertSame(['valid' => 'ok'], $loaded);
 
         unlink($filePath);
     }

--- a/tests/framework/i18n/GettextPoFileTest.php
+++ b/tests/framework/i18n/GettextPoFileTest.php
@@ -10,6 +10,7 @@ namespace yiiunit\framework\i18n;
 
 use yii\i18n\GettextPoFile;
 use yiiunit\TestCase;
+use Yii;
 
 /**
  * @group i18n
@@ -40,7 +41,7 @@ class GettextPoFileTest extends TestCase
         $this->assertArrayHasKey("Nunc vel sapien nunc, a pretium nulla.\nPellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.", $context1);
 
         $this->assertArrayHasKey("The other\n\ncontext.\n", $context2);
-        $this->assertArrayHasKey("test1\\\ntest2\n\\\\\ntest3", $context2);
+        $this->assertArrayHasKey("test1\\ntest2\n\\\ntest3", $context2);
 
         // translated messages
         $this->assertTrue(in_array('', $context1));
@@ -49,7 +50,7 @@ class GettextPoFileTest extends TestCase
         $this->assertTrue(in_array('Короткий перевод.', $context1));
 
         $this->assertTrue(in_array("Другой\n\nконтекст.\n", $context2));
-        $this->assertTrue(in_array("тест1\\\nтест2\n\\\\\nтест3", $context2));
+        $this->assertTrue(in_array("тест1\\nтест2\n\\\nтест3", $context2));
     }
 
     public function testSave(): void
@@ -106,5 +107,31 @@ class GettextPoFileTest extends TestCase
 
         $this->assertArrayHasKey("\rCarriage returns\r", $context2);
         $this->assertTrue(in_array("\rВозвраты кареток\r", $context2));
+    }
+
+    public function testSaveLoadRoundTripWithSpecialCharacters(): void
+    {
+        $poFile = new GettextPoFile();
+        $filePath = Yii::getAlias('@yiiunit/runtime') . '/po-roundtrip-' . getmypid() . '.po';
+
+        $context = 'roundtrip';
+        $rawMessages = [
+            'msg1' => 'back\\slash',
+            'msg2' => 'trailing\\',
+            'msg3' => 'quote"inside',
+            'msg4' => "new\nline",
+            'msg5' => 'C:\\temp\\file "q"\nend',
+        ];
+        $messages = [];
+        foreach ($rawMessages as $id => $message) {
+            $messages[$context . chr(4) . $id] = $message;
+        }
+
+        $poFile->save($filePath, $messages);
+        $loaded = $poFile->load($filePath, $context);
+
+        $this->assertSame($rawMessages, $loaded);
+
+        unlink($filePath);
     }
 }


### PR DESCRIPTION
### Motivation

`GettextPoFile` mishandles backslashes in three compounding ways:

1. `encode()` escapes `"`, `\n`, `\t`, `\r` but **not the backslash itself**. A message ending in a backslash produces a `msgstr "x\"` line where the closing quote becomes part of an escape sequence; on re-parse the unterminated string swallows following entries and corrupts the catalog.
2. `decode()` unescapes `\n`, `\r`, `\t`, `\"` as independent sequential replacements without honoring escaped backslashes, so the two-character sequence `\` + `\n`-escape decodes to a stray backslash plus a newline instead of a literal backslash followed by `n`.
3. The `load()` extraction pattern places a single-backslash negative lookbehind before closing quotes (`".*(?<!\\)"`). It cannot parse strings whose last character is an escaped backslash — the real closing quote looks escaped to it — and such messages silently disappear from the loaded catalog.

### Changes

* `encode()`: escape the backslash first, then the other special characters.
* `decode()`: replace the sequential replacements with one escape-aware pass handling `\\`, `\"`, `\n`, `\r`, `\t` per gettext conventions (unknown escapes pass through unchanged).
* `load()`: use an explicit escape-aware quoted-string token (`"(?:[^"\\]|\\.)*"`) for context, msgid and msgstr sections, with lazy inter-string whitespace so a message block cannot consume the separator required by the following entry.

### Tests

New round-trip test in `tests/framework/i18n/GettextPoFileTest.php`: save/load of messages containing mid-string and trailing backslashes, quotes, newlines and combined cases; expectations in the existing `testLoad` updated where the fixture asserted the old incorrect decoding of `\\n`.
