### PR TITLE
Fix docblock typos across framework

### DIFF
--- a/framework/db/Command.php
+++ b/framework/db/Command.php
@@ -1281,7 +1281,7 @@ class Command extends Component
      * }
      * ```
      *
-     * The callable will recieve a database exception thrown and a current attempt
+     * The callable will receive a database exception thrown and a current attempt
      * (to execute the command) number starting from 1.
      *
      * @param callable $handler a PHP callback to handle database exceptions.

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -541,7 +541,7 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param string $table
      * @param array|Query $insertColumns
      * @param array|bool $updateColumns
-     * @param Constraint[] $constraints this parameter recieves a matched constraint list.
+     * @param Constraint[] $constraints this parameter receives a matched constraint list.
      * The constraints will be unique by their column names.
      * @return array
      * @since 2.0.14

--- a/framework/db/QueryBuilder.php
+++ b/framework/db/QueryBuilder.php
@@ -569,7 +569,7 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * @param string $name table name. The table name may contain schema name if any. Do not quote the table name.
      * @param string[] $columns source column list.
-     * @param Constraint[] $constraints this parameter optionally recieves a matched constraint list.
+     * @param Constraint[] $constraints this parameter optionally receives a matched constraint list.
      * The constraints will be unique by their column names.
      * @return string[] column list.
      */

--- a/framework/web/Controller.php
+++ b/framework/web/Controller.php
@@ -309,7 +309,7 @@ class Controller extends BaseController
     }
 
     /**
-     * Run the according filter_var logic for teh given type.
+     * Run the according filter_var logic for the given type.
      * @param string $param The value to filter.
      * @param string $typeName The type name.
      * @return mixed|null The resulting value, or null if validation failed or the type can't be validated.

--- a/framework/web/DbSession.php
+++ b/framework/web/DbSession.php
@@ -204,7 +204,7 @@ class DbSession extends MultiFieldSession
         // exception must be caught in session write handler
         // https://www.php.net/manual/en/function.session-set-save-handler.php#refsect1-function.session-set-save-handler-notes
         try {
-            // ensure backwards compatability (fixed #9438)
+            // ensure backwards compatibility (fixed #9438)
             if ($this->writeCallback && !$this->fields) {
                 $this->fields = $this->composeFields();
             }


### PR DESCRIPTION
Fixes a handful of misspellings in PHPDoc comments/inline comments across the framework. Comment-only changes, no behavior affected.

- `framework/web/Controller.php`: "teh" → "the"
- `framework/web/DbSession.php`: "compatability" → "compatibility"
- `framework/db/QueryBuilder.php`: "recieves" → "receives" (2 occurrences)
- `framework/db/Command.php`: "recieve" → "receive"

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -