### PR TITLE
Fix unnecessary query when accessing a relation on a new ActiveRecord

### DIFF
--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -330,8 +330,13 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     public function one($db = null)
     {
-        // See the note in `all()` about why `emulateExecution` is checked after building the command.
+        // See the notes in `all()` about why `emulateExecution` is checked both before and after
+        // building the command.
         // https://github.com/yiisoft/yii2/issues/21077
+        if ($this->emulateExecution) {
+            return null;
+        }
+
         $command = $this->createCommand($db);
 
         if ($this->emulateExecution) {

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -140,10 +140,17 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     public function all($db = null)
     {
-        // Build the command before checking `emulateExecution`: for a relation lazily accessed on
+        // Short-circuit before `createCommand()` if `emulateExecution` is already set: otherwise,
+        // building the command still runs `prepare()`, which for a `via()` relation queries the
+        // junction relation regardless of the flag set on this (outer) query.
+        if ($this->emulateExecution) {
+            return [];
+        }
+
+        // Build the command before re-checking `emulateExecution`: for a relation lazily accessed on
         // a model whose link attribute(s) are not set (e.g. a new, unsaved record), `createCommand()`
         // triggers `prepare()`, which may enable `emulateExecution` once it determines the relation
-        // can't match any row. Checking the flag only after building the command lets that
+        // can't match any row. Checking the flag again after building the command lets that
         // determination happen before we hit the database.
         // https://github.com/yiisoft/yii2/issues/21077
         $command = $this->createCommand($db);

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -140,7 +140,19 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     public function all($db = null)
     {
-        return parent::all($db);
+        // Build the command before checking `emulateExecution`: for a relation lazily accessed on
+        // a model whose link attribute(s) are not set (e.g. a new, unsaved record), `createCommand()`
+        // triggers `prepare()`, which may enable `emulateExecution` once it determines the relation
+        // can't match any row. Checking the flag only after building the command lets that
+        // determination happen before we hit the database.
+        // https://github.com/yiisoft/yii2/issues/21077
+        $command = $this->createCommand($db);
+
+        if ($this->emulateExecution) {
+            return [];
+        }
+
+        return $this->populate($command->queryAll());
     }
 
     /**

--- a/framework/db/ActiveQuery.php
+++ b/framework/db/ActiveQuery.php
@@ -323,7 +323,15 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     public function one($db = null)
     {
-        $row = parent::one($db);
+        // See the note in `all()` about why `emulateExecution` is checked after building the command.
+        // https://github.com/yiisoft/yii2/issues/21077
+        $command = $this->createCommand($db);
+
+        if ($this->emulateExecution) {
+            return null;
+        }
+
+        $row = $command->queryOne();
         if ($row !== false) {
             $models = $this->populate([$row]);
             return reset($models) ?: null;

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1719,6 +1719,43 @@ abstract class ActiveRecordTest extends DatabaseTestCase
     }
 
     /**
+     * When `emulateExecution()` is explicitly set on a `via()` relation query, no query should be
+     * sent to the database for either the outer relation or the intermediate junction relation.
+     *
+     * @see https://github.com/yiisoft/yii2/issues/21077
+     * @see https://github.com/yiisoft/yii2/pull/21085#discussion_r3946653606
+     */
+    public function testViaRelationWithEmulateExecutionDoesNotQueryDatabase(): void
+    {
+        // warm up the schema cache so it is not queried during the assertions below
+        Order::getTableSchema();
+        OrderItem::getTableSchema();
+        Item::getTableSchema();
+
+        $db = Order::getDb();
+        $enableLogging = $db->enableLogging;
+        $enableProfiling = $db->enableProfiling;
+        $db->enableLogging = true;
+        $db->enableProfiling = true;
+
+        try {
+            $order = Order::findOne(1);
+            $this->assertFalse($order->getIsNewRecord());
+
+            Yii::getLogger()->messages = [];
+            $this->assertSame([], $order->getItems()->emulateExecution()->all());
+            $this->assertCount(0, Yii::getLogger()->messages);
+
+            Yii::getLogger()->messages = [];
+            $this->assertNull($order->getItems()->emulateExecution()->one());
+            $this->assertCount(0, Yii::getLogger()->messages);
+        } finally {
+            $db->enableLogging = $enableLogging;
+            $db->enableProfiling = $enableProfiling;
+        }
+    }
+
+    /**
      * @see https://github.com/yiisoft/yii2/issues/12213
      */
     public function testUnlinkAllOnCondition(): void

--- a/tests/framework/db/ActiveRecordTest.php
+++ b/tests/framework/db/ActiveRecordTest.php
@@ -1683,6 +1683,42 @@ abstract class ActiveRecordTest extends DatabaseTestCase
     }
 
     /**
+     * Accessing a relation on a model whose link attribute(s) are not set (e.g. a new, unsaved record)
+     * can never match a row, so no query should be sent to the database.
+     *
+     * @see https://github.com/yiisoft/yii2/issues/21077
+     */
+    public function testLazyRelationOnNewRecordDoesNotQueryDatabase(): void
+    {
+        // warm up the schema cache so it is not queried during the assertions below
+        Customer::getTableSchema();
+        Order::getTableSchema();
+        Profile::getTableSchema();
+
+        $db = Customer::getDb();
+        $enableLogging = $db->enableLogging;
+        $enableProfiling = $db->enableProfiling;
+        $db->enableLogging = true;
+        $db->enableProfiling = true;
+
+        try {
+            $customer = new Customer();
+            $this->assertTrue($customer->getIsNewRecord());
+
+            Yii::getLogger()->messages = [];
+            $this->assertSame([], $customer->ordersPlain);
+            $this->assertCount(0, Yii::getLogger()->messages);
+
+            Yii::getLogger()->messages = [];
+            $this->assertNull($customer->profile);
+            $this->assertCount(0, Yii::getLogger()->messages);
+        } finally {
+            $db->enableLogging = $enableLogging;
+            $db->enableProfiling = $enableProfiling;
+        }
+    }
+
+    /**
      * @see https://github.com/yiisoft/yii2/issues/12213
      */
     public function testUnlinkAllOnCondition(): void


### PR DESCRIPTION
Fixes #21077.

Accessing a lazily-loaded relation (`hasOne`/`hasMany`) on a model whose link
attribute(s) are not set — e.g. a new, unsaved record — can never match a row.
Yii already has a mechanism for this: `Query::$emulateExecution`, which short-circuits
`all()`/`one()` before touching the database.

For eager loading (`with()`), this already works correctly, because
`ActiveRelationTrait::populateRelation()` calls `filterByModels()` (which sets the flag)
*before* calling `all()`/`one()`.

For lazy loading (`$model->relationName`), it didn't: `ActiveQuery::all()`/`one()` checked
`emulateExecution` *before* `createCommand()` ran — but the flag is only set inside
`prepare()`, which `createCommand()` triggers. So the check always saw the flag still
`false`, and a `WHERE (0=1)` query was sent anyway.

The fix builds the command first (safe — no DB call happens until `queryAll()`/`queryOne()`
is actually invoked), then checks the flag, so the determination made during `prepare()`
is honored before the database is hit. Scoped to `ActiveQuery` only; the base `Query`
class and its documented `emulateExecution()` contract for non-AR queries are untouched.

Added a regression test (`testLazyRelationOnNewRecordDoesNotQueryDatabase`) that asserts,
via query-log message count, that no SQL is sent for either a `hasMany` or `hasOne`
relation accessed on an unsaved record. Confirmed the test fails (3 log messages) without
the fix and passes (0) with it. Full `sqlite` `ActiveRecordTest` suite (138 tests) and
`QueryTest` suite pass with no regressions.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #21077