### PR TITLE
docs: fix typo writting -> writing

### DIFF
--- a/docs/documentation_style_guide.md
+++ b/docs/documentation_style_guide.md
@@ -54,7 +54,7 @@ containing the translations. The following shows an example for German:
   - Refer to classes using the full namespace: `yii\base\Model`
   - Refer to class properties using the static syntax even if they are not static: `yii\base\Model::$validators`
   - Refer to class methods using the static syntax even if they are not static and include parenthesis to make it clear, that it is a method: `yii\base\Model::validate()`
-  - references to code objects should be writing in `[[]]` to generate links to the API documentation. E.g. `[[yii\base\Model]]`, `[[yii\base\Model::$validators]]`, or `[[yii\base\Model::validate()]]`.
+  - references to code objects should be written in `[[]]` to generate links to the API documentation. E.g. `[[yii\base\Model]]`, `[[yii\base\Model::$validators]]`, or `[[yii\base\Model::validate()]]`.
 
 ## Capitalizations
 

--- a/docs/documentation_style_guide.md
+++ b/docs/documentation_style_guide.md
@@ -54,7 +54,7 @@ containing the translations. The following shows an example for German:
   - Refer to classes using the full namespace: `yii\base\Model`
   - Refer to class properties using the static syntax even if they are not static: `yii\base\Model::$validators`
   - Refer to class methods using the static syntax even if they are not static and include parenthesis to make it clear, that it is a method: `yii\base\Model::validate()`
-  - references to code objects should be writting in `[[]]` to generate links to the API documentation. E.g. `[[yii\base\Model]]`, `[[yii\base\Model::$validators]]`, or `[[yii\base\Model::validate()]]`.
+  - references to code objects should be writing in `[[]]` to generate links to the API documentation. E.g. `[[yii\base\Model]]`, `[[yii\base\Model::$validators]]`, or `[[yii\base\Model::validate()]]`.
 
 ## Capitalizations
 


### PR DESCRIPTION
Corrects the misspelling `writting` -> `writing` in `docs/documentation_style_guide.md`.

Documentation only, no behaviour change.